### PR TITLE
BUG: Fixup float16 conversion error path and add tests

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -124,6 +124,9 @@ static float
 MyPyFloat_AsFloat(PyObject *obj)
 {
     double d_val = MyPyFloat_AsDouble(obj);
+    if (error_converting(d_val)) {
+        return -1;
+    }
     float res = (float)d_val;
     if (NPY_UNLIKELY(npy_isinf(res) && !npy_isinf(d_val))) {
         if (PyUFunc_GiveFloatingpointErrors("cast", NPY_FPE_OVERFLOW) < 0) {
@@ -138,6 +141,9 @@ static npy_half
 MyPyFloat_AsHalf(PyObject *obj)
 {
     double d_val = MyPyFloat_AsDouble(obj);
+    if (error_converting(d_val)) {
+        return -1;
+    }
     npy_half res = npy_double_to_half(d_val);
     if (NPY_UNLIKELY(npy_half_isinf(res) && !npy_isinf(d_val))) {
         if (PyUFunc_GiveFloatingpointErrors("cast", NPY_FPE_OVERFLOW) < 0) {

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -904,3 +904,24 @@ def test_empty_string():
     assert_array_equal(res, b"")
     assert res.shape == (2, 10)
     assert res.dtype == "S1"
+
+
+@pytest.mark.parametrize("dtype", ["S", "U", object])
+@pytest.mark.parametrize("res_dt,hug_val",
+    [("float16", "1e30"), ("float32", "1e200")])
+def test_string_to_float_coercion_errors(dtype, res_dt, hug_val):
+    # This test primarly tests setitem
+    val = np.array(["3M"], dtype=dtype)[0]  # use the scalar
+
+    with pytest.raises(ValueError):
+        np.array(val, dtype=res_dt)
+
+    val = np.array([hug_val], dtype=dtype)[0]  # use the scalar
+
+    with np.errstate(all="warn"):
+        with pytest.warns(RuntimeWarning):
+            np.array(val, dtype=res_dt)
+
+    with np.errstate(all="raise"):
+        with pytest.raises(FloatingPointError):
+            np.array(val, dtype=res_dt)

--- a/numpy/_core/tests/test_half.py
+++ b/numpy/_core/tests/test_half.py
@@ -93,6 +93,21 @@ class TestHalf:
         arr = np.ones(3, dtype=np.float16).astype(string_dt)
         assert arr.dtype == expected_dt
 
+    @pytest.mark.parametrize("dtype", ["S", "U", object])
+    def test_to_half_cast_error(self, dtype):
+        arr = np.array(["3M"], dtype=dtype)
+        with pytest.raises(ValueError):
+            arr.astype(np.float16)
+
+        arr = np.array(["23490349034"], dtype=dtype)
+        with np.errstate(all="warn"):
+            with pytest.warns(RuntimeWarning):
+                arr.astype(np.float16)
+
+        with np.errstate(all="raise"):
+            with pytest.raises(FloatingPointError):
+                arr.astype(np.float16)
+
     @pytest.mark.parametrize("string_dt", ["S", "U"])
     def test_half_conversion_from_string(self, string_dt):
         string = np.array("3.1416", dtype=string_dt)


### PR DESCRIPTION
I had modified the code to not purely rely on PyErr_Occurred() for error propagation, but missed this conversion call. This also applied to float conversions actually.

Closes gh-29896