### PR TITLE
BUG, DOC, TYP: ``empty`` and ``zeros`` runtime signatures, and missing ``device`` parameter docs

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1293,7 +1293,10 @@ add_newdoc('numpy._core.multiarray', 'asfortranarray',
 
 add_newdoc('numpy._core.multiarray', 'empty',
     """
-    empty(shape, dtype=float, order='C', *, device=None, like=None)
+    empty(shape, dtype=None, order='C', *, device=None, like=None)
+    --
+
+    empty(shape, dtype=None, order='C', *, device=None, like=None)
 
     Return a new array of given shape and type, without initializing entries.
 
@@ -1306,8 +1309,7 @@ add_newdoc('numpy._core.multiarray', 'empty',
         `numpy.float64`.
     order : {'C', 'F'}, optional, default: 'C'
         Whether to store multi-dimensional data in row-major
-        (C-style) or column-major (Fortran-style) order in
-        memory.
+        (C-style) or column-major (Fortran-style) order in memory.
     device : str, optional
         The device on which to place the created array. Default: ``None``.
         For Array-API interoperability only, so must be ``"cpu"`` if passed.
@@ -1363,11 +1365,14 @@ add_newdoc('numpy._core.multiarray', 'scalar',
     string. If `obj` is not given, it will be interpreted as None for object
     type and as zeros for all other types.
 
-    """)
+    """)  # sufficient null bytes for all number dtypes
 
 add_newdoc('numpy._core.multiarray', 'zeros',
     """
-    zeros(shape, dtype=float, order='C', *, like=None)
+    zeros(shape, dtype=None, order='C', *, device=None, like=None)
+    --
+
+    zeros(shape, dtype=None, order='C', *, device=None, like=None)
 
     Return a new array of given shape and type, filled with zeros.
 
@@ -1380,8 +1385,12 @@ add_newdoc('numpy._core.multiarray', 'zeros',
         `numpy.float64`.
     order : {'C', 'F'}, optional, default: 'C'
         Whether to store multi-dimensional data in row-major
-        (C-style) or column-major (Fortran-style) order in
-        memory.
+        (C-style) or column-major (Fortran-style) order in memory.
+    device : str, optional
+        The device on which to place the created array. Default: ``None``.
+        For Array-API interoperability only, so must be ``"cpu"`` if passed.
+
+        .. versionadded:: 2.0.0
     ${ARRAY_FUNCTION_LIKE}
 
         .. versionadded:: 1.20.0
@@ -1423,7 +1432,8 @@ add_newdoc('numpy._core.multiarray', 'zeros',
     """)
 
 add_newdoc('numpy._core.multiarray', 'set_typeDict',
-    """set_typeDict(dict)
+    """
+    set_typeDict(dict)
 
     Set the internal dictionary that can look up an array type using a
     registered code.

--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -1,6 +1,6 @@
 # TODO: Sort out any and all missing functions in this namespace
 import datetime as dt
-from _typeshed import StrOrBytesPath, SupportsLenAndGetItem
+from _typeshed import Incomplete, StrOrBytesPath, SupportsLenAndGetItem
 from collections.abc import Callable, Iterable, Sequence
 from typing import (
     Any,
@@ -10,9 +10,7 @@ from typing import (
     Protocol,
     SupportsIndex,
     TypeAlias,
-    TypedDict,
     TypeVar,
-    Unpack,
     final,
     overload,
     type_check_only,
@@ -32,7 +30,6 @@ from numpy import (  # type: ignore[attr-defined]
     _SupportsBuffer,
     _SupportsFileMethods,
     broadcast,
-    # Re-exports
     busdaycalendar,
     complexfloating,
     correlate,
@@ -54,7 +51,6 @@ from numpy import (  # type: ignore[attr-defined]
     signedinteger,
     str_,
     timedelta64,
-    # The rest
     ufunc,
     uint8,
     unsignedinteger,
@@ -62,10 +58,9 @@ from numpy import (  # type: ignore[attr-defined]
 )
 from numpy._typing import (
     ArrayLike,
-    # DTypes
     DTypeLike,
-    # Arrays
     NDArray,
+    _AnyShape,
     _ArrayLike,
     _ArrayLikeBool_co,
     _ArrayLikeBytes_co,
@@ -82,7 +77,6 @@ from numpy._typing import (
     _IntLike_co,
     _NestedSequence,
     _ScalarLike_co,
-    # Shapes
     _Shape,
     _ShapeLike,
     _SupportsArrayFunc,
@@ -192,18 +186,15 @@ __all__ = [
 
 _ScalarT = TypeVar("_ScalarT", bound=generic)
 _DTypeT = TypeVar("_DTypeT", bound=np.dtype)
-_ArrayT = TypeVar("_ArrayT", bound=ndarray[Any, Any])
-_ArrayT_co = TypeVar(
-    "_ArrayT_co",
-    bound=ndarray[Any, Any],
-    covariant=True,
-)
+_ArrayT = TypeVar("_ArrayT", bound=ndarray)
+_ArrayT_co = TypeVar("_ArrayT_co", bound=ndarray, covariant=True)
+_ShapeT = TypeVar("_ShapeT", bound=_Shape)
+# TODO: fix the names of these typevars
 _ReturnType = TypeVar("_ReturnType")
 _IDType = TypeVar("_IDType")
 _Nin = TypeVar("_Nin", bound=int)
 _Nout = TypeVar("_Nout", bound=int)
 
-_ShapeT = TypeVar("_ShapeT", bound=_Shape)
 _Array: TypeAlias = ndarray[_ShapeT, dtype[_ScalarT]]
 _Array1D: TypeAlias = ndarray[tuple[int], dtype[_ScalarT]]
 
@@ -237,11 +228,6 @@ class _SupportsArray(Protocol[_ArrayT_co]):
     def __array__(self, /) -> _ArrayT_co: ...
 
 @type_check_only
-class _KwargsEmpty(TypedDict, total=False):
-    device: L["cpu"] | None
-    like: _SupportsArrayFunc | None
-
-@type_check_only
 class _ConstructorEmpty(Protocol):
     # 1-D shape
     @overload
@@ -250,8 +236,10 @@ class _ConstructorEmpty(Protocol):
         /,
         shape: SupportsIndex,
         dtype: None = None,
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
     ) -> _Array1D[float64]: ...
     @overload
     def __call__(
@@ -259,8 +247,10 @@ class _ConstructorEmpty(Protocol):
         /,
         shape: SupportsIndex,
         dtype: _DTypeT | _SupportsDType[_DTypeT],
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
     ) -> ndarray[tuple[int], _DTypeT]: ...
     @overload
     def __call__(
@@ -268,18 +258,22 @@ class _ConstructorEmpty(Protocol):
         /,
         shape: SupportsIndex,
         dtype: type[_ScalarT],
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
     ) -> _Array1D[_ScalarT]: ...
     @overload
     def __call__(
         self,
         /,
         shape: SupportsIndex,
-        dtype: DTypeLike | None = ...,
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
-    ) -> _Array1D[Any]: ...
+        dtype: DTypeLike | None = None,
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
+    ) -> _Array1D[Incomplete]: ...
 
     # known shape
     @overload
@@ -288,8 +282,10 @@ class _ConstructorEmpty(Protocol):
         /,
         shape: _AnyShapeT,
         dtype: None = None,
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
     ) -> _Array[_AnyShapeT, float64]: ...
     @overload
     def __call__(
@@ -297,8 +293,10 @@ class _ConstructorEmpty(Protocol):
         /,
         shape: _AnyShapeT,
         dtype: _DTypeT | _SupportsDType[_DTypeT],
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
     ) -> ndarray[_AnyShapeT, _DTypeT]: ...
     @overload
     def __call__(
@@ -306,18 +304,22 @@ class _ConstructorEmpty(Protocol):
         /,
         shape: _AnyShapeT,
         dtype: type[_ScalarT],
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
     ) -> _Array[_AnyShapeT, _ScalarT]: ...
     @overload
     def __call__(
         self,
         /,
         shape: _AnyShapeT,
-        dtype: DTypeLike | None = ...,
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
-    ) -> _Array[_AnyShapeT, Any]: ...
+        dtype: DTypeLike | None = None,
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
+    ) -> _Array[_AnyShapeT, Incomplete]: ...
 
     # unknown shape
     @overload
@@ -325,34 +327,42 @@ class _ConstructorEmpty(Protocol):
         self, /,
         shape: _ShapeLike,
         dtype: None = None,
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
     ) -> NDArray[float64]: ...
     @overload
     def __call__(
         self, /,
         shape: _ShapeLike,
         dtype: _DTypeT | _SupportsDType[_DTypeT],
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
-    ) -> ndarray[Any, _DTypeT]: ...
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
+    ) -> ndarray[_AnyShape, _DTypeT]: ...
     @overload
     def __call__(
         self, /,
         shape: _ShapeLike,
         dtype: type[_ScalarT],
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
     ) -> NDArray[_ScalarT]: ...
     @overload
     def __call__(
         self,
         /,
         shape: _ShapeLike,
-        dtype: DTypeLike | None = ...,
-        order: _OrderCF = ...,
-        **kwargs: Unpack[_KwargsEmpty],
-    ) -> NDArray[Any]: ...
+        dtype: DTypeLike | None = None,
+        order: _OrderCF = "C",
+        *,
+        device: L["cpu"] | None = None,
+        like: _SupportsArrayFunc | None = None,
+    ) -> NDArray[Incomplete]: ...
 
 # using `Final` or `TypeAlias` will break stubtest
 error = Exception

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -5982,7 +5982,13 @@ def test_frommethod_signature(fn, signature):
 @pytest.mark.parametrize(
     ('fn', 'signature'),
     [
-        (np.ma.empty, "(*args, fill_value=None, hardmask=False, **kwargs)"),
+        (
+            np.ma.empty,
+            (
+                "(shape, dtype=None, order='C', *, device=None, like=None, "
+                "fill_value=None, hardmask=False)"
+            ),
+        ),
         (np.ma.empty_like, "(*args, **kwargs)"),
         (np.ma.squeeze, "(a, axis=None, *, fill_value=None, hardmask=False)"),
         (

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -189,7 +189,10 @@ assert_type(np.ones(_shape_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]
 assert_type(np.ones(_shape_nd), np.ndarray[tuple[int, ...], np.dtype[np.float64]])
 assert_type(np.ones(_shape_1d, dtype=np.int64), np.ndarray[tuple[int], np.dtype[np.int64]])
 assert_type(np.ones(_shape_like), npt.NDArray[np.float64])
-assert_type(np.ones(_shape_like, dtype=np.dtypes.Int64DType()), np.ndarray[Any, np.dtypes.Int64DType])
+assert_type(
+    np.ones(_shape_like, dtype=np.dtypes.Int64DType()),
+    np.ndarray[tuple[Any, ...], np.dtypes.Int64DType],
+)
 assert_type(np.ones(_shape_like, dtype=int), npt.NDArray[Any])
 assert_type(np.ones(mixed_shape), npt.NDArray[np.float64])
 


### PR DESCRIPTION
Following #30104, #30114, #30121, #30124, #30126, #30137, and #30138; this adds the missing `__text_signature__`s to `empty`, `zeros`, and updates the relevant stubs.
Note that because `ones` and `full` are python functions, they did not have this issue.

This also adds docs for the `device` parameter of `zeros`, which apparently was missing.

---

Before:

```pycon
>>> import numpy as np
>>> from inspect import signature
>>> signature(np.empty)
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    signature(np.empty)
    ~~~~~~~~~^^^^^^^^^^
  File "/home/joren/.local/share/uv/python/cpython-3.14-linux-x86_64-gnu/lib/python3.14/inspect.py", line 3312, in signature
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped,
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                   globals=globals, locals=locals, eval_str=eval_str,
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                   annotation_format=annotation_format)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/joren/.local/share/uv/python/cpython-3.14-linux-x86_64-gnu/lib/python3.14/inspect.py", line 3027, in from_callable
    return _signature_from_callable(obj, sigcls=cls,
                                    follow_wrapper_chains=follow_wrapped,
                                    globals=globals, locals=locals, eval_str=eval_str,
                                    annotation_format=annotation_format)
  File "/home/joren/.local/share/uv/python/cpython-3.14-linux-x86_64-gnu/lib/python3.14/inspect.py", line 2508, in _signature_from_callable
    return _signature_from_builtin(sigcls, obj,
                                   skip_bound_arg=skip_bound_arg)
  File "/home/joren/.local/share/uv/python/cpython-3.14-linux-x86_64-gnu/lib/python3.14/inspect.py", line 2292, in _signature_from_builtin
    raise ValueError("no signature found for builtin {!r}".format(func))
ValueError: no signature found for builtin <built-in function empty>
```

After:

```pycon
>>> import numpy as np
>>> from inspect import signature
>>> signature(np.empty)
<Signature (shape, dtype=None, order='C', *, device=None, like=None)>
>>> signature(np.zeros)
<Signature (shape, dtype=None, order='C', *, device=None, like=None)>
```