### PR TITLE
BUG, TYP: ``ndarray`` method runtime signatures

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1696,18 +1696,23 @@ class _ArrayOrScalarCommon:
     def dump(self, file: StrOrBytesPath | SupportsWrite[bytes]) -> None: ...
     def dumps(self) -> bytes: ...
     def tobytes(self, order: _OrderKACF = ...) -> bytes: ...
-    def tofile(self, fid: StrOrBytesPath | _SupportsFileMethods, sep: str = ..., format: str = ...) -> None: ...
+    def tofile(self, fid: StrOrBytesPath | _SupportsFileMethods, /, sep: str = "", format: str = "%s") -> None: ...
     # generics and 0d arrays return builtin scalars
     def tolist(self) -> Any: ...
     def to_device(self, device: L["cpu"], /, *, stream: int | Any | None = ...) -> Self: ...
 
     # NOTE: for `generic`, these two methods don't do anything
-    def fill(self, value: Incomplete, /) -> None: ...
-    def put(self, /, indices: _ArrayLikeInt_co, values: ArrayLike, mode: _ModeKind = "raise") -> None: ...
+    def fill(self, /, value: Incomplete) -> None: ...
+    def put(self, indices: _ArrayLikeInt_co, values: ArrayLike, /, mode: _ModeKind = "raise") -> None: ...
 
     # NOTE: even on `generic` this seems to work
     def setflags(
-        self, /, write: builtins.bool | None = None, align: builtins.bool | None = None, uic: builtins.bool | None = None
+        self,
+        /,
+        *,
+        write: builtins.bool | None = None,
+        align: builtins.bool | None = None,
+        uic: builtins.bool | None = None,
     ) -> None: ...
 
     @property
@@ -1813,9 +1818,10 @@ class _ArrayOrScalarCommon:
         /,
         axis: _ShapeLike | None = None,
         out: None = None,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = ...,
