### PR TITLE
MAINT: Take advantage of C++ for more robust use of the PyGILState_* API.

### DIFF
--- a/numpy/_core/include/numpy/npy_common.h
+++ b/numpy/_core/include/numpy/npy_common.h
@@ -387,6 +387,39 @@ typedef struct
     long double _Val[2];
 } npy_clongdouble;
 
+//
+// In C++ code, use this at the beginning of a scope, e.g.
+//
+//     {
+//         EnsureGIL ensure_gil{};
+//         [code that uses the Python C API here]
+//     }
+//
+// instead of
+//
+//     NPY_ALLOW_C_API_DEF
+//     NPY_ALLOW_C_API
+//     [code that uses the Python C API here]
+//     NPY_DISABLE_C_API
+//
+// This ensures that PyGILState_Release(__save__) is called,  even if the
+// wrapped code throws an exception or executes a return or a goto.
+//
+class EnsureGIL
+{
+    PyGILState_STATE __save__;
+
+public:
+
+    EnsureGIL() {
+        __save__ = PyGILState_Ensure();
+    }
+
+    ~EnsureGIL() {
+        PyGILState_Release(__save__);
+    }
+};
+
 #else
 
 #include <complex.h>

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -1933,8 +1933,7 @@ string_to_bytes(PyArrayMethod_Context *context, char *const data[],
 
         for (size_t i=0; i<s.size; i++) {
             if (((unsigned char *)s.buf)[i] > 127) {
-                NPY_ALLOW_C_API_DEF;
-                NPY_ALLOW_C_API;
+                EnsureGIL ensure_gil{};
                 PyObject *str = PyUnicode_FromStringAndSize(s.buf, s.size);
 
                 if (str == NULL) {
@@ -1962,7 +1961,6 @@ string_to_bytes(PyArrayMethod_Context *context, char *const data[],
                 PyErr_SetObject(PyExceptionInstance_Class(exc), exc);
                 Py_DECREF(exc);
                 Py_DECREF(str);
-                NPY_DISABLE_C_API;
                 goto fail;
             }
         }

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -186,11 +186,12 @@ unique_numeric(PyArrayObject *self, npy_bool equal_nan)
     * Returns a new NumPy array containing the unique values of the input array of numeric (integer or complex).
     * This function uses hashing to identify uniqueness efficiently.
     */
-    NPY_ALLOW_C_API_DEF;
-    NPY_ALLOW_C_API;
-    PyArray_Descr *descr = PyArray_DESCR(self);
-    Py_INCREF(descr);
-    NPY_DISABLE_C_API;
+    PyArray_Descr *descr;
+    {
+        EnsureGIL ensure_gil{};
+        descr = PyArray_DESCR(self);
+        Py_INCREF(descr);
+    }
 
     PyThreadState *_save1 = PyEval_SaveThread();
 
@@ -223,23 +224,25 @@ unique_numeric(PyArrayObject *self, npy_bool equal_nan)
     npy_intp length = hashset.size();
 
     PyEval_RestoreThread(_save1);
-    NPY_ALLOW_C_API;
-    PyObject *res_obj = PyArray_NewFromDescr(
-        &PyArray_Type,
-        descr,
-        1, // ndim
-        &length, // shape
-        NULL, // strides
-        NULL, // data
-        // This flag is needed to be able to call .sort on it.
-        NPY_ARRAY_WRITEABLE, // flags
-        NULL // obj
-    );
+    PyObject *res_obj;
+    {
+        EnsureGIL ensure_gil{};
+        res_obj = PyArray_NewFromDescr(
+            &PyArray_Type,
+            descr,
+            1, // ndim
+            &length, // shape
+            NULL, // strides
+            NULL, // data
+            // This flag is needed to be able to call .sort on it.
+            NPY_ARRAY_WRITEABLE, // flags
+            NULL // obj
+        );
 
-    if (res_obj == NULL) {
-        return NULL;
+        if (res_obj == NULL) {
+            return NULL;
+        }
     }
-    NPY_DISABLE_C_API;
     PyThreadState *_save2 = PyEval_SaveThread();
     auto save2_dealloc = finally([&]() {
         PyEval_RestoreThread(_save2);
@@ -263,11 +266,12 @@ unique_string(PyArrayObject *self, npy_bool equal_nan)
     * Returns a new NumPy array containing the unique values of the input array of fixed size strings.
     * This function uses hashing to identify uniqueness efficiently.
     */
-    NPY_ALLOW_C_API_DEF;
-    NPY_ALLOW_C_API;
-    PyArray_Descr *descr = PyArray_DESCR(self);
-    Py_INCREF(descr);
-    NPY_DISABLE_C_API;
+    PyArray_Descr *descr;
+    {
+        EnsureGIL ensure_gil{};
+        descr = PyArray_DESCR(self);
+        Py_INCREF(descr);
+    }
 
     PyThreadState *_save1 = PyEval_SaveThread();
 
@@ -303,23 +307,24 @@ unique_string(PyArrayObject *self, npy_bool equal_nan)
     npy_intp length = hashset.size();
 
     PyEval_RestoreThread(_save1);
-    NPY_ALLOW_C_API;
-    PyObject *res_obj = PyArray_NewFromDescr(
-        &PyArray_Type,
-        descr,
-        1, // ndim
-        &length, // shape
-        NULL, // strides
-        NULL, // data
-        // This flag is needed to be able to call .sort on it.
-        NPY_ARRAY_WRITEABLE, // flags
-        NULL // obj
-    );
-
+    PyObject *res_obj;
+    {
+        EnsureGIL ensure_gil{};
+        res_obj = PyArray_NewFromDescr(
+            &PyArray_Type,
+            descr,
+            1, // ndim
+            &length, // shape
+            NULL, // strides
+            NULL, // data
+            // This flag is needed to be able to call .sort on it.
+            NPY_ARRAY_WRITEABLE, // flags
+            NULL // obj
+        );
+    }
     if (res_obj == NULL) {
         return NULL;
     }
-    NPY_DISABLE_C_API;
     PyThreadState *_save2 = PyEval_SaveThread();
     auto save2_dealloc = finally([&]() {
         PyEval_RestoreThread(_save2);
@@ -342,11 +347,12 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
     * Returns a new NumPy array containing the unique values of the input array.
     * This function uses hashing to identify uniqueness efficiently.
     */
-    NPY_ALLOW_C_API_DEF;
-    NPY_ALLOW_C_API;
-    PyArray_Descr *descr = PyArray_DESCR(self);
-    Py_INCREF(descr);
-    NPY_DISABLE_C_API;
+    PyArray_Descr *descr;
+    {
+        EnsureGIL ensure_gil{};
+        descr = PyArray_DESCR(self);
+        Py_INCREF(descr);
+    }
 
     PyThreadState *_save1 = PyEval_SaveThread();
 
@@ -412,24 +418,28 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
     npy_intp length = hashset.size();
 
     PyEval_RestoreThread(_save1);
-    NPY_ALLOW_C_API;
-    PyObject *res_obj = PyArray_NewFromDescr(
-        &PyArray_Type,
-        descr,
-        1, // ndim
-        &length, // shape
-        NULL, // strides
-        NULL, // data
-        // This flag is needed to be able to call .sort on it.
-        NPY_ARRAY_WRITEABLE, // flags
-        NULL // obj
-    );
-    if (res_obj == NULL) {
-        return NULL;
+
+    PyObject *res_obj;
+    PyArray_Descr *res_descr;
+    {
+        EnsureGIL ensure_gil{};
+        res_obj = PyArray_NewFromDescr(
+            &PyArray_Type,
+            descr,
+            1, // ndim
+            &length, // shape
+            NULL, // strides
+            NULL, // data
+            // This flag is needed to be able to call .sort on it.
+            NPY_ARRAY_WRITEABLE, // flags
+            NULL // obj
+        );
+        if (res_obj == NULL) {
+            return NULL;
+        }
+        res_descr = PyArray_DESCR((PyArrayObject *)res_obj);
+        Py_INCREF(res_descr);
     }
-    PyArray_Descr *res_descr = PyArray_DESCR((PyArrayObject *)res_obj);
-    Py_INCREF(res_descr);
-    NPY_DISABLE_C_API;
 
     PyThreadState *_save2 = PyEval_SaveThread();
     auto save2_dealloc = finally([&]() {


### PR DESCRIPTION
In C++ code, instead of writing

    NPY_ALLOW_C_API_DEF
    NPY_ALLOW_C_API
    [code that uses the Python C API here]
    NPY_DISABLE_C_API

we can write

    {
        EnsureGIL ensure_gil{};
        [code that uses the Python C API here]
    }

This ensures that `PyGILState_Release(__save__)` is called,  even if the wrapped code throws an exception or executes a return or a goto. The latter currently occurs in a few places in our code.