### PR TITLE
MAINT,BUG: make later arguments in array2string keyword only.

### DIFF
--- a/doc/release/upcoming_changes/30068.expired.rst
+++ b/doc/release/upcoming_changes/30068.expired.rst
@@ -4,7 +4,8 @@
 The following long-deprecated APIs have been removed or converted to errors:
 
 * The ``style`` parameter has been removed from ``numpy.array2string``.
-  This argument had no effect since Numpy 1.14.0.
+  This argument had no effect since Numpy 1.14.0.  Any arguments following
+  it, such as ``formatter`` have now been made keyword-only.
 
 * Calling ``np.sum(generator)`` directly on a generator object now raises a `TypeError`.
   This behavior was deprecated in NumPy 1.15.0. Use ``np.sum(np.fromiter(generator))``

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -619,18 +619,18 @@ def _array2string(a, options, separator=' ', prefix=""):
 def _array2string_dispatcher(
         a, max_line_width=None, precision=None,
         suppress_small=None, separator=None, prefix=None,
-        formatter=None, threshold=None,
+        *, formatter=None, threshold=None,
         edgeitems=None, sign=None, floatmode=None, suffix=None,
-        *, legacy=None):
+        legacy=None):
     return (a,)
 
 
 @array_function_dispatch(_array2string_dispatcher, module='numpy')
 def array2string(a, max_line_width=None, precision=None,
                  suppress_small=None, separator=' ', prefix="",
-                 formatter=None, threshold=None,
+                 *, formatter=None, threshold=None,
                  edgeitems=None, sign=None, floatmode=None, suffix="",
-                 *, legacy=None):
+                 legacy=None):
     """
     Return a string representation of an array.
 

--- a/numpy/_core/arrayprint.pyi
+++ b/numpy/_core/arrayprint.pyi
@@ -98,13 +98,13 @@ def array2string(
     suppress_small: bool | None = None,
     separator: str = " ",
     prefix: str = "",
+    *,
     formatter: _FormatDict | None = None,
     threshold: int | None = None,
     edgeitems: int | None = None,
     sign: _Sign | None = None,
     floatmode: _FloatMode | None = None,
     suffix: str = "",
-    *,
     legacy: _Legacy | None = None,
 ) -> str: ...
 


### PR DESCRIPTION
In #30068, the deprecated `style` argument from `array2string` was removed. With that, however, all following arguments shift one up if used as positional arguments. This seems highly undesirable, as any code that used those positional arguments will now fail.

The only solution would seem to be to make those later arguments keyword-only -- which this PR does.

p.s. It seems highly unlikely that all positional arguments were used in the wild, but our code in astropy that implements `__array_function__` did, and broke by #30068. We don't mind adjusting, but it seemed better to just fix the problem here.