### PR TITLE
MAINT: remove deprecated in numpy/lib/_function_base_impl.py

### DIFF
--- a/doc/release/upcoming_changes/29997.expired.rst
+++ b/doc/release/upcoming_changes/29997.expired.rst
@@ -1,12 +1,11 @@
-Removal of deprecated `trapz` function, `disp` method, and `bias`/`ddof` args in `corrcoef`
+Removal of deprecated `trapz` function, `disp` function, and `bias`/`ddof` args in `corrcoef`
 -------------------------------------------------------------------------------------------
 
 The following long-deprecated APIs have been removed:
 
 * ``numpy.trapz`` — deprecated since NumPy 2.0 (2023-08-18). Use ``numpy.trapezoid`` or
   ``scipy.integrate`` functions instead.
-* ``disp`` method — deprecated in earlier releases and no longer functional. Use your own printing function instead.
+* ``disp`` function — deprecated from 2.0 release and no longer functional. Use your own printing function instead.
 * ``bias`` and ``ddof`` arguments in ``numpy.corrcoef`` — these had no effect since NumPy 1.10.
 
-Associated tests and type stubs have been updated or removed accordingly.
 

--- a/doc/release/upcoming_changes/29997.expired.rst
+++ b/doc/release/upcoming_changes/29997.expired.rst
@@ -1,5 +1,5 @@
 Removal of deprecated `trapz` function, `disp` function, and `bias`/`ddof` args in `corrcoef`
--------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------
 
 The following long-deprecated APIs have been removed:
 

--- a/doc/release/upcoming_changes/29997.expired.rst
+++ b/doc/release/upcoming_changes/29997.expired.rst
@@ -1,5 +1,5 @@
-Removal of deprecated `trapz` function, `disp` function, and `bias`/`ddof` args in `corrcoef`
---------------------------------------------------------------------------------------------
+Removal of deprecated functions and arguments
+---------------------------------------------
 
 The following long-deprecated APIs have been removed:
 

--- a/doc/release/upcoming_changes/29997.expired.rst
+++ b/doc/release/upcoming_changes/29997.expired.rst
@@ -1,0 +1,12 @@
+Removal of deprecated `trapz` function, `disp` method, and `bias`/`ddof` args in `corrcoef`
+-------------------------------------------------------------------------------------------
+
+The following long-deprecated APIs have been removed:
+
+* ``numpy.trapz`` — deprecated since NumPy 2.0 (2023-08-18). Use ``numpy.trapezoid`` or
+  ``scipy.integrate`` functions instead.
+* ``disp`` method — deprecated in earlier releases and no longer functional. Use your own printing function instead.
+* ``bias`` and ``ddof`` arguments in ``numpy.corrcoef`` — these had no effect since NumPy 1.10.
+
+Associated tests and type stubs have been updated or removed accordingly.
+

--- a/doc/release/upcoming_changes/29997.expired.rst
+++ b/doc/release/upcoming_changes/29997.expired.rst
@@ -7,5 +7,3 @@ The following long-deprecated APIs have been removed:
   ``scipy.integrate`` functions instead.
 * ``disp`` function — deprecated from 2.0 release and no longer functional. Use your own printing function instead.
 * ``bias`` and ``ddof`` arguments in ``numpy.corrcoef`` — these had no effect since NumPy 1.10.
-
-

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -505,7 +505,6 @@ else:
         sinc,
         sort_complex,
         trapezoid,
-        trapz,
         trim_zeros,
         unwrap,
         vectorize,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -460,7 +460,6 @@ from numpy.lib._function_base_impl import (  # type: ignore[deprecated]
     blackman,
     kaiser,
     trapezoid,
-    trapz,
     i0,
     meshgrid,
     delete,
@@ -686,7 +685,7 @@ __all__ = [  # noqa: RUF022
     "gradient", "angle", "unwrap", "sort_complex", "flip", "rot90", "extract", "place",
     "vectorize", "asarray_chkfinite", "average", "bincount", "digitize", "cov",
     "corrcoef", "median", "sinc", "hamming", "hanning", "bartlett", "blackman",
-    "kaiser", "trapezoid", "trapz", "i0", "meshgrid", "delete", "insert", "append",
+    "kaiser", "trapezoid", "i0", "meshgrid", "delete", "insert", "append",
     "interp", "quantile",
     # lib._twodim_base_impl.__all__
     "diag", "diagflat", "eye", "fliplr", "flipud", "tri", "triu", "tril", "vander",

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -280,9 +280,8 @@ class TestMathAlias(_DeprecationTestCase):
 class TestLibImports(_DeprecationTestCase):
     # Deprecated in Numpy 1.26.0, 2023-09
     def test_lib_functions_deprecation_call(self):
-        from numpy import row_stack, trapz
+        from numpy import row_stack
         from numpy._core.numerictypes import maximum_sctype
-        from numpy.lib._function_base_impl import disp
         from numpy.lib._npyio_impl import recfromcsv, recfromtxt
         from numpy.lib._shape_base_impl import get_array_wrap
         from numpy.lib._utils_impl import safe_eval
@@ -295,12 +294,10 @@ class TestLibImports(_DeprecationTestCase):
         self.assert_deprecated(lambda: recfromcsv(data_gen()))
         self.assert_deprecated(lambda: recfromtxt(data_gen(), **kwargs))
 
-        self.assert_deprecated(lambda: disp("test"))
         self.assert_deprecated(get_array_wrap)
         self.assert_deprecated(lambda: maximum_sctype(int))
 
         self.assert_deprecated(lambda: row_stack([[]]))
-        self.assert_deprecated(lambda: trapz([1], [1]))
         self.assert_deprecated(lambda: np.chararray)
 
 

--- a/numpy/_expired_attrs_2_0.py
+++ b/numpy/_expired_attrs_2_0.py
@@ -61,7 +61,6 @@ __expired_attributes__ = {
         "or use `typing.deprecated`.",
     "deprecate_with_doc": "Emit `DeprecationWarning` with `warnings.warn` "
         "directly, or use `typing.deprecated`.",
-    "disp": "Use your own printing function instead.",
     "find_common_type":
         "Use `numpy.promote_types` or `numpy.result_type` instead. "
         "To achieve semantics for the `scalar_types` argument, use "

--- a/numpy/_expired_attrs_2_0.pyi
+++ b/numpy/_expired_attrs_2_0.pyi
@@ -47,7 +47,6 @@ class _ExpiredAttributesType(TypedDict):
     recfromtxt: str
     deprecate: str
     deprecate_with_doc: str
-    disp: str
     find_common_type: str
     round_: str
     get_array_wrap: str

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2926,11 +2926,6 @@ def corrcoef(x, y=None, rowvar=True, *,
     interval [-1,  1] in an attempt to improve on that situation but is not
     much help in the complex case.
 
-    This function accepts but discards arguments `bias` and `ddof`.  This is
-    for backwards compatibility with previous versions of this function.  These
-    arguments had no effect on the return values of the function and can be
-    safely ignored in this and previous versions of numpy.
-
     Examples
     --------
     >>> import numpy as np

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2869,13 +2869,13 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     return c.squeeze()
 
 
-def _corrcoef_dispatcher(x, y=None, rowvar=None, bias=None, ddof=None, *,
+def _corrcoef_dispatcher(x, y=None, rowvar=None, *,
                          dtype=None):
     return (x, y)
 
 
 @array_function_dispatch(_corrcoef_dispatcher)
-def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
+def corrcoef(x, y=None, rowvar=True, *,
              dtype=None):
     """
     Return Pearson product-moment correlation coefficients.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2,7 +2,6 @@ import builtins
 import collections.abc
 import functools
 import re
-import sys
 import warnings
 
 import numpy as np
@@ -68,7 +67,7 @@ __all__ = [
     'rot90', 'extract', 'place', 'vectorize', 'asarray_chkfinite', 'average',
     'bincount', 'digitize', 'cov', 'corrcoef',
     'median', 'sinc', 'hamming', 'hanning', 'bartlett',
-    'blackman', 'kaiser', 'trapezoid', 'trapz', 'i0',
+    'blackman', 'kaiser', 'trapezoid', 'i0',
     'meshgrid', 'delete', 'insert', 'append', 'interp',
     'quantile'
     ]
@@ -2119,62 +2118,6 @@ def place(arr, mask, vals):
     return _place(arr, mask, vals)
 
 
-def disp(mesg, device=None, linefeed=True):
-    """
-    Display a message on a device.
-
-    .. deprecated:: 2.0
-        Use your own printing function instead.
-
-    Parameters
-    ----------
-    mesg : str
-        Message to display.
-    device : object
-        Device to write message. If None, defaults to ``sys.stdout`` which is
-        very similar to ``print``. `device` needs to have ``write()`` and
-        ``flush()`` methods.
-    linefeed : bool, optional
-        Option whether to print a line feed or not. Defaults to True.
-
-    Raises
-    ------
-    AttributeError
-        If `device` does not have a ``write()`` or ``flush()`` method.
-
-    Examples
-    --------
-    >>> import numpy as np
-
-    Besides ``sys.stdout``, a file-like object can also be used as it has
-    both required methods:
-
-    >>> from io import StringIO
-    >>> buf = StringIO()
-    >>> np.disp('"Display" in a file', device=buf)
-    >>> buf.getvalue()
-    '"Display" in a file\\n'
-
-    """
-
-    # Deprecated in NumPy 2.0, 2023-07-11
-    warnings.warn(
-        "`disp` is deprecated, "
-        "use your own printing function instead. "
-        "(deprecated in NumPy 2.0)",
-        DeprecationWarning,
-        stacklevel=2
-    )
-
-    if device is None:
-        device = sys.stdout
-    if linefeed:
-        device.write(f'{mesg}\n')
-    else:
-        device.write(f'{mesg}')
-    device.flush()
-
-
 # See https://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
 _DIMENSION_NAME = r'\w+'
 _CORE_DIMENSION_LIST = f'(?:{_DIMENSION_NAME}(?:,{_DIMENSION_NAME})*)?'
@@ -2959,14 +2902,7 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
         variable, with observations in the columns. Otherwise, the relationship
         is transposed: each column represents a variable, while the rows
         contain observations.
-    bias : _NoValue, optional
-        Has no effect, do not use.
 
-        .. deprecated:: 1.10.0
-    ddof : _NoValue, optional
-        Has no effect, do not use.
-
-        .. deprecated:: 1.10.0
     dtype : data-type, optional
         Data-type of the result. By default, the return data-type will have
         at least `numpy.float64` precision.
@@ -3061,10 +2997,6 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, ddof=np._NoValue, *,
              1.        ]])
 
     """
-    if bias is not np._NoValue or ddof is not np._NoValue:
-        # 2015-03-15, 1.10
-        warnings.warn('bias and ddof have no effect and are deprecated',
-                      DeprecationWarning, stacklevel=2)
     c = cov(x, y, rowvar, dtype=dtype)
     try:
         d = diag(c)
@@ -5078,24 +5010,6 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
         y = np.asarray(y)
         ret = add.reduce(d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0, axis)
     return ret
-
-
-@set_module('numpy')
-def trapz(y, x=None, dx=1.0, axis=-1):
-    """
-    `trapz` is deprecated in NumPy 2.0.
-
-    Please use `trapezoid` instead, or one of the numerical integration
-    functions in `scipy.integrate`.
-    """
-    # Deprecated in NumPy 2.0, 2023-08-18
-    warnings.warn(
-        "`trapz` is deprecated. Use `trapezoid` instead, or one of the "
-        "numerical integration functions in `scipy.integrate`.",
-        DeprecationWarning,
-        stacklevel=2
-    )
-    return trapezoid(y, x=x, dx=dx, axis=axis)
 
 
 def _meshgrid_dispatcher(*xi, copy=None, sparse=None, indexing=None):

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -14,7 +14,7 @@ from typing import (
     overload,
     type_check_only,
 )
-from typing_extensions import TypeIs, deprecated
+from typing_extensions import TypeIs
 
 import numpy as np
 from numpy import (
@@ -87,7 +87,6 @@ __all__ = [
     "blackman",
     "kaiser",
     "trapezoid",
-    "trapz",
     "i0",
     "meshgrid",
     "delete",
@@ -990,10 +989,6 @@ def trapezoid(
     floating | complexfloating | timedelta64
     | NDArray[floating | complexfloating | timedelta64 | object_]
 ): ...
-
-@deprecated("Use 'trapezoid' instead")
-def trapz(y: ArrayLike, x: ArrayLike | None = None, dx: float = 1.0, axis: int = -1) -> generic | NDArray[generic]: ...
-
 @overload
 def meshgrid(
     *,

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -565,10 +565,6 @@ class TestSelect:
         m = np.isnan(d)
         assert_equal(select([m], [d]), [0, 0, 0, np.nan, 0, 0])
 
-    def test_deprecated_empty(self):
-        assert_raises(ValueError, select, [], [], 3j)
-        assert_raises(ValueError, select, [], [])
-
     def test_non_bool_deprecation(self):
         choices = self.choices
         conditions = self.conditions[:]
@@ -2475,28 +2471,6 @@ class TestCorrCoef:
         tgt2 = corrcoef(self.A, self.B)
         assert_almost_equal(tgt2, self.res2)
         assert_(np.all(np.abs(tgt2) <= 1.0))
-
-    def test_ddof(self):
-        # ddof raises DeprecationWarning
-        with warnings.catch_warnings():
-            warnings.simplefilter("always")
-            pytest.warns(DeprecationWarning, corrcoef, self.A, ddof=-1)
-            warnings.simplefilter('ignore', DeprecationWarning)
-            # ddof has no or negligible effect on the function
-            assert_almost_equal(corrcoef(self.A, ddof=-1), self.res1)
-            assert_almost_equal(corrcoef(self.A, self.B, ddof=-1), self.res2)
-            assert_almost_equal(corrcoef(self.A, ddof=3), self.res1)
-            assert_almost_equal(corrcoef(self.A, self.B, ddof=3), self.res2)
-
-    def test_bias(self):
-        # bias raises DeprecationWarning
-        with warnings.catch_warnings():
-            warnings.simplefilter("always")
-            pytest.warns(DeprecationWarning, corrcoef, self.A, self.B, 1, 0)
-            pytest.warns(DeprecationWarning, corrcoef, self.A, bias=0)
-            warnings.simplefilter('ignore', DeprecationWarning)
-            # bias has no or negligible effect on the function
-            assert_almost_equal(corrcoef(self.A, bias=1), self.res1)
 
     def test_complex(self):
         x = np.array([[1, 2, 3], [1j, 2j, 3j]])

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1729,8 +1729,8 @@ def cov(x, y=None, rowvar=True, bias=False, allow_masked=True, ddof=None):
     return result
 
 
-def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, allow_masked=True,
-             ddof=np._NoValue):
+def corrcoef(x, y=None, rowvar=True, allow_masked=True,
+             ):
     """
     Return Pearson product-moment correlation coefficients.
 
@@ -1751,6 +1751,11 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, allow_masked=True,
         variable, with observations in the columns. Otherwise, the relationship
         is transposed: each column represents a variable, while the rows
         contain observations.
+    allow_masked : bool, optional
+        If True, masked values are propagated pair-wise: if a value is masked
+        in `x`, the corresponding value is masked in `y`.
+        If False, raises an exception.  Because `bias` is deprecated, this
+        argument needs to be treated as keyword only to avoid a warning.
 
     See Also
     --------

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1762,13 +1762,6 @@ def corrcoef(x, y=None, rowvar=True, allow_masked=True,
     numpy.corrcoef : Equivalent function in top-level NumPy module.
     cov : Estimate the covariance matrix.
 
-    Notes
-    -----
-    This function accepts but discards arguments `bias` and `ddof`.  This is
-    for backwards compatibility with previous versions of this function.  These
-    arguments had no effect on the return values of the function and can be
-    safely ignored in this and previous versions of numpy.
-
     Examples
     --------
     >>> import numpy as np

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1751,19 +1751,6 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, allow_masked=True,
         variable, with observations in the columns. Otherwise, the relationship
         is transposed: each column represents a variable, while the rows
         contain observations.
-    bias : _NoValue, optional
-        Has no effect, do not use.
-
-        .. deprecated:: 1.10.0
-    allow_masked : bool, optional
-        If True, masked values are propagated pair-wise: if a value is masked
-        in `x`, the corresponding value is masked in `y`.
-        If False, raises an exception.  Because `bias` is deprecated, this
-        argument needs to be treated as keyword only to avoid a warning.
-    ddof : _NoValue, optional
-        Has no effect, do not use.
-
-        .. deprecated:: 1.10.0
 
     See Also
     --------
@@ -1791,10 +1778,6 @@ def corrcoef(x, y=None, rowvar=True, bias=np._NoValue, allow_masked=True,
       dtype=float64)
 
     """
-    msg = 'bias and ddof have no effect and are deprecated'
-    if bias is not np._NoValue or ddof is not np._NoValue:
-        # 2015-03-15, 1.10
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
     # Estimate the covariance matrix.
     corr = cov(x, y, rowvar, allow_masked=allow_masked)
     # The non-masked version returns a masked value for a scalar.

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -6,7 +6,6 @@ Adapted from the original test_ma by Pierre Gerard-Marchant
 
 """
 import itertools
-import warnings
 
 import pytest
 
@@ -1406,53 +1405,12 @@ class TestCorrcoef:
         data2 = array(np.random.rand(12))
         return data, data2
 
-    def test_ddof(self):
-        # ddof raises DeprecationWarning
-        x, y = self._create_data()
-        expected = np.corrcoef(x)
-        expected2 = np.corrcoef(x, y)
-        with pytest.warns(DeprecationWarning):
-            corrcoef(x, ddof=-1)
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', "bias and ddof have no effect", DeprecationWarning)
-
-            # ddof has no or negligible effect on the function
-            assert_almost_equal(np.corrcoef(x, ddof=0), corrcoef(x, ddof=0))
-            assert_almost_equal(corrcoef(x, ddof=-1), expected)
-            assert_almost_equal(corrcoef(x, y, ddof=-1), expected2)
-            assert_almost_equal(corrcoef(x, ddof=3), expected)
-            assert_almost_equal(corrcoef(x, y, ddof=3), expected2)
-
-    def test_bias(self):
-        x, y = self._create_data()
-        expected = np.corrcoef(x)
-        # bias raises DeprecationWarning
-        with pytest.warns(DeprecationWarning):
-            corrcoef(x, y, True, False)
-        with pytest.warns(DeprecationWarning):
-            corrcoef(x, y, True, True)
-        with pytest.warns(DeprecationWarning):
-            corrcoef(x, y, bias=False)
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', "bias and ddof have no effect", DeprecationWarning)
-            # bias has no or negligible effect on the function
-            assert_almost_equal(corrcoef(x, bias=1), expected)
-
     def test_1d_without_missing(self):
         # Test cov on 1D variable w/o missing values
         x = self._create_data()[0]
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
         assert_almost_equal(np.corrcoef(x, rowvar=False),
                             corrcoef(x, rowvar=False))
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', "bias and ddof have no effect", DeprecationWarning)
-            assert_almost_equal(np.corrcoef(x, rowvar=False, bias=True),
-                                corrcoef(x, rowvar=False, bias=True))
 
     def test_2d_without_missing(self):
         # Test corrcoef on 1 2D variable w/o missing values
@@ -1460,11 +1418,6 @@ class TestCorrcoef:
         assert_almost_equal(np.corrcoef(x), corrcoef(x))
         assert_almost_equal(np.corrcoef(x, rowvar=False),
                             corrcoef(x, rowvar=False))
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', "bias and ddof have no effect", DeprecationWarning)
-            assert_almost_equal(np.corrcoef(x, rowvar=False, bias=True),
-                                corrcoef(x, rowvar=False, bias=True))
 
     def test_1d_with_missing(self):
         # Test corrcoef 1 1D variable w/missing values
@@ -1472,14 +1425,8 @@ class TestCorrcoef:
         x[-1] = masked
         x -= x.mean()
         nx = x.compressed()
-        assert_almost_equal(np.corrcoef(nx), corrcoef(x))
         assert_almost_equal(np.corrcoef(nx, rowvar=False),
                             corrcoef(x, rowvar=False))
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', "bias and ddof have no effect", DeprecationWarning)
-            assert_almost_equal(np.corrcoef(nx, rowvar=False, bias=True),
-                                corrcoef(x, rowvar=False, bias=True))
         try:
             corrcoef(x, allow_masked=False)
         except ValueError:
@@ -1489,14 +1436,6 @@ class TestCorrcoef:
         assert_almost_equal(np.corrcoef(nx, nx[::-1]), corrcoef(x, x[::-1]))
         assert_almost_equal(np.corrcoef(nx, nx[::-1], rowvar=False),
                             corrcoef(x, x[::-1], rowvar=False))
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', "bias and ddof have no effect", DeprecationWarning)
-            # ddof and bias have no or negligible effect on the function
-            assert_almost_equal(np.corrcoef(nx, nx[::-1]),
-                                corrcoef(x, x[::-1], bias=1))
-            assert_almost_equal(np.corrcoef(nx, nx[::-1]),
-                                corrcoef(x, x[::-1], ddof=2))
 
     def test_2d_with_missing(self):
         # Test corrcoef on 2D variable w/ missing value
@@ -1507,16 +1446,6 @@ class TestCorrcoef:
         test = corrcoef(x)
         control = np.corrcoef(x)
         assert_almost_equal(test[:-1, :-1], control[:-1, :-1])
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', "bias and ddof have no effect", DeprecationWarning)
-            # ddof and bias have no or negligible effect on the function
-            assert_almost_equal(corrcoef(x, ddof=-2)[:-1, :-1],
-                                control[:-1, :-1])
-            assert_almost_equal(corrcoef(x, ddof=3)[:-1, :-1],
-                                control[:-1, :-1])
-            assert_almost_equal(corrcoef(x, bias=1)[:-1, :-1],
-                                control[:-1, :-1])
 
 
 class TestPolynomial:

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -1,7 +1,5 @@
-import warnings
-
 import numpy as np
-from numpy.testing import assert_, assert_allclose, assert_array_equal
+from numpy.testing import assert_, assert_array_equal
 
 
 class TestRegression:
@@ -58,19 +56,6 @@ class TestRegression:
         mout = np.ma.array(-1, dtype=float)
         a.var(out=mout)
         assert_(mout._data == 0)
-
-    def test_ddof_corrcoef(self):
-        # See gh-3336
-        x = np.ma.masked_equal([1, 2, 3, 4, 5], 4)
-        y = np.array([2, 2.5, 3.1, 3, 5])
-        # this test can be removed after deprecation.
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore', "bias and ddof have no effect", DeprecationWarning)
-            r0 = np.ma.corrcoef(x, y, ddof=0)
-            r1 = np.ma.corrcoef(x, y, ddof=1)
-            # ddof should not have an effect (it gets cancelled out)
-            assert_allclose(r0.data, r1.data)
 
     def test_mask_not_backmangled(self):
         # See gh-10314.  Test case taken from gh-3140.

--- a/numpy/matlib.pyi
+++ b/numpy/matlib.pyi
@@ -450,7 +450,6 @@ from numpy import (  # noqa: F401
     trace,
     transpose,
     trapezoid,
-    trapz,
     tri,
     tril,
     tril_indices,


### PR DESCRIPTION
This PR is related to gh-11521 and removes long-deprecated code paths in`numpy/lib/_function_base_impl`:

- Removed `numpy.trapz`, deprecated in NumPy 2.0 (2023-08-18)
- Removed `disp` method
- Removed `bias` and `ddof` arguments from `numpy.corrcoef`.
-  Removed associated tests from `numpy/lib/tests/test_function_base.py` and
  `numpy/_core/test_deprecations.py`

Associated tests and type stubs were also updated. All tests and Ruff checks pass locally.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
