### PR TITLE
ENH, API: Add `sort_compare` slot to DType and use sort wrappers if provided

### DIFF
--- a/doc/release/upcoming_changes/29987.new_feature.rst
+++ b/doc/release/upcoming_changes/29987.new_feature.rst
@@ -1,0 +1,5 @@
+`NPY_DT_sort_compare` DType slot for custom sorting
+---------------------------------------------------
+User-defined dtypes can now implement custom sorting using the new
+`NPY_DT_sort_compare` DType slot. This mechanism can be used in place of the
+`NPY_DT_PyArray_ArrFuncs_compare` slot which may be deprecated in the future.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2085,7 +2085,8 @@ struct contains a ``flags`` field which is a bitwise OR of ``NPY_SORTKIND``
 values indicating the kind of sort to perform (that is, whether it is a
 stable and/or descending sort). If the strided loop depends on the flags,
 a good way to deal with this is to define :c:macro:`NPY_METH_get_loop`,
-and not set any of the other loop slots.
+and not set any of the other loop slots. Note that for both ascending and
+descending sorts, NaN-like values should be sorted to the end.
 
 .. c:struct:: PyArrayMethod_SortParameters
 
@@ -3718,14 +3719,22 @@ member of ``PyArrayDTypeMeta_Spec`` struct.
 
 .. c:macro:: NPY_DT_sort_compare
 
-.. c:type:: int (PyArrayDTypeMeta_CompareFuncWithDescr)( \
-                char *a, char *b, PyArray_Descr *descr)
+.. c:type:: int (PyArrayDTypeMeta_CompareFuncWithContext)( \
+                char *a, char *b, PyArrayMethod_Context *context)
 
    If defined, implements a comparison function for sorting arrays of this DType,
    which can be used instead of the full sort loops (see :ref:`array-methods-sorting`).
    If defined, NumPy will use this function to implement all sorting algorithms for
-   the DType. Should return a negative value if *a* < *b*, zero if *a* == *b*, and
-   a positive value if *a* > *b*.
+   the DType.
+
+   The `parameters` member of the *context* can be used to access the sorting parameters
+   of type ``PyArrayMethod_SortParameters``, which are the same as passed to the sort
+   ArrayMethods. This can be used to determine if the sort is ascending or descending.
+
+   The function must return a negative value if *a* < *b*, zero if *a* == *b*,
+   and a positive value if *a* > *b*. If the sort is descending, the comparison
+   result should be inverted, however NaN handling should remain the same (i.e., NaNs
+   are always considered larger than any other value, regardless of sort order).
 
 PyArray_ArrFuncs slots
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2097,6 +2097,10 @@ and not set any of the other loop slots.
 These specs can be registered using :c:func:`PyUFunc_AddLoopsFromSpecs`
 along with other ufunc loops.
 
+Alternatively, custom sorting and argsorting for a DType can be
+registered by defining the DType slot :c:macro:`NPY_DT_sort_compare`
+with a comparison function.
+
 API for calling array methods
 -----------------------------
 
@@ -3712,6 +3716,17 @@ member of ``PyArrayDTypeMeta_Spec`` struct.
        The number of decimal digits of precision. Corresponds to ``DIG`` from C
        standard macros (e.g., ``FLT_DIG``, ``DBL_DIG``).
 
+.. c:macro:: NPY_DT_sort_compare
+
+.. c:type:: int (PyArrayDTypeMeta_CompareFuncWithDescr)( \
+                char *a, char *b, PyArray_Descr *descr)
+
+   If defined, implements a comparison function for sorting arrays of this DType,
+   which can be used instead of the full sort loops (see :ref:`array-methods-sorting`).
+   If defined, NumPy will use this function to implement all sorting algorithms for
+   the DType. Should return a negative value if *a* < *b*, zero if *a* == *b*, and
+   a positive value if *a* > *b*.
+
 PyArray_ArrFuncs slots
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3738,6 +3753,8 @@ DType API slots but for now we have exposed the legacy
 .. c:macro:: NPY_DT_PyArray_ArrFuncs_compare
 
    Computes a comparison for `numpy.sort`, implements ``PyArray_CompareFunc``.
+   This slot may be deprecated in the future in favor of the
+   ``NPY_DT_sort_compare`` DType API slot.
 
 .. c:macro:: NPY_DT_PyArray_ArrFuncs_argmax
 
@@ -3781,13 +3798,17 @@ DType API slots but for now we have exposed the legacy
 
    An array of PyArray_SortFunc of length ``NPY_NSORTS``. If set, allows
    defining custom sorting implementations for each of the sorting