-        where: _ArrayLikeBool_co = True,
+        *,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> Any: ...
     @overload
     def max(
@@ -1823,9 +1829,10 @@ class _ArrayOrScalarCommon:
         /,
         axis: _ShapeLike | None,
         out: _ArrayT,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = ...,
-        where: _ArrayLikeBool_co = True,
+        *,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> _ArrayT: ...
     @overload
     def max(
@@ -1834,9 +1841,9 @@ class _ArrayOrScalarCommon:
         axis: _ShapeLike | None = None,
         *,
         out: _ArrayT,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = ...,
-        where: _ArrayLikeBool_co = True,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> _ArrayT: ...
 
     @overload
@@ -1845,9 +1852,10 @@ class _ArrayOrScalarCommon:
         /,
         axis: _ShapeLike | None = None,
         out: None = None,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = ...,
-        where: _ArrayLikeBool_co = True,
+        *,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> Any: ...
     @overload
     def min(
@@ -1855,9 +1863,10 @@ class _ArrayOrScalarCommon:
         /,
         axis: _ShapeLike | None,
         out: _ArrayT,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = ...,
-        where: _ArrayLikeBool_co = True,
+        *,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> _ArrayT: ...
     @overload
     def min(
@@ -1866,9 +1875,9 @@ class _ArrayOrScalarCommon:
         axis: _ShapeLike | None = None,
         *,
         out: _ArrayT,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = ...,
-        where: _ArrayLikeBool_co = True,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> _ArrayT: ...
 
     @overload
@@ -1878,9 +1887,10 @@ class _ArrayOrScalarCommon:
         axis: _ShapeLike | None = None,
         dtype: DTypeLike | None = None,
         out: None = None,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = 0,
-        where: _ArrayLikeBool_co = True,
+        *,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> Any: ...
     @overload
     def sum(
@@ -1889,9 +1899,10 @@ class _ArrayOrScalarCommon:
         axis: _ShapeLike | None,
         dtype: DTypeLike | None,
         out: _ArrayT,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = 0,
-        where: _ArrayLikeBool_co = True,
+        *,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> _ArrayT: ...
     @overload
     def sum(
@@ -1901,9 +1912,9 @@ class _ArrayOrScalarCommon:
         dtype: DTypeLike | None = None,
         *,
         out: _ArrayT,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = 0,
-        where: _ArrayLikeBool_co = True,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> _ArrayT: ...
 
     @overload
@@ -1913,9 +1924,10 @@ class _ArrayOrScalarCommon:
         axis: _ShapeLike | None = None,
         dtype: DTypeLike | None = None,
         out: None = None,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = 1,
-        where: _ArrayLikeBool_co = True,
+        *,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> Any: ...
     @overload
     def prod(
@@ -1924,9 +1936,10 @@ class _ArrayOrScalarCommon:
         axis: _ShapeLike | None,
         dtype: DTypeLike | None,
         out: _ArrayT,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = 1,
-        where: _ArrayLikeBool_co = True,
+        *,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> _ArrayT: ...
     @overload
     def prod(
@@ -1936,9 +1949,9 @@ class _ArrayOrScalarCommon:
         dtype: DTypeLike | None = None,
         *,
         out: _ArrayT,
-        keepdims: builtins.bool = False,
-        initial: _NumberLike_co = 1,
-        where: _ArrayLikeBool_co = True,
+        keepdims: builtins.bool | _NoValueType = ...,
+        initial: _NumberLike_co | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> _ArrayT: ...
 
     @overload
@@ -1947,9 +1960,9 @@ class _ArrayOrScalarCommon:
         axis: _ShapeLike | None = None,
         dtype: DTypeLike | None = None,
         out: None = None,
-        keepdims: builtins.bool = False,
         *,
-        where: _ArrayLikeBool_co = True,
+        keepdims: builtins.bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> Any: ...
     @overload
     def mean(
@@ -1958,9 +1971,9 @@ class _ArrayOrScalarCommon:
         axis: _ShapeLike | None,
         dtype: DTypeLike | None,
         out: _ArrayT,
-        keepdims: builtins.bool = False,
         *,
-        where: _ArrayLikeBool_co = True,
+        keepdims: builtins.bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> _ArrayT: ...
     @overload
     def mean(
@@ -1970,8 +1983,8 @@ class _ArrayOrScalarCommon:
         dtype: DTypeLike | None = None,
         *,
         out: _ArrayT,
-        keepdims: builtins.bool = False,
-        where: _ArrayLikeBool_co = True,
+        keepdims: builtins.bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> _ArrayT: ...
 
     @overload
@@ -1981,11 +1994,11 @@ class _ArrayOrScalarCommon:
         dtype: DTypeLike | None = None,
         out: None = None,
         ddof: float = 0,
-        keepdims: builtins.bool = False,
         *,
-        where: _ArrayLikeBool_co = True,
-        mean: _ArrayLikeNumber_co = ...,
-        correction: float = ...,
+        keepdims: builtins.bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
+        mean: _ArrayLikeNumber_co | _NoValueType = ...,
+        correction: float | _NoValueType = ...,
     ) -> Any: ...
     @overload
     def std(
@@ -1994,11 +2007,11 @@ class _ArrayOrScalarCommon:
         dtype: DTypeLike | None,
         out: _ArrayT,
         ddof: float = 0,
-        keepdims: builtins.bool = False,
         *,
-        where: _ArrayLikeBool_co = True,
-        mean: _ArrayLikeNumber_co = ...,
-        correction: float = ...,
+        keepdims: builtins.bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
+        mean: _ArrayLikeNumber_co | _NoValueType = ...,
+        correction: float | _NoValueType = ...,
     ) -> _ArrayT: ...
     @overload
     def std(
@@ -2008,10 +2021,10 @@ class _ArrayOrScalarCommon:
         *,
         out: _ArrayT,
         ddof: float = 0,
-        keepdims: builtins.bool = False,
-        where: _ArrayLikeBool_co = True,
-        mean: _ArrayLikeNumber_co = ...,
-        correction: float = ...,
+        keepdims: builtins.bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
+        mean: _ArrayLikeNumber_co | _NoValueType = ...,
+        correction: float | _NoValueType = ...,
     ) -> _ArrayT: ...
 
     @overload
@@ -2021,11 +2034,11 @@ class _ArrayOrScalarCommon:
         dtype: DTypeLike | None = None,
         out: None = None,
         ddof: float = 0,
-        keepdims: builtins.bool = False,
         *,
-        where: _ArrayLikeBool_co = True,
-        mean: _ArrayLikeNumber_co = ...,
-        correction: float = ...,
+        keepdims: builtins.bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
+        mean: _ArrayLikeNumber_co | _NoValueType = ...,
+        correction: float | _NoValueType = ...,
     ) -> Any: ...
     @overload
     def var(
@@ -2034,11 +2047,11 @@ class _ArrayOrScalarCommon:
         dtype: DTypeLike | None,
         out: _ArrayT,
         ddof: float = 0,
-        keepdims: builtins.bool = False,
         *,
-        where: _ArrayLikeBool_co = True,
-        mean: _ArrayLikeNumber_co = ...,
-        correction: float = ...,
+        keepdims: builtins.bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
+        mean: _ArrayLikeNumber_co | _NoValueType = ...,
+        correction: float | _NoValueType = ...,
     ) -> _ArrayT: ...
     @overload
     def var(
@@ -2048,10 +2061,10 @@ class _ArrayOrScalarCommon:
         *,
         out: _ArrayT,
         ddof: float = 0,
-        keepdims: builtins.bool = False,
-        where: _ArrayLikeBool_co = True,
-        mean: _ArrayLikeNumber_co = ...,
-        correction: float = ...,
+        keepdims: builtins.bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
+        mean: _ArrayLikeNumber_co | _NoValueType = ...,
+        correction: float | _NoValueType = ...,
     ) -> _ArrayT: ...
 
 class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
@@ -2218,14 +2231,13 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def tolist(self, /) -> Any: ...
 
     @overload
-    def resize(self, new_shape: _ShapeLike, /, *, refcheck: builtins.bool = ...) -> None: ...
+    def resize(self, new_shape: _ShapeLike, /, *, refcheck: builtins.bool = True) -> None: ...
     @overload
-    def resize(self, /, *new_shape: SupportsIndex, refcheck: builtins.bool = ...) -> None: ...
-
-    def setflags(self, write: builtins.bool = ..., align: builtins.bool = ..., uic: builtins.bool = ...) -> None: ...  # type: ignore[override]
+    def resize(self, /, *new_shape: SupportsIndex, refcheck: builtins.bool = True) -> None: ...
 
     def squeeze(
         self,
+        /,
         axis: SupportsIndex | tuple[SupportsIndex, ...] | None = ...,
     ) -> ndarray[_AnyShape, _DTypeT_co]: ...
 
@@ -2314,8 +2326,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     @overload
     def partition(
         self,
-        /,
         kth: _ArrayLikeInt,
+        /,
         axis: SupportsIndex = -1,
         kind: _PartitionKind = "introselect",
         order: None = None,
@@ -2323,8 +2335,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     @overload
     def partition(
         self: NDArray[void],
-        /,
         kth: _ArrayLikeInt,
+        /,
         axis: SupportsIndex = -1,
         kind: _PartitionKind = "introselect",
         order: str | Sequence[str] | None = None,
@@ -2334,8 +2346,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     @overload
     def argpartition(
         self,
-        /,
         kth: _ArrayLikeInt,
+        /,
         axis: SupportsIndex | None = -1,
         kind: _PartitionKind = "introselect",
         order: None = None,
@@ -2343,8 +2355,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     @overload
     def argpartition(
         self: NDArray[void],
-        /,
         kth: _ArrayLikeInt,
+        /,
         axis: SupportsIndex | None = -1,
         kind: _PartitionKind = "introselect",
         order: str | Sequence[str] | None = None,
@@ -2353,19 +2365,19 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     #
     def diagonal(
         self,
-        offset: SupportsIndex = ...,
-        axis1: SupportsIndex = ...,
-        axis2: SupportsIndex = ...,
+        offset: SupportsIndex = 0,
+        axis1: SupportsIndex = 0,
+        axis2: SupportsIndex = 1,
     ) -> ndarray[_AnyShape, _DTypeT_co]: ...
 
     # 1D + 1D returns a scalar;
     # all other with at least 1 non-0D array return an ndarray.
     @overload
-    def dot(self, b: _ScalarLike_co, out: None = None) -> NDArray[Any]: ...
+    def dot(self, b: _ScalarLike_co, /, out: None = None) -> NDArray[Any]: ...
     @overload
-    def dot(self, b: ArrayLike, out: None = None) -> Any: ...
+    def dot(self, b: ArrayLike, /, out: None = None) -> Any: ...
     @overload
-    def dot(self, b: ArrayLike, out: _ArrayT) -> _ArrayT: ...
+    def dot(self, b: ArrayLike, /, out: _ArrayT) -> _ArrayT: ...
 
     # `nonzero()` raises for 0d arrays/generics
     def nonzero(self) -> tuple[ndarray[tuple[int], np.dtype[intp]], ...]: ...
@@ -2374,49 +2386,55 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def searchsorted(
         self,  # >= 1D array
         v: _ScalarLike_co,  # 0D array-like
-        side: _SortSide = ...,
-        sorter: _ArrayLikeInt_co | None = ...,
+        /,
+        side: _SortSide = "left",
+        sorter: _ArrayLikeInt_co | None = None,
     ) -> intp: ...
     @overload
     def searchsorted(
         self,  # >= 1D array
         v: ArrayLike,
-        side: _SortSide = ...,
-        sorter: _ArrayLikeInt_co | None = ...,
+        /,
+        side: _SortSide = "left",
+        sorter: _ArrayLikeInt_co | None = None,
     ) -> NDArray[intp]: ...
 
     def sort(
         self,
-        axis: SupportsIndex = ...,
-        kind: _SortKind | None = ...,
-        order: str | Sequence[str] | None = ...,
+        /,
+        axis: SupportsIndex = -1,
+        kind: _SortKind | None = None,
+        order: str | Sequence[str] | None = None,
         *,
-        stable: builtins.bool | None = ...,
+        stable: builtins.bool | None = None,
     ) -> None: ...
 
     # Keep in sync with `MaskedArray.trace`
     @overload
     def trace(
         self,  # >= 2D array
-        offset: SupportsIndex = ...,
-        axis1: SupportsIndex = ...,
-        axis2: SupportsIndex = ...,
-        dtype: DTypeLike | None = ...,
+        /,
+        offset: SupportsIndex = 0,
+        axis1: SupportsIndex = 0,
+        axis2: SupportsIndex = 1,
+        dtype: DTypeLike | None = None,
         out: None = None,
     ) -> Any: ...
     @overload
     def trace(
         self,  # >= 2D array
-        offset: SupportsIndex = ...,
-        axis1: SupportsIndex = ...,
-        axis2: SupportsIndex = ...,
-        dtype: DTypeLike | None = ...,
+        /,
+        offset: SupportsIndex = 0,
+        axis1: SupportsIndex = 0,
+        axis2: SupportsIndex = 1,
+        dtype: DTypeLike | None = None,
         *,
         out: _ArrayT,
     ) -> _ArrayT: ...
     @overload
     def trace(
         self,  # >= 2D array
+        /,
         offset: SupportsIndex,
         axis1: SupportsIndex,
         axis2: SupportsIndex,
@@ -2428,6 +2446,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def take(
         self: NDArray[_ScalarT],
         indices: _IntLike_co,
+        /,
         axis: SupportsIndex | None = ...,
         out: None = None,
         mode: _ModeKind = ...,
@@ -2436,6 +2455,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def take(
         self,
         indices: _ArrayLikeInt_co,
+        /,
         axis: SupportsIndex | None = ...,
         out: None = None,
         mode: _ModeKind = ...,
@@ -2444,6 +2464,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def take(
         self,
         indices: _ArrayLikeInt_co,
+        /,
         axis: SupportsIndex | None = ...,
         *,
         out: _ArrayT,
@@ -2453,23 +2474,16 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def take(
         self,
         indices: _ArrayLikeInt_co,
+        /,
         axis: SupportsIndex | None,
         out: _ArrayT,
         mode: _ModeKind = ...,
     ) -> _ArrayT: ...
 
     @overload
-    def repeat(
-        self,
-        repeats: _ArrayLikeInt_co,
-        axis: None = None,
-    ) -> ndarray[tuple[int], _DTypeT_co]: ...
+    def repeat(self, repeats: _ArrayLikeInt_co, /, axis: None = None) -> ndarray[tuple[int], _DTypeT_co]: ...
     @overload
-    def repeat(
-        self,
-        repeats: _ArrayLikeInt_co,
-        axis: SupportsIndex,
-    ) -> ndarray[_AnyShape, _DTypeT_co]: ...
+    def repeat(self, repeats: _ArrayLikeInt_co, /, axis: SupportsIndex) -> ndarray[_AnyShape, _DTypeT_co]: ...
 
     def flatten(self, /, order: _OrderKACF = "C") -> ndarray[tuple[int], _DTypeT_co]: ...
     def ravel(self, /, order: _OrderKACF = "C") -> ndarray[tuple[int], _DTypeT_co]: ...
@@ -2592,11 +2606,11 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     @overload  # (dtype: ?, type: T)
     def view(self, /, dtype: DTypeLike, type: type[_ArrayT]) -> _ArrayT: ...
 
-    def setfield(self, /, val: ArrayLike, dtype: DTypeLike, offset: SupportsIndex = 0) -> None: ...
+    def setfield(self, val: ArrayLike, /, dtype: DTypeLike, offset: SupportsIndex = 0) -> None: ...
     @overload
-    def getfield(self, dtype: _DTypeLike[_ScalarT], offset: SupportsIndex = 0) -> NDArray[_ScalarT]: ...
+    def getfield(self, /, dtype: _DTypeLike[_ScalarT], offset: SupportsIndex = 0) -> NDArray[_ScalarT]: ...
     @overload
-    def getfield(self, dtype: DTypeLike, offset: SupportsIndex = 0) -> NDArray[Any]: ...
+    def getfield(self, /, dtype: DTypeLike, offset: SupportsIndex = 0) -> NDArray[Any]: ...
 
     def __index__(self: NDArray[integer], /) -> int: ...
     def __complex__(self: NDArray[number | np.bool | object_], /) -> complex: ...
@@ -3659,7 +3673,7 @@ class generic(_ArrayOrScalarCommon, Generic[_ItemT_co]):
         out: Never = ...,
     ) -> Never: ...
     def diagonal(self: Never, /, offset: Never = ..., axis1: Never = ..., axis2: Never = ...) -> Never: ...  # type: ignore[misc]
-    def swapaxes(self: Never, /, axis1: Never, axis2: Never) -> Never: ...  # type: ignore[misc]
+    def swapaxes(self: Never, axis1: Never, axis2: Never, /) -> Never: ...  # type: ignore[misc]
     def sort(self: Never, /, axis: Never = ..., kind: Never = ..., order: Never = ...) -> Never: ...  # type: ignore[misc]
     def nonzero(self: Never, /) -> Never: ...  # type: ignore[misc]
     def setfield(self: Never, /, val: Never, dtype: Never, offset: Never = ...) -> None: ...  # type: ignore[misc]
@@ -3755,7 +3769,7 @@ class generic(_ArrayOrScalarCommon, Generic[_ItemT_co]):
         mode: _ModeKind = ...,
     ) -> _ArrayT: ...
 
-    def repeat(self, repeats: _ArrayLikeInt_co, axis: SupportsIndex | None = None) -> ndarray[tuple[int], dtype[Self]]: ...
+    def repeat(self, repeats: _ArrayLikeInt_co, /, axis: SupportsIndex | None = None) -> ndarray[tuple[int], dtype[Self]]: ...
     def flatten(self, /, order: _OrderKACF = "C") -> ndarray[tuple[int], dtype[Self]]: ...
     def ravel(self, /, order: _OrderKACF = "C") -> ndarray[tuple[int], dtype[Self]]: ...
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2982,6 +2982,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('mT',
             [5, 7]]])
 
     """))
+
 ##############################################################################
 #
 # ndarray methods
@@ -2991,6 +2992,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('mT',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__array__',
     """
+    __array__($self, dtype=None, /, *, copy=None)
+    --
+
     a.__array__([dtype], *, copy=None)
 
     For ``dtype`` parameter it returns a new reference to self if
@@ -3010,6 +3014,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__array__',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_finalize__',
     """
+    __array_finalize__($self, obj, /)
+    --
+
     a.__array_finalize__(obj, /)
 
     Present so subclasses can call super. Does nothing.
@@ -3019,7 +3026,10 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_finalize__',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_wrap__',
     """
-    a.__array_wrap__(array[, context], /)
+    __array_wrap__($self, array, context=None, return_scalar=True, /)
+    --
+
+    a.__array_wrap__(array[, context[, return_scalar]], /)
 
     Returns a view of `array` with the same type as self.
 
@@ -3028,6 +3038,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_wrap__',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__copy__',
     """
+    __copy__($self, /)
+    --
+
     a.__copy__()
 
     Used if :func:`copy.copy` is called on an array. Returns a copy of the array.
@@ -3039,6 +3052,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__copy__',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__class_getitem__',
     """
+    __class_getitem__($cls, item, /)
+    --
+
     a.__class_getitem__(item, /)
 
     Return a parametrized wrapper around the `~numpy.ndarray` type.
@@ -3069,6 +3085,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__class_getitem__',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__deepcopy__',
     """
+    __deepcopy__($self, memo, /)
+    --
+
     a.__deepcopy__(memo, /)
 
     Used if :func:`copy.deepcopy` is called on an array.
@@ -3078,6 +3097,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__deepcopy__',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__reduce__',
     """
+    __reduce__($self, /)
+    --
+
     a.__reduce__()
 
     For pickling.
@@ -3087,6 +3109,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__reduce__',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__setstate__',
     """
+    __setstate__($self, state, /)
+    --
+
     a.__setstate__(state, /)
 
     For unpickling.
@@ -3109,6 +3134,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__setstate__',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('all',
     """
+    all($self, /, axis=None, out=None, keepdims=False, *, where=True)
+    --
+
     a.all(axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue)
 
     Returns True if all elements evaluate to True.
@@ -3124,6 +3152,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('all',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('any',
     """
+    any($self, /, axis=None, out=None, keepdims=False, *, where=True)
+    --
+
     a.any(axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue)
 
     Returns True if any of the elements of `a` evaluate to True.
@@ -3139,6 +3170,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('any',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('argmax',
     """
+    argmax($self, /, axis=None, out=None, *, keepdims=False)
+    --
+
     a.argmax(axis=None, out=None, *, keepdims=False)
 
     Return indices of the maximum values along the given axis.
@@ -3154,6 +3188,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('argmax',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('argmin',
     """
+    argmin($self, /, axis=None, out=None, *, keepdims=False)
+    --
+
     a.argmin(axis=None, out=None, *, keepdims=False)
 
     Return indices of the minimum values along the given axis.
@@ -3169,7 +3206,10 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('argmin',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('argsort',
     """
-    a.argsort(axis=-1, kind=None, order=None)
+    argsort($self, /, axis=-1, kind=None, order=None, *, stable=None)
+    --
+
+    a.argsort(axis=-1, kind=None, order=None, *, stable=None)
 
     Returns the indices that would sort this array.
 
@@ -3184,6 +3224,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('argsort',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('argpartition',
     """
+    argpartition($self, kth, /, axis=-1, kind='introselect', order=None)
+    --
+
     a.argpartition(kth, axis=-1, kind='introselect', order=None)
 
     Returns the indices that would partition this array.
@@ -3199,6 +3242,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('argpartition',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('astype',
     """
+    astype($self, /, dtype, order='K', casting='unsafe', subok=True, copy=True)
+    --
+
     a.astype(dtype, order='K', casting='unsafe', subok=True, copy=True)
 
     Copy of the array, cast to a specified type.
@@ -3278,6 +3324,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('astype',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('byteswap',
     """
+    byteswap($self, /, inplace=False)
+    --
+
     a.byteswap(inplace=False)
 
     Swap the bytes of the array elements
@@ -3333,6 +3382,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('byteswap',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('choose',
     """
+    choose($self, /, choices, out=None, mode='raise')
+    --
+
     a.choose(choices, out=None, mode='raise')
 
     Use an index array to construct a new array from a set of choices.
@@ -3348,6 +3400,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('choose',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('clip',
     """
+    clip($self, /, min=None, max=None, out=None, **kwargs)
+    --
+
     a.clip(min=np._NoValue, max=np._NoValue, out=None, **kwargs)
 
     Return an array whose values are limited to ``[min, max]``.
@@ -3364,6 +3419,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('clip',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('compress',
     """
+    compress($self, /, condition, axis=None, out=None)
+    --
+
     a.compress(condition, axis=None, out=None)
 
     Return selected slices of this array along given axis.
@@ -3379,6 +3437,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('compress',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('conj',
     """
+    conj($self, /)
+    --
+
     a.conj()
 
     Complex-conjugate all elements.
@@ -3394,6 +3455,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('conj',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('conjugate',
     """
+    conjugate($self, /)
+    --
+
     a.conjugate()
 
     Return the complex conjugate, element-wise.
@@ -3409,6 +3473,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('conjugate',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('copy',
     """
+    copy($self, /, order='C')
+    --
+
     a.copy(order='C')
 
     Return a copy of the array.
@@ -3482,6 +3549,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('copy',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('cumprod',
     """
+    cumprod($self, /, axis=None, dtype=None, out=None)
+    --
+
     a.cumprod(axis=None, dtype=None, out=None)
 
     Return the cumulative product of the elements along the given axis.
@@ -3497,6 +3567,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('cumprod',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('cumsum',
     """
+    cumsum($self, /, axis=None, dtype=None, out=None)
+    --
+
     a.cumsum(axis=None, dtype=None, out=None)
 
     Return the cumulative sum of the elements along the given axis.
@@ -3512,6 +3585,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('cumsum',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('diagonal',
     """
+    diagonal($self, /, offset=0, axis1=0, axis2=1)
+    --
+
     a.diagonal(offset=0, axis1=0, axis2=1)
 
     Return specified diagonals. In NumPy 1.9 the returned array is a
@@ -3527,11 +3603,23 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('diagonal',
     """))
 
 
-add_newdoc('numpy._core.multiarray', 'ndarray', ('dot'))
+add_newdoc('numpy._core.multiarray', 'ndarray', ('dot',
+    """
+    dot($self, other, /, out=None)
+    --
+
+    a.dot(other, /, out=None)
+
+    Refer to :func:`numpy.dot` for full documentation.
+
+    """))
 
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('dump',
     """
+    dump($self, /, file)
+    --
+
     a.dump(file)
 
     Dump a pickle of the array to the specified file.
@@ -3547,6 +3635,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('dump',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('dumps',
     """
+    dumps($self, /)
+    --
+
     a.dumps()
 
     Returns the pickle of the array as a string.
@@ -3561,6 +3652,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('dumps',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('fill',
     """
+    fill($self, /, value)
+    --
+
     a.fill(value)
 
     Fill the array with a scalar value.
@@ -3605,6 +3699,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('fill',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('flatten',
     """
+    flatten($self, /, order='C')
+    --
+
     a.flatten(order='C')
 
     Return a copy of the array collapsed into one dimension.
@@ -3644,6 +3741,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('flatten',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('getfield',
     """
+    getfield($self, /, dtype, offset=0)
+    --
+
     a.getfield(dtype, offset=0)
 
     Returns a field of the given array as a certain type.
@@ -3687,6 +3787,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('getfield',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('item',
     """
+    item($self, /, *args)
+    --
+
     a.item(*args)
 
     Copy an element of an array to a standard Python scalar and return it.
@@ -3753,6 +3856,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('item',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('max',
     """
+    max($self, /, axis=None, out=None, **kwargs)
+    --
+
     a.max(axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue, where=np._NoValue)
 
     Return the maximum along a given axis.
@@ -3768,6 +3874,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('max',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('mean',
     """
+    mean($self, /, axis=None, dtype=None, out=None, **kwargs)
+    --
+
     a.mean(axis=None, dtype=None, out=None, keepdims=np._NoValue, *, where=np._NoValue)
 
     Returns the average of the array elements along given axis.
@@ -3783,6 +3892,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('mean',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('min',
     """
+    min($self, /, axis=None, out=None, **kwargs)
+    --
+
     a.min(axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue, where=np._NoValue)
 
     Return the minimum along a given axis.
@@ -3798,6 +3910,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('min',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('nonzero',
     """
+    nonzero($self, /)
+    --
+
     a.nonzero()
 
     Return the indices of the elements that are non-zero.
@@ -3813,6 +3928,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('nonzero',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('prod',
     """
+    prod($self, /, axis=None, dtype=None, out=None, **kwargs)
+    --
+
     a.prod(axis=None, dtype=None, out=None, keepdims=np._NoValue,
         initial=np._NoValue, where=np._NoValue)
 
@@ -3829,6 +3947,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('prod',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('put',
     """
+    put($self, indices, values, /, mode='raise')
+    --
+
     a.put(indices, values, mode='raise')
 
     Set ``a.flat[n] = values[n]`` for all `n` in indices.
@@ -3844,6 +3965,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('put',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('ravel',
     """
+    ravel($self, /, order='C')
+    --
+
     a.ravel([order])
 
     Return a flattened array.
@@ -3861,6 +3985,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('ravel',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('repeat',
     """
+    repeat($self, repeats, /, axis=None)
+    --
+
     a.repeat(repeats, axis=None)
 
     Repeat elements of an array.
@@ -3876,6 +4003,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('repeat',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('reshape',
     """
+    reshape($self, /, *shape, order='C', copy=None)
+    --
+
     a.reshape(shape, /, *, order='C', copy=None)
 
     Returns an array containing the same data with a new shape.
@@ -3898,6 +4028,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('reshape',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('resize',
     """
+    resize($self, /, *new_shape, refcheck=True)
+    --
+
     a.resize(new_shape, refcheck=True)
 
     Change shape and size of array in-place.
@@ -3992,6 +4125,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('resize',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('round',
     """
+    round($self, /, decimals=0, out=None)
+    --
+
     a.round(decimals=0, out=None)
 
     Return `a` with each element rounded to the given number of decimals.
@@ -4007,6 +4143,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('round',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('searchsorted',
     """
+    searchsorted($self, v, /, side='left', sorter=None)
+    --
+
     a.searchsorted(v, side='left', sorter=None)
 
     Find indices where elements of v should be inserted in a to maintain order.
@@ -4022,6 +4161,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('searchsorted',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('setfield',
     """
+    setfield($self, val, /, dtype, offset=0)
+    --
+
     a.setfield(val, dtype, offset=0)
 
     Put a value into a specified place in a field defined by a data-type.
@@ -4074,6 +4216,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('setfield',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('setflags',
     """
+    setflags($self, /, *, write=None, align=None, uic=None)
+    --
+
     a.setflags(write=None, align=None, uic=None)
 
     Set array flags WRITEABLE, ALIGNED, WRITEBACKIFCOPY,
@@ -4151,7 +4296,10 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('setflags',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('sort',
     """
-    a.sort(axis=-1, kind=None, order=None)
+    sort($self, /, axis=-1, kind=None, order=None, *, stable=None)
+    --
+
+    a.sort(axis=-1, kind=None, order=None, *, stable=None)
 
     Sort an array in-place. Refer to `numpy.sort` for full documentation.
 
@@ -4171,6 +4319,13 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('sort',
         be specified as a string, and not all fields need be specified,
         but unspecified fields will still be used, in the order in which
         they come up in the dtype, to break ties.
+    stable : bool, optional
+        Sort stability. If ``True``, the returned array will maintain
+        the relative order of ``a`` values which compare as equal.
+        If ``False`` or ``None``, this is not guaranteed. Internally,
+        this option selects ``kind='stable'``. Default: ``None``.
+
+        .. versionadded:: 2.0.0
 
     See Also
     --------
@@ -4211,6 +4366,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('sort',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
     """
+    partition($self, kth, /, axis=-1, kind='introselect', order=None)
+    --
+
     a.partition(kth, axis=-1, kind='introselect', order=None)
 
     Partially sorts the elements in the array in such a way that the value of
@@ -4270,6 +4428,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('squeeze',
     """
+    squeeze($self, /, axis=None)
+    --
+
     a.squeeze(axis=None)
 
     Remove axes of length one from `a`.
@@ -4285,6 +4446,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('squeeze',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('std',
     """
+    std($self, /, axis=None, dtype=None, out=None, ddof=0, **kwargs)
+    --
+
     a.std(axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *, where=np._NoValue, mean=np._NoValue)
 
     Returns the standard deviation of the array elements along given axis.
@@ -4300,6 +4464,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('std',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('sum',
     """
+    sum($self, /, axis=None, dtype=None, out=None, **kwargs)
+    --
+
     a.sum(axis=None, dtype=None, out=None, keepdims=np._NoValue, initial=np._NoValue, where=np._NoValue)
 
     Return the sum of the array elements over the given axis.
@@ -4315,7 +4482,10 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('sum',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('swapaxes',
     """
-    a.swapaxes(axis1, axis2)
+    swapaxes($self, axis1, axis2, /)
+    --
+
+    a.swapaxes(axis1, axis2, /)
 
     Return a view of the array with `axis1` and `axis2` interchanged.
 
@@ -4330,6 +4500,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('swapaxes',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('take',
     """
+    take($self, indices, /, axis=None, out=None, mode='raise')
+    --
+
     a.take(indices, axis=None, out=None, mode='raise')
 
     Return an array formed from the elements of `a` at the given indices.
@@ -4345,7 +4518,10 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('take',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('tofile',
     """
-    a.tofile(fid, sep="", format="%s")
+    tofile($self, fid, /, sep='', format='%s')
+    --
+
+    a.tofile(fid, sep='', format='%s')
 
     Write array to a file as text or binary (default).
 
@@ -4385,6 +4561,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('tofile',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('tolist',
     """
+    tolist($self, /)
+    --
+
     a.tolist()
 
     Return the array as an ``a.ndim``-levels deep nested list of Python scalars.
@@ -4448,7 +4627,11 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('tolist',
     """))
 
 
-add_newdoc('numpy._core.multiarray', 'ndarray', ('tobytes', """
+add_newdoc('numpy._core.multiarray', 'ndarray', ('tobytes',
+    """
+    tobytes($self, /, order='C')
+    --
+
     a.tobytes(order='C')
 
     Construct Python bytes containing the raw data bytes in the array.
@@ -4491,6 +4674,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('tobytes', """
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('trace',
     """
+    trace($self, /, offset=0, axis1=0, axis2=1, dtype=None, out=None)
+    --
+
     a.trace(offset=0, axis1=0, axis2=1, dtype=None, out=None)
 
     Return the sum along diagonals of the array.
@@ -4506,6 +4692,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('trace',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('transpose',
     """
+    transpose($self, /, *axes)
+    --
+
     a.transpose(*axes)
 
     Returns a view of the array with axes transposed.
@@ -4563,6 +4752,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('transpose',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('var',
     """
+    var($self, /, axis=None, dtype=None, out=None, ddof=0, **kwargs)
+    --
+
     a.var(axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *, where=np._NoValue, mean=np._NoValue)
 
     Returns the variance of the array elements, along given axis.
@@ -4578,6 +4770,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('var',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('view',
     """
+    view($self, /, *args, **kwargs)
+    --
+
     a.view([dtype][, type])
 
     New view of array with the same data.

--- a/numpy/typing/tests/data/pass/ndarray_conversion.py
+++ b/numpy/typing/tests/data/pass/ndarray_conversion.py
@@ -74,14 +74,8 @@ complex_array.getfield(float, offset=8)
 
 # setflags
 nd.setflags()
-
-nd.setflags(True)
 nd.setflags(write=True)
-
-nd.setflags(True, True)
 nd.setflags(write=True, align=True)
-
-nd.setflags(True, True, False)
 nd.setflags(write=True, align=True, uic=False)
 
 # fill is pretty simple


### PR DESCRIPTION
Same story as #30104, but for ``ndarray`` this time.

This fixes a `ValueError` from being raised when using `inspect.signature` on the `ndarray` methods. 
The typing stubs changes are needed because stubtest is now able to "see" the actual signatures, which was causing several errors (related to pos-only parameters mostly).

This also adds a (very minimal) docstring for `ndarray.dot`, which was apparently missing (see the rendered docs from [before](https://numpy.org/devdocs/reference/generated/numpy.ndarray.dot.html) and [after](https://output.circle-artifacts.com/output/job/742a3ba6-4e81-4f2d-9221-081994e6f1ba/artifacts/0/doc/build/html/reference/generated/numpy.ndarray.dot.html))