### PR TITLE
MAINT: Remove removed array methods

### DIFF
--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -865,34 +865,6 @@ array_matrix_transpose_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
     return PyArray_MatrixTranspose(self);
 }
 
-static PyObject *
-array_ptp(PyArrayObject *self, void *NPY_UNUSED(ignored))
-{
-    PyErr_SetString(PyExc_AttributeError,
-                    "`ptp` was removed from the ndarray class in NumPy 2.0. "
-                    "Use np.ptp(arr, ...) instead.");
-    return NULL;
-}
-
-static PyObject *
-array_newbyteorder(PyArrayObject *self, PyObject *args)
-{
-    PyErr_SetString(PyExc_AttributeError,
-                    "`newbyteorder` was removed from the ndarray class "
-                    "in NumPy 2.0. "
-                    "Use `arr.view(arr.dtype.newbyteorder(order))` instead.");
-    return NULL;
-}
-
-static PyObject *
-array_itemset(PyArrayObject *self, PyObject *args)
-{
-    PyErr_SetString(PyExc_AttributeError,
-                    "`itemset` was removed from the ndarray class in "
-                    "NumPy 2.0. Use `arr[index] = value` instead.");
-    return NULL;
-}
-
 NPY_NO_EXPORT PyGetSetDef array_getsetlist[] = {
     {"ndim",
         (getter)array_ndim_get,
@@ -956,18 +928,6 @@ NPY_NO_EXPORT PyGetSetDef array_getsetlist[] = {
         NULL, NULL},
     {"mT",
         (getter)array_matrix_transpose_get,
-        NULL,
-        NULL, NULL},
-    {"ptp",
-        (getter)array_ptp,
-        NULL,
-        NULL, NULL},
-    {"newbyteorder",
-        (getter)array_newbyteorder,
-        NULL,
-        NULL, NULL},
-    {"itemset",
-        (getter)array_itemset,
         NULL,
         NULL, NULL},
     {"device",

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1940,33 +1940,6 @@ gentype_transpose_get(PyObject *self, void *NPY_UNUSED(ignored))
     return self;
 }
 
-static PyObject *
-gentype_newbyteorder(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
-{
-    PyErr_SetString(PyExc_AttributeError, 
-                    "`newbyteorder` was removed from scalar types in NumPy 2.0. "
-                    "Use `sc.view(sc.dtype.newbyteorder(order))` instead.");
-    return NULL;
-}
-
-static PyObject *
-gentype_itemset(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
-{
-    PyErr_SetString(PyExc_AttributeError, 
-                    "`itemset` was removed from scalar types in NumPy 2.0 "
-                    "because scalars are immutable.");
-    return NULL;
-}
-
-static PyObject *
-gentype_ptp(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
-{
-    PyErr_SetString(PyExc_AttributeError, 
-                    "`ptp` was removed from scalar types in NumPy 2.0. "
-                    "For a scalar, the range of values always equals 0.");
-    return NULL;
-}
-
 
 static PyGetSetDef gentype_getsets[] = {
     {"ndim",
@@ -2010,15 +1983,6 @@ static PyGetSetDef gentype_getsets[] = {
         (setter)0, NULL, NULL},
     {"T",
         (getter)gentype_transpose_get,
-        (setter)0, NULL, NULL},
-    {"newbyteorder",
-        (getter)gentype_newbyteorder,
-        (setter)0, NULL, NULL},
-    {"itemset",
-        (getter)gentype_itemset,
-        (setter)0, NULL, NULL},
-    {"ptp",
-        (getter)gentype_ptp,
         (setter)0, NULL, NULL},
     {"device",
         (getter)array_device,

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -288,10 +288,10 @@ class TestMatrixReturn:
             'argmin', 'choose', 'dump', 'dumps', 'fill', 'getfield',
             'getA', 'getA1', 'item', 'nonzero', 'put', 'putmask', 'resize',
             'searchsorted', 'setflags', 'setfield', 'sort',
-            'partition', 'argpartition', 'newbyteorder', 'to_device',
+            'partition', 'argpartition', 'to_device',
             'take', 'tofile', 'tolist', 'tobytes', 'all', 'any',
             'sum', 'argmax', 'argmin', 'min', 'max', 'mean', 'var', 'ptp',
-            'prod', 'std', 'ctypes', 'itemset', 'bitwise_count',
+            'prod', 'std', 'ctypes', 'bitwise_count',
             ]
         for attrib in dir(a):
             if attrib.startswith('_') or attrib in excluded_methods:

--- a/numpy/typing/tests/data/reveal/ndarray_conversion.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_conversion.pyi
@@ -37,7 +37,6 @@ any_sctype: np.ndarray[Any, Any]
 assert_type(any_dtype.tolist(), Any)
 assert_type(any_sctype.tolist(), Any)
 
-# itemset does not return a value
 # tobytes is pretty simple
 # tofile does not return a value
 # dump does not return a value


### PR DESCRIPTION
(that's not a typo in the title)

The `ptp`, `itemset`, and `newbyteorder` methods of `ndarray` and `generic` were removed in numpy 2. However, they still existed, but attempting to call them resulted in an `AttributeError` with a paradoxical message

> `ptp` was removed from the ndarray class in NumPy 2.0. Use np.ptp(arr, ...) instead.

So that got me thinking: "how can something that is removed raise an error?". After a bit of digging, I found the relevant C code, and got rid of it at the root. That way, we avoid causality-breaking parodoxes, making it less likely that the universe will collapse in on itself.

Before:

```py
>>> np.ndarray.ptp
<attribute 'ptp' of 'numpy.ndarray' objects>

>>> np.array(1).ptp()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[2], line 1
----> 1 np.array(1).ptp()

AttributeError: `ptp` was removed from the ndarray class in NumPy 2.0. Use np.ptp(arr, ...) instead.
```

After:

```py
>>> np.ndarray.ptp
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[1], line 1
----> 1 np.ndarray.ptp

AttributeError: type object 'numpy.ndarray' has no attribute 'ptp'

>>> np.array(1).ptp()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[4], line 1
----> 1 np.array(1).ptp()

AttributeError: 'numpy.ndarray' object has no attribute 'ptp'
```

It's the same with `itemset` and  `newbyteorder`.