### PR TITLE
BUG: update requires to requirements in numpy.multiarray see #30142

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1793,7 +1793,7 @@ cleanup:;
  */
 NPY_NO_EXPORT PyObject *
 PyArray_CheckFromAny(PyObject *op, PyArray_Descr *descr, int min_depth,
-                     int max_depth, int requires, PyObject *context)
+                     int max_depth, int requirements, PyObject *context)
 {
     npy_dtype_info dt_info = {NULL, NULL};
 
@@ -1814,7 +1814,7 @@ PyArray_CheckFromAny(PyObject *op, PyArray_Descr *descr, int min_depth,
     }
 
     PyObject* ret =  PyArray_CheckFromAny_int(
-        op, dt_info.descr, dt_info.dtype, min_depth, max_depth, requires,
+        op, dt_info.descr, dt_info.dtype, min_depth, max_depth, requirements,
         context);
 
     Py_XDECREF(dt_info.descr);
@@ -1829,11 +1829,11 @@ PyArray_CheckFromAny(PyObject *op, PyArray_Descr *descr, int min_depth,
 NPY_NO_EXPORT PyObject *
 PyArray_CheckFromAny_int(PyObject *op, PyArray_Descr *in_descr,
                          PyArray_DTypeMeta *in_DType, int min_depth,
-                         int max_depth, int requires, PyObject *context)
+                         int max_depth, int requirements, PyObject *context)
 {
     PyObject *obj;
     Py_XINCREF(in_descr);  /* take ownership as we may replace it */
-    if (requires & NPY_ARRAY_NOTSWAPPED) {
+    if (requirements & NPY_ARRAY_NOTSWAPPED) {
         if (!in_descr && PyArray_Check(op)) {
             in_descr = PyArray_DESCR((PyArrayObject *)op);
             Py_INCREF(in_descr);
@@ -1848,16 +1848,16 @@ PyArray_CheckFromAny_int(PyObject *op, PyArray_Descr *in_descr,
 
     int was_scalar;
     obj = PyArray_FromAny_int(op, in_descr, in_DType, min_depth,
-                              max_depth, requires, context, &was_scalar);
+                              max_depth, requirements, context, &was_scalar);
     Py_XDECREF(in_descr);
     if (obj == NULL) {
         return NULL;
     }
 
-    if ((requires & NPY_ARRAY_ELEMENTSTRIDES)
+    if ((requirements & NPY_ARRAY_ELEMENTSTRIDES)
             && !PyArray_ElementStrides(obj)) {
         PyObject *ret;
-        if (requires & NPY_ARRAY_ENSURENOCOPY) {
+        if (requirements & NPY_ARRAY_ENSURENOCOPY) {
             PyErr_SetString(PyExc_ValueError, npy_no_copy_err_msg);
             return NULL;
         }

--- a/numpy/_core/src/multiarray/ctors.h
+++ b/numpy/_core/src/multiarray/ctors.h
@@ -68,11 +68,11 @@ PyArray_FromAny(PyObject *op, PyArray_Descr *newtype, int min_depth,
 NPY_NO_EXPORT PyObject *
 PyArray_CheckFromAny_int(PyObject *op, PyArray_Descr *in_descr,
                          PyArray_DTypeMeta *in_DType, int min_depth,
-                         int max_depth, int requires, PyObject *context);
+                         int max_depth, int requirements, PyObject *context);
 
 NPY_NO_EXPORT PyObject *
 PyArray_CheckFromAny(PyObject *op, PyArray_Descr *descr, int min_depth,
-                     int max_depth, int requires, PyObject *context);
+                     int max_depth, int requirements, PyObject *context);
 
 NPY_NO_EXPORT PyObject *
 PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags);


### PR DESCRIPTION
### Summary:
In response to a [failure in compilation](https://github.com/numpy/numpy/actions/runs/19056916192/job/54429123184?pr=30142#step:5:901) of #30142 where the `requires` identifier is reserved in C++-20. 

### What was done:
`requires` has been replaced with `requirements` to match [documentation](https://numpy.org/devdocs/reference/c-api/array.html#c.PyArray_CheckFromAny). 

Closes #30151 