### PR TITLE
BUG: Fix handling by ``unique`` of signed zero in complex types.

### DIFF
--- a/benchmarks/benchmarks/bench_lib.py
+++ b/benchmarks/benchmarks/bench_lib.py
@@ -125,7 +125,7 @@ class Unique(Benchmark):
         # sizes of the 1D arrays
         [200, int(2e5)],
         # percent of np.nan in arrays
-        [10., 90.],
+        [0.0, 10., 90.],
         # percent of unique values in arrays
         [0.2, 20.],
         # dtypes of the arrays

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -1291,3 +1291,12 @@ class TestUnique:
         arr1d = np.array([np.nan, 0, 0, np.nan])
         with pytest.raises(TypeError, match="integer argument expected"):
             np.unique(arr1d, axis=0.0, equal_nan=False)
+
+    @pytest.mark.parametrize('dt', [np.dtype('F'), np.dtype('D')])
+    @pytest.mark.parametrize('values', [[complex(0.0, -1), complex(-0.0, -1), 0],
+                                        [-200, complex(-200, -0.0), -1],
+                                        [-25, 3, -5j, complex(-25, -0.0), 3j]])
+    def test_unique_complex_signed_zeros(self, dt, values):
+        z = np.array(values, dtype=dt)
+        u = np.unique(z)
+        assert len(u) == len(values) - 1


### PR DESCRIPTION
When hashing a complex type, convert any real or imaginary part from -0.0 to 0.0 before computing the hash.

Closes gh-30123.