### PR TITLE
TST: Add unit test for RISC-V CPU features

### DIFF
--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -439,10 +439,10 @@ class Test_RISCV_Features(AbstractTest):
     features = ["RVV"]
 
     def load_flags(self):
-            self.load_flags_auxv()
-            if not self.features_flags:
-                # Let the test fail and dump if we cannot read HWCAP.
-                return
-            hwcap = int(next(iter(self.features_flags)), 16)
-            if hwcap & (1 << 21):  # HWCAP_RISCV_V
-                self.features_flags.add("RVV")
+        self.load_flags_auxv()
+        if not self.features_flags:
+            # Let the test fail and dump if we cannot read HWCAP.
+            return
+        hwcap = int(next(iter(self.features_flags)), 16)
+        if hwcap & (1 << 21):  # HWCAP_RISCV_V
+            self.features_flags.add("RVV")

--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -437,15 +437,12 @@ is_riscv = re.match(r"^(riscv)", machine, re.IGNORECASE)
 @pytest.mark.skipif(not is_linux or not is_riscv, reason="Only for Linux and RISC-V")
 class Test_RISCV_Features(AbstractTest):
     features = ["RVV"]
-    features_map = {"RVV": "V"}
 
     def load_flags(self):
-        self.features_flags = set()
-        with open('/proc/cpuinfo') as fd:
-            for line in fd:
-                if line.startswith("isa"):
-                    isa_string = line.split(':', 1)[1].strip()
-                    base_isa_part = isa_string.split('_')[0]
-                    if 'v' in base_isa_part:
-                        self.features_flags.add("V")
-                    break
+            self.load_flags_auxv()
+            if not self.features_flags:
+                # Let the test fail and dump if we cannot read HWCAP.
+                return
+            hwcap = int(next(iter(self.features_flags)), 16)
+            if hwcap & (1 << 21):  # HWCAP_RISCV_V
+                self.features_flags.add("RVV")

--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -431,3 +431,22 @@ class Test_LOONGARCH_Features(AbstractTest):
 
     def load_flags(self):
         self.load_flags_cpuinfo("Features")
+
+
+is_riscv = re.match(r"^(riscv)", machine, re.IGNORECASE)
+@pytest.mark.skipif(not is_linux or not is_riscv, reason="Only for Linux and RISC-V")
+class Test_RISCV_Features(AbstractTest):
+    features = ["RVV"]
+    features_map = {"RVV": "V"}
+
+    def load_flags(self):
+        self.features_flags = set()
+        with open('/proc/cpuinfo') as fd:
+            for line in fd:
+                if line.startswith("isa"):
+                    isa_string = line.split(':', 1)[1].strip()
+                    base_isa_part = isa_string.split('_')[0]
+                    if 'v' in base_isa_part:
+                        self.features_flags.add("V")
+                    break
+

--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -449,4 +449,3 @@ class Test_RISCV_Features(AbstractTest):
                     if 'v' in base_isa_part:
                         self.features_flags.add("V")
                     break
-


### PR DESCRIPTION
Test environment: Banana Pi BPI-F3 (SpacemiT K1 8-core RISC-V chip) gcc/g++ version 14.2.0
Test command: spin test -- -k "test_cpu_features" -v

<img width="1599" height="817" alt="Test_RISCV_Features" src="https://github.com/user-attachments/assets/29b41f07-78db-41a2-845f-3977da55b725" />
