### PR TITLE
TST: use requirements/test_requirements across CI

### DIFF
--- a/.github/meson_actions/action.yml
+++ b/.github/meson_actions/action.yml
@@ -30,8 +30,7 @@ runs:
       TERM: xterm-256color
     run: |
       echo "::group::Installing Test Dependencies"
-      pip install pytest pytest-xdist pytest-timeout hypothesis typing_extensions
-      pip install -r requirements/setuptools_requirement.txt
+      python -m pip install -r requirements/test_requirements.txt
       echo "::endgroup::"
       echo "::group::Test NumPy"
       spin test -- --durations=10 --timeout=600

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -35,8 +35,7 @@ jobs:
         sudo apt install -y python3 python3-pip python3-dev ninja-build gfortran \
                             build-essential libopenblas-dev liblapack-dev pkg-config
         pip install --upgrade pip
-        pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout spin
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         echo "/home/runner/.local/bin" >> $GITHUB_PATH
 
     - name: Meson Build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -236,7 +236,7 @@ jobs:
     # - name: Check docstests
     #   shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
     #   run: |
-    #     pip install scipy-doctest>=1.8.0 hypothesis==6.104.1 matplotlib scipy pandas
+    #     pip install -r requirements/doc_requirements.txt -r requirements/test_requirements.txt
     #     spin check-docs -v
     #     spin check-tutorials -v
 

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         # Install OpenBLAS
         if [[ $USE_NIGHTLY_OPENBLAS == "true" ]]; then
             python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy-openblas32
@@ -113,7 +113,6 @@ jobs:
       env:
         TERM: xterm-256color
       run: |
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         spin test -j auto -- --timeout=600 --durations=10
 
 
@@ -135,8 +134,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
-        pip install pytest hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
     - name: Build (LP64)
       run: spin build -- -Dblas=openblas -Dlapack=openblas -Ddisable-optimization=true -Dallow-noblas=false
@@ -171,8 +169,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
-        pip install pytest hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
     - name: Build
       run: spin build -- -Ddisable-optimization=true -Dallow-noblas=false
@@ -205,8 +202,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         sudo apt-get update
         sudo apt-get install libopenblas-dev cmake
         sudo apt-get remove pkg-config
@@ -234,7 +230,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         sudo apt-get update
         sudo apt-get install liblapack-dev pkg-config
 
@@ -244,7 +240,6 @@ jobs:
 
     - name: Test
       run: |
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         spin test -j auto -- numpy/linalg  --timeout=600 --durations=10
 
 
@@ -268,7 +263,7 @@ jobs:
 
     - name: Install PyPI dependencies
       run: |
-        pip install --break-system-packages -r requirements/build_requirements.txt
+        pip install --break-system-packages -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
     - name: Build
       run: |
@@ -276,7 +271,6 @@ jobs:
 
     - name: Test
       run: |
-        pip install --break-system-packages pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         spin test -j auto -- numpy/linalg  --timeout=600 --durations=10
 
 
@@ -297,7 +291,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         pip install mkl mkl-devel
 
     - name: Repair MKL pkg-config files and symlinks
@@ -361,7 +355,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         sudo apt-get update
         sudo apt-get install libblis-dev libopenblas-dev pkg-config
 
@@ -398,7 +392,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         sudo apt-get update
         sudo apt-get install libatlas-base-dev pkg-config
 

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -263,7 +263,7 @@ jobs:
 
     - name: Install PyPI dependencies
       run: |
-        pip install --break-system-packages -r requirements/build_requirements.txt -r requirements/test_requirements.txt
+        pip install --break-system-packages -r requirements/build_requirements.txt
 
     - name: Build
       run: |
@@ -271,6 +271,9 @@ jobs:
 
     - name: Test
       run: |
+        # do not use test_requirements.txt, it includes coverage which requires
+        # sqlite3, which is not available on OpenSUSE python
+        pip install --break-system-packages pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         spin test -j auto -- numpy/linalg  --timeout=600 --durations=10
 
 

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -136,7 +136,7 @@ jobs:
           git config --global --add safe.directory /numpy &&
           # No need to build ninja from source, the host ninja is used for the build
           grep -v ninja /numpy/requirements/build_requirements.txt > /tmp/build_requirements.txt &&
-          python -m pip install -r /tmp/build_requirements.txt -r requirements/test_requirements.txt &&
+          python -m pip install -r /tmp/build_requirements.txt -r /numpy/requirements/test_requirements.txt &&
           rm -f /usr/local/bin/ninja && mkdir -p /usr/local/bin && ln -s /host/usr/bin/ninja /usr/local/bin/ninja
         "
         docker commit the_container the_container

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -236,7 +236,7 @@ jobs:
           rm -f /usr/bin/ld.bfd && ln -s /host/usr/bin/${TOOLCHAIN_NAME}-ld.bfd /usr/bin/ld.bfd &&
           rm -f /usr/bin/ninja && ln -s /host/usr/bin/ninja /usr/bin/ninja &&
           git config --global --add safe.directory /numpy &&
