### PR TITLE
BUG: allow division between object-dtype arrays and timedelta objects

### DIFF
--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -1252,9 +1252,10 @@ PyUFunc_DivisionTypeResolver(PyUFuncObject *ufunc,
     type_num2 = PyArray_DESCR(operands[1])->type_num;
 
     /* Use the default when datetime and timedelta are not involved */
-    if (!PyTypeNum_ISDATETIME(type_num1) && !PyTypeNum_ISDATETIME(type_num2)) {
-        return PyUFunc_DefaultTypeResolver(ufunc, casting, operands,
-                    type_tup, out_dtypes);
+    if ((!PyTypeNum_ISDATETIME(type_num1) && !PyTypeNum_ISDATETIME(type_num2)) ||
+            (PyTypeNum_ISOBJECT(type_num1) || PyTypeNum_ISOBJECT(type_num2))) {
+        return PyUFunc_DefaultTypeResolver(ufunc, casting, operands, type_tup,
+                                           out_dtypes);
     }
 
     if (type_num1 == NPY_TIMEDELTA) {
@@ -1327,14 +1328,6 @@ PyUFunc_DivisionTypeResolver(PyUFuncObject *ufunc,
         else {
             return raise_binary_type_reso_error(ufunc, operands);
         }
-    }
-    else if (PyTypeNum_ISOBJECT(type_num1) || PyTypeNum_ISOBJECT(type_num2)) {
-        /* Delegate to the default resolver. 
-        * This selects the generic O->O object loop (elementwise Python op),
-        * allowing operations with Python timedelta objects inside object arrays.
-        */
-        return PyUFunc_DefaultTypeResolver(ufunc, casting, operands,
-                    type_tup, out_dtypes);
     }
     else {
         return raise_binary_type_reso_error(ufunc, operands);

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -1328,6 +1328,14 @@ PyUFunc_DivisionTypeResolver(PyUFuncObject *ufunc,
             return raise_binary_type_reso_error(ufunc, operands);
         }
     }
+    else if (PyTypeNum_ISOBJECT(type_num1) || PyTypeNum_ISOBJECT(type_num2)) {
+        /* Delegate to the default resolver. 
+        * This selects the generic O->O object loop (elementwise Python op),
+        * allowing operations with Python timedelta objects inside object arrays.
+        */
+        return PyUFunc_DefaultTypeResolver(ufunc, casting, operands,
+                    type_tup, out_dtypes);
+    }
     else {
         return raise_binary_type_reso_error(ufunc, operands);
     }

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -2700,6 +2700,54 @@ class TestDateTime:
         td2 = np.timedelta64(td, unit)
         _assert_equal_hash(td, td2)
 
+    @pytest.mark.parametrize(
+        "inputs, divisor, expected",
+        [
+            (
+                np.array(
+                    [datetime.timedelta(seconds=20), datetime.timedelta(days=2)],
+                    dtype="object",
+                ),
+                np.int64(2),
+                np.array(
+                    [datetime.timedelta(seconds=10), datetime.timedelta(days=1)],
+                    dtype="object",
+                ),
+            ),
+            (
+                np.array(
+                    [datetime.timedelta(seconds=20), datetime.timedelta(days=2)],
+                    dtype="object",
+                ),
+                np.timedelta64(2, "s"),
+                np.array(
+                    [10.0, 24.0 * 60.0 * 60.0],
+                    dtype="object",
+                ),
+            ),
+            (
+                datetime.timedelta(seconds=2),
+                np.array(
+                    [datetime.timedelta(seconds=20), datetime.timedelta(days=2)],
+                    dtype="object",
+                ),
+                np.array(
+                    [1.0 / 10.0, 1.0 / (24.0 * 60.0 * 60.0)],
+                    dtype="object",
+                ),
+            ),
+        ],
+    )
+    def test_true_divide_object_by_timedelta(
+        self,
+        inputs: np.ndarray | type[np.generic],
+        divisor: np.ndarray | type[np.generic],
+        expected: np.ndarray,
+    ):
+        # gh-30025
+        results = inputs / divisor
+        assert_array_equal(results, expected)
+
 
 class TestDateTimeData:
 

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -1,5 +1,4 @@
 import ctypes as ct
-import datetime
 import itertools
 import pickle
 import sys
@@ -726,54 +725,6 @@ class TestUfunc:
         res = np.true_divide(~a, a)
         assert_(res == 0.0)
         assert_(res.dtype.name == 'float64')
-
-    @pytest.mark.parametrize(
-        "inputs, divisor, expected",
-        [
-            (
-                np.array(
-                    [datetime.timedelta(seconds=20), datetime.timedelta(days=2)],
-                    dtype="object",
-                ),
-                np.int64(2),
-                np.array(
-                    [datetime.timedelta(seconds=10), datetime.timedelta(days=1)],
-                    dtype="object",
-                ),
-            ),
-            (
-                np.array(
-                    [datetime.timedelta(seconds=20), datetime.timedelta(days=2)],
-                    dtype="object",
-                ),
-                np.timedelta64(2, "s"),
-                np.array(
-                    [10.0, 24.0 * 60.0 * 60.0],
-                    dtype="object",
-                ),
-            ),
-            (
-                datetime.timedelta(seconds=2),
-                np.array(
-                    [datetime.timedelta(seconds=20), datetime.timedelta(days=2)],
-                    dtype="object",
-                ),
-                np.array(
-                    [1.0 / 10.0, 1.0 / (24.0 * 60.0 * 60.0)],
-                    dtype="object",
-                ),
-            ),
-        ],
-    )
-    def test_true_divide_object_by_timedelta(
-        self,
-        inputs: np.ndarray | type[np.generic],
-        divisor: np.ndarray | type[np.generic],
-        expected: np.ndarray,
-    ):
-        # gh-30025
-        results = inputs / divisor
-        assert_array_equal(results, expected)
 
     def test_sum_stability(self):
         a = np.ones(500, dtype=np.float32)


### PR DESCRIPTION
Closes #30025 

Fixes a bug where dividing an object-dtype array containing Python timedelta objects by a NumPy timedelta64 scalar would raise a `_UFuncBinaryResolutionError`. The operation now falls back to the generic object ufunc loop, enabling elementwise Python evaluation consistent with other object operations.

* Example

```python
arr = np.array([timedelta(seconds=1)], dtype="object")
scalar = np.timedelta64(10, 's')
arr / scalar 
# Used to be _UFuncBinaryResolutionError
# Now returns array([0.1]) dtype=object
```

* Notes

Other arithmetic ops ( `+`, `-`, `*` ) have similar inconsistencies. I plan to open follow-up MRs if needed.