### PR TITLE
TYP: remove implicit re-export in ``_core._exceptions``

### DIFF
--- a/numpy/_core/_exceptions.pyi
+++ b/numpy/_core/_exceptions.pyi
@@ -3,7 +3,6 @@ from typing import Any, Final, TypeVar, overload
 
 import numpy as np
 from numpy import _CastingKind
-from numpy._utils import set_module as set_module
 
 ###
 


### PR DESCRIPTION
Because it's not there at runtime either.

I believe that this takes care of the last (fixable) stubtest errors in `numpy._core` (assuming that #29991, #29993, #29994, #29999, and #30002 get merged).
