### PR TITLE
MAINT: Not show signature in git_version

### DIFF
--- a/numpy/_build_utils/gitversion.py
+++ b/numpy/_build_utils/gitversion.py
@@ -28,7 +28,7 @@ def git_version(version):
     git_hash = ''
     try:
         p = subprocess.Popen(
-            ['git', 'log', '-1', '--format="%H %aI"'],
+            ['git', '-c', 'log.showSignature=false', 'log', '-1', '--format="%H %aI"'],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=os.path.dirname(__file__),


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

When $HOME/.gitconfig has `log.showSignature=true`, git log is like this

```
(main) $ git log -1 --format="%H %aI"
gpg: Signature made Wed 05 Nov 2025 07:57:32 AM JST
gpg:                using RSA key B5690EEEBB952194
gpg: Can't check signature: No public key
7aa023f008969a43648aaf4c3e707349abc7a2f7 2025-11-04T23:57:32+01:00
```

In this way, git_version() is prevented. We should pass -c log.showSignature=false explicitly to hide the signature 