### PR TITLE
DOC: Add note on meson buildtype for debug builds

### DIFF
--- a/doc/source/dev/development_advanced_debugging.rst
+++ b/doc/source/dev/development_advanced_debugging.rst
@@ -244,6 +244,25 @@ The ``spin`` `development workflow tool
 <https://github.com/scientific-python/spin>`_. has built-in support for working
 with both ``gdb`` and ``lldb`` via the ``spin gdb`` and ``spin lldb`` commands.
 
+.. note::
+
+   Building with ``-Dbuildtype=debug`` has a couple of important effects to
+   be aware of:
+
+   * **Assertions are enabled**: This build type does not define the ``NDEBUG``
+     macro, which means that any C-level assertions in the code will be
+     active. This is very useful for debugging, as it can help pinpoint
+     where an unexpected condition occurs.
+
+   * **Compiler flags may need overriding**: Some compiler toolchains,
+     particularly those from ``conda-forge``, may set optimization flags
+     like ``-O2`` by default. These can override the ``debug`` build type.
+     To ensure a true debug build in such environments, you may need to
+     manually unset or override this flag.
+
+   For more details on both points, see the `meson-python guide on
+   debug builds <https://mesonbuild.com/meson-python/how-to-guides/debug-builds.html>`_.
+
 For both debuggers, it's advisable to build NumPy in either the ``debug`` or
 ``debugoptimized`` meson build profile. To use ``debug`` you can pass the option
 via ``spin build``:


### PR DESCRIPTION
Closes #29826.

Updates the "Building With Debug Symbols" documentation by including important nuances, as suggested by @lucascolley.

The main changes are:
* Added a note explaining that `debug` builds enable C-level assertions, making it helpful for debugging.
* Warning users that some toolchains (like `conda-forge`) may require manually overriding default optimization flags to get a true debug build.
* Includes a link to the `meson-python` guide for more detailed information.