### PR TITLE
ENH: Reduce compute time for `tobytes` in non-contiguos paths

### DIFF
--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -14,8 +14,7 @@ class Core(Benchmark):
         self.l_view = [memoryview(a) for a in self.l]
         self.l10x10 = np.ones((10, 10))
         self.float64_dtype = np.dtype(np.float64)
-        self.noncontig = np.arange(10000).reshape(100, 100).T
-        assert not self.noncontig.flags.contiguous
+        self.arr = np.arange(10000).reshape(100, 100)
 
     def time_array_1(self):
         np.array(1)
@@ -51,10 +50,7 @@ class Core(Benchmark):
         np.can_cast(self.l10x10, self.float64_dtype)
 
     def time_tobytes_noncontiguous(self):
-        self.noncontig.tobytes()
-
-    def time_tobytes_contiguous(self):
-        np.ascontiguousarray(self.noncontig).tobytes()
+        self.arr.T.tobytes()
 
     def time_can_cast_same_kind(self):
         np.can_cast(self.l10x10, self.float64_dtype, casting="same_kind")

--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -14,6 +14,8 @@ class Core(Benchmark):
         self.l_view = [memoryview(a) for a in self.l]
         self.l10x10 = np.ones((10, 10))
         self.float64_dtype = np.dtype(np.float64)
+        self.noncontig = np.arange(10000).reshape(100, 100).T
+        assert not self.noncontig.flags.contiguous
 
     def time_array_1(self):
         np.array(1)
@@ -47,6 +49,12 @@ class Core(Benchmark):
 
     def time_can_cast(self):
         np.can_cast(self.l10x10, self.float64_dtype)
+        
+    def time_tobytes_noncontiguous(self):
+        self.noncontig.tobytes()
+        
+    def time_tobytes_contiguous(self):
+        np.ascontiguousarray(self.noncontig).tobytes()
 
     def time_can_cast_same_kind(self):
         np.can_cast(self.l10x10, self.float64_dtype, casting="same_kind")

--- a/benchmarks/benchmarks/bench_core.py
+++ b/benchmarks/benchmarks/bench_core.py
@@ -49,10 +49,10 @@ class Core(Benchmark):
 
     def time_can_cast(self):
         np.can_cast(self.l10x10, self.float64_dtype)
-        
+
     def time_tobytes_noncontiguous(self):
         self.noncontig.tobytes()
-        
+
     def time_tobytes_contiguous(self):
         np.ascontiguousarray(self.noncontig).tobytes()
 

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -429,7 +429,7 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
 
     }
 
-    /* Non-contiguous, No References, No Init Path.  */
+    /* Non-contiguous, Has References and/or Init Path.  */
     PyArrayObject *contig = (PyArrayObject *)PyArray_Ravel(self, order);
     if (contig == NULL) {
         return NULL;

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -335,11 +335,7 @@ NPY_NO_EXPORT PyObject *
 PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
 {
     npy_intp numbytes;
-    npy_intp i;
-    char *dptr;
-    int elsize;
     PyObject *ret;
-    PyArrayIterObject *it;
 
     if (order == NPY_ANYORDER)
         order = PyArray_ISFORTRAN(self) ? NPY_FORTRANORDER : NPY_CORDER;

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -369,6 +369,7 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
         
         /* Writable Buffer */
         char* dest = PyBytes_AS_STRING(ret);
+        memset(dest, 0, numbytes);
         
         /* Strides compute */
         npy_intp *strides = PyArray_malloc(PyArray_NDIM(self) * sizeof(npy_intp));
@@ -396,6 +397,7 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
             }
         }
 
+        Py_INCREF(PyArray_DESCR(self));
         /* Array view */
         PyArrayObject *dest_array = (PyArrayObject *)PyArray_NewFromDescr(
             &PyArray_Type,

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -353,11 +353,11 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
         return PyBytes_FromStringAndSize(PyArray_DATA(self), (Py_ssize_t) numbytes);
     }
     