-          python -m pip install --break-system-packages -r /numpy/requirements/build_requirements.txt -r requirements/test_requirements.txt
+          python -m pip install --break-system-packages -r /numpy/requirements/build_requirements.txt -r /numpy/requirements/test_requirements.txt
         "
         docker commit the_container the_container
         mkdir -p "~/docker_${TOOLCHAIN_NAME}"

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -236,7 +236,8 @@ jobs:
           rm -f /usr/bin/ld.bfd && ln -s /host/usr/bin/${TOOLCHAIN_NAME}-ld.bfd /usr/bin/ld.bfd &&
           rm -f /usr/bin/ninja && ln -s /host/usr/bin/ninja /usr/bin/ninja &&
           git config --global --add safe.directory /numpy &&
-          python -m pip install --break-system-packages -r /numpy/requirements/build_requirements.txt -r /numpy/requirements/test_requirements.txt
+          python -m pip install --break-system-packages -r /numpy/requirements/build_requirements.txt &&
+          python -m pip install --break-system-packages pytest pytest-xdist hypothesis typing_extensions
         "
         docker commit the_container the_container
         mkdir -p "~/docker_${TOOLCHAIN_NAME}"

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -236,7 +236,7 @@ jobs:
           rm -f /usr/bin/ld.bfd && ln -s /host/usr/bin/${TOOLCHAIN_NAME}-ld.bfd /usr/bin/ld.bfd &&
           rm -f /usr/bin/ninja && ln -s /host/usr/bin/ninja /usr/bin/ninja &&
           git config --global --add safe.directory /numpy &&
-          python -m pip install --break-system-packages -r /numpy/requirements/build_requirements.txt -r requirements/test_requirements.txt &&
+          python -m pip install --break-system-packages -r /numpy/requirements/build_requirements.txt -r requirements/test_requirements.txt
         "
         docker commit the_container the_container
         mkdir -p "~/docker_${TOOLCHAIN_NAME}"

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -136,7 +136,8 @@ jobs:
           git config --global --add safe.directory /numpy &&
           # No need to build ninja from source, the host ninja is used for the build
           grep -v ninja /numpy/requirements/build_requirements.txt > /tmp/build_requirements.txt &&
-          python -m pip install -r /tmp/build_requirements.txt -r /numpy/requirements/test_requirements.txt &&
+          python -m pip install -r /tmp/build_requirements.txt &&
+          python -m pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout &&
           rm -f /usr/local/bin/ninja && mkdir -p /usr/local/bin && ln -s /host/usr/bin/ninja /usr/local/bin/ninja
         "
         docker commit the_container the_container

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -136,8 +136,7 @@ jobs:
           git config --global --add safe.directory /numpy &&
           # No need to build ninja from source, the host ninja is used for the build
           grep -v ninja /numpy/requirements/build_requirements.txt > /tmp/build_requirements.txt &&
-          python -m pip install -r /tmp/build_requirements.txt &&
-          python -m pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout &&
+          python -m pip install -r /tmp/build_requirements.txt -r requirements/test_requirements.txt &&
           rm -f /usr/local/bin/ninja && mkdir -p /usr/local/bin && ln -s /host/usr/bin/ninja /usr/local/bin/ninja
         "
         docker commit the_container the_container
@@ -237,8 +236,7 @@ jobs:
           rm -f /usr/bin/ld.bfd && ln -s /host/usr/bin/${TOOLCHAIN_NAME}-ld.bfd /usr/bin/ld.bfd &&
           rm -f /usr/bin/ninja && ln -s /host/usr/bin/ninja /usr/bin/ninja &&
           git config --global --add safe.directory /numpy &&
-          python -m pip install --break-system-packages -r /numpy/requirements/build_requirements.txt &&
-          python -m pip install --break-system-packages pytest pytest-xdist hypothesis typing_extensions
+          python -m pip install --break-system-packages -r /numpy/requirements/build_requirements.txt -r requirements/test_requirements.txt &&
         "
         docker commit the_container the_container
         mkdir -p "~/docker_${TOOLCHAIN_NAME}"

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -132,8 +132,7 @@ jobs:
         python-version: '3.11'
     - name: Install dependencies
       run: |
-        python -m pip install -r requirements/build_requirements.txt
-        python -m pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
+        python -m pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
     - name: Build
       run: |
         spin build -- ${{ matrix.config.args }}
@@ -208,8 +207,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install -r requirements/build_requirements.txt
-        python -m pip install pytest pytest-xdist hypothesis typing_extensions
+        python -m pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
     - name: Build
       run: CC=gcc-13 CXX=g++-13 spin build -- -Denable-openmp=true -Dallow-noblas=true -Dcpu-baseline=avx512_skx -Dtest-simd='BASELINE,AVX512_KNL,AVX512_KNM,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL,AVX512_SPR'
@@ -259,8 +257,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install -r requirements/build_requirements.txt
-        python -m pip install pytest pytest-xdist hypothesis typing_extensions
+        python -m pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
     - name: Build
       run: CC=gcc-13 CXX=g++-13 spin build -- -Denable-openmp=true -Dallow-noblas=true -Dcpu-baseline=avx512_spr

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -130,9 +130,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
-        pip install -r requirements/setuptools_requirement.txt
-        pip install pytest pytest-xdist pytest-timeout hypothesis
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
     - name: Build against Accelerate (LP64)
       run: spin build -- -Ddisable-optimization=true -Dallow-noblas=false


### PR DESCRIPTION
Closes #29916 

CI was not consistently using `requirements/test_requirements.txt`. I corrected this by grepping for `hypothesis` in all the github CI workflows. There is one left in the disabled cygwin workflow file.