### PR TITLE
DEV: Set correct ``PYTHONPATH`` in ``spin stubtest``

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -528,13 +528,19 @@ def mypy(ctx):
     default=False,
     help="Concise output format",
 )
-def stubtest(*, concise: bool) -> None:
+@meson.build_dir_option
+def stubtest(*, concise: bool, build_dir: str) -> None:
     """🧐 Run stubtest on NumPy's .pyi stubs
 
     Requires mypy to be installed
     """
-    ctx = click.get_current_context()
-    ctx.invoke(build)
+    click.get_current_context().invoke(build)
+    meson._set_pythonpath(build_dir)
+    print(f"{build_dir = !r}")
+
+    import sysconfig
+    purellib = sysconfig.get_paths()["purelib"]
+    print(f"{purellib = !r}")
 
     stubtest_dir = curdir.parent / 'tools' / 'stubtest'
     mypy_config = stubtest_dir / 'mypy.ini'
@@ -549,6 +555,7 @@ def stubtest(*, concise: bool) -> None:
     if concise:
         cmd.append('--concise')
     cmd.append('numpy')
+
     spin.util.run(cmd)
 
 


### PR DESCRIPTION
It turns out that I forgot to set the `PYTHONPATH` to the `build-install` dir in #30035. And because I had done a `uv pip install I didn't notice it was using `.venv`  instead.

The `meson._set_pythonpath` trick is also used in the `spin ipython`, so I assumed that this means it's ok to use then.