### PR TITLE
TST: Make temporary file usage thread safe

### DIFF
--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -5579,20 +5579,18 @@ class TestIO:
 
     @pytest.fixture(params=["string", "path_obj"])
     def param_filename(self, tmp_path, request):
-        # This fixture covers two cases:
-        # one where the filename is a string and
-        # another where it is a pathlib object
-        filename = tmp_path / "file"
-        if request.param == "string":
-            filename = str(filename)
-        yield filename
+        # This fixtures returns string or path_obj
+        # so that every test doesn't need to have the
+        # paramterize marker.
+        return request.param
 
-    def _threaded_filename(self, path, thread_index):
-        # Makes sure the param_filename fixture is thread safe
-        if isinstance(path, str):
-            return path + str(thread_index)
-        else:
-            return pathlib.Path(path).with_name("file" + str(thread_index))
+    def _threaded_filename(self, tmp_path, param):
+        # Handles two cases, where filename should
+        # be a string, or a path object.
+        path = tmp_path / "file"
+        if param == "string":
+            return str(path)
+        return path
 
     def test_nofile(self):
         # this should probably be supported as a file
@@ -5623,22 +5621,22 @@ class TestIO:
         d = np.fromstring("1,2", sep=",", dtype=np.int64, count=0)
         assert d.shape == (0,)
 
