### PR TITLE
BLD: change file extension for libnpymath on win-arm64 from .a to .lib

### DIFF
--- a/doc/release/upcoming_changes/29750.change.rst
+++ b/doc/release/upcoming_changes/29750.change.rst
@@ -1,0 +1,5 @@
+The ``npymath`` and ``npyrandom`` libraries now have a ``.lib`` rather than a
+``.a`` file extension, for compatibility for building with MSVC and
+``setuptools``. Please note that using these static libraries is discouraged
+and for existing projects using it, it's best to use it with a matching
+compiler toolchain, which is ``clang-cl`` on Windows on Arm.

--- a/doc/release/upcoming_changes/29750.change.rst
+++ b/doc/release/upcoming_changes/29750.change.rst
@@ -1,5 +1,5 @@
 The ``npymath`` and ``npyrandom`` libraries now have a ``.lib`` rather than a
-``.a`` file extension, for compatibility for building with MSVC and
+``.a`` file extension on win-arm64, for compatibility for building with MSVC and
 ``setuptools``. Please note that using these static libraries is discouraged
 and for existing projects using it, it's best to use it with a matching
 compiler toolchain, which is ``clang-cl`` on Windows on Arm.

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -32,7 +32,7 @@ endif
 # than a `.a` file extension in order not to break including them in a
 # distutils-based build (see gh-23981 and
 # https://mesonbuild.com/FAQ.html#why-does-building-my-project-with-msvc-output-static-libraries-called-libfooa)
-if is_windows and cc.get_id() == 'msvc'
+if is_windows and cc.get_id() in ['msvc', 'clang-cl']
   name_prefix_staticlib = ''
   name_suffix_staticlib = 'lib'
 else


### PR DESCRIPTION
Backport of #29750.

Closes gh-29577

Should work fine, if it doesn't for some reason then we'll notice in downstream CI jobs that consume nightly wheels.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
