### PR TITLE
TYP: Fix incompatible defaults in ``polyfit``, ``histogram``, and ``histogramdd``

### DIFF
--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -27,14 +27,14 @@ def histogram(
     a: ArrayLike,
     bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: tuple[float, float] | None = None,
-    density: bool = None,
+    density: bool | None = None,
     weights: ArrayLike | None = None,
 ) -> tuple[NDArray[Any], NDArray[Any]]: ...
 
 def histogramdd(
     sample: ArrayLike,
     bins: SupportsIndex | ArrayLike = 10,
-    range: Sequence[tuple[float, float]] = None,
+    range: Sequence[tuple[float, float]] | None = None,
     density: bool | None = None,
     weights: ArrayLike | None = None,
 ) -> tuple[NDArray[Any], tuple[NDArray[Any], ...]]: ...

--- a/numpy/lib/_polynomial_impl.pyi
+++ b/numpy/lib/_polynomial_impl.pyi
@@ -138,7 +138,8 @@ def polyfit(
     rcond: float | None = None,
     full: L[False] = False,
     w: _ArrayLikeFloat_co | None = None,
-    cov: L[True, "unscaled"] = False,
+    *,
+    cov: L[True, "unscaled"],
 ) -> _2Tup[NDArray[float64]]: ...
 @overload
 def polyfit(
@@ -148,7 +149,8 @@ def polyfit(
     rcond: float | None = None,
     full: L[False] = False,
     w: _ArrayLikeFloat_co | None = None,
-    cov: L[True, "unscaled"] = False,
+    *,
+    cov: L[True, "unscaled"],
 ) -> _2Tup[NDArray[complex128]]: ...
 @overload
 def polyfit(


### PR DESCRIPTION
The default values weren't assignable to the types of the parameters.
