### PR TITLE
BLD: use scipy-openblas 0.3.30.7

### DIFF
--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin==0.15
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.30.0.6
+scipy-openblas32==0.3.30.0.7

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin==0.15
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.30.0.6
-scipy-openblas64==0.3.30.0.6
+scipy-openblas32==0.3.30.0.7
+scipy-openblas64==0.3.30.0.7


### PR DESCRIPTION
Fixes #30092.

Rather than update the OpenBLAS version, this PR uses a patched version of OpenBLAS that incorporate the fix from https://github.com/OpenMathLib/OpenBLAS/issues/5520. That should minimize the risk in updating the dependency so close to the new release cut-off date.