### PR TITLE
BUG, DOC: ``ndarray`` dunder method runtime signatures and missing docs

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2315,8 +2315,10 @@ add_newdoc('numpy._core.multiarray', 'c_einsum',
 
 add_newdoc('numpy._core.multiarray', 'ndarray',
     """
-    ndarray(shape, dtype=float, buffer=None, offset=0,
-            strides=None, order=None)
+    ndarray(shape, dtype=None, buffer=None, offset=0, strides=None, order=None)
+    --
+
+    ndarray(shape, dtype=float, buffer=None, offset=0, strides=None, order=None)
 
     An array object represents a multidimensional, homogeneous array
     of fixed-size items.  An associated data-type object describes the
@@ -2339,6 +2341,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray',
         Shape of created array.
     dtype : data-type, optional
         Any object that can be interpreted as a numpy data type.
+        Default is `numpy.float64`.
     buffer : object exposing buffer interface, optional
         Used to fill the array with data.
     offset : int, optional
@@ -2456,21 +2459,6 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_priority__',
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_struct__',
     """Array protocol: C-struct side."""))
 
-add_newdoc('numpy._core.multiarray', 'ndarray', ('__dlpack__',
-    """
-    a.__dlpack__(*, stream=None, max_version=None, dl_device=None, copy=None)
-
-    DLPack Protocol: Part of the Array API.
-
-    """))
-
-add_newdoc('numpy._core.multiarray', 'ndarray', ('__dlpack_device__',
-    """
-    a.__dlpack_device__()
-
-    DLPack Protocol: Part of the Array API.
-
-    """))
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('base',
     """
@@ -3084,6 +3072,42 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_finalize__',
     """))
 
 
+add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_function__',
+    """
+    __array_function__($self, /, func, types, args, kwargs)
+    --
+
+    a.__array_function__(func, types, args, kwargs)
+
+    See :ref:`NEP 18 <NEP18>` and :ref:`NEP 35 <NEP35>` for details.
+
+    """))
+
+
+add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_namespace__',
+    """
+    __array_namespace__($self, /, *, api_version=None)
+    --
+
+    a.__array_namespace__(*, api_version=None)
+
+    For Array API compatibility.
+
+    """))
+
+
+add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_ufunc__',
+    """
+    __array_ufunc__($self, ufunc, method, /, *inputs, **kwargs)
+    --
+
+    a.__array_ufunc__(ufunc, method, /, *inputs, **kwargs)
+
+    See :ref:`NEP 13 <NEP13>` for details.
+
+    """))
+
+
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_wrap__',
     """
     __array_wrap__($self, array, context=None, return_scalar=True, /)
@@ -3092,6 +3116,38 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__array_wrap__',
     a.__array_wrap__(array[, context[, return_scalar]], /)
 
     Returns a view of `array` with the same type as self.
+
+    """))
+
+
+add_newdoc('numpy._core.multiarray', 'ndarray', ('__class_getitem__',
+    """
+    __class_getitem__($cls, item, /)
+    --
+
+    ndarray[shape, dtype]
+
+    Return a parametrized wrapper around the `~numpy.ndarray` type.
+
+    .. versionadded:: 1.22
+
+    Returns
+    -------
+    alias : types.GenericAlias
+        A parametrized `~numpy.ndarray` type.
+
+    Examples
+    --------
+    >>> import numpy as np
+
+    >>> np.ndarray[tuple[int], np.dtype[np.uint8]]
+    numpy.ndarray[tuple[int], numpy.dtype[numpy.uint8]]
+
+    See Also
+    --------
+    :pep:`585` : Type hinting generics in standard collections.
+    numpy.typing.NDArray : An ndarray alias :term:`generic <generic type>`
+                        w.r.t. its `dtype.type <numpy.dtype.type>`.
 
     """))
 
@@ -3110,39 +3166,6 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__copy__',
     """))
 
 
-add_newdoc('numpy._core.multiarray', 'ndarray', ('__class_getitem__',
-    """
-    __class_getitem__($cls, item, /)
-    --
-
-    a.__class_getitem__(item, /)
-
-    Return a parametrized wrapper around the `~numpy.ndarray` type.
-
-    .. versionadded:: 1.22
-
-    Returns
-    -------
-    alias : types.GenericAlias
-        A parametrized `~numpy.ndarray` type.
-
-    Examples
-    --------
-    >>> from typing import Any
-    >>> import numpy as np
-
-    >>> np.ndarray[Any, np.dtype[np.uint8]]
-    numpy.ndarray[typing.Any, numpy.dtype[numpy.uint8]]
-
-    See Also
-    --------
-    :pep:`585` : Type hinting generics in standard collections.
-    numpy.typing.NDArray : An ndarray alias :term:`generic <generic type>`
-                        w.r.t. its `dtype.type <numpy.dtype.type>`.
-
-    """))
-
-
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__deepcopy__',
     """
     __deepcopy__($self, memo, /)
@@ -3155,12 +3178,49 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__deepcopy__',
     """))
 
 
