### PR TITLE
ENH: Set DLPack tensor `shape` and `strides` to NULL iff `ndim == 0`.

### DIFF
--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -285,10 +285,6 @@ fill_dl_tensor_information(
     }
 
     dl_tensor->ndim = ndim;
-    if (PyArray_IS_C_CONTIGUOUS(self)) {
-        /* No need to pass strides, so just NULL it again */
-        dl_tensor->strides = NULL;
-    }
     dl_tensor->byte_offset = 0;
 
     return 0;
@@ -351,9 +347,8 @@ create_dlpack_capsule(
         dl_tensor = &managed->dl_tensor;
     }
 
-    dl_tensor->shape = (int64_t *)((char *)ptr + offset);
-    /* Note that strides may be set to NULL later if C-contiguous */
-    dl_tensor->strides = dl_tensor->shape + ndim;
+    dl_tensor->shape = (ndim > 0) ? (int64_t *)((char *)ptr + offset) : NULL;
+    dl_tensor->strides = (ndim > 0) ? dl_tensor->shape + ndim : NULL;
 
     if (fill_dl_tensor_information(dl_tensor, self, result_device) < 0) {
         PyMem_Free(ptr);


### PR DESCRIPTION
DLPack allows, but does not require, `DLTensor.strides` to be `NULL`  if `PyArray_IS_C_CONTIGUOUS`.
Previously, in this case, NumPy set the `strides` pointer to `NULL`.
Now, NumPy will supply a valid pointer to correctly initialized strides when `ndim > 0`.

This change can improve performance for downstream users.  For example, nanobind can be used to import a NumPy array using the DLPack protocol to make the array available to C++ code.  If `DLTensor.strides` is `NULL`, nanobind allocates and initializes a `strides` array.  This redundant work is now avoided since NumPy provides a pointer to the `strides`, which it allocated and initialized anyway.

If `ndim == 0`, this PR sets both `shape` and `strides` to `NULL`.
Previously, `strides` was was set to `NULL` (since `PyArray_IS_C_CONTIGUOUS`), but `shape` pointed past the end of allocated memory.  For security and debugability, `NULL` is preferred.
