### PR TITLE
DEP: Raise `TypeError` on attempt to convert array with `ndim > 0` to…

### DIFF
--- a/doc/release/upcoming_changes/29841.expired.rst
+++ b/doc/release/upcoming_changes/29841.expired.rst
@@ -1,0 +1,6 @@
+Raise `TypeError` on attempt to convert array with `ndim > 0` to scalar
+-----------------------------------------------------------------------
+Conversion of an array with `ndim > 0` to a scalar was deprecated in
+NumPy 1.25.  Now, attempting to do so raises `TypeError`.
+Ensure you extract a single element from your array before performing
+this operation.

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -449,24 +449,6 @@ check_is_convertible_to_scalar(PyArrayObject *v)
         return 0;
     }
 
-    /* Remove this if-else block when the deprecation expires */
-    if (PyArray_SIZE(v) == 1) {
-        /* Numpy 1.25.0, 2023-01-02 */
-        if (DEPRECATE(
-                "Conversion of an array with ndim > 0 to a scalar "
-                "is deprecated, and will error in future. "
-                "Ensure you extract a single element from your array "
-                "before performing this operation. "
-                "(Deprecated NumPy 1.25.)") < 0) {
-            return -1;
-        }
-        return 0;
-    } else {
-        PyErr_SetString(PyExc_TypeError,
-            "only length-1 arrays can be converted to Python scalars");
-        return -1;
-    }
-
     PyErr_SetString(PyExc_TypeError,
             "only 0-dimensional arrays can be converted to Python scalars");
     return -1;

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -241,18 +241,6 @@ class TestQuantileInterpolationDeprecation(_DeprecationTestCase):
                 func([0., 1.], 0., interpolation="nearest", method="nearest")
 
 
-class TestScalarConversion(_DeprecationTestCase):
-    # 2023-01-02, 1.25.0
-    def test_float_conversion(self):
-        self.assert_deprecated(float, args=(np.array([3.14]),))
-
-    def test_behaviour(self):
-        b = np.array([[3.14]])
-        c = np.zeros(5)
-        with pytest.warns(DeprecationWarning):
-            c[0] = b
-
-
 class TestPyIntConversion(_DeprecationTestCase):
     message = r".*stop allowing conversion of out-of-bound.*"
 


### PR DESCRIPTION
This PR removes deprecated functionality, as requested in #29835 