### PR TITLE
BLD: use blobless checkout on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ jobs:
   build:
     <<: *defaults
     steps:
-      - checkout
+      - checkout:
+          method: blobless
 
       - run:
           name: check skip
@@ -110,7 +111,8 @@ jobs:
   deploy:
     <<: *defaults
     steps:
-      - checkout
+      - checkout:
+          method: blobless
 
       - attach_workspace:
           at: ~/repo


### PR DESCRIPTION
CirrusCI added an [option to use blobless checkout](https://circleci.com/changelog/introducing-a-faster-checkout-option). This will become the default on Nov 3. Let's proactively make sure we can use it. 