### PR TITLE
BUG, TYP: ufunc method signatures

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -6,7 +6,7 @@ import ctypes as ct
 import array as _array
 import datetime as dt
 from abc import abstractmethod
-from types import EllipsisType, GetSetDescriptorType, ModuleType, TracebackType, MappingProxyType, GenericAlias
+from types import EllipsisType, ModuleType, TracebackType, MappingProxyType, GenericAlias
 from decimal import Decimal
 from fractions import Fraction
 from uuid import UUID
@@ -5671,7 +5671,7 @@ class ufunc:
     @property
     def __name__(self) -> LiteralString: ...
     @property
-    def __qualname__(self) -> LiteralString: ...
+    def __qualname__(self) -> LiteralString: ...  # pyright: ignore[reportIncompatibleVariableOverride]
     @property
     def __doc__(self) -> str: ...  # type: ignore[override]
     @property
@@ -5700,18 +5700,43 @@ class ufunc:
     @property
     def signature(self) -> LiteralString | None: ...
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+    def __call__(self, /, *args: Any, **kwargs: Any) -> Any: ...
+
     # The next four methods will always exist, but they will just
     # raise a ValueError ufuncs with that don't accept two input
     # arguments and return one output argument. Because of that we
     # can't type them very precisely.
-    def reduce(self, /, *args: Any, **kwargs: Any) -> Any: ...
-    def accumulate(self, /, *args: Any, **kwargs: Any) -> NDArray[Any]: ...
-    def reduceat(self, /, *args: Any, **kwargs: Any) -> NDArray[Any]: ...
-    def outer(self, *args: Any, **kwargs: Any) -> Any: ...
-    # Similarly at won't be defined for ufuncs that return multiple
+    def accumulate(
+        self,
+        array: ArrayLike,
+        /,
+        axis: SupportsIndex = 0,
+        dtype: DTypeLike | None = None,
+        out: ndarray | EllipsisType | None = None,
+    ) -> NDArray[Incomplete]: ...
+    def reduce(
+        self,
+        array: ArrayLike,
+        /,
+        axis: _ShapeLike | None = 0,
+        dtype: DTypeLike | None = None,
+        out: ndarray | EllipsisType | None = None,
+        **kwargs: Incomplete,
+    ) -> Incomplete: ...
+    def reduceat(
+        self,
+        array: ArrayLike,
+        /,
+        indices: _ArrayLikeInt_co,
+        axis: SupportsIndex = 0,
+        dtype: DTypeLike | None = None,
+        out: ndarray | EllipsisType | None = None,
+    ) -> NDArray[Incomplete]: ...
+    def outer(self, A: ArrayLike, B: ArrayLike, /, **kwargs: Incomplete) -> NDArray[Incomplete]: ...
+
+    # Similarly `at` won't be defined for ufuncs that return multiple
     # outputs, so we can't type it very precisely.
