### PR TITLE
MAINT: Rewrite setitem to use the new API (mostly)

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -155,7 +155,7 @@ MyPyFloat_FromHalf(npy_half h)
 
 /*
  * Handle case of assigning from an array scalar in setitem.
- * NOTE/TODO(seberg): This was important, but is now only userd
+ * NOTE/TODO(seberg): This was important, but is now only used
  * for *nested* 0-D arrays which makes it dubious whether it should
  * remain used.
  * (At the point of writing, I did not want to worry about BC though.)
@@ -810,7 +810,7 @@ STRING_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
         Py_DECREF(temp);
         return -1;
     }
-    memcpy(ov, ptr, PyArray_MIN(descr->elsize,len));
+    memcpy(ov, ptr, PyArray_MIN(descr->elsize, len));
     /*
      * If string length is smaller than room in array
      * Then fill the rest of the element size with NULL

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -46,6 +46,20 @@
 #include "umathmodule.h"
 #include "npy_static_data.h"
 
+/**begin repeat
+ * #NAME = BOOL,
+ *         BYTE, UBYTE, SHORT, USHORT, INT, UINT,
+ *         LONG, ULONG, LONGLONG, ULONGLONG,
+ *         HALF, FLOAT, DOUBLE, LONGDOUBLE,
+ *         CFLOAT, CDOUBLE, CLONGDOUBLE,
+ *         DATETIME, TIMEDELTA#
+ */
+static inline void
+@NAME@_copyswap(void *dst, void *src, int swap, void *arr);
+
+/**end repeat**/
+
+
 /*
  * Define a stack allocated dummy array with only the minimum information set:
  *   1. The descr, the main field interesting here.
@@ -98,7 +112,7 @@ MyPyFloat_AsDouble(PyObject *obj)
     }
     num = PyNumber_Float(obj);
     if (num == NULL) {
-        return NPY_NAN;
+        return -1;
     }
     ret = PyFloat_AS_DOUBLE(num);
     Py_DECREF(num);
@@ -127,7 +141,7 @@ MyPyFloat_AsHalf(PyObject *obj)
     npy_half res = npy_double_to_half(d_val);
     if (NPY_UNLIKELY(npy_half_isinf(res) && !npy_isinf(d_val))) {
         if (PyUFunc_GiveFloatingpointErrors("cast", NPY_FPE_OVERFLOW) < 0) {
-            return npy_double_to_half(-1.);
+            return -1;  // exception return as integer
         }
     }
     return res;
@@ -139,10 +153,16 @@ MyPyFloat_FromHalf(npy_half h)
     return PyFloat_FromDouble(npy_half_to_double(h));
 }
 
-/* Handle case of assigning from an array scalar in setitem */
+/*
+ * Handle case of assigning from an array scalar in setitem.
+ * NOTE/TODO(seberg): This was important, but is now only userd
+ * for *nested* 0-D arrays which makes it dubious whether it should
+ * remain used.
+ * (At the point of writing, I did not want to worry about BC though.)
+ */
 static int
-convert_to_scalar_and_retry(PyObject *op, void *ov, void *vap,
-                      int (*setitem)(PyObject *op, void *ov, void *vap))
+convert_to_scalar_and_retry(PyArray_Descr *descr, PyObject *op, char *ov,
+                      int (*setitem)(PyArray_Descr *descr, PyObject *op, char *ov))
 {
     PyObject *temp;
 
@@ -153,7 +173,7 @@ convert_to_scalar_and_retry(PyObject *op, void *ov, void *vap,
         return -1;
     }
     else {
-        int res = setitem(temp, ov, vap);
+        int res = setitem(descr, temp, ov);
         Py_DECREF(temp);
         return res;
     }
@@ -326,9 +346,8 @@ static PyObject *
 }
 
 NPY_NO_EXPORT int
