### PR TITLE
MAINT: fix math markup (\times -> \\times) in numpy.linalg.multidot docstring Notes section

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2938,7 +2938,7 @@ def multi_dot(arrays, *, out=None):
             return A.shape[0] * A.shape[1] * B.shape[1]
 
     Assume we have three matrices
-    :math:`A_{10 \times 100}, B_{100 \times 5}, C_{5 \times 50}`.
+    :math:`A_{10 \\times 100}, B_{100 \\times 5}, C_{5 \\times 50}`.
 
     The costs for the two different parenthesizations are as follows::
 


### PR DESCRIPTION
On the NumPy documentation page for [numpy.linalg.mutli_dot](https://numpy.org/doc/stable/reference/generated/numpy.linalg.multi_dot.html#numpy.linalg.multi_dot), the math markup in Notes was previously

```python
:math:`A_{10 \times 100}, B_{100 \times 5}, C_{5 \times 50}`.
```

which did not render correctly as it was detected as an escape sequence. This has been updated to

```python
:math:`A_{10 \\times 100}, B_{100 \\times 5}, C_{5 \\times 50}`.
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
