### PR TITLE
ENH: add warning when calling ufunc with 'where' and without 'out'

### DIFF
--- a/doc/release/upcoming_changes/29813.new_feature.rst
+++ b/doc/release/upcoming_changes/29813.new_feature.rst
@@ -1,0 +1,6 @@
+Warning emitted when using `where` without `out`
+------------------------------------------------
+Ufuncs called with a ``where`` mask and without an ``out`` positional or kwarg will
+now emit a warning. This usage tends to trip up users who expect some value in
+output locations where the mask is ``False`` (the ufunc will not touch those
+locations). The warning can be supressed by using ``out=None``.

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4486,6 +4486,15 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
         return override;
     }
 
+    /* Warn if "where" is used without "out", issue 29561 */
+    if ((where_obj != NULL) && (full_args.out == NULL) && (out_obj != Py_None)) {
+        if (PyErr_Warn(PyExc_RuntimeWarning,
+                "'where' used without 'out', expect unitialized memory in output. "
+                "If this is intentional, use out=None.") < 0) {
+            goto fail;
+        }
+    }
+
     if (outer) {
         /* Outer uses special preparation of inputs (expand dims) */
         PyObject *new_in = prepare_input_arguments_for_outer(full_args.in, ufunc);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4487,7 +4487,7 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
     }
 
     /* Warn if "where" is used without "out", issue 29561 */
