### PR TITLE
ENH: Fix type promotion issues in `np.searchsorted`

### DIFF
--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2068,7 +2068,7 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
         !PyArray_CHKFLAGS(ap2, NPY_ARRAY_CARRAY_RO) ||
         !PyArray_CHKFLAGS(ap2, NPY_ARRAY_NOTSWAPPED)) {
         PyArrayObject* old_ap2 = ap2;
-        ap2 = (PyArrayObject *)PyArray_CheckFromAny(old_ap2, dtype,
+        ap2 = (PyArrayObject *)PyArray_CheckFromAny(op2, dtype,
                                     0, 0,
                                     NPY_ARRAY_CARRAY_RO | NPY_ARRAY_NOTSWAPPED,
                                     NULL);

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2033,18 +2033,17 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
      * NEP 50 promotion rules. We use a temporary conversion to detect if
      * op2 is a Python scalar and mark it appropriately.
      */
-    PyArrayObject *op2_tmp = (PyArrayObject *)PyArray_FROM_O(op2);
-    if (op2_tmp == NULL) {
+    ap2 = (PyArrayObject *)PyArray_FROM_O(op2);
+    if (ap2 == NULL) {
         goto fail;
     }
     
     /* Mark if op2 was a Python scalar for proper NEP 50 promotion */
-    npy_mark_tmp_array_if_pyscalar(op2, op2_tmp, NULL);
+    npy_mark_tmp_array_if_pyscalar(op2, ap2, NULL);
     
     /* Now use ResultType with both arrays for proper promotion */
-    PyArrayObject *arrs[2] = { op1, op2_tmp };
+    PyArrayObject *arrs[2] = {op1, ap2};
     dtype = PyArray_ResultType(2, arrs, 0, NULL);
-    Py_DECREF(op2_tmp);
     
     if (dtype == NULL) {
         goto fail;
@@ -2063,15 +2062,24 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
         return NULL;
     }
     
-
+    /* Reuse ap2 wherever possible */
     /* need ap2 as contiguous array and of right dtype (note: steals dtype reference) */
-    ap2 = (PyArrayObject *)PyArray_CheckFromAny(op2, dtype,
-                                0, 0,
-                                NPY_ARRAY_CARRAY_RO | NPY_ARRAY_NOTSWAPPED,
-                                NULL);
-    if (ap2 == NULL) {
-        return NULL;
+    if (!PyArray_EquivTypes(PyArray_DESCR(ap2), dtype) ||
+        !PyArray_CHKFLAGS(ap2, NPY_ARRAY_CARRAY_RO) ||
+        !PyArray_CHKFLAGS(ap2, NPY_ARRAY_NOTSWAPPED)) {
+        PyArrayObject* old_ap2 = ap2;
+        ap2 = (PyArrayObject *)PyArray_CheckFromAny(old_ap2, dtype,
+                                    0, 0,
+                                    NPY_ARRAY_CARRAY_RO | NPY_ARRAY_NOTSWAPPED,
+                                    NULL);
+        Py_DECREF(old_ap2);
+        if (ap2 == NULL) {
+            return NULL;
+        }
+    } else {
+        Py_DECREF(dtype);
     }
+    
     /*
      * The dtype reference we had was used for creating ap2, which may have
      * replaced it with another. So here we copy the dtype of ap2 and use it for `ap1`.

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2061,7 +2061,6 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
         Py_DECREF(dtype);
         return NULL;
     }
-    
     /* Reuse ap2 wherever possible */
     /* need ap2 as contiguous array and of right dtype (note: steals dtype reference) */
     if (!PyArray_EquivTypes(PyArray_DESCR(ap2), dtype) ||

--- a/numpy/_core/tests/test_item_selection.py
+++ b/numpy/_core/tests/test_item_selection.py
@@ -24,7 +24,8 @@ class TestTake:
         # default (non-specialized) path.
         types = int, object, np.dtype([('', 'i2', 3)])
         for t in types:
-            # ta works, even if the array may be odd if buffer interface is used
+            # ta works, even if the array may be odd if buffer interface is
+            # used
             ta = np.array(a if np.issubdtype(t, np.number) else a_str, dtype=t)
             tresult = list(ta.T.copy())
             for index_array in index_arrays:
@@ -169,8 +170,8 @@ class TestPut:
 
 class TestSearchSorted:
     def test_large_uint64(self):
-        a = np.arange(2**62, 2**62+100, 1, dtype=np.uint64)
-        result = np.searchsorted(a, 2**62+25)
+        a = np.arange(2**62, 2**62 + 100, 1, dtype=np.uint64)
+        result = np.searchsorted(a, 2**62 + 25)
         assert result == 25
 
     def test_python_int_scalar(self):

--- a/numpy/_core/tests/test_item_selection.py
+++ b/numpy/_core/tests/test_item_selection.py
@@ -9,24 +9,20 @@ from numpy.testing import HAS_REFCOUNT, assert_, assert_array_equal, assert_rais
 class TestTake:
     def test_simple(self):
         a = [[1, 2], [3, 4]]
-        a_str = [[b"1", b"2"], [b"3", b"4"]]
-        modes = ["raise", "wrap", "clip"]
+        a_str = [[b'1', b'2'], [b'3', b'4']]
+        modes = ['raise', 'wrap', 'clip']
         indices = [-1, 4]
-        index_arrays = [
-            np.empty(0, dtype=np.intp),
-            np.empty((), dtype=np.intp),
-            np.empty((1, 1), dtype=np.intp),
-        ]
-        real_indices = {
-            "raise": {-1: 1, 4: IndexError},
-            "wrap": {-1: 1, 4: 0},
-            "clip": {-1: 0, 4: 1},
-        }
+        index_arrays = [np.empty(0, dtype=np.intp),
+                        np.empty((), dtype=np.intp),
+                        np.empty((1, 1), dtype=np.intp)]
+        real_indices = {'raise': {-1: 1, 4: IndexError},
+                        'wrap': {-1: 1, 4: 0},
+                        'clip': {-1: 0, 4: 1}}
         # Currently all types but object, use the same function generation.
         # So it should not be necessary to test all. However test also a non
         # refcounted struct on top of object, which has a size that hits the
         # default (non-specialized) path.
-        types = int, object, np.dtype([("", "i2", 3)])
+        types = int, object, np.dtype([('', 'i2', 3)])
         for t in types:
             # ta works, even if the array may be odd if buffer interface is used
             ta = np.array(a if np.issubdtype(t, np.number) else a_str, dtype=t)
@@ -40,9 +36,8 @@ class TestTake:
                         real_index = real_indices[mode][index]
                         if real_index is IndexError and index_array.size != 0:
                             index_array.put(0, index)
-                            assert_raises(
-                                IndexError, ta.take, index_array, mode=mode, axis=1
-                            )
+                            assert_raises(IndexError, ta.take, index_array,
+                                          mode=mode, axis=1)
                         elif index_array.size != 0:
                             index_array.put(0, index)
                             res = ta.take(index_array, mode=mode, axis=1)
@@ -55,31 +50,25 @@ class TestTake:
         objects = [object() for i in range(10)]
         if HAS_REFCOUNT:
             orig_rcs = [sys.getrefcount(o) for o in objects]
-        for mode in ("raise", "clip", "wrap"):
+        for mode in ('raise', 'clip', 'wrap'):
             a = np.array(objects)
             b = np.array([2, 2, 4, 5, 3, 5])
             a.take(b, out=a[:6], mode=mode)
             del a
             if HAS_REFCOUNT:
-                assert_(
-                    all(
-                        sys.getrefcount(o) == rc + 1 for o, rc in zip(objects, orig_rcs)
-                    )
-                )
+                assert_(all(sys.getrefcount(o) == rc + 1
+                            for o, rc in zip(objects, orig_rcs)))
             # not contiguous, example:
             a = np.array(objects * 2)[::2]
             a.take(b, out=a[:6], mode=mode)
             del a
             if HAS_REFCOUNT:
-                assert_(
-                    all(
-                        sys.getrefcount(o) == rc + 1 for o, rc in zip(objects, orig_rcs)
-                    )
-                )
+                assert_(all(sys.getrefcount(o) == rc + 1
+                            for o, rc in zip(objects, orig_rcs)))
 
     def test_unicode_mode(self):
         d = np.arange(10)
-        k = b"\xc3\xa4".decode("UTF8")
+        k = b'\xc3\xa4'.decode("UTF8")
         assert_raises(ValueError, d.take, 5, mode=k)
 
     def test_empty_partition(self):
@@ -116,7 +105,7 @@ class TestPutMask:
         zeros = arr.copy()
 
         np.putmask(arr, mask, vals)
-        assert_array_equal(arr[mask], vals[: len(mask)][mask])
+        assert_array_equal(arr[mask], vals[:len(mask)][mask])
         assert_array_equal(arr[~mask], zeros[~mask])
 
     @pytest.mark.parametrize("dtype", list(np.typecodes["All"])[1:] + ["i,O"])
@@ -162,10 +151,10 @@ class TestPut:
                 indx_put = indx_put + len(arr)
 
         np.put(arr, indx_put, vals, mode=mode)
-        assert_array_equal(arr[indx], vals[: len(indx)])
+        assert_array_equal(arr[indx], vals[:len(indx)])
         untouched = np.ones(len(arr), dtype=bool)
         untouched[indx] = False
-        assert_array_equal(arr[untouched], zeros[: untouched.sum()])
+        assert_array_equal(arr[untouched], zeros[:untouched.sum()])
 
     @pytest.mark.parametrize("dtype", list(np.typecodes["All"])[1:] + ["i,O"])
     @pytest.mark.parametrize("mode", ["raise", "wrap", "clip"])
@@ -180,8 +169,8 @@ class TestPut:
 
 class TestSearchSorted:
     def test_large_uint64(self):
-        a = np.arange(2**62, 2**62 + 100, 1, dtype=np.uint64)
-        result = np.searchsorted(a, 2**62 + 25)
+        a = np.arange(2**62, 2**62+100, 1, dtype=np.uint64)
+        result = np.searchsorted(a, 2**62+25)
         assert result == 25
 
     def test_python_int_scalar(self):
@@ -190,7 +179,7 @@ class TestSearchSorted:
         assert result == 25
 
     def test_out_of_bounds(self):
-        a = np.arange(2**7, 2**7 + 100, 1, np.uint8)
+        a = np.arange(2 ** 7, 2 ** 7 + 100, 1, np.uint8)
         # `uint8` overflow for 1000.
         with pytest.raises(OverflowError):
             result = np.searchsorted(a, 1000)


### PR DESCRIPTION
Fixes #29727

The fix modifies `PyArray_SearchSorted` to:

1. **Convert the search value to an array first** using `PyArray_FROM_O()`
2. **Mark it as a Python scalar** using `npy_mark_tmp_array_if_pyscalar()` if applicable
3. **Use proper NEP 50 promotion** by calling `PyArray_ResultType()` with both arrays

This ensures that when a Python integer is passed to search in a uint64 array, the promotion correctly keeps the uint64 dtype instead of promoting to float64.