### PR TITLE
BUG: param_parse couldn't handle nested parentheses

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -3082,12 +3082,12 @@ def param_parse(d, params):
     >>> param_parse(d, params)
     3
     """
-    if "(" in d:
-        # this dimension expression is an array
-        dname = d[:d.find("(")]
+    dname = d[:d.find("(")] if "(" in d else ""
+    if dname:
+        # Text precedes the first "(", so this is array-parameter
+        # indexing such as pa(1) or myparamarray(nested(dim)).
         ddims = d[d.find("(") + 1:d.rfind(")")]
-        # this dimension expression is also a parameter;
-        # parse it recursively
+        # the index is itself an expression over params; parse it recursively
         index = int(param_parse(ddims, params))
         return str(params[dname][index])
     elif d in params:

--- a/numpy/f2py/tests/src/crackfortran/gh28095.f90
+++ b/numpy/f2py/tests/src/crackfortran/gh28095.f90
@@ -1,0 +1,13 @@
+module util
+integer mx_intl_curves
+integer mx_supply_curves
+integer mx_units
+parameter(mx_intl_curves = 12)
+parameter(mx_supply_curves = 14)
+parameter(mx_units = 1800)
+real*4 cmm_cl_btus((mx_supply_curves + mx_intl_curves), mx_units)
+contains
+ subroutine test
+ write(*,*) 'Hello'
+ end subroutine test
+end module util

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -417,6 +417,42 @@ class TestParamEval:
         pytest.raises(ValueError, crackfortran.param_eval, v, g_params, params,
                       dimspec=dimspec)
 
+
+class TestParamParseNestedParens:
+    # issue gh-28095: grouping parens in a dimension expression such as
+    # (mx_supply_curves + mx_intl_curves) must fold to a concrete size,
+    # not be mistaken for pa(index) array-parameter indexing.
+    def test_grouping_parens_fold(self):
+        params = {"mx_supply_curves": 14, "mx_intl_curves": 12}
+        out = crackfortran.param_parse(
+            "(mx_supply_curves + mx_intl_curves)", params)
+        assert out.replace(" ", "") == "(14+12)"
+
+    def test_grouping_parens_with_trailing_factor(self):
+        # A grouping paren need not span the whole token; the factor
+        # outside the parentheses must survive substitution.
+        params = {"n": 3, "m": 1800}
+        out = crackfortran.param_parse("(n + 1)*m", params)
+        assert out.replace(" ", "") == "(3+1)*1800"
+
+    def test_array_index_still_works(self):
+        params = {"pa": {1: 3, 2: 5}}
+        assert crackfortran.param_parse("pa(1)", params) == "3"
+        assert crackfortran.param_parse("pa(2)", params) == "5"
+
+    def test_nested_array_index(self):
+        params = {"dim": 2, "nested": {1: 1, 2: 2, 3: 3},
+                  "myparamarray": {1: 10, 2: 20, 3: 30}}
+        assert crackfortran.param_parse(
+            "myparamarray(nested(dim))", params) == "20"
+
+    def test_dimension_substituted_in_module(self):
+        fpath = util.getpath("tests", "src", "crackfortran", "gh28095.f90")
+        mod = crackfortran.crackfortran([str(fpath)])
+        vs = mod[0]["vars"]["cmm_cl_btus"]
+        assert vs["dimension"] == ["26", "1800"]
+
+
 @pytest.mark.slow
 class TestLowerF2PYDirective(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "gh27697.f90")]


### PR DESCRIPTION
BUG:  param_parse couldn't handle nested parentheses - see https://github.com/numpy/numpy/issues/28095.  

This adds a function that determines the appropriate order of nested parentheses and  properly assigns the dimensions based on the order of operations. It solves the case outlined in https://github.com/numpy/numpy/issues/28095, so that all parameters are mapped properly and assigned values.

BUG: param_eval expects v to be a string, but get_parameters sets v to integers in 2 cases.

```
            if real16pattern.search(v):
                v = 8
            elif real8pattern.search(v):
                v = 4
```

by enclosing those values in single quotes, now v is a string, which removes the error message: "param_eval: got eval() arg 1 must be a string, bytes or code object on 4." which is triggered when those two if statements are activated.

This is my first pull request for numpy - I'm not sure if I need to create test cases.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
