### PR TITLE
TYP: fix ``testing.assert_warns`` decorator order

### DIFF
--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -359,11 +359,11 @@ def assert_array_max_ulp(
 ) -> NDArray[Any]: ...
 
 #
-@deprecated("Please use warnings.catch_warnings or pytest.warns instead")
 @overload
+@deprecated("Please use warnings.catch_warnings or pytest.warns instead")
 def assert_warns(warning_class: _WarningSpec) -> _GeneratorContextManager[None]: ...
-@deprecated("Please use warnings.catch_warnings or pytest.warns instead")
 @overload
+@deprecated("Please use warnings.catch_warnings or pytest.warns instead")
 def assert_warns(warning_class: _WarningSpec, func: Callable[_Tss, _T], *args: _Tss.args, **kwargs: _Tss.kwargs) -> _T: ...
 
 #


### PR DESCRIPTION
mypy wants it to be the other way around, and reported

> @overload should be placed before @deprecated