### PR TITLE
DOC: Add URL to valgrind tool in Advanced Debugging Page

### DIFF
--- a/doc/source/dev/development_advanced_debugging.rst
+++ b/doc/source/dev/development_advanced_debugging.rst
@@ -36,7 +36,8 @@ However, you can ensure that we can track down such issues more easily:
   consider creating an additional simpler test as well.
   This can be helpful, because often it is only easy to find which test
   triggers an issue and not which line of the test.
-* Never use ``np.empty`` if data is read/used. ``valgrind`` will notice this
+* Never use ``np.empty`` if data is read/used.
+  `Valgrind <https://valgrind.org/>`_ will notice this
   and report an error. When you do not care about values, you can generate
   random values instead.
 
@@ -131,7 +132,8 @@ to mark them, but expect some false positives.
 ``valgrind``
 ============
 
-Valgrind is a powerful tool to find certain memory access problems and should
+`Valgrind <https://valgrind.org/>`_ is a powerful tool
+to find certain memory access problems and should
 be run on complicated C code.
 Basic use of ``valgrind`` usually requires no more than::
 

--- a/doc/source/dev/development_advanced_debugging.rst
+++ b/doc/source/dev/development_advanced_debugging.rst
@@ -170,7 +170,7 @@ Valgrind helps:
   Python allocators.)
 
 Even though using valgrind for memory leak detection is slow and less sensitive
-it can be a convenient: you can run most programs with valgrind without
+it can be convenient: you can run most programs with valgrind without
 modification.
 
 Things to be aware of:
@@ -233,7 +233,7 @@ The NumPy developers often use both ``gdb`` and ``lldb`` to debug Numpy. As a
 rule of thumb, ``gdb`` is often easier to use on Linux while ``lldb`` is easier
 to use on a Mac environment. They have disjoint user interfaces, so you will need to
 learn how to use whichever one you land on. The ``gdb`` to ``lldb`` `command map
-<https://lldb.llvm.org/use/map.html>`_ is a convnient reference for how to
+<https://lldb.llvm.org/use/map.html>`_ is a convenient reference for how to
 accomplish common recipes in both debuggers.
 
 


### PR DESCRIPTION
Add URL to valgrind tool in Advanced Debugging Page:
https://valgrind.org/

https://numpy.org/devdocs/dev/development_advanced_debugging.html