### PR TITLE
DOC: Update docstring for `count_nonzero`

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -523,11 +523,11 @@ def count_nonzero(a, axis=None, *, keepdims=False):
     --------
     >>> import numpy as np
     >>> np.count_nonzero(np.eye(4))
-    4
+    np.int64(4)
     >>> a = np.array([[0, 1, 7, 0],
     ...               [3, 0, 2, 19]])
     >>> np.count_nonzero(a)
-    5
+    np.int64(5)
     >>> np.count_nonzero(a, axis=0)
     array([1, 1, 2, 1])
     >>> np.count_nonzero(a, axis=1)


### PR DESCRIPTION
The return type of the function was changed in 2.3.0, but the docstring
remained the same (gh-28774).

Addresses gh-17562
(addressed by the change to `count_nonzero` but not yet closed)