-    /* Avoid Ravel where possible for lesser copies. */
+    /* Avoid Ravel where possible for fewer copies. */
     if (!PyDataType_REFCHK(PyArray_DESCR(self)) && 
         ((PyArray_DESCR(self)->flags & NPY_NEEDS_INIT) == 0)) {
         
-        /* Allocate final Byte Object */
+        /* Allocate final Bytes Object */
         ret = PyBytes_FromStringAndSize(NULL, (Py_ssize_t) numbytes);
         if (ret == NULL) {
             return NULL;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10411,18 +10411,6 @@ def test_getfield():
     pytest.raises(ValueError, a.getfield, 'uint8', 16)
     pytest.raises(ValueError, a.getfield, 'uint64', 0)
 
-@pytest.mark.parametrize("shape", [(3, 224, 224), (8, 512, 512)])
-def test_tobytes_noncontiguous_not_slower_than_copy(shape):
-    # Test correctness non-contiguos paths for `tobytes`
-    rng = np.random.default_rng(0)
-    arr = rng.standard_normal(shape, dtype=np.float32)
-    noncontig = arr.transpose(1, 2, 0)
-
-    # correctness
-    expected = np.ascontiguousarray(noncontig).tobytes()
-    got = noncontig.tobytes()
-    assert got == expected
-
 class TestViewDtype:
     """
     Verify that making a view of a non-contiguous array works as expected.

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10411,6 +10411,28 @@ def test_getfield():
     pytest.raises(ValueError, a.getfield, 'uint8', 16)
     pytest.raises(ValueError, a.getfield, 'uint64', 0)
 
+@pytest.mark.parametrize("shape", [(3, 224, 224), (8, 512, 512)])
+def test_tobytes_noncontiguous_not_slower_than_copy(shape):
+    rng = np.random.default_rng(0)
+    arr = rng.standard_normal(shape, dtype=np.float32)
+    noncontig = arr.transpose(1, 2, 0)
+
+    # correctness   
+    expected = np.ascontiguousarray(noncontig).tobytes()
+    got = noncontig.tobytes()
+    assert got == expected
+
+    n_iter = 5
+    def bench(fn):
+        start = time.perf_counter()
+        for _ in range(n_iter):
+            fn()
+        return time.perf_counter() - start
+
+    t_contig = bench(lambda: np.ascontiguousarray(noncontig).tobytes())
+    t_direct = bench(noncontig.tobytes)
+
+    assert t_direct <= t_contig * 1.5
 
 class TestViewDtype:
     """

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10418,7 +10418,7 @@ def test_tobytes_noncontiguous_not_slower_than_copy(shape):
     arr = rng.standard_normal(shape, dtype=np.float32)
     noncontig = arr.transpose(1, 2, 0)
 
-    # correctness   
+    # correctness
     expected = np.ascontiguousarray(noncontig).tobytes()
     got = noncontig.tobytes()
     assert got == expected

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3792,6 +3792,18 @@ class TestMethods:
         assert_(isinstance(a.ravel('A'), ArraySubclass))
         assert_(isinstance(a.ravel('K'), ArraySubclass))
 
+    @pytest.mark.parametrize("shape", [(3, 224, 224), (8, 512, 512)])
+    def test_tobytes_no_copy_fastpath(self, shape):
+        # Test correctness of non-contiguous paths for `tobytes`
+        rng = np.random.default_rng(0)
+        arr = rng.standard_normal(shape, dtype=np.float32)
+        noncontig = arr.transpose(1, 2, 0)
+
+        # correctness
+        expected = np.ascontiguousarray(noncontig).tobytes()
+        got = noncontig.tobytes()
+        assert got == expected
+
     def test_swapaxes(self):
         a = np.arange(1 * 2 * 3 * 4).reshape(1, 2, 3, 4).copy()
         idx = np.indices(a.shape)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -16,7 +16,6 @@ import tempfile
 import warnings
 import weakref
 from contextlib import contextmanager
-import time
 
 # Need to test an object that does not fully implement math interface
 from datetime import datetime, timedelta
@@ -10414,6 +10413,7 @@ def test_getfield():
 
 @pytest.mark.parametrize("shape", [(3, 224, 224), (8, 512, 512)])
 def test_tobytes_noncontiguous_not_slower_than_copy(shape):
+    # Test correctness non-contiguos paths for `tobytes`
     rng = np.random.default_rng(0)
     arr = rng.standard_normal(shape, dtype=np.float32)
     noncontig = arr.transpose(1, 2, 0)
@@ -10422,18 +10422,6 @@ def test_tobytes_noncontiguous_not_slower_than_copy(shape):
     expected = np.ascontiguousarray(noncontig).tobytes()
     got = noncontig.tobytes()
     assert got == expected
-
-    n_iter = 5
-    def bench(fn):
-        start = time.perf_counter()
-        for _ in range(n_iter):
-            fn()
-        return time.perf_counter() - start
-
-    t_contig = bench(lambda: np.ascontiguousarray(noncontig).tobytes())
-    t_direct = bench(noncontig.tobytes)
-
-    assert t_direct <= t_contig * 1.5
 
 class TestViewDtype:
     """

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -16,6 +16,7 @@ import tempfile
 import warnings
 import weakref
 from contextlib import contextmanager
+import time
 
 # Need to test an object that does not fully implement math interface
 from datetime import datetime, timedelta

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -72,18 +72,6 @@ class TestRegression:
         a = np.ones(2)
         assert_(a is np.asarray(a, order='F'))
 
-    @pytest.mark.parametrize("shape", [(3, 224, 224), (8, 512, 512)])
-    def test_tobytes_no_copy_fastpath(self, shape):
-        # Test correctness of non-contiguous paths for `tobytes`
-        rng = np.random.default_rng(0)
-        arr = rng.standard_normal(shape, dtype=np.float32)
-        noncontig = arr.transpose(1, 2, 0)
-
-        # correctness
-        expected = np.ascontiguousarray(noncontig).tobytes()
-        got = noncontig.tobytes()
-        assert got == expected
-
     def test_ravel_with_order(self):
         # Check that ravel works when order='F' and array C/F-contiguous
         a = np.ones(2)

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -72,6 +72,18 @@ class TestRegression:
         a = np.ones(2)
         assert_(a is np.asarray(a, order='F'))
 
+    @pytest.mark.parametrize("shape", [(3, 224, 224), (8, 512, 512)])
+    def test_tobytes_no_copy_fastpath(self, shape):
+        # Test correctness of non-contiguous paths for `tobytes`
+        rng = np.random.default_rng(0)
+        arr = rng.standard_normal(shape, dtype=np.float32)
+        noncontig = arr.transpose(1, 2, 0)
+
+        # correctness
+        expected = np.ascontiguousarray(noncontig).tobytes()
+        got = noncontig.tobytes()
+        assert got == expected
+
     def test_ravel_with_order(self):
         # Check that ravel works when order='F' and array C/F-contiguous
         a = np.ones(2)


### PR DESCRIPTION
Fixes #30048 

This PR adopts better copying strategies than the previous element by element copying for non-contiguos paths.