### PR TITLE
TST: Remove recwarn from tests

### DIFF
--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -723,22 +723,22 @@ class TestNanFunctions_MeanVarStd(SharedNanFunctionsTestsMixin):
                 res = nf(_ndat, axis=1, ddof=ddof)
                 assert_almost_equal(res, tgt)
 
-    def test_ddof_too_big(self, recwarn):
+    def test_ddof_too_big(self):
         nanfuncs = [np.nanvar, np.nanstd]
         stdfuncs = [np.var, np.std]
         dsize = [len(d) for d in _rdat]
         for nf, rf in zip(nanfuncs, stdfuncs):
             for ddof in range(5):
-                with warnings.catch_warnings():
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter('always')
                     warnings.simplefilter('ignore', ComplexWarning)
                     tgt = [ddof >= d for d in dsize]
                     res = nf(_ndat, axis=1, ddof=ddof)
                     assert_equal(np.isnan(res), tgt)
                 if any(tgt):
-                    assert_(len(recwarn) == 1)
-                    recwarn.pop(RuntimeWarning)
+                    assert_(len(w) == 1)
                 else:
-                    assert_(len(recwarn) == 0)
+                    assert_(len(w) == 0)
 
     @pytest.mark.parametrize("axis", [None, 0, 1])
     @pytest.mark.parametrize("dtype", np.typecodes["AllFloat"])


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
I'm working on making the NumPy test suite more thread-safe and able to be run under `pytest-run-parallel` (talk about it more here #29552). Looks like `recwarn` isn't thread-safe, so this PR introduces a change to make any tests that uses the `recwarn` fixture (so far just 1) use the `warnings.catch_warnings` context instead. The test in question already was using that, so it makes it so `warnings.catch_warnings` records the warnings now instead of `recwarn`.