+add_newdoc('numpy._core.multiarray', 'ndarray', ('__dlpack__',
+    """
+    __dlpack__($self, /, *, stream=None, max_version=None, dl_device=None, copy=None)
+    --
+
+    a.__dlpack__(*, stream=None, max_version=None, dl_device=None, copy=None)
+
+    Exports the array for consumption by ``from_dlpack()`` as a DLPack capsule.
+
+    """))
+
+
+add_newdoc('numpy._core.multiarray', 'ndarray', ('__dlpack_device__',
+    """
+    __dlpack_device__($self, /)
+    --
+
+    a.__dlpack_device__()
+
+    Returns device type (``1``) and device ID (``0``) in DLPack format.
+    Meant for use within ``from_dlpack()``.
+
+    """))
+
+
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__reduce__',
     """
     __reduce__($self, /)
     --
 
     a.__reduce__()
+
+    For pickling.
+
+    """))
+
+
+add_newdoc('numpy._core.multiarray', 'ndarray', ('__reduce_ex__',
+    """
+    __reduce_ex__($self, protocol, /)
+    --
+
+    a.__reduce_ex__(protocol, /)
 
     For pickling.
 
@@ -4572,6 +4632,31 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('take',
     See Also
     --------
     numpy.take : equivalent function
+
+    """))
+
+
+add_newdoc('numpy._core.multiarray', 'ndarray', ('to_device',
+    """
+    to_device($self, device, /, *, stream=None)
+    --
+
+    a.to_device(device, /, *, stream=None)
+
+    For Array API compatibility.  Since NumPy only supports CPU arrays, this
+    method is a no-op that returns the same array.
+
+    Parameters
+    ----------
+    device : "cpu"
+        Must be ``"cpu"``.
+    stream : None, optional
+        Currently unsupported.
+
+    Returns
+    -------
+    out : Self
+        Returns the same array.
 
     """))
 

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -2899,7 +2899,8 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
     /* for the sys module */
     {"__sizeof__",
         (PyCFunction) array_sizeof,
-        METH_NOARGS, NULL},
+        METH_NOARGS,
+        "__sizeof__($self, /)\n--\n\nSize in memory."},
 
     /* for the copy module */
     {"__copy__",
@@ -2928,11 +2929,13 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
 
     {"__complex__",
         (PyCFunction) array_complex,
-        METH_VARARGS, NULL},
+        METH_VARARGS,
+        "__complex__($self, /)\n--\n\ncomplex(self)"},
 
     {"__format__",
         (PyCFunction) array_format,
-        METH_VARARGS, NULL},
+        METH_VARARGS,
+        "__format__($self, spec, /)\n--\n\nformat(self[, spec])"},
 
     {"__class_getitem__",
         (PyCFunction)array_class_getitem,

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10880,8 +10880,9 @@ def test_array_dunder_array_preserves_dtype_on_none(dtype):
 @pytest.mark.parametrize(
     "methodname",
     [
-        "__array__", "__array_finalize__", "__array_wrap__",
-        "__copy__", "__deepcopy__", "__reduce__", "__setstate__",
+        "__array__", "__array_finalize__", "__array_function__", "__array_ufunc__",
+        "__array_wrap__", "__complex__", "__copy__", "__deepcopy__",
+        "__reduce__", "__reduce_ex__", "__setstate__",
         "all", "any", "argmax", "argmin", "argsort", "argpartition", "astype",
         "byteswap", "choose", "clip", "compress", "conj", "conjugate", "copy",
         "cumprod", "cumsum", "diagonal", "dot", "dump", "dumps", "fill", "flatten",
@@ -10889,6 +10890,7 @@ def test_array_dunder_array_preserves_dtype_on_none(dtype):
         "repeat", "reshape", "resize", "round", "searchsorted", "setfield", "setflags",
         "sort", "partition", "squeeze", "std", "sum", "swapaxes", "take", "tofile",
         "tolist", "tobytes", "trace", "transpose", "var", "view",
+        "__array_namespace__", "__dlpack__", "__dlpack_device__", "to_device",
     ],
 )
 def test_array_method_signatures(methodname: str):


### PR DESCRIPTION
This fixes `inspect.signature` for 

- `ndarray`
- `ndarray.__array_function__`
- `ndarray.__array_ufunc__`
- `ndarray.__complex__`
- `ndarray.__format__`
- `ndarray.__sizeof__`
- `ndarray.__reduce_ex__`
- `ndarray.__array_namespace__`
- `ndarray.__dlpack__`
- `ndarray.__dlpack_device__`
- `ndarray.to_device`

Docstrings *were* also missing for these methods.

Related to #30104, #30114, #30121, #30124, #30126, #30137, #30138, #30140, #30143, #30146, and #30147.