### PR TITLE
BUG: ``broadcast`` runtime signatures

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -638,6 +638,9 @@ add_newdoc('numpy._core', 'nested_iters',
 
 add_newdoc('numpy._core', 'broadcast',
     """
+    broadcast(*arrays)
+    --
+
     Produce an object that mimics broadcasting.
 
     Parameters
@@ -807,8 +810,13 @@ add_newdoc('numpy._core', 'broadcast', ('size',
 
     """))
 
+# methods
+
 add_newdoc('numpy._core', 'broadcast', ('reset',
     """
+    reset($self, /)
+    --
+
     reset()
 
     Reset the broadcasted result's iterator(s).

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1,3 +1,4 @@
+import inspect
 import itertools
 import math
 import platform
@@ -18,6 +19,7 @@ from numpy.exceptions import AxisError
 from numpy.random import rand, randint, randn
 from numpy.testing import (
     HAS_REFCOUNT,
+    IS_PYPY,
     IS_WASM,
     assert_,
     assert_almost_equal,
@@ -4173,6 +4175,19 @@ class TestBroadcast:
         with pytest.raises(ValueError, match=r"arg 0 with shape \(1, 3\) and "
                                              r"arg 2 with shape \(2,\)"):
             np.broadcast([[1, 2, 3]], [[4], [5]], [6, 7])
+
+    @pytest.mark.skipif(sys.flags.optimize == 2, reason="Python running -OO")
+    @pytest.mark.xfail(IS_PYPY, reason="PyPy does not modify tp_doc")
+    def test_signatures(self):
+        sig_new = inspect.signature(np.broadcast)
+        assert len(sig_new.parameters) == 1
+        assert "arrays" in sig_new.parameters
+        assert sig_new.parameters["arrays"].kind == inspect.Parameter.VAR_POSITIONAL
+
+        sig_reset = inspect.signature(np.broadcast.reset)
+        assert len(sig_reset.parameters) == 1
+        assert "self" in sig_reset.parameters
+        assert sig_reset.parameters["self"].kind == inspect.Parameter.POSITIONAL_ONLY
 
 
 class TestKeepdims:


### PR DESCRIPTION
Following #30104, #30114, #30121, #30124, and #30126, this adds the missing `__text_signature__`s to the ``broadcast`` constructor and its `reset` method.

before:

```pycon
>>> from inspect import signature
>>> signature(np.broadcast)
Traceback (most recent call last):
[...]
ValueError: no signature found for builtin type <class 'numpy.broadcast'>
>>> signature(np.broadcast.reset)
Traceback (most recent call last):
[...]
ValueError: no signature found for builtin <method 'reset' of 'numpy.broadcast' objects>
```

after:

```pycon
>>> from inspect import signature
>>> signature(np.broadcast)
<Signature (*arrays)>
>>> signature(np.broadcast.reset)
<Signature (self, /)>
```