### PR TITLE
DOC: Clarify signed vs unsigned ``intptr_t`` vs ``uintptr_t`` in basics.types

### DIFF
--- a/doc/source/user/basics.types.rst
+++ b/doc/source/user/basics.types.rst
@@ -227,7 +227,7 @@ confusion with builtin python type names, such as `numpy.bool_`.
     * - N/A
       - ``'P'``
       - ``uintptr_t``
-      - Guaranteed to hold pointers. Character code only (Python and C).
+      - Guaranteed to hold pointers without sign. Character code only (Python and C).
 
     * - `numpy.int32` or `numpy.int64`
       - `numpy.long`


### PR DESCRIPTION
Clarified that uintptr_t is for pointers without sign as opposed to intptr_t.

Improves consistency across descriptions in regards to signed vs unsigned types.


Note: I am just a beginner with Numpy getting started with the docs so apologies if I misunderstood it.
