### PR TITLE
TST: Convert mixed_types_structured to method

### DIFF
--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -40,10 +40,9 @@ def test_comment_multiple_chars(comment):
     assert_equal(a, [[1.5, 2.5], [3.0, 4.0], [5.5, 6.0]])
 
 
-@pytest.fixture
 def mixed_types_structured():
     """
-    Fixture providing heterogeneous input data with a structured dtype, along
+    Function providing heterogeneous input data with a structured dtype, along
     with the associated structured array.
     """
     data = StringIO(
@@ -74,15 +73,14 @@ def mixed_types_structured():
 
 
 @pytest.mark.parametrize('skiprows', [0, 1, 2, 3])
-def test_structured_dtype_and_skiprows_no_empty_lines(
-        skiprows, mixed_types_structured):
-    data, dtype, expected = mixed_types_structured
+def test_structured_dtype_and_skiprows_no_empty_lines(skiprows):
+    data, dtype, expected = mixed_types_structured()
     a = np.loadtxt(data, dtype=dtype, delimiter=";", skiprows=skiprows)
     assert_array_equal(a, expected[skiprows:])
 
 
-def test_unpack_structured(mixed_types_structured):
-    data, dtype, expected = mixed_types_structured
+def test_unpack_structured():
+    data, dtype, expected = mixed_types_structured()
 
     a, b, c, d = np.loadtxt(data, dtype=dtype, delimiter=";", unpack=True)
     assert_array_equal(a, expected["f0"])


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
I've been working on making the NumPy test suite more thread safe. When running tests in `numpy/lib/tests/test_loadtxt.py` that use the custom `mixed_types_structured` fixture, they fail when ran under [pytest-run-parallel](https://github.com/Quansight-Labs/pytest-run-parallel), giving AssertionErrors. Here's the [test run](https://gist.github.com/bwhitt7/f5bb34c3bdd1ed0a6fd8d3f4fd728b8e) with errors if you're interested in seeing that.

I'm somewhat unsure why the usage of a fixture is triggering this, but since fixtures are shared between threads, `np.loadtxt` may be modifying the fixture values in some way that result in subsequent tests dealing with different data. Regardless, changing this from a fixture to a method fixes the issue.