### PR TITLE
DOC: Add warning and examples for sliding_window_view

### DIFF
--- a/numpy/lib/_stride_tricks_impl.py
+++ b/numpy/lib/_stride_tricks_impl.py
@@ -173,6 +173,14 @@ def sliding_window_view(x, window_shape, axis=None, *,
 
     Notes
     -----
+    .. warning::
+
+       This function creates views with overlapping memory. When
+       ``writeable=True``, writing to the view will modify the original array
+       and may affect multiple view positions. See the examples below and
+       :doc:`this guide </user/basics.copies>`
+       about the difference between copies and views.
+
     For many applications using a sliding window view can be convenient, but
     potentially very slow. Often specialized solutions exist, for example:
 
@@ -296,6 +304,31 @@ def sliding_window_view(x, window_shape, axis=None, *,
     >>> moving_average = v.mean(axis=-1)
     >>> moving_average
     array([1., 2., 3., 4.])
+
+    The two examples below demonstrate the effect of ``writeable=True``.
+
+    Creating a view with the default ``writeable=False`` and then writing to
+    it raises an error.
+
+    >>> v = sliding_window_view(x, 3)
+    >>> v[0,1] = 10
+    Traceback (most recent call last):
+    ...
+    ValueError: assignment destination is read-only
+
+    Creating a view with ``writeable=True`` and then writing to it changes
+    the original array and multiple view positions.
+
+    >>> x = np.arange(6)  # reset x for the second example
+    >>> v = sliding_window_view(x, 3, writeable=True)
+    >>> v[0,1] = 10
+    >>> x
+    array([ 0, 10,  2,  3,  4,  5])
+    >>> v
+    array([[ 0, 10,  2],
+           [10,  2,  3],
+           [ 2,  3,  4],
+           [ 3,  4,  5]])
 
     Note that a sliding window approach is often **not** optimal (see Notes).
     """


### PR DESCRIPTION
Closes #29677.

### Description of the problem solved

The existing documentation for `numpy.lib.stride_tricks.sliding_window_view` does not sufficiently warn users about the risks of using `writeable=True`. When the returned view is modified, it also modifies the original array and can affect multiple positions within the view itself due to overlapping memory. This can lead to silent, hard-to-debug errors in user code that assumes the view is an independent copy.

### Summary of changes

* A `.. warning::` directive has been added to the `Notes` section of the docstring. This warning explains the shared memory behavior and links to the user guide on copies and views.
* Two new code examples have been appended to the `Examples` section:
    1.  The first demonstrates the correct `ValueError` that is raised when trying to write to a default, read-only view.
    2.  The second demonstrates how writing to a `writeable=True` view modifies both the original array and other parts of the view.

These changes directly address the suggestions in the original issue and make the documentation safer and clearer for users.

---
### Checklist

- [x] I have read the [NumPy contributor guide](https://numpy.org/devdocs/dev/index.html).
- [x] This is a documentation-only change.
- [x] The new documentation is clear and readable.
- [x] The change is supported by the conversation in the linked issue.