### PR TITLE
PERF: Intern strings used to build global tuples.

### DIFF
--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -64,6 +64,9 @@ intern_strings(void)
     INTERN_STRING(pyvals_name, "UFUNC_PYVALS_NAME");
     INTERN_STRING(legacy, "legacy");
     INTERN_STRING(__doc__, "__doc__");
+    INTERN_STRING(copy, "copy");
+    INTERN_STRING(dl_device, "dl_device");
+    INTERN_STRING(max_version, "max_version");
     return 0;
 }
 
@@ -169,7 +172,8 @@ initialize_static_globals(void)
         return -1;
     }
 
-    npy_static_pydata.kwnames_is_copy = Py_BuildValue("(s)", "copy");
+    npy_static_pydata.kwnames_is_copy =
+            Py_BuildValue("(O)", npy_interned_str.copy);
     if (npy_static_pydata.kwnames_is_copy == NULL) {
         return -1;
     }
@@ -185,7 +189,9 @@ initialize_static_globals(void)
     }
 
     npy_static_pydata.dl_call_kwnames =
-            Py_BuildValue("(sss)", "dl_device", "copy", "max_version");
+            Py_BuildValue("(OOO)", npy_interned_str.dl_device,
+                                   npy_interned_str.copy,
+                                   npy_interned_str.max_version);
     if (npy_static_pydata.dl_call_kwnames == NULL) {
         return -1;
     }

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -43,6 +43,9 @@ typedef struct npy_interned_str_struct {
     PyObject *pyvals_name;
     PyObject *legacy;
     PyObject *__doc__;
+    PyObject *copy;
+    PyObject *dl_device;
+    PyObject *max_version;
 } npy_interned_str_struct;
 
 /*


### PR DESCRIPTION
This PR improves performance of `npy_parse_arguments()` when `kwnames` is from `npy_static_pydata` by interning the strings used to build the tuples.

The code path in that function (commented with `Super-fast path, check identity:`) will not find the `key` if the string in the `kwnames` has not been interned.  Instead, `Slow fallback, if identity checks failed for some reason` is required.

Consider `y = np.from_dlpack(x, copy=False)` from `test_copy(self)` in `test_dlpack.py`.
The function `from_dlpack()` calls `x.__dlpack__()` with `npy_static_pydata.dl_call_kwnames`.
Then, `__dlpack__()` calls `npy_parse_arguments()`.
With this PR, `dl_call_kwnames` is a tuple of interned strings, so the fast path succeeds.
Previously, the string objects in `dl_call_kwnames` were not interned, so the slow fallback path was used.

In typical usage, one of either `from_dlpack()` or `__dlpack__()` is implemented by a framework other than NumPy.
That other framework should also intern the strings used in its `kwnames` tuple.
