### PR TITLE
CI: Python 3.14 stable

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,7 +58,7 @@ jobs:
       MESON_ARGS: "-Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none"
     strategy:
       matrix:
-        version: ["3.11", "3.12", "3.13", "3.14-dev", "3.14t-dev"]
+        version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
-        python-version: "3.14t-dev"
+        python-version: "3.14t"
 
     - name: Install build dependencies from PyPI
       run: |
@@ -97,7 +97,7 @@ jobs:
       - name: Build and install
         run: |
           python -m pip install . -v -Ccompile-args="-j2" -Csetup-args="-Dallow-noblas=true" 2>&1 | tee build.log
-      
+
       - name: Check warnings
         uses: ./.github/check-warnings
         with:


### PR DESCRIPTION
Python π was released 2 weeks ago, so we don't need to use the `-dev` versions anymore.