### PR TITLE
BUG: Fix repr of polynomial for non-standard dtypes

### DIFF
--- a/doc/release/upcoming_changes/29668.bug.rst
+++ b/doc/release/upcoming_changes/29668.bug.rst
@@ -1,0 +1,1 @@
+Fix ``__repr__`` for ``numpy.polynomial`` classes with non-standard dtypes.

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -320,12 +320,17 @@ class ABCPolyBase(abc.ABC):
         self._symbol = symbol
 
     def __repr__(self):
-        coef = repr(self.coef)[6:-1]
-        domain = repr(self.domain)[6:-1]
-        window = repr(self.window)[6:-1]
-        name = self.__class__.__name__
-        return (f"{name}({coef}, domain={domain}, window={window}, "
-                f"symbol='{self.symbol}')")
+        s_coef = repr(self.coef)
+        coef = s_coef[s_coef.find('['):s_coef.rfind(']')+1]
+
+        s_domain = repr(self.domain)
+        domain = s_domain[s_domain.find('['):s_domain.rfind(']')+1]
+
+        s_window = repr(self.window)
+        window = s_window[s_window.find('['):s_window.rfind(']')+1]
+
+        return (f"{self.__class__.__name__}({coef}, "
+            f"domain={domain}, window={window}, symbol='{self.symbol}')")
 
     def __format__(self, fmt_str):
         if fmt_str == '':

--- a/numpy/polynomial/_polybase.py
+++ b/numpy/polynomial/_polybase.py
@@ -321,13 +321,13 @@ class ABCPolyBase(abc.ABC):
 
     def __repr__(self):
         s_coef = repr(self.coef)
-        coef = s_coef[s_coef.find('['):s_coef.rfind(']')+1]
+        coef = s_coef[s_coef.find('['):s_coef.rfind(']') + 1]
 
         s_domain = repr(self.domain)
-        domain = s_domain[s_domain.find('['):s_domain.rfind(']')+1]
+        domain = s_domain[s_domain.find('['):s_domain.rfind(']') + 1]
 
         s_window = repr(self.window)
-        window = s_window[s_window.find('['):s_window.rfind(']')+1]
+        window = s_window[s_window.find('['):s_window.rfind(']') + 1]
 
         return (f"{self.__class__.__name__}({coef}, "
             f"domain={domain}, window={window}, symbol='{self.symbol}')")


### PR DESCRIPTION
Fixes #29668

**Problem:**

The `__repr__` method in `numpy.polynomial._polybase.ABCPolyBase` used fixed string slicing to format the `coef`, `domain`, and `window` arrays. This failed when a non-default `dtype` was present in the array's string representation, leading to an incorrect `repr`.

**Solution:**

This PR changes the implementation to robustly find the start `[` and end `]` brackets of the array's string representation. This correctly extracts the list of values regardless of whether a `dtype` is present, fixing the bug for non-standard dtypes while also preserving the correct output for default dtypes.