### PR TITLE
DOC: Correct typos in numpy API documentation

### DIFF
--- a/doc/source/user/basics.subclassing.rst
+++ b/doc/source/user/basics.subclassing.rst
@@ -567,7 +567,7 @@ which inputs and outputs it converted. Hence, e.g.,
 Note that another approach would be to use ``getattr(ufunc,
 methods)(*inputs, **kwargs)`` instead of the ``super`` call. For this example,
 the result would be identical, but there is a difference if another operand
-also defines ``__array_ufunc__``. E.g., lets assume that we evaluate
+also defines ``__array_ufunc__``. E.g., let's assume that we evaluate
 ``np.add(a, b)``, where ``b`` is an instance of another class ``B`` that has
 an override.  If you use ``super`` as in the example,
 ``ndarray.__array_ufunc__`` will notice that ``b`` has an override, which

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -4,7 +4,7 @@
  * pointers to do fast operations on the given input functions.
  * It thus adds an abstraction layer around individual ufunc loops.
  *
- * Unlike methods, a ArrayMethod can have multiple inputs and outputs.
+ * Unlike methods, an ArrayMethod can have multiple inputs and outputs.
  * This has some serious implication for garbage collection, and as far
  * as I (@seberg) understands, it is not possible to always guarantee correct
  * cyclic garbage collection of dynamically created DTypes with methods.

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -96,7 +96,7 @@ use_new_as_default(PyArray_DTypeMeta *self)
         return NULL;
     }
     /*
-     * Lets not trust that the DType is implemented correctly
+     * Let's not trust that the DType is implemented correctly
      * TODO: Should probably do an exact type-check (at least unless this is
      *       an abstract DType).
      */

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -88,7 +88,7 @@ def test_array_array():
     o = type("o", (object,),
              {"__array_struct__": a.__array_struct__})
     # wasn't what I expected... is np.array(o) supposed to equal a ?
-    # instead we get a array([...], dtype=">V18")
+    # instead we get an array([...], dtype=">V18")
     assert_equal(bytes(np.array(o).data), bytes(a.data))
 
     # test __array__

--- a/numpy/_core/tests/test_errstate.py
+++ b/numpy/_core/tests/test_errstate.py
@@ -87,7 +87,7 @@ class TestErrstate:
 
     @pytest.mark.skipif(IS_WASM, reason="wasm doesn't support asyncio")
     def test_asyncio_safe(self):
-        # asyncio may not always work, lets assume its fine if missing
+        # asyncio may not always work, let's assume its fine if missing
         # Pyodide/wasm doesn't support it.  If this test makes problems,
         # it should just be skipped liberally (or run differently).
         asyncio = pytest.importorskip("asyncio")

--- a/numpy/f2py/symbolic.py
+++ b/numpy/f2py/symbolic.py
@@ -1478,7 +1478,7 @@ class _FromStringWorker:
                 if isinstance(items, Expr):
                     return items
             if paren in ['ROUNDDIV', 'SQUARE']:
-                # Expression is a array constructor
+                # Expression is an array constructor
                 if isinstance(items, Expr):
                     items = (items,)
                 return as_array(items)

--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -645,7 +645,7 @@ def _read_array_header(fp, version, max_header_size=_MAX_HEADER_SIZE):
             "may be necessary.")
 
     # The header is a pretty-printed string representation of a literal
-    # Python dictionary with trailing newlines padded to a ARRAY_ALIGN byte
+    # Python dictionary with trailing newlines padded to an ARRAY_ALIGN byte
     # boundary. The keys are strings.
     #   "shape" : tuple of int
     #   "fortran_order" : bool

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2574,7 +2574,7 @@ M   33  21.99
 
     @pytest.mark.parametrize("ndim", [0, 1, 2])
     def test_ndmin_keyword(self, ndim: int):
-        # lets have the same behaviour of ndmin as loadtxt
+        # let's have the same behaviour of ndmin as loadtxt
         # as they should be the same for non-missing values
         txt = "42"
 


### PR DESCRIPTION
Correct typos in numpy API documentation

1. lets -> let's
2. a array -> an array

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
