### PR TITLE
BUG: avoid segmentation fault in string_expandtabs_length_promoter

### DIFF
--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -941,7 +941,7 @@ string_expandtabs_length_promoter(PyObject *NPY_UNUSED(ufunc),
         PyArray_DTypeMeta *const op_dtypes[], PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
-    Py_INCREF(op_dtypes[0]);
+    Py_XINCREF(op_dtypes[0]);
     new_op_dtypes[0] = op_dtypes[0];
     new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_Int64DType);
     new_op_dtypes[2] = PyArray_DTypeFromTypeNum(NPY_DEFAULT_INT);

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 
 import numpy as np
+from numpy._core._exceptions import _UFuncNoLoopError
 from numpy.testing import IS_PYPY, assert_array_equal, assert_raises
 from numpy.testing._private.utils import requires_memory
 
@@ -820,6 +821,20 @@ class TestMethods:
         with pytest.raises(OverflowError, match="new string is too long"):
             np.strings.expandtabs(np.array("\ta\n\tb", dtype=dt), sys.maxsize)
             np.strings.expandtabs(np.array("\ta\n\tb", dtype=dt), 2**61)
+
+    def test_expandtabs_length_not_cause_segfault(self, dt):
+        # see gh-28829
+        with pytest.raises(
+            _UFuncNoLoopError,
+            match="did not contain a loop with signature matching types",
+        ):
+            np._core.strings._expandtabs_length.reduce(np.zeros(200))
+
+        with pytest.raises(
+            _UFuncNoLoopError,
+            match="did not contain a loop with signature matching types",
+        ):
+            np.strings.expandtabs(np.zeros(200))
 
     FILL_ERROR = "The fill character must be exactly one character long"
 


### PR DESCRIPTION
Backport of #29368.

Fix to use `Py_XINCREF` instead of `Py_INCREF` to safely handle the case where `op_dtypes[0]` is NULL

### Root Cause

* When calling `string_expandtabs_length_promoter`, the first item of `op_dtypes` can be NULL.

### Rationale

* As noted in [this comment regarding `ops`](https://github.com/numpy/numpy/blob/main/numpy/_core/src/umath/ufunc_object.c#L2315), legacy type resolution does not handle NULL well. Therefore, I changed the logic to use the second item instead.

### Outcome

* `numpy._core.strings._expandtabs_length.reduce(numpy.zeros(200))` now raises a `UFuncTypeError`, instead of causing a segmentation fault.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
