### PR TITLE
ENH: ensure intent(inplace) does not mangle input array

### DIFF
--- a/doc/release/upcoming_changes/29929.improvement.rst
+++ b/doc/release/upcoming_changes/29929.improvement.rst
@@ -4,6 +4,16 @@ the input array was modified in-place, changing its dtype and
 replacing its data by a corrected copy.  Now, instead, the corrected
 copy is kept a separate array, which, after being passed and
 presumably modified by the fortran routine, is copied back to the
-input routine. This means one no longer has the risk that pre-existing
-views or slices of the input array start pointing to unallocated
-memory.
+input routine.  The above means one no longer has the risk that
+pre-existing views or slices of the input array start pointing to
+unallocated memory (at the price of increased overhead for the
+write-back copy at the end of the call).
+
+A potential problem would be that one might get very different results
+if one, e.g., previously passed in an integer array where a double
+array was expected: the writeback to integer would likely give wrong
+results.  To avoid such situations, ``intent(inplace)`` will now only
+allow arrays that have equivalent type to that used in the fortran
+routine, i.e., ``dtype.kind`` is the same. For instance, a routine
+expecting double would be able to receive float, but would raise on
+integer input.

--- a/doc/release/upcoming_changes/29929.improvement.rst
+++ b/doc/release/upcoming_changes/29929.improvement.rst
@@ -1,0 +1,9 @@
+For ``f2py``, the behaviour of ``intent(inplace)`` has improved.
+Previously, if an input array did not have the right dtype or order,
+the input array was modified in-place, changing its dtype and
+replacing its data by a corrected copy.  Now, instead, the corrected
+copy is kept a separate array, which, after being passed and
+presumably modified by the fortran routine, is copied back to the
+input routine. This means one no longer has the risk that pre-existing
+views or slices of the input array start pointing to unallocated
+memory.

--- a/doc/source/f2py/f2py.getting-started.rst
+++ b/doc/source/f2py/f2py.getting-started.rst
@@ -154,9 +154,8 @@ Fortran subroutine ``FIB`` is accessible via ``fib1.fib``::
     Clearly, this is unexpected, as Fortran typically passes by reference. That
     the above example worked with ``dtype=float`` is considered accidental.
 
-    F2PY provides an ``intent(inplace)`` attribute that modifies the attributes
-    of an input array so that any changes made by the Fortran routine will be
-    reflected in the input argument. For example, if one specifies the
+    F2PY provides an ``intent(inplace)`` attribute that ensures that changes
+    are copied back to the input argument. For example, if one specifies the
     ``intent(inplace) a`` directive (see :ref:`f2py-attributes` for details),
     then the example above would read::
 

--- a/doc/source/f2py/python-usage.rst
+++ b/doc/source/f2py/python-usage.rst
@@ -116,7 +116,7 @@ two notable exceptions:
   :term:`proper-contiguous <contiguous>` and have a compatible ``dtype``,
   otherwise an exception is raised.
 * ``intent(inplace)`` array arguments must be arrays. If these have
-  incompatible order or type, a converted copy is passed in, which is
+  incompatible order or size, a converted copy is passed in, which is
   copied back into the original array on exit (see the ``intent(inplace)``
   :ref:`attribute <f2py-attributes>` for more information).
 

--- a/doc/source/f2py/python-usage.rst
+++ b/doc/source/f2py/python-usage.rst
@@ -115,8 +115,9 @@ two notable exceptions:
 * ``intent(inout)`` array arguments must always be
   :term:`proper-contiguous <contiguous>` and have a compatible ``dtype``,
   otherwise an exception is raised.
