### PR TITLE
BUG: avoid negating INT_MIN in PyArray_Round implementation

### DIFF
--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -652,7 +652,15 @@ PyArray_Round(PyArrayObject *a, int decimals, PyArrayObject *out)
     else {
         op1 = n_ops.true_divide;
         op2 = n_ops.multiply;
-        decimals = -decimals;
+        if (decimals == INT_MIN) {
+            // not technically correct but it doesn't matter because no one in
+            // this millenium is using floating point numbers with enough
+            // accuracy for this to matter
+            decimals = INT_MAX;
+        }
+        else {
+            decimals = -decimals;
+        }
     }
     if (!out) {
         if (PyArray_ISINTEGER(a)) {


### PR DESCRIPTION
c.f. https://huntr.com/bounties/49928a2c-c6bb-4c1c-80ec-5d7bf708bf28 where this almost led to a CVE getting reported against NumPy.

Addresses one of the issues reported in https://github.com/numpy/numpy/issues/28829.

For those who are unaware: the value of `INT_MIN` is `-INT_MAX - 1` (negating using two's complement arithmetic), so that means that if C used two's complement `-INT_MIN == INT_MIN`. For that reason, `-INT_MIN` is UB according to the C standard. You are always supposed to do a check like this when negating a signed integer, but it is often skipped.

I learned while working on this that passing `round` a negative `ndigits` is supported. Round with `ndigits!=0` is the same as round with `ndigits==0`, but transformed in the following way: `round(x * 10**ndigits, 0) / 10**ndigits`. The same formula holds for positive and negative ndigits. 

No tests because it's annoying to write a test for this case (see https://github.com/python/cpython/issues/132474 -- it turns out `round(2**31, -2**31)` will hang CPython...).

Open to suggestions if people want to do a more thorough job of this but at least this prevents the segfault.

Ping @devdanzin, this seems relevant to your interests.