### PR TITLE
ENH: Speedup `np.vectorize` wrapped functions when keyword args are present

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -377,3 +377,19 @@ class Where(Benchmark):
 
     def time_interleaved_ones_x8(self):
         np.where(self.rep_ones_8)
+
+
+class Vectorize(Benchmark):
+    """
+    Performance tests for numpy.vectorize
+    """
+    def setup(self):
+        self.a = np.arange(10)
+        self.b = 20
+        self.c = 30
+    
+    def time_vectorize_positional_or_kw_args(self):
+        # Test performance of np.vectorize when there are no keyword only arguments.
+        def func(a, b, /, c):
+            return a + b + c
+        res = np.vectorize(func)(self.a, self.b, c=self.c)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2070,6 +2070,41 @@ class TestVectorize:
             def foo():
                 return "bar"
 
+    def test_positional_only(self):
+        # Test np.vectorize when there are some positional only arguments.
+        def func(a, b, /, c, d, e, f):
+            return sum((a, b, c, d, e, f))
+        res = np.vectorize(func)(np.arange(3), np.arange(3), c=1, d=2, e=3, f=4)
+        assert_array_equal(res, [10, 12, 14])
+
+    def test_kw_only(self):
+        # Test np.vectorize when there are some keyword only arguments.
+        def func(a, b, /, c, d, *, e, f):
+            return sum((a, b, c, d, e, f))
+        res = np.vectorize(func)(np.arange(3), np.arange(3), c=1, d=2, e=3, f=4)
+        assert_array_equal(res, [10, 12, 14])
+
+    def test_all_kw_args(self):
+        # Test np.vectorize when every argument is passed as kwarg.
+        def func(a, b, c=-1):
+            return a + b + c
+        res = np.vectorize(func)(a=np.arange(3), b=np.arange(3), c=np.arange(3))
+        assert_array_equal(res, [0, 3, 6])
+
+    def test_error_missing_params(self):
+        # Test np.vectorize when some positional arguments are missing.
+        def func(a, b, c=-1):
+            return a + b + c
+        with pytest.raises(TypeError):
+            res = np.vectorize(func)(a=20, c=30)
+
+    def test_error_positional_only_args(self):
+        # Test np.vectorize when positional arguments are passed as keyword arguments.
+        def func(a, b, /, c):
+            return a + b + c
+        with pytest.raises(TypeError):
+            res = np.vectorize(func)(np.arange(5), b=20, c=30)
+
     def test_positional_regression_9477(self):
         # This supplies the first keyword argument as a positional,
         # to ensure that they are still properly forwarded after the


### PR DESCRIPTION
Fixes https://github.com/numpy/numpy/issues/30116

---

`np.vectorize` wrapped functions, when keyword arguments are involved were doing a some sanitization steps in every call to the function.

This commit enhances `vectorize._call_as_normal` to avoid these sanization steps when function only has pure positional / positional_or_keyword type params. We filter them by looking into `inspect.signature(foo).parameters`

Taking example from https://github.com/numpy/numpy/issues/30116 with this changes:
```
>>> def func(a, b):
...     return a + b

>>> %time _ = np.vectorize(func)(np.arange(10**7), 1)
CPU times: user 534 ms, sys: 76.8 ms, total: 611 ms
Wall time: 610 ms

>>> %time _ = np.vectorize(func)(np.arange(10**7), b=1) # equivalent performance as above.
CPU times: user 543 ms, sys: 67.3 ms, total: 610 ms
Wall time: 614 ms
```

Thanks!