-* ``intent(inplace)`` array arguments  will be changed *in situ* if the argument
-  has a different type than expected (see the ``intent(inplace)``
+* ``intent(inplace)`` array arguments must be arrays. If these have
+  incompatible order or type, a converted copy is passed in, which is
+  copied back into the original array on exit (see the ``intent(inplace)``
   :ref:`attribute <f2py-attributes>` for more information).
 
 In general, if a NumPy array is :term:`proper-contiguous <contiguous>` and has

--- a/doc/source/f2py/signature-file.rst
+++ b/doc/source/f2py/signature-file.rst
@@ -392,14 +392,15 @@ The following attributes can be used by F2PY.
   * ``inplace``
       The corresponding argument is considered to be an input/output or *in situ* output
       argument. ``intent(inplace)`` arguments must be NumPy arrays of a proper
-      size. If the type of an array is not "proper" or the array is
+      size. If the size of an array is not "proper" or the array is
       non-contiguous then the routine will be passed a fixed copy of array,
       which has the :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` flag set, so that the
       result will be copied back to the original array on exit.
 
       .. note::
 
-        ``intent(inplace)`` is recommended over ``inout``, but not over ``in,out``.
+         Since copies may be made, ``intent(inplace)`` can be slower than expected.
+         It is recommended over ``inout``, but not over ``in,out``.
 
   * ``out``
       The corresponding argument is considered to be a return variable. It is appended to the

--- a/doc/source/f2py/signature-file.rst
+++ b/doc/source/f2py/signature-file.rst
@@ -393,17 +393,13 @@ The following attributes can be used by F2PY.
       The corresponding argument is considered to be an input/output or *in situ* output
       argument. ``intent(inplace)`` arguments must be NumPy arrays of a proper
       size. If the type of an array is not "proper" or the array is
-      non-contiguous then the array will be modified in-place to fix the type and
-      make it contiguous.
+      non-contiguous then the routine will be passed a fixed copy of array,
+      which has the :c:data:`NPY_ARRAY_WRITEBACKIFCOPY` flag set, so that the
+      result will be copied back to the original array on exit.
 
       .. note::
 
-        Using ``intent(inplace)`` is generally not recommended either.
-
-        For example, when slices have been taken from an ``intent(inplace)`` argument
-        then after in-place changes, the data pointers for the slices may point to
-        an unallocated memory area.
-
+        ``intent(inplace)`` is recommended over ``inout``, but not over ``in,out``.
 
   * ``out``
       The corresponding argument is considered to be a return variable. It is appended to the

--- a/numpy/f2py/rules.py
+++ b/numpy/f2py/rules.py
@@ -96,6 +96,7 @@ from .auxfuncs import (
     isintent_copy,
     isintent_hide,
     isintent_inout,
+    isintent_inplace,
     isintent_nothide,
     isintent_out,
     isintent_overwrite,
@@ -1200,6 +1201,17 @@ if (#varname#_cb.capi==Py_None) {
     }
     if (f2py_success) {"""]},
                       ],
+        'pyobjfrom': [
+            {l_and(isintent_inplace, l_not(isintent_out)): """\
+        f2py_success = (PyArray_ResolveWritebackIfCopy(capi_#varname#_as_array) >= 0);
+        if (f2py_success) { /* inplace array #varname# has been written back to */"""},
+            {l_and(isintent_inplace, isintent_out): """\
+        f2py_success = (PyArray_ResolveWritebackIfCopy(capi_#varname#_as_array) >= 0);
+        if (f2py_success) { /* return written-back-to inplace array #varname# */
+        Py_INCREF(#varname#_capi);
+        Py_SETREF(capi_#varname#_as_array, (PyArrayObject*)#varname#_capi);"""},
+            ],
+        'closepyobjfrom': {isintent_inplace: '    } /*if (f2py_success) of #varname# pyobjfrom*/'},
         'cleanupfrompyobj': [  # note that this list will be reversed
             ('    }  '
              '/* if (capi_#varname#_as_array == NULL) ... else of #varname# */'),

--- a/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
+++ b/numpy/f2py/tests/src/array_from_pyobj/wrapmodule.c
@@ -120,10 +120,37 @@ static PyObject *f2py_rout_wrap_attrs(PyObject *capi_self,
                        PyArray_ITEMSIZE(arr));
 }
 
+static char doc_f2py_rout_wrap_resolve_write_back_if_copy[] = "\
+Function signature:\n\
+  resolvewritebackifcopy(arr)\n\
+  Calls PyArray_ResolveWriteBackIfCopy\n\
+Required arguments:\n"
+"  arr : input array object\n"
+"Return objects:\n"
+"  return_code : int\n"
+;
+static PyObject *f2py_rout_wrap_resolve_write_back_if_copy(PyObject *capi_self,
+                                      PyObject *capi_args) {
+  PyObject *arr_capi = Py_None;
+  PyArrayObject *arr = NULL;
+  if (!PyArg_ParseTuple(capi_args,"O!|:wrap.resolve_write_back_if_copy",
+                        &PyArray_Type,&arr_capi)) {
+    return NULL;
+  }
+  arr = (PyArrayObject *)arr_capi;
+  int res = PyArray_ResolveWritebackIfCopy(arr);
+  if (res < 0) {
+      return NULL;
+  }
+  return Py_BuildValue("i",res);
+}
+
 static PyMethodDef f2py_module_methods[] = {
 
   {"call",f2py_rout_wrap_call,METH_VARARGS,doc_f2py_rout_wrap_call},
   {"array_attrs",f2py_rout_wrap_attrs,METH_VARARGS,doc_f2py_rout_wrap_attrs},
+  {"resolve_write_back_if_copy",f2py_rout_wrap_resolve_write_back_if_copy,
+   METH_VARARGS,doc_f2py_rout_wrap_resolve_write_back_if_copy},
   {NULL,NULL}
 };
 

--- a/numpy/f2py/tests/src/inplace/foo.f
+++ b/numpy/f2py/tests/src/inplace/foo.f
@@ -1,0 +1,31 @@
+c     Test inplace calculations in array c, by squaring all its values.
+c     As a sanity check on the input, stores the original content in copy.
+      subroutine inplace(c, m1, m2, copy)
+      integer*4 m1, m2, i, j
+      real*4 c(m1, m2), copy(m1, m2)
+cf2py intent(inplace) c
+cf2py intent(out) copy
+cf2py integer, depend(c), intent(hide) :: m1 = len(c)
+cf2py integer, depend(c), intent(hide) :: m2 = shape(c, 1)
+      do i=1,m1
+         do j=1,m2
+            copy(i, j) = c(i, j)
+            c(i, j) = c(i, j) ** 2
+         end do
+      end do
+      end
+
+      subroutine inplace_out(c, m1, m2, copy)
+      integer*4 m1, m2, i, j
+      real*4 c(m1, m2), copy(m1, m2)
+cf2py intent(inplace, out) c
+cf2py intent(out) copy
+cf2py integer, depend(c), intent(hide) :: m1 = len(c)
+cf2py integer, depend(c), intent(hide) :: m2 = shape(c, 1)
+      do i=1,m1
+         do j=1,m2
+            copy(i, j) = c(i, j)
+            c(i, j) = c(i, j) ** 2
+         end do
+      end do
+      end

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -321,7 +321,17 @@ class Array:
         assert self.arr_attr[5][-2:] == self.pyarr_attr[5][-2:], repr((
             self.arr_attr[5], self.pyarr_attr[5]
             ))  # descr
-        assert self.arr_attr[6] == self.pyarr_attr[6], repr((
+        arr_flags = self.arr_attr[6]
+        if intent.is_intent("inplace") and not (
+                obj.dtype == typ and obj.flags["F_CONTIGUOUS"]
+        ):
+            assert flags2names(8192) == ["WRITEBACKIFCOPY"]
+            assert (arr_flags & 8192), f"{flags2names(8192)} not set."
+            arr_flags -= 8192  # Not easy to set on pyarr.
+        else:
+            assert not (arr_flags & 8192)
+
+        assert arr_flags == self.pyarr_attr[6], repr((
             self.arr_attr[6],
             self.pyarr_attr[6],
             flags2names(0 * self.arr_attr[6] - self.pyarr_attr[6]),
@@ -651,14 +661,34 @@ class TestSharedMemory:
         assert not obj.flags["FORTRAN"] and obj.flags["CONTIGUOUS"]
         shape = obj.shape
         a = self.array(shape, intent.inplace, obj)
+        # Spot check that they contain the same information initially.
         assert obj[1][2] == a.arr[1][2], repr((obj, a.arr))
-        a.arr[1][2] = 54
-        assert obj[1][2] == a.arr[1][2] == np.array(54, dtype=self.type.dtype)
+        # If we change a.arr, that will not immediatetly be reflected in obj.
+        change_item = 54 if self.type.dtype != bool else False
+        a.arr[1][2] = change_item
+        assert a.arr[1][2] == np.array(change_item, dtype=self.type.dtype)
+        assert obj[1][2] != np.array(change_item, dtype=self.type.dtype)
+        # This is because our implementation uses writebackifcopy.
+        assert a.arr.flags["WRITEBACKIFCOPY"]
+        assert a.arr.base is obj
+        # It has a different organization from obj.
+        assert a.arr.flags["FORTRAN"] and not a.arr.flags["CONTIGUOUS"]
+        # If we resolve the write-back, obj will be propertly filled.
+        code = wrap.resolve_write_back_if_copy(a.arr)
+        assert code == 1, "no write-back resolution was done!"
+        assert obj[1][2] == np.array(change_item, dtype=self.type.dtype)
+        # Check that the original's attributes are not messed up.
+        assert not obj.flags["FORTRAN"] and obj.flags["CONTIGUOUS"]
+
+    def test_inplace_f_order(self):
+        # If the input array is suitable, it will just be used.
+        obj = np.array(self.num23seq, dtype=self.type.dtype, order="F")
+        assert obj.flags["FORTRAN"] and not obj.flags["CONTIGUOUS"]
+        a = self.array(obj.shape, intent.inplace, obj)
         assert a.arr is obj
-        assert obj.flags["FORTRAN"]  # obj attributes are changed inplace!
-        assert not obj.flags["CONTIGUOUS"]
 
     def test_inplace_from_casttype(self):
+        # Similar to above, but including casting.
         for t in self.type.cast_types():
             if t is self.type:
                 continue
@@ -669,10 +699,22 @@ class TestSharedMemory:
             shape = obj.shape
             a = self.array(shape, intent.inplace, obj)
             assert obj[1][2] == a.arr[1][2], repr((obj, a.arr))
-            a.arr[1][2] = 54
-            assert obj[1][2] == a.arr[1][2] == np.array(54,
-                                                        dtype=self.type.dtype)
-            assert a.arr is obj
-            assert obj.flags["FORTRAN"]  # obj attributes changed inplace!
-            assert not obj.flags["CONTIGUOUS"]
-            assert obj.dtype.type is self.type.type  # obj changed inplace!
+            change_item = 54 if self.type.dtype != bool else False
+            a.arr[1][2] = change_item
+            assert a.arr[1][2] == np.array(change_item, dtype=self.type.dtype)
+            # Not yet propagated.
+            assert obj[1][2] != np.array(change_item, dtype=self.type.dtype)
+            assert a.arr.flags["WRITEBACKIFCOPY"]
+            assert a.arr.base is obj
+            # Propagate back to obj, ignoring warnings about loosing .imag.
+            if (np.issubdtype(a.arr.dtype, np.complexfloating)
+                    and not np.issubdtype(t.dtype, np.complexfloating)):
+                with pytest.warns(np.exceptions.ComplexWarning):
+                    code = wrap.resolve_write_back_if_copy(a.arr)
+            else:
+                code = wrap.resolve_write_back_if_copy(a.arr)
+            assert code == 1, "no write-back resolution was done!"
+            assert obj[1][2] == np.array(change_item, dtype=self.type.dtype)
+            # Should not affect attributes.
+            assert not obj.flags["FORTRAN"] and obj.flags["CONTIGUOUS"]
+            assert obj.dtype.type is not self.type.type

--- a/numpy/f2py/tests/test_inplace.py
+++ b/numpy/f2py/tests/test_inplace.py
@@ -1,0 +1,43 @@
+
+import pytest
+
+import numpy as np
+from numpy.f2py.tests import util
+from numpy.testing import assert_array_equal
+
+
+@pytest.mark.slow
+class TestInplace(util.F2PyTest):
+    sources = [util.getpath("tests", "src", "inplace", "foo.f")]
+
+    @pytest.mark.parametrize("func", ["inplace", "inplace_out"])
+    @pytest.mark.parametrize("writeable", ["writeable", "readonly"])
+    @pytest.mark.parametrize("view", [
+        None, (), (slice(None, 2, None), slice(None, None, 2))])
+    @pytest.mark.parametrize("dtype", ["f4", "f8"])
+    def test_inplace(self, dtype, view, writeable, func):
+        # Test inplace modifications of an input array.
+        a = np.arange(12.0, dtype=dtype).reshape((3, 4)).copy()
+        a.flags.writeable = writeable == "writeable"
+        k = a if view is None else a[view]
+
+        ffunc = getattr(self.module, func)
+        if not a.flags.writeable:
+            with pytest.raises(ValueError, match="WRITEBACKIFCOPY base is read-only"):
+                ffunc(k)
+            return
+
+        ref_k = k
+        exp_copy = k.copy()
+        exp_k = k ** 2
+        exp_a = a.copy()
+        exp_a[view or ()] = exp_k
+        if func == "inplace_out":
+            kout, copy = ffunc(k)
+            assert kout is k
+        else:
+            copy = ffunc(k)
+        assert_array_equal(copy, exp_copy)
+        assert k is ref_k
+        assert np.allclose(k, exp_k)
+        assert np.allclose(a, exp_a)

--- a/numpy/f2py/tests/test_inplace.py
+++ b/numpy/f2py/tests/test_inplace.py
@@ -41,3 +41,9 @@ class TestInplace(util.F2PyTest):
         assert k is ref_k
         assert np.allclose(k, exp_k)
         assert np.allclose(a, exp_a)
+
+    @pytest.mark.parametrize("func", ["inplace", "inplace_out"])
+    def test_inplace_error(self, func):
+        ffunc = getattr(self.module, func)
+        with pytest.raises(ValueError, match="input.*not compatible"):
+            ffunc(np.array([1 + 1j]))


### PR DESCRIPTION
While looking at trying to store data on instances, I ran into problems with f2py assuming one could just swap data between array instances. This is pretty bad form, but was probably necessary at the time, since we did not yet have `WRITEBACKIFCOPY`. But now we do. So, this PR uses it.

The commits are
1. Make the required changes and test them with a new piece of fortran code;
2. Adjust the tests that check the wrapper directly. This needed a small addition to `wrap`;
3. Adjust the documentation;
4. Changelog entry.

I'm quite pleased with how this turned out!