### PR TITLE
DOC: add example for out in concatenate

### DIFF
--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -256,7 +256,12 @@ def concatenate(arrays, axis=None, out=None, *, dtype=None, casting=None):
     >>> import numpy as np
     >>> a = np.array([[1, 2], [3, 4]])
     >>> b = np.array([[5, 6]])
-    >>> np.concatenate((a, b), axis=0)
+    >>> c = np.array([[7, 8], [9, 10], [11, 12]])
+    >>> np.concatenate((a, b), axis=0, out=c)
+    array([[1, 2],
+           [3, 4],
+           [5, 6]])
+    >>> c
     array([[1, 2],
            [3, 4],
            [5, 6]])


### PR DESCRIPTION
## Description
This adds an example of the 'out' parameter with an argument in the 'concatenate' function present in 'numpy/_core/multiarray.py'.

## Motivation
It may be a bit tricky to understand what the 'out' parameter does.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
