### PR TITLE
TYP: fix ``ndarray.sort(stable=True)``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1721,7 +1721,7 @@ class _ArrayOrScalarCommon:
         kind: _SortKind | None = ...,
         order: str | Sequence[str] | None = ...,
         *,
-        stable: bool | None = ...,
+        stable: builtins.bool | None = ...,
     ) -> NDArray[intp]: ...
 
     @overload  # axis=None (default), out=None (default), keepdims=False (default)
@@ -2382,7 +2382,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kind: _SortKind | None = ...,
         order: str | Sequence[str] | None = ...,
         *,
-        stable: bool | None = ...,
+        stable: builtins.bool | None = ...,
     ) -> None: ...
 
     # Keep in sync with `MaskedArray.trace`

--- a/numpy/typing/tests/data/pass/ndarray_misc.py
+++ b/numpy/typing/tests/data/pass/ndarray_misc.py
@@ -53,7 +53,12 @@ A.argmin(axis=0)
 A.argmin(out=B_int0)
 
 i4.argsort()
+i4.argsort(stable=True)
 A.argsort()
+A.argsort(stable=True)
+
+A.sort()
+A.sort(stable=True)
 
 i4.choose([()])
 _choices = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]], dtype=np.int32)


### PR DESCRIPTION
The `stable` parameter of `ndarray.[arg]sort` and `generic.argsort` was annotated to only accept `np.bool` values, causing them to reject calls with `stable=True`.