### PR TITLE
MAINT: remove obsolete ``generic.tostring`` method descriptor and docstring

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -6850,9 +6850,6 @@ add_newdoc('numpy._core.numerictypes', 'generic',
            refer_to_array_attribute('tolist'))
 
 add_newdoc('numpy._core.numerictypes', 'generic',
-           refer_to_array_attribute('tostring'))
-
-add_newdoc('numpy._core.numerictypes', 'generic',
            refer_to_array_attribute('trace'))
 
 add_newdoc('numpy._core.numerictypes', 'generic',

--- a/numpy/_core/defchararray.py
+++ b/numpy/_core/defchararray.py
@@ -496,7 +496,6 @@ class chararray(ndarray):
     title
     tofile
     tolist
-    tostring
     translate
     transpose
     upper

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2185,7 +2185,7 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
  * #name = take, getfield, put, repeat, tofile, mean, trace, diagonal, clip,
  *         std, var, sum, cumsum, prod, cumprod, compress, sort, argsort,
  *         round, argmax, argmin, max, min, any, all, astype, resize,
- *         reshape, choose, tostring, tobytes, copy, searchsorted, view,
+ *         reshape, choose, tobytes, copy, searchsorted, view,
  *         flatten, ravel, squeeze#
  */
 static PyObject *
@@ -2642,9 +2642,6 @@ static PyMethodDef gentype_methods[] = {
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"tofile",
         (PyCFunction)gentype_tofile,
-        METH_VARARGS | METH_KEYWORDS, NULL},
-    {"tostring",
-        (PyCFunction)gentype_tostring,
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"byteswap",
         (PyCFunction)gentype_byteswap,


### PR DESCRIPTION
The method was removed in 2.3, but the method descriptor was still there on the `numpy.generic` type, which could be pretty confusing:

```pycon
>>> import numpy as np
>>> np.int8.tostring
<method 'tostring' of 'numpy.generic' objects>
>>> np.int8().tostring()
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    np.int8().tostring()
    ~~~~~~~~~~~~~~~~~~^^
AttributeError: 'numpy.ndarray' object has no attribute 'tostring'
```