### PR TITLE
BUG: Fix np.unique return_index for complex NaN arrays

### DIFF
--- a/doc/release/upcoming_changes/30113.improvement.rst
+++ b/doc/release/upcoming_changes/30113.improvement.rst
@@ -1,0 +1,8 @@
+``np.unique`` with ``return_index`` now returns correct indices for complex NaN
+-------------------------------------------------------------------------------
+Fixed a bug where `numpy.unique` with ``return_index=True`` and
+``equal_nan=True`` would not return the index of the first occurrence of NaN
+values in complex arrays. Previously, after sorting, it would return the index
+of the first NaN in the sorted order rather than the first NaN in the original
+array order. The function now correctly returns the index of the first NaN
+occurrence in the input array.


### PR DESCRIPTION
Fixes #30113

## Description
When using `np.unique` with `return_index=True` and `equal_nan=True` on complex arrays containing NaN values, the function was not returning the index of the first occurrence of NaN in the original array.

## Root Cause
After sorting, the code would return the index of the first NaN in the sorted array, which might not correspond to the first NaN in the original unsorted array.

## Solution
This PR fixes the issue by finding all NaN positions in the sorted array, checking their original indices through the permutation array, and returning the index of the NaN with the smallest original index.

## Changes
- Fixed `_unique1d` function in `numpy/lib/_arraysetops_impl.py`
- Added comprehensive test case `test_unique_complex_nan_return_index`
- Fixed incorrect existing test expectation
- Added release note

## Testing
- All 41 tests in TestUnique pass
- Verified bug exists on main branch
- Verified fix works correctly with various edge cases