### PR TITLE
CI: Use POWER10 GHA runner for NumPy test jobs

### DIFF
--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -20,7 +20,7 @@ jobs:
     # It requires a native ppc64le GHA runner, which is not available on forks.
     # For more details, see: https://github.com/numpy/numpy/issues/29125
     if: github.repository == 'numpy/numpy'
-    runs-on: ubuntu-24.04-ppc64le
+    runs-on: ubuntu-24.04-ppc64le-p10
     name: "Native PPC64LE"
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
This PR updates the CI configuration to run NumPy tests on a POWER10 self-hosted runner instead of the default environment (Power9). The change ensures SIMD-related tests (previously skipped on Power9) are now executed and validated on Power10 hardware where VSX4 is supported.

**Background / Motivation**

Earlier, the NumPy CI for ppc64le was running on POWER9 hardware.
Many tests (especially those in test_simd.py) were skipped due to lack of VSX4 SIMD support.
Follow-up investigation showed these tests pass correctly on POWER10 after fixes introduced in PR [https://github.com/numpy/numpy/pull/29893].

Moving to a POWER10 runner ensures better test coverage and validates modern hardware capabilities.

cc: @rgommers @ghatwala