### PR TITLE
MAINT: replace use of ``asanyarray`` with ``out=...`` to keep arrays

### DIFF
--- a/numpy/_core/_methods.py
+++ b/numpy/_core/_methods.py
@@ -185,15 +185,14 @@ def _var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *,
     # Compute sum of squared deviations from mean
     # Note that x may not be inexact and that we need it to be an array,
     # not a scalar.
-    x = asanyarray(arr - arrmean)
-
+    x = um.subtract(arr, arrmean, out=...)
     if issubclass(arr.dtype.type, (nt.floating, nt.integer)):
-        x = um.multiply(x, x, out=x)
+        x = um.square(x, out=x)
     # Fast-paths for built-in complex types
-    elif x.dtype in _complex_to_float:
-        xv = x.view(dtype=(_complex_to_float[x.dtype], (2,)))
-        um.multiply(xv, xv, out=xv)
-        x = um.add(xv[..., 0], xv[..., 1], out=x.real).real
+    elif (_float_dtype := _complex_to_float.get(x.dtype)) is not None:
+        xv = x.view(dtype=(_float_dtype, (2,)))
+        um.square(xv, out=xv)
+        x = um.add(xv[..., 0], xv[..., 1], out=x.real)
     # Most general case; includes handling object arrays containing imaginary
     # numbers and complex types with non-native byteorder
     else:

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -42,6 +42,7 @@ from numpy._core.umath import (
     arctan2,
     cos,
     exp,
+    floor,
     frompyfunc,
     less_equal,
     minimum,
@@ -4679,9 +4680,8 @@ def _lerp(a, b, t, out=None):
     out : array_like
         Output array.
     """
-    diff_b_a = subtract(b, a)
-    # asanyarray is a stop-gap until gh-13105
-    lerp_interpolation = asanyarray(add(a, diff_b_a * t, out=out))
+    diff_b_a = b - a
+    lerp_interpolation = add(a, diff_b_a * t, out=... if out is None else out)
     subtract(b, diff_b_a * (1 - t), out=lerp_interpolation, where=t >= 0.5,
              casting='unsafe', dtype=type(lerp_interpolation.dtype))
     if lerp_interpolation.ndim == 0 and out is None:
@@ -4773,8 +4773,8 @@ def _get_indexes(arr, virtual_indexes, valid_values_count):
     (previous_indexes, next_indexes): Tuple
         A Tuple of virtual_indexes neighbouring indexes
     """
-    previous_indexes = np.asanyarray(np.floor(virtual_indexes))
-    next_indexes = np.asanyarray(previous_indexes + 1)
+    previous_indexes = floor(virtual_indexes, out=...)
+    next_indexes = add(previous_indexes, 1, out=...)
     indexes_above_bounds = virtual_indexes >= valid_values_count - 1
     # When indexes is above max index, take the max value of the array
     if indexes_above_bounds.any():

--- a/numpy/lib/_ufunclike_impl.py
+++ b/numpy/lib/_ufunclike_impl.py
@@ -57,7 +57,7 @@ def fix(x, out=None):
 
     """
     # promote back to an array if flattened
-    res = nx.asanyarray(nx.ceil(x, out=out))
+    res = nx.ceil(x, out=... if out is None else out)
     res = nx.floor(x, out=res, where=nx.greater_equal(x, 0))
 
     # when no out argument is passed and no subclasses are involved, flatten

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3895,7 +3895,7 @@ class TestQuantile:
 
         q = np.quantile(x, .5)
         assert_equal(q, 1.75)
-        assert_equal(type(q), np.float64)
+        assert isinstance(q, float)
 
         q = np.quantile(x, Fraction(1, 2))
         assert_equal(q, Fraction(7, 4))

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2016,18 +2016,14 @@ def cond(x, p=None):
         r = r.astype(result_t, copy=False)
 
     # Convert nans to infs unless the original array had nan entries
-    r = asarray(r)
     nan_mask = isnan(r)
     if nan_mask.any():
         nan_mask &= ~isnan(x).any(axis=(-2, -1))
         if r.ndim > 0:
             r[nan_mask] = inf
         elif nan_mask:
-            r[()] = inf
-
-    # Convention is to return scalars instead of 0d arrays
-    if r.ndim == 0:
-        r = r[()]
+            # Convention is to return scalars instead of 0d arrays.
+            r = r.dtype.type(inf)
 
     return r
 


### PR DESCRIPTION
With #28576, it has become possible to ensure that when calling a ufunc, the output is guaranteed to be an array.

This PR uses that to replace `np.asanyarray` calls in some functions. I'm not sure this is complete -- these were just parts of code for which test failed if `np.anyarray(scalar)` is made to return a read-only array (see #29876).

I do think there are all small improvements, though.