### PR TITLE
CI: Update ARM job (armhf_test) to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,7 +166,7 @@ jobs:
     # running on aarch64 (ARM 64-bit) GitHub runners.
     needs: [smoke_test]
     if: github.repository == 'numpy/numpy'
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
@@ -177,11 +177,9 @@ jobs:
     - name: Creates new container
       run: |
         docker run --name the_container --interactive \
-          -v $(pwd):/numpy arm32v7/ubuntu:22.04 /bin/linux32 /bin/bash -c "
+          -v $(pwd):/numpy arm32v7/ubuntu:24.04 /bin/linux32 /bin/bash -c "
           apt update &&
-          apt install -y ninja-build cmake git python3 python-is-python3 python3-dev python3-pip python3-venv &&
-          python -m pip install -r /numpy/requirements/build_requirements.txt &&
-          python -m pip install -r /numpy/requirements/test_requirements.txt
+          apt install -y ninja-build cmake git python3 python-is-python3 python3-dev python3-pip python3-venv
         "
         docker commit the_container the_container
 
@@ -190,7 +188,12 @@ jobs:
         docker run --rm -e "TERM=xterm-256color" \
           -v $(pwd):/numpy the_container \
           /bin/script -e -q -c "/bin/linux32 /bin/bash --noprofile --norc -eo pipefail -c '
-            cd /numpy && spin build
+            cd /numpy &&
+            python -m venv venv &&
+            source venv/bin/activate &&
+            python -m pip install -r /numpy/requirements/build_requirements.txt &&
+            python -m pip install -r /numpy/requirements/test_requirements.txt &&
+            spin build
           '"
 
     - name: Meson Log
@@ -202,7 +205,7 @@ jobs:
         docker run --rm -e "TERM=xterm-256color" \
           -v $(pwd):/numpy the_container \
           /bin/script -e -q -c "/bin/linux32 /bin/bash --noprofile --norc -eo pipefail -c '
-            cd /numpy && spin test -m full -- --timeout=600 --durations=10
+            cd /numpy && source venv/bin/activate && spin test -m full -- --timeout=600 --durations=10
           '"
 
   benchmark:


### PR DESCRIPTION
Closes #30086 

* Update the image used for the armhf_test CI job to one based on Ubuntu 24.04. (`ubuntu-24.04-arm`)
* Use a virtual environment to comply with [PEP 668](https://peps.python.org/pep-0668/), which is automatically enforced on Ubuntu 24.04.

Notes:

One job running on the `ubuntu:24.04-arm` runner was abruptly canceled. Here is the log for reference: 
* https://github.com/numpy/numpy/actions/runs/18915094882/job/53996862849

Similar issues were reported about nine months ago.
* https://github.com/orgs/community/discussions/148648#discussioncomment-12080023

I have encountered this issue only once after making this change.
If it continues to occur, we may need to consider reverting to `ubuntu-22.04-arm`.
