### PR TITLE
STY: rename @classmethod arg to cls

### DIFF
--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1631,17 +1631,17 @@ class TestImplementation:
     """
 
     @classmethod
-    def setup_class(self):
-        self.MISSING = 0x80
-        self.INITIALIZED = 0x40
-        self.OUTSIDE_ARENA = 0x20
-        self.LONG = 0x10
-        self.dtype = StringDType(na_object=np.nan)
-        self.sizeofstr = self.dtype.itemsize
-        sp = self.dtype.itemsize // 2  # pointer size = sizeof(size_t)
+    def setup_class(cls):
+        cls.MISSING = 0x80
+        cls.INITIALIZED = 0x40
+        cls.OUTSIDE_ARENA = 0x20
+        cls.LONG = 0x10
+        cls.dtype = StringDType(na_object=np.nan)
+        cls.sizeofstr = cls.dtype.itemsize
+        sp = cls.dtype.itemsize // 2  # pointer size = sizeof(size_t)
         # Below, size is not strictly correct, since it really uses
         # 7 (or 3) bytes, but good enough for the tests here.
-        self.view_dtype = np.dtype([
+        cls.view_dtype = np.dtype([
             ('offset', f'u{sp}'),
             ('size', f'u{sp // 2}'),
             ('xsiz', f'V{sp // 2 - 1}'),
@@ -1652,13 +1652,13 @@ class TestImplementation:
             ('size', f'u{sp // 2}'),
             ('offset', f'u{sp}'),
         ])
-        self.s_empty = ""
-        self.s_short = "01234"
-        self.s_medium = "abcdefghijklmnopqrstuvwxyz"
-        self.s_long = "-=+" * 100
-        self.a = np.array(
-            [self.s_empty, self.s_short, self.s_medium, self.s_long],
-            self.dtype)
+        cls.s_empty = ""
+        cls.s_short = "01234"
+        cls.s_medium = "abcdefghijklmnopqrstuvwxyz"
+        cls.s_long = "-=+" * 100
+        cls.a = np.array(
+            [cls.s_empty, cls.s_short, cls.s_medium, cls.s_long],
+            cls.dtype)
 
     def get_view(self, a):
         # Cannot view a StringDType as anything else directly, since


### PR DESCRIPTION
Backport of #29948.

For some reason this was causing stubtest to crash :shrug:
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
