### PR TITLE
TST: use requirements/test_requirements across CI (#29919)

### DIFF
--- a/.github/meson_actions/action.yml
+++ b/.github/meson_actions/action.yml
@@ -30,8 +30,7 @@ runs:
       TERM: xterm-256color
     run: |
       echo "::group::Installing Test Dependencies"
-      pip install pytest pytest-xdist pytest-timeout hypothesis typing_extensions
-      pip install -r requirements/setuptools_requirement.txt
+      python -m pip install -r requirements/test_requirements.txt
       echo "::endgroup::"
       echo "::group::Test NumPy"
       spin test -- --durations=10 --timeout=600

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -271,7 +271,7 @@ jobs:
     # - name: Check docstests
     #   shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
     #   run: |
-    #     pip install scipy-doctest==1.6.0 hypothesis==6.104.1 matplotlib scipy pytz pandas
+    #     pip install -r requirements/doc_requirements.txt -r requirements/test_requirements.txt
     #     spin check-docs -v
     #     spin check-tutorials -v
 

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         # Install OpenBLAS
         if [[ $USE_NIGHTLY_OPENBLAS == "true" ]]; then
             python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy-openblas32
@@ -113,7 +113,6 @@ jobs:
       env:
         TERM: xterm-256color
       run: |
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         spin test -j auto -- --timeout=600 --durations=10
 
 
@@ -135,8 +134,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
-        pip install pytest hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
     - name: Build (LP64)
       run: spin build -- -Dblas=openblas -Dlapack=openblas -Ddisable-optimization=true -Dallow-noblas=false
@@ -171,8 +169,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
-        pip install pytest hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
     - name: Build
       run: spin build -- -Ddisable-optimization=true -Dallow-noblas=false
@@ -205,8 +202,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         sudo apt-get update
         sudo apt-get install libopenblas-dev cmake
         sudo apt-get remove pkg-config
@@ -234,7 +230,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         sudo apt-get update
         sudo apt-get install liblapack-dev pkg-config
 
@@ -244,7 +240,6 @@ jobs:
 
     - name: Test
       run: |
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         spin test -j auto -- numpy/linalg  --timeout=600 --durations=10
 
 
@@ -276,6 +271,8 @@ jobs:
 
     - name: Test
       run: |
+        # do not use test_requirements.txt, it includes coverage which requires
+        # sqlite3, which is not available on OpenSUSE python
         pip install --break-system-packages pytest pytest-xdist hypothesis typing_extensions pytest-timeout
         spin test -j auto -- numpy/linalg  --timeout=600 --durations=10
 
@@ -297,7 +294,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         pip install mkl mkl-devel
 
     - name: Repair MKL pkg-config files and symlinks
@@ -361,7 +358,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         sudo apt-get update
         sudo apt-get install libblis-dev libopenblas-dev pkg-config
 
@@ -398,7 +395,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt
-        pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         sudo apt-get update
         sudo apt-get install libatlas-base-dev pkg-config
 

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -132,8 +132,7 @@ jobs:
         python-version: '3.11'
     - name: Install dependencies
       run: |
-        python -m pip install -r requirements/build_requirements.txt
-        python -m pip install pytest pytest-xdist hypothesis typing_extensions pytest-timeout
+        python -m pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
     - name: Build
       run: |
         spin build -- ${{ matrix.config.args }}
@@ -208,8 +207,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install -r requirements/build_requirements.txt
-        python -m pip install pytest pytest-xdist hypothesis typing_extensions
+        python -m pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
     - name: Build
       run: CC=gcc-13 CXX=g++-13 spin build -- -Denable-openmp=true -Dallow-noblas=true -Dcpu-baseline=avx512_skx -Dtest-simd='BASELINE,AVX512_KNL,AVX512_KNM,AVX512_SKX,AVX512_CLX,AVX512_CNL,AVX512_ICL,AVX512_SPR'
@@ -259,8 +257,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install -r requirements/build_requirements.txt
-        python -m pip install pytest pytest-xdist hypothesis typing_extensions
+        python -m pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
     - name: Build
       run: CC=gcc-13 CXX=g++-13 spin build -- -Denable-openmp=true -Dallow-noblas=true -Dcpu-baseline=avx512_spr

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -135,9 +135,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -r requirements/build_requirements.txt
-        pip install -r requirements/setuptools_requirement.txt
-        pip install pytest pytest-xdist pytest-timeout hypothesis
+        pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
 
     - name: Build against Accelerate (LP64)
       run: spin build -- -Ddisable-optimization=true -Dallow-noblas=false


### PR DESCRIPTION
Backport of #29919.

Closes #29916 

CI was not consistently using `requirements/test_requirements.txt`. I corrected this by grepping for `hypothesis` in all the github CI workflows. There is one left in the disabled cygwin workflow file.

* TST: use requirements/test_requirements across CI

* fixes

* fixes

* fixes

* fixes

* fixes

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