-   algorithms numpy implements.
+   algorithms numpy implements. This slot may be deprecated in the future
+   in favor of the ArrayMethod API for sorting
+   (see :ref:`array-methods-sorting`).
 
 .. c:macro:: NPY_DT_PyArray_ArrFuncs_argsort
 
    An array of PyArray_ArgSortFunc of length ``NPY_NSORTS``. If set,
    allows defining custom argsorting implementations for each of the
-   sorting algorithms numpy implements.
+   sorting algorithms numpy implements. This slot may be deprecated in
+   the future in favor of the ArrayMethod API for argsorting
+   (see :ref:`array-methods-sorting`).
 
 Macros and Static Inline Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -545,6 +545,7 @@ typedef struct {
     NPY_SORTKIND flags;
 } PyArrayMethod_SortParameters;
 
-typedef int (PyArrayDTypeMeta_CompareFuncWithDescr)(char *, char *, PyArray_Descr *);
+typedef int (PyArrayDTypeMeta_CompareFuncWithContext)(
+        char *, char *, PyArrayMethod_Context *context);
 
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY___DTYPE_API_H_ */

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -394,6 +394,7 @@ typedef int (PyArrayMethod_PromoterFunction)(PyObject *ufunc,
 #define NPY_DT_get_fill_zero_loop 10
 #define NPY_DT_finalize_descr 11
 #define NPY_DT_get_constant 12
+#define NPY_DT_sort_compare 13
 
 // These PyArray_ArrFunc slots will be deprecated and replaced eventually
 // getitem and setitem can be defined as a performance optimization;
@@ -543,5 +544,7 @@ typedef PyObject *(PyArrayDTypeMeta_GetItem)(PyArray_Descr *, char *);
 typedef struct {
     NPY_SORTKIND flags;
 } PyArrayMethod_SortParameters;
+
+typedef int (PyArrayDTypeMeta_CompareFuncWithDescr)(char *, char *, PyArray_Descr *);
 
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY___DTYPE_API_H_ */

--- a/numpy/_core/src/common/npy_sort.h.src
+++ b/numpy/_core/src/common/npy_sort.h.src
@@ -5,6 +5,7 @@
 #include <Python.h>
 #include <numpy/npy_common.h>
 #include <numpy/ndarraytypes.h>
+#include <numpy/ndarrayobject.h>
 
 #define NPY_ENOMEM 1
 #define NPY_ECOMP 2
@@ -106,6 +107,40 @@ NPY_NO_EXPORT int npy_aquicksort(void *vec, npy_intp *ind, npy_intp cnt, void *a
 NPY_NO_EXPORT int npy_aheapsort(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
 NPY_NO_EXPORT int npy_amergesort(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
 NPY_NO_EXPORT int npy_atimsort(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
+
+/*
+ *****************************************************************************
+ **                     NEW-STYLE GENERIC SORT LOOPS                        **
+ *****************************************************************************
+ */
+
+NPY_NO_EXPORT int npy_quicksort_loop(PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata);
+NPY_NO_EXPORT int npy_mergesort_loop(PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata);
+NPY_NO_EXPORT int npy_aquicksort_loop(PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata);
+NPY_NO_EXPORT int npy_amergesort_loop(PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata);
+
+/*
+ *****************************************************************************
+ **                      GENERIC SORT IMPLEMENTATIONS                       **
+ *****************************************************************************
+ */
+
+NPY_NO_EXPORT int npy_quicksort_impl(void *start, npy_intp num, void *varr,
+                                     npy_intp elsize, PyArray_CompareFunc *cmp);
+NPY_NO_EXPORT int npy_mergesort_impl(void *start, npy_intp num, void *varr,
+                                     npy_intp elsize, PyArray_CompareFunc *cmp);
+NPY_NO_EXPORT int npy_aquicksort_impl(void *vv, npy_intp *tosort, npy_intp num, void *varr,
+                                      npy_intp elsize, PyArray_CompareFunc *cmp);
+NPY_NO_EXPORT int npy_amergesort_impl(void *v, npy_intp *tosort, npy_intp num, void *varr,
+                                      npy_intp elsize, PyArray_CompareFunc *cmp);
 
 #ifdef __cplusplus
 }

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -343,11 +343,11 @@ fill_arraymethod_from_slots(
                 }
             }
             if (i >= meth->nin && NPY_DT_is_parametric(res->dtypes[i])) {
-                PyErr_Format(PyExc_TypeError,
-                        "must provide a `resolve_descriptors` function if any "
-                        "output DType is parametric. (method: %s)",
-                        spec->name);
-                return -1;
+                // PyErr_Format(PyExc_TypeError,
+                //         "must provide a `resolve_descriptors` function if any "
+                //         "output DType is parametric. (method: %s)",
+                //         spec->name);
+                // return -1;
             }
         }
     }

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -182,71 +182,6 @@ PyArray_ArrFuncs default_funcs = {
 
 
 NPY_NO_EXPORT int
-wrap_legacy_sort_loop(PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata, PyArray_SortFunc *sortfunc)
-{
-    char *start = data[0];
-    npy_intp num = dimensions[0];
-    void *arr = context->descriptors[0];
-    return sortfunc(start, num, arr);
-}
-
-
-NPY_NO_EXPORT int
-wrap_legacy_argsort_loop(PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata, PyArray_ArgSortFunc *argsortfunc)
-{
-    char *start = data[0];
-    npy_intp num = dimensions[0];
-    void *arr = context->descriptors[0];
-    npy_intp *out = (npy_intp *)data[1];
-    return argsortfunc(start, out, num, arr);
-}
-
-
-NPY_NO_EXPORT int
-default_defaultsort_loop(PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata)
-{
-    return wrap_legacy_sort_loop(context, data, dimensions, strides, transferdata,
-        &npy_quicksort);
-}
-
-
-NPY_NO_EXPORT int
-default_stablesort_loop(PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata)
-{
-    return wrap_legacy_sort_loop(context, data, dimensions, strides, transferdata,
-        &npy_mergesort);
-}
-
-
-NPY_NO_EXPORT int
-default_defaultargsort_loop(PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata)
-{
-    return wrap_legacy_argsort_loop(context, data, dimensions, strides, transferdata,
-        &npy_aquicksort);
-}
-
-
-NPY_NO_EXPORT int
-default_stableargsort_loop(PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata)
-{
-    return wrap_legacy_argsort_loop(context, data, dimensions, strides, transferdata,
-        &npy_amergesort);
-}
-
-
-NPY_NO_EXPORT int
 default_sort_get_loop(
         PyArrayMethod_Context *context,
         int aligned, int move_references,
@@ -262,10 +197,10 @@ default_sort_get_loop(
     }
 
     if (parameters->flags == NPY_SORT_STABLE) {
-        *out_loop = (PyArrayMethod_StridedLoop *)default_stablesort_loop;
+        *out_loop = (PyArrayMethod_StridedLoop *)npy_mergesort_loop;
     }
     else if (parameters->flags == NPY_SORT_DEFAULT) {
-        *out_loop = (PyArrayMethod_StridedLoop *)default_defaultsort_loop;
+        *out_loop = (PyArrayMethod_StridedLoop *)npy_quicksort_loop;
     }
     else {
         PyErr_SetString(PyExc_RuntimeError, "unsupported sort kind");
@@ -291,10 +226,10 @@ default_argsort_get_loop(
     }
 
     if (parameters->flags == NPY_SORT_STABLE) {
-        *out_loop = (PyArrayMethod_StridedLoop *)default_stableargsort_loop;
+        *out_loop = (PyArrayMethod_StridedLoop *)npy_amergesort_loop;
     }
     else if (parameters->flags == NPY_SORT_DEFAULT) {
-        *out_loop = (PyArrayMethod_StridedLoop *)default_defaultargsort_loop;
+        *out_loop = (PyArrayMethod_StridedLoop *)npy_aquicksort_loop;
     }
     else {
         PyErr_SetString(PyExc_RuntimeError, "unsupported sort kind");

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -332,7 +332,7 @@ wrap_default_sort_methods(PyArray_DTypeMeta *cls)
     PyBoundArrayMethodObject *sort_method = PyArrayMethod_FromSpec_int(
             &sort_spec, 1);
     if (sort_method == NULL) {
-        PyDataMem_Free(sort_name);
+        PyDataMem_FREE(sort_name);
         return -1;
     }
     NPY_DT_SLOTS(cls)->sort_meth = sort_method->method;
@@ -361,7 +361,7 @@ wrap_default_sort_methods(PyArray_DTypeMeta *cls)
     PyBoundArrayMethodObject *argsort_method = PyArrayMethod_FromSpec_int(
             &argsort_spec, 1);
     if (argsort_method == NULL) {
-        PyDataMem_Free(argsort_name);
+        PyDataMem_FREE(argsort_name);
         return -1;
     }
     NPY_DT_SLOTS(cls)->argsort_meth = argsort_method->method;

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -179,26 +179,6 @@ dtypemeta_wrap_legacy_descriptor(
 NPY_NO_EXPORT void
 initialize_legacy_dtypemeta_aliases(_PyArray_LegacyDescr **_builtin_descrs);
 
-NPY_NO_EXPORT int
-default_defaultsort_loop(PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata);
-
-NPY_NO_EXPORT int
-default_stablesort_loop(PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata);
-
-NPY_NO_EXPORT int
-default_defaultargsort_loop(PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata);
-
-NPY_NO_EXPORT int
-default_stableargsort_loop(PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata);
-
 /*
  * NumPy's builtin DTypes:
  */

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -73,6 +73,11 @@ typedef struct {
      */
     PyArrayDTypeMeta_GetConstant *get_constant;
     /*
+     * Function to compare two values of this type, given a descriptor.
+     * Used for sorting if custom loops are not provided.
+     */
+    PyArrayDTypeMeta_CompareFuncWithDescr *sort_compare;
+    /*
      * The casting implementation (ArrayMethod) to convert between two
      * instances of this DType, stored explicitly for fast access:
      */
@@ -100,7 +105,7 @@ typedef struct {
 
 // This must be updated if new slots before within_dtype_castingimpl
 // are added
-#define NPY_NUM_DTYPE_SLOTS 12
+#define NPY_NUM_DTYPE_SLOTS 13
 #define NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS 22
 #define NPY_DT_MAX_ARRFUNCS_SLOT \
   NPY_NUM_DTYPE_PYARRAY_ARRFUNCS_SLOTS + _NPY_DT_ARRFUNCS_OFFSET
@@ -173,6 +178,26 @@ dtypemeta_wrap_legacy_descriptor(
 
 NPY_NO_EXPORT void
 initialize_legacy_dtypemeta_aliases(_PyArray_LegacyDescr **_builtin_descrs);
+
+NPY_NO_EXPORT int
+default_defaultsort_loop(PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata);
+
+NPY_NO_EXPORT int
+default_stablesort_loop(PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata);
+
+NPY_NO_EXPORT int
+default_defaultargsort_loop(PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata);
+
+NPY_NO_EXPORT int
+default_stableargsort_loop(PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata);
 
 /*
  * NumPy's builtin DTypes:

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -76,7 +76,7 @@ typedef struct {
      * Function to compare two values of this type, given a descriptor.
      * Used for sorting if custom loops are not provided.
      */
-    PyArrayDTypeMeta_CompareFuncWithDescr *sort_compare;
+    PyArrayDTypeMeta_CompareFuncWithContext *sort_compare;
     /*
      * The casting implementation (ArrayMethod) to convert between two
      * instances of this DType, stored explicitly for fast access:

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1227,7 +1227,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
         return 0;
     }
     
-    if (method_flags != NULL) {
+    if (strided_loop != NULL) {
         needs_api = *method_flags & NPY_METH_REQUIRES_PYAPI;
     }
     else {
@@ -1441,7 +1441,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
     rstride = PyArray_STRIDE(rop, axis);
     needidxbuffer = rstride != sizeof(npy_intp);
 
-    if (method_flags != NULL) {
+    if (strided_loop != NULL) {
         needs_api = *method_flags & NPY_METH_REQUIRES_PYAPI;
     }
     else {
@@ -3142,7 +3142,7 @@ PyArray_Sort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
     PyArrayMethod_Context context = {0};
     PyArray_Descr *loop_descrs[2];
     NpyAuxData *auxdata = NULL;
-    NPY_ARRAYMETHOD_FLAGS *method_flags = NULL;
+    NPY_ARRAYMETHOD_FLAGS method_flags = 0;
 
     PyArray_SortFunc **sort_table = NULL;
     PyArray_SortFunc *sort = NULL;
@@ -3184,7 +3184,7 @@ PyArray_Sort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
         npy_intp strides[2] = {loop_descrs[0]->elsize, loop_descrs[1]->elsize};
 
         if (sort_method->get_strided_loop(
-            &context, 1, 0, strides, &strided_loop, &auxdata, method_flags) < 0) {
+            &context, 1, 0, strides, &strided_loop, &auxdata, &method_flags) < 0) {
             ret = -1;
             goto fail;
         }
@@ -3229,7 +3229,7 @@ PyArray_Sort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
     }
 
     ret = _new_sortlike(op, axis, sort, strided_loop,
-                        &context, auxdata, method_flags, NULL, NULL, 0);
+                        &context, auxdata, &method_flags, NULL, NULL, 0);
 
 fail:
     if (sort_method != NULL) {
@@ -3259,7 +3259,7 @@ PyArray_ArgSort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
     PyArrayMethod_Context context = {0};
     PyArray_Descr *loop_descrs[2];
     NpyAuxData *auxdata = NULL;
-    NPY_ARRAYMETHOD_FLAGS *method_flags = NULL;
+    NPY_ARRAYMETHOD_FLAGS method_flags = 0;
 
     PyArray_ArgSortFunc **argsort_table = NULL;
     PyArray_ArgSortFunc *argsort = NULL;
@@ -3295,7 +3295,7 @@ PyArray_ArgSort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
         npy_intp strides[2] = {loop_descrs[0]->elsize, loop_descrs[1]->elsize};
 
         if (argsort_method->get_strided_loop(
-            &context, 1, 0, strides, &strided_loop, &auxdata, method_flags) < 0) {
+            &context, 1, 0, strides, &strided_loop, &auxdata, &method_flags) < 0) {
             ret = NULL;
             goto fail;
         }
@@ -3346,7 +3346,7 @@ PyArray_ArgSort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
     }
 
     ret = _new_argsortlike(op2, axis, argsort, strided_loop,
-                           &context, auxdata, method_flags, NULL, NULL, 0);
+                           &context, auxdata, &method_flags, NULL, NULL, 0);
     Py_DECREF(op2);
 
 fail:

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -18,6 +18,7 @@
 #include "conversion_utils.h"
 #include "npy_import.h"
 #include "multiarraymodule.h"
+#include "npy_sort.h"
 
 /*
  * Internal helper to create new instances
@@ -685,7 +686,7 @@ stringdtype_defaultsort_loop(
 {
     return stringdtype_wrap_sort_loop(
             context, data, dimensions, strides, transferdata,
-            &default_defaultsort_loop);
+            &npy_quicksort_loop);
 }
 
 int
@@ -696,7 +697,7 @@ stringdtype_stablesort_loop(
 {
     return stringdtype_wrap_sort_loop(
             context, data, dimensions, strides, transferdata,
-            &default_stablesort_loop);
+            &npy_mergesort_loop);
 }
 
 int
@@ -707,7 +708,7 @@ stringdtype_defaultargsort_loop(
 {
     return stringdtype_wrap_sort_loop(
             context, data, dimensions, strides, transferdata,
-            &default_defaultargsort_loop);
+            &npy_aquicksort_loop);
 }
 
 int
@@ -718,7 +719,7 @@ stringdtype_stableargsort_loop(
 {
     return stringdtype_wrap_sort_loop(
             context, data, dimensions, strides, transferdata,
-            &default_stableargsort_loop);
+            &npy_amergesort_loop);
 }
 
 int

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -731,10 +731,7 @@ stringdtype_get_sort_loop(
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
     PyArrayMethod_SortParameters *parameters = (PyArrayMethod_SortParameters *)context->parameters;
-
-    if (PyDataType_FLAGCHK(context->descriptors[0], NPY_NEEDS_PYAPI)) {
-        *flags |= NPY_METH_REQUIRES_PYAPI;
-    }
+    *flags |= NPY_METH_NO_FLOATINGPOINT_ERRORS;
 
     if (parameters->flags == NPY_SORT_STABLE) {
         *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_stablesort_loop;
@@ -759,10 +756,7 @@ stringdtype_get_argsort_loop(
         NPY_ARRAYMETHOD_FLAGS *flags)
 {
     PyArrayMethod_SortParameters *parameters = (PyArrayMethod_SortParameters *)context->parameters;
-
-    if (PyDataType_FLAGCHK(context->descriptors[0], NPY_NEEDS_PYAPI)) {
-        *flags |= NPY_METH_REQUIRES_PYAPI;
-    }
+    *flags |= NPY_METH_NO_FLOATINGPOINT_ERRORS;
 
     if (parameters->flags == NPY_SORT_STABLE) {
         *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_stableargsort_loop;

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -463,8 +463,8 @@ compare(void *a, void *b, void *arr)
 int
 stringdtype_sort_compare(void *a, void *b, void *descr)
 {
-    PyArray_StringDTypeObject *descr_obj = (PyArray_StringDTypeObject *)descr;
-    int ret = _compare(a, b, descr_obj, descr_obj);
+    PyArray_StringDTypeObject *sdescr = (PyArray_StringDTypeObject *)descr;
+    int ret = _compare(a, b, sdescr, sdescr);
     return ret;
 }
 

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -795,6 +795,7 @@ init_stringdtype_sorts(void)
     if (sort_method == NULL) {
         return -1;
     }
+    Py_DECREF(NPY_DT_SLOTS(stringdtype)->sort_meth);
     NPY_DT_SLOTS(stringdtype)->sort_meth = sort_method->method;
     Py_INCREF(sort_method->method);
     Py_DECREF(sort_method);
@@ -818,6 +819,7 @@ init_stringdtype_sorts(void)
     if (argsort_method == NULL) {
         return -1;
     }
+    Py_DECREF(NPY_DT_SLOTS(stringdtype)->argsort_meth);
     NPY_DT_SLOTS(stringdtype)->argsort_meth = argsort_method->method;
     Py_INCREF(argsort_method->method);
     Py_DECREF(argsort_method);

--- a/numpy/_core/src/multiarray/stringdtype/dtype.h
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.h
@@ -19,6 +19,10 @@ new_stringdtype_instance(PyObject *na_object, int coerce);
 NPY_NO_EXPORT int
 init_string_dtype(void);
 
+NPY_NO_EXPORT int
+_compare_with_descending(void *a, void *b, PyArray_StringDTypeObject *descr_a,
+         PyArray_StringDTypeObject *descr_b, int descending);
+
 // Assumes that the caller has already acquired the allocator locks for both
 // descriptors
 NPY_NO_EXPORT int

--- a/numpy/_core/src/npysort/mergesort.cpp
+++ b/numpy/_core/src/npysort/mergesort.cpp
@@ -389,8 +389,7 @@ npy_mergesort_loop(PyArrayMethod_Context *context,
     PyArray_CompareFunc *cmp;
     fill_sort_data_with_context(context, &elsize, &cmp);
 
-    return npy_mergesort_impl(data[0], dimensions[0], context->descriptors[0],
-                              elsize, cmp);
+    return npy_mergesort_impl(data[0], dimensions[0], context, elsize, cmp);
 }
 
 NPY_NO_EXPORT int
@@ -489,7 +488,7 @@ npy_amergesort_loop(PyArrayMethod_Context *context,
     fill_sort_data_with_context(context, &elsize, &cmp);
 
     return npy_amergesort_impl(data[0], (npy_intp *)data[1], dimensions[0],
-                               context->descriptors[0], elsize, cmp);
+                               context, elsize, cmp);
 }
 
 NPY_NO_EXPORT int

--- a/numpy/_core/src/npysort/mergesort.cpp
+++ b/numpy/_core/src/npysort/mergesort.cpp
@@ -381,13 +381,34 @@ npy_mergesort0(char *pl, char *pr, char *pw, char *vp, npy_intp elsize,
 }
 
 NPY_NO_EXPORT int
+npy_mergesort_loop(PyArrayMethod_Context *context,
+                   char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+                   NpyAuxData *transferdata)
+{
+    npy_intp elsize;
+    PyArray_CompareFunc *cmp;
+    fill_sort_data_with_context(context, &elsize, &cmp);
+
+    return npy_mergesort_impl(data[0], dimensions[0], context->descriptors[0],
+                              elsize, cmp);
+}
+
+NPY_NO_EXPORT int
 npy_mergesort(void *start, npy_intp num, void *varr)
 {
     void *arr = varr;
     npy_intp elsize;
     PyArray_CompareFunc *cmp;
-    fill_sort_data_with_arr_or_descr(arr, &elsize, &cmp);
+    fill_sort_data_with_array(arr, &elsize, &cmp);
     
+    return npy_mergesort_impl(start, num, varr, elsize, cmp);
+}
+
+NPY_NO_EXPORT int
+npy_mergesort_impl(void *start, npy_intp num, void *varr,
+                   npy_intp elsize, PyArray_CompareFunc *cmp)
+{
+    void *arr = varr;
     char *pl = (char *)start;
     char *pr = pl + num * elsize;
     char *pw;
@@ -459,13 +480,34 @@ npy_amergesort0(npy_intp *pl, npy_intp *pr, char *v, npy_intp *pw,
 }
 
 NPY_NO_EXPORT int
+npy_amergesort_loop(PyArrayMethod_Context *context,
+                    char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+                    NpyAuxData *transferdata)
+{
+    npy_intp elsize;
+    PyArray_CompareFunc *cmp;
+    fill_sort_data_with_context(context, &elsize, &cmp);
+
+    return npy_amergesort_impl(data[0], (npy_intp *)data[1], dimensions[0],
+                               context->descriptors[0], elsize, cmp);
+}
+
+NPY_NO_EXPORT int
 npy_amergesort(void *v, npy_intp *tosort, npy_intp num, void *varr)
 {
     void *arr = varr;
     npy_intp elsize;
     PyArray_CompareFunc *cmp;
-    fill_sort_data_with_arr_or_descr(arr, &elsize, &cmp);
-    
+    fill_sort_data_with_array(arr, &elsize, &cmp);
+
+    return npy_amergesort_impl(v, tosort, num, varr, elsize, cmp);
+}
+
+NPY_NO_EXPORT int
+npy_amergesort_impl(void *v, npy_intp *tosort, npy_intp num, void *varr,
+                   npy_intp elsize, PyArray_CompareFunc *cmp)
+{
+    void *arr = varr;
     npy_intp *pl, *pr, *pw;
 
     /* Items that have zero size don't make sense to sort */

--- a/numpy/_core/src/npysort/mergesort.cpp
+++ b/numpy/_core/src/npysort/mergesort.cpp
@@ -337,7 +337,7 @@ string_amergesort_(type *v, npy_intp *tosort, npy_intp num, void *varr)
 
 static void
 npy_mergesort0(char *pl, char *pr, char *pw, char *vp, npy_intp elsize,
-               PyArray_CompareFunc *cmp, PyArrayObject *arr)
+               PyArray_CompareFunc *cmp, void *arr)
 {
     char *pi, *pj, *pk, *pm;
 
@@ -383,9 +383,11 @@ npy_mergesort0(char *pl, char *pr, char *pw, char *vp, npy_intp elsize,
 NPY_NO_EXPORT int
 npy_mergesort(void *start, npy_intp num, void *varr)
 {
-    PyArrayObject *arr = (PyArrayObject *)varr;
-    npy_intp elsize = PyArray_ITEMSIZE(arr);
-    PyArray_CompareFunc *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
+    void *arr = varr;
+    npy_intp elsize;
+    PyArray_CompareFunc *cmp;
+    fill_sort_data_with_arr_or_descr(arr, &elsize, &cmp);
+    
     char *pl = (char *)start;
     char *pr = pl + num * elsize;
     char *pw;
@@ -413,7 +415,7 @@ npy_mergesort(void *start, npy_intp num, void *varr)
 
 static void
 npy_amergesort0(npy_intp *pl, npy_intp *pr, char *v, npy_intp *pw,
-                npy_intp elsize, PyArray_CompareFunc *cmp, PyArrayObject *arr)
+                npy_intp elsize, PyArray_CompareFunc *cmp, void *arr)
 {
     char *vp;
     npy_intp vi, *pi, *pj, *pk, *pm;
@@ -459,9 +461,11 @@ npy_amergesort0(npy_intp *pl, npy_intp *pr, char *v, npy_intp *pw,
 NPY_NO_EXPORT int
 npy_amergesort(void *v, npy_intp *tosort, npy_intp num, void *varr)
 {
-    PyArrayObject *arr = (PyArrayObject *)varr;
-    npy_intp elsize = PyArray_ITEMSIZE(arr);
-    PyArray_CompareFunc *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
+    void *arr = varr;
+    npy_intp elsize;
+    PyArray_CompareFunc *cmp;
+    fill_sort_data_with_arr_or_descr(arr, &elsize, &cmp);
+    
     npy_intp *pl, *pr, *pw;
 
     /* Items that have zero size don't make sense to sort */

--- a/numpy/_core/src/npysort/npysort_common.h
+++ b/numpy/_core/src/npysort/npysort_common.h
@@ -41,6 +41,28 @@ extern "C" {
 #define INTP_SWAP(a,b) {npy_intp tmp = (b); (b)=(a); (a) = tmp;}
 
 /*
+ ******************************************************************************
+ **                        SORTING WRAPPERS                                  **
+ *****************************************************************************
+ */
+
+static inline void
+fill_sort_data_with_arr_or_descr(void *varr_or_descr,
+    npy_intp *elsize, PyArray_CompareFunc **cmp)
+{
+    if (PyArray_Check(varr_or_descr)) {
+        PyArrayObject *arr = (PyArrayObject *)varr_or_descr;
+        *elsize = PyArray_ITEMSIZE(arr);
+        *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
+    }
+    else {
+        PyArray_Descr *descr = (PyArray_Descr *)varr_or_descr;
+        *elsize = descr->elsize;
+        *cmp = (PyArray_CompareFunc *)NPY_DT_SLOTS(NPY_DTYPE(descr))->sort_compare;
+    }
+}
+
+/*
  *****************************************************************************
  **                        COMPARISON FUNCTIONS                             **
  *****************************************************************************

--- a/numpy/_core/src/npysort/npysort_common.h
+++ b/numpy/_core/src/npysort/npysort_common.h
@@ -47,19 +47,20 @@ extern "C" {
  */
 
 static inline void
-fill_sort_data_with_arr_or_descr(void *varr_or_descr,
-    npy_intp *elsize, PyArray_CompareFunc **cmp)
+fill_sort_data_with_array(void *varr, npy_intp *elsize, PyArray_CompareFunc **cmp)
 {
-    if (PyArray_Check(varr_or_descr)) {
-        PyArrayObject *arr = (PyArrayObject *)varr_or_descr;
-        *elsize = PyArray_ITEMSIZE(arr);
-        *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
-    }
-    else {
-        PyArray_Descr *descr = (PyArray_Descr *)varr_or_descr;
-        *elsize = descr->elsize;
-        *cmp = (PyArray_CompareFunc *)NPY_DT_SLOTS(NPY_DTYPE(descr))->sort_compare;
-    }
+    PyArrayObject *arr = (PyArrayObject *)varr;
+    *elsize = PyArray_ITEMSIZE(arr);
+    *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
+}
+
+static inline void
+fill_sort_data_with_context(
+    PyArrayMethod_Context *context, npy_intp *elsize, PyArray_CompareFunc **cmp)
+{
+    PyArray_Descr *descr = (PyArray_Descr *)context->descriptors[0];
+    *elsize = descr->elsize;
+    *cmp = (PyArray_CompareFunc *)NPY_DT_SLOTS(NPY_DTYPE(descr))->sort_compare;
 }
 
 /*

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -508,9 +508,11 @@ string_aquicksort_(type *vv, npy_intp *tosort, npy_intp num, void *varr)
 NPY_NO_EXPORT int
 npy_quicksort(void *start, npy_intp num, void *varr)
 {
-    PyArrayObject *arr = (PyArrayObject *)varr;
-    npy_intp elsize = PyArray_ITEMSIZE(arr);
-    PyArray_CompareFunc *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
+    void *arr = varr;
+    npy_intp elsize;
+    PyArray_CompareFunc *cmp;
+    fill_sort_data_with_arr_or_descr(arr, &elsize, &cmp);
+    
     char *vp;
     char *pl = (char *)start;
     char *pr = pl + (num - 1) * elsize;
@@ -613,9 +615,11 @@ NPY_NO_EXPORT int
 npy_aquicksort(void *vv, npy_intp *tosort, npy_intp num, void *varr)
 {
     char *v = (char *)vv;
-    PyArrayObject *arr = (PyArrayObject *)varr;
-    npy_intp elsize = PyArray_ITEMSIZE(arr);
-    PyArray_CompareFunc *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
+    void *arr = varr;
+    npy_intp elsize;
+    PyArray_CompareFunc *cmp;
+    fill_sort_data_with_arr_or_descr(arr, &elsize, &cmp);
+    
     char *vp;
     npy_intp *pl = tosort;
     npy_intp *pr = tosort + num - 1;

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -514,8 +514,7 @@ npy_quicksort_loop(PyArrayMethod_Context *context,
     PyArray_CompareFunc *cmp;
     fill_sort_data_with_context(context, &elsize, &cmp);
 
-    return npy_quicksort_impl(data[0], dimensions[0], context->descriptors[0],
-                              elsize, cmp);
+    return npy_quicksort_impl(data[0], dimensions[0], context, elsize, cmp);
 }
 
 NPY_NO_EXPORT int
@@ -641,7 +640,7 @@ npy_aquicksort_loop(PyArrayMethod_Context *context,
     fill_sort_data_with_context(context, &elsize, &cmp);
 
     return npy_aquicksort_impl(data[0], (npy_intp *)data[1], dimensions[0],
-                               context->descriptors[0], elsize, cmp);
+                               context, elsize, cmp);
 }
 
 NPY_NO_EXPORT int


### PR DESCRIPTION
This follows #29900 and #29737 to add a `sort_compare` slot to the DType, which can be used to enable sorting for user dtypes without completely redefining the sort. Also uses it in `StringDType` to allocate the lock just once and thus fixes #26510.

Also, there are now wrappers for the existing sorts, so it is probably easier to move to the array method API later. However doing so would require templating the SIMD sorts and doing other infrastructure gymnastics, so not done here. This does not implement descending, which can actually also be done as a follow-up if we keep the API the same and just flip the comparison twice.

This still needs release notes and docs but wanted to push this before to clarify direction. Unfortunately, it is quite verbose, especially for StringDType. ping @seberg @mhvk @ngoldbaum if you're interested - thanks!