### PR TITLE
DOC:Add note about debug build caveats in spin build --help

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -80,6 +80,15 @@ def changelog(token, revision_range):
 )
 @spin.util.extend_command(spin.cmds.meson.build)
 def build(*, parent_callback, with_scipy_openblas, **kwargs):
+    """
+    🔧 Build package with Meson/ninja.
+
+    Note:
+    -----
+    Debug builds (using `-- -Dbuildtype=debug`) include many additional checks
+    and assertions. They run significantly slower and are intended for
+    development and debugging — not for performance testing or production use.
+    """
     if with_scipy_openblas:
         _config_openblas(with_scipy_openblas)
     parent_callback(**kwargs)


### PR DESCRIPTION
Closes #29941

This PR adds a note in the `spin build --help` output explaining that debug builds (`-- -Dbuildtype=debug`) include additional checks and assertions, making them slower and meant for development or debugging use only.

