### PR TITLE
DOC: Remove nonexistent ``order`` parameter docs of ``ma.asanyarray``

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -8629,9 +8629,6 @@ def asanyarray(a, dtype=None):
         Input data, in any form that can be converted to an array.
     dtype : dtype, optional
         By default, the data-type is inferred from the input data.
-    order : {'C', 'F'}, optional
-        Whether to use row-major ('C') or column-major ('FORTRAN') memory
-        representation.  Default is 'C'.
 
     Returns
     -------


### PR DESCRIPTION
An alternative would be to actually add the `order` parameter (but then this would still be worth backporting).