### PR TITLE
TYP: fix stubtest errors in ``lib._function_base_impl``

### DIFF
--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -626,7 +626,6 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> floating: ...
 @overload
 def percentile(
@@ -639,7 +638,6 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> complexfloating: ...
 @overload
 def percentile(
@@ -652,7 +650,6 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> timedelta64: ...
 @overload
 def percentile(
@@ -665,7 +662,6 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> datetime64: ...
 @overload
 def percentile(
@@ -678,7 +674,6 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> Any: ...
 @overload
 def percentile(
@@ -691,7 +686,6 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> NDArray[floating]: ...
 @overload
 def percentile(
@@ -704,7 +698,6 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> NDArray[complexfloating]: ...
 @overload
 def percentile(
@@ -717,7 +710,6 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> NDArray[timedelta64]: ...
 @overload
 def percentile(
@@ -730,7 +722,6 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> NDArray[datetime64]: ...
 @overload
 def percentile(
@@ -743,7 +734,6 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> NDArray[object_]: ...
 @overload
 def percentile(
@@ -756,7 +746,6 @@ def percentile(
     keepdims: bool = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> Any: ...
 @overload
 def percentile(
@@ -769,7 +758,6 @@ def percentile(
     keepdims: bool = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> _ArrayT: ...
 @overload
 def percentile(
@@ -782,7 +770,6 @@ def percentile(
     method: _MethodKind = "linear",
     keepdims: bool = False,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> _ArrayT: ...
 
 # NOTE: keep in sync with `percentile`
@@ -797,7 +784,6 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> floating: ...
 @overload
 def quantile(
@@ -810,7 +796,6 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> complexfloating: ...
 @overload
 def quantile(
@@ -823,7 +808,6 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> timedelta64: ...
 @overload
 def quantile(
@@ -836,7 +820,6 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> datetime64: ...
 @overload
 def quantile(
@@ -849,7 +832,6 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> Any: ...
 @overload
 def quantile(
@@ -862,7 +844,6 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> NDArray[floating]: ...
 @overload
 def quantile(
@@ -875,7 +856,6 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> NDArray[complexfloating]: ...
 @overload
 def quantile(
@@ -888,7 +868,6 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> NDArray[timedelta64]: ...
 @overload
 def quantile(
@@ -901,7 +880,6 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> NDArray[datetime64]: ...
 @overload
 def quantile(
@@ -914,7 +892,6 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> NDArray[object_]: ...
 @overload
 def quantile(
@@ -927,7 +904,6 @@ def quantile(
     keepdims: bool = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> Any: ...
 @overload
 def quantile(
@@ -940,7 +916,6 @@ def quantile(
     keepdims: bool = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> _ArrayT: ...
 @overload
 def quantile(
@@ -953,7 +928,6 @@ def quantile(
     method: _MethodKind = "linear",
     keepdims: bool = False,
     weights: _ArrayLikeFloat_co | None = None,
-    interpolation: None = None,  # deprecated
 ) -> _ArrayT: ...
 
 _ScalarT_fm = TypeVar(

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -415,6 +415,7 @@ def sort_complex(a: ArrayLike) -> NDArray[complexfloating]: ...
 def trim_zeros(
     filt: _TrimZerosSequence[_T],
     trim: L["f", "b", "fb", "bf"] = "fb",
+    axis: _ShapeLike | None = None,
 ) -> _T: ...
 
 @overload

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -288,21 +288,21 @@ def gradient(
 ) -> Any: ...
 
 @overload
-def diff(
+def diff(  # type: ignore[overload-overlap]
     a: _T,
     n: L[0],
     axis: SupportsIndex = -1,
-    prepend: ArrayLike = ...,
-    append: ArrayLike = ...,
+    prepend: ArrayLike | _NoValueType = ...,  # = _NoValue
+    append: ArrayLike | _NoValueType = ...,  # = _NoValue
 ) -> _T: ...
 @overload
 def diff(
     a: ArrayLike,
     n: int = 1,
     axis: SupportsIndex = -1,
-    prepend: ArrayLike = ...,
-    append: ArrayLike = ...,
-) -> NDArray[Any]: ...
+    prepend: ArrayLike | _NoValueType = ...,  # = _NoValue
+    append: ArrayLike | _NoValueType = ...,  # = _NoValue
+) -> NDArray[Incomplete]: ...
 
 @overload  # float scalar
 def interp(

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -627,6 +627,7 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> floating: ...
 @overload
 def percentile(
@@ -639,6 +640,7 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> complexfloating: ...
 @overload
 def percentile(
@@ -651,6 +653,7 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> timedelta64: ...
 @overload
 def percentile(
@@ -663,6 +666,7 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> datetime64: ...
 @overload
 def percentile(
@@ -675,6 +679,7 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> Any: ...
 @overload
 def percentile(
@@ -687,6 +692,7 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> NDArray[floating]: ...
 @overload
 def percentile(
@@ -699,6 +705,7 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> NDArray[complexfloating]: ...
 @overload
 def percentile(
@@ -711,6 +718,7 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> NDArray[timedelta64]: ...
 @overload
 def percentile(
@@ -723,6 +731,7 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> NDArray[datetime64]: ...
 @overload
 def percentile(
@@ -735,6 +744,7 @@ def percentile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> NDArray[object_]: ...
 @overload
 def percentile(
@@ -747,6 +757,7 @@ def percentile(
     keepdims: bool = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> Any: ...
 @overload
 def percentile(
@@ -759,6 +770,7 @@ def percentile(
     keepdims: bool = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> _ArrayT: ...
 @overload
 def percentile(
@@ -771,6 +783,7 @@ def percentile(
     method: _MethodKind = "linear",
     keepdims: bool = False,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> _ArrayT: ...
 
 # NOTE: keep in sync with `percentile`
@@ -785,6 +798,7 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> floating: ...
 @overload
 def quantile(
@@ -797,6 +811,7 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> complexfloating: ...
 @overload
 def quantile(
@@ -809,6 +824,7 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> timedelta64: ...
 @overload
 def quantile(
@@ -821,6 +837,7 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> datetime64: ...
 @overload
 def quantile(
@@ -833,6 +850,7 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> Any: ...
 @overload
 def quantile(
@@ -845,6 +863,7 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> NDArray[floating]: ...
 @overload
 def quantile(
@@ -857,6 +876,7 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> NDArray[complexfloating]: ...
 @overload
 def quantile(
@@ -869,6 +889,7 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> NDArray[timedelta64]: ...
 @overload
 def quantile(
@@ -881,6 +902,7 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> NDArray[datetime64]: ...
 @overload
 def quantile(
@@ -893,6 +915,7 @@ def quantile(
     keepdims: L[False] = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> NDArray[object_]: ...
 @overload
 def quantile(
@@ -905,6 +928,7 @@ def quantile(
     keepdims: bool = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> Any: ...
 @overload
 def quantile(
@@ -917,6 +941,7 @@ def quantile(
     keepdims: bool = False,
     *,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> _ArrayT: ...
 @overload
 def quantile(
@@ -929,6 +954,7 @@ def quantile(
     method: _MethodKind = "linear",
     keepdims: bool = False,
     weights: _ArrayLikeFloat_co | None = None,
+    interpolation: None = None,  # deprecated
 ) -> _ArrayT: ...
 
 _ScalarT_fm = TypeVar(

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -231,7 +231,6 @@ def piecewise(
         Callable[Concatenate[NDArray[_ScalarT], _Pss], NDArray[_ScalarT | Any]]
         | _ScalarT | object
     ],
-    /,
     *args: _Pss.args,
     **kw: _Pss.kwargs,
 ) -> NDArray[_ScalarT]: ...
@@ -243,7 +242,6 @@ def piecewise(
         Callable[Concatenate[NDArray[Any], _Pss], NDArray[Any]]
         | object
     ],
-    /,
     *args: _Pss.args,
     **kw: _Pss.kwargs,
 ) -> NDArray[Any]: ...

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -478,7 +478,7 @@ def cov(
 # NOTE `bias` and `ddof` are deprecated and ignored
 @overload
 def corrcoef(
-    m: _ArrayLikeFloat_co,
+    x: _ArrayLikeFloat_co,
     y: _ArrayLikeFloat_co | None = None,
     rowvar: bool = True,
     bias: _NoValueType = ...,
@@ -488,7 +488,7 @@ def corrcoef(
 ) -> NDArray[floating]: ...
 @overload
 def corrcoef(
-    m: _ArrayLikeComplex_co,
+    x: _ArrayLikeComplex_co,
     y: _ArrayLikeComplex_co | None = None,
     rowvar: bool = True,
     bias: _NoValueType = ...,
@@ -498,7 +498,7 @@ def corrcoef(
 ) -> NDArray[complexfloating]: ...
 @overload
 def corrcoef(
-    m: _ArrayLikeComplex_co,
+    x: _ArrayLikeComplex_co,
     y: _ArrayLikeComplex_co | None = None,
     rowvar: bool = True,
     bias: _NoValueType = ...,
@@ -508,7 +508,7 @@ def corrcoef(
 ) -> NDArray[_ScalarT]: ...
 @overload
 def corrcoef(
-    m: _ArrayLikeComplex_co,
+    x: _ArrayLikeComplex_co,
     y: _ArrayLikeComplex_co | None = None,
     rowvar: bool = True,
     bias: _NoValueType = ...,


### PR DESCRIPTION
- `corrcoef`: wrong parameter name
- `diff`: default argument not assignable to parameter type
- ~`percentile` and `quantile`: missing (deprecated) `interpolation` kwarg~
- `piecewise`: the first three parameters shouldn't be positional-only
- `trim_zeros`: missing `axis` parameter (since 2.2.0)