### PR TITLE
BLD: update scipy-openblas, use -Dpkg_config_path (#30049)

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -85,16 +85,13 @@ jobs:
         fi
         mkdir -p ./.openblas
         python -c"import scipy_openblas32 as ob32; print(ob32.get_pkg_config())" > ./.openblas/scipy-openblas.pc
-        echo "PKG_CONFIG_PATH=${{ github.workspace }}/.openblas" >> $GITHUB_ENV
-        ld_library_path=$(python -c"import scipy_openblas32 as ob32; print(ob32.get_lib_dir())")
-        echo "LD_LIBRARY_PATH=$ld_library_path" >> $GITHUB_ENV
 
     - name: Build
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       env:
         TERM: xterm-256color
       run:
-        spin build -- --werror -Dallow-noblas=false
+        spin build -- --werror -Dallow-noblas=false -Dpkg_config_path=${PWD}/.openblas
 
     - name: Check build-internal dependencies
       run:

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin==0.15
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.30.0.1
+scipy-openblas32==0.3.30.0.6

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin==0.15
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.30.0.1
-scipy-openblas64==0.3.30.0.1
+scipy-openblas32==0.3.30.0.6
+scipy-openblas64==0.3.30.0.6


### PR DESCRIPTION
Backport of #30049.

Closes https://github.com/numpy/numpy/issues/29391 by patching OpenBLAS. Hopefully by the time 0.3.31 is released we can remove the patch.

Also use spin build -- -Dpkg_config_path= instead of setting PKG_CONFIG_PATH in the normal (non-wheel building) CI.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
