### PR TITLE
ENH: Enable native half-precision scalar conversion operations on RISC-V

### DIFF
--- a/numpy/_core/src/common/half.hpp
+++ b/numpy/_core/src/common/half.hpp
@@ -42,6 +42,9 @@ class Half final {
     #elif defined(__ARM_FP16_FORMAT_IEEE)
         __fp16 f16 = __fp16(f);
         bits_ = BitCast<uint16_t>(f16);
+    #elif defined(__riscv_zfh)
+        _Float16 f16 = _Float16(f);
+        bits_ = BitCast<uint16_t>(f16);
     #else
         bits_ = half_private::FromFloatBits(BitCast<uint32_t>(f));
     #endif
@@ -59,6 +62,9 @@ class Half final {
         __asm__ __volatile__ ("xscvdphp %x0,%x1" : "=wa" (bits_) : "wa" (f));
     #elif defined(__ARM_FP16_FORMAT_IEEE)
         __fp16 f16 = __fp16(f);
+        bits_ = BitCast<uint16_t>(f16);
+    #elif defined(__riscv_zfh)
+        _Float16 f16 = _Float16(f);
         bits_ = BitCast<uint16_t>(f16);
     #else
         bits_ = half_private::FromDoubleBits(BitCast<uint64_t>(f));
@@ -82,6 +88,8 @@ class Half final {
         return vec_extract(vf32, 0);
     #elif defined(__ARM_FP16_FORMAT_IEEE)
         return float(BitCast<__fp16>(bits_));
+    #elif defined(__riscv_zfh)
+        return float(BitCast<_Float16>(bits_));
     #else
         return BitCast<float>(half_private::ToFloatBits(bits_));
     #endif
@@ -102,6 +110,8 @@ class Half final {
         return f64;
     #elif defined(__ARM_FP16_FORMAT_IEEE)
         return double(BitCast<__fp16>(bits_));
+    #elif defined(__riscv_zfh)
+        return double(BitCast<_Float16>(bits_));
     #else
         return BitCast<double>(half_private::ToDoubleBits(bits_));
     #endif


### PR DESCRIPTION
Test environment: Banana Pi BPI-F3 (SpacemiT K1 8-core RISC-V chip) gcc version 14.2.0
Test command: `spin bench --compare HEAD~1 -t "bench_scalar"`


(numpy_venv) root@yangwang:/home/yangwang/numpy# `gcc -E -dM - </dev/null | grep __riscv_zfh`
#define __riscv_zfhmin 1000000
#define __riscv_zfh 1000000


(numpy_venv) root@yangwang:/home/yangwang/numpy#` cat /proc/cpuinfo | grep isa`
isa             : rv64imafdcv_zicbom_zicboz_zicntr_zicond_zicsr_zifencei_zihintpause_zihpm_zfh_zfhmin_zca_zcd_zba_zbb_zbc_zbs_zkt_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_zvkt_sscofpmf_sstc_svinval_svnapot_svpbmt


(numpy_venv) root@yangwang:/home/yangwang/numpy# git log -2
commit 3876f75e01076ce5a78e4ea215b4cafa28e9b80b (HEAD -> main)
Author: Wang Yang <yangwang@iscas.ac.cn>
Date:   Tue Nov 4 13:26:57 2025 +0800
ENH: Enable native half-precision scalar conversion operations on RISC-V

commit 1e424dae42a2d560520b6e053e8e60ac4205bfc7 (origin/main, origin/HEAD)
Author: Rafael Laboissière <rafael@laboissiere.net>
Date:   Sun Nov 2 18:46:22 2025 +0100

BUG: Avoid compilation error of wrapper file generated with SWIG >= 4.4 (#30128)



<img width="1709" height="491" alt="half_float_riscv_zfh" src="https://github.com/user-attachments/assets/0ca4f10c-79bb-4678-9975-b76269cfd9ba" />
