### PR TITLE
TST: clarify logic in float_alias_names test

### DIFF
--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1687,9 +1687,9 @@ class TestDTypeClasses:
 
     @pytest.mark.parametrize("name",
             ["Half", "Float", "Double", "CFloat", "CDouble"])
-    def test_float_alias_names(self, name):
+    def test_float_alias_names_not_present(self, name):
         with pytest.raises(AttributeError):
-            getattr(numpy.dtypes, name + "DType") is numpy.dtypes.Float16DType
+            getattr(numpy.dtypes, name + "DType")
 
     def test_scalar_helper_all_dtypes(self):
         for dtype in np.dtypes.__all__:

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1688,8 +1688,7 @@ class TestDTypeClasses:
     @pytest.mark.parametrize("name",
             ["Half", "Float", "Double", "CFloat", "CDouble"])
     def test_float_alias_names_not_present(self, name):
-        with pytest.raises(AttributeError):
-            getattr(numpy.dtypes, name + "DType")
+        assert not hasattr(numpy.dtypes, f"{name}DType")
 
     def test_scalar_helper_all_dtypes(self):
         for dtype in np.dtypes.__all__:


### PR DESCRIPTION
I noticed some hard-to-decipher logic in this test case; I think this change brings the test closer to its intended purpose.