### PR TITLE
TYP: fix and improve ``{f,i}info`` stubs in ``_core.getlimits``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -121,10 +121,7 @@ from numpy._typing import (  # type: ignore[deprecated]
     _FloatingCodes,
     _ComplexFloatingCodes,
     _InexactCodes,
-    _NumberCodes,
     _CharacterCodes,
-    _FlexibleCodes,
-    _GenericCodes,
     # Ufuncs
     _UFunc_Nin1_Nout1,
     _UFunc_Nin2_Nout1,
@@ -313,6 +310,10 @@ from numpy._core.arrayprint import (
 from numpy._core.einsumfunc import (
     einsum,
     einsum_path,
+)
+from numpy._core.getlimits import (
+    finfo,
+    iinfo,
 )
 
 from numpy._core.multiarray import (
@@ -779,9 +780,7 @@ _ScalarT_co = TypeVar("_ScalarT_co", bound=generic, default=Any, covariant=True)
 _NumberT = TypeVar("_NumberT", bound=number)
 _InexactT = TypeVar("_InexactT", bound=inexact)
 _RealNumberT = TypeVar("_RealNumberT", bound=floating | integer)
-_FloatingT_co = TypeVar("_FloatingT_co", bound=floating, default=floating, covariant=True)
 _IntegerT = TypeVar("_IntegerT", bound=integer)
-_IntegerT_co = TypeVar("_IntegerT_co", bound=integer, default=integer, covariant=True)
 _NonObjectScalarT = TypeVar("_NonObjectScalarT", bound=np.bool | number | flexible | datetime64 | timedelta64)
 
 _NBit = TypeVar("_NBit", bound=NBitBase, default=Any)  # pyright: ignore[reportDeprecated]
@@ -944,7 +943,7 @@ _CastingKind: TypeAlias = L["no", "equiv", "safe", "same_kind", "same_value", "u
 
 _OrderKACF: TypeAlias = L["K", "A", "C", "F"] | None
 _OrderACF: TypeAlias = L["A", "C", "F"] | None
-_OrderCF: TypeAlias = L["C", "F"] | None
+_OrderCF: TypeAlias = L["C", "F"] | None  # noqa: PYI047
 
 _ModeKind: TypeAlias = L["raise", "wrap", "clip"]
 _PartitionKind: TypeAlias = L["introselect"]
@@ -3577,7 +3576,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
 # See https://github.com/numpy/numpy-stubs/pull/80 for more details.
 class generic(_ArrayOrScalarCommon, Generic[_ItemT_co]):
     @abstractmethod
-    def __new__(self) -> None: ...
+    def __new__(cls) -> None: ...
     def __hash__(self) -> int: ...
     @overload
     def __array__(self, dtype: None = None, /) -> ndarray[tuple[()], dtype[Self]]: ...
@@ -5792,53 +5791,6 @@ class busdaycalendar:
     def weekmask(self) -> NDArray[np.bool]: ...
     @property
     def holidays(self) -> NDArray[datetime64]: ...
-
-class finfo(Generic[_FloatingT_co]):
-    dtype: Final[dtype[_FloatingT_co]]
-    bits: Final[int]
-    eps: Final[_FloatingT_co]
-    epsneg: Final[_FloatingT_co]
-    iexp: Final[int]
-    machep: Final[int]
-    max: Final[_FloatingT_co]
-    maxexp: Final[int]
-    min: Final[_FloatingT_co]
-    minexp: Final[int]
-    negep: Final[int]
-    nexp: Final[int]
-    nmant: Final[int]
-    precision: Final[int]
-    resolution: Final[_FloatingT_co]
-    smallest_subnormal: Final[_FloatingT_co]
-    @property
-    def smallest_normal(self) -> _FloatingT_co: ...
-    @property
-    def tiny(self) -> _FloatingT_co: ...
-    @overload
-    def __new__(cls, dtype: inexact[_NBit1] | _DTypeLike[inexact[_NBit1]]) -> finfo[floating[_NBit1]]: ...
-    @overload
-    def __new__(cls, dtype: complex | type[complex]) -> finfo[float64]: ...
-    @overload
-    def __new__(cls, dtype: str) -> finfo[floating]: ...
-
-class iinfo(Generic[_IntegerT_co]):
-    dtype: Final[dtype[_IntegerT_co]]
-    kind: Final[LiteralString]
-    bits: Final[int]
-    key: Final[LiteralString]
-    @property
-    def min(self) -> int: ...
-    @property
-    def max(self) -> int: ...
-
-    @overload
-    def __new__(
-        cls, dtype: _IntegerT_co | _DTypeLike[_IntegerT_co]
-    ) -> iinfo[_IntegerT_co]: ...
-    @overload
-    def __new__(cls, dtype: int | type[int]) -> iinfo[int_]: ...
-    @overload
-    def __new__(cls, dtype: str) -> iinfo[Any]: ...
 
 @final
 class nditer:

--- a/numpy/_core/getlimits.pyi
+++ b/numpy/_core/getlimits.pyi
@@ -1,3 +1,114 @@
-from numpy import finfo, iinfo
+from types import GenericAlias
+from typing import Final, Generic, Self, overload
+from typing_extensions import TypeVar
+
+import numpy as np
+from numpy._typing import (
+    _CLongDoubleCodes,
+    _Complex64Codes,
+    _Complex128Codes,
+    _DTypeLike,
+    _Float16Codes,
+    _Float32Codes,
+    _Float64Codes,
+    _Int8Codes,
+    _Int16Codes,
+    _Int32Codes,
+    _Int64Codes,
+    _IntPCodes,
+    _LongDoubleCodes,
+    _UInt8Codes,
+    _UInt16Codes,
+    _UInt32Codes,
+    _UInt64Codes,
+)
 
 __all__ = ["finfo", "iinfo"]
+
+###
+
+_IntegerT_co = TypeVar("_IntegerT_co", bound=np.integer, default=np.integer, covariant=True)
+_FloatingT_co = TypeVar("_FloatingT_co", bound=np.floating, default=np.floating, covariant=True)
+
+###
+
+class iinfo(Generic[_IntegerT_co]):
+    dtype: np.dtype[_IntegerT_co]
+    bits: Final[int]
+    kind: Final[str]
+    key: Final[str]
+
+    @property
+    def min(self, /) -> int: ...
+    @property
+    def max(self, /) -> int: ...
+
+    #
+    @overload
+    def __init__(self, /, int_type: _IntegerT_co | _DTypeLike[_IntegerT_co]) -> None: ...
+    @overload
+    def __init__(self: iinfo[np.int_], /, int_type: _IntPCodes | type[int] | int) -> None: ...
+    @overload
+    def __init__(self: iinfo[np.int8], /, int_type: _Int8Codes) -> None: ...
+    @overload
+    def __init__(self: iinfo[np.uint8], /, int_type: _UInt8Codes) -> None: ...
+    @overload
+    def __init__(self: iinfo[np.int16], /, int_type: _Int16Codes) -> None: ...
+    @overload
+    def __init__(self: iinfo[np.uint16], /, int_type: _UInt16Codes) -> None: ...
+    @overload
+    def __init__(self: iinfo[np.int32], /, int_type: _Int32Codes) -> None: ...
+    @overload
+    def __init__(self: iinfo[np.uint32], /, int_type: _UInt32Codes) -> None: ...
+    @overload
+    def __init__(self: iinfo[np.int64], /, int_type: _Int64Codes) -> None: ...
+    @overload
+    def __init__(self: iinfo[np.uint64], /, int_type: _UInt64Codes) -> None: ...
+    @overload
+    def __init__(self, /, int_type: str) -> None: ...
+
+    #
+    @classmethod
+    def __class_getitem__(cls, item: object, /) -> GenericAlias: ...
+
+class finfo(Generic[_FloatingT_co]):
+    dtype: np.dtype[_FloatingT_co]
+    eps: _FloatingT_co
+    epsneg: _FloatingT_co
+    resolution: _FloatingT_co
+    smallest_subnormal: _FloatingT_co
+    max: _FloatingT_co
+    min: _FloatingT_co
+
+    bits: Final[int]
+    iexp: Final[int]
+    machep: Final[int]
+    maxexp: Final[int]
+    minexp: Final[int]
+    negep: Final[int]
+    nexp: Final[int]
+    nmant: Final[int]
+    precision: Final[int]
+
+    @property
+    def smallest_normal(self, /) -> _FloatingT_co: ...
+    @property
+    def tiny(self, /) -> _FloatingT_co: ...
+
+    #
+    @overload
+    def __new__(cls, dtype: _FloatingT_co | _DTypeLike[_FloatingT_co]) -> Self: ...
+    @overload
+    def __new__(cls, dtype: _Float16Codes) -> finfo[np.float16]: ...
+    @overload
+    def __new__(cls, dtype: _Float32Codes | _Complex64Codes | _DTypeLike[np.complex64]) -> finfo[np.float32]: ...
+    @overload
+    def __new__(cls, dtype: _Float64Codes | _Complex128Codes | type[complex] | complex) -> finfo[np.float64]: ...
+    @overload
+    def __new__(cls, dtype: _LongDoubleCodes | _CLongDoubleCodes | _DTypeLike[np.clongdouble]) -> finfo[np.longdouble]: ...
+    @overload
+    def __new__(cls, dtype: str) -> finfo: ...
+
+    #
+    @classmethod
+    def __class_getitem__(cls, item: object, /) -> GenericAlias: ...

--- a/numpy/typing/tests/data/reveal/getlimits.pyi
+++ b/numpy/typing/tests/data/reveal/getlimits.pyi
@@ -1,11 +1,11 @@
-from typing import Any, LiteralString, assert_type
+from typing import assert_type
 
 import numpy as np
-from numpy._typing import _64Bit
 
 f: float
 f8: np.float64
 c8: np.complex64
+c16: np.complex128
 
 i: int
 i8: np.int64
@@ -15,9 +15,10 @@ finfo_f8: np.finfo[np.float64]
 iinfo_i8: np.iinfo[np.int64]
 
 assert_type(np.finfo(f), np.finfo[np.float64])
-assert_type(np.finfo(f8), np.finfo[np.floating[_64Bit]])
+assert_type(np.finfo(f8), np.finfo[np.float64])
 assert_type(np.finfo(c8), np.finfo[np.float32])
-assert_type(np.finfo("f2"), np.finfo[np.floating])
+assert_type(np.finfo(c16), np.finfo[np.float64])
+assert_type(np.finfo("f2"), np.finfo[np.float16])
 
 assert_type(finfo_f8.dtype, np.dtype[np.float64])
 assert_type(finfo_f8.bits, int)
@@ -41,11 +42,12 @@ assert_type(finfo_f8.smallest_subnormal, np.float64)
 assert_type(np.iinfo(i), np.iinfo[np.int_])
 assert_type(np.iinfo(i8), np.iinfo[np.int64])
 assert_type(np.iinfo(u4), np.iinfo[np.uint32])
-assert_type(np.iinfo("i2"), np.iinfo[Any])
+assert_type(np.iinfo("i2"), np.iinfo[np.int16])
+assert_type(np.iinfo("u2"), np.iinfo[np.uint16])
 
 assert_type(iinfo_i8.dtype, np.dtype[np.int64])
-assert_type(iinfo_i8.kind, LiteralString)
+assert_type(iinfo_i8.kind, str)
 assert_type(iinfo_i8.bits, int)
-assert_type(iinfo_i8.key, LiteralString)
+assert_type(iinfo_i8.key, str)
 assert_type(iinfo_i8.min, int)
 assert_type(iinfo_i8.max, int)


### PR DESCRIPTION
This is a port of numpy/numtype#125 with some modifications for the sake of backwards compatibility.

The reason for moving these classes to the `_core.getlimits` stubs is because that's also where they're defined at runtime. It also helps make `__init__.pyi` less monolithic.
