### PR TITLE
MAINT, TST: Increase tolerance in fft test.

### DIFF
--- a/numpy/fft/tests/test_pocketfft.py
+++ b/numpy/fft/tests/test_pocketfft.py
@@ -55,7 +55,7 @@ class TestFFT1D:
     def test_identity_long_short_reversed(self, dtype):
         # Also test explicitly given number of points in reversed order.
         maxlen = 16
-        atol = 5 * np.spacing(np.array(1., dtype=dtype))
+        atol = 6 * np.spacing(np.array(1., dtype=dtype))
         x = random(maxlen).astype(dtype) + 1j * random(maxlen).astype(dtype)
         xx = np.concatenate([x, np.zeros_like(x)])
         for i in range(1, maxlen * 2):


### PR DESCRIPTION
`test_identity_long_short_reversed` fails fairly often, so increase the test tolerance by a bit. Note that `random` is used throughout this test module without a seed, but should be OK as the tolerance is set by the type spacing at 1, which should be out of range for the generated random values.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
