### PR TITLE
Fix memory leak in import_array()

### DIFF
--- a/numpy/_core/src/umath/_operand_flag_tests.c
+++ b/numpy/_core/src/umath/_operand_flag_tests.c
@@ -57,13 +57,13 @@ PyMODINIT_FUNC PyInit__operand_flag_tests(void)
     PyObject *m = NULL;
     PyObject *ufunc;
 
+    import_array();
+    import_umath();
+
     m = PyModule_Create(&moduledef);
     if (m == NULL) {
         goto fail;
     }
-
-    import_array();
-    import_umath();
 
     ufunc = PyUFunc_FromFuncAndData(funcs, data, types, 1, 2, 0,
                                     PyUFunc_None, "inplace_add",

--- a/numpy/_core/src/umath/_struct_ufunc_tests.c
+++ b/numpy/_core/src/umath/_struct_ufunc_tests.c
@@ -123,14 +123,14 @@ PyMODINIT_FUNC PyInit__struct_ufunc_tests(void)
     PyArray_Descr *dtype;
     PyArray_Descr *dtypes[3];
 
+    import_array();
+    import_umath();
+
     m = PyModule_Create(&moduledef);
 
     if (m == NULL) {
         return NULL;
     }
-
-    import_array();
-    import_umath();
 
     add_triplet = PyUFunc_FromFuncAndData(NULL, NULL, NULL, 0, 2, 1,
                                           PyUFunc_None, "add_triplet",


### PR DESCRIPTION
## Summary
Fixes memory leak when import_array() or import_umath() fail by moving the import calls before PyModule_Create().

## Changes
- Moved import_array() and import_umath() before module creation in:
 - numpy/_core/src/umath/_operand_flag_tests.c
 - numpy/_core/src/umath/_struct_ufunc_tests.c

## Explanation
The import_array() and import_umath() macros contain `return NULL` statements. When called after PyModule_Create(), a failure causes the function to exit immediately without cleaning up the module object, resulting in a memory leak.

By calling these imports before creating any Python objects, if they fail, there's nothing to clean up.
