### PR TITLE
ENH: In spec registration, allow looking up ufuncs in any module.

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1895,7 +1895,10 @@ with the rest of the ArrayMethod API.
 
         .. c:member:: const char *name
 
-            The name of the ufunc to add the loop to.
+            The name of the ufunc to add the loop to, in the form like that of
+            entry points, ``(module ':')? (object '.')* name``, with ``numpy``
+            the default module. Examples: ``sin``, ``strings.str_len``,
+            ``numpy.strings:str_len``.
 
         .. c:member:: PyArrayMethod_Spec *spec
 

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -759,6 +759,7 @@ py.extension_module('_multiarray_tests',
     'src/common/mem_overlap.c',
     'src/common/npy_argparse.c',
     'src/common/npy_hashtable.cpp',
+    'src/common/npy_import.c',
     src_file.process('src/common/templ_common.h.src')
   ],
   c_args: c_args_common,

--- a/numpy/_core/src/common/npy_import.c
+++ b/numpy/_core/src/common/npy_import.c
@@ -19,3 +19,44 @@ init_import_mutex(void) {
 #endif
     return 0;
 }
+
+
+/*! \brief Import a Python object from an entry point string.
+
+ * The name should be of the form "(module ':')? (object '.')* attr".
+ * If no module is present, it is assumed to be "numpy".
+ * On error, returns NULL.
+ */
+NPY_NO_EXPORT PyObject*
+npy_import_entry_point(const char *entry_point) {
+    PyObject *result;
+    const char *item;
+
+    const char *colon = strchr(entry_point, ':');
+    if (colon) { // there is a module.
+        result = PyUnicode_FromStringAndSize(entry_point, colon - entry_point);
+        if (result != NULL) {
+            Py_SETREF(result, PyImport_Import(result));
+        }
+        item = colon + 1;
+    }
+    else {
+        result = PyImport_ImportModule("numpy");
+        item = entry_point;
+    }
+
+    const char *dot = item - 1;
+    while (result != NULL && dot != NULL) {
+        item = dot + 1;
+        dot = strchr(item, '.');
+        PyObject *string = PyUnicode_FromStringAndSize(
+            item, dot ? dot - item : strlen(item));
+        if (string == NULL) {
+            Py_DECREF(result);
+            return NULL;
+        }
+        Py_SETREF(result, PyObject_GetAttr(result, string));
+        Py_DECREF(string);
+    }
+    return result;
+}

--- a/numpy/_core/src/common/npy_import.h
+++ b/numpy/_core/src/common/npy_import.h
@@ -112,11 +112,20 @@ npy_cache_import_runtime(const char *module, const char *attr, PyObject **obj) {
 #endif
         Py_DECREF(value);
     }
-    return 0;    
+    return 0;
 }
 
 NPY_NO_EXPORT int
 init_import_mutex(void);
+
+/*! \brief Import a Python object from an entry point string.
+
+ * The name should be of the form "(module ':')? (object '.')* attr".
+ * If no module is present, it is assumed to be "numpy".
+ * On error, returns NULL.
+ */
+NPY_NO_EXPORT PyObject*
+npy_import_entry_point(const char *entry_point);
 
 #ifdef __cplusplus
 }

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -7,6 +7,7 @@
 #include "numpy/arrayscalars.h"
 #include "numpy/npy_math.h"
 #include "numpy/halffloat.h"
+#include "npy_import.h"
 #include "common.h"
 #include "npy_argparse.h"
 #include "mem_overlap.h"
@@ -2238,6 +2239,15 @@ run_scalar_intp_from_sequence(PyObject *NPY_UNUSED(self), PyObject *obj)
     return PyArray_IntTupleFromIntp(1, vals);
 }
 
+static PyObject *
+_npy_import_entry_point(PyObject *NPY_UNUSED(self), PyObject *obj) {
+    PyObject *res = PyUnicode_AsASCIIString(obj);
+    if (res != NULL) {
+        Py_SETREF(res, npy_import_entry_point(PyBytes_AS_STRING(res)));
+    }
+    return res;
+}
+
 static PyMethodDef Multiarray_TestsMethods[] = {
     {"argparse_example_function",
          (PyCFunction)argparse_example_function,
@@ -2422,6 +2432,9 @@ static PyMethodDef Multiarray_TestsMethods[] = {
     {"run_intp_converter",
         run_intp_converter,
         METH_VARARGS, NULL},
+    {"npy_import_entry_point",
+        _npy_import_entry_point,
+        METH_O, NULL},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 

--- a/numpy/_core/src/umath/_scaled_float_dtype.c
+++ b/numpy/_core/src/umath/_scaled_float_dtype.c
@@ -947,7 +947,7 @@ sfloat_argsort_resolve_descriptors(
 {
     assert(given_descrs[1] == NULL || given_descrs[1]->type_num == NPY_INTP);
     assert(PyArray_IsNativeByteOrder(given_descrs[0]->byteorder));
-    
+
     loop_descrs[0] = given_descrs[0];
     Py_INCREF(loop_descrs[0]);
     loop_descrs[1] = PyArray_DescrFromType(NPY_INTP);
@@ -1026,11 +1026,12 @@ sfloat_init_ufuncs(void) {
     argsort_spec.casting = NPY_NO_CASTING;
     argsort_spec.flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
 
+    /* here we chose weirdish names to test the lookup mechanism */
     PyUFunc_LoopSlot loops[] = {
         {"multiply", &multiply_spec},
-        {"add", &add_spec},
-        {"sort", &sort_spec},
-        {"argsort", &argsort_spec},
+        {"_core._multiarray_umath.add", &add_spec},
+        {"numpy:sort", &sort_spec},
+        {"numpy._core.fromnumeric:argsort", &argsort_spec},
         {NULL, NULL}
     };
     if (PyUFunc_AddLoopsFromSpecs(loops) < 0) {

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -213,7 +213,7 @@ PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots)
 
     PyUFunc_LoopSlot *slot;
     for (slot = slots; slot->name != NULL; slot++) {
-        PyObject *ufunc = npy_import("numpy", slot->name);
+        PyObject *ufunc = npy_import_entry_point(slot->name);
         if (ufunc == NULL) {
             return -1;
         }


### PR DESCRIPTION
This allows the addition of loops from specs also from more complicated names such as `numpy:strings.str_len`. cc @MaanasArora 

p.s. I really shouldn't have gone for doing it in C, but it turned out fairly simple, so I guess why not...