-@TYPE@_setitem(PyObject *op, void *ov, void *vap)
+@TYPE@_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
 {
-    PyArrayObject *ap = vap;
     @type@ temp;  /* ensures alignment */
 
 #if @is_int@
@@ -366,28 +385,23 @@ NPY_NO_EXPORT int
     }
     else {
         temp = (@type@)@func2@(op);
-    }
-    if (PyErr_Occurred()) {
-        PyObject *type, *value, *traceback;
-        PyErr_Fetch(&type, &value, &traceback);
-        if (PySequence_NoString_Check(op)) {
-            PyErr_SetString(PyExc_ValueError,
-                    "setting an array element with a sequence.");
-            npy_PyErr_ChainExceptionsCause(type, value, traceback);
+        if (temp == (@type@)-1 && PyErr_Occurred()) {
+            PyObject *type, *value, *traceback;
+            PyErr_Fetch(&type, &value, &traceback);
+            if (PySequence_NoString_Check(op)) {
+                PyErr_SetString(PyExc_ValueError,
+                        "setting an array element with a sequence.");
+                npy_PyErr_ChainExceptionsCause(type, value, traceback);
+            }
+            else {
+                PyErr_Restore(type, value, traceback);
+            }
+            return -1;
         }
-        else {
-            PyErr_Restore(type, value, traceback);
-        }
-        return -1;
     }
-    if (ap == NULL || PyArray_ISBEHAVED(ap)) {
-        assert(npy_is_aligned(ov, NPY_ALIGNOF(@type@)));
-        *((@type@ *)ov)=temp;
-    }
-    else {
-        PyDataType_GetArrFuncs(PyArray_DESCR(ap))->copyswap(ov, &temp, PyArray_ISBYTESWAPPED(ap),
-                                       ap);
-    }
+    // Support descr == NULL for some scalarmath paths.
+    @TYPE@_copyswap(
+        ov, &temp, descr != NULL && PyDataType_ISBYTESWAPPED(descr), NULL);
     return 0;
 }
 
@@ -433,18 +447,16 @@ static PyObject *
  * #suffix = f, , l#
  */
 NPY_NO_EXPORT int
-@NAME@_setitem(PyObject *op, void *ov, void *vap)
+@NAME@_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
 {
-    PyArrayObject *ap = vap;
     Py_complex oop;
     @type@ temp;
 
-    if (PyArray_IsZeroDim(op)) {
-        return convert_to_scalar_and_retry(op, ov, vap, @NAME@_setitem);
-    }
-
     if (PyArray_IsScalar(op, @kind@)){
         temp = PyArrayScalar_VAL(op, @kind@);
+    }
+    else if (PyArray_IsZeroDim(op)) {
+        return convert_to_scalar_and_retry(descr, op, ov, @NAME@_setitem);
     }
     else {
         if (op == Py_None) {
@@ -504,10 +516,8 @@ NPY_NO_EXPORT int
 #endif
     }
 
-    memcpy(ov, &temp, NPY_SIZEOF_@NAME@);
-    if (ap != NULL && PyArray_ISBYTESWAPPED(ap)) {
-        byte_swap_vector(ov, 2, sizeof(@ftype@));
-    }
+    @NAME@_copyswap(
+        ov, &temp, descr != NULL && PyDataType_ISBYTESWAPPED(descr), NULL);
     return 0;
 }
 
@@ -589,18 +599,16 @@ LONGDOUBLE_getitem(void *ip, void *ap)
 }
 
 NPY_NO_EXPORT int
-LONGDOUBLE_setitem(PyObject *op, void *ov, void *vap)
+LONGDOUBLE_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
 {
-    PyArrayObject *ap = vap;
     /* ensure alignment */
     npy_longdouble temp;
 
-    if (PyArray_IsZeroDim(op)) {
-        return convert_to_scalar_and_retry(op, ov, vap, LONGDOUBLE_setitem);
-    }
-
     if (PyArray_IsScalar(op, LongDouble)) {
         temp = PyArrayScalar_VAL(op, LongDouble);
+    }
+    else if (PyArray_IsZeroDim(op)) {
+        return convert_to_scalar_and_retry(descr, op, ov, LONGDOUBLE_setitem);
     }
     else {
         /* In case something funny happened in PyArray_IsScalar */
@@ -612,13 +620,9 @@ LONGDOUBLE_setitem(PyObject *op, void *ov, void *vap)
     if (PyErr_Occurred()) {
         return -1;
     }
-    if (ap == NULL || PyArray_ISBEHAVED(ap)) {
-        *((npy_longdouble *)ov) = temp;
-    }
-    else {
-        copy_and_swap(ov, &temp, PyArray_ITEMSIZE(ap), 1, 0,
-                      PyArray_ISBYTESWAPPED(ap));
-    }
+    // Support descr == NULL for scalarmath paths
+    LONGDOUBLE_copyswap(
+        ov, &temp, descr != NULL && PyDataType_ISBYTESWAPPED(descr), NULL);
     return 0;
 }
 
@@ -664,12 +668,10 @@ UNICODE_getitem(void *ip, void *vap)
 }
 
 static int
