### PR TITLE
MAINT: bump ``hypothesis`` to ``6.142.2``

### DIFF
--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -2,7 +2,7 @@ Cython
 wheel==0.38.1
 setuptools==65.5.1 ; python_version < '3.12'
 setuptools         ; python_version >= '3.12'
-hypothesis==6.137.1
+hypothesis==6.142.2
 pytest==7.4.0
 pytest-cov==4.1.0
 meson


### PR DESCRIPTION
This is needed to avoid a crash in stubtest.

For context, see:
- https://github.com/HypothesisWorks/hypothesis/pull/4564
- https://github.com/python/mypy/issues/20064