-    def at(self, /, *args: Any, **kwargs: Any) -> None: ...
+    def at(self, a: ndarray, indices: _ArrayLikeInt_co, b: ArrayLike | None = None, /) -> None: ...
 
     #
     def resolve_dtypes(

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -4799,7 +4799,7 @@ add_newdoc('numpy._core.umath', '_add_newdoc_ufunc',
 
 add_newdoc('numpy._core.multiarray', 'get_handler_name',
     """
-    get_handler_name(a: ndarray) -> str,None
+    get_handler_name(a: ndarray) -> str | None
 
     Return the name of the memory handler used by `a`. If not provided, return
     the name of the memory handler that will be used to allocate data for the
@@ -5171,6 +5171,9 @@ add_newdoc('numpy._core', 'ufunc', ('signature',
 
 add_newdoc('numpy._core', 'ufunc', ('reduce',
     """
+    reduce($self, array, /, axis=0, dtype=None, out=None, **kwargs)
+    --
+
     reduce(array, axis=0, dtype=None, out=None, keepdims=False, initial=<no value>, where=True)
 
     Reduces `array`'s dimension by one, by applying ufunc along one axis.
@@ -5297,6 +5300,9 @@ add_newdoc('numpy._core', 'ufunc', ('reduce',
 
 add_newdoc('numpy._core', 'ufunc', ('accumulate',
     """
+    accumulate($self, array, /, axis=0, dtype=None, out=None)
+    --
+
     accumulate(array, axis=0, dtype=None, out=None)
 
     Accumulate the result of applying the operator to all elements.
@@ -5375,6 +5381,9 @@ add_newdoc('numpy._core', 'ufunc', ('accumulate',
 
 add_newdoc('numpy._core', 'ufunc', ('reduceat',
     """
+    reduceat($self, array, /, indices, axis=0, dtype=None, out=None)
+    --
+
     reduceat(array, indices, axis=0, dtype=None, out=None)
 
     Performs a (local) reduce with specified slices over a single axis.
@@ -5483,6 +5492,9 @@ add_newdoc('numpy._core', 'ufunc', ('reduceat',
 
 add_newdoc('numpy._core', 'ufunc', ('outer',
     r"""
+    outer($self, A, B, /, **kwargs)
+    --
+
     outer(A, B, /, **kwargs)
 
     Apply the ufunc `op` to all pairs (a, b) with a in `A` and b in `B`.
@@ -5554,6 +5566,9 @@ add_newdoc('numpy._core', 'ufunc', ('outer',
 
 add_newdoc('numpy._core', 'ufunc', ('at',
     """
+    at($self, a, indices, b=None, /)
+    --
+
     at(a, indices, b=None, /)
 
     Performs unbuffered in place operation on operand 'a' for elements
@@ -5605,6 +5620,9 @@ add_newdoc('numpy._core', 'ufunc', ('at',
 
 add_newdoc('numpy._core', 'ufunc', ('resolve_dtypes',
     """
+    resolve_dtypes($self, dtypes, *, signature=None, casting=None, reduction=False)
+    --
+
     resolve_dtypes(dtypes, *, signature=None, casting=None, reduction=False)
 
     Find the dtypes NumPy will use for the operation.  Both input and
@@ -5677,6 +5695,9 @@ add_newdoc('numpy._core', 'ufunc', ('resolve_dtypes',
 
 add_newdoc('numpy._core', 'ufunc', ('_resolve_dtypes_and_context',
     """
+    _resolve_dtypes_and_context($self, dtypes, *, signature=None, casting=None, reduction=False)
+    --
+
     _resolve_dtypes_and_context(dtypes, *, signature=None, casting=None, reduction=False)
 
     See `numpy.ufunc.resolve_dtypes` for parameter information.  This
@@ -5700,6 +5721,9 @@ add_newdoc('numpy._core', 'ufunc', ('_resolve_dtypes_and_context',
 
 add_newdoc('numpy._core', 'ufunc', ('_get_strided_loop',
     """
+    _get_strided_loop($self, call_info, /, *, fixed_strides=None)
+    --
+
     _get_strided_loop(call_info, /, *, fixed_strides=None)
 
     This function fills in the ``call_info`` capsule to include all
@@ -6453,7 +6477,7 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('__le__',
 
 add_newdoc('numpy._core.multiarray', 'dtype', ('__gt__',
     """
-    __ge__(value, /)
+    __gt__(value, /)
 
     Return ``self > value``.
 

--- a/numpy/_core/function_base.py
+++ b/numpy/_core/function_base.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import operator
 import types
 import warnings
@@ -477,6 +478,9 @@ def _add_docstring(obj, doc, warn_on_python):
             "Prefer to attach it directly to the source.",
             UserWarning,
             stacklevel=3)
+
+    doc = inspect.cleandoc(doc)
+
     try:
         add_docstring(obj, doc)
     except Exception:
@@ -494,10 +498,10 @@ def add_newdoc(place, obj, doc, warn_on_python=True):
     ----------
     place : str
         The absolute name of the module to import from
-    obj : str or None
+    obj : str | None
         The name of the object to add documentation to, typically a class or
         function name.
-    doc : {str, Tuple[str, str], List[Tuple[str, str]]}
+    doc : str | tuple[str, str] | list[tuple[str, str]]
         If a string, the documentation to apply to `obj`
 
         If a tuple, then the first element is interpreted as an attribute
@@ -534,12 +538,10 @@ def add_newdoc(place, obj, doc, warn_on_python=True):
     if isinstance(doc, str):
         if "${ARRAY_FUNCTION_LIKE}" in doc:
             doc = overrides.get_array_function_like_doc(new, doc)
-        _add_docstring(new, doc.strip(), warn_on_python)
+        _add_docstring(new, doc, warn_on_python)
     elif isinstance(doc, tuple):
         attr, docstring = doc
-        _add_docstring(getattr(new, attr), docstring.strip(), warn_on_python)
+        _add_docstring(getattr(new, attr), docstring, warn_on_python)
     elif isinstance(doc, list):
         for attr, docstring in doc:
-            _add_docstring(
-                getattr(new, attr), docstring.strip(), warn_on_python
-            )
+            _add_docstring(getattr(new, attr), docstring, warn_on_python)

--- a/numpy/_core/tests/test_function_base.py
+++ b/numpy/_core/tests/test_function_base.py
@@ -492,7 +492,7 @@ class TestAdd_newdoc:
         # test that np.add_newdoc did attach a docstring successfully:
         tgt = "Current flat index into the array."
         assert_equal(np._core.flatiter.index.__doc__[:len(tgt)], tgt)
-        assert_(len(np._core.ufunc.identity.__doc__) > 300)
+        assert_(len(np._core.ufunc.identity.__doc__) > 250)
         assert_(len(np.lib._index_tricks_impl.mgrid.__doc__) > 300)
 
     @pytest.mark.skipif(sys.flags.optimize == 2, reason="Python running -OO")

--- a/numpy/_typing/_ufunc.pyi
+++ b/numpy/_typing/_ufunc.pyi
@@ -6,12 +6,14 @@ four private subclasses, one for each combination of
 `~ufunc.nin` and `~ufunc.nout`.
 """  # noqa: PYI021
 
+from _typeshed import Incomplete
 from types import EllipsisType
 from typing import (
     Any,
     Generic,
     Literal,
     LiteralString,
+    Never,
     NoReturn,
     Protocol,
     SupportsIndex,
@@ -49,7 +51,7 @@ _Signature = TypeVar("_Signature", bound=LiteralString, covariant=True)
 _NIn = TypeVar("_NIn", bound=int, covariant=True)
 _NOut = TypeVar("_NOut", bound=int, covariant=True)
 _ReturnType_co = TypeVar("_ReturnType_co", covariant=True)
-_ArrayT = TypeVar("_ArrayT", bound=np.ndarray[Any, Any])
+_ArrayT = TypeVar("_ArrayT", bound=np.ndarray)
 
 @type_check_only
 class _SupportsArrayUFunc(Protocol):
@@ -69,6 +71,11 @@ class _UFunc3Kwargs(TypedDict, total=False):
     subok: bool
     signature: _3Tuple[str | None] | str | None
 
+@type_check_only
+class _ReduceKwargs(TypedDict, total=False):
+    initial: Incomplete  # = <no value>
+    where: _ArrayLikeBool_co | None  # = True
+
 # NOTE: `reduce`, `accumulate`, `reduceat` and `outer` raise a ValueError for
 # ufuncs that don't accept two input arguments and return one output argument.
 # In such cases the respective methods return `NoReturn`
@@ -86,7 +93,7 @@ class _UFunc_Nin1_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: i
     @property
     def __name__(self) -> _NameType: ...
     @property
-    def __qualname__(self) -> _NameType: ...
+    def __qualname__(self) -> _NameType: ...  # pyright: ignore[reportIncompatibleVariableOverride]
     @property
     def ntypes(self) -> _NTypes: ...
     @property
@@ -105,62 +112,57 @@ class _UFunc_Nin1_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: i
         self,
         x1: _ScalarLike_co,
         /,
-        out: EllipsisType | None = ...,
+        out: None = None,
         *,
-        where: _ArrayLikeBool_co | None = ...,
+        dtype: DTypeLike | None = None,
+        where: _ArrayLikeBool_co | None = True,
         casting: _CastingKind = ...,
         order: _OrderKACF = ...,
-        dtype: DTypeLike | None = ...,
         subok: bool = ...,
         signature: str | _2Tuple[str | None] = ...,
-    ) -> Any: ...
+    ) -> Incomplete: ...
     @overload
     def __call__(
         self,
         x1: ArrayLike,
         /,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = ...,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = None,
         *,
-        where: _ArrayLikeBool_co | None = ...,
+        dtype: DTypeLike | None = None,
+        where: _ArrayLikeBool_co | None = True,
         casting: _CastingKind = ...,
         order: _OrderKACF = ...,
-        dtype: DTypeLike | None = ...,
         subok: bool = ...,
         signature: str | _2Tuple[str | None] = ...,
-    ) -> NDArray[Any]: ...
+    ) -> NDArray[Incomplete]: ...
     @overload
     def __call__(
         self,
         x1: _SupportsArrayUFunc,
         /,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = ...,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = None,
         *,
-        where: _ArrayLikeBool_co | None = ...,
+        dtype: DTypeLike | None = None,
+        where: _ArrayLikeBool_co | None = True,
         casting: _CastingKind = ...,
         order: _OrderKACF = ...,
-        dtype: DTypeLike | None = ...,
         subok: bool = ...,
         signature: str | _2Tuple[str | None] = ...,
-    ) -> Any: ...
+    ) -> Incomplete: ...
 
-    def at(
-        self,
-        a: _SupportsArrayUFunc,
-        indices: _ArrayLikeInt_co,
-        /,
-    ) -> None: ...
+    def accumulate(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduce(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduceat(self, array: Never, /, indices: Never) -> NoReturn: ...  # type: ignore[override]
+    def outer(self, A: Never, B: Never, /) -> NoReturn: ...  # type: ignore[override]
 
-    def reduce(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def accumulate(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def reduceat(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def outer(self, *args: object, **kwargs: object) -> NoReturn: ...
+    def at(self, a: np.ndarray | _SupportsArrayUFunc, indices: _ArrayLikeInt_co, /) -> None: ...  # type: ignore[override]
 
 @type_check_only
 class _UFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
     @property
-    def __qualname__(self) -> _NameType: ...
+    def __qualname__(self) -> _NameType: ...  # pyright: ignore[reportIncompatibleVariableOverride]
     @property
     def ntypes(self) -> _NTypes: ...
     @property
@@ -184,121 +186,141 @@ class _UFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: i
         *,
         dtype: DTypeLike | None = None,
         **kwds: Unpack[_UFunc3Kwargs],
-    ) -> Any: ...
+    ) -> Incomplete: ...
     @overload  # (array-like, array) -> array
     def __call__(
         self,
         x1: ArrayLike,
-        x2: NDArray[Any],
+        x2: np.ndarray,
         /,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = None,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = None,
         *,
         dtype: DTypeLike | None = None,
         **kwds: Unpack[_UFunc3Kwargs],
-    ) -> NDArray[Any]: ...
+    ) -> NDArray[Incomplete]: ...
     @overload  # (array, array-like) -> array
     def __call__(
         self,
-        x1: NDArray[Any],
+        x1: np.ndarray,
         x2: ArrayLike,
         /,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = None,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = None,
         *,
         dtype: DTypeLike | None = None,
         **kwds: Unpack[_UFunc3Kwargs],
-    ) -> NDArray[Any]: ...
+    ) -> NDArray[Incomplete]: ...
     @overload  # (array-like, array-like, out=array) -> array
     def __call__(
         self,
         x1: ArrayLike,
         x2: ArrayLike,
         /,
-        out: NDArray[Any] | tuple[NDArray[Any]],
+        out: np.ndarray | tuple[np.ndarray],
         *,
         dtype: DTypeLike | None = None,
         **kwds: Unpack[_UFunc3Kwargs],
-    ) -> NDArray[Any]: ...
+    ) -> NDArray[Incomplete]: ...
     @overload  # (array-like, array-like) -> array | scalar
     def __call__(
         self,
         x1: ArrayLike,
         x2: ArrayLike,
         /,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = None,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = None,
         *,
         dtype: DTypeLike | None = None,
         **kwds: Unpack[_UFunc3Kwargs],
-    ) -> NDArray[Any] | Any: ...
-
-    def at(
-        self,
-        a: NDArray[Any],
-        indices: _ArrayLikeInt_co,
-        b: ArrayLike,
-        /,
-    ) -> None: ...
-
-    def reduce(
-        self,
-        array: ArrayLike,
-        axis: _ShapeLike | None = ...,
-        dtype: DTypeLike | None = ...,
-        out: NDArray[Any] | EllipsisType | None = ...,
-        keepdims: bool = ...,
-        initial: Any = ...,
-        where: _ArrayLikeBool_co = ...,
-    ) -> Any: ...
+    ) -> NDArray[Incomplete] | Incomplete: ...
 
     def accumulate(
         self,
         array: ArrayLike,
-        axis: SupportsIndex = ...,
-        dtype: DTypeLike | None = ...,
-        out: NDArray[Any] | EllipsisType | None = ...,
-    ) -> NDArray[Any]: ...
+        /,
+        axis: SupportsIndex = 0,
+        dtype: DTypeLike | None = None,
+        out: np.ndarray | EllipsisType | None = None,
+    ) -> NDArray[Incomplete]: ...
+
+    @overload  # type: ignore[override]
+    def reduce(  # out=None (default), keepdims=False (default)
+        self,
+        array: ArrayLike,
+        /,
+        axis: _ShapeLike | None = 0,
+        dtype: DTypeLike | None = None,
+        out: None = None,
+        *,
+        keepdims: Literal[False] = False,
+        **kwargs: Unpack[_ReduceKwargs],
+    ) -> Incomplete: ...
+    @overload  # out=ndarray or out=...
+    def reduce(
+        self,
+        array: ArrayLike,
+        /,
+        axis: _ShapeLike | None = 0,
+        dtype: DTypeLike | None = None,
+        *,
+        out: np.ndarray | EllipsisType,
+        keepdims: bool = False,
+        **kwargs: Unpack[_ReduceKwargs],
+    ) -> NDArray[Incomplete]: ...
+    @overload  # keepdims=True
+    def reduce(
+        self,
+        array: ArrayLike,
+        /,
+        axis: _ShapeLike | None = 0,
+        dtype: DTypeLike | None = None,
+        out: np.ndarray | EllipsisType | None = None,
+        *,
+        keepdims: Literal[True],
+        **kwargs: Unpack[_ReduceKwargs],
+    ) -> NDArray[Incomplete]: ...
 
     def reduceat(
         self,
         array: ArrayLike,
+        /,
         indices: _ArrayLikeInt_co,
-        axis: SupportsIndex = ...,
-        dtype: DTypeLike | None = ...,
-        out: NDArray[Any] | EllipsisType | None = ...,
-    ) -> NDArray[Any]: ...
+        axis: SupportsIndex = 0,
+        dtype: DTypeLike | None = None,
+        out: np.ndarray | EllipsisType | None = None,
+    ) -> NDArray[Incomplete]: ...
 
-    @overload  # (scalar, scalar) -> scalar
-    def outer(
+    @overload  # type: ignore[override]
+    def outer(  # (scalar, scalar) -> scalar
         self,
         A: _ScalarLike_co,
         B: _ScalarLike_co,
         /,
         *,
-        out: EllipsisType | None = None,
+        out: None = None,
         dtype: DTypeLike | None = None,
         **kwds: Unpack[_UFunc3Kwargs],
-    ) -> Any: ...
+    ) -> Incomplete: ...
     @overload  # (array-like, array) -> array
     def outer(
         self,
         A: ArrayLike,
-        B: NDArray[Any],
+        B: np.ndarray,
         /,
         *,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = None,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = None,
         dtype: DTypeLike | None = None,
         **kwds: Unpack[_UFunc3Kwargs],
-    ) -> NDArray[Any]: ...
+    ) -> NDArray[Incomplete]: ...
     @overload  # (array, array-like) -> array
     def outer(
         self,
-        A: NDArray[Any],
+        A: np.ndarray,
         B: ArrayLike,
         /,
         *,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = None,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = None,
         dtype: DTypeLike | None = None,
         **kwds: Unpack[_UFunc3Kwargs],
-    ) -> NDArray[Any]: ...
+    ) -> NDArray[Incomplete]: ...
     @overload  # (array-like, array-like, out=array) -> array
     def outer(
         self,
@@ -306,10 +328,10 @@ class _UFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: i
         B: ArrayLike,
         /,
         *,
-        out: NDArray[Any] | tuple[NDArray[Any]],
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType,
         dtype: DTypeLike | None = None,
         **kwds: Unpack[_UFunc3Kwargs],
-    ) -> NDArray[Any]: ...
+    ) -> NDArray[Incomplete]: ...
     @overload  # (array-like, array-like) -> array | scalar
     def outer(
         self,
@@ -317,17 +339,25 @@ class _UFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: i
         B: ArrayLike,
         /,
         *,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = None,
+        out: None = None,
         dtype: DTypeLike | None = None,
         **kwds: Unpack[_UFunc3Kwargs],
-    ) -> NDArray[Any] | Any: ...
+    ) -> NDArray[Incomplete] | Incomplete: ...
+
+    def at(  # type: ignore[override]
+        self,
+        a: np.ndarray | _SupportsArrayUFunc,
+        indices: _ArrayLikeInt_co,
+        b: ArrayLike,
+        /,
+    ) -> None: ...
 
 @type_check_only
 class _UFunc_Nin1_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
     @property
-    def __qualname__(self) -> _NameType: ...
+    def __qualname__(self) -> _NameType: ...  # pyright: ignore[reportIncompatibleVariableOverride]
     @property
     def ntypes(self) -> _NTypes: ...
     @property
@@ -350,58 +380,58 @@ class _UFunc_Nin1_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: i
         /,
         *,
         out: EllipsisType | None = ...,
-        where: _ArrayLikeBool_co | None = ...,
+        dtype: DTypeLike | None = None,
+        where: _ArrayLikeBool_co | None = True,
         casting: _CastingKind = ...,
         order: _OrderKACF = ...,
-        dtype: DTypeLike | None = ...,
         subok: bool = ...,
         signature: str | _3Tuple[str | None] = ...,
-    ) -> _2Tuple[Any]: ...
+    ) -> _2Tuple[Incomplete]: ...
     @overload
     def __call__(
         self,
         x1: ArrayLike,
-        out1: NDArray[Any] | EllipsisType | None = ...,
-        out2: NDArray[Any] | None = ...,
+        out1: np.ndarray | EllipsisType | None = ...,
+        out2: np.ndarray | None = ...,
         /,
         *,
-        out: _2Tuple[NDArray[Any]] | EllipsisType = ...,
-        where: _ArrayLikeBool_co | None = ...,
+        out: _2Tuple[np.ndarray] | EllipsisType = ...,
+        dtype: DTypeLike | None = None,
+        where: _ArrayLikeBool_co | None = True,
         casting: _CastingKind = ...,
         order: _OrderKACF = ...,
-        dtype: DTypeLike | None = ...,
         subok: bool = ...,
         signature: str | _3Tuple[str | None] = ...,
-    ) -> _2Tuple[NDArray[Any]]: ...
+    ) -> _2Tuple[NDArray[Incomplete]]: ...
     @overload
     def __call__(
         self,
         x1: _SupportsArrayUFunc,
-        out1: NDArray[Any] | EllipsisType | None = ...,
-        out2: NDArray[Any] | None = ...,
+        out1: np.ndarray | EllipsisType | None = ...,
+        out2: np.ndarray | None = ...,
         /,
         *,
-        out: _2Tuple[NDArray[Any]] | EllipsisType = ...,
-        where: _ArrayLikeBool_co | None = ...,
+        out: _2Tuple[np.ndarray] | EllipsisType = ...,
+        dtype: DTypeLike | None = None,
+        where: _ArrayLikeBool_co | None = True,
         casting: _CastingKind = ...,
         order: _OrderKACF = ...,
-        dtype: DTypeLike | None = ...,
         subok: bool = ...,
         signature: str | _3Tuple[str | None] = ...,
-    ) -> _2Tuple[Any]: ...
+    ) -> _2Tuple[Incomplete]: ...
 
-    def at(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def reduce(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def accumulate(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def reduceat(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def outer(self, *args: object, **kwargs: object) -> NoReturn: ...
+    def accumulate(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduce(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduceat(self, array: Never, /, indices: Never) -> NoReturn: ...  # type: ignore[override]
+    def outer(self, A: Never, B: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def at(self, a: Never, indices: Never, /) -> NoReturn: ...  # type: ignore[override]
 
 @type_check_only
 class _UFunc_Nin2_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
     @property
-    def __qualname__(self) -> _NameType: ...
+    def __qualname__(self) -> _NameType: ...  # pyright: ignore[reportIncompatibleVariableOverride]
     @property
     def ntypes(self) -> _NTypes: ...
     @property
@@ -425,43 +455,43 @@ class _UFunc_Nin2_Nout2(ufunc, Generic[_NameType, _NTypes, _IDType]):  # type: i
         /,
         *,
         out: EllipsisType | None = ...,
-        where: _ArrayLikeBool_co | None = ...,
+        dtype: DTypeLike | None = None,
+        where: _ArrayLikeBool_co | None = True,
         casting: _CastingKind = ...,
         order: _OrderKACF = ...,
-        dtype: DTypeLike | None = ...,
         subok: bool = ...,
         signature: str | _4Tuple[str | None] = ...,
-    ) -> _2Tuple[Any]: ...
+    ) -> _2Tuple[Incomplete]: ...
     @overload
     def __call__(
         self,
         x1: ArrayLike,
         x2: ArrayLike,
-        out1: NDArray[Any] | EllipsisType | None = ...,
-        out2: NDArray[Any] | None = ...,
+        out1: np.ndarray | EllipsisType | None = ...,
+        out2: np.ndarray | None = ...,
         /,
         *,
-        out: _2Tuple[NDArray[Any]] | EllipsisType = ...,
-        where: _ArrayLikeBool_co | None = ...,
+        out: _2Tuple[np.ndarray] | EllipsisType = ...,
+        dtype: DTypeLike | None = None,
+        where: _ArrayLikeBool_co | None = True,
         casting: _CastingKind = ...,
         order: _OrderKACF = ...,
-        dtype: DTypeLike | None = ...,
         subok: bool = ...,
         signature: str | _4Tuple[str | None] = ...,
-    ) -> _2Tuple[NDArray[Any]]: ...
+    ) -> _2Tuple[NDArray[Incomplete]]: ...
 
-    def at(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def reduce(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def accumulate(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def reduceat(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def outer(self, *args: object, **kwargs: object) -> NoReturn: ...
+    def accumulate(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduce(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduceat(self, array: Never, /, indices: Never) -> NoReturn: ...  # type: ignore[override]
+    def outer(self, A: Never, B: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def at(self, a: Never, indices: Never, b: Never, /) -> NoReturn: ...  # type: ignore[override]
 
 @type_check_only
 class _GUFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType, _Signature]):  # type: ignore[misc]
     @property
     def __name__(self) -> _NameType: ...
     @property
-    def __qualname__(self) -> _NameType: ...
+    def __qualname__(self) -> _NameType: ...  # pyright: ignore[reportIncompatibleVariableOverride]
     @property
     def ntypes(self) -> _NTypes: ...
     @property
@@ -482,36 +512,36 @@ class _GUFunc_Nin2_Nout1(ufunc, Generic[_NameType, _NTypes, _IDType, _Signature]
         x1: ArrayLike,
         x2: ArrayLike,
         /,
-        out: EllipsisType | None = ...,
+        out: EllipsisType | None = None,
         *,
+        dtype: DTypeLike | None = None,
         casting: _CastingKind = ...,
         order: _OrderKACF = ...,
-        dtype: DTypeLike | None = ...,
         subok: bool = ...,
         signature: str | _3Tuple[str | None] = ...,
         axes: list[_2Tuple[SupportsIndex]] = ...,
-    ) -> Any: ...
+    ) -> Incomplete: ...
     @overload
     def __call__(
         self,
         x1: ArrayLike,
         x2: ArrayLike,
         /,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType,
         *,
+        dtype: DTypeLike | None = None,
         casting: _CastingKind = ...,
         order: _OrderKACF = ...,
-        dtype: DTypeLike | None = ...,
         subok: bool = ...,
         signature: str | _3Tuple[str | None] = ...,
         axes: list[_2Tuple[SupportsIndex]] = ...,
-    ) -> NDArray[Any]: ...
+    ) -> NDArray[Incomplete]: ...
 
-    def at(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def reduce(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def accumulate(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def reduceat(self, *args: object, **kwargs: object) -> NoReturn: ...
-    def outer(self, *args: object, **kwargs: object) -> NoReturn: ...
+    def accumulate(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduce(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduceat(self, array: Never, /, indices: Never) -> NoReturn: ...  # type: ignore[override]
+    def outer(self, A: Never, B: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def at(self, a: Never, indices: Never, b: Never, /) -> NoReturn: ...  # type: ignore[override]
 
 @type_check_only
 class _PyFunc_Kwargs_Nargs2(TypedDict, total=False):
@@ -569,7 +599,7 @@ class _PyFunc_Nin1_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: igno
         self,
         x1: _ScalarLike_co,
         /,
-        out: EllipsisType | None = ...,
+        out: EllipsisType | None = None,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs2],
     ) -> _ReturnType_co: ...
     @overload
@@ -577,7 +607,7 @@ class _PyFunc_Nin1_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: igno
         self,
         x1: ArrayLike,
         /,
-        out: EllipsisType | None = ...,
+        out: EllipsisType | None = None,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs2],
     ) -> _ReturnType_co | NDArray[np.object_]: ...
     @overload
@@ -593,15 +623,16 @@ class _PyFunc_Nin1_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: igno
         self,
         x1: _SupportsArrayUFunc,
         /,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = ...,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = None,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs2],
-    ) -> Any: ...
+    ) -> Incomplete: ...
 
-    def at(self, a: _SupportsArrayUFunc, ixs: _ArrayLikeInt_co, /) -> None: ...
-    def reduce(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
-    def accumulate(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
-    def reduceat(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
-    def outer(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def accumulate(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduce(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduceat(self, array: Never, /, indices: Never) -> NoReturn: ...  # type: ignore[override]
+    def outer(self, A: Never, B: Never, /) -> NoReturn: ...  # type: ignore[override]
+
+    def at(self, a: np.ndarray | _SupportsArrayUFunc, indices: _ArrayLikeInt_co, /) -> None: ...  # type: ignore[override]
 
 @type_check_only
 class _PyFunc_Nin2_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: ignore[misc]
@@ -624,7 +655,7 @@ class _PyFunc_Nin2_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: igno
         x1: _ScalarLike_co,
         x2: _ScalarLike_co,
         /,
-        out: EllipsisType | None = ...,
+        out: EllipsisType | None = None,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
     ) -> _ReturnType_co: ...
     @overload
@@ -651,151 +682,127 @@ class _PyFunc_Nin2_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: igno
         x1: _SupportsArrayUFunc,
         x2: _SupportsArrayUFunc | ArrayLike,
         /,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = ...,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = None,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
-    ) -> Any: ...
+    ) -> Incomplete: ...
     @overload
     def __call__(
         self,
         x1: ArrayLike,
         x2: _SupportsArrayUFunc,
         /,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = ...,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = None,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
-    ) -> Any: ...
+    ) -> Incomplete: ...
 
-    def at(self, a: _SupportsArrayUFunc, ixs: _ArrayLikeInt_co, b: ArrayLike, /) -> None: ...
-
-    @overload
-    def reduce(
+    @overload  # type: ignore[override]
+    def accumulate(
         self,
-        /,
         array: ArrayLike,
-        axis: _ShapeLike | None,
-        dtype: DTypeLike | None,
+        /,
+        axis: SupportsIndex = 0,
+        dtype: DTypeLike | None = None,
+        out: EllipsisType | None = None,
+    ) -> NDArray[np.object_]: ...
+    @overload
+    def accumulate(
+        self,
+        array: ArrayLike,
+        /,
+        axis: SupportsIndex = 0,
+        dtype: DTypeLike | None = None,
+        *,
         out: _ArrayT,
-        keepdims: bool = ...,
-        initial: _ScalarLike_co = ...,
-        where: _ArrayLikeBool_co = ...,
     ) -> _ArrayT: ...
-    @overload
-    def reduce(
+
+    @overload  # type: ignore[override]
+    def reduce(  # out=array
         self,
-        /,
         array: ArrayLike,
-        axis: _ShapeLike | None = ...,
-        dtype: DTypeLike | None = ...,
+        /,
+        axis: _ShapeLike | None = 0,
+        dtype: DTypeLike | None = None,
         *,
         out: _ArrayT | tuple[_ArrayT],
-        keepdims: bool = ...,
-        initial: _ScalarLike_co = ...,
-        where: _ArrayLikeBool_co = ...,
+        keepdims: bool = False,
+        **kwargs: Unpack[_ReduceKwargs],
     ) -> _ArrayT: ...
-    @overload
+    @overload  # out=...
     def reduce(
         self,
-        /,
         array: ArrayLike,
-        axis: _ShapeLike | None = ...,
-        dtype: DTypeLike | None = ...,
-        out: EllipsisType | None = ...,
+        /,
+        axis: _ShapeLike | None = 0,
+        dtype: DTypeLike | None = None,
+        *,
+        out: EllipsisType,
+        keepdims: bool = False,
+        **kwargs: Unpack[_ReduceKwargs],
+    ) -> NDArray[np.object_]: ...
+    @overload  # keepdims=True
+    def reduce(
+        self,
+        array: ArrayLike,
+        /,
+        axis: _ShapeLike | None = 0,
+        dtype: DTypeLike | None = None,
+        out: EllipsisType | None = None,
         *,
         keepdims: Literal[True],
-        initial: _ScalarLike_co = ...,
-        where: _ArrayLikeBool_co = ...,
+        **kwargs: Unpack[_ReduceKwargs],
     ) -> NDArray[np.object_]: ...
     @overload
     def reduce(
         self,
-        /,
         array: ArrayLike,
-        axis: _ShapeLike | None = ...,
-        dtype: DTypeLike | None = ...,
-        out: EllipsisType | None = ...,
-        keepdims: bool = ...,
-        initial: _ScalarLike_co = ...,
-        where: _ArrayLikeBool_co = ...,
+        /,
+        axis: _ShapeLike | None = 0,
+        dtype: DTypeLike | None = None,
+        out: EllipsisType | None = None,
+        keepdims: bool = False,
+        **kwargs: Unpack[_ReduceKwargs],
     ) -> _ReturnType_co | NDArray[np.object_]: ...
 
-    @overload
+    @overload  # type: ignore[override]
     def reduceat(
         self,
-        /,
         array: ArrayLike,
-        indices: _ArrayLikeInt_co,
-        axis: SupportsIndex,
-        dtype: DTypeLike | None,
-        out: _ArrayT,
-    ) -> _ArrayT: ...
-    @overload
-    def reduceat(
-        self,
         /,
-        array: ArrayLike,
         indices: _ArrayLikeInt_co,
-        axis: SupportsIndex = ...,
-        dtype: DTypeLike | None = ...,
+        axis: SupportsIndex = 0,
+        dtype: DTypeLike | None = None,
         *,
         out: _ArrayT | tuple[_ArrayT],
     ) -> _ArrayT: ...
     @overload
     def reduceat(
         self,
-        /,
         array: ArrayLike,
+        /,
         indices: _ArrayLikeInt_co,
-        axis: SupportsIndex = ...,
-        dtype: DTypeLike | None = ...,
-        out: EllipsisType | None = ...,
+        axis: SupportsIndex = 0,
+        dtype: DTypeLike | None = None,
+        out: EllipsisType | None = None,
     ) -> NDArray[np.object_]: ...
     @overload
     def reduceat(
         self,
-        /,
         array: _SupportsArrayUFunc,
+        /,
         indices: _ArrayLikeInt_co,
-        axis: SupportsIndex = ...,
-        dtype: DTypeLike | None = ...,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = ...,
-    ) -> Any: ...
+        axis: SupportsIndex = 0,
+        dtype: DTypeLike | None = None,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = None,
+    ) -> Incomplete: ...
 
-    @overload
-    def accumulate(
-        self,
-        /,
-        array: ArrayLike,
-        axis: SupportsIndex,
-        dtype: DTypeLike | None,
-        out: _ArrayT,
-    ) -> _ArrayT: ...
-    @overload
-    def accumulate(
-        self,
-        /,
-        array: ArrayLike,
-        axis: SupportsIndex = ...,
-        dtype: DTypeLike | None = ...,
-        *,
-        out: _ArrayT | tuple[_ArrayT],
-    ) -> _ArrayT: ...
-    @overload
-    def accumulate(
-        self,
-        /,
-        array: ArrayLike,
-        axis: SupportsIndex = ...,
-        dtype: DTypeLike | None = ...,
-        out: EllipsisType | None = ...,
-    ) -> NDArray[np.object_]: ...
-
-    @overload
+    @overload  # type: ignore[override]
     def outer(
         self,
         A: _ScalarLike_co,
         B: _ScalarLike_co,
         /,
         *,
-        out: EllipsisType | None = ...,
+        out: EllipsisType | None = None,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
     ) -> _ReturnType_co: ...
     @overload
@@ -805,7 +812,7 @@ class _PyFunc_Nin2_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: igno
         B: ArrayLike,
         /,
         *,
-        out: EllipsisType | None = ...,
+        out: EllipsisType | None = None,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
     ) -> _ReturnType_co | NDArray[np.object_]: ...
     @overload
@@ -825,9 +832,9 @@ class _PyFunc_Nin2_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: igno
         B: _SupportsArrayUFunc | ArrayLike,
         /,
         *,
-        out: EllipsisType | None = ...,
+        out: EllipsisType | None = None,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
-    ) -> Any: ...
+    ) -> Incomplete: ...
     @overload
     def outer(
         self,
@@ -835,9 +842,17 @@ class _PyFunc_Nin2_Nout1(ufunc, Generic[_ReturnType_co, _IDType]):  # type: igno
         B: _SupportsArrayUFunc | ArrayLike,
         /,
         *,
-        out: EllipsisType | None = ...,
+        out: EllipsisType | None = None,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs3],
-    ) -> Any: ...
+    ) -> Incomplete: ...
+
+    def at(  # type: ignore[override]
+        self,
+        a: np.ndarray | _SupportsArrayUFunc,
+        indices: _ArrayLikeInt_co,
+        b: ArrayLike,
+        /,
+    ) -> None: ...
 
 @type_check_only
 class _PyFunc_Nin3P_Nout1(ufunc, Generic[_ReturnType_co, _IDType, _NIn]):  # type: ignore[misc]
@@ -893,15 +908,15 @@ class _PyFunc_Nin3P_Nout1(ufunc, Generic[_ReturnType_co, _IDType, _NIn]):  # typ
         x3: _SupportsArrayUFunc | ArrayLike,
         /,
         *xs: _SupportsArrayUFunc | ArrayLike,
-        out: NDArray[Any] | tuple[NDArray[Any]] | EllipsisType | None = ...,
+        out: np.ndarray | tuple[np.ndarray] | EllipsisType | None = ...,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs4P],
-    ) -> Any: ...
+    ) -> Incomplete: ...
 
-    def at(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
-    def reduce(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
-    def accumulate(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
-    def reduceat(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
-    def outer(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def accumulate(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduce(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduceat(self, array: Never, /, indices: Never) -> NoReturn: ...  # type: ignore[override]
+    def outer(self, A: Never, B: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def at(self, a: Never, indices: Never, /, *args: Never) -> NoReturn: ...  # type: ignore[override]
 
 @type_check_only
 class _PyFunc_Nin1P_Nout2P(ufunc, Generic[_ReturnType_co, _IDType, _NIn, _NOut]):  # type: ignore[misc]
@@ -949,12 +964,12 @@ class _PyFunc_Nin1P_Nout2P(ufunc, Generic[_ReturnType_co, _IDType, _NIn, _NOut])
         x1: _SupportsArrayUFunc | ArrayLike,
         /,
         *xs: _SupportsArrayUFunc | ArrayLike,
-        out: _2PTuple[NDArray[Any]] | EllipsisType | None = ...,
+        out: _2PTuple[np.ndarray] | EllipsisType | None = ...,
         **kwargs: Unpack[_PyFunc_Kwargs_Nargs3P],
-    ) -> Any: ...
+    ) -> Incomplete: ...
 
-    def at(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
-    def reduce(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
-    def accumulate(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
-    def reduceat(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
-    def outer(self, /, *args: Any, **kwargs: Any) -> NoReturn: ...
+    def accumulate(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduce(self, array: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def reduceat(self, array: Never, /, indices: Never) -> NoReturn: ...  # type: ignore[override]
+    def outer(self, A: Never, B: Never, /) -> NoReturn: ...  # type: ignore[override]
+    def at(self, a: Never, indices: Never, /, *args: Never) -> NoReturn: ...  # type: ignore[override]

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -99,44 +99,44 @@ assert_type(np.bitwise_count(i8), Any)
 assert_type(np.bitwise_count(AR_i8), npt.NDArray[Any])
 
 def test_absolute_outer_invalid() -> None:
-    assert_type(np.absolute.outer(), NoReturn)
+    assert_type(np.absolute.outer(AR_f8, AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_frexp_outer_invalid() -> None:
-    assert_type(np.frexp.outer(), NoReturn)
+    assert_type(np.frexp.outer(AR_f8, AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_divmod_outer_invalid() -> None:
-    assert_type(np.divmod.outer(), NoReturn)
+    assert_type(np.divmod.outer(AR_f8, AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_matmul_outer_invalid() -> None:
-    assert_type(np.matmul.outer(), NoReturn)
+    assert_type(np.matmul.outer(AR_f8, AR_f8), NoReturn)  # type: ignore[arg-type]
 
 def test_absolute_reduceat_invalid() -> None:
-    assert_type(np.absolute.reduceat(), NoReturn)
+    assert_type(np.absolute.reduceat(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
 def test_frexp_reduceat_invalid() -> None:
-    assert_type(np.frexp.reduceat(), NoReturn)
+    assert_type(np.frexp.reduceat(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
 def test_divmod_reduceat_invalid() -> None:
-    assert_type(np.divmod.reduceat(), NoReturn)
+    assert_type(np.divmod.reduceat(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
 def test_matmul_reduceat_invalid() -> None:
-    assert_type(np.matmul.reduceat(), NoReturn)
+    assert_type(np.matmul.reduceat(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
 
 def test_absolute_reduce_invalid() -> None:
-    assert_type(np.absolute.reduce(), NoReturn)
+    assert_type(np.absolute.reduce(AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_frexp_reduce_invalid() -> None:
-    assert_type(np.frexp.reduce(), NoReturn)
+    assert_type(np.frexp.reduce(AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_divmod_reduce_invalid() -> None:
-    assert_type(np.divmod.reduce(), NoReturn)
+    assert_type(np.divmod.reduce(AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_matmul_reduce_invalid() -> None:
-    assert_type(np.matmul.reduce(), NoReturn)
+    assert_type(np.matmul.reduce(AR_f8), NoReturn)  # type: ignore[arg-type]
 
 def test_absolute_accumulate_invalid() -> None:
-    assert_type(np.absolute.accumulate(), NoReturn)
+    assert_type(np.absolute.accumulate(AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_frexp_accumulate_invalid() -> None:
-    assert_type(np.frexp.accumulate(), NoReturn)
+    assert_type(np.frexp.accumulate(AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_divmod_accumulate_invalid() -> None:
-    assert_type(np.divmod.accumulate(), NoReturn)
+    assert_type(np.divmod.accumulate(AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_matmul_accumulate_invalid() -> None:
-    assert_type(np.matmul.accumulate(), NoReturn)
+    assert_type(np.matmul.accumulate(AR_f8), NoReturn)  # type: ignore[arg-type]
 
 def test_frexp_at_invalid() -> None:
-    assert_type(np.frexp.at(), NoReturn)
+    assert_type(np.frexp.at(AR_f8, i8), NoReturn)  # type: ignore[arg-type]
 def test_divmod_at_invalid() -> None:
-    assert_type(np.divmod.at(), NoReturn)
+    assert_type(np.divmod.at(AR_f8, i8, AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_matmul_at_invalid() -> None:
-    assert_type(np.matmul.at(), NoReturn)
+    assert_type(np.matmul.at(AR_f8, i8, AR_f8), NoReturn)  # type: ignore[arg-type]


### PR DESCRIPTION
closes #30095

Because stubtest is now able to pick up on the `ufunc` method signatures, this required updating the stubs accordingly. The ufunc stubs are pretty messy as you can see, so it took a bit of effort to get it all aligned.