### PR TITLE
DEV: separate stubtest allowlist for py312+

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -538,13 +538,15 @@ def stubtest(*, concise: bool) -> None:
 
     stubtest_dir = curdir.parent / 'tools' / 'stubtest'
     mypy_config = stubtest_dir / 'mypy.ini'
-    allowlist = stubtest_dir / 'allowlist.txt'
+    allowlists = [stubtest_dir / 'allowlist.txt']
+    if sys.version_info >= (3, 12):
+        allowlists.append(stubtest_dir / 'allowlist_py312.txt')
 
     cmd = [
         'stubtest',
         '--ignore-disjoint-bases',
         f'--mypy-config-file={mypy_config}',
-        f'--allowlist={allowlist}',
+        *(f'--allowlist={allowlist}' for allowlist in allowlists),
     ]
     if concise:
         cmd.append('--concise')

--- a/tools/stubtest/allowlist.txt
+++ b/tools/stubtest/allowlist.txt
@@ -31,13 +31,8 @@ numpy\.f2py\.__main__
 # inexpressible: the `dtype.type` class-attribute is `None` unless instantiated
 numpy(\..+)?\.dtype\.type
 
-# mypy false positive "... is not a Union" errors (py314 only?)
-numpy\.typing\.ArrayLike
-numpy\.typing\.DTypeLike
-
 # distutils
 numpy\.distutils.*
-numpy\.f2py\._backends\._distutils
 
 # import errors
 numpy\._build_utils.*

--- a/tools/stubtest/allowlist_py312.txt
+++ b/tools/stubtest/allowlist_py312.txt
@@ -1,0 +1,8 @@
+# python >= 3.12
+
+# false positive "... is not a Union" errors
+numpy\.typing\.ArrayLike
+numpy\.typing\.DTypeLike
+
+# only exists before Python 3.12
+numpy\.f2py\._backends\._distutils


### PR DESCRIPTION
This should take care of 3/6 stubtest errors (unused allowlist entries) on Python 3.11:
https://github.com/numpy/numpy/actions/runs/18691969608/job/53299696133?pr=30043