### PR TITLE
DOC: Add how-to-numerical-issues to howtos_index.rst

### DIFF
--- a/doc/source/user/howtos_index.rst
+++ b/doc/source/user/howtos_index.rst
@@ -17,3 +17,5 @@ the package, see the :ref:`API reference <reference>`.
    how-to-verify-bug
    how-to-partition
    how-to-print
+   how-to-numerical-issues
+


### PR DESCRIPTION
Follow-up to #29786.

Adds the new page `how-to-numerical-issues.rst` to the How-tos table of contents
(`doc/source/user/howtos_index.rst`) so that it appears in the rendered docs
navigation.

This was mentioned in the original PR description but not committed, and was
caught in review. Thanks for the reminder!
