### PR TITLE
BUG: Fix np.strings.slice if start > stop

### DIFF
--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2271,6 +2271,7 @@ slice_strided_loop(PyArrayMethod_Context *context, char *const data[],
                                            ? codepoint_offsets[stop]
                                            : (unsigned char *)is.buf + is.size);
             npy_intp outsize = stop_bounded - start_bounded;
+            outsize = outsize < 0 ? 0 : outsize;
 
             if (load_new_string(ops, &os, outsize, oallocator, "slice") < 0) {
                 goto fail;

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -992,7 +992,8 @@ class TestMethods:
         (6,),  # test index past the end
         (6, None),
         (6, None, -1),
-        (6, 7),  # test stop index past the end
+        (6, 7),  # test start and stop index past the end
+        (4, 3),  # test start > stop index
         (-1,),
         (-1, None),
         (-1, None, -1),
@@ -1016,8 +1017,16 @@ class TestMethods:
         (None, None, -1),
         ([0, 6], [-1, 0], [2, -1]),
     ])
-    def test_slice(self, args, dt):
-        buf = np.array(["hello", "world"], dtype=dt)
+    @pytest.mark.parametrize("buf", [
+        ["hello", "world"],
+        ['hello world', 'γεια σου κόσμε', '你好世界', '👋 🌍'],
+    ])
+    def test_slice(self, args, buf, dt):
+        if dt == "S" and "你好世界" in buf:
+            pytest.skip("Bytes dtype does not support non-ascii input")
+        if len(buf) == 4:
+            args = tuple(s * 2 if isinstance(s, list) else s for s in args)
+        buf = np.array(buf, dtype=dt)
         act = np.strings.slice(buf, *args)
         bcast_args = tuple(np.broadcast_to(arg, buf.shape) for arg in args)
         res = np.array([s[slice(*arg)]


### PR DESCRIPTION
If the slice start > stop, then `slice_strided_loop()` attempts to allocate a string of negative size, causing a MemoryError. To replicate:
```
>>> a = np.array(['test-strings'], dtype="T")
>>> np.strings.slice(a, 6, 5)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "lib/python3.12/site-packages/numpy/_core/strings.py", line 1813, in slice
    return _slice(a, start, stop, step)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
MemoryError: Failed to allocate string in slice
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
