### PR TITLE
DOC: Clarify advanced vs basic indexing tuple definition

### DIFF
--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -277,11 +277,14 @@ operations. For example::
 Advanced indexing
 -----------------
 
-Advanced indexing is triggered when the selection object, *obj*, is a
-non-tuple sequence object, an :class:`ndarray` (of data type integer or bool),
+Advanced indexing is triggered when the selection object *obj* is a non-tuple
+sequence object, an :class:`ndarray` (of data type integer or bool),
 or a tuple with at least one sequence object or ndarray (of data type
-integer or bool). There are two types of advanced indexing: integer
-and Boolean.
+integer or bool). In short, advanced indexing occurs when one of the indices
+is an array or sequence, and :ref:`basic-indexing` occurs for all
+other cases (e.g., integer scalars, :class:`slice` objects, or tuples of
+only these). There are two types of advanced indexing: integer and Boolean.
+
 
 Advanced indexing always returns a *copy* of the data (contrast with
 basic slicing that returns a :term:`view`).


### PR DESCRIPTION
The existing definition of advanced indexing was slightly confusing about what triggers it versus basic indexing when using a tuple.

This commit adds a note to explicitly state that a tuple containing *only* slices, integers, ellipsis, or newaxis triggers basic indexing, while a tuple containing *at least one* list or ndarray triggers advanced indexing.

Relates to #30022.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