-UNICODE_setitem(PyObject *op, void *ov, void *vap)
+UNICODE_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
 {
-    PyArrayObject *ap = vap;
-
     if (PyArray_IsZeroDim(op)) {
-        return convert_to_scalar_and_retry(op, ov, vap, UNICODE_setitem);
+        return convert_to_scalar_and_retry(descr, op, ov, UNICODE_setitem);
     }
 
     if (PySequence_NoString_Check(op)) {
@@ -691,7 +693,7 @@ UNICODE_setitem(PyObject *op, void *ov, void *vap)
     }
 
     /* truncate if needed */
-    Py_ssize_t max_len = PyArray_ITEMSIZE(ap) >> 2;
+    Py_ssize_t max_len = descr->elsize >> 2;
     Py_ssize_t actual_len = PyUnicode_GetLength(temp);
     if (actual_len < 0) {
         Py_DECREF(temp);
@@ -708,7 +710,8 @@ UNICODE_setitem(PyObject *op, void *ov, void *vap)
     Py_ssize_t num_bytes = actual_len * 4;
 
     char *buffer;
-    if (!PyArray_ISALIGNED(ap)) {
+    int aligned = npy_is_aligned(ov, NPY_ALIGNOF(Py_UCS4));
+    if (!aligned) {
         buffer = PyArray_malloc(num_bytes);
         if (buffer == NULL) {
             Py_DECREF(temp);
@@ -725,16 +728,16 @@ UNICODE_setitem(PyObject *op, void *ov, void *vap)
         return -1;
     }
 
-    if (!PyArray_ISALIGNED(ap)) {
+    if (!aligned) {
         memcpy(ov, buffer, num_bytes);
         PyArray_free(buffer);
     }
 
     /* Fill in the rest of the space with 0 */
-    if (PyArray_ITEMSIZE(ap) > num_bytes) {
-        memset((char*)ov + num_bytes, 0, (PyArray_ITEMSIZE(ap) - num_bytes));
+    if (descr->elsize > num_bytes) {
+        memset((char*)ov + num_bytes, 0, (descr->elsize - num_bytes));
     }
-    if (PyArray_ISBYTESWAPPED(ap)) {
+    if (PyDataType_ISBYTESWAPPED(descr)) {
         byte_swap_vector(ov, actual_len, 4);
     }
     Py_DECREF(temp);
@@ -762,15 +765,14 @@ STRING_getitem(void *ip, void *vap)
 }
 
 static int
-STRING_setitem(PyObject *op, void *ov, void *vap)
+STRING_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
 {
-    PyArrayObject *ap = vap;
     char *ptr;
     Py_ssize_t len;
     PyObject *temp = NULL;
 
     if (PyArray_IsZeroDim(op)) {
-        return convert_to_scalar_and_retry(op, ov, vap, STRING_setitem);
+        return convert_to_scalar_and_retry(descr, op, ov, STRING_setitem);
     }
 
     if (PySequence_NoString_Check(op)) {
@@ -808,13 +810,13 @@ STRING_setitem(PyObject *op, void *ov, void *vap)
         Py_DECREF(temp);
         return -1;
     }
-    memcpy(ov, ptr, PyArray_MIN(PyArray_ITEMSIZE(ap),len));
+    memcpy(ov, ptr, PyArray_MIN(descr->elsize,len));
     /*
      * If string length is smaller than room in array
      * Then fill the rest of the element size with NULL
      */
-    if (PyArray_ITEMSIZE(ap) > len) {
-        memset((char *)ov + len, 0, (PyArray_ITEMSIZE(ap) - len));
+    if (descr->elsize > len) {
+        memset((char *)ov + len, 0, (descr->elsize - len));
     }
     Py_DECREF(temp);
     return 0;
@@ -841,7 +843,7 @@ OBJECT_getitem(void *ip, void *NPY_UNUSED(ap))
 
 
 static int
-OBJECT_setitem(PyObject *op, void *ov, void *NPY_UNUSED(ap))
+OBJECT_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
 {
     PyObject *obj;
 
@@ -867,11 +869,9 @@ VOID_getitem(void *input, void *vap)
     _PyArray_LegacyDescr *descr = (_PyArray_LegacyDescr *)PyArray_DESCR(vap);
 
     if (PyDataType_HASFIELDS(descr)) {
-        PyObject *key;
         PyObject *names;
         int i, n;
         PyObject *ret;
-        PyObject *tup;
         PyArrayObject_fields dummy_fields = get_dummy_stack_array(ap);
         PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
 
@@ -882,9 +882,7 @@ VOID_getitem(void *input, void *vap)
         for (i = 0; i < n; i++) {
             npy_intp offset;
             PyArray_Descr *new;
-            key = PyTuple_GET_ITEM(names, i);
-            tup = PyDict_GetItem(descr->fields, key); // noqa: borrowed-ref OK
-            if (_unpack_field(tup, &new, &offset) < 0) {
+            if (_unpack_field_index(descr, i, &new, &offset) < 0) {
                 Py_DECREF(ret);
                 return NULL;
             }
@@ -969,14 +967,10 @@ NPY_NO_EXPORT int
 _setup_field(int i, _PyArray_LegacyDescr *descr, PyArrayObject *arr,
             npy_intp *offset_p, char *dstdata)
 {
-    PyObject *key;
-    PyObject *tup;
     PyArray_Descr *new;
     npy_intp offset;
 
-    key = PyTuple_GET_ITEM(descr->names, i);
-    tup = PyDict_GetItem(descr->fields, key); // noqa: borrowed-ref OK
-    if (_unpack_field(tup, &new, &offset) < 0) {
+    if (_unpack_field_index(descr, i, &new, &offset) < 0) {
         return -1;
     }
 
@@ -1029,18 +1023,17 @@ _copy_and_return_void_setitem(_PyArray_LegacyDescr *dstdescr, char *dstdata,
 }
 
 static int
-VOID_setitem(PyObject *op, void *input, void *vap)
+VOID_setitem(PyArray_Descr *descr_, PyObject *op, char *ip)
 {
-    char *ip = input;
-    PyArrayObject *ap = vap;
-    int itemsize = PyArray_ITEMSIZE(ap);
+    _PyArray_LegacyDescr *descr = (_PyArray_LegacyDescr *)descr_;
+    int itemsize = descr->elsize;
     int res;
-    _PyArray_LegacyDescr *descr = (_PyArray_LegacyDescr *)PyArray_DESCR(ap);
 
     if (PyDataType_HASFIELDS(descr)) {
         PyObject *errmsg;
         npy_int i;
         npy_intp offset;
+        PyArray_Descr *field_descr;
         int failed = 0;
 
         /* If op is 0d-ndarray or numpy scalar, directly get dtype & data ptr */
@@ -1073,23 +1066,18 @@ VOID_setitem(PyObject *op, void *input, void *vap)
                 return -1;
             }
 
-            PyArrayObject_fields dummy_fields = get_dummy_stack_array(ap);
-            PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
-
             for (i = 0; i < names_size; i++) {
-                PyObject *item;
-
-                if (_setup_field(i, descr, dummy_arr, &offset, ip) == -1) {
-                    failed = 1;
-                    break;
-                }
-                item = PyTuple_GetItem(op, i);
+                PyObject *item = PyTuple_GetItem(op, i);
                 if (item == NULL) {
                     failed = 1;
                     break;
                 }
+                if (_unpack_field_index(descr, i, &field_descr, &offset) < 0) {
+                    failed = 1;
+                    break;
+                }
                 /* use setitem to set this field */
-                if (PyArray_SETITEM(dummy_arr, ip + offset, item) < 0) {
+                if (NPY_DT_CALL_setitem(field_descr, item, ip + offset) < 0) {
                     failed = 1;
                     break;
                 }
@@ -1099,17 +1087,13 @@ VOID_setitem(PyObject *op, void *input, void *vap)
             /* Otherwise must be non-void scalar. Try to assign to each field */
             npy_intp names_size = PyTuple_GET_SIZE(descr->names);
 
-            PyArrayObject_fields dummy_fields = get_dummy_stack_array(ap);
-            PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
-
             for (i = 0; i < names_size; i++) {
-                /* temporarily make ap have only this field */
-                if (_setup_field(i, descr, dummy_arr, &offset, ip) == -1) {
+                if (_unpack_field_index(descr, i, &field_descr, &offset) < 0) {
                     failed = 1;
                     break;
                 }
                 /* use setitem to set this field */
-                if (PyArray_SETITEM(dummy_arr, ip + offset, op) < 0) {
+                if (NPY_DT_CALL_setitem(field_descr, op, ip + offset) < 0) {
                     failed = 1;
                     break;
                 }
@@ -1139,7 +1123,7 @@ VOID_setitem(PyObject *op, void *input, void *vap)
         PyArrayObject *ret = (PyArrayObject *)PyArray_NewFromDescrAndBase(
                 &PyArray_Type, descr->subarray->base,
                 shape.len, shape.ptr, NULL, ip,
-                PyArray_FLAGS(ap), NULL, NULL);
+                NPY_ARRAY_WRITEABLE, NULL, NULL);
         npy_free_cache_dim_obj(shape);
         if (!ret) {
             return -1;
@@ -1217,15 +1201,14 @@ TIMEDELTA_getitem(void *ip, void *vap)
 }
 
 static int
-DATETIME_setitem(PyObject *op, void *ov, void *vap)
+DATETIME_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
 {
-    PyArrayObject *ap = vap;
     /* ensure alignment */
     npy_datetime temp = 0;
     PyArray_DatetimeMetaData *meta = NULL;
 
     /* Get the datetime units metadata */
-    meta = get_datetime_metadata_from_dtype(PyArray_DESCR(ap));
+    meta = get_datetime_metadata_from_dtype(descr);
     if (meta == NULL) {
         return -1;
     }
@@ -1237,27 +1220,20 @@ DATETIME_setitem(PyObject *op, void *ov, void *vap)
     }
 
     /* Copy the value into the output */
-    if (ap == NULL || PyArray_ISBEHAVED(ap)) {
-        *((npy_datetime *)ov)=temp;
-    }
-    else {
-        PyDataType_GetArrFuncs(PyArray_DESCR(ap))->copyswap(ov, &temp, PyArray_ISBYTESWAPPED(ap),
-                                       ap);
-    }
-
+    DATETIME_copyswap(
+        ov, &temp, descr != NULL && PyDataType_ISBYTESWAPPED(descr), NULL);
     return 0;
 }
 
 static int
-TIMEDELTA_setitem(PyObject *op, void *ov, void *vap)
+TIMEDELTA_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
 {
-    PyArrayObject *ap = vap;
     /* ensure alignment */
     npy_timedelta temp = 0;
     PyArray_DatetimeMetaData *meta = NULL;
 
     /* Get the datetime units metadata */
-    meta = get_datetime_metadata_from_dtype(PyArray_DESCR(ap));
+    meta = get_datetime_metadata_from_dtype(descr);
     if (meta == NULL) {
         return -1;
     }
@@ -1268,17 +1244,37 @@ TIMEDELTA_setitem(PyObject *op, void *ov, void *vap)
         return -1;
     }
 
-    /* Copy the value into the output */
-    if (ap == NULL || PyArray_ISBEHAVED(ap)) {
-        *((npy_timedelta *)ov)=temp;
-    }
-    else {
-        PyDataType_GetArrFuncs(PyArray_DESCR(ap))->copyswap(ov, &temp, PyArray_ISBYTESWAPPED(ap),
-                                       ap);
-    }
-
+    TIMEDELTA_copyswap(
+        ov, &temp, descr != NULL && PyDataType_ISBYTESWAPPED(descr), NULL);
     return 0;
 }
+
+
+/**begin repeat
+ *
+ * #NAME = BOOL,
+ *         BYTE, UBYTE, SHORT, USHORT, INT, UINT,
+ *         LONG, ULONG, LONGLONG, ULONGLONG,
+ *         HALF, FLOAT, DOUBLE, LONGDOUBLE,
+ *         CFLOAT, CDOUBLE, CLONGDOUBLE,
+ *         OBJECT, STRING, UNICODE, VOID,
+ *         DATETIME, TIMEDELTA#
+ */
+
+/*
+ * Legacy fallback setitem, should be deprecated, but if anyone calls
+ * our setitem *without* an array (or stealing it for their dtype)
+ * they might need it. E.g. a NumPy 3 should probably just dump it all, though.
+ */
+static int
+@NAME@_legacy_setitem(PyObject *value, void *data, void *vap)
+{
+    // Most builtins allow descr to be NULL traditionally, so assume it's OK
+    PyArray_Descr *descr = vap == NULL ? NULL : PyArray_DESCR((PyArrayObject *)vap);
+    return @NAME@_setitem(descr, value, data);
+}
+
+/**end repeat**/
 
 
 /*
@@ -1536,7 +1532,7 @@ static void
         if (temp == NULL) {
             return;
         }
-        if (@to@_setitem(temp, op, aop)) {
+        if (@to@_setitem(PyArray_DESCR(aop), temp, (char *)op)) {
             Py_DECREF(temp);
             return;
         }
@@ -1584,7 +1580,7 @@ static void
             Py_INCREF(Py_False);
             temp = Py_False;
         }
-        if (@to@_setitem(temp, op, aop)) {
+        if (@to@_setitem(PyArray_DESCR(aop), temp, (char *)op)) {
             Py_DECREF(temp);
             return;
         }
@@ -1949,7 +1945,7 @@ _basic_copy(void *dst, void *src, int elsize) {
  *         npy_half, npy_float, npy_double, npy_longdouble,
  *         npy_datetime, npy_timedelta#
  */
-static void
+static inline void
 @fname@_copyswapn (void *dst, npy_intp dstride, void *src, npy_intp sstride,
                    npy_intp n, int swap, void *NPY_UNUSED(arr))
 {
@@ -1960,7 +1956,7 @@ static void
     }
 }
 
-static void
+static inline void
 @fname@_copyswap (void *dst, void *src, int swap, void *NPY_UNUSED(arr))
 {
     /* copy first if needed */
@@ -2042,7 +2038,7 @@ static void
     /* ignore swap */
 }
 
-static void
+static inline void
 @fname@_copyswap (void *dst, void *src, int NPY_UNUSED(swap),
         void *NPY_UNUSED(arr))
 {
@@ -2075,7 +2071,7 @@ static void
     }
 }
 
-static void
+static inline void
 @fname@_copyswap (void *dst, void *src, int swap, void *NPY_UNUSED(arr))
 {
     /* copy first if needed */
@@ -2220,7 +2216,7 @@ OBJECT_copyswapn(PyObject **dst, npy_intp dstride, PyObject **src,
     return;
 }
 
-static void
+static inline void
 OBJECT_copyswap(PyObject **dst, PyObject **src, int NPY_UNUSED(swap),
         void *NPY_UNUSED(arr))
 {
@@ -2451,7 +2447,7 @@ UNICODE_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
 }
 
 
-static void
+static inline void
 STRING_copyswap(char *dst, char *src, int NPY_UNUSED(swap), PyArrayObject *arr)
 {
     assert(arr != NULL);
@@ -2462,7 +2458,7 @@ STRING_copyswap(char *dst, char *src, int NPY_UNUSED(swap), PyArrayObject *arr)
     _basic_copy(dst, src, PyArray_ITEMSIZE(arr));
 }
 
-static void
+static inline void
 UNICODE_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
 {
     int itemsize;
@@ -3018,9 +3014,8 @@ UNICODE_compare(npy_ucs4 *ip1, npy_ucs4 *ip2,
 static int
 VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
 {
-    PyArray_Descr *descr;
-    PyObject *names, *key;
-    PyObject *tup;
+    _PyArray_LegacyDescr *descr;
+    PyObject *names;
     PyArrayObject_fields dummy_struct;
     PyArrayObject *dummy = (PyArrayObject *)&dummy_struct;
     char *nip1, *nip2;
@@ -3033,18 +3028,16 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
     if (mem_handler == NULL) {
         goto finish;
     }
-    descr = PyArray_DESCR(ap);
+    descr = (_PyArray_LegacyDescr *)PyArray_DESCR(ap);
     /*
      * Compare on the first-field.  If equal, then
      * compare on the second-field, etc.
      */
-    names = PyDataType_NAMES(descr);
+    names = descr->names;
     for (i = 0; i < PyTuple_GET_SIZE(names); i++) {
         PyArray_Descr *new;
         npy_intp offset;
-        key = PyTuple_GET_ITEM(names, i);
-        tup = PyDict_GetItem(PyDataType_FIELDS(descr), key); // noqa: borrowed-ref OK
-        if (_unpack_field(tup, &new, &offset) < 0) {
+        if (_unpack_field_index(descr, i, &new, &offset) < 0) {
             goto finish;
         }
         /* Set the fields needed by compare or copyswap */
@@ -4029,7 +4022,7 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
         @from@_to_VOID
     },
     @from@_getitem,
-    @from@_setitem,
+    @from@_legacy_setitem,
     (PyArray_CopySwapNFunc*)@from@_copyswapn,
     (PyArray_CopySwapFunc*)@from@_copyswap,
     (PyArray_CompareFunc*)@from@_compare,
@@ -4148,7 +4141,7 @@ static PyArray_ArrFuncs _Py@NAME@_ArrFuncs = {
         @from@_to_VOID
     },
     @from@_getitem,
-    @from@_setitem,
+    @from@_legacy_setitem,
     (PyArray_CopySwapNFunc*)@from@_copyswapn,
     (PyArray_CopySwapFunc*)@from@_copyswap,
     (PyArray_CompareFunc*)@from@_compare,
@@ -4594,6 +4587,7 @@ set_typeinfo(PyObject *dict)
     if (dtypemeta == NULL) {
         return -1;
     }
+    NPY_DT_SLOTS(dtypemeta)->setitem = @NAME@_setitem;
     NPY_DT_SLOTS(dtypemeta)->get_constant = @NAME@_get_constant;
 
     /**end repeat**/

--- a/numpy/_core/src/multiarray/arraytypes.h.src
+++ b/numpy/_core/src/multiarray/arraytypes.h.src
@@ -44,7 +44,7 @@ small_correlate(const char * d_, npy_intp dstride,
  */
 
 NPY_NO_EXPORT int
-@TYPE@_setitem(PyObject *obj, void *data_ptr, void *arr);
+@TYPE@_setitem(PyArray_Descr *descr, PyObject *obj, char *data_ptr);
 
 /**end repeat**/
 

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -328,6 +328,30 @@ _unpack_field(PyObject *value, PyArray_Descr **descr, npy_intp *offset)
     return 0;
 }
 
+
+/**
+ * Unpack a field from a structured dtype. The field index must be valid.
+ *
+ * @param descr The dtype to unpack.
+ * @param index The index of the field to unpack.
+ * @param odescr will be set to the field's dtype
+ * @param offset will be set to the field's offset
+ *
+ * @return -1 on failure, 0 on success.
+ */
+ NPY_NO_EXPORT int
+ _unpack_field_index(
+    _PyArray_LegacyDescr *descr,
+    npy_intp index,
+    PyArray_Descr **odescr,
+    npy_intp *offset)
+ {
+    PyObject *key = PyTuple_GET_ITEM(descr->names, index);
+    PyObject *tup = PyDict_GetItem(descr->fields, key);  // noqa: borrowed-ref OK
+    return _unpack_field(tup, odescr, offset);
+ }
+
+
 /*
  * check whether arrays with datatype dtype might have object fields. This will
  * only happen for structured dtypes (which may have hidden objects even if the

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -65,11 +65,22 @@ convert_shape_to_string(npy_intp n, npy_intp const *vals, char *ending);
 NPY_NO_EXPORT void
 dot_alignment_error(PyArrayObject *a, int i, PyArrayObject *b, int j);
 
+
 /**
  * unpack tuple of PyDataType_FIELDS(dtype) (descr, offset, title[not-needed])
  */
 NPY_NO_EXPORT int
 _unpack_field(PyObject *value, PyArray_Descr **descr, npy_intp *offset);
+
+/**
+ * Unpack a field from a structured dtype by index.
+ */
+NPY_NO_EXPORT int
+_unpack_field_index(
+   _PyArray_LegacyDescr *descr,
+   npy_intp index,
+   PyArray_Descr **odescr,
+   npy_intp *offset);
 
 /*
  * check whether arrays with datatype dtype might have object fields. This will

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -288,8 +288,7 @@ PyArray_GETITEM(const PyArrayObject *arr, const char *itemptr)
 static inline int
 PyArray_SETITEM(PyArrayObject *arr, char *itemptr, PyObject *v)
 {
-    return PyDataType_GetArrFuncs(((PyArrayObject_fields *)arr)->descr)->setitem(
-            v, itemptr, arr);
+    return NPY_DT_CALL_setitem(PyArray_DESCR(arr), v, itemptr);
 }
 
 // Like PyArray_DESCR_REPLACE, but calls ensure_canonical instead of DescrNew

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -519,15 +519,10 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
         if (buff == NULL) {
             return PyErr_NoMemory();
         }
-        /* copyswap needs an array object, but only actually cares about the
-         * dtype
-         */
-        PyArrayObject_fields dummy_arr;
-        if (base == NULL) {
-            dummy_arr.descr = descr;
-            base = (PyObject *)&dummy_arr;
+        memcpy(buff, data, itemsize);
+        if (swap) {
+            byte_swap_vector(buff, itemsize / 4, 4);
         }
-        copyswap(buff, data, swap, base);
 
         /* truncation occurs here */
         PyObject *u = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, buff, itemsize / 4);

--- a/numpy/_core/src/umath/_scaled_float_dtype.c
+++ b/numpy/_core/src/umath/_scaled_float_dtype.c
@@ -107,7 +107,7 @@ sfloat_getitem(char *data, PyArrayObject *arr)
 
 
 static int
-sfloat_setitem(PyObject *obj, char *data, PyArrayObject *arr)
+sfloat_setitem(PyArray_Descr *descr_, PyObject *obj, char *data)
 {
     if (!PyFloat_CheckExact(obj)) {
         PyErr_SetString(PyExc_NotImplementedError,
@@ -115,7 +115,7 @@ sfloat_setitem(PyObject *obj, char *data, PyArrayObject *arr)
         return -1;
     }
 
-    PyArray_SFloatDescr *descr = (PyArray_SFloatDescr *)PyArray_DESCR(arr);
+    PyArray_SFloatDescr *descr = (PyArray_SFloatDescr *)descr_;
     double value = PyFloat_AsDouble(obj);
     value /= descr->scaling;
 
@@ -131,9 +131,10 @@ NPY_DType_Slots sfloat_slots = {
     .default_descr = &sfloat_default_descr,
     .common_dtype = &sfloat_common_dtype,
     .common_instance = &sfloat_common_instance,
+    .setitem = &sfloat_setitem,
     .f = {
         .getitem = (PyArray_GetItemFunc *)&sfloat_getitem,
-        .setitem = (PyArray_SetItemFunc *)&sfloat_setitem,
+        .setitem = NULL,
     }
 };
 

--- a/numpy/_core/src/umath/scalarmath.c.src
+++ b/numpy/_core/src/umath/scalarmath.c.src
@@ -1242,7 +1242,7 @@ static PyObject *
              */
             return PyGenericArrType_Type.tp_as_number->nb_@oper@(a,b);
         case CONVERT_PYSCALAR:
-            if (@NAME@_setitem(other, (char *)&other_val, NULL) < 0) {
+            if (@NAME@_setitem(NULL, other, (char *)&other_val) < 0) {
                 return NULL;
             }
             break;
@@ -1393,7 +1393,7 @@ static PyObject *
             return PyGenericArrType_Type.tp_as_number->nb_true_divide(a,b);
         case CONVERT_PYSCALAR:
             /* This is the special behavior, convert to float64 directly */
-            if (DOUBLE_setitem(other, (char *)&other_val, NULL) < 0) {
+            if (DOUBLE_setitem(NULL, other, (char *)&other_val) < 0) {
                 return NULL;
             }
             break;
@@ -1512,7 +1512,7 @@ static PyObject *
         case PROMOTION_REQUIRED:
             return PyGenericArrType_Type.tp_as_number->nb_power(a, b, modulo);
         case CONVERT_PYSCALAR:
-            if (@NAME@_setitem(other, (char *)&other_val, NULL) < 0) {
+            if (@NAME@_setitem(NULL, other, (char *)&other_val) < 0) {
                 return NULL;
             }
             break;
@@ -1920,7 +1920,7 @@ static PyObject*
         case PROMOTION_REQUIRED:
             return PyGenericArrType_Type.tp_richcompare(self, other, cmp_op);
         case CONVERT_PYSCALAR:
-            if (@NAME@_setitem(other, (char *)&arg2, NULL) < 0) {
+            if (@NAME@_setitem(NULL, other, (char *)&arg2) < 0) {
                 return NULL;
             }
             break;

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -266,11 +266,6 @@ class TestScalarDiscovery:
             # Ensure we have a full-precision number if available
             scalar = type(scalar)((scalar * 2)**0.5)
 
-        if type(scalar) is rational:
-            # Rational generally fails due to a missing cast. In the future
-            # object casts should automatically be defined based on `setitem`.
-            pytest.xfail("Rational to object cast is undefined currently.")
-
         # Use casting from object:
         arr = np.array(scalar, dtype=object).astype(scalar.dtype)
 


### PR DESCRIPTION
This has a mild speed advantage since `PyArray_Pack` had this hack in place to ensure that we have an "array" to pass on.  This hack is now only used in extreme cases (i.e. user dtypes).

This gives a very slight speed advantage, but mostly, I like to change this.

It would be nice to change `getitem` as well, but `getitem` is trickier due to structured dtypes.

I wanted to first just remove `->setitem` but one (brutal!) test failed and I reconsidered things thinking that someone might be using `descr->setitem` without an array which would be broken without keeping an explicit definition around.

The 0-D unpacking path should be unimportant these days (it only applies to _nested_ arrays so the tests don't even notice it) but I kept it around for now anyway.


EDIT: It would be good to do the same thing for `_getitem` but it needs some thought and probably a second `_getitem` version that supports a `base` "owning" object...