### PR TITLE
ENH: Add registration for sorting loops using new ufunc convenience function

### DIFF
--- a/doc/release/upcoming_changes/29900.c_api.rst
+++ b/doc/release/upcoming_changes/29900.c_api.rst
@@ -1,0 +1,5 @@
+A new `PyUFunc_AddLoopsFromSpecs` convenience function has been added to the C API.
+-----------------------------------------------------------------------------------
+This function allows adding multiple ufunc loops from their specs in one call using
+a NULL-terminated array of `PyUFunc_LoopSlot` structs. It allows registering
+sorting and argsorting loops using the new ArrayMethod API.

--- a/doc/release/upcoming_changes/29900.new_feature.rst
+++ b/doc/release/upcoming_changes/29900.new_feature.rst
@@ -1,0 +1,9 @@
+DType sorting and argsorting supports the ArrayMethod API
+---------------------------------------------------------
+User-defined dtypes can now implement custom sorting and argsorting using
+the ArrayMethod API. This mechanism can be used in place of the `PyArray_ArrFuncs`
+slots which may be deprecated in the future.
+
+The sorting and argsorting methods are registered by passing the arraymethod
+specs that implement the operations to the new `PyUFunc_AddLoopsFromSpecs` function.
+See the ArrayMethod API documentation for details.

--- a/numpy/_core/code_generators/cversions.txt
+++ b/numpy/_core/code_generators/cversions.txt
@@ -80,5 +80,7 @@
 0x00000013 = 2b8f1f4da822491ff030b2b37dff07e3
 # Version 20 (NumPy 2.3.0)
 0x00000014 = e56b74d32a934d085e7c3414cb9999b8,
-# Version 21 (NumPy 2.4.0) Add 'same_value' casting, header additions
-0x00000015 = e56b74d32a934d085e7c3414cb9999b8,
+# Version 21 (NumPy 2.4.0)
+# Add 'same_value' casting, header additions.
+# General loop registration for ufuncs, sort, and argsort
+0x00000015 = fbd24fc5b2ba4f7cd3606ec6128de7a5

--- a/numpy/_core/code_generators/numpy_api.py
+++ b/numpy/_core/code_generators/numpy_api.py
@@ -412,7 +412,7 @@ multiarray_funcs_api = {
 }
 
 ufunc_types_api = {
-    'PyUFunc_Type':                             (0,)
+    'PyUFunc_Type':                             (0,),
 }
 
 ufunc_funcs_api = {
@@ -468,6 +468,8 @@ ufunc_funcs_api = {
     'PyUFunc_AddPromoter':                           (44, MinVersion("2.0")),
     'PyUFunc_AddWrappingLoop':                       (45, MinVersion("2.0")),
     'PyUFunc_GiveFloatingpointErrors':               (46, MinVersion("2.0")),
+    # End 2.0 API
+    'PyUFunc_AddLoopsFromSpecs':                     (47, MinVersion("2.4")),
 }
 
 # List of all the dicts which define the C API

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -145,6 +145,13 @@ typedef struct {
 } PyArrayMethod_Spec;
 
 
+// This is used for the convenience function `PyUFunc_AddLoopsFromSpecs`
+typedef struct {
+    const char *name;
+    PyArrayMethod_Spec *spec;
+} PyUFunc_LoopSlot;
+
+
 /*
  * ArrayMethod slots
  * -----------------

--- a/numpy/_core/src/common/npy_import.h
+++ b/numpy/_core/src/common/npy_import.h
@@ -6,6 +6,10 @@
 #include "numpy/npy_common.h"
 #include "npy_atomic.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Cached references to objects obtained via an import. All of these are
  * can be initialized at any time by npy_cache_import_runtime.
@@ -45,6 +49,8 @@ typedef struct npy_runtime_imports_struct {
     PyObject *_var;
     PyObject *_view_is_safe;
     PyObject *_void_scalar_to_string;
+    PyObject *sort;
+    PyObject *argsort;
 } npy_runtime_imports_struct;
 
 NPY_VISIBILITY_HIDDEN extern npy_runtime_imports_struct npy_runtime_imports;
@@ -111,5 +117,9 @@ npy_cache_import_runtime(const char *module, const char *attr, PyObject **obj) {
 
 NPY_NO_EXPORT int
 init_import_mutex(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* NUMPY_CORE_SRC_COMMON_NPY_IMPORT_H_ */

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -47,6 +47,7 @@
 
 #include "numpy/ndarraytypes.h"
 #include "numpy/npy_3kcompat.h"
+#include "npy_import.h"
 #include "common.h"
 #include "npy_pycompat.h"
 
@@ -190,6 +191,83 @@ PyUFunc_AddLoopFromSpec_int(PyObject *ufunc, PyArrayMethod_Spec *spec, int priv)
         return -1;
     }
     return PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
