### PR TITLE
SIMD, BLD: Backport FPMATH mode on x86-32 and filter successor CPU features

### DIFF
--- a/doc/source/reference/simd/build-options.rst
+++ b/doc/source/reference/simd/build-options.rst
@@ -97,8 +97,23 @@ Having issues with AVX512 features?
 You may have some reservations about including of ``AVX512`` or
 any other CPU feature and you want to exclude from the dispatched features::
 
-    python -m build --wheel -Csetup-args=-Dcpu-dispatch="max -avx512f -avx512cd \
+    python -m build --wheel -Csetup-args=-Dcpu-dispatch="max -avx512f"
+
+which is equivalent to::
+
+    python -m build --wheel -Csetup-args=-Dcpu-dispatch="max -avx512f -avx512cd 
     -avx512_knl -avx512_knm -avx512_skx -avx512_clx -avx512_cnl -avx512_icl -avx512_spr"
+
+Since excluding ``AVX512F`` also excludes all CPU features that imply it.
+
+You can also enable the required features without enabling ``max``::
+
+    python -m build --wheel -Csetup-args=-Dcpu-dispatch="avx2 fma3"
+
+.. note::
+  
+  Please refer to :ref:`opt-supported-features` to know which features
+  are implied by others.
 
 .. _opt-supported-features:
 
@@ -126,6 +141,10 @@ Special options
 
 - ``NATIVE``: Enables all CPU features that supported by the host CPU,
   this operation is based on the compiler flags (``-march=native``, ``-xHost``, ``/QxHost``)
+
+- ``DETECT``: Detects the features enabled by the compiler. This option is appended by default
+  to ``cpu-baseline`` if ``-march``, ``-mcpu``, ``-xhost``, or ``/QxHost`` is set in
+  the environment variable ``CFLAGS``.
 
 - ``MIN``: Enables the minimum CPU features that can safely run on a wide range of platforms:
 

--- a/meson_cpu/meson.build
+++ b/meson_cpu/meson.build
@@ -207,8 +207,17 @@ foreach opt_name, conf : parse_options
       endforeach
     else
       filterd = []
+      # filter out the features that are in the accumulate list 
+      # including any successor features
       foreach fet : result
-        if fet not in accumulate
+        escape = false
+        foreach fet2 : accumulate
+          if fet2 in mod_features.implicit_c(fet)
+            escape = true
+            break
+          endif
+        endforeach
+        if not escape
           filterd += fet
         endif
       endforeach

--- a/meson_cpu/x86/meson.build
+++ b/meson_cpu/x86/meson.build
@@ -1,8 +1,13 @@
 source_root = meson.project_source_root()
 mod_features = import('features')
-
+# Use SSE for floating-point on x86-32 to ensure numeric consistency.
+# The x87 FPU's 80-bit internal precision causes unpredictable rounding
+# and overflow behavior when converting to smaller types. SSE maintains
+# strict 32/64-bit precision throughout all calculations.
+cpu_family = host_machine.cpu_family()
+SSE_FPMATH = cpu_family == 'x86'? ['-mfpmath=sse'] : []
 SSE = mod_features.new(
-  'SSE', 1,  args: '-msse',
+  'SSE', 1,  args: ['-msse'] + SSE_FPMATH,
   test_code: files(source_root + '/numpy/distutils/checks/cpu_sse.c')[0]
 )
 SSE2 = mod_features.new(


### PR DESCRIPTION
Two major bugs need to be merged as part of gh-28896 and must be fixed:

- Force SSE-based floating-point on 32-bit x86 systems to avoid x87 FPU's 80-bit internal precision causing unpredictable rounding and overflow behavior when converting to smaller types.

- Fix filtering out successor features when an implied feature is removed through build options `--cpu-baseline` and `--cpu-dispatch`. Documentation `build-options` has been updated for this case.

- Updates `build-options` to add missing explanation about option `detect`.

Please, see [this comment](https://github.com/numpy/numpy/pull/28896) for more details.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
