### PR TITLE
DEP: Remove ``delimitor`` kwarg from ``ma.mrecords.fromtextfile``

### DIFF
--- a/doc/release/upcoming_changes/30021.expired.rst
+++ b/doc/release/upcoming_changes/30021.expired.rst
@@ -1,0 +1,5 @@
+Remove ``delimitor`` parameter from ``numpy.ma.mrecords.fromtextfile()``
+------------------------------------------------------------------------
+
+The ``delimitor`` parameter was deprecated in NumPy 1.22.0 and has been
+removed from ``numpy.ma.mrecords.fromtextfile()``. Use ``delimiter`` instead.

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -657,8 +657,7 @@ def openfile(fname):
 
 
 def fromtextfile(fname, delimiter=None, commentchar='#', missingchar='',
-                 varnames=None, vartypes=None,
-                 *, delimitor=np._NoValue):  # backwards compatibility
+                 varnames=None, vartypes=None):
     """
     Creates a mrecarray from data stored in the file `filename`.
 
@@ -682,16 +681,6 @@ def fromtextfile(fname, delimiter=None, commentchar='#', missingchar='',
 
 
     Ultra simple: the varnames are in the header, one line"""
-    if delimitor is not np._NoValue:
-        if delimiter is not None:
-            raise TypeError("fromtextfile() got multiple values for argument "
-                            "'delimiter'")
-        # NumPy 1.22.0, 2021-09-23
-        warnings.warn("The 'delimitor' keyword argument of "
-                      "numpy.ma.mrecords.fromtextfile() is deprecated "
-                      "since NumPy 1.22.0, use 'delimiter' instead.",
-                      DeprecationWarning, stacklevel=2)
-        delimiter = delimitor
 
     # Try to open the file.
     ftext = openfile(fname)

--- a/numpy/ma/mrecords.pyi
+++ b/numpy/ma/mrecords.pyi
@@ -89,8 +89,6 @@ def fromtextfile(
     missingchar="",
     varnames=None,
     vartypes=None,
-    # NOTE: deprecated: NumPy 1.22.0, 2021-09-23
-    # delimitor=...,
 ): ...
 
 def addfield(mrecord, newfield, newfieldname=None): ...

--- a/numpy/ma/tests/test_deprecations.py
+++ b/numpy/ma/tests/test_deprecations.py
@@ -1,9 +1,6 @@
 """Test deprecation and future warnings.
 
 """
-import io
-import textwrap
-
 import pytest
 
 import numpy as np
@@ -66,21 +63,3 @@ class TestMinimumMaximum:
         result = ma_max(data1d)
         assert_equal(result, ma_max(data1d, axis=None))
         assert_equal(result, ma_max(data1d, axis=0))
-
-
-class TestFromtextfile:
-    def test_fromtextfile_delimitor(self):
-        # NumPy 1.22.0, 2021-09-23
-
-        textfile = io.StringIO(textwrap.dedent(
-            """
-            A,B,C,D
-            'string 1';1;1.0;'mixed column'
-            'string 2';2;2.0;
-            'string 3';3;3.0;123
-            'string 4';4;4.0;3.14
-            """
-        ))
-
-        with pytest.warns(DeprecationWarning):
-            result = np.ma.mrecords.fromtextfile(textfile, delimitor=';')


### PR DESCRIPTION
it has been deprecated since NumPy 1.22.0