### PR TITLE
MAINT: Remove ``_core.MachAr`` remnants

### DIFF
--- a/numpy/_core/__init__.py
+++ b/numpy/_core/__init__.py
@@ -187,18 +187,6 @@ def _DType_reduce(DType):
     return _DType_reconstruct, (scalar_type,)
 
 
-def __getattr__(name):
-    # Deprecated 2022-11-22, NumPy 1.25.
-    if name == "MachAr":
-        import warnings
-        warnings.warn(
-            "The `np._core.MachAr` is considered private API (NumPy 1.24)",
-            DeprecationWarning, stacklevel=2,
-        )
-        return _machar.MachAr
-    raise AttributeError(f"Module {__name__!r} has no attribute {name!r}")
-
-
 import copyreg
 
 copyreg.pickle(ufunc, _ufunc_reduce)


### PR DESCRIPTION
I'm not sure what this was still doing here, because accessing it will result in a `NameError`:

```py
In [1]: np._core.MachAr
<ipython-input-1-a529026e93f8>:1: DeprecationWarning: The `np._core.MachAr` is considered private API (NumPy 1.24)
  np._core.MachAr
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
Cell In[1], line 1
----> 1 np._core.MachAr

File ~/Workspace/numpy/build-install/usr/lib/python3.14/site-packages/numpy/_core/__init__.py:198, in __getattr__(name)
    193     import warnings
    194     warnings.warn(
    195         "The `np._core.MachAr` is considered private API (NumPy 1.24)",
    196         DeprecationWarning, stacklevel=2,
    197     )
--> 198     return _machar.MachAr
    199 raise AttributeError(f"Module {__name__!r} has no attribute {name!r}")

NameError: name '_machar' is not defined
```

I wasn't able to find anything resembling the `MachAr` type or the `_machar` module either. So I'm guessing it was recently removed then?

Towards #11521 then, I guess.