+}
+
+
+/*UFUNC_API
+ * Add multiple loops to ufuncs from ArrayMethod specs. This also
+ * handles the registration of sort and argsort methods for dtypes
+ * from ArrayMethod specs.
+ */
+NPY_NO_EXPORT int
+PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots)
+{
+    static PyObject *sort = NULL;
+    static PyObject *argsort = NULL;
+    if (sort == NULL) {
+        sort = npy_import("numpy", "sort");
+        if (sort == NULL) {
+            return -1;
+        }
+    }
+    if (argsort == NULL) {
+        argsort = npy_import("numpy", "argsort");
+        if (argsort == NULL) {
+            return -1;
+        }
+    }
+
+    PyUFunc_LoopSlot *slot;
+    for (slot = slots; slot->name != NULL; slot++) {
+        PyObject *ufunc = npy_import("numpy", slot->name);
+        if (ufunc == NULL) {
+            return -1;
+        }
+
+        if (ufunc == sort) {
+            Py_DECREF(ufunc);
+
+            PyArray_DTypeMeta *dtype = slot->spec->dtypes[0];
+            PyBoundArrayMethodObject *sort_meth = PyArrayMethod_FromSpec_int(slot->spec, 0);
+            if (sort_meth == NULL) {
+                PyErr_Format(PyExc_TypeError, "Failed to create sort method for %R", dtype);
+                return -1;
+            }
+
+            NPY_DT_SLOTS(dtype)->sort_meth = sort_meth->method;
+            Py_INCREF(sort_meth->method);
+            Py_DECREF(sort_meth);
+        }
+        else if (ufunc == argsort) {
+            Py_DECREF(ufunc);
+
+            PyArray_DTypeMeta *dtype = slot->spec->dtypes[0];
+            PyBoundArrayMethodObject *argsort_meth = PyArrayMethod_FromSpec_int(slot->spec, 0);
+            if (argsort_meth == NULL) {
+                PyErr_Format(PyExc_TypeError, "Failed to create argsort method for %R", dtype);
+                return -1;
+            }
+
+            NPY_DT_SLOTS(dtype)->argsort_meth = argsort_meth->method;
+            Py_INCREF(argsort_meth->method);
+            Py_DECREF(argsort_meth);
+        }
+        else {
+            if (!PyObject_TypeCheck(ufunc, &PyUFunc_Type)) {
+                PyErr_Format(PyExc_TypeError, "%s was not a ufunc!", slot->name);
+                Py_DECREF(ufunc);
+                return -1;
+            }
+
+            int ret = PyUFunc_AddLoopFromSpec_int(ufunc, slot->spec, 0);
+            Py_DECREF(ufunc);
+            if (ret < 0) {
+                return -1;
+            }
+        }
+    }
+
+    return 0;
 }
 
 

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -224,7 +224,6 @@ PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots)
             PyArray_DTypeMeta *dtype = slot->spec->dtypes[0];
             PyBoundArrayMethodObject *sort_meth = PyArrayMethod_FromSpec_int(slot->spec, 0);
             if (sort_meth == NULL) {
-                PyErr_Format(PyExc_TypeError, "Failed to create sort method for %R", dtype);
                 return -1;
             }
 
@@ -238,7 +237,6 @@ PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots)
             PyArray_DTypeMeta *dtype = slot->spec->dtypes[0];
             PyBoundArrayMethodObject *argsort_meth = PyArrayMethod_FromSpec_int(slot->spec, 0);
             if (argsort_meth == NULL) {
-                PyErr_Format(PyExc_TypeError, "Failed to create argsort method for %R", dtype);
                 return -1;
             }
 

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -202,19 +202,13 @@ PyUFunc_AddLoopFromSpec_int(PyObject *ufunc, PyArrayMethod_Spec *spec, int priv)
 NPY_NO_EXPORT int
 PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots)
 {
-    static PyObject *sort = NULL;
-    static PyObject *argsort = NULL;
-    if (sort == NULL) {
-        sort = npy_import("numpy", "sort");
-        if (sort == NULL) {
-            return -1;
-        }
+    if (npy_cache_import_runtime(
+            "numpy", "sort", &npy_runtime_imports.sort) < 0) {
+        return -1;
     }
-    if (argsort == NULL) {
-        argsort = npy_import("numpy", "argsort");
-        if (argsort == NULL) {
-            return -1;
-        }
+    if (npy_cache_import_runtime(
+            "numpy", "argsort", &npy_runtime_imports.argsort) < 0) {
+        return -1;
     }
 
     PyUFunc_LoopSlot *slot;
@@ -224,7 +218,7 @@ PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots)
             return -1;
         }
 
-        if (ufunc == sort) {
+        if (ufunc == npy_runtime_imports.sort) {
             Py_DECREF(ufunc);
 
             PyArray_DTypeMeta *dtype = slot->spec->dtypes[0];
@@ -238,7 +232,7 @@ PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots)
             Py_INCREF(sort_meth->method);
             Py_DECREF(sort_meth);
         }
-        else if (ufunc == argsort) {
+        else if (ufunc == npy_runtime_imports.argsort) {
             Py_DECREF(ufunc);
 
             PyArray_DTypeMeta *dtype = slot->spec->dtypes[0];

--- a/numpy/_core/src/umath/dispatching.h
+++ b/numpy/_core/src/umath/dispatching.h
@@ -16,6 +16,9 @@ PyUFunc_AddLoop(PyUFuncObject *ufunc, PyObject *info, int ignore_duplicate);
 NPY_NO_EXPORT int
 PyUFunc_AddLoopFromSpec_int(PyObject *ufunc, PyArrayMethod_Spec *spec, int priv);
 
+NPY_NO_EXPORT int
+PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots);
+
 NPY_NO_EXPORT PyArrayMethodObject *
 promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
         PyArrayObject *const ops[],


### PR DESCRIPTION
Follows #29737 to actually add the registration for the new-style sorts and argsorts. This is done using a `PyUFunc_AddLoopsFromSpecs` convenience function that can accept multiple ufunc names and arraymethod specs using slots, special-casing the `"sort"` and `"argsort"` names. The `sfloat` test is updated to use this registration.

Thanks for reviewing!