### PR TITLE
CI, TYP: Fix stubtest CI failures on py311

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -561,7 +561,9 @@ def stubtest(*, concise: bool, build_dir: str) -> None:
     stubtest_dir = curdir.parent / 'tools' / 'stubtest'
     mypy_config = stubtest_dir / 'mypy.ini'
     allowlists = [stubtest_dir / 'allowlist.txt']
-    if sys.version_info >= (3, 12):
+    if sys.version_info < (3, 12):
+        allowlists.append(stubtest_dir / 'allowlist_py311.txt')
+    else:
         allowlists.append(stubtest_dir / 'allowlist_py312.txt')
 
     cmd = [

--- a/tools/stubtest/allowlist_py311.txt
+++ b/tools/stubtest/allowlist_py311.txt
@@ -1,0 +1,3 @@
+# python == 3.11.*
+
+numpy\.distutils\..*


### PR DESCRIPTION
As can be seen in https://github.com/numpy/numpy/actions/runs/18756463021/job/53509587499?pr=30060, stubtest is failing on Python 3.11 because of missing `distutils` stubs. This adds a Python3.11 specific "allowlist" to ignore these errors.
We need a separate allowlist for this, because stubtest reports unused allowlist entries as errors. So we can't globally ignore the `numpy\.distutils\..*` pattern, as that would result in errors on all other Python versions.