### PR TITLE
BLD: update scipy-openblas, use -Dpkg_config_path

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -85,16 +85,13 @@ jobs:
         fi
         mkdir -p ./.openblas
         python -c"import scipy_openblas32 as ob32; print(ob32.get_pkg_config())" > ./.openblas/scipy-openblas.pc
-        echo "PKG_CONFIG_PATH=${{ github.workspace }}/.openblas" >> $GITHUB_ENV
-        ld_library_path=$(python -c"import scipy_openblas32 as ob32; print(ob32.get_lib_dir())")
-        echo "LD_LIBRARY_PATH=$ld_library_path" >> $GITHUB_ENV
 
     - name: Build
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       env:
         TERM: xterm-256color
       run:
-        spin build -- --werror -Dallow-noblas=false
+        spin build -- --werror -Dallow-noblas=false -Dpkg_config_path=${PWD}/.openblas
 
     - name: Check build-internal dependencies
       run:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,13 +39,12 @@ jobs:
     - name: Install pkg-config
       run: |
         choco install -y --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
-        echo "PKG_CONFIG_PATH=${{ github.workspace }}/.openblas" >> $env:GITHUB_ENV
 
     - name: Install NumPy (Clang-cl)
       run: |
         "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'" | Out-File $PWD/clang-cl-build.ini -Encoding ascii
         pip install -r requirements/ci_requirements.txt
-        spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
+        spin build --with-scipy-openblas=32 -j2 -- -Dpkg_config_path=$PWD/.openblas --vsenv --native-file=$PWD/clang-cl-build.ini
 
     - name: Meson Log
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,12 +39,13 @@ jobs:
     - name: Install pkg-config
       run: |
         choco install -y --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
+        echo "PKG_CONFIG_PATH=${{ github.workspace }}/.openblas" >> $env:GITHUB_ENV
 
     - name: Install NumPy (Clang-cl)
       run: |
         "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'" | Out-File $PWD/clang-cl-build.ini -Encoding ascii
         pip install -r requirements/ci_requirements.txt
-        spin build --with-scipy-openblas=32 -j2 -- -Dpkg_config_path=$PWD/.openblas --vsenv --native-file=$PWD/clang-cl-build.ini
+        spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
 
     - name: Meson Log
       shell: bash

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin==0.15
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.30.0.4
+scipy-openblas32==0.3.30.0.6

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin==0.15
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.30.0.1
+scipy-openblas32==0.3.30.0.4

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin==0.15
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.30.0.1
-scipy-openblas64==0.3.30.0.1
+scipy-openblas32==0.3.30.0.4
+scipy-openblas64==0.3.30.0.4

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin==0.15
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.30.0.4
-scipy-openblas64==0.3.30.0.4
+scipy-openblas32==0.3.30.0.6
+scipy-openblas64==0.3.30.0.6


### PR DESCRIPTION
Closes #29391 by patching OpenBLAS. Hopefully by the time 0.3.31 is released we can remove the patch.

Also use `spin build -- -Dpkg_config_path=` instead of setting `PKG_CONFIG_PATH` in the normal (non-wheel building) CI.