### PR TITLE
DEP: remove the ``fix_imports`` parameter from ``save()``

### DIFF
--- a/doc/release/upcoming_changes/29984.expired.rst
+++ b/doc/release/upcoming_changes/29984.expired.rst
@@ -1,0 +1,5 @@
+Removed ``fix_imports`` parameter from ``numpy.save``
+-----------------------------------------------------
+
+The ``fix_imports`` parameter was deprecated in NumPy 2.1.0 and is now removed.
+This flag has been ignored since NumPy 1.17 and was only needed to support loading files in Python 2 that were written in Python 3.

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -11,7 +11,7 @@ import pytest
 import numpy as np
 import numpy._core._struct_ufunc_tests as struct_ufunc
 from numpy._core._multiarray_tests import fromstring_null_term_c_api  # noqa: F401
-from numpy.testing import assert_raises, temppath
+from numpy.testing import assert_raises
 
 
 class _DeprecationTestCase:
@@ -390,29 +390,6 @@ class TestDeprecatedDTypeParenthesizedRepeatCount(_DeprecationTestCase):
     @pytest.mark.parametrize("string", ["(2)i,", "(3)3S,", "f,(2)f"])
     def test_parenthesized_repeat_count(self, string):
         self.assert_deprecated(np.dtype, args=(string,))
-
-
-class TestDeprecatedSaveFixImports(_DeprecationTestCase):
-    # Deprecated in Numpy 2.1, 2024-05
-    message = "The 'fix_imports' flag is deprecated and has no effect."
-
-    def test_deprecated(self):
-        with temppath(suffix='.npy') as path:
-            sample_args = (path, np.array(np.zeros((1024, 10))))
-            self.assert_not_deprecated(np.save, args=sample_args)
-            self.assert_deprecated(np.save, args=sample_args,
-                                kwargs={'fix_imports': True})
-            self.assert_deprecated(np.save, args=sample_args,
-                                kwargs={'fix_imports': False})
-            for allow_pickle in [True, False]:
-                self.assert_not_deprecated(np.save, args=sample_args,
-                                        kwargs={'allow_pickle': allow_pickle})
-                self.assert_deprecated(np.save, args=sample_args,
-                                    kwargs={'allow_pickle': allow_pickle,
-                                            'fix_imports': True})
-                self.assert_deprecated(np.save, args=sample_args,
-                                    kwargs={'allow_pickle': allow_pickle,
-                                            'fix_imports': False})
 
 
 class TestAddNewdocUFunc(_DeprecationTestCase):

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -497,12 +497,12 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
                     f"Failed to interpret file {file!r} as a pickle") from e
 
 
-def _save_dispatcher(file, arr, allow_pickle=None, fix_imports=None):
+def _save_dispatcher(file, arr, allow_pickle=None):
     return (arr,)
 
 
 @array_function_dispatch(_save_dispatcher)
-def save(file, arr, allow_pickle=True, fix_imports=np._NoValue):
+def save(file, arr, allow_pickle=True):
     """
     Save an array to a binary file in NumPy ``.npy`` format.
 
@@ -523,12 +523,6 @@ def save(file, arr, allow_pickle=True, fix_imports=np._NoValue):
         require libraries that are not available, and not all pickled data is
         compatible between different versions of Python).
         Default: True
-    fix_imports : bool, optional
-        The `fix_imports` flag is deprecated and has no effect.
-
-        .. deprecated:: 2.1
-            This flag is ignored since NumPy 1.17 and was only needed to
-            support loading in Python 2 some files written in Python 3.
 
     See Also
     --------
@@ -565,12 +559,6 @@ def save(file, arr, allow_pickle=True, fix_imports=np._NoValue):
     >>> print(a, b)
     # [1 2] [1 3]
     """
-    if fix_imports is not np._NoValue:
-        # Deprecated 2024-05-16, NumPy 2.1
-        warnings.warn(
-            "The 'fix_imports' flag is deprecated and has no effect. "
-            "(Deprecated in NumPy 2.1)",
-            DeprecationWarning, stacklevel=2)
     if hasattr(file, 'write'):
         file_ctx = contextlib.nullcontext(file)
     else:
@@ -581,8 +569,7 @@ def save(file, arr, allow_pickle=True, fix_imports=np._NoValue):
 
     with file_ctx as fid:
         arr = np.asanyarray(arr)
-        format.write_array(fid, arr, allow_pickle=allow_pickle,
-                           pickle_kwargs={'fix_imports': fix_imports})
+        format.write_array(fid, arr, allow_pickle=allow_pickle)
 
 
 def _savez_dispatcher(file, *args, allow_pickle=True, **kwds):

--- a/numpy/lib/_npyio_impl.pyi
+++ b/numpy/lib/_npyio_impl.pyi
@@ -21,7 +21,7 @@ from typing import (
     overload,
     type_check_only,
 )
-from typing_extensions import TypeVar, deprecated, override
+from typing_extensions import TypeVar, override
 
 import numpy as np
 from numpy._core.multiarray import packbits, unpackbits
@@ -105,19 +105,8 @@ def load(
     max_header_size: int = 10_000,
 ) -> Any: ...
 
-@overload
 def save(file: _FNameWriteBytes, arr: ArrayLike, allow_pickle: bool = True) -> None: ...
-@overload
-@deprecated("The 'fix_imports' flag is deprecated in NumPy 2.1.")
-def save(file: _FNameWriteBytes, arr: ArrayLike, allow_pickle: bool, fix_imports: bool) -> None: ...
-@overload
-@deprecated("The 'fix_imports' flag is deprecated in NumPy 2.1.")
-def save(file: _FNameWriteBytes, arr: ArrayLike, allow_pickle: bool = True, *, fix_imports: bool) -> None: ...
-
-#
 def savez(file: _FNameWriteBytes, *args: ArrayLike, allow_pickle: bool = True, **kwds: ArrayLike) -> None: ...
-
-#
 def savez_compressed(file: _FNameWriteBytes, *args: ArrayLike, allow_pickle: bool = True, **kwds: ArrayLike) -> None: ...
 
 # File-like objects only have to implement `__iter__` and,

--- a/numpy/typing/tests/data/fail/npyio.pyi
+++ b/numpy/typing/tests/data/fail/npyio.pyi
@@ -12,8 +12,8 @@ AR_i8: npt.NDArray[np.int64]
 
 np.load(str_file)  # type: ignore[arg-type]
 
-np.save(bytes_path, AR_i8)  # type: ignore[call-overload]
-np.save(str_path, AR_i8, fix_imports=True)  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
+np.save(bytes_path, AR_i8)  # type: ignore[arg-type]
+np.save(str_path, AR_i8, fix_imports=True)  # type: ignore[call-arg]
 
 np.savez(bytes_path, AR_i8)  # type: ignore[arg-type]
 


### PR DESCRIPTION
It was deprecated 17 months ago in 2.1.

Towards #11521