### PR TITLE
TST: Remove unnecessary test__datasource thread-unsafe markers

### DIFF
--- a/numpy/lib/tests/test__datasource.py
+++ b/numpy/lib/tests/test__datasource.py
@@ -88,7 +88,6 @@ def invalid_httpfile():
     return http_fakefile
 
 
-@pytest.mark.thread_unsafe(reason="mkdtemp thread-unsafe")
 class TestDataSourceOpen:
     def test_ValidHTTP(self, tmp_path):
         ds = datasource.DataSource(tmp_path)
@@ -157,7 +156,6 @@ class TestDataSourceOpen:
         assert_equal(magic_line, result)
 
 
-@pytest.mark.thread_unsafe(reason="mkdtemp thread-unsafe")
 class TestDataSourceExists:
     def test_ValidHTTP(self, tmp_path):
         ds = datasource.DataSource(tmp_path)
@@ -184,7 +182,6 @@ class TestDataSourceExists:
         assert_equal(ds.exists(tmpfile), False)
 
 
-@pytest.mark.thread_unsafe(reason="mkdtemp thread-unsafe")
 class TestDataSourceAbspath:
     def test_ValidHTTP(self, tmp_path):
         ds = datasource.DataSource(tmp_path)
@@ -247,7 +244,6 @@ class TestDataSourceAbspath:
             os.sep = orig_os_sep
 
 
-@pytest.mark.thread_unsafe(reason="mkdtemp thread-unsafe")
 class TestRepositoryAbspath:
     def test_ValidHTTP(self, tmp_path):
         repos = datasource.Repository(valid_baseurl(), tmp_path)
@@ -275,7 +271,6 @@ class TestRepositoryAbspath:
             os.sep = orig_os_sep
 
 
-@pytest.mark.thread_unsafe(reason="mkdtemp thread-unsafe")
 class TestRepositoryExists:
     def test_ValidFile(self, tmp_path):
         # Create local temp file
@@ -305,7 +300,6 @@ class TestRepositoryExists:
         assert_(repos.exists(tmpfile))
 
 
-@pytest.mark.thread_unsafe(reason="mkdtemp thread-unsafe")
 class TestOpenFunc:
     def test_DataSourceOpen(self, tmp_path):
         local_file = valid_textfile(tmp_path)


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
In a previous PR (#29816) I marked up tests that were thread-unsafe when ran under [pytest-run-parallel](https://github.com/Quansight-Labs/pytest-run-parallel). A few markers I put there are no longer needed since I ended up fixing the issues with the tests in a separate PR (#29858). Forgot to actually get rid of the markers, so that's what this PR is for.