### PR TITLE
CI: Use ``uv`` instead of ``pip`` in the mypy workflow

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -55,17 +55,21 @@ jobs:
         submodules: recursive
         fetch-tags: true
         persist-credentials: false
-
-    - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+    - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       with:
         python-version: ${{ matrix.os_python[1] }}
+        activate-environment: true
+        cache-dependency-glob: |
+          requirements/build_requirements.txt
+          requirements/test_requirements.txt
     - name: Install dependencies
-      run: |
-        pip install -r requirements/build_requirements.txt
-        # orjson makes mypy faster but the default requirements.txt
-        # can't install it because orjson doesn't support 32 bit Linux
-        pip install orjson
-        pip install -r requirements/test_requirements.txt
+      # orjson makes mypy faster but the default requirements.txt
+      # can't install it because orjson doesn't support 32 bit Linux
+      run: >-
+        uv pip install
+        -r requirements/build_requirements.txt
+        -r requirements/test_requirements.txt
+        orjson
     - name: Build
       run: |
         spin build -j2 -- -Dallow-noblas=true -Ddisable-optimization=true --vsenv


### PR DESCRIPTION
Because that's what the cool kids are doing nowadays