### PR TITLE
TST: do not use matplotlib 3.10.6

### DIFF
--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -5,8 +5,7 @@ pydata-sphinx-theme>=0.15.2
 sphinx-copybutton
 sphinx-design
 scipy
-matplotlib
-pyparsing<3.3
+matplotlib!=3.10.6
 pandas
 breathe>4.33.0
 ipython!=8.1.0


### PR DESCRIPTION
Now that matplotlib 3.10.7 is released, with a fix to use pyparsing 3.0, redo #29833 to avoid matplotlib 3.10.6 instead of pinning pyparsing.