### PR TITLE
TYP: add missing `__slots__`

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -5736,6 +5736,8 @@ pow = power
 true_divide = divide
 
 class errstate:
+    __slots__ = "_all", "_call", "_divide", "_invalid", "_over", "_token", "_under"
+
     def __init__(
         self,
         *,

--- a/numpy/exceptions.pyi
+++ b/numpy/exceptions.pyi
@@ -17,6 +17,8 @@ class TooHardError(RuntimeError): ...
 class DTypePromotionError(TypeError): ...
 
 class AxisError(ValueError, IndexError):
+    __slots__ = "_msg", "axis", "ndim"
+
     axis: int | None
     ndim: int | None
     @overload

--- a/numpy/lib/_index_tricks_impl.pyi
+++ b/numpy/lib/_index_tricks_impl.pyi
@@ -106,6 +106,8 @@ class ndindex:
     def ndincr(self, /) -> None: ...
 
 class nd_grid(Generic[_BoolT_co]):
+    __slots__ = ("sparse",)
+
     sparse: _BoolT_co
     def __init__(self, sparse: _BoolT_co = ...) -> None: ...
     @overload
@@ -115,10 +117,14 @@ class nd_grid(Generic[_BoolT_co]):
 
 @final
 class MGridClass(nd_grid[L[False]]):
+    __slots__ = ()
+
     def __init__(self) -> None: ...
 
 @final
 class OGridClass(nd_grid[L[True]]):
+    __slots__ = ()
+
     def __init__(self) -> None: ...
 
 class AxisConcatenator(Generic[_AxisT_co, _MatrixT_co, _NDMinT_co, _Trans1DT_co]):
@@ -155,13 +161,19 @@ class AxisConcatenator(Generic[_AxisT_co, _MatrixT_co, _NDMinT_co, _Trans1DT_co]
 
 @final
 class RClass(AxisConcatenator[L[0], L[False], L[1], L[-1]]):
+    __slots__ = ()
+
     def __init__(self, /) -> None: ...
 
 @final
 class CClass(AxisConcatenator[L[-1], L[False], L[2], L[0]]):
+    __slots__ = ()
+
     def __init__(self, /) -> None: ...
 
 class IndexExpression(Generic[_BoolT_co]):
+    __slots__ = ("maketuple",)
+
     maketuple: _BoolT_co
     def __init__(self, maketuple: _BoolT_co) -> None: ...
     @overload

--- a/numpy/lib/mixins.pyi
+++ b/numpy/lib/mixins.pyi
@@ -13,6 +13,8 @@ __all__ = ["NDArrayOperatorsMixin"]
 # As such, only little type safety can be provided here.
 
 class NDArrayOperatorsMixin(ABC):
+    __slots__ = ()
+
     @abstractmethod
     def __array_ufunc__(
         self,

--- a/numpy/ma/extras.pyi
+++ b/numpy/ma/extras.pyi
@@ -110,12 +110,16 @@ def cov(x, y=None, rowvar=True, bias=False, allow_masked=True, ddof=None): ...
 def corrcoef(x, y=None, rowvar=True, bias=..., allow_masked=True, ddof=...): ...
 
 class MAxisConcatenator(AxisConcatenator):
+    __slots__ = ()
+
     @staticmethod
     def concatenate(arrays: Incomplete, axis: int = 0) -> Incomplete: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]
     @classmethod
     def makemat(cls, arr: Incomplete) -> Incomplete: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleVariableOverride]
 
 class mr_class(MAxisConcatenator):
+    __slots__ = ()
+
     def __init__(self) -> None: ...
 
 mr_: mr_class


### PR DESCRIPTION
as caught by https://github.com/JelleZijlstra/stubdefaulter, analogous to numpy/numtype#723