### PR TITLE
BUG: Fix check of PyMem_Calloc return value.

### DIFF
--- a/numpy/_core/src/umath/wrapping_array_method.c
+++ b/numpy/_core/src/umath/wrapping_array_method.c
@@ -114,7 +114,7 @@ get_wrapping_auxdata(void)
     }
     else {
         res = PyMem_Calloc(1, sizeof(wrapping_auxdata));
-        if (res < 0) {
+        if (res == NULL) {
             PyErr_NoMemory();
             return NULL;
         }


### PR DESCRIPTION
Stumbled across this while reviewing our handling of `PyMem_` allocation functions.