### PR TITLE
MAINT: bump ``ruff`` from ``0.12.0`` to ``0.14.0``

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
   - breathe>4.33.0
   # For linting
   - cython-lint
-  - ruff=0.12.0
+  - ruff=0.14.0
   - gitpython
   # Used in some tests
   - cffi

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -29,8 +29,8 @@ class TestReturnInteger(util.F2PyTest):
         pytest.raises(IndexError, t, [])
         pytest.raises(IndexError, t, ())
 
-        pytest.raises(Exception, t, t)  # noqa: B017
-        pytest.raises(Exception, t, {})  # noqa: B017
+        pytest.raises(TypeError, t, t)
+        pytest.raises(TypeError, t, {})
 
         if tname in ["t8", "s8"]:
             pytest.raises(OverflowError, t, 100000000000000000000000)

--- a/numpy/f2py/tests/test_return_integer.py
+++ b/numpy/f2py/tests/test_return_integer.py
@@ -29,8 +29,8 @@ class TestReturnInteger(util.F2PyTest):
         pytest.raises(IndexError, t, [])
         pytest.raises(IndexError, t, ())
 
-        pytest.raises(Exception, t, t)
-        pytest.raises(Exception, t, {})
+        pytest.raises(Exception, t, t)  # noqa: B017
+        pytest.raises(Exception, t, {})  # noqa: B017
 
         if tname in ["t8", "s8"]:
             pytest.raises(OverflowError, t, 100000000000000000000000)

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -39,8 +39,8 @@ class TestReturnReal(util.F2PyTest):
         pytest.raises(IndexError, t, [])
         pytest.raises(IndexError, t, ())
 
-        pytest.raises(Exception, t, t)
-        pytest.raises(Exception, t, {})
+        pytest.raises(Exception, t, t)  # noqa: B017
+        pytest.raises(Exception, t, {})  # noqa: B017
 
         try:
             r = t(10**400)

--- a/numpy/f2py/tests/test_return_real.py
+++ b/numpy/f2py/tests/test_return_real.py
@@ -39,8 +39,8 @@ class TestReturnReal(util.F2PyTest):
         pytest.raises(IndexError, t, [])
         pytest.raises(IndexError, t, ())
 
-        pytest.raises(Exception, t, t)  # noqa: B017
-        pytest.raises(Exception, t, {})  # noqa: B017
+        pytest.raises(TypeError, t, t)
+        pytest.raises(TypeError, t, {})
 
         try:
             r = t(10**400)

--- a/numpy/tests/test_configtool.py
+++ b/numpy/tests/test_configtool.py
@@ -1,4 +1,3 @@
-import importlib
 import importlib.metadata
 import os
 import pathlib

--- a/requirements/linter_requirements.txt
+++ b/requirements/linter_requirements.txt
@@ -1,4 +1,4 @@
 # keep in sync with `environment.yml`
 cython-lint
-ruff==0.12.0
+ruff==0.14.0
 GitPython>=3.1.30

--- a/ruff.toml
+++ b/ruff.toml
@@ -54,8 +54,6 @@ ignore = [
     "ISC002",  # Implicitly concatenated string literals over multiple lines
     # flake8-pie
     "PIE790",  # Unnecessary `pass` statement
-    # pandas-vet
-    "PD901",   # Avoid using the generic variable name `df` for DataFrames
     # perflint
     "PERF401", # Use a list comprehension to create a transformed list
     # pycodestyle/error


### PR DESCRIPTION
relevant release notes:

- https://github.com/astral-sh/ruff/releases/tag/0.14.0
- https://github.com/astral-sh/ruff/releases/tag/0.13.3
- https://github.com/astral-sh/ruff/releases/tag/0.13.2
- https://github.com/astral-sh/ruff/releases/tag/0.13.1
- https://github.com/astral-sh/ruff/releases/tag/0.13.0
- https://github.com/astral-sh/ruff/releases/tag/0.12.12
- https://github.com/astral-sh/ruff/releases/tag/0.12.11
- https://github.com/astral-sh/ruff/releases/tag/0.12.10
- https://github.com/astral-sh/ruff/releases/tag/0.12.9
- https://github.com/astral-sh/ruff/releases/tag/0.12.8
- https://github.com/astral-sh/ruff/releases/tag/0.12.7
- https://github.com/astral-sh/ruff/releases/tag/0.12.6
- https://github.com/astral-sh/ruff/releases/tag/0.12.5
- https://github.com/astral-sh/ruff/releases/tag/0.12.4
- https://github.com/astral-sh/ruff/releases/tag/0.12.3
- https://github.com/astral-sh/ruff/releases/tag/0.12.2
- https://github.com/astral-sh/ruff/releases/tag/0.12.1
