### PR TITLE
TYP: minor fixes related to ``errstate``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -292,8 +292,7 @@ from numpy._core._ufunc_config import (
     getbufsize,
     seterrcall,
     geterrcall,
-    _ErrKind,
-    _ErrCall,
+    errstate,
 )
 
 from numpy._core.arrayprint import (
@@ -756,8 +755,6 @@ _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
 _RealT_co = TypeVar("_RealT_co", covariant=True)
 _ImagT_co = TypeVar("_ImagT_co", covariant=True)
-
-_CallableT = TypeVar("_CallableT", bound=Callable[..., object])
 
 _DTypeT = TypeVar("_DTypeT", bound=dtype)
 _DTypeT_co = TypeVar("_DTypeT_co", bound=dtype, default=dtype, covariant=True)
@@ -5734,29 +5731,6 @@ mod = remainder
 permute_dims = transpose
 pow = power
 true_divide = divide
-
-class errstate:
-    __slots__ = "_all", "_call", "_divide", "_invalid", "_over", "_token", "_under"
-
-    def __init__(
-        self,
-        *,
-        call: _ErrCall = ...,
-        all: _ErrKind | None = None,
-        divide: _ErrKind | None = None,
-        over: _ErrKind | None = None,
-        under: _ErrKind | None = None,
-        invalid: _ErrKind | None = None,
-    ) -> None: ...
-    def __enter__(self) -> None: ...
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-        /,
-    ) -> None: ...
-    def __call__(self, func: _CallableT) -> _CallableT: ...
 
 # TODO: The type of each `__next__` and `iters` return-type depends
 # on the length and dtype of `args`; we can't describe this behavior yet

--- a/numpy/_core/_ufunc_config.pyi
+++ b/numpy/_core/_ufunc_config.pyi
@@ -1,12 +1,22 @@
 from _typeshed import SupportsWrite
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias, TypedDict, type_check_only
+from types import TracebackType
+from typing import Any, Final, Literal, TypeAlias, TypedDict, TypeVar, type_check_only
 
-from numpy import errstate as errstate
+__all__ = [
+    "seterr",
+    "geterr",
+    "setbufsize",
+    "getbufsize",
+    "seterrcall",
+    "geterrcall",
+    "errstate",
+]
 
 _ErrKind: TypeAlias = Literal["ignore", "warn", "raise", "call", "print", "log"]
-_ErrFunc: TypeAlias = Callable[[str, int], Any]
-_ErrCall: TypeAlias = _ErrFunc | SupportsWrite[str]
+_ErrCall: TypeAlias = Callable[[str, int], Any] | SupportsWrite[str]
+
+_CallableT = TypeVar("_CallableT", bound=Callable[..., object])
 
 @type_check_only
 class _ErrDict(TypedDict):
@@ -14,6 +24,36 @@ class _ErrDict(TypedDict):
     over: _ErrKind
     under: _ErrKind
     invalid: _ErrKind
+
+###
+
+class _unspecified: ...
+
+_Unspecified: Final[_unspecified]
+
+class errstate:
+    __slots__ = "_all", "_call", "_divide", "_invalid", "_over", "_token", "_under"
+
+    def __init__(
+        self,
+        /,
+        *,
+        call: _ErrCall | _unspecified = ...,  # = _Unspecified
+        all: _ErrKind | None = None,
+        divide: _ErrKind | None = None,
+        over: _ErrKind | None = None,
+        under: _ErrKind | None = None,
+        invalid: _ErrKind | None = None,
+    ) -> None: ...
+    def __call__(self, /, func: _CallableT) -> _CallableT: ...
+    def __enter__(self) -> None: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+        /,
+    ) -> None: ...
 
 def seterr(
     all: _ErrKind | None = None,
@@ -27,5 +67,3 @@ def setbufsize(size: int) -> int: ...
 def getbufsize() -> int: ...
 def seterrcall(func: _ErrCall | None) -> _ErrCall | None: ...
 def geterrcall() -> _ErrCall | None: ...
-
-# See `numpy/__init__.pyi` for the `errstate` class and `no_nep5_warnings`


### PR DESCRIPTION
- move the `np.errstate` stub from `__init__.pyi` to `_core/_ufunc_config.pyi` to better match the runtime situation.
- stub the `_unspecified` class and `_Unspecified` sentinel in `_core._ufunc_config`
- correct mismatching parameter type and parameter default of the `call` kwarg in `errstate.__init__`
- add missing `__all__` in `_core/_ufunc_config.pyi`