### PR TITLE
ENH: cleanup warning generation and unmark xfailed tests

### DIFF
--- a/numpy/_core/src/common/npy_longdouble.c
+++ b/numpy/_core/src/common/npy_longdouble.c
@@ -144,8 +144,8 @@ npy_longdouble_from_PyLong(PyObject *long_obj) {
     result = NumPyOS_ascii_strtold(cstr, &end);
     if (errno == ERANGE) {
         /* strtold returns INFINITY of the correct sign. */
-        if (PyErr_Warn(PyExc_RuntimeWarning,
-                "overflow encountered in conversion from python long") < 0) {
+        if (PyErr_WarnEx(PyExc_RuntimeWarning,
+                "overflow encountered in conversion from python long", 1) < 0) {
             goto fail;
         }
     }

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -541,8 +541,8 @@ string_to_long_double(PyObject*op)
         errno = 0;
         temp = NumPyOS_ascii_strtold(s, &end);
         if (errno == ERANGE) {
-           if (PyErr_Warn(PyExc_RuntimeWarning,
-                   "overflow encountered in conversion from string") < 0) {
+           if (PyErr_WarnEx(PyExc_RuntimeWarning,
+                   "overflow encountered in conversion from string", 1) < 0) {
                Py_XDECREF(b);
                return 0;
            }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1304,12 +1304,12 @@ _array_from_buffer_3118(PyObject *memoryview)
             return NULL;
         }
 
-        if (PyErr_Warn(
+        if (PyErr_WarnEx(
                     PyExc_RuntimeWarning,
                     "A builtin ctypes object gave a PEP3118 format "
                     "string that does not match its itemsize, so a "
                     "best-guess will be made of the data type. "
-                    "Newer versions of python may behave correctly.") < 0) {
+                    "Newer versions of python may behave correctly.", 1) < 0) {
             Py_DECREF(descr);
             return NULL;
         }

--- a/numpy/_core/src/multiarray/flagsobject.c
+++ b/numpy/_core/src/multiarray/flagsobject.c
@@ -185,7 +185,7 @@ static char *msg = "future versions will not create a writeable "
             PyArrayFlagsObject *self, void *NPY_UNUSED(ignored)) \
     { \
         if (self->flags & NPY_ARRAY_WARN_ON_WRITE) { \
-            if (PyErr_Warn(PyExc_FutureWarning, msg) < 0) {\
+            if (PyErr_WarnEx(PyExc_FutureWarning, msg, 1) < 0) {\
                 return NULL; \
             } \
         }\

--- a/numpy/_core/src/umath/extobj.c
+++ b/numpy/_core/src/umath/extobj.c
@@ -398,7 +398,7 @@ _error_handler(const char *name, int method, PyObject *pyfunc, char *errtype,
     switch(method) {
     case UFUNC_ERR_WARN:
         PyOS_snprintf(msg, sizeof(msg), "%s encountered in %s", errtype, name);
-        if (PyErr_Warn(PyExc_RuntimeWarning, msg) < 0) {
+        if (PyErr_WarnEx(PyExc_RuntimeWarning, msg, 1) < 0) {
             goto fail;
         }
         break;

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4488,9 +4488,9 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
 
     /* Warn if "where" is used without "out", issue 29561 */
     if ((where_obj != NULL) && (full_args.out == NULL) && (out_obj == NULL)) {
-        if (PyErr_Warn(PyExc_UserWarning,
+        if (PyErr_WarnEx(PyExc_UserWarning,
                 "'where' used without 'out', expect unitialized memory in output. "
-                "If this is intentional, use out=None.") < 0) {
+                "If this is intentional, use out=None.", 1) < 0) {
             goto fail;
         }
     }

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -1868,11 +1868,9 @@ class TestBool:
     def test_cast_from_void(self):
         self._test_cast_from_flexible(np.void)
 
-    @pytest.mark.xfail(reason="See gh-9847")
     def test_cast_from_unicode(self):
         self._test_cast_from_flexible(np.str_)
 
-    @pytest.mark.xfail(reason="See gh-9847")
     def test_cast_from_bytes(self):
         self._test_cast_from_flexible(np.bytes_)
 


### PR DESCRIPTION
~@mhvk noticed that~ (Edit: it was [someone else](https://github.com/numpy/numpy/pull/29813#issuecomment-3342253909), sorry Martin) I used `PyErr_Warn()` which was [deprecated in python 2.5](https://docs.python.org/3/whatsnew/2.5.html#build-and-c-api-changes) but not removed, so I went ahead and changed all the instances explicitly instead of relying [on the macro](https://github.com/python/cpython/blob/1c5b28405a77df68d40991051b4c0769e728bf76/Include/cpython/warnings.h#L19) 
```
// DEPRECATED: Use PyErr_WarnEx() instead.
#define PyErr_Warn(category, msg) PyErr_WarnEx((category), (msg), 1)
```

When running tests, I noticed two tests that XPASS (i.e. are expected to fail but pass successfully) so I removed the marker.