### PR TITLE
TYP: minor fixes related to ``errstate`` (#29914)

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -295,8 +295,7 @@ from numpy._core._ufunc_config import (
     getbufsize,
     seterrcall,
     geterrcall,
-    _ErrKind,
-    _ErrCall,
+    errstate,
 )
 
 from numpy._core.arrayprint import (
@@ -755,8 +754,6 @@ _T_co = TypeVar("_T_co", covariant=True)
 _T_contra = TypeVar("_T_contra", contravariant=True)
 _RealT_co = TypeVar("_RealT_co", covariant=True)
 _ImagT_co = TypeVar("_ImagT_co", covariant=True)
-
-_CallableT = TypeVar("_CallableT", bound=Callable[..., object])
 
 _DTypeT = TypeVar("_DTypeT", bound=dtype)
 _DTypeT_co = TypeVar("_DTypeT_co", bound=dtype, default=dtype, covariant=True)
@@ -5661,29 +5658,6 @@ bitwise_invert = invert
 bitwise_right_shift = right_shift
 permute_dims = transpose
 pow = power
-
-class errstate:
-    __slots__ = "_all", "_call", "_divide", "_invalid", "_over", "_token", "_under"
-
-    def __init__(
-        self,
-        *,
-        call: _ErrCall = ...,
-        all: _ErrKind | None = ...,
-        divide: _ErrKind | None = ...,
-        over: _ErrKind | None = ...,
-        under: _ErrKind | None = ...,
-        invalid: _ErrKind | None = ...,
-    ) -> None: ...
-    def __enter__(self) -> None: ...
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        traceback: TracebackType | None,
-        /,
-    ) -> None: ...
-    def __call__(self, func: _CallableT) -> _CallableT: ...
 
 # TODO: The type of each `__next__` and `iters` return-type depends
 # on the length and dtype of `args`; we can't describe this behavior yet

--- a/numpy/_core/_ufunc_config.pyi
+++ b/numpy/_core/_ufunc_config.pyi
@@ -1,13 +1,21 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias, TypedDict, type_check_only
+from types import TracebackType
+from typing import Any, Final, Literal, TypeAlias, TypedDict, TypeVar, type_check_only
 
-from _typeshed import SupportsWrite
-
-from numpy import errstate as errstate
+__all__ = [
+    "seterr",
+    "geterr",
+    "setbufsize",
+    "getbufsize",
+    "seterrcall",
+    "geterrcall",
+    "errstate",
+]
 
 _ErrKind: TypeAlias = Literal["ignore", "warn", "raise", "call", "print", "log"]
-_ErrFunc: TypeAlias = Callable[[str, int], Any]
-_ErrCall: TypeAlias = _ErrFunc | SupportsWrite[str]
+_ErrCall: TypeAlias = Callable[[str, int], Any] | SupportsWrite[str]
+
+_CallableT = TypeVar("_CallableT", bound=Callable[..., object])
 
 @type_check_only
 class _ErrDict(TypedDict):
@@ -15,6 +23,36 @@ class _ErrDict(TypedDict):
     over: _ErrKind
     under: _ErrKind
     invalid: _ErrKind
+
+###
+
+class _unspecified: ...
+
+_Unspecified: Final[_unspecified]
+
+class errstate:
+    __slots__ = "_all", "_call", "_divide", "_invalid", "_over", "_token", "_under"
+
+    def __init__(
+        self,
+        /,
+        *,
+        call: _ErrCall | _unspecified = ...,  # = _Unspecified
+        all: _ErrKind | None = None,
+        divide: _ErrKind | None = None,
+        over: _ErrKind | None = None,
+        under: _ErrKind | None = None,
+        invalid: _ErrKind | None = None,
+    ) -> None: ...
+    def __call__(self, /, func: _CallableT) -> _CallableT: ...
+    def __enter__(self) -> None: ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+        /,
+    ) -> None: ...
 
 def seterr(
     all: _ErrKind | None = ...,
@@ -28,5 +66,3 @@ def setbufsize(size: int) -> int: ...
 def getbufsize() -> int: ...
 def seterrcall(func: _ErrCall | None) -> _ErrCall | None: ...
 def geterrcall() -> _ErrCall | None: ...
-
-# See `numpy/__init__.pyi` for the `errstate` class and `no_nep5_warnings`

--- a/numpy/_core/_ufunc_config.pyi
+++ b/numpy/_core/_ufunc_config.pyi
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from _typeshed import SupportsWrite
 from types import TracebackType
 from typing import Any, Final, Literal, TypeAlias, TypedDict, TypeVar, type_check_only
 


### PR DESCRIPTION
Backport of #29914.

- move the `np.errstate` stub from `__init__.pyi` to `_core/_ufunc_config.pyi` to better match the runtime situation.
- stub the `_unspecified` class and `_Unspecified` sentinel in `_core._ufunc_config`
- correct mismatching parameter type and parameter default of the `call` kwarg in `errstate.__init__`
- add missing `__all__` in `_core/_ufunc_config.pyi`

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