-    if ((where_obj != NULL) && (full_args.out == NULL) && (out_obj != Py_None)) {
+    if ((where_obj != NULL) && (full_args.out == NULL) && (out_obj == NULL)) {
         if (PyErr_Warn(PyExc_UserWarning,
                 "'where' used without 'out', expect unitialized memory in output. "
                 "If this is intentional, use out=None.") < 0) {

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4488,7 +4488,7 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
 
     /* Warn if "where" is used without "out", issue 29561 */
     if ((where_obj != NULL) && (full_args.out == NULL) && (out_obj != Py_None)) {
-        if (PyErr_Warn(PyExc_RuntimeWarning,
+        if (PyErr_Warn(PyExc_UserWarning,
                 "'where' used without 'out', expect unitialized memory in output. "
                 "If this is intentional, use out=None.") < 0) {
             goto fail;

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -1743,11 +1743,13 @@ class TestUfunc:
     def test_where_warns(self):
         a = np.arange(7)
         mask = a % 2 == 0
-        with warnings.catch_warnings(record=True) as w_where:
-            warnings.simplefilter('always')
-            result = np.add(a, a, where=mask)
-        assert len(w_where) == 1
-        assert "'where'" in str(w_where[0])
+        with pytest.warns(UserWarning, match="'where' used without 'out'"):
+            result1 = np.add(a, a, where=mask)
+        # Does not warn
+        result2 = np.add(a, a, where=mask, out=None)
+        # Sanity check
+        assert np.all(result1[::2] == [0, 4, 8, 12])
+        assert np.all(result2[::2] == [0, 4, 8, 12])
 
     @staticmethod
     def identityless_reduce_arrs():

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -1710,9 +1710,6 @@ class TestUfunc:
         assert_equal(a, [[0, 27], [14, 5]])
 
     def test_where_param_buffer_output(self):
-        # This test is temporarily skipped because it requires
-        # adding masking features to the nditer to work properly
-
         # With casting on output
         a = np.ones(10, np.int64)
         b = np.ones(10, np.int64)
@@ -1724,12 +1721,12 @@ class TestUfunc:
         # With casting and allocated output
         a = np.array([1], dtype=np.int64)
         m = np.array([True], dtype=bool)
-        assert_equal(np.sqrt(a, where=m), [1])
+        assert_equal(np.sqrt(a, where=m, out=None), [1])
 
         # No casting and allocated output
         a = np.array([1], dtype=np.float64)
         m = np.array([True], dtype=bool)
-        assert_equal(np.sqrt(a, where=m), [1])
+        assert_equal(np.sqrt(a, where=m, out=None), [1])
 
     def test_where_with_broadcasting(self):
         # See gh-17198
@@ -1742,6 +1739,15 @@ class TestUfunc:
         b_where = np.broadcast_to(b, a.shape)[where]
         assert_array_equal((a[where] < b_where), out[where].astype(bool))
         assert not out[~where].any()  # outside mask, out remains all 0
+
+    def test_where_warns(self):
+        a = np.arange(7)
+        mask = a % 2 == 0
+        with warnings.catch_warnings(record=True) as w_where:
+            warnings.simplefilter('always')
+            result = np.add(a, a, where=mask)
+        assert len(w_where) == 1
+        assert "'where'" in str(w_where[0])
 
     @staticmethod
     def identityless_reduce_arrs():

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -3156,7 +3156,8 @@ class TestSpecialMethods:
         do_test(lambda a: np.add(0, 0, out=(a,)), lambda a: (0, 0, a))
 
         # Also check the where mask handling:
-        do_test(lambda a: np.add(a, 0, where=False), lambda a: (a, 0))
+        out = np.zeros([1], dtype=float)
+        do_test(lambda a: np.add(a, 0, where=False, out=None), lambda a: (a, 0))
         do_test(lambda a: np.add(0, 0, a, where=False), lambda a: (0, 0, a))
 
     def test_wrap_with_iterable(self):
@@ -3713,7 +3714,7 @@ class TestSpecialMethods:
 
                 kwargs = kwargs.copy()
                 if "out" in kwargs:
-                    kwargs["out"] = self._unwrap(kwargs["out"])
+                    kwargs["out"] = self._unwrap(kwargs["out"])[0]
                     if kwargs["out"] is NotImplemented:
                         return NotImplemented
 
@@ -3734,6 +3735,7 @@ class TestSpecialMethods:
                     else:
                         kwargs["where"] = kwargs["where"][0]
 
+                print(f"{kwargs=}")
                 r = super().__array_ufunc__(ufunc, method, *inputs, **kwargs)
                 if r is not NotImplemented:
                     r = r.view(type(self))
@@ -3744,21 +3746,28 @@ class TestSpecialMethods:
 
         array = np.array([1, 2, 3])
         where = np.array([True, False, True])
-        expected = ufunc(array, where=where)
+        out = np.zeros(3, dtype=array.dtype)
+        expected = ufunc(array, where=where, out=out)
 
         with pytest.raises(TypeError):
-            ufunc(array, where=where.view(OverriddenArrayOld))
+            ufunc(
+                array, 
+                where=where.view(OverriddenArrayOld), 
+                out=out,
+            )
 
         result_1 = ufunc(
             array,
-            where=where.view(OverriddenArrayNew)
+            where=where.view(OverriddenArrayNew),
+            out=out,
         )
         assert isinstance(result_1, OverriddenArrayNew)
         assert np.all(np.array(result_1) == expected, where=where)
 
         result_2 = ufunc(
             array.view(OverriddenArrayNew),
-            where=where.view(OverriddenArrayNew)
+            where=where.view(OverriddenArrayNew),
+            out=out.view(OverriddenArrayNew),
         )
         assert isinstance(result_2, OverriddenArrayNew)
         assert np.all(np.array(result_2) == expected, where=where)

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -3735,7 +3735,6 @@ class TestSpecialMethods:
                     else:
                         kwargs["where"] = kwargs["where"][0]
 
-                print(f"{kwargs=}")
                 r = super().__array_ufunc__(ufunc, method, *inputs, **kwargs)
                 if r is not NotImplemented:
                     r = r.view(type(self))

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -3751,8 +3751,8 @@ class TestSpecialMethods:
 
         with pytest.raises(TypeError):
             ufunc(
-                array, 
-                where=where.view(OverriddenArrayOld), 
+                array,
+                where=where.view(OverriddenArrayOld),
                 out=out,
             )
 


### PR DESCRIPTION
Closes #29804, related to # #17192, #29561 and maybe more

Users naively add a `where` argument without a proper `out` argument, and are surprised when the `False` values of the where mask are uninitialized. This PR adds a warning. The warning can be surpressed by using `where=mask, out=None`. That came in handy in some obscure tests.