### PR TITLE
DOC: Fix Returns section formatting in linalg.qr and linalg.svd

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -1024,7 +1024,7 @@ def qr(a, mode='reduced'):
     Notes
     -----
     When mode is 'reduced' or 'complete', the result will be a namedtuple with
-    the attributes `Q` and `R`.
+    the attributes ``Q`` and ``R``.
 
     This is an interface to the LAPACK routines ``dgeqrf``, ``zgeqrf``,
     ``dorgqr``, and ``zungqr``.

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -995,9 +995,6 @@ def qr(a, mode='reduced'):
 
     Returns
     -------
-    When mode is 'reduced' or 'complete', the result will be a namedtuple with
-    the attributes `Q` and `R`.
-
     Q : ndarray of float or complex, optional
         A matrix with orthonormal columns. When mode = 'complete' the
         result is an orthogonal/unitary matrix depending on whether or not
@@ -1026,6 +1023,9 @@ def qr(a, mode='reduced'):
 
     Notes
     -----
+    When mode is 'reduced' or 'complete', the result will be a namedtuple with
+    the attributes `Q` and `R`.
+
     This is an interface to the LAPACK routines ``dgeqrf``, ``zgeqrf``,
     ``dorgqr``, and ``zungqr``.
 
@@ -1696,9 +1696,6 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
 
     Returns
     -------
-    When `compute_uv` is True, the result is a namedtuple with the following
-    attribute names:
-
     U : { (..., M, M), (..., M, K) } array
         Unitary array(s). The first ``a.ndim - 2`` dimensions have the same
         size as those of the input `a`. The size of the last two dimensions
@@ -1726,6 +1723,9 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
 
     Notes
     -----
+    When `compute_uv` is True, the result is a namedtuple with the following
+    attribute names: `U`, `S`, and `Vh`.
+
     The decomposition is performed using LAPACK routine ``_gesdd``.
 
     SVD is usually described for the factorization of a 2D matrix :math:`A`.


### PR DESCRIPTION
Move initial return information from Returns section to Notes section to comply with numpydoc standards and fix rendering issues.

Fixes #29779
[skip actions][skip azp][skip cirrus]

## Description
Move initial narrative text from Returns section to Notes section to comply with numpydoc standards and fix rendering issues.

## Changes Made
- Moved explanatory text about namedtuple returns from Returns section to Notes section for both `qr()` and `svd()` functions
- Maintained all original content while fixing the structure
- Ensured Returns section only contains actual return parameters

## Related Issue
Fixes #29779

## Documentation
This is a documentation-only change that improves the rendering of the API reference.

## Checklist
- [x] I have read the [contributing guidelines](https://numpy.org/doc/stable/dev/index.html#guidelines)
- [x] Builds locally without issues
- [x] Documentation change only
- [x] Follows numpydoc standards

## References
- [numpydoc style guide](https://numpydoc.readthedocs.io/en/latest/format.html#sections)
