### PR TITLE
BUG: np.setbufsize should raise ValueError for negative input

### DIFF
--- a/numpy/_core/_ufunc_config.py
+++ b/numpy/_core/_ufunc_config.py
@@ -187,6 +187,9 @@ def setbufsize(size):
     8192
 
     """
+    if size < 0:
+        raise ValueError("buffer size must be non-negative")
+        
     old = _get_extobj_dict()["bufsize"]
     extobj = _make_extobj(bufsize=size)
     _extobj_contextvar.set(extobj)

--- a/numpy/_core/_ufunc_config.py
+++ b/numpy/_core/_ufunc_config.py
@@ -189,7 +189,6 @@ def setbufsize(size):
     """
     if size < 0:
         raise ValueError("buffer size must be non-negative")
-        
     old = _get_extobj_dict()["bufsize"]
     extobj = _make_extobj(bufsize=size)
     _extobj_contextvar.set(extobj)

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4704,6 +4704,18 @@ def test_reduceat():
     np.setbufsize(ncu.UFUNC_BUFSIZE_DEFAULT)
     assert_array_almost_equal(h1, h2)
 
+def test_negative_value_raises():
+    with pytest.raises(ValueError, match="buffer size must be non-negative"):
+        np.setbufsize(-5)
+
+    old = np.getbufsize()
+    try:
+        prev = np.setbufsize(4096)
+        assert prev == old
+        assert np.getbufsize() == 4096
+    finally:
+        np.setbufsize(old)
+
 def test_reduceat_empty():
     """Reduceat should work with empty arrays"""
     indices = np.array([], 'i4')


### PR DESCRIPTION
Backport of #29774 .

### Closes #29651

This PR fixes an issue where `np.setbufsize` silently accepted negative
values. Passing a negative value now raises a `ValueError` with a clear
error message.

### Changes
- Added a check in `np.setbufsize` to raise `ValueError` when `size < 0`.
- Added a new unit test `test_negative_value_raises` in
  `numpy/_core/tests/test_umath.py`.

### Example
```python
>>> import numpy as np
>>> np.setbufsize(-5)
Traceback (most recent call last):
    ...
ValueError: buffer size must be non-negative

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
