### PR TITLE
BUG: Avoid compilation error of wrapper file generated with SWIG >= 4.4

### DIFF
--- a/numpy/_core/code_generators/generate_numpy_api.py
+++ b/numpy/_core/code_generators/generate_numpy_api.py
@@ -157,6 +157,12 @@ _import_array(void)
   return 0;
 }
 
+#if (SWIG_VERSION < 0x040400)
+#define _RETURN_VALUE NULL
+#else
+#define _RETURN_VALUE 0
+#endif
+
 #define import_array() { \
   if (_import_array() < 0) { \
     PyErr_Print(); \
@@ -164,7 +170,7 @@ _import_array(void)
         PyExc_ImportError, \
         "numpy._core.multiarray failed to import" \
     ); \
-    return NULL; \
+    return _RETURN_VALUE; \
   } \
 }
 


### PR DESCRIPTION
The `import_array` macro, which is defined in the file `numpy/core/code_generators/generate_numpy_api.py`, is intended for use inside an internal SWIG function that is called in the generated C wrapper file. This macro contains a return statement whose argument must match the function definition.

Until version 4.3 of SWIG, the aforementioned function returned a `void*` value. However, in version 4.4, the return value was changed to `int`. This causes compilation of code using import_array() to fail with the following error message: `returning 'void *' from a function with return type 'int' makes integer from pointer without a cast [-Wint-conversion].`

This commit resolves the issue by returning either `NULL` or `0`, depending on the SWIG version being used (< 4.4 or >= 4.4, respectively). This change has been successfully tested against SWIG versions 4.3 and 4.4.

Closes: numpy/numpy#30122

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
