### PR TITLE
BUG, TYP: ``_core.multiarray.*`` function runtime signatures

### DIFF
--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -114,11 +114,20 @@ array_function_from_c_func_and_dispatcher = functools.partial(
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.empty_like)
 def empty_like(
-    prototype, dtype=None, order=None, subok=None, shape=None, *, device=None
+    prototype, dtype=None, order="K", subok=True, shape=None, *, device=None
 ):
     """
-    empty_like(prototype, dtype=None, order='K', subok=True, shape=None, *,
-               device=None)
+    empty_like(
+        prototype,
+        /,
+        dtype=None,
+        order='K',
+        subok=True,
+        shape=None,
+        *,
+        device=None,
+    )
+    --
 
     Return a new array with the same shape and type as a given array.
 
@@ -186,15 +195,18 @@ def empty_like(
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.concatenate)
-def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
+def concatenate(arrays, axis=0, out=None, *, dtype=None, casting="same_kind"):
     """
     concatenate(
-        (a1, a2, ...),
+        arrays,
+        /,
         axis=0,
         out=None,
+        *,
         dtype=None,
-        casting="same_kind"
+        casting="same_kind",
     )
+    --
 
     Join a sequence of arrays along an existing axis.
 
@@ -295,7 +307,7 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.inner)
-def inner(a, b):
+def inner(a, b, /):
     """
     inner(a, b, /)
 
@@ -389,7 +401,7 @@ def inner(a, b):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.where)
-def where(condition, x=None, y=None):
+def where(condition, x=None, y=None, /):
     """
     where(condition, [x, y], /)
 
@@ -465,7 +477,7 @@ def where(condition, x=None, y=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.lexsort)
-def lexsort(keys, axis=None):
+def lexsort(keys, axis=-1):
     """
     lexsort(keys, axis=-1)
 
@@ -586,7 +598,7 @@ def lexsort(keys, axis=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.can_cast)
-def can_cast(from_, to, casting=None):
+def can_cast(from_, to, casting="safe"):
     """
     can_cast(from_, to, casting='safe')
 
@@ -648,7 +660,7 @@ def can_cast(from_, to, casting=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.min_scalar_type)
-def min_scalar_type(a):
+def min_scalar_type(a, /):
     """
     min_scalar_type(a, /)
 
@@ -862,7 +874,7 @@ def dot(a, b, out=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.vdot)
-def vdot(a, b):
+def vdot(a, b, /):
     r"""
     vdot(a, b, /)
 
@@ -925,7 +937,7 @@ def vdot(a, b):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.bincount)
-def bincount(x, weights=None, minlength=None):
+def bincount(x, /, weights=None, minlength=0):
     """
     bincount(x, /, weights=None, minlength=0)
 
@@ -1001,7 +1013,7 @@ def bincount(x, weights=None, minlength=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.ravel_multi_index)
-def ravel_multi_index(multi_index, dims, mode=None, order=None):
+def ravel_multi_index(multi_index, dims, mode="raise", order="C"):
     """
     ravel_multi_index(multi_index, dims, mode='raise', order='C')
 
@@ -1059,7 +1071,7 @@ def ravel_multi_index(multi_index, dims, mode=None, order=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.unravel_index)
-def unravel_index(indices, shape=None, order=None):
+def unravel_index(indices, shape, order="C"):
     """
     unravel_index(indices, shape, order='C')
 
@@ -1104,7 +1116,7 @@ def unravel_index(indices, shape=None, order=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.copyto)
-def copyto(dst, src, casting=None, where=None):
+def copyto(dst, src, casting="same_kind", where=True):
     """
     copyto(dst, src, casting='same_kind', where=True)
 
@@ -1156,7 +1168,7 @@ def copyto(dst, src, casting=None, where=None):
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.putmask)
 def putmask(a, /, mask, values):
     """
-    putmask(a, mask, values)
+    putmask(a, /, mask, values)
 
     Changes elements of an array based on conditional and input values.
 
@@ -1200,7 +1212,7 @@ def putmask(a, /, mask, values):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.packbits)
-def packbits(a, axis=None, bitorder='big'):
+def packbits(a, /, axis=None, bitorder="big"):
     """
     packbits(a, /, axis=None, bitorder='big')
 
@@ -1257,7 +1269,7 @@ def packbits(a, axis=None, bitorder='big'):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.unpackbits)
-def unpackbits(a, axis=None, count=None, bitorder='big'):
+def unpackbits(a, /, axis=None, count=None, bitorder="big"):
     """
     unpackbits(a, /, axis=None, count=None, bitorder='big')
 
@@ -1337,9 +1349,9 @@ def unpackbits(a, axis=None, count=None, bitorder='big'):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.shares_memory)
-def shares_memory(a, b, max_work=None):
+def shares_memory(a, b, /, max_work=-1):
     """
-    shares_memory(a, b, /, max_work=None)
+    shares_memory(a, b, /, max_work=-1)
 
     Determine if two arrays share memory.
 
