### PR TITLE
PERF: allow creation of read-only array views of scalars

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -37,6 +37,7 @@
 
 #include "get_attr_string.h"
 #include "array_coercion.h"
+#include "scalartypes.h"
 
 #include "umathmodule.h"
 
@@ -1600,6 +1601,44 @@ PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
         goto cleanup;
     }
 
+    if (cache == NULL && !(flags & (NPY_ARRAY_WRITEABLE
+                                    | NPY_ARRAY_ENSURECOPY
+                                    | NPY_ARRAY_FORCECAST))) {
+        /*
+         * For scalar input and an array where no copy, no writeable, and no
+         * forced casting is requested, try a fast path for python float or
+         * numpy scalar: they can be the array base, as long as their dtype
+         * matches that requested.
+         *
+         * The no forced casting is to avoid returning a read-only array
+         * for np.asanyarray(scalar) -- this breaks lots of code.
+         * TODO: better as its own flag?
+         *
+         * Note: This does not work as trivially for PyLong and PyComplex.
+         */
+        assert(ndim == 0);
+        void *data = NULL;
+        int ok = 0;
+        if (PyFloat_CheckExact(op)) {
+            if ((ok = dtype->type_num == NPY_FLOAT64)) {
+                data = (void *)&(((PyFloatObject *)op)->ob_fval);
+            }
+        }
+        else if (is_anyscalar_exact(op)) {
+            if ((ok = _typenum_fromtypeobj((PyObject *)Py_TYPE(op), 0)
+                      == dtype->type_num)) {
+                data = scalar_value(op, dtype);
+            }
+        }
+        if (ok) {
+            Py_INCREF(dtype);
+            ret = (PyArrayObject *)PyArray_NewFromDescrAndBase(
+                &PyArray_Type, dtype, 0, NULL, NULL,
+                data, flags, NULL, op);
+            goto cleanup;
+        }
+    }
+
     /* Got the correct parameters, but the cache may already hold the result */
     if (cache != NULL && !(cache->sequence)) {
         /*
@@ -2389,7 +2428,7 @@ PyArray_FromInterface(PyObject *origin)
         goto fail;
     }
     if (use_scalar_assign) {
-        /* 
+        /*
          * NOTE(seberg): I honestly doubt anyone is using this scalar path and we
          * could probably just deprecate (or just remove it in a 3.0 version).
          */

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1660,10 +1660,13 @@ _array_fromobject_generic(
     }
 
     if (copy == NPY_COPY_ALWAYS) {
-        flags = NPY_ARRAY_ENSURECOPY;
+        flags = NPY_ARRAY_ENSURECOPY | NPY_ARRAY_FORCECAST;
     }
     else if (copy == NPY_COPY_NEVER) {
         flags = NPY_ARRAY_ENSURENOCOPY;
+    }
+    else {
+        flags = NPY_ARRAY_FORCECAST;
     }
     if (order == NPY_CORDER) {
         flags |= NPY_ARRAY_C_CONTIGUOUS;
@@ -1677,8 +1680,6 @@ _array_fromobject_generic(
     if (!subok) {
         flags |= NPY_ARRAY_ENSUREARRAY;
     }
-
-    flags |= NPY_ARRAY_FORCECAST;
 
     ret = (PyArrayObject *)PyArray_CheckFromAny_int(
             op, dtype, in_DType, 0, ndmax, flags, NULL);

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -752,11 +752,11 @@ def test_iter_flags_errors():
     assert_raises(ValueError, nditer, a,
                 [], [['readonly', 'writeonly', 'readwrite']])
     # Python scalars are always readonly
-    assert_raises(TypeError, nditer, 1.5, [], [['writeonly']])
-    assert_raises(TypeError, nditer, 1.5, [], [['readwrite']])
+    assert_raises(ValueError, nditer, 1.5, [], [['writeonly']])
+    assert_raises(ValueError, nditer, 1.5, [], [['readwrite']])
     # Array scalars are always readonly
-    assert_raises(TypeError, nditer, np.int32(1), [], [['writeonly']])
-    assert_raises(TypeError, nditer, np.int32(1), [], [['readwrite']])
+    assert_raises(ValueError, nditer, np.int32(1), [], [['writeonly']])
+    assert_raises(ValueError, nditer, np.int32(1), [], [['readwrite']])
     # Check readonly array
     a.flags.writeable = False
     assert_raises(ValueError, nditer, a, [], [['writeonly']])
@@ -1034,9 +1034,9 @@ def test_iter_scalar_cast_errors():
     # Check that invalid casts are caught
 
     # Need to allow copying/buffering for write casts of scalars to occur
-    assert_raises(TypeError, nditer, np.float32(2), [],
+    assert_raises(ValueError, nditer, np.float32(2), [],
                 [['readwrite']], op_dtypes=[np.dtype('f8')])
-    assert_raises(TypeError, nditer, 2.5, [],
+    assert_raises(ValueError, nditer, 2.5, [],
                 [['readwrite']], op_dtypes=[np.dtype('f4')])
     # 'f8' -> 'f4' isn't a safe cast if the value would overflow
     assert_raises(TypeError, nditer, np.float64(1e60), [],


### PR DESCRIPTION
In ufuncs in particular, a bottleneck for dealing with scalars is turning them into arrays.  This PR adds a short-cut for those classes in PyArray_FromAny, where if the array is not specifically requested to be writeable, a readable view of the scalar is returned.  For python scalars, only float is supported; int and complex are more tricky (strings and bytes should presumably be possible, but I didn't add them yet).

Timings:
```                                                                                                                                         
a = np.float64(1.5)                                                                                                                         
%timeit np.array(a, copy=False)  # Comparing with copy=True on main.                                                                        
167->110 ns for float64, 94 ns for float                                                                                                    
%timeit np.add(a, a)                                                                                                                        
512->431 ns for float64,                                                                                                                    
                                                                                                                                            
a = 1.5                                                                                                                                     
%timeit np.array(a, copy=False)  # Comparing with copy=True on main.                                                                        
167->110 ns for float64, 94 ns for float                                                                                                    
%timeit np.add(a, a)                                                                                                                        
526->414 ns                                                                                                                                 
```                                                                                                                                         
An annoyance is that quite a bit of code relies on `np.asanyarray(scalar)` to return a writeable array.  As implemented, this is ensured by checking the `PyArray_FORCECAST` flag, which can be safely unset for `copy=False`. As a result, however, some of the error messages change in nature. This could be resolved with a new flag, if needed. Alternatively, this whole machinery could just be moved to `convert_ufunc_arguments`, since those arguably benefit most from this.
