### PR TITLE
FIX: Use memcpy when casting `_TYPE1` to `@rtype1@`

### DIFF
--- a/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1110,7 +1110,9 @@ static GCC_CAST_OPT_LEVEL int
 #    else
        dst_value = _CONVERT_FN(src_value[0]);
 #      if @same_value@
-            if (@prefix@_check_same_value_@name1@_to_@name2@(*(@rtype1@ *)&src_value[0]) < 0) {
+            @rtype1@ rtmp;
+            memcpy(&rtmp, &src_value[0], sizeof(rtmp));
+            if (@prefix@_check_same_value_@name1@_to_@name2@(rtmp) < 0) {
                 return -1;
             }
             if (src_value[1] != 0) {
@@ -1125,7 +1127,9 @@ static GCC_CAST_OPT_LEVEL int
 #    else
        *(_TYPE2 *)dst = _CONVERT_FN(src_value[0]);
 #      if @same_value@
-            if (@prefix@_check_same_value_@name1@_to_@name2@(*(@rtype1@ *)&src_value[0]) < 0) {
+            @rtype1@ rtmp;
+            memcpy(&rtmp, &src_value[0], sizeof(rtmp));
+            if (@prefix@_check_same_value_@name1@_to_@name2@(rtmp) < 0) {
                 return -1;
             }
             if (src_value[1] != 0) {
@@ -1157,7 +1161,9 @@ static GCC_CAST_OPT_LEVEL int
     dst_value = _CONVERT_FN(src_value);
 #   if !@is_bool2@
 #     if @same_value@
-        if (@prefix@_check_same_value_@name1@_to_@name2@(*(@rtype1@ *)&src_value) < 0) {
+        @rtype1@ rtmp;
+        memcpy(&rtmp, &src_value, sizeof(rtmp));
+        if (@prefix@_check_same_value_@name1@_to_@name2@(rtmp) < 0) {
             return -1;
         }
 #     endif //same_value

--- a/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1111,7 +1111,12 @@ static GCC_CAST_OPT_LEVEL int
        dst_value = _CONVERT_FN(src_value[0]);
 #      if @same_value@
             @rtype1@ rtmp;
-            memcpy(&rtmp, &src_value[0], sizeof(rtmp));
+            #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 12
+                /* To avoid strict-aliasing issues */
+                memcpy(&rtmp, &src_value[0], sizeof(rtmp));
+            #else
+                rtmp = *(@rtype1@ *)&src_value[0];
+            #endif
             if (@prefix@_check_same_value_@name1@_to_@name2@(rtmp) < 0) {
                 return -1;
             }
@@ -1128,7 +1133,12 @@ static GCC_CAST_OPT_LEVEL int
        *(_TYPE2 *)dst = _CONVERT_FN(src_value[0]);
 #      if @same_value@
             @rtype1@ rtmp;
-            memcpy(&rtmp, &src_value[0], sizeof(rtmp));
+            #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 12
+                /* To avoid strict-aliasing issues */
+                memcpy(&rtmp, &src_value[0], sizeof(rtmp));
+            #else
+                rtmp = *(@rtype1@ *)&src_value[0];
+            #endif
             if (@prefix@_check_same_value_@name1@_to_@name2@(rtmp) < 0) {
                 return -1;
             }
@@ -1162,7 +1172,12 @@ static GCC_CAST_OPT_LEVEL int
 #   if !@is_bool2@
 #     if @same_value@
         @rtype1@ rtmp;
-        memcpy(&rtmp, &src_value, sizeof(rtmp));
+        #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 12
+            /* To avoid strict-aliasing issues */
+            memcpy(&rtmp, &src_value, sizeof(rtmp));
+        #else
+            rtmp = *(@rtype1@ *)&src_value;
+        #endif
         if (@prefix@_check_same_value_@name1@_to_@name2@(rtmp) < 0) {
             return -1;
         }


### PR DESCRIPTION
Closes #30056 

When handling the half type (`npy_half`), `_TYPE1` and `@rtype1@` are not the same. To avoid compiler warnings, `memcpy` is applied.

## Build Log

Strict aliasing compiler warnings have been resolved.

* Before: https://github.com/numpy/numpy/actions/runs/18784139665/job/53598512452#step:4:1135
* After: https://github.com/numpy/numpy/actions/runs/18802875842/job/53652985421


## Details

* When `_TYPE1` and `@rtype1@` differ, the expression `*(@rtype1@ *)&src_value[0]` results in dereferencing between incompatible types, which triggers compiler warnings under strict aliasing rules.
To avoid this, `memcpy` is applied to safely copy the bytes without violating aliasing or alignment requirements.

* I think `memcpy` is typically highly optimized by modern compilers for small fixed-size copies, so no performance regression is expected.
But, If necessary, benchmark results can be added for confirmation.

* According to the commit history, @mattip has recently worked on this area.
I would appreciate it if you could take a look and let me know if you have any suggestions or concerns.

