### PR TITLE
MAINT: Avoid assumptions about how memory is allocated

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2248,19 +2248,18 @@ Shape Manipulation
         PyArrayObject* self, PyArray_Dims* newshape, int refcheck, \
         NPY_ORDER fortran)
 
-    Equivalent to :meth:`ndarray.resize<numpy.ndarray.resize>` (*self*, *newshape*, refcheck
-    ``=`` *refcheck*, order= fortran ). This function only works on
-    single-segment arrays. It changes the shape of *self* inplace and
-    will reallocate the memory for *self* if *newshape* has a
-    different total number of elements then the old shape. If
-    reallocation is necessary, then *self* must own its data, have
-    *self* - ``>base==NULL``, have *self* - ``>weakrefs==NULL``, and
-    (unless refcheck is 0) not be referenced by any other array.
-    The fortran argument can be :c:data:`NPY_ANYORDER`, :c:data:`NPY_CORDER`,
-    or :c:data:`NPY_FORTRANORDER`. It currently has no effect. Eventually
-    it could be used to determine how the resize operation should view
-    the data when constructing a differently-dimensioned array.
-    Returns None on success and NULL on error.
+    Equivalent to :meth:`ndarray.resize<numpy.ndarray.resize>` (*self*, *newshape*, *refcheck*).
+    This function only works on single-segment arrays. It changes the shape of
+    *self* inplace and will reallocate the memory for *self* if *newshape* has
+    a different total number of elements then the old shape. If reallocation is
+    necessary, then *self* must own its data, have *self* - ``>base==NULL``,
+    have *self* - ``>weakrefs==NULL``, and (unless refcheck is 0) not be
+    referenced by any other array.  The fortran argument can be
+    :c:data:`NPY_ANYORDER`, :c:data:`NPY_CORDER`, or
+    :c:data:`NPY_FORTRANORDER`.  It currently has no effect. Eventually it
+    could be used to determine how the resize operation should view the data
+    when constructing a differently-dimensioned array.  Returns None on success
+    and NULL on error.
 
 .. c:function:: PyObject* PyArray_Transpose( \
         PyArrayObject* self, PyArray_Dims* permute)

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2390,7 +2390,7 @@ PyArray_FromInterface(PyObject *origin)
         goto fail;
     }
     if (use_scalar_assign) {
-        /* 
+        /*
          * NOTE(seberg): I honestly doubt anyone is using this scalar path and we
          * could probably just deprecate (or just remove it in a 3.0 version).
          */
@@ -3732,21 +3732,20 @@ PyArray_FromFile(FILE *fp, PyArray_Descr *dtype, npy_intp num, char *sep)
     }
     if (((npy_intp) nread) < num) {
         /*
-         * Realloc memory for smaller number of elements, use original dtype
-         * which may have include a subarray (and is used for `nread`).
+         * Resize array to smaller number of elements. Note that original
+         * dtype may have included a subarray, so we may not be 1-d.
          */
-        const size_t nsize = PyArray_MAX(nread,1) * dtype->elsize;
-        char *tmp;
-
-        /* The handler is always valid */
-        if((tmp = PyDataMem_UserRENEW(PyArray_DATA(ret), nsize,
-                                     PyArray_HANDLER(ret))) == NULL) {
+        npy_intp dims[NPY_MAXDIMS];
+        dims[0] = (npy_intp)nread;
+        for (int i = 1; i < PyArray_NDIM(ret); i++) {
+            dims[i] = PyArray_DIMS(ret)[i];
+        }
+        PyArray_Dims new_dims = {dims, PyArray_NDIM(ret)};
+        if (PyArray_Resize_int(ret, &new_dims, 0) < 0) {
             Py_DECREF(dtype);
             Py_DECREF(ret);
-            return PyErr_NoMemory();
+            return NULL;
         }
-        ((PyArrayObject_fields *)ret)->data = tmp;
-        PyArray_DIMS(ret)[0] = nread;
     }
     Py_DECREF(dtype);
     return (PyObject *)ret;
@@ -3998,6 +3997,7 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
     PyObject *iter = NULL;
     PyArrayObject *ret = NULL;
     npy_intp i, elsize, elcount;
+    npy_intp dims[NPY_MAXDIMS];
 
     if (dtype == NULL) {
         return NULL;
@@ -4037,6 +4037,9 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
     if (ret == NULL) {
         goto done;
     }
+    /* set up for possible resizing */
+    memcpy(dims, PyArray_DIMS(ret), PyArray_NDIM(ret)*sizeof(npy_intp));
+    PyArray_Dims new_dims = {dims, PyArray_NDIM(ret)};
 
     char *item = PyArray_BYTES(ret);
     for (i = 0; i < count || count == -1; i++, item += elsize) {
@@ -4044,14 +4047,12 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
         if (value == NULL) {
             if (PyErr_Occurred()) {
                 /* Fetching next item failed perhaps due to exhausting iterator */
-                goto done;
+                goto fail;
             }
             break;
         }
 
         if (NPY_UNLIKELY(i >= elcount) && elsize != 0) {
-            char *new_data = NULL;
-            npy_intp nbytes;
             /*
               Grow PyArray_DATA(ret):
               this is similar for the strategy for PyListObject, but we use
@@ -4060,31 +4061,18 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
                     be suitable to reuse here.
             */
             elcount = (i >> 1) + (i < 4 ? 4 : 2) + i;
-            if (!npy_mul_sizes_with_overflow(&nbytes, elcount, elsize)) {
-                /* The handler is always valid */
-                new_data = PyDataMem_UserRENEW(
-                        PyArray_BYTES(ret), nbytes, PyArray_HANDLER(ret));
-            }
-            if (new_data == NULL) {
-                PyErr_SetString(PyExc_MemoryError,
-                        "cannot allocate array memory");
+            dims[0] = elcount;
+            if (PyArray_Resize_int(ret, &new_dims, 0) < 0) {
                 Py_DECREF(value);
-                goto done;
+                goto fail;
             }
-            ((PyArrayObject_fields *)ret)->data = new_data;
-            /* resize array for cleanup: */
-            PyArray_DIMS(ret)[0] = elcount;
             /* Reset `item` pointer to point into realloc'd chunk */
-            item = new_data + i * elsize;
-            if (PyDataType_FLAGCHK(dtype, NPY_NEEDS_INIT)) {
-                /* Initialize new chunk: */
-                memset(item, 0, nbytes - i * elsize);
-            }
+            item = ((char *)PyArray_DATA(ret)) + i * elsize;
         }
 
         if (PyArray_Pack(dtype, item, value) < 0) {
             Py_DECREF(value);
-            goto done;
+            goto fail;
         }
         Py_DECREF(value);
     }
@@ -4093,46 +4081,22 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
         PyErr_Format(PyExc_ValueError,
                 "iterator too short: Expected %zd but iterator had only %zd "
                 "items.", (Py_ssize_t)count, (Py_ssize_t)i);
-        goto done;
+        goto fail;
     }
 
     /*
      * Realloc the data so that don't keep extra memory tied up and fix
      * the arrays first dimension (there could be more than one).
      */
-    if (i == 0 || elsize == 0) {
-        /* The size cannot be zero for realloc. */
+    dims[0] = i;
+    if (!PyArray_Resize_int(ret, &new_dims, 0)) {
+        goto done;
     }
-    else {
-        /* Resize array to actual final size (it may be too large) */
-        /* The handler is always valid */
-        char *new_data = PyDataMem_UserRENEW(
-                PyArray_DATA(ret), i * elsize, PyArray_HANDLER(ret));
 
-        if (new_data == NULL) {
-            PyErr_SetString(PyExc_MemoryError,
-                    "cannot allocate array memory");
-            goto done;
-        }
-        ((PyArrayObject_fields *)ret)->data = new_data;
+  fail:
+    Py_CLEAR(ret);
 
-        if (count < 0) {
-            /*
-             * If the count was smaller than zero, the strides may be all 0
-             * (even in the later dimensions for `count < 0`!
-             * Thus, fix all strides here again for C-contiguity.
-             */
-            int oflags;
-            _array_fill_strides(
-                    PyArray_STRIDES(ret), PyArray_DIMS(ret), PyArray_NDIM(ret),
-                    PyArray_ITEMSIZE(ret), NPY_ARRAY_C_CONTIGUOUS, &oflags);
-            PyArray_STRIDES(ret)[0] = elsize;
-            assert(oflags & NPY_ARRAY_C_CONTIGUOUS);
-        }
-    }
-    PyArray_DIMS(ret)[0] = i;
-
- done:
+  done:
     Py_XDECREF(iter);
     Py_XDECREF(dtype);
     if (PyErr_Occurred()) {

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1175,8 +1175,7 @@ array_resize(PyArrayObject *self, PyObject *args, PyObject *kwds)
     Py_ssize_t size = PyTuple_Size(args);
     int refcheck = 1;
     PyArray_Dims newshape;
-    PyObject *ret, *obj;
-
+    PyObject *obj;
 
     if (!NpyArg_ParseKeywords(kwds, "|i", kwlist,  &refcheck)) {
         return NULL;
@@ -1199,12 +1198,11 @@ array_resize(PyArrayObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    ret = PyArray_Resize(self, &newshape, refcheck, NPY_ANYORDER);
+    int ret = PyArray_Resize_int(self, &newshape, refcheck);
     npy_free_cache_dim_obj(newshape);
-    if (ret == NULL) {
+    if (ret < 0) {
         return NULL;
     }
-    Py_DECREF(ret);
     Py_RETURN_NONE;
 }
 

--- a/numpy/_core/src/multiarray/shape.h
+++ b/numpy/_core/src/multiarray/shape.h
@@ -4,6 +4,12 @@
 #include "conversion_utils.h"
 
 /*
+ * Internal version of PyArray_Resize that returns -1 on error, 0 otherwise.
+ */
+NPY_NO_EXPORT int
+PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck);
+
+/*
  * Creates a sorted stride perm matching the KEEPORDER behavior
  * of the NpyIter object. Because this operates based on multiple
  * input strides, the 'stride' member of the npy_stride_sort_item


### PR DESCRIPTION
While trying to store data on the instance, I found that there were a few places where code needlessly relies on details of memory allocation. Since those cases are useful to fix even though I'm considering a better scheme that would not have problems, I thought I might as well put them in a separate PR.

For ease of reference, the three commits are:

MAINT: Avoid "fooling deallocator" in array_descr_set
Found this caused problems while trying to implement storing the
dimensions and strides on the instance.  Splitting it out since it is
generally bad form to assume too much about the inner workings of, e.g.,
the deallocator, and it has no real benefits beyond trying to be clever.

MAINT: Use PyArray_Resize to grow arrays in FromFile and FromIter
Found this while trying to implement storage on the instance, but
factored it out since it seems better form to just have one place
in numpy where arrays are resized inplace (which ideally would not
happen at all, but here is quite logical).

For PyArray_FromFile, there is little benefit beyond that, but in
PyArray_FromIter, it allows removing quite a bit of code that
duplicated what PyArray_Resize does.

MAINT: Ensure PyArray_Resize replaces empty allcation with 1 byte.
Minimum allocation should be 1, not elsize.  Also use the default
function to deallocate dimension & strides.