### PR TITLE
MAINT: Remove ``NDArrayOperatorsMixin.um`` class attribute ``umath`` reexport

### DIFF
--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -1,6 +1,7 @@
 """
 Mixin classes for custom array types that don't inherit from ndarray.
 """
+from numpy._core import umath as um
 
 __all__ = ['NDArrayOperatorsMixin']
 
@@ -135,7 +136,6 @@ class NDArrayOperatorsMixin:
     ArrayLike preserve a well-defined casting hierarchy.
 
     """
-    from numpy._core import umath as um
 
     __slots__ = ()
     # Like np.ndarray, this mixin class implements "Option 1" from the ufunc


### PR DESCRIPTION
Since #28035 the (internal) `numpy._core.umath` import was exposed as a *class attribute* `um` on `NDArrayOperatorsMixin`, and therefore also on all of its subclasses:

```python
In [1]: from numpy.lib.mixins import NDArrayOperatorsMixin

In [2]: class BadArray(NDArrayOperatorsMixin): ...

In [3]: BadArray.um
Out[3]: <module 'numpy._core.umath' from '/home/joren/Workspace/numpy/build-install/usr/lib/python3.14/site-packages/numpy/_core/umath.py'>
```

Judging from #28035 it doesn't look like this addition to the public API was intentional. I'm guessing that the intention was to reducing namespace pollution. 
But either way, it's probably best to get rid of this class class attribute before someone actually starts using it.