### PR TITLE
ENH: speedup numpy.quantile when weights are provided

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4895,7 +4895,7 @@ def _quantile(
         weights = np.asanyarray(weights)
         if axis != 0:
             weights = np.moveaxis(weights, axis, destination=0)
-        index_array = np.argsort(arr, axis=0, kind="stable")
+        index_array = np.argsort(arr, axis=0)
 
         # arr = arr[index_array, ...]  # but this adds trailing dimensions of
         # 1.


### PR DESCRIPTION
In the implementation `numpy.quantile(..., weights=w, method="inverted_cdf")`, the argsort doesn't need to be stable.

See some elements of proof here: https://github.com/scikit-learn/scikit-learn/pull/32285

Because it's just an optimization, I don't think this requires new tests. Speedup for big arrays might be up to ~2x.

I wrote an initial proof in the equivalent PR for scikit-learn: https://github.com/scikit-learn/scikit-learn/pull/32285. But while reading carefully the doc of [numpy.quantile](https://numpy.org/doc/stable/reference/generated/numpy.quantile.html) I found a new simpler formulation:

The doc says:

> **Weighted quantiles:**
> More formally, the quantile at probability level $q$ of a cumulative distribution function $F(y)=P(Y \leq y)$ with probability measure $P$ is defined as any number $x$ that fulfills the *coverage conditions*
> 
> $$ P(Y < x) \leq q \quad \text{and} \quad P(Y \leq x) \geq q$$
> 
> with random variable $Y \sim P$. Sample quantiles, the result of `quantile`, provide nonparametric estimation of the underlying population counterparts, represented by the unknown $F$, given a data vector $a$ of length `n`.
> 
> Some of the estimators above arise when one considers $F$ as the empirical distribution function of the data, i.e. $F(y) = \frac{1}{n} \sum_i 1_{a_i \leq y}$.
> Then, different methods correspond to different choices of $x$ that fulfill the above coverage conditions. Methods that follow this approach are `inverted_cdf` and `averaged_inverted_cdf`.
> 
> For weighted quantiles, the coverage conditions still hold. The empirical cumulative distribution is simply replaced by its weighted version, i.e. $P(Y \leq t) = \frac{1}{\sum_i w_i} \sum_i w_i 1_{x_i \leq t}$.
> Only `method="inverted_cdf"` supports weights.

Well, it's fairly clear that the weighted version of empirical cumulative distribution function: $F_w(t) = P(Y \leq t) = \frac{1}{\sum_i w_i} \sum_i w_i 1_{x_i \leq t}$ has no notion of ordering in it. So the stability of the sort has no impact.
