### PR TITLE
TYP: fix stubtest error in ``numpy.typing``

### DIFF
--- a/numpy/typing/__init__.pyi
+++ b/numpy/typing/__init__.pyi
@@ -1,0 +1,3 @@
+from numpy._typing import ArrayLike, DTypeLike, NBitBase, NDArray
+
+__all__ = ["ArrayLike", "DTypeLike", "NBitBase", "NDArray"]


### PR DESCRIPTION
Stubtest was reporting this error:

```
numpy.typing.PytestTester is not present at runtime
```

False positive or not, it suggests that mypy thinks that `numpy.typing.PytestTester` exists, and that it is public API.

This adds a minimal stub, which resolves this issue.