### PR TITLE
BUG: Fix INT_MIN % -1 to return 0 for all signed integer types

### DIFF
--- a/numpy/_core/src/umath/loops_modulo.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_modulo.dispatch.c.src
@@ -490,7 +490,6 @@ vsx4_simd_@func@_by_scalar_contig_@sfx@(char **args, npy_intp len)
 #else /* fmod and remainder */
     for (; len > 0; --len, ++src1, ++dst1) {
         const npyv_lanetype_@sfx@ a = *src1;
-        /* Fix PPC64LE: INT_MIN % -1 should be 0, not INT_MIN */
         if (NPY_UNLIKELY(a == NPY_MIN_INT@len@ && scalar == -1)) {
             *dst1 = 0;
         } else {

--- a/numpy/_core/src/umath/loops_modulo.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_modulo.dispatch.c.src
@@ -490,12 +490,17 @@ vsx4_simd_@func@_by_scalar_contig_@sfx@(char **args, npy_intp len)
 #else /* fmod and remainder */
     for (; len > 0; --len, ++src1, ++dst1) {
         const npyv_lanetype_@sfx@ a = *src1;
-        *dst1 = a % scalar;
+        /* Fix PPC64LE: INT_MIN % -1 should be 0, not INT_MIN */
+        if (NPY_UNLIKELY(a == NPY_MIN_INT@len@ && scalar == -1)) {
+            *dst1 = 0;
+        } else {
+            *dst1 = a % scalar;
 #if @id@ == 1 /* remainder */
-        if (!((a > 0) == (scalar > 0) || *dst1 == 0)) {
-            *dst1 += scalar;
-        }
+            if (!((a > 0) == (scalar > 0) || *dst1 == 0)) {
+                *dst1 += scalar;
+            }
 #endif
+        }
     }
 #endif
     npyv_cleanup();


### PR DESCRIPTION
**Summary of changes**

- Explicitly handle the case INT_MIN % -1 in scalar tail loops for fmod and remainder kernels.

- Set the result to 0 to avoid undefined behavior and align with NumPy/Python expected semantics.

- Ensures portable, correct behavior across all architectures, including POWER10 (ppc64le).

**Background / Motivation**
On POWER10 systems, several SIMD tests were failing due to integer overflow when evaluating INT_MIN % -1, an undefined operation in C.
Python defines this operation to return 0, and this change updates NumPy’s low-level implementation to match that behavior.

**Issue Reference**
Fixes: [#29731](https://github.com/numpy/numpy/issues/29731) — [POWER10] SIMD tests failing with integer overflow (previously skipped)

cc: @seiko2plus @rgommers @ghatwala