### PR TITLE
TYP: ``linalg.svdvals``: fix inconsistent signature and add dtype overloads

### DIFF
--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -16,14 +16,12 @@ from numpy import (
     complex128,
     complexfloating,
     float64,
-    # other
     floating,
     int32,
     object_,
     signedinteger,
     timedelta64,
     unsignedinteger,
-    # re-exports
     vecdot,
 )
 from numpy._core.fromnumeric import matrix_transpose
@@ -38,9 +36,11 @@ from numpy._typing import (
     _ArrayLikeComplex_co,
     _ArrayLikeFloat_co,
     _ArrayLikeInt_co,
+    _ArrayLikeNumber_co,
     _ArrayLikeObject_co,
     _ArrayLikeTD64_co,
     _ArrayLikeUInt_co,
+    _NestedSequence,
 )
 from numpy.linalg import LinAlgError
 
@@ -301,9 +301,15 @@ def svd(
     hermitian: bool = False,
 ) -> NDArray[floating]: ...
 
-def svdvals(
-    x: _ArrayLikeInt_co | _ArrayLikeFloat_co | _ArrayLikeComplex_co
-) -> NDArray[floating]: ...
+# the ignored `overload-overlap` mypy error below is a false-positive
+@overload
+def svdvals(  # type: ignore[overload-overlap]
+    x: _ArrayLike[np.float64 | np.complex128 | np.integer | np.bool] | _NestedSequence[complex], /
+) -> NDArray[np.float64]: ...
+@overload
+def svdvals(x: _ArrayLike[np.float32 | np.complex64], /) -> NDArray[np.float32]: ...
+@overload
+def svdvals(x: _ArrayLikeNumber_co, /) -> NDArray[floating]: ...
 
 # TODO: Returns a scalar for 2D arrays and
 # a `(x.ndim - 2)`` dimensionl array otherwise

--- a/numpy/typing/tests/data/fail/linalg.pyi
+++ b/numpy/typing/tests/data/fail/linalg.pyi
@@ -32,6 +32,10 @@ np.linalg.eigh(AR_O, UPLO="bob")  # type: ignore[call-overload]
 
 np.linalg.svd(AR_O)  # type: ignore[arg-type]
 
+np.linalg.svdvals(AR_O)  # type: ignore[arg-type]
+np.linalg.svdvals(AR_M)  # type: ignore[arg-type]
+np.linalg.svdvals(x=AR_f8)  # type: ignore[call-overload]
+
 np.linalg.cond(AR_O)  # type: ignore[arg-type]
 np.linalg.cond(AR_f8, p="bob")  # type: ignore[arg-type]
 

--- a/numpy/typing/tests/data/reveal/linalg.pyi
+++ b/numpy/typing/tests/data/reveal/linalg.pyi
@@ -10,8 +10,11 @@ from numpy.linalg._linalg import (
     SVDResult,
 )
 
+float_list_2d: list[list[float]]
 AR_i8: npt.NDArray[np.int64]
+AR_f4: npt.NDArray[np.float32]
 AR_f8: npt.NDArray[np.float64]
+AR_c8: npt.NDArray[np.complex64]
 AR_c16: npt.NDArray[np.complex128]
 AR_O: npt.NDArray[np.object_]
 AR_m: npt.NDArray[np.timedelta64]
@@ -78,6 +81,16 @@ assert_type(np.linalg.svd(AR_i8, True, False), npt.NDArray[np.float64])
 assert_type(np.linalg.svd(AR_f8, compute_uv=False), npt.NDArray[np.floating])
 assert_type(np.linalg.svd(AR_c16, compute_uv=False), npt.NDArray[np.floating])
 assert_type(np.linalg.svd(AR_c16, True, False), npt.NDArray[np.floating])
+
+assert_type(np.linalg.svdvals(AR_b), npt.NDArray[np.float64])
+assert_type(np.linalg.svdvals(AR_i8), npt.NDArray[np.float64])
+assert_type(np.linalg.svdvals(AR_f4), npt.NDArray[np.float32])
+assert_type(np.linalg.svdvals(AR_c8), npt.NDArray[np.float32])
+assert_type(np.linalg.svdvals(AR_f8), npt.NDArray[np.float64])
+assert_type(np.linalg.svdvals(AR_c16), npt.NDArray[np.float64])
+assert_type(np.linalg.svdvals([[1, 2], [3, 4]]), npt.NDArray[np.float64])
+assert_type(np.linalg.svdvals([[1.0, 2.0], [3.0, 4.0]]), npt.NDArray[np.float64])
+assert_type(np.linalg.svdvals([[1j, 2j], [3j, 4j]]), npt.NDArray[np.float64])
 
 assert_type(np.linalg.cond(AR_i8), Any)
 assert_type(np.linalg.cond(AR_f8), Any)


### PR DESCRIPTION
This fixes a stubtest error (`x` should be positional-only) and improves the return type for 32- and 64-bits array-likes 
Oh yea and there weren't any type-tests for it yet, so I added some.