-    def test_empty_files_text(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_empty_files_text(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         with open(tmp_filename, 'w') as f:
             pass
         y = np.fromfile(tmp_filename)
         assert_(y.size == 0, "Array not empty")
 
-    def test_empty_files_binary(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_empty_files_binary(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         with open(tmp_filename, 'wb') as f:
             pass
         y = np.fromfile(tmp_filename, sep=" ")
         assert_(y.size == 0, "Array not empty")
 
-    def test_roundtrip_file(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_roundtrip_file(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = self._create_data()
         with open(tmp_filename, 'wb') as f:
             x.tofile(f)
@@ -5647,15 +5645,15 @@ class TestIO:
             y = np.fromfile(f, dtype=x.dtype)
         assert_array_equal(y, x.flat)
 
-    def test_roundtrip(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_roundtrip(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = self._create_data()
         x.tofile(tmp_filename)
         y = np.fromfile(tmp_filename, dtype=x.dtype)
         assert_array_equal(y, x.flat)
 
-    def test_roundtrip_dump_pathlib(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_roundtrip_dump_pathlib(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = self._create_data()
         p = pathlib.Path(tmp_filename)
         x.dump(p)
@@ -5688,9 +5686,9 @@ class TestIO:
         y = np.fromstring(s, sep="@")
         assert_array_equal(x, y)
 
-    def test_unseekable_fromfile(self, param_filename, thread_index):
+    def test_unseekable_fromfile(self, tmp_path, param_filename):
         # gh-6246
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = self._create_data()
         x.tofile(tmp_filename)
 
@@ -5702,18 +5700,18 @@ class TestIO:
             f.tell = fail
             assert_raises(OSError, np.fromfile, f, dtype=x.dtype)
 
-    def test_io_open_unbuffered_fromfile(self, param_filename, thread_index):
+    def test_io_open_unbuffered_fromfile(self, tmp_path, param_filename):
         # gh-6632
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = self._create_data()
         x.tofile(tmp_filename)
         with open(tmp_filename, 'rb', buffering=0) as f:
             y = np.fromfile(f, dtype=x.dtype)
             assert_array_equal(y, x.flat)
 
-    def test_largish_file(self, param_filename, thread_index):
+    def test_largish_file(self, tmp_path, param_filename):
         # check the fallocate path on files > 16MB
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         d = np.zeros(4 * 1024 ** 2)
         d.tofile(tmp_filename)
         assert_equal(os.path.getsize(tmp_filename), d.nbytes)
@@ -5732,21 +5730,21 @@ class TestIO:
             d.tofile(f)
         assert_equal(os.path.getsize(tmp_filename), d.nbytes * 2)
 
-    def test_io_open_buffered_fromfile(self, param_filename, thread_index):
+    def test_io_open_buffered_fromfile(self, tmp_path, param_filename):
         # gh-6632
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = self._create_data()
         x.tofile(tmp_filename)
         with open(tmp_filename, 'rb', buffering=-1) as f:
             y = np.fromfile(f, dtype=x.dtype)
         assert_array_equal(y, x.flat)
 
-    def test_file_position_after_fromfile(self, param_filename, thread_index):
+    def test_file_position_after_fromfile(self, tmp_path, param_filename):
         # gh-4118
         sizes = [io.DEFAULT_BUFFER_SIZE // 8,
                  io.DEFAULT_BUFFER_SIZE,
                  io.DEFAULT_BUFFER_SIZE * 8]
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
 
         for size in sizes:
             with open(tmp_filename, 'wb') as f:
@@ -5762,12 +5760,12 @@ class TestIO:
                     pos = f.tell()
                 assert_equal(pos, 10, err_msg=err_msg)
 
-    def test_file_position_after_tofile(self, param_filename, thread_index):
+    def test_file_position_after_tofile(self, tmp_path, param_filename):
         # gh-4118
         sizes = [io.DEFAULT_BUFFER_SIZE // 8,
                  io.DEFAULT_BUFFER_SIZE,
                  io.DEFAULT_BUFFER_SIZE * 8]
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
 
         for size in sizes:
             err_msg = "%d" % (size,)
@@ -5788,9 +5786,9 @@ class TestIO:
                 pos = f.tell()
             assert_equal(pos, 10, err_msg=err_msg)
 
-    def test_load_object_array_fromfile(self, param_filename, thread_index):
+    def test_load_object_array_fromfile(self, tmp_path, param_filename):
         # gh-12300
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         with open(tmp_filename, 'w') as f:
             # Ensure we have a file with consistent contents
             pass
@@ -5802,8 +5800,8 @@ class TestIO:
         assert_raises_regex(ValueError, "Cannot read into object array",
                             np.fromfile, tmp_filename, dtype=object)
 
-    def test_fromfile_offset(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_fromfile_offset(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = self._create_data()
         with open(tmp_filename, 'wb') as f:
             x.tofile(f)
@@ -5839,14 +5837,14 @@ class TestIO:
                     sep=",", offset=1)
 
     @pytest.mark.skipif(IS_PYPY, reason="bug in PyPy's PyNumber_AsSsize_t")
-    def test_fromfile_bad_dup(self, param_filename, thread_index, monkeypatch):
+    def test_fromfile_bad_dup(self, tmp_path, param_filename, monkeypatch):
         def dup_str(fd):
             return 'abc'
 
         def dup_bigint(fd):
             return 2**68
 
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = self._create_data()
 
         with open(tmp_filename, 'wb') as f:
@@ -5895,44 +5893,44 @@ class TestIO:
         else:
             assert False, request.param
 
-    def test_nan(self, param_filename, thread_index, decimal_sep_localization):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_nan(self, tmp_path, param_filename, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         self._check_from(
             b"nan +nan -nan NaN nan(foo) +NaN(BAR) -NAN(q_u_u_x_)",
             [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
             tmp_filename,
             sep=' ')
 
-    def test_inf(self, param_filename, thread_index, decimal_sep_localization):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_inf(self, tmp_path, param_filename, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         self._check_from(
             b"inf +inf -inf infinity -Infinity iNfInItY -inF",
             [np.inf, np.inf, -np.inf, np.inf, -np.inf, np.inf, -np.inf],
             tmp_filename,
             sep=' ')
 
-    def test_numbers(self, param_filename, thread_index, decimal_sep_localization):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_numbers(self, tmp_path, param_filename, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         self._check_from(
             b"1.234 -1.234 .3 .3e55 -123133.1231e+133",
             [1.234, -1.234, .3, .3e55, -123133.1231e+133],
             tmp_filename,
             sep=' ')
 
-    def test_binary(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_binary(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         self._check_from(
             b'\x00\x00\x80?\x00\x00\x00@\x00\x00@@\x00\x00\x80@',
             np.array([1, 2, 3, 4]),
             tmp_filename,
             dtype='<f4')
 
-    def test_string(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_string(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         self._check_from(b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, sep=',')
 
-    def test_counted_string(self, param_filename, thread_index, decimal_sep_localization):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_counted_string(self, tmp_path, param_filename, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         self._check_from(
             b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, count=4, sep=',')
         self._check_from(
@@ -5940,43 +5938,43 @@ class TestIO:
         self._check_from(
             b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, count=-1, sep=',')
 
-    def test_string_with_ws(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_string_with_ws(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         self._check_from(
             b'1 2  3     4   ', [1, 2, 3, 4], tmp_filename, dtype=int, sep=' ')
 
-    def test_counted_string_with_ws(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_counted_string_with_ws(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         self._check_from(
             b'1 2  3     4   ', [1, 2, 3], tmp_filename, count=3, dtype=int,
             sep=' ')
 
-    def test_ascii(self, param_filename, thread_index, decimal_sep_localization):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_ascii(self, tmp_path, param_filename, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         self._check_from(
             b'1 , 2 , 3 , 4', [1., 2., 3., 4.], tmp_filename, sep=',')
         self._check_from(
             b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, dtype=float, sep=',')
 
-    def test_malformed(self, param_filename, thread_index, decimal_sep_localization):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_malformed(self, tmp_path, param_filename, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         with assert_raises(ValueError):
             self._check_from(
                 b'1.234 1,234', [1.234, 1.], tmp_filename, sep=' ')
 
-    def test_long_sep(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_long_sep(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         self._check_from(
             b'1_x_3_x_4_x_5', [1, 3, 4, 5], tmp_filename, sep='_x_')
 
-    def test_dtype(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_dtype(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         v = np.array([1, 2, 3, 4], dtype=np.int_)
         self._check_from(b'1,2,3,4', v, tmp_filename, sep=',', dtype=np.int_)
 
-    def test_dtype_bool(self, param_filename, thread_index):
+    def test_dtype_bool(self, tmp_path, param_filename):
         # can't use _check_from because fromstring can't handle True/False
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         v = np.array([True, False, True, False], dtype=np.bool)
         s = b'1,0,-2.3,0'
         with open(tmp_filename, 'wb') as f:
@@ -5985,8 +5983,8 @@ class TestIO:
         assert_(y.dtype == '?')
         assert_array_equal(y, v)
 
-    def test_tofile_sep(self, param_filename, thread_index, decimal_sep_localization):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_tofile_sep(self, tmp_path, param_filename, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = np.array([1.51, 2, 3.51, 4], dtype=float)
         with open(tmp_filename, 'w') as f:
             x.tofile(f, sep=',')
@@ -5996,8 +5994,8 @@ class TestIO:
         y = np.array([float(p) for p in s.split(',')])
         assert_array_equal(x, y)
 
-    def test_tofile_format(self, param_filename, thread_index, decimal_sep_localization):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_tofile_format(self, tmp_path, param_filename, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = np.array([1.51, 2, 3.51, 4], dtype=float)
         with open(tmp_filename, 'w') as f:
             x.tofile(f, sep=',', format='%.2f')
@@ -6005,8 +6003,8 @@ class TestIO:
             s = f.read()
         assert_equal(s, '1.51,2.00,3.51,4.00')
 
-    def test_tofile_cleanup(self, param_filename, thread_index):
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+    def test_tofile_cleanup(self, tmp_path, param_filename):
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = np.zeros((10), dtype=object)
         with open(tmp_filename, 'wb') as f:
             assert_raises(OSError, lambda: x.tofile(f, sep=''))
@@ -6017,9 +6015,9 @@ class TestIO:
         assert_raises(OSError, lambda: x.tofile(tmp_filename))
         os.remove(tmp_filename)
 
-    def test_fromfile_subarray_binary(self, param_filename, thread_index):
+    def test_fromfile_subarray_binary(self, tmp_path, param_filename):
         # Test subarray dtypes which are absorbed into the shape
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         x = np.arange(24, dtype="i4").reshape(2, 3, 4)
         x.tofile(tmp_filename)
         res = np.fromfile(tmp_filename, dtype="(3,4)i4")
@@ -6030,9 +6028,9 @@ class TestIO:
             # binary fromstring raises
             np.fromstring(x_str, dtype="(3,4)i4")
 
-    def test_parsing_subarray_unsupported(self, param_filename, thread_index):
+    def test_parsing_subarray_unsupported(self, tmp_path, param_filename):
         # We currently do not support parsing subarray dtypes
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         data = "12,42,13," * 50
         with pytest.raises(ValueError):
             expected = np.fromstring(data, dtype="(3,)i", sep=",")
@@ -6043,11 +6041,11 @@ class TestIO:
         with pytest.raises(ValueError):
             np.fromfile(tmp_filename, dtype="(3,)i", sep=",")
 
-    def test_read_shorter_than_count_subarray(self, param_filename, thread_index):
+    def test_read_shorter_than_count_subarray(self, tmp_path, param_filename):
         # Test that requesting more values does not cause any problems
         # in conjunction with subarray dimensions being absorbed into the
         # array dimension.
-        tmp_filename = self._threaded_filename(param_filename, thread_index)
+        tmp_filename = self._threaded_filename(tmp_path, param_filename)
         expected = np.arange(511 * 10, dtype="i").reshape(-1, 10)
 
         binary = expected.tobytes()

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -16,7 +16,6 @@ import tempfile
 import warnings
 import weakref
 from contextlib import contextmanager
-import threading
 
 # Need to test an object that does not fully implement math interface
 from datetime import datetime, timedelta
@@ -2476,20 +2475,6 @@ class TestMethods:
         a[0] = 42
         with pytest.raises(AssertionError):
             assert_array_equal(a, b)
-
-    def test__deepcopy___void_scalar(self):
-        # see comments in gh-29643
-        value = np.void('Rex', dtype=[('name', 'U10')])
-        value_deepcopy = value.__deepcopy__(None)
-        value[0] = None
-        assert value_deepcopy[0] == 'Rex'
-
-    @pytest.mark.parametrize("sctype", [np.int64, np.float32, np.float64])
-    def test__deepcopy__scalar(self, sctype):
-        # test optimization from gh-29656
-        value = sctype(1.1)
-        value_deepcopy = value.__deepcopy__(None)
-        assert value is value_deepcopy
 
     def test__deepcopy__catches_failure(self):
         class MyObj:

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -16,6 +16,7 @@ import tempfile
 import warnings
 import weakref
 from contextlib import contextmanager
+import threading
 
 # Need to test an object that does not fully implement math interface
 from datetime import datetime, timedelta
@@ -2475,6 +2476,20 @@ class TestMethods:
         a[0] = 42
         with pytest.raises(AssertionError):
             assert_array_equal(a, b)
+
+    def test__deepcopy___void_scalar(self):
+        # see comments in gh-29643
+        value = np.void('Rex', dtype=[('name', 'U10')])
+        value_deepcopy = value.__deepcopy__(None)
+        value[0] = None
+        assert value_deepcopy[0] == 'Rex'
+
+    @pytest.mark.parametrize("sctype", [np.int64, np.float32, np.float64])
+    def test__deepcopy__scalar(self, sctype):
+        # test optimization from gh-29656
+        value = sctype(1.1)
+        value_deepcopy = value.__deepcopy__(None)
+        assert value is value_deepcopy
 
     def test__deepcopy__catches_failure(self):
         class MyObj:
@@ -5577,14 +5592,22 @@ class TestIO:
         x[0, :, 1] = [np.nan, np.inf, -np.inf, np.nan]
         return x
 
-    def _create_filename(self, path, param):
+    @pytest.fixture(params=["string", "path_obj"])
+    def param_filename(self, tmp_path, request):
         # This fixture covers two cases:
         # one where the filename is a string and
         # another where it is a pathlib object
-        filename = path / "file"
-        if param == "string":
+        filename = tmp_path / "file"
+        if request.param == "string":
             filename = str(filename)
-        return filename
+        yield filename
+
+    def _threaded_filename(self, path, thread_index):
+        # Makes sure the param_filename fixture is thread safe
+        if isinstance(path, str):
+            return path + str(thread_index)
+        else:
+            return pathlib.Path(path).with_name("file" + str(thread_index))
 
     def test_nofile(self):
         # this should probably be supported as a file
@@ -5615,25 +5638,22 @@ class TestIO:
         d = np.fromstring("1,2", sep=",", dtype=np.int64, count=0)
         assert d.shape == (0,)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_empty_files_text(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_empty_files_text(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         with open(tmp_filename, 'w') as f:
             pass
         y = np.fromfile(tmp_filename)
         assert_(y.size == 0, "Array not empty")
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_empty_files_binary(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_empty_files_binary(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         with open(tmp_filename, 'wb') as f:
             pass
         y = np.fromfile(tmp_filename, sep=" ")
         assert_(y.size == 0, "Array not empty")
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_roundtrip_file(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_roundtrip_file(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = self._create_data()
         with open(tmp_filename, 'wb') as f:
             x.tofile(f)
@@ -5642,17 +5662,15 @@ class TestIO:
             y = np.fromfile(f, dtype=x.dtype)
         assert_array_equal(y, x.flat)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_roundtrip(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_roundtrip(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = self._create_data()
         x.tofile(tmp_filename)
         y = np.fromfile(tmp_filename, dtype=x.dtype)
         assert_array_equal(y, x.flat)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_roundtrip_dump_pathlib(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_roundtrip_dump_pathlib(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = self._create_data()
         p = pathlib.Path(tmp_filename)
         x.dump(p)
@@ -5685,10 +5703,9 @@ class TestIO:
         y = np.fromstring(s, sep="@")
         assert_array_equal(x, y)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_unseekable_fromfile(self, tmp_path, param):
+    def test_unseekable_fromfile(self, param_filename, thread_index):
         # gh-6246
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = self._create_data()
         x.tofile(tmp_filename)
 
@@ -5700,20 +5717,18 @@ class TestIO:
             f.tell = fail
             assert_raises(OSError, np.fromfile, f, dtype=x.dtype)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_io_open_unbuffered_fromfile(self, tmp_path, param):
+    def test_io_open_unbuffered_fromfile(self, param_filename, thread_index):
         # gh-6632
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = self._create_data()
         x.tofile(tmp_filename)
         with open(tmp_filename, 'rb', buffering=0) as f:
             y = np.fromfile(f, dtype=x.dtype)
             assert_array_equal(y, x.flat)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_largish_file(self, tmp_path, param):
+    def test_largish_file(self, param_filename, thread_index):
         # check the fallocate path on files > 16MB
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         d = np.zeros(4 * 1024 ** 2)
         d.tofile(tmp_filename)
         assert_equal(os.path.getsize(tmp_filename), d.nbytes)
@@ -5732,23 +5747,21 @@ class TestIO:
             d.tofile(f)
         assert_equal(os.path.getsize(tmp_filename), d.nbytes * 2)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_io_open_buffered_fromfile(self, tmp_path, param):
+    def test_io_open_buffered_fromfile(self, param_filename, thread_index):
         # gh-6632
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = self._create_data()
         x.tofile(tmp_filename)
         with open(tmp_filename, 'rb', buffering=-1) as f:
             y = np.fromfile(f, dtype=x.dtype)
         assert_array_equal(y, x.flat)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_file_position_after_fromfile(self, tmp_path, param):
+    def test_file_position_after_fromfile(self, param_filename, thread_index):
         # gh-4118
         sizes = [io.DEFAULT_BUFFER_SIZE // 8,
                  io.DEFAULT_BUFFER_SIZE,
                  io.DEFAULT_BUFFER_SIZE * 8]
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
 
         for size in sizes:
             with open(tmp_filename, 'wb') as f:
@@ -5764,13 +5777,12 @@ class TestIO:
                     pos = f.tell()
                 assert_equal(pos, 10, err_msg=err_msg)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_file_position_after_tofile(self, tmp_path, param):
+    def test_file_position_after_tofile(self, param_filename, thread_index):
         # gh-4118
         sizes = [io.DEFAULT_BUFFER_SIZE // 8,
                  io.DEFAULT_BUFFER_SIZE,
                  io.DEFAULT_BUFFER_SIZE * 8]
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
 
         for size in sizes:
             err_msg = "%d" % (size,)
@@ -5791,10 +5803,9 @@ class TestIO:
                 pos = f.tell()
             assert_equal(pos, 10, err_msg=err_msg)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_load_object_array_fromfile(self, tmp_path, param):
+    def test_load_object_array_fromfile(self, param_filename, thread_index):
         # gh-12300
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         with open(tmp_filename, 'w') as f:
             # Ensure we have a file with consistent contents
             pass
@@ -5806,9 +5817,8 @@ class TestIO:
         assert_raises_regex(ValueError, "Cannot read into object array",
                             np.fromfile, tmp_filename, dtype=object)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_fromfile_offset(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_fromfile_offset(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = self._create_data()
         with open(tmp_filename, 'wb') as f:
             x.tofile(f)
@@ -5844,15 +5854,14 @@ class TestIO:
                     sep=",", offset=1)
 
     @pytest.mark.skipif(IS_PYPY, reason="bug in PyPy's PyNumber_AsSsize_t")
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_fromfile_bad_dup(self, tmp_path, param, monkeypatch):
+    def test_fromfile_bad_dup(self, param_filename, thread_index, monkeypatch):
         def dup_str(fd):
             return 'abc'
 
         def dup_bigint(fd):
             return 2**68
 
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = self._create_data()
 
         with open(tmp_filename, 'wb') as f:
@@ -5901,50 +5910,44 @@ class TestIO:
         else:
             assert False, request.param
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_nan(self, tmp_path, param, decimal_sep_localization):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_nan(self, param_filename, thread_index, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         self._check_from(
             b"nan +nan -nan NaN nan(foo) +NaN(BAR) -NAN(q_u_u_x_)",
             [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
             tmp_filename,
             sep=' ')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_inf(self, tmp_path, param, decimal_sep_localization):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_inf(self, param_filename, thread_index, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         self._check_from(
             b"inf +inf -inf infinity -Infinity iNfInItY -inF",
             [np.inf, np.inf, -np.inf, np.inf, -np.inf, np.inf, -np.inf],
             tmp_filename,
             sep=' ')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_numbers(self, tmp_path, param, decimal_sep_localization):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_numbers(self, param_filename, thread_index, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         self._check_from(
             b"1.234 -1.234 .3 .3e55 -123133.1231e+133",
             [1.234, -1.234, .3, .3e55, -123133.1231e+133],
             tmp_filename,
             sep=' ')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_binary(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_binary(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         self._check_from(
             b'\x00\x00\x80?\x00\x00\x00@\x00\x00@@\x00\x00\x80@',
             np.array([1, 2, 3, 4]),
             tmp_filename,
             dtype='<f4')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_string(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_string(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         self._check_from(b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, sep=',')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_counted_string(self, tmp_path, param, decimal_sep_localization):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_counted_string(self, param_filename, thread_index, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         self._check_from(
             b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, count=4, sep=',')
         self._check_from(
@@ -5952,50 +5955,43 @@ class TestIO:
         self._check_from(
             b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, count=-1, sep=',')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_string_with_ws(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_string_with_ws(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         self._check_from(
             b'1 2  3     4   ', [1, 2, 3, 4], tmp_filename, dtype=int, sep=' ')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_counted_string_with_ws(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_counted_string_with_ws(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         self._check_from(
             b'1 2  3     4   ', [1, 2, 3], tmp_filename, count=3, dtype=int,
             sep=' ')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_ascii(self, tmp_path, param, decimal_sep_localization):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_ascii(self, param_filename, thread_index, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         self._check_from(
             b'1 , 2 , 3 , 4', [1., 2., 3., 4.], tmp_filename, sep=',')
         self._check_from(
             b'1,2,3,4', [1., 2., 3., 4.], tmp_filename, dtype=float, sep=',')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_malformed(self, tmp_path, param, decimal_sep_localization):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_malformed(self, param_filename, thread_index, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         with assert_raises(ValueError):
             self._check_from(
                 b'1.234 1,234', [1.234, 1.], tmp_filename, sep=' ')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_long_sep(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_long_sep(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         self._check_from(
             b'1_x_3_x_4_x_5', [1, 3, 4, 5], tmp_filename, sep='_x_')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_dtype(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_dtype(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         v = np.array([1, 2, 3, 4], dtype=np.int_)
         self._check_from(b'1,2,3,4', v, tmp_filename, sep=',', dtype=np.int_)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_dtype_bool(self, tmp_path, param):
+    def test_dtype_bool(self, param_filename, thread_index):
         # can't use _check_from because fromstring can't handle True/False
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         v = np.array([True, False, True, False], dtype=np.bool)
         s = b'1,0,-2.3,0'
         with open(tmp_filename, 'wb') as f:
@@ -6004,9 +6000,8 @@ class TestIO:
         assert_(y.dtype == '?')
         assert_array_equal(y, v)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_tofile_sep(self, tmp_path, param, decimal_sep_localization):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_tofile_sep(self, param_filename, thread_index, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = np.array([1.51, 2, 3.51, 4], dtype=float)
         with open(tmp_filename, 'w') as f:
             x.tofile(f, sep=',')
@@ -6016,9 +6011,8 @@ class TestIO:
         y = np.array([float(p) for p in s.split(',')])
         assert_array_equal(x, y)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_tofile_format(self, tmp_path, param, decimal_sep_localization):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_tofile_format(self, param_filename, thread_index, decimal_sep_localization):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = np.array([1.51, 2, 3.51, 4], dtype=float)
         with open(tmp_filename, 'w') as f:
             x.tofile(f, sep=',', format='%.2f')
@@ -6026,9 +6020,8 @@ class TestIO:
             s = f.read()
         assert_equal(s, '1.51,2.00,3.51,4.00')
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_tofile_cleanup(self, tmp_path, param):
-        tmp_filename = self._create_filename(tmp_path, param)
+    def test_tofile_cleanup(self, param_filename, thread_index):
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = np.zeros((10), dtype=object)
         with open(tmp_filename, 'wb') as f:
             assert_raises(OSError, lambda: x.tofile(f, sep=''))
@@ -6039,10 +6032,9 @@ class TestIO:
         assert_raises(OSError, lambda: x.tofile(tmp_filename))
         os.remove(tmp_filename)
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_fromfile_subarray_binary(self, tmp_path, param):
+    def test_fromfile_subarray_binary(self, param_filename, thread_index):
         # Test subarray dtypes which are absorbed into the shape
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         x = np.arange(24, dtype="i4").reshape(2, 3, 4)
         x.tofile(tmp_filename)
         res = np.fromfile(tmp_filename, dtype="(3,4)i4")
@@ -6053,10 +6045,9 @@ class TestIO:
             # binary fromstring raises
             np.fromstring(x_str, dtype="(3,4)i4")
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_parsing_subarray_unsupported(self, tmp_path, param):
+    def test_parsing_subarray_unsupported(self, param_filename, thread_index):
         # We currently do not support parsing subarray dtypes
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         data = "12,42,13," * 50
         with pytest.raises(ValueError):
             expected = np.fromstring(data, dtype="(3,)i", sep=",")
@@ -6067,12 +6058,11 @@ class TestIO:
         with pytest.raises(ValueError):
             np.fromfile(tmp_filename, dtype="(3,)i", sep=",")
 
-    @pytest.mark.parametrize("param", ["string", "path_obj"])
-    def test_read_shorter_than_count_subarray(self, tmp_path, param):
+    def test_read_shorter_than_count_subarray(self, param_filename, thread_index):
         # Test that requesting more values does not cause any problems
         # in conjunction with subarray dimensions being absorbed into the
         # array dimension.
-        tmp_filename = self._create_filename(tmp_path, param)
+        tmp_filename = self._threaded_filename(param_filename, thread_index)
         expected = np.arange(511 * 10, dtype="i").reshape(-1, 10)
 
         binary = expected.tobytes()

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -20,12 +20,6 @@ try:
 except ModuleNotFoundError:
     HAVE_SCPDT = False
 
-try:
-    import pytest_run_parallel  # noqa: F401
-    PARALLEL_RUN_AVALIABLE = True
-except ModuleNotFoundError:
-    PARALLEL_RUN_AVALIABLE = False
-
 _old_fpu_mode = None
 _collect_results = {}
 
@@ -148,12 +142,6 @@ def check_fpu_mode(request):
 @pytest.fixture(autouse=True)
 def add_np(doctest_namespace):
     doctest_namespace['np'] = numpy
-
-
-if not PARALLEL_RUN_AVALIABLE:
-    @pytest.fixture
-    def thread_index():
-        return 0
 
 
 if HAVE_SCPDT:

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -20,6 +20,11 @@ try:
 except ModuleNotFoundError:
     HAVE_SCPDT = False
 
+try:
+    import pytest_run_parallel  # noqa: F401
+    PARALLEL_RUN_AVALIABLE = True
+except ModuleNotFoundError:
+    PARALLEL_RUN_AVALIABLE = False
 
 _old_fpu_mode = None
 _collect_results = {}
@@ -143,6 +148,12 @@ def check_fpu_mode(request):
 @pytest.fixture(autouse=True)
 def add_np(doctest_namespace):
     doctest_namespace['np'] = numpy
+
+
+if not PARALLEL_RUN_AVALIABLE:
+    @pytest.fixture
+    def thread_index():
+        return 0
 
 
 if HAVE_SCPDT:

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -20,6 +20,7 @@ try:
 except ModuleNotFoundError:
     HAVE_SCPDT = False
 
+
 _old_fpu_mode = None
 _collect_results = {}
 

--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -89,246 +89,222 @@ def invalid_httpfile():
 
 
 class TestDataSourceOpen:
-    def setup_method(self):
-        self.tmpdir = mkdtemp()
-        self.ds = datasource.DataSource(self.tmpdir)
-
-    def teardown_method(self):
-        rmtree(self.tmpdir)
-        del self.ds
-
-    def test_ValidHTTP(self):
-        fh = self.ds.open(valid_httpurl())
+    def test_ValidHTTP(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        fh = ds.open(valid_httpurl())
         assert_(fh)
         fh.close()
 
-    def test_InvalidHTTP(self):
+    def test_InvalidHTTP(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
         url = invalid_httpurl()
-        assert_raises(OSError, self.ds.open, url)
+        assert_raises(OSError, ds.open, url)
         try:
-            self.ds.open(url)
+            ds.open(url)
         except OSError as e:
             # Regression test for bug fixed in r4342.
             assert_(e.errno is None)
 
-    def test_InvalidHTTPCacheURLError(self):
-        assert_raises(URLError, self.ds._cache, invalid_httpurl())
+    def test_InvalidHTTPCacheURLError(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        assert_raises(URLError, ds._cache, invalid_httpurl())
 
-    def test_ValidFile(self):
-        local_file = valid_textfile(self.tmpdir)
-        fh = self.ds.open(local_file)
+    def test_ValidFile(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        local_file = valid_textfile(tmp_path)
+        fh = ds.open(local_file)
         assert_(fh)
         fh.close()
 
-    def test_InvalidFile(self):
-        invalid_file = invalid_textfile(self.tmpdir)
-        assert_raises(OSError, self.ds.open, invalid_file)
+    def test_InvalidFile(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        invalid_file = invalid_textfile(tmp_path)
+        assert_raises(OSError, ds.open, invalid_file)
 
-    def test_ValidGzipFile(self):
+    def test_ValidGzipFile(self, tmp_path):
         try:
             import gzip
         except ImportError:
             # We don't have the gzip capabilities to test.
             pytest.skip()
         # Test datasource's internal file_opener for Gzip files.
-        filepath = os.path.join(self.tmpdir, 'foobar.txt.gz')
+        ds = datasource.DataSource(tmp_path)
+        filepath = os.path.join(tmp_path, 'foobar.txt.gz')
         fp = gzip.open(filepath, 'w')
         fp.write(magic_line)
         fp.close()
-        fp = self.ds.open(filepath)
+        fp = ds.open(filepath)
         result = fp.readline()
         fp.close()
         assert_equal(magic_line, result)
 
-    def test_ValidBz2File(self):
+    def test_ValidBz2File(self, tmp_path):
         try:
             import bz2
         except ImportError:
             # We don't have the bz2 capabilities to test.
             pytest.skip()
         # Test datasource's internal file_opener for BZip2 files.
-        filepath = os.path.join(self.tmpdir, 'foobar.txt.bz2')
+        ds = datasource.DataSource(tmp_path)
+        filepath = os.path.join(tmp_path, 'foobar.txt.bz2')
         fp = bz2.BZ2File(filepath, 'w')
         fp.write(magic_line)
         fp.close()
-        fp = self.ds.open(filepath)
+        fp = ds.open(filepath)
         result = fp.readline()
         fp.close()
         assert_equal(magic_line, result)
 
 
 class TestDataSourceExists:
-    def setup_method(self):
-        self.tmpdir = mkdtemp()
-        self.ds = datasource.DataSource(self.tmpdir)
+    def test_ValidHTTP(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        assert_(ds.exists(valid_httpurl()))
 
-    def teardown_method(self):
-        rmtree(self.tmpdir)
-        del self.ds
+    def test_InvalidHTTP(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        assert_equal(ds.exists(invalid_httpurl()), False)
 
-    def test_ValidHTTP(self):
-        assert_(self.ds.exists(valid_httpurl()))
-
-    def test_InvalidHTTP(self):
-        assert_equal(self.ds.exists(invalid_httpurl()), False)
-
-    def test_ValidFile(self):
+    def test_ValidFile(self, tmp_path):
         # Test valid file in destpath
-        tmpfile = valid_textfile(self.tmpdir)
-        assert_(self.ds.exists(tmpfile))
+        ds = datasource.DataSource(tmp_path)
+        tmpfile = valid_textfile(tmp_path)
+        assert_(ds.exists(tmpfile))
         # Test valid local file not in destpath
         localdir = mkdtemp()
         tmpfile = valid_textfile(localdir)
-        assert_(self.ds.exists(tmpfile))
+        assert_(ds.exists(tmpfile))
         rmtree(localdir)
 
-    def test_InvalidFile(self):
-        tmpfile = invalid_textfile(self.tmpdir)
-        assert_equal(self.ds.exists(tmpfile), False)
+    def test_InvalidFile(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        tmpfile = invalid_textfile(tmp_path)
+        assert_equal(ds.exists(tmpfile), False)
 
 
 class TestDataSourceAbspath:
-    def setup_method(self):
-        self.tmpdir = os.path.abspath(mkdtemp())
-        self.ds = datasource.DataSource(self.tmpdir)
-
-    def teardown_method(self):
-        rmtree(self.tmpdir)
-        del self.ds
-
-    def test_ValidHTTP(self):
-        scheme, netloc, upath, pms, qry, frg = urlparse(valid_httpurl())
-        local_path = os.path.join(self.tmpdir, netloc,
+    def test_ValidHTTP(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        _, netloc, upath, _, _, _ = urlparse(valid_httpurl())
+        local_path = os.path.join(tmp_path, netloc,
                                   upath.strip(os.sep).strip('/'))
-        assert_equal(local_path, self.ds.abspath(valid_httpurl()))
+        assert_equal(local_path, ds.abspath(valid_httpurl()))
 
-    def test_ValidFile(self):
-        tmpfile = valid_textfile(self.tmpdir)
+    def test_ValidFile(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        tmpfile = valid_textfile(tmp_path)
         tmpfilename = os.path.split(tmpfile)[-1]
         # Test with filename only
-        assert_equal(tmpfile, self.ds.abspath(tmpfilename))
+        assert_equal(tmpfile, ds.abspath(tmpfilename))
         # Test filename with complete path
-        assert_equal(tmpfile, self.ds.abspath(tmpfile))
+        assert_equal(tmpfile, ds.abspath(tmpfile))
 
-    def test_InvalidHTTP(self):
-        scheme, netloc, upath, pms, qry, frg = urlparse(invalid_httpurl())
-        invalidhttp = os.path.join(self.tmpdir, netloc,
+    def test_InvalidHTTP(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        _, netloc, upath, _, _, _ = urlparse(invalid_httpurl())
+        invalidhttp = os.path.join(tmp_path, netloc,
                                    upath.strip(os.sep).strip('/'))
-        assert_(invalidhttp != self.ds.abspath(valid_httpurl()))
+        assert_(invalidhttp != ds.abspath(valid_httpurl()))
 
-    def test_InvalidFile(self):
-        invalidfile = valid_textfile(self.tmpdir)
-        tmpfile = valid_textfile(self.tmpdir)
+    def test_InvalidFile(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        invalidfile = valid_textfile(tmp_path)
+        tmpfile = valid_textfile(tmp_path)
         tmpfilename = os.path.split(tmpfile)[-1]
         # Test with filename only
-        assert_(invalidfile != self.ds.abspath(tmpfilename))
+        assert_(invalidfile != ds.abspath(tmpfilename))
         # Test filename with complete path
-        assert_(invalidfile != self.ds.abspath(tmpfile))
+        assert_(invalidfile != ds.abspath(tmpfile))
 
-    def test_sandboxing(self):
-        tmpfile = valid_textfile(self.tmpdir)
+    def test_sandboxing(self, tmp_path):
+        ds = datasource.DataSource(tmp_path)
+        tmpfile = valid_textfile(tmp_path)
         tmpfilename = os.path.split(tmpfile)[-1]
 
-        tmp_path = lambda x: os.path.abspath(self.ds.abspath(x))
+        path = lambda x: os.path.abspath(ds.abspath(x))
 
-        assert_(tmp_path(valid_httpurl()).startswith(self.tmpdir))
-        assert_(tmp_path(invalid_httpurl()).startswith(self.tmpdir))
-        assert_(tmp_path(tmpfile).startswith(self.tmpdir))
-        assert_(tmp_path(tmpfilename).startswith(self.tmpdir))
+        assert_(path(valid_httpurl()).startswith(str(tmp_path)))
+        assert_(path(invalid_httpurl()).startswith(str(tmp_path)))
+        assert_(path(tmpfile).startswith(str(tmp_path)))
+        assert_(path(tmpfilename).startswith(str(tmp_path)))
         for fn in malicious_files:
-            assert_(tmp_path(http_path + fn).startswith(self.tmpdir))
-            assert_(tmp_path(fn).startswith(self.tmpdir))
+            assert_(path(http_path + fn).startswith(str(tmp_path)))
+            assert_(path(fn).startswith(str(tmp_path)))
 
-    def test_windows_os_sep(self):
+    def test_windows_os_sep(self, tmp_path):
         orig_os_sep = os.sep
         try:
             os.sep = '\\'
-            self.test_ValidHTTP()
-            self.test_ValidFile()
-            self.test_InvalidHTTP()
-            self.test_InvalidFile()
-            self.test_sandboxing()
+            self.test_ValidHTTP(tmp_path)
+            self.test_ValidFile(tmp_path)
+            self.test_InvalidHTTP(tmp_path)
+            self.test_InvalidFile(tmp_path)
+            self.test_sandboxing(tmp_path)
         finally:
             os.sep = orig_os_sep
 
 
 class TestRepositoryAbspath:
-    def setup_method(self):
-        self.tmpdir = os.path.abspath(mkdtemp())
-        self.repos = datasource.Repository(valid_baseurl(), self.tmpdir)
-
-    def teardown_method(self):
-        rmtree(self.tmpdir)
-        del self.repos
-
-    def test_ValidHTTP(self):
-        scheme, netloc, upath, pms, qry, frg = urlparse(valid_httpurl())
-        local_path = os.path.join(self.repos._destpath, netloc,
+    def test_ValidHTTP(self, tmp_path):
+        repos = datasource.Repository(valid_baseurl(), tmp_path)
+        _, netloc, upath, _, _, _ = urlparse(valid_httpurl())
+        local_path = os.path.join(repos._destpath, netloc,
                                   upath.strip(os.sep).strip('/'))
-        filepath = self.repos.abspath(valid_httpfile())
+        filepath = repos.abspath(valid_httpfile())
         assert_equal(local_path, filepath)
 
-    def test_sandboxing(self):
-        tmp_path = lambda x: os.path.abspath(self.repos.abspath(x))
-        assert_(tmp_path(valid_httpfile()).startswith(self.tmpdir))
+    def test_sandboxing(self, tmp_path):
+        repos = datasource.Repository(valid_baseurl(), tmp_path)
+        path = lambda x: os.path.abspath(repos.abspath(x))
+        assert_(path(valid_httpfile()).startswith(str(tmp_path)))
         for fn in malicious_files:
-            assert_(tmp_path(http_path + fn).startswith(self.tmpdir))
-            assert_(tmp_path(fn).startswith(self.tmpdir))
+            assert_(path(http_path + fn).startswith(str(tmp_path)))
+            assert_(path(fn).startswith(str(tmp_path)))
 
-    def test_windows_os_sep(self):
+    def test_windows_os_sep(self, tmp_path):
         orig_os_sep = os.sep
         try:
             os.sep = '\\'
-            self.test_ValidHTTP()
-            self.test_sandboxing()
+            self.test_ValidHTTP(tmp_path)
+            self.test_sandboxing(tmp_path)
         finally:
             os.sep = orig_os_sep
 
 
 class TestRepositoryExists:
-    def setup_method(self):
-        self.tmpdir = mkdtemp()
-        self.repos = datasource.Repository(valid_baseurl(), self.tmpdir)
-
-    def teardown_method(self):
-        rmtree(self.tmpdir)
-        del self.repos
-
-    def test_ValidFile(self):
+    def test_ValidFile(self, tmp_path):
         # Create local temp file
-        tmpfile = valid_textfile(self.tmpdir)
-        assert_(self.repos.exists(tmpfile))
+        repos = datasource.Repository(valid_baseurl(), tmp_path)
+        tmpfile = valid_textfile(tmp_path)
+        assert_(repos.exists(tmpfile))
 
-    def test_InvalidFile(self):
-        tmpfile = invalid_textfile(self.tmpdir)
-        assert_equal(self.repos.exists(tmpfile), False)
+    def test_InvalidFile(self, tmp_path):
+        repos = datasource.Repository(valid_baseurl(), tmp_path)
+        tmpfile = invalid_textfile(tmp_path)
+        assert_equal(repos.exists(tmpfile), False)
 
-    def test_RemoveHTTPFile(self):
-        assert_(self.repos.exists(valid_httpurl()))
+    def test_RemoveHTTPFile(self, tmp_path):
+        repos = datasource.Repository(valid_baseurl(), tmp_path)
+        assert_(repos.exists(valid_httpurl()))
 
-    def test_CachedHTTPFile(self):
+    def test_CachedHTTPFile(self, tmp_path):
         localfile = valid_httpurl()
         # Create a locally cached temp file with an URL based
         # directory structure.  This is similar to what Repository.open
         # would do.
-        scheme, netloc, upath, pms, qry, frg = urlparse(localfile)
-        local_path = os.path.join(self.repos._destpath, netloc)
+        repos = datasource.Repository(valid_baseurl(), tmp_path)
+        _, netloc, _, _, _, _ = urlparse(localfile)
+        local_path = os.path.join(repos._destpath, netloc)
         os.mkdir(local_path, 0o0700)
         tmpfile = valid_textfile(local_path)
-        assert_(self.repos.exists(tmpfile))
+        assert_(repos.exists(tmpfile))
 
 
 class TestOpenFunc:
-    def setup_method(self):
-        self.tmpdir = mkdtemp()
-
-    def teardown_method(self):
-        rmtree(self.tmpdir)
-
-    def test_DataSourceOpen(self):
-        local_file = valid_textfile(self.tmpdir)
+    def test_DataSourceOpen(self, tmp_path):
+        local_file = valid_textfile(tmp_path)
         # Test case where destpath is passed in
-        fp = datasource.open(local_file, destpath=self.tmpdir)
+        fp = datasource.open(local_file, destpath=tmp_path)
         assert_(fp)
         fp.close()
         # Test case where default destpath is used


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This PR is related to #29552 and also a sort of continuation of #29816. With the newest version of `pytest-run-parallel`, most usages of `tmp_path` should be thread safe. However there are a few instances of temporary files being used in the test suite that do not use the pytest `tmp_path` fixtures and thus are still thread-unsafe. This PR attempts to fix these thread safety issues.

In `numpy/_core/tests/test_multiarray.py::TestIO`:
- This was a bit tricky to fix and make thread safe. The way `pytest-run-parallel` patches `tmp_path` is by creating directories for each thread. However this only works if the `tmp_path` fixture is called directly by a test. In this case, `tmp_path` is called by another fixture, `tmp_filename`. I made it so it's an explicit method called by each test instead. This of course introduces more code changes since the fixture was parameterized, so I had to include these parameters wherever `tmp_filename` was originally used.
- Another change was to `test_fromfile_bad_dup`. This mutates `os.dup` in a way that's extremely thread unsafe and leads to following tests giving all sorts of errors. This test could be marked as thread unsafe, but I wanted to try using `monkeypatch`. This is a bit more of a pytest-like way of handling this mutation, and will automatically mark the test are thread-unsafe.

In `numpy/lib/tests/test__datasource.py`:
- A bit more of a simple change, makes it so the `datasource.Datasource` instance is created in each test using `tmp_path`. Originally the teardown had it so this datasource object was deleted. I'm unsure if this is needed, but if it is, it would require including `del ds` in each test that declares the datasource object. I can add this if folks think it's necessary.