### PR TITLE
MAINT: delete unused variables in unary logical dispatch

### DIFF
--- a/numpy/_core/src/umath/loops_logical.dispatch.cpp
+++ b/numpy/_core/src/umath/loops_logical.dispatch.cpp
@@ -111,7 +111,6 @@ struct UnaryLogicalTraits;
 
 template<>
 struct UnaryLogicalTraits<logical_not_t> {
-    static constexpr bool is_not = true;
     static constexpr auto scalar_op = std::equal_to<bool>{};
 
     HWY_INLINE HWY_ATTR vec_u8 simd_op(vec_u8 v) {
@@ -122,7 +121,6 @@ struct UnaryLogicalTraits<logical_not_t> {
 
 template<>
 struct UnaryLogicalTraits<absolute_t> {
-    static constexpr bool is_not = false;
     static constexpr auto scalar_op = std::not_equal_to<bool>{};
 
     HWY_INLINE HWY_ATTR vec_u8 simd_op(vec_u8 v) {


### PR DESCRIPTION
Backport of #29843.

Clang complains on current `main`:

```
[2/5] Compiling C++ object numpy/_core/libloops_logical.dispatch.h_baseline.a.p/src_umath_loops_logical.dispatch.cpp.o
../numpy/_core/src/umath/loops_logical.dispatch.cpp:111:27: warning: unused variable 'is_not' [-Wunused-const-variable]
  111 |     static constexpr bool is_not    = true;
      |                           ^~~~~~
../numpy/_core/src/umath/loops_logical.dispatch.cpp:124:27: warning: unused variable 'is_not' [-Wunused-const-variable]
  124 |     static constexpr bool is_not    = false;
      |                           ^~~~~~
2 warnings generated.
```


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
