### PR TITLE
CI: Run mypy on Python 3.14 and ignore more paths

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os_python:
-          - [macos-latest, '3.13']
+          - [macos-latest, '3.14']
           - [ubuntu-latest, '3.12']
           - [windows-latest, '3.11']
     steps:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -18,11 +18,14 @@ on:
       - main
       - maintenance/**
     paths-ignore:
-      - 'benchmarks/'
       - '.circlecl/'
+      - '.devcontainer/'
+      - 'benchmarks/'
+      - 'branding/'
       - 'docs/'
       - 'meson_cpu/'
       - 'tools/'
+      - 'vendored-meson/'
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
I did the lazy thing here and changed 3.13 to 3.14, seeing as there are more typing differences in 3.13->π then there are in 3.12->3.13