### PR TITLE
BUG: Fix assert in nditer buffer setup

### DIFF
--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -199,6 +199,11 @@ class TestRavelUnravelIndex:
         with assert_raises(ValueError):
             np.unravel_index([1], (2, 1, 0))
 
+    def test_regression_size_1_index(self):
+        # actually tests the nditer size one index tracking
+        # regression test for gh-29690
+        np.unravel_index(np.array([[1, 0, 1, 0]], dtype=np.uint32), (4,))
+
 class TestGrid:
     def test_basic(self):
         a = mgrid[-1:1:10j]


### PR DESCRIPTION
When using a buffered iteration, there was a new assert to check that strides were set up nicely to ensure that we are not missing dimension coalescing.

However, when the strides are set up to track an index, then they were still set up with a 0 for length 1.
I _think_ that is just unnecessary (i.e. the assert is correct to point it out).  But, let's do this first for backporting at least.

Closes gh-29690