### PR TITLE
CI: Fix loongarch64 CI (#29856)

### DIFF
--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Initialize binfmt_misc for qemu-user-static
       run: |
-          docker run --rm --privileged loongcr.lcpu.dev/multiarch/archlinux --reset -p yes
+          docker run --rm --privileged tonistiigi/binfmt:qemu-v10.0.4-56 --install all
 
     - name: Install GCC cross-compilers
       run: |


### PR DESCRIPTION
Backport of #29856.

closes #29855


* CI: Fix loongarch64 CI by moving to the latest tag of tonistiigi/binfmt which come with qemu-10

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
