### PR TITLE
BLD: Upgrade spin requirement to version 0.15

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Uninstall pytest-xdist (conflicts with TSAN)
         run: pip uninstall -y pytest-xdist
 
+      - name: Upgrade spin (gh-29777)
+        run: pip install -U spin
+
       - name: Build NumPy with ThreadSanitizer
         run: python -m spin build -- -Db_sanitize=thread
 

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - ninja
   - pkg-config
   - meson-python
-  - spin==0.13
+  - spin==0.15
   - ccache
   # For testing
   - pytest

--- a/requirements/build_requirements.txt
+++ b/requirements/build_requirements.txt
@@ -1,5 +1,5 @@
 meson-python>=0.13.1
 Cython>=3.0.6
 ninja
-spin==0.14
+spin==0.15
 build

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
-spin==0.14
+spin==0.15
 # Keep this in sync with ci_requirements.txt
 scipy-openblas32==0.3.30.0.1

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
-spin==0.14
+spin==0.15
 # Keep this in sync with ci32_requirements.txt
 scipy-openblas32==0.3.30.0.1
 scipy-openblas64==0.3.30.0.1


### PR DESCRIPTION
`spin` 0.15 pins its `click` dependency to avoid the newly released `click` version 8.3.0.