### PR TITLE
DOC: Make random numbers in documentation deterministic

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -654,3 +654,18 @@ try_examples_global_warning_text = (
     " report them on the"
     " [NumPy issue tracker](https://github.com/numpy/numpy/issues)."
 )
+
+
+# -----------------------------------------------------------------------------
+# Reproducible builds
+# -----------------------------------------------------------------------------
+
+# Seed the random number generators with a fixed value to make build results
+# reproducible. The actual seed does not matter as long as it is deterministic.
+
+# Seed legacy RNG
+numpy.random.seed(42)
+# Monkeypatch default_rng to return a deterministically seeded instance
+numpy.random.default_rng = \
+    lambda seed=None, actual_default_rng=numpy.random.default_rng: \
+        actual_default_rng(seed if seed is not None else 42)


### PR DESCRIPTION
Seeding the RNG with a fixed seed makes the documentation examples involving random numbers deterministic, which aids in reproducible builds.

The documentation is still not fully reproducible because of the inherent randomness of the `%timeit` directive. The only solution I can think of is running those benchmarks once and hard-code them in the documentation, but I believe that is better done in a separate pull request.
