### PR TITLE
TYP: stub ``linalg.lapack_lite.LapackError``

### DIFF
--- a/numpy/linalg/lapack_lite.pyi
+++ b/numpy/linalg/lapack_lite.pyi
@@ -57,6 +57,8 @@ class _ZUNGQR(TypedDict):
 
 _ilp64: Final[bool] = ...
 
+class LapackError(Exception): ...
+
 def dgelsd(
     m: int,
     n: int,


### PR DESCRIPTION
stubtest reported this as an error:

```
numpy.linalg.lapack_lite.LapackError is not present in stub
```