@@ -1416,9 +1428,9 @@ def shares_memory(a, b, max_work=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.may_share_memory)
-def may_share_memory(a, b, max_work=None):
+def may_share_memory(a, b, /, max_work=0):
     """
-    may_share_memory(a, b, /, max_work=None)
+    may_share_memory(a, b, /, max_work=0)
 
     Determine if two arrays might share memory
 
@@ -1458,14 +1470,14 @@ def may_share_memory(a, b, max_work=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.is_busday)
-def is_busday(dates, weekmask=None, holidays=None, busdaycal=None, out=None):
+def is_busday(dates, weekmask="1111100", holidays=None, busdaycal=None, out=None):
     """
     is_busday(
         dates,
         weekmask='1111100',
         holidays=None,
         busdaycal=None,
-        out=None
+        out=None,
     )
 
     Calculates which of the given dates are valid days, and which are not.
@@ -1517,7 +1529,7 @@ def is_busday(dates, weekmask=None, holidays=None, busdaycal=None, out=None):
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.busday_offset)
-def busday_offset(dates, offsets, roll=None, weekmask=None, holidays=None,
+def busday_offset(dates, offsets, roll="raise", weekmask="1111100", holidays=None,
                   busdaycal=None, out=None):
     """
     busday_offset(
@@ -1527,7 +1539,7 @@ def busday_offset(dates, offsets, roll=None, weekmask=None, holidays=None,
         weekmask='1111100',
         holidays=None,
         busdaycal=None,
-        out=None
+        out=None,
     )
 
     First adjusts the date to fall on a valid day according to
@@ -1619,7 +1631,7 @@ def busday_offset(dates, offsets, roll=None, weekmask=None, holidays=None,
 
 
 @array_function_from_c_func_and_dispatcher(_multiarray_umath.busday_count)
-def busday_count(begindates, enddates, weekmask=None, holidays=None,
+def busday_count(begindates, enddates, weekmask="1111100", holidays=(),
                  busdaycal=None, out=None):
     """
     busday_count(
@@ -1692,9 +1704,8 @@ def busday_count(begindates, enddates, weekmask=None, holidays=None,
     return (begindates, enddates, weekmask, holidays, out)
 
 
-@array_function_from_c_func_and_dispatcher(
-    _multiarray_umath.datetime_as_string)
-def datetime_as_string(arr, unit=None, timezone=None, casting=None):
+@array_function_from_c_func_and_dispatcher(_multiarray_umath.datetime_as_string)
+def datetime_as_string(arr, unit=None, timezone="naive", casting="same_kind"):
     """
     datetime_as_string(arr, unit=None, timezone='naive', casting='same_kind')
 

--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -18,7 +18,7 @@ from typing import (
 from typing_extensions import CapsuleType
 
 import numpy as np
-from numpy import (  # type: ignore[attr-defined]
+from numpy import (
     _AnyShapeT,
     _CastingKind,
     _CopyMode,
@@ -413,43 +413,47 @@ empty: Final[_ConstructorEmpty] = ...
 @overload
 def empty_like(
     prototype: _ArrayT,
+    /,
     dtype: None = None,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: _ShapeLike | None = ...,
+    order: _OrderKACF = "K",
+    subok: bool = True,
+    shape: _ShapeLike | None = None,
     *,
-    device: L["cpu"] | None = ...,
+    device: L["cpu"] | None = None,
 ) -> _ArrayT: ...
 @overload
 def empty_like(
     prototype: _ArrayLike[_ScalarT],
+    /,
     dtype: None = None,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: _ShapeLike | None = ...,
+    order: _OrderKACF = "K",
+    subok: bool = True,
+    shape: _ShapeLike | None = None,
     *,
-    device: L["cpu"] | None = ...,
+    device: L["cpu"] | None = None,
 ) -> NDArray[_ScalarT]: ...
 @overload
 def empty_like(
-    prototype: Any,
+    prototype: Incomplete,
+    /,
     dtype: _DTypeLike[_ScalarT],
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: _ShapeLike | None = ...,
+    order: _OrderKACF = "K",
+    subok: bool = True,
+    shape: _ShapeLike | None = None,
     *,
-    device: L["cpu"] | None = ...,
+    device: L["cpu"] | None = None,
 ) -> NDArray[_ScalarT]: ...
 @overload
 def empty_like(
-    prototype: Any,
-    dtype: DTypeLike | None = ...,
-    order: _OrderKACF = ...,
-    subok: bool = ...,
-    shape: _ShapeLike | None = ...,
+    prototype: Incomplete,
+    /,
+    dtype: DTypeLike | None = None,
+    order: _OrderKACF = "K",
+    subok: bool = True,
+    shape: _ShapeLike | None = None,
     *,
-    device: L["cpu"] | None = ...,
-) -> NDArray[Any]: ...
+    device: L["cpu"] | None = None,
+) -> NDArray[Incomplete]: ...
 
 @overload
 def array(
@@ -536,44 +540,44 @@ def unravel_index(indices: _ArrayLikeInt_co, shape: _ShapeLike, order: _OrderCF 
 
 # NOTE: Allow any sequence of array-like objects
 @overload
-def concatenate(  # type: ignore[misc]
+def concatenate(
     arrays: _ArrayLike[_ScalarT],
     /,
-    axis: SupportsIndex | None = ...,
+    axis: SupportsIndex | None = 0,
     out: None = None,
     *,
     dtype: None = None,
-    casting: _CastingKind | None = ...
+    casting: _CastingKind | None = "same_kind",
 ) -> NDArray[_ScalarT]: ...
-@overload
-def concatenate(  # type: ignore[misc]
-    arrays: SupportsLenAndGetItem[ArrayLike],
-    /,
-    axis: SupportsIndex | None = ...,
-    out: None = None,
-    *,
-    dtype: _DTypeLike[_ScalarT],
-    casting: _CastingKind | None = ...
-) -> NDArray[_ScalarT]: ...
-@overload
-def concatenate(  # type: ignore[misc]
-    arrays: SupportsLenAndGetItem[ArrayLike],
-    /,
-    axis: SupportsIndex | None = ...,
-    out: None = None,
-    *,
-    dtype: DTypeLike | None = None,
-    casting: _CastingKind | None = ...
-) -> NDArray[Any]: ...
 @overload
 def concatenate(
     arrays: SupportsLenAndGetItem[ArrayLike],
     /,
-    axis: SupportsIndex | None = ...,
+    axis: SupportsIndex | None = 0,
+    out: None = None,
+    *,
+    dtype: _DTypeLike[_ScalarT],
+    casting: _CastingKind | None = "same_kind",
+) -> NDArray[_ScalarT]: ...
+@overload
+def concatenate(
+    arrays: SupportsLenAndGetItem[ArrayLike],
+    /,
+    axis: SupportsIndex | None = 0,
+    out: None = None,
+    *,
+    dtype: DTypeLike | None = None,
+    casting: _CastingKind | None = "same_kind",
+) -> NDArray[Incomplete]: ...
+@overload
+def concatenate(
+    arrays: SupportsLenAndGetItem[ArrayLike],
+    /,
+    axis: SupportsIndex | None = 0,
     *,
     out: _ArrayT,
-    dtype: DTypeLike | None = ...,
-    casting: _CastingKind | None = ...
+    dtype: DTypeLike | None = None,
+    casting: _CastingKind | None = "same_kind",
 ) -> _ArrayT: ...
 @overload
 def concatenate(
@@ -582,115 +586,80 @@ def concatenate(
     axis: SupportsIndex | None,
     out: _ArrayT,
     *,
-    dtype: DTypeLike | None = ...,
-    casting: _CastingKind | None = ...
+    dtype: DTypeLike | None = None,
+    casting: _CastingKind | None = "same_kind",
 ) -> _ArrayT: ...
 
-def inner(
-    a: ArrayLike,
-    b: ArrayLike,
-    /,
-) -> Any: ...
+def inner(a: ArrayLike, b: ArrayLike, /) -> Incomplete: ...
 
 @overload
-def where(
-    condition: ArrayLike,
-    /,
-) -> tuple[NDArray[intp], ...]: ...
+def where(condition: ArrayLike, x: None = None, y: None = None, /) -> tuple[NDArray[intp], ...]: ...
 @overload
-def where(
-    condition: ArrayLike,
-    x: ArrayLike,
-    y: ArrayLike,
-    /,
-) -> NDArray[Any]: ...
+def where(condition: ArrayLike, x: ArrayLike, y: ArrayLike, /) -> NDArray[Incomplete]: ...
 
-def lexsort(
-    keys: ArrayLike,
-    axis: SupportsIndex | None = ...,
-) -> Any: ...
+def lexsort(keys: ArrayLike, axis: SupportsIndex = -1) -> NDArray[intp]: ...
 
-def can_cast(
-    from_: ArrayLike | DTypeLike,
-    to: DTypeLike,
-    casting: _CastingKind | None = ...,
-) -> bool: ...
+def can_cast(from_: ArrayLike | DTypeLike, to: DTypeLike, casting: _CastingKind = "safe") -> bool: ...
 
 def min_scalar_type(a: ArrayLike, /) -> dtype: ...
-
 def result_type(*arrays_and_dtypes: ArrayLike | DTypeLike | None) -> dtype: ...
 
 @overload
-def dot(a: ArrayLike, b: ArrayLike, out: None = None) -> Any: ...
+def dot(a: ArrayLike, b: ArrayLike, out: None = None) -> Incomplete: ...
 @overload
 def dot(a: ArrayLike, b: ArrayLike, out: _ArrayT) -> _ArrayT: ...
 
 @overload
-def vdot(a: _ArrayLikeBool_co, b: _ArrayLikeBool_co, /) -> np.bool: ...  # type: ignore[misc]
+def vdot(a: _ArrayLikeBool_co, b: _ArrayLikeBool_co, /) -> np.bool: ...
 @overload
-def vdot(a: _ArrayLikeUInt_co, b: _ArrayLikeUInt_co, /) -> unsignedinteger: ...  # type: ignore[misc]
+def vdot(a: _ArrayLikeUInt_co, b: _ArrayLikeUInt_co, /) -> unsignedinteger: ...
 @overload
-def vdot(a: _ArrayLikeInt_co, b: _ArrayLikeInt_co, /) -> signedinteger: ...  # type: ignore[misc]
+def vdot(a: _ArrayLikeInt_co, b: _ArrayLikeInt_co, /) -> signedinteger: ...
 @overload
-def vdot(a: _ArrayLikeFloat_co, b: _ArrayLikeFloat_co, /) -> floating: ...  # type: ignore[misc]
+def vdot(a: _ArrayLikeFloat_co, b: _ArrayLikeFloat_co, /) -> floating: ...
 @overload
-def vdot(a: _ArrayLikeComplex_co, b: _ArrayLikeComplex_co, /) -> complexfloating: ...  # type: ignore[misc]
+def vdot(a: _ArrayLikeComplex_co, b: _ArrayLikeComplex_co, /) -> complexfloating: ...
 @overload
 def vdot(a: _ArrayLikeTD64_co, b: _ArrayLikeTD64_co, /) -> timedelta64: ...
 @overload
-def vdot(a: _ArrayLikeObject_co, b: Any, /) -> Any: ...
+def vdot(a: _ArrayLikeObject_co, b: object, /) -> Any: ...
 @overload
-def vdot(a: Any, b: _ArrayLikeObject_co, /) -> Any: ...
+def vdot(a: object, b: _ArrayLikeObject_co, /) -> Any: ...
 
-def bincount(
-    x: ArrayLike,
-    /,
-    weights: ArrayLike | None = ...,
-    minlength: SupportsIndex = ...,
-) -> NDArray[intp]: ...
+def bincount(x: ArrayLike, /, weights: ArrayLike | None = None, minlength: SupportsIndex = 0) -> NDArray[intp]: ...
 
-def copyto(
-    dst: NDArray[Any],
-    src: ArrayLike,
-    casting: _CastingKind | None = ...,
-    where: _ArrayLikeBool_co | None = ...,
-) -> None: ...
+def copyto(dst: ndarray, src: ArrayLike, casting: _CastingKind = "same_kind", where: object = True) -> None: ...
+def putmask(a: ndarray, /, mask: _ArrayLikeBool_co, values: ArrayLike) -> None: ...
 
-def putmask(
-    a: NDArray[Any],
-    /,
-    mask: _ArrayLikeBool_co,
-    values: ArrayLike,
-) -> None: ...
+_BitOrder: TypeAlias = L["big", "little"]
 
-def packbits(
-    a: _ArrayLikeInt_co,
-    /,
-    axis: SupportsIndex | None = ...,
-    bitorder: L["big", "little"] = ...,
-) -> NDArray[uint8]: ...
+@overload
+def packbits(a: _ArrayLikeInt_co, /, axis: None = None, bitorder: _BitOrder = "big") -> ndarray[tuple[int], dtype[uint8]]: ...
+@overload
+def packbits(a: _ArrayLikeInt_co, /, axis: SupportsIndex, bitorder: _BitOrder = "big") -> NDArray[uint8]: ...
 
+@overload
 def unpackbits(
     a: _ArrayLike[uint8],
     /,
-    axis: SupportsIndex | None = ...,
-    count: SupportsIndex | None = ...,
-    bitorder: L["big", "little"] = ...,
+    axis: None = None,
+    count: SupportsIndex | None = None,
+    bitorder: _BitOrder = "big",
+) -> ndarray[tuple[int], dtype[uint8]]: ...
+@overload
+def unpackbits(
+    a: _ArrayLike[uint8],
+    /,
+    axis: SupportsIndex,
+    count: SupportsIndex | None = None,
+    bitorder: _BitOrder = "big",
 ) -> NDArray[uint8]: ...
 
-def shares_memory(
-    a: object,
-    b: object,
-    /,
-    max_work: int | None = ...,
-) -> bool: ...
+_MaxWork: TypeAlias = L[-1, 0]
 
-def may_share_memory(
-    a: object,
-    b: object,
-    /,
-    max_work: int | None = ...,
-) -> bool: ...
+# any two python objects will be accepted, not just `ndarray`s
+def shares_memory(a: object, b: object, /, max_work: _MaxWork = -1) -> bool: ...
+def may_share_memory(a: object, b: object, /, max_work: _MaxWork = 0) -> bool: ...
 
 @overload
 def asarray(
@@ -1096,175 +1065,180 @@ def datetime_data(
 # The datetime functions perform unsafe casts to `datetime64[D]`,
 # so a lot of different argument types are allowed here
 
+_ToDates: TypeAlias = dt.date | _NestedSequence[dt.date]
+_ToDeltas: TypeAlias = dt.timedelta | _NestedSequence[dt.timedelta]
+
 @overload
-def busday_count(  # type: ignore[misc]
+def busday_count(
     begindates: _ScalarLike_co | dt.date,
     enddates: _ScalarLike_co | dt.date,
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates = (),
+    busdaycal: busdaycalendar | None = None,
     out: None = None,
 ) -> int_: ...
 @overload
-def busday_count(  # type: ignore[misc]
-    begindates: ArrayLike | dt.date | _NestedSequence[dt.date],
-    enddates: ArrayLike | dt.date | _NestedSequence[dt.date],
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+def busday_count(
+    begindates: ArrayLike | _ToDates,
+    enddates: ArrayLike | _ToDates,
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates = (),
+    busdaycal: busdaycalendar | None = None,
     out: None = None,
 ) -> NDArray[int_]: ...
 @overload
 def busday_count(
-    begindates: ArrayLike | dt.date | _NestedSequence[dt.date],
-    enddates: ArrayLike | dt.date | _NestedSequence[dt.date],
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+    begindates: ArrayLike | _ToDates,
+    enddates: ArrayLike | _ToDates,
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates = (),
+    busdaycal: busdaycalendar | None = None,
     *,
     out: _ArrayT,
 ) -> _ArrayT: ...
 @overload
 def busday_count(
-    begindates: ArrayLike | dt.date | _NestedSequence[dt.date],
-    enddates: ArrayLike | dt.date | _NestedSequence[dt.date],
+    begindates: ArrayLike | _ToDates,
+    enddates: ArrayLike | _ToDates,
     weekmask: ArrayLike,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None,
+    holidays: ArrayLike | _ToDates,
     busdaycal: busdaycalendar | None,
     out: _ArrayT,
 ) -> _ArrayT: ...
 
 # `roll="raise"` is (more or less?) equivalent to `casting="safe"`
 @overload
-def busday_offset(  # type: ignore[misc]
+def busday_offset(
     dates: datetime64 | dt.date,
     offsets: _TD64Like_co | dt.timedelta,
-    roll: L["raise"] = ...,
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+    roll: L["raise"] = "raise",
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates | None = None,
+    busdaycal: busdaycalendar | None = None,
     out: None = None,
 ) -> datetime64: ...
 @overload
-def busday_offset(  # type: ignore[misc]
-    dates: _ArrayLike[datetime64] | dt.date | _NestedSequence[dt.date],
-    offsets: _ArrayLikeTD64_co | dt.timedelta | _NestedSequence[dt.timedelta],
-    roll: L["raise"] = ...,
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+def busday_offset(
+    dates: _ArrayLike[datetime64] | _NestedSequence[dt.date],
+    offsets: _ArrayLikeTD64_co | _ToDeltas,
+    roll: L["raise"] = "raise",
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates | None = None,
+    busdaycal: busdaycalendar | None = None,
     out: None = None,
 ) -> NDArray[datetime64]: ...
 @overload
-def busday_offset(  # type: ignore[misc]
-    dates: _ArrayLike[datetime64] | dt.date | _NestedSequence[dt.date],
-    offsets: _ArrayLikeTD64_co | dt.timedelta | _NestedSequence[dt.timedelta],
-    roll: L["raise"] = ...,
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+def busday_offset(
+    dates: _ArrayLike[datetime64] | _ToDates,
+    offsets: _ArrayLikeTD64_co | _ToDeltas,
+    roll: L["raise"] = "raise",
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates | None = None,
+    busdaycal: busdaycalendar | None = None,
     *,
     out: _ArrayT,
 ) -> _ArrayT: ...
 @overload
-def busday_offset(  # type: ignore[misc]
-    dates: _ArrayLike[datetime64] | dt.date | _NestedSequence[dt.date],
-    offsets: _ArrayLikeTD64_co | dt.timedelta | _NestedSequence[dt.timedelta],
+def busday_offset(
+    dates: _ArrayLike[datetime64] | _ToDates,
+    offsets: _ArrayLikeTD64_co | _ToDeltas,
     roll: L["raise"],
     weekmask: ArrayLike,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None,
+    holidays: ArrayLike | _ToDates | None,
     busdaycal: busdaycalendar | None,
     out: _ArrayT,
 ) -> _ArrayT: ...
 @overload
-def busday_offset(  # type: ignore[misc]
+def busday_offset(
     dates: _ScalarLike_co | dt.date,
     offsets: _ScalarLike_co | dt.timedelta,
     roll: _RollKind,
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates | None = None,
+    busdaycal: busdaycalendar | None = None,
     out: None = None,
 ) -> datetime64: ...
 @overload
-def busday_offset(  # type: ignore[misc]
-    dates: ArrayLike | dt.date | _NestedSequence[dt.date],
-    offsets: ArrayLike | dt.timedelta | _NestedSequence[dt.timedelta],
+def busday_offset(
+    dates: ArrayLike | _NestedSequence[dt.date],
+    offsets: ArrayLike | _ToDeltas,
     roll: _RollKind,
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates | None = None,
+    busdaycal: busdaycalendar | None = None,
     out: None = None,
 ) -> NDArray[datetime64]: ...
 @overload
 def busday_offset(
-    dates: ArrayLike | dt.date | _NestedSequence[dt.date],
-    offsets: ArrayLike | dt.timedelta | _NestedSequence[dt.timedelta],
+    dates: ArrayLike | _ToDates,
+    offsets: ArrayLike | _ToDeltas,
     roll: _RollKind,
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates | None = None,
+    busdaycal: busdaycalendar | None = None,
     *,
     out: _ArrayT,
 ) -> _ArrayT: ...
 @overload
 def busday_offset(
-    dates: ArrayLike | dt.date | _NestedSequence[dt.date],
-    offsets: ArrayLike | dt.timedelta | _NestedSequence[dt.timedelta],
+    dates: ArrayLike | _ToDates,
+    offsets: ArrayLike | _ToDeltas,
     roll: _RollKind,
     weekmask: ArrayLike,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None,
+    holidays: ArrayLike | _ToDates | None,
     busdaycal: busdaycalendar | None,
     out: _ArrayT,
 ) -> _ArrayT: ...
 
 @overload
-def is_busday(  # type: ignore[misc]
+def is_busday(
     dates: _ScalarLike_co | dt.date,
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates | None = None,
+    busdaycal: busdaycalendar | None = None,
     out: None = None,
 ) -> np.bool: ...
 @overload
-def is_busday(  # type: ignore[misc]
+def is_busday(
     dates: ArrayLike | _NestedSequence[dt.date],
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates | None = None,
+    busdaycal: busdaycalendar | None = None,
     out: None = None,
 ) -> NDArray[np.bool]: ...
 @overload
 def is_busday(
-    dates: ArrayLike | _NestedSequence[dt.date],
-    weekmask: ArrayLike = ...,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None = ...,
-    busdaycal: busdaycalendar | None = ...,
+    dates: ArrayLike | _ToDates,
+    weekmask: ArrayLike = "1111100",
+    holidays: ArrayLike | _ToDates | None = None,
+    busdaycal: busdaycalendar | None = None,
     *,
     out: _ArrayT,
 ) -> _ArrayT: ...
 @overload
 def is_busday(
-    dates: ArrayLike | _NestedSequence[dt.date],
+    dates: ArrayLike | _ToDates,
     weekmask: ArrayLike,
-    holidays: ArrayLike | dt.date | _NestedSequence[dt.date] | None,
+    holidays: ArrayLike | _ToDates | None,
     busdaycal: busdaycalendar | None,
     out: _ArrayT,
 ) -> _ArrayT: ...
 
+_TimezoneContext: TypeAlias = L["naive", "UTC", "local"] | dt.tzinfo
+
 @overload
-def datetime_as_string(  # type: ignore[misc]
+def datetime_as_string(
     arr: datetime64 | dt.date,
-    unit: L["auto"] | _UnitKind | None = ...,
-    timezone: L["naive", "UTC", "local"] | dt.tzinfo = ...,
-    casting: _CastingKind = ...,
+    unit: L["auto"] | _UnitKind | None = None,
+    timezone: _TimezoneContext = "naive",
+    casting: _CastingKind = "same_kind",
 ) -> str_: ...
 @overload
 def datetime_as_string(
     arr: _ArrayLikeDT64_co | _NestedSequence[dt.date],
-    unit: L["auto"] | _UnitKind | None = ...,
-    timezone: L["naive", "UTC", "local"] | dt.tzinfo = ...,
-    casting: _CastingKind = ...,
+    unit: L["auto"] | _UnitKind | None = None,
+    timezone: _TimezoneContext = "naive",
+    casting: _CastingKind = "same_kind",
 ) -> NDArray[str_]: ...
 
 @overload

--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -18,7 +18,7 @@ from typing import (
 from typing_extensions import CapsuleType
 
 import numpy as np
-from numpy import (
+from numpy import (  # type: ignore[attr-defined]  # Python >=3.12
     _AnyShapeT,
     _CastingKind,
     _CopyMode,

--- a/numpy/lib/_index_tricks_impl.pyi
+++ b/numpy/lib/_index_tricks_impl.pyi
@@ -1,4 +1,4 @@
-from _typeshed import Incomplete
+from _typeshed import Incomplete, SupportsLenAndGetItem
 from collections.abc import Sequence
 from typing import (
     Any,
@@ -14,11 +14,15 @@ from typing import (
 from typing_extensions import TypeVar
 
 import numpy as np
+from numpy import _CastingKind
 from numpy._core.multiarray import ravel_multi_index, unravel_index
 from numpy._typing import (
     ArrayLike,
+    DTypeLike,
     NDArray,
     _AnyShape,
+    _ArrayLike,
+    _DTypeLike,
     _FiniteNestedSequence,
     _NestedSequence,
     _SupportsArray,
@@ -149,13 +153,62 @@ class AxisConcatenator(Generic[_AxisT_co, _MatrixT_co, _NDMinT_co, _Trans1DT_co]
     def __getitem__(self, key: Incomplete, /) -> Incomplete: ...
     def __len__(self, /) -> L[0]: ...
 
-    #
+    # Keep in sync with _core.multiarray.concatenate
     @staticmethod
     @overload
-    def concatenate(*a: ArrayLike, axis: SupportsIndex | None = 0, out: _ArrayT) -> _ArrayT: ...
+    def concatenate(
+        arrays: _ArrayLike[_ScalarT],
+        /,
+        axis: SupportsIndex | None = 0,
+        out: None = None,
+        *,
+        dtype: None = None,
+        casting: _CastingKind | None = "same_kind",
+    ) -> NDArray[_ScalarT]: ...
     @staticmethod
     @overload
-    def concatenate(*a: ArrayLike, axis: SupportsIndex | None = 0, out: None = None) -> NDArray[Incomplete]: ...
+    def concatenate(
+        arrays: SupportsLenAndGetItem[ArrayLike],
+        /,
+        axis: SupportsIndex | None = 0,
+        out: None = None,
+        *,
+        dtype: _DTypeLike[_ScalarT],
+        casting: _CastingKind | None = "same_kind",
+    ) -> NDArray[_ScalarT]: ...
+    @staticmethod
+    @overload
+    def concatenate(
+        arrays: SupportsLenAndGetItem[ArrayLike],
+        /,
+        axis: SupportsIndex | None = 0,
+        out: None = None,
+        *,
+        dtype: DTypeLike | None = None,
+        casting: _CastingKind | None = "same_kind",
+    ) -> NDArray[Incomplete]: ...
+    @staticmethod
+    @overload
+    def concatenate(
+        arrays: SupportsLenAndGetItem[ArrayLike],
+        /,
+        axis: SupportsIndex | None = 0,
+        *,
+        out: _ArrayT,
+        dtype: DTypeLike | None = None,
+        casting: _CastingKind | None = "same_kind",
+    ) -> _ArrayT: ...
+    @staticmethod
+    @overload
+    def concatenate(
+        arrays: SupportsLenAndGetItem[ArrayLike],
+        /,
+        axis: SupportsIndex | None,
+        out: _ArrayT,
+        *,
+        dtype: DTypeLike | None = None,
+        casting: _CastingKind | None = "same_kind",
+    ) -> _ArrayT: ...
 
 @final
 class RClass(AxisConcatenator[L[0], L[False], L[1], L[-1]]):

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -3431,6 +3431,7 @@ def empty(
 @overload
 def empty_like(
     a: _MArrayT,
+    /,
     dtype: None = None,
     order: _OrderKACF = "K",
     subok: bool = True,
@@ -3441,6 +3442,7 @@ def empty_like(
 @overload
 def empty_like(
     a: _ArrayLike[_ScalarT],
+    /,
     dtype: None = None,
     order: _OrderKACF = "K",
     subok: bool = True,
@@ -3450,7 +3452,8 @@ def empty_like(
 ) -> _MaskedArray[_ScalarT]: ...
 @overload
 def empty_like(
-    a: object,
+    a: Incomplete,
+    /,
     dtype: _DTypeLike[_ScalarT],
     order: _OrderKACF = "K",
     subok: bool = True,
@@ -3460,7 +3463,8 @@ def empty_like(
 ) -> _MaskedArray[_ScalarT]: ...
 @overload
 def empty_like(
-    a: object,
+    a: Incomplete,
+    /,
     dtype: DTypeLike | None = None,
     order: _OrderKACF = "K",
     subok: bool = True,

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -5989,7 +5989,13 @@ def test_frommethod_signature(fn, signature):
                 "fill_value=None, hardmask=False)"
             ),
         ),
-        (np.ma.empty_like, "(*args, **kwargs)"),
+        (
+            np.ma.empty_like,
+            (
+                "(prototype, /, dtype=None, order='K', subok=True, shape=None, *, "
+                "device=None)"
+            ),
+        ),
         (np.ma.squeeze, "(a, axis=None, *, fill_value=None, hardmask=False)"),
         (
             np.ma.identity,

--- a/numpy/typing/tests/data/fail/multiarray.pyi
+++ b/numpy/typing/tests/data/fail/multiarray.pyi
@@ -26,10 +26,10 @@ np.copyto(AR_LIKE_f, AR_f8)  # type: ignore[arg-type]
 np.putmask(AR_LIKE_f, [True, True, False], 1.5)  # type: ignore[arg-type]
 
 np.packbits(AR_f8)  # type: ignore[arg-type]
-np.packbits(AR_u1, bitorder=">")  # type: ignore[arg-type]
+np.packbits(AR_u1, bitorder=">")  # type: ignore[call-overload]
 
 np.unpackbits(AR_i8)  # type: ignore[arg-type]
-np.unpackbits(AR_u1, bitorder=">")  # type: ignore[arg-type]
+np.unpackbits(AR_u1, bitorder=">")  # type: ignore[call-overload]
 
 np.shares_memory(1, 1, max_work=i8)  # type: ignore[arg-type]
 np.may_share_memory(1, 1, max_work=i8)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/pass/multiarray.py
+++ b/numpy/typing/tests/data/pass/multiarray.py
@@ -70,7 +70,8 @@ np.packbits(AR_u1)
 np.unpackbits(AR_u1)
 
 np.shares_memory(1, 2)
-np.shares_memory(AR_f8, AR_f8, max_work=1)
+np.shares_memory(AR_f8, AR_f8, max_work=-1)
 
 np.may_share_memory(1, 2)
-np.may_share_memory(AR_f8, AR_f8, max_work=1)
+np.may_share_memory(AR_f8, AR_f8, max_work=0)
+np.may_share_memory(AR_f8, AR_f8, max_work=-1)

--- a/numpy/typing/tests/data/reveal/multiarray.pyi
+++ b/numpy/typing/tests/data/reveal/multiarray.pyi
@@ -66,7 +66,7 @@ assert_type(np.inner(AR_f8, AR_i8), Any)
 assert_type(np.where([True, True, False]), tuple[npt.NDArray[np.intp], ...])
 assert_type(np.where([True, True, False], 1, 0), npt.NDArray[Any])
 
-assert_type(np.lexsort([0, 1, 2]), Any)
+assert_type(np.lexsort([0, 1, 2]), npt.NDArray[np.intp])
 
 assert_type(np.can_cast(np.dtype("i8"), int), bool)
 assert_type(np.can_cast(AR_f8, "f8"), bool)
@@ -94,16 +94,19 @@ assert_type(np.copyto(AR_f8, [1., 1.5, 1.6]), None)
 
 assert_type(np.putmask(AR_f8, [True, True, False], 1.5), None)
 
-assert_type(np.packbits(AR_i8), npt.NDArray[np.uint8])
-assert_type(np.packbits(AR_u1), npt.NDArray[np.uint8])
+assert_type(np.packbits(AR_i8),  np.ndarray[tuple[int], np.dtype[np.uint8]])
+assert_type(np.packbits(AR_u1),  np.ndarray[tuple[int], np.dtype[np.uint8]])
+assert_type(np.packbits(AR_i8, axis=1), npt.NDArray[np.uint8])
+assert_type(np.packbits(AR_u1, axis=1), npt.NDArray[np.uint8])
 
-assert_type(np.unpackbits(AR_u1), npt.NDArray[np.uint8])
+assert_type(np.unpackbits(AR_u1), np.ndarray[tuple[int], np.dtype[np.uint8]])
+assert_type(np.unpackbits(AR_u1, axis=1), npt.NDArray[np.uint8])
 
 assert_type(np.shares_memory(1, 2), bool)
-assert_type(np.shares_memory(AR_f8, AR_f8, max_work=1), bool)
+assert_type(np.shares_memory(AR_f8, AR_f8, max_work=-1), bool)
 
 assert_type(np.may_share_memory(1, 2), bool)
-assert_type(np.may_share_memory(AR_f8, AR_f8, max_work=1), bool)
+assert_type(np.may_share_memory(AR_f8, AR_f8, max_work=0), bool)
 
 assert_type(np.promote_types(np.int32, np.int64), np.dtype)
 assert_type(np.promote_types("f4", float), np.dtype)


### PR DESCRIPTION
This is yet another batch of `inspect.signature` fixes, similar to #30104, #30114, #30121, #30124, #30126, #30137, #30138, and #30140. The following functions are affected:

- `numpy.empty_like`
- `numpy.concatenate`
- `numpy.inner`
- `numpy.where`
- `numpy.lexsort`
- `numpy.can_cast`
- `numpy.min_scalar_type`
- `numpy.result_type`
- `numpy.dot`
- `numpy.vdot`
- `numpy.bincount`
- `numpy.ravel_multi_index`
- `numpy.unravel_index`
- `numpy.copyto,`
- `numpy.putmask`
- `numpy.packbits`
- `numpy.unpackbits`
- `numpy.shares_memory`
- `numpy.may_share_memory`
- `numpy.is_busday`
- `numpy.busday_offset`
- `numpy.busday_count`
- `numpy.datetime_as_string`