### PR TITLE
ENH, PERF: allocate memory as part of the array object for scalars

### DIFF
--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -2179,8 +2179,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
             PyDataMem_UserFREE(PyArray_DATA(self), n_tofree, handler);
             PyArray_CLEARFLAGS(self, NPY_ARRAY_OWNDATA);
         }
-        else if (PyArray_DATA(self) !=
-                 (void *)((char *)self + Py_TYPE(self)->tp_basicsize)) {
+        else if (!_PyArray_DATA_ON_INSTANCE(self)) {
             /*
              * Without a handler, data should be on the instance; if not,
              * someone arbitrarily set NPY_ARRAY_OWNDATA, so raise.

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -2169,7 +2169,8 @@ array_setstate(PyArrayObject *self, PyObject *args)
         }
     }
 
-    if ((PyArray_FLAGS(self) & NPY_ARRAY_OWNDATA)) {
+    if ((PyArray_FLAGS(self) & NPY_ARRAY_OWNDATA)
+        && PyArray_DATA(self) != (char *)self + Py_TYPE(self)->tp_basicsize) {
         /*
          * Allocation will never be 0, see comment in ctors.c
          * line 820

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -120,11 +120,10 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
                                            newnbytes == 0 ? 1 : newnbytes,
                                            handler);
         }
-        else if (PyArray_DATA(self) ==
-                 (void *)((char *)self + Py_TYPE(self)->tp_basicsize)) {
+        else if (_PyArray_DATA_ON_INSTANCE(self)) {
             /*
              * data was stored on instance, so has no reference.
-             * TODO: make this a plain else; see text in array_dealloc.
+             * TODO: make this a plain else; see comment in array_dealloc.
              */
             if (newnbytes <= oldnbytes) {
                 new_data = PyArray_DATA(self);

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6172,6 +6172,16 @@ class TestResize:
                 np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]).flat)
         assert_array_equal(x[9:].flat, 0)
 
+    def test_scalar(self):
+        x = np.array(1.5)
+        if IS_PYPY:
+            x.resize((5, 5), refcheck=False)
+        else:
+            x.resize((5, 5))
+        expected = np.zeros((5, 5))
+        expected[0, 0] = 1.5
+        assert_array_equal(x, expected)
+
     def test_check_reference(self):
         x = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
         y = x


### PR DESCRIPTION
The overhead of allocating memory for array data becomes large when the inputs are scalars. So for those this PR allocates memory as part of the object using `tp_alloc`. (This solves the same problem #29876 aimed to solve, but arguably in a much nicer manner.)

EDIT: quite a bit of the changes are just changes in indentation, so may want to review ignoring that, via https://github.com/numpy/numpy/pull/29878/files?w=1

Timings
```
%timeit np.empty(())
112->67 ns  (custom py311: 89->61)

a = 1.6
%timeit np.array(a)
134->89 ns (custom py311: 105->79)

%timeit np.add(a, a)
527->413 ns (390 ns for np.float64); custom py311 459->370)
```

In principle, this could be trivially extended to doing this generally when the required amount of memory is small.

Notes/queries
- The above requires setting `tp_itemsize=1` for the array object, which means that always at least 1 extra byte gets allocated [1].  I verified that with the current struct, this does not increase the size of the object (it remains 96 bytes).  Alignment should be OK, since the last item on the current struct is a pointer.
- Given the change I had to make to `__setstate__`, it might be an idea to add a flag that tells whether the data is on the object. That avoids comparing pointers. Logically, one might want to use `mem_handler == NULL` for that, but apparently that is already assumed to mean the data was gotten with `malloc`. Maybe `mem_handler = `Py_None` is reasonable?

[1] https://github.com/python/cpython/blob/37d16f7f620d79af7db1c00c8d638122af889bf9/Objects/typeobject.c#L2490-L2497
