### PR TITLE
TYP: fix return type annotation for normalize_axis_tuple utility

### DIFF
--- a/numpy/lib/_array_utils_impl.pyi
+++ b/numpy/lib/_array_utils_impl.pyi
@@ -17,7 +17,7 @@ def normalize_axis_tuple(
     ndim: int,
     argname: str | None = None,
     allow_duplicate: bool | None = False,
-) -> tuple[int, int]: ...
+) -> tuple[int, ...]: ...
 
 def normalize_axis_index(
     axis: int = ...,


### PR DESCRIPTION
The tuple returned from this function can have any length.