### PR TITLE
ENH: Add ``stable`` kwarg to ``chararray.argsort``

### DIFF
--- a/numpy/_core/defchararray.py
+++ b/numpy/_core/defchararray.py
@@ -718,7 +718,7 @@ class chararray(ndarray):
     def __rmod__(self, other):
         return NotImplemented
 
-    def argsort(self, axis=-1, kind=None, order=None):
+    def argsort(self, axis=-1, kind=None, order=None, *, stable=None):
         """
         Return the indices that sort the array lexicographically.
 
@@ -736,7 +736,7 @@ class chararray(ndarray):
               dtype='|S5')
 
         """
-        return self.__array__().argsort(axis, kind, order)
+        return self.__array__().argsort(axis, kind, order, stable=stable)
     argsort.__doc__ = ndarray.argsort.__doc__
 
     def capitalize(self):

--- a/numpy/_core/tests/test_defchararray.py
+++ b/numpy/_core/tests/test_defchararray.py
@@ -694,6 +694,11 @@ class TestOperations:
         return np.array([['efg', '456'],
                          ['051', 'tuv']]).view(np.char.chararray)
 
+    def test_argsort(self):
+        arr = np.array(['abc'] * 4).view(np.char.chararray)
+        actual = arr.argsort(stable=True)
+        assert_array_equal(actual, [0, 1, 2, 3])
+
     def test_add(self):
         A, B = self.A(), self.B()
         AB = np.array([['abcefg', '123456'],


### PR DESCRIPTION
For compatibility with `ndarray.argsort` (it was violating the Liskov substitution principle).