### PR TITLE
TST: Fix misc thread unsafe data races

### DIFF
--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -2895,7 +2895,7 @@ def _is_buffered(iterator):
         return True
     return False
 
-@pytest.mark.parametrize("a",
+@pytest.mark.parametrize("arrs",
         [np.zeros((3,), dtype='f8'),
          np.zeros((9876, 3 * 5), dtype='f8')[::2, :],
          np.zeros((4, 312, 124, 3), dtype='f8')[::2, :, ::2, :],
@@ -2904,10 +2904,11 @@ def _is_buffered(iterator):
          np.zeros((9,), dtype='f8')[::3],
          np.zeros((9876, 3 * 10), dtype='f8')[::2, ::5],
          np.zeros((4, 312, 124, 3), dtype='f8')[::2, :, ::2, ::-1]])
-def test_iter_writemasked(a):
+def test_iter_writemasked(arrs):
     # Note, the slicing above is to ensure that nditer cannot combine multiple
     # axes into one.  The repetition is just to make things a bit more
     # interesting.
+    a = arrs.copy()
     shape = a.shape
     reps = shape[-1] // 3
     msk = np.empty(shape, dtype=bool)

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -1768,10 +1768,11 @@ class TestUfunc:
         a = a[1:, 1:, 1:]
         yield a
 
-    @pytest.mark.parametrize("a", identityless_reduce_arrs())
+    @pytest.mark.parametrize("arrs", identityless_reduce_arrs())
     @pytest.mark.parametrize("pos", [(1, 0, 0), (0, 1, 0), (0, 0, 1)])
-    def test_identityless_reduction(self, a, pos):
+    def test_identityless_reduction(self, arrs, pos):
         # np.minimum.reduce is an identityless reduction
+        a = arrs.copy()
         a[...] = 1
         a[pos] = 0
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -125,8 +125,6 @@ class RoundtripTest:
 
             arr_reloaded = np.load(load_file, **load_kwds)
 
-            self.arr = arr
-            self.arr_reloaded = arr_reloaded
         finally:
             if not isinstance(target_file, BytesIO):
                 target_file.close()
@@ -134,6 +132,8 @@ class RoundtripTest:
                 if 'arr_reloaded' in locals():
                     if not isinstance(arr_reloaded, np.lib.npyio.NpzFile):
                         os.remove(target_file.name)
+
+        return arr, arr_reloaded
 
     def check_roundtrips(self, a):
         self.roundtrip(a)
@@ -195,26 +195,26 @@ class RoundtripTest:
 
 class TestSaveLoad(RoundtripTest):
     def roundtrip(self, *args, **kwargs):
-        RoundtripTest.roundtrip(self, np.save, *args, **kwargs)
-        assert_equal(self.arr[0], self.arr_reloaded)
-        assert_equal(self.arr[0].dtype, self.arr_reloaded.dtype)
-        assert_equal(self.arr[0].flags.fnc, self.arr_reloaded.flags.fnc)
+        arr, arr_reloaded = RoundtripTest.roundtrip(self, np.save, *args, **kwargs)
+        assert_equal(arr[0], arr_reloaded)
+        assert_equal(arr[0].dtype, arr_reloaded.dtype)
+        assert_equal(arr[0].flags.fnc, arr_reloaded.flags.fnc)
 
 
 class TestSavezLoad(RoundtripTest):
     def roundtrip(self, *args, **kwargs):
-        RoundtripTest.roundtrip(self, np.savez, *args, **kwargs)
+        arr, arr_reloaded = RoundtripTest.roundtrip(self, np.savez, *args, **kwargs)
         try:
-            for n, arr in enumerate(self.arr):
-                reloaded = self.arr_reloaded['arr_%d' % n]
-                assert_equal(arr, reloaded)
-                assert_equal(arr.dtype, reloaded.dtype)
-                assert_equal(arr.flags.fnc, reloaded.flags.fnc)
+            for n, a in enumerate(arr):
+                reloaded = arr_reloaded['arr_%d' % n]
+                assert_equal(a, reloaded)
+                assert_equal(a.dtype, reloaded.dtype)
+                assert_equal(a.flags.fnc, reloaded.flags.fnc)
         finally:
             # delete tempfile, must be done here on windows
-            if self.arr_reloaded.fid:
-                self.arr_reloaded.fid.close()
-                os.remove(self.arr_reloaded.fid.name)
+            if arr_reloaded.fid:
+                arr_reloaded.fid.close()
+                os.remove(arr_reloaded.fid.name)
 
     def test_load_non_npy(self):
         """Test loading non-.npy files and name mapping in .npz."""


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This PR is related to #29552 and also a sort of continuation of #29816. A few usages of `@pytest.mark.parametrize` resulted in data races when ran in parallel threads using [pytest-run-parallel](github.com/Quansight-Labs/pytest-run-parallel). By making it so the tests instead use a `.copy` of the parameterized values (as suggested by @lysnikolaou), this gets rid of the data race.

This also gives a small edit to `numpy/lib/tests/test_io.py` to fix up some data races there.