### PR TITLE
DEP: Remove ``ndarray.ctypes.get_*`` methods (deprecated since 1.21)

### DIFF
--- a/doc/release/upcoming_changes/29986.expired.rst
+++ b/doc/release/upcoming_changes/29986.expired.rst
@@ -1,0 +1,10 @@
+Removal of four undocumented ``ndarray.ctypes`` methods
+-------------------------------------------------------
+Four undocumented methods of the ``ndarray.ctypes`` object have been removed:
+
+* ``_ctypes.get_data()`` (use ``_ctypes.data`` instead)
+* ``_ctypes.get_shape()`` (use ``_ctypes.shape`` instead)
+* ``_ctypes.get_strides()`` (use ``_ctypes.strides`` instead)
+* ``_ctypes.get_as_parameter()`` (use ``_ctypes._as_parameter_`` instead)
+
+These methods have been deprecated since NumPy 1.21.

--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -365,46 +365,6 @@ class _ctypes:
         """
         return self.data_as(ctypes.c_void_p)
 
-    # Numpy 1.21.0, 2021-05-18
-
-    def get_data(self):
-        """Deprecated getter for the `_ctypes.data` property.
-
-        .. deprecated:: 1.21
-        """
-        warnings.warn('"get_data" is deprecated. Use "data" instead',
-                      DeprecationWarning, stacklevel=2)
-        return self.data
-
-    def get_shape(self):
-        """Deprecated getter for the `_ctypes.shape` property.
-
-        .. deprecated:: 1.21
-        """
-        warnings.warn('"get_shape" is deprecated. Use "shape" instead',
-                      DeprecationWarning, stacklevel=2)
-        return self.shape
-
-    def get_strides(self):
-        """Deprecated getter for the `_ctypes.strides` property.
-
-        .. deprecated:: 1.21
-        """
-        warnings.warn('"get_strides" is deprecated. Use "strides" instead',
-                      DeprecationWarning, stacklevel=2)
-        return self.strides
-
-    def get_as_parameter(self):
-        """Deprecated getter for the `_ctypes._as_parameter_` property.
-
-        .. deprecated:: 1.21
-        """
-        warnings.warn(
-            '"get_as_parameter" is deprecated. Use "_as_parameter_" instead',
-            DeprecationWarning, stacklevel=2,
-        )
-        return self._as_parameter_
-
 
 def _newnames(datatype, order):
     """

--- a/numpy/_core/_internal.pyi
+++ b/numpy/_core/_internal.pyi
@@ -2,7 +2,7 @@ import ctypes as ct
 import re
 from collections.abc import Callable, Iterable
 from typing import Any, Final, Generic, Self, overload
-from typing_extensions import TypeVar, deprecated
+from typing_extensions import TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -46,16 +46,6 @@ class _ctypes(Generic[_PT_co]):
     def data_as(self, /, obj: type[_CastT]) -> _CastT: ...
     def shape_as(self, /, obj: type[_CT]) -> ct.Array[_CT]: ...
     def strides_as(self, /, obj: type[_CT]) -> ct.Array[_CT]: ...
-
-    #
-    @deprecated('"get_data" is deprecated. Use "data" instead')
-    def get_data(self, /) -> _PT_co: ...
-    @deprecated('"get_shape" is deprecated. Use "shape" instead')
-    def get_shape(self, /) -> ct.Array[c_intp]: ...
-    @deprecated('"get_strides" is deprecated. Use "strides" instead')
-    def get_strides(self, /) -> ct.Array[c_intp]: ...
-    @deprecated('"get_as_parameter" is deprecated. Use "_as_parameter_" instead')
-    def get_as_parameter(self, /) -> ct.c_void_p: ...
 
 class dummy_ctype(Generic[_T_co]):
     _cls: type[_T_co]

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -197,20 +197,9 @@ class FlatteningConcatenateUnsafeCast(_DeprecationTestCase):
 
 
 class TestCtypesGetter(_DeprecationTestCase):
-    # Deprecated 2021-05-18, Numpy 1.21.0
-    warning_cls = DeprecationWarning
     ctypes = np.array([1]).ctypes
 
-    @pytest.mark.parametrize(
-        "name", ["get_data", "get_shape", "get_strides", "get_as_parameter"]
-    )
-    def test_deprecated(self, name: str) -> None:
-        func = getattr(self.ctypes, name)
-        self.assert_deprecated(func)
-
-    @pytest.mark.parametrize(
-        "name", ["data", "shape", "strides", "_as_parameter_"]
-    )
+    @pytest.mark.parametrize("name", ["data", "shape", "strides", "_as_parameter_"])
     def test_not_deprecated(self, name: str) -> None:
         self.assert_not_deprecated(lambda: getattr(self.ctypes, name))
 

--- a/numpy/typing/tests/data/pass/ndarray_misc.py
+++ b/numpy/typing/tests/data/pass/ndarray_misc.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 import operator
 from typing import Any, cast
 
-import pytest
-
 import numpy as np
 import numpy.typing as npt
 
@@ -189,14 +187,3 @@ A_float = np.array([[1, 5], [2, 4], [np.nan, np.nan]])
 A_void: npt.NDArray[np.void] = np.empty(3, [("yop", float), ("yap", float)])
 A_void["yop"] = A_float[:, 0]
 A_void["yap"] = A_float[:, 1]
-
-# deprecated
-
-with pytest.deprecated_call():
-    ctypes_obj.get_data()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
-with pytest.deprecated_call():
-    ctypes_obj.get_shape()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
-with pytest.deprecated_call():
-    ctypes_obj.get_strides()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]
-with pytest.deprecated_call():
-    ctypes_obj.get_as_parameter()  # type: ignore[deprecated]  # pyright: ignore[reportDeprecated]


### PR DESCRIPTION
This removes the following deprecated `numpy._core._internal._ctypes` methods:

- `get_data()`
- `get_shape()`
- `get_strides()`
- `get_as_parameter()`

Towards #11521