### PR TITLE
MAINT,API: Introduce __numpy_dtype__ and fix dtype attribute recursion

### DIFF
--- a/doc/release/upcoming_changes/30179.new_feature.rst
+++ b/doc/release/upcoming_changes/30179.new_feature.rst
@@ -1,0 +1,13 @@
+New ``__numpy_dtype__`` protocol
+--------------------------------
+NumPy now has a new ``__numpy_dtype__`` protocol. NumPy will check
+for this attribute when converting to a NumPy dtype via ``np.dtype(obj)``
+or any ``dtype=`` argument.
+
+Downstream projects are encouraged to implement this for all dtype like
+objects which may previously have used a ``.dtype`` attribute that returned
+a NumPy dtype.
+For array-like objects we encourage you to implement ``__numpy_dtype__``
+with a warning or error to _prevent_ using e.g. ``dtype=dataframe`` in
+NumPy functions (it may be good to go via a Deprecation).
+We expect deprecating coercion via ``.dtype`` in the future.

--- a/doc/release/upcoming_changes/30179.new_feature.rst
+++ b/doc/release/upcoming_changes/30179.new_feature.rst
@@ -7,7 +7,7 @@ or any ``dtype=`` argument.
 Downstream projects are encouraged to implement this for all dtype like
 objects which may previously have used a ``.dtype`` attribute that returned
 a NumPy dtype.
-For array-like objects we encourage you to implement ``__numpy_dtype__``
-with a warning or error to _prevent_ using e.g. ``dtype=dataframe`` in
-NumPy functions (it may be good to go via a Deprecation).
-We expect deprecating coercion via ``.dtype`` in the future.
+We expect to deprecate ``.dtype`` in the future to prevent interpreting
+array-like objects with a ``.dtype`` attribute as a dtype.
+If you wish you can implement ``__numpy_dtype__`` to ensure an earlier
+warning or error (``.dtype`` is ignored if this is found).

--- a/doc/source/user/basics.interoperability.rst
+++ b/doc/source/user/basics.interoperability.rst
@@ -65,6 +65,18 @@ and outputs a NumPy ndarray (which is generally a view of the input object's dat
 buffer). The :ref:`dlpack:python-spec` page explains the ``__dlpack__`` protocol
 in detail.
 
+``dtype`` interoperability
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Similar to ``__array__()`` for array objects, defining ``__numpy_dtype__``
+allows a custom dtype object to be interoperable with NumPy.
+The ``__numpy_dtype__`` must return a NumPy dtype instance (note that
+``np.float64`` is not a dtype instance, ``np.dtype(np.float64)`` is).
+
+.. versionadded:: 2.4
+   Before NumPy 2.4 a ``.dtype`` attribute was treated similarly. As of NumPy 2.4
+   both is accepted and implementing ``__numpy_dtype__`` prevents ``.dtype``
+   from being checked.
+
 The array interface protocol
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/numpy/_core/src/multiarray/descriptor.h
+++ b/numpy/_core/src/multiarray/descriptor.h
@@ -44,9 +44,6 @@ NPY_NO_EXPORT PyObject *arraydescr_protocol_descr_get(
 NPY_NO_EXPORT PyObject *
 array_set_typeDict(PyObject *NPY_UNUSED(ignored), PyObject *args);
 
-NPY_NO_EXPORT PyArray_Descr *
-_arraydescr_try_convert_from_dtype_attr(PyObject *obj);
-
 
 NPY_NO_EXPORT int
 is_dtype_struct_simple_unaligned_layout(PyArray_Descr *dtype);

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -38,6 +38,7 @@ intern_strings(void)
     INTERN_STRING(array_ufunc, "__array_ufunc__");
     INTERN_STRING(array_wrap, "__array_wrap__");
     INTERN_STRING(array_finalize, "__array_finalize__");
+    INTERN_STRING(numpy_dtype, "__numpy_dtype__");
     INTERN_STRING(implementation, "_implementation");
     INTERN_STRING(axis1, "axis1");
     INTERN_STRING(axis2, "axis2");

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -24,6 +24,7 @@ typedef struct npy_interned_str_struct {
     PyObject *array_wrap;
     PyObject *array_finalize;
     PyObject *array_ufunc;
+    PyObject *numpy_dtype;
     PyObject *implementation;
     PyObject *axis1;
     PyObject *axis2;

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1580,19 +1580,19 @@ class TestFromDTypeAttribute:
         assert np.dtype(dt) == np.float64
         assert np.dtype(dt()) == np.float64
 
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
-    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
-    def test_recursion(self):
+    def test_recursive(self):
+        # This used to recurse. It now doesn't, we enforce the
+        # dtype attribute to be a dtype (and will not recurse).
         class dt:
             pass
 
         dt.dtype = dt
-        with pytest.raises(RecursionError):
+        with pytest.raises(ValueError):
             np.dtype(dt)
 
         dt_instance = dt()
         dt_instance.dtype = dt
-        with pytest.raises(RecursionError):
+        with pytest.raises(ValueError):
             np.dtype(dt_instance)
 
     def test_void_subtype(self):
@@ -1605,19 +1605,56 @@ class TestFromDTypeAttribute:
         np.dtype(dt)
         np.dtype(dt(1))
 
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
-    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
-    def test_void_subtype_recursion(self):
+    def test_void_subtype_recursive(self):
+        # Used to recurse, but dtype is now enforced to be a dtype instance
+        # so that we do not recurse.
         class vdt(np.void):
             pass
 
         vdt.dtype = vdt
 
-        with pytest.raises(RecursionError):
+        with pytest.raises(ValueError):
             np.dtype(vdt)
 
-        with pytest.raises(RecursionError):
+        with pytest.raises(ValueError):
             np.dtype(vdt(1))
+
+
+class TestFromDTypeProtocol:
+    def test_simple(self):
+        class A:
+            dtype = np.dtype("f8")
+
+        assert np.dtype(A()) == np.dtype(np.float64)
+
+    def test_not_a_dtype(self):
+        # This also prevents coercion as a trivial path, although
+        # a custom error may be nicer.
+        class ArrayLike:
+            __numpy_dtype__ = None
+            dtype = np.dtype("f8")
+
+        with pytest.raises(ValueError, match=".*__numpy_dtype__.*"):
+            np.dtype(ArrayLike())
+
+    def test_prevent_dtype_explicit(self):
+        class ArrayLike:
+            @property
+            def __numpy_dtype__(self):
+                raise RuntimeError("my error!")
+
+        with pytest.raises(RuntimeError, match="my error!"):
+            np.dtype(ArrayLike())
+
+    def test_type_object(self):
+        class TypeWithProperty:
+            @property
+            def __numpy_dtype__(self):
+                raise RuntimeError("not reached")
+
+        # Arbitrary types go to object currently, and the
+        # protocol doesn't prevent that.
+        assert np.dtype(TypeWithProperty) == object
 
 
 class TestDTypeClasses:


### PR DESCRIPTION
This is a lot more complex then I expected. We, correctly, deprecated `.dtype` attribute lookup recursion, however...
The code still had a `try/except` that still recursed and that try except carried meaning at least in a weird path of:
```
class mydtype(np.void):
    dtype = ...
```

Now does that make sense? Maybe not... we also fall back to object in some paths which should have been broken when a dtype attribute existed on a type but it is a property/descriptor.

So, this removes the recursion, but adds a check for `__get__` to filter out those cases, this is something we successfully did for other protocols `__array__`, `__array_interface__`, etc.
