### PR TITLE
BUG: Fix check of PyMem_Calloc return value. (#30176)

### DIFF
--- a/numpy/_core/src/umath/wrapping_array_method.c
+++ b/numpy/_core/src/umath/wrapping_array_method.c
@@ -114,7 +114,7 @@ get_wrapping_auxdata(void)
     }
     else {
         res = PyMem_Calloc(1, sizeof(wrapping_auxdata));
-        if (res < 0) {
+        if (res == NULL) {
             PyErr_NoMemory();
             return NULL;
         }


### PR DESCRIPTION
Backport of #30176.

Stumbled across this while reviewing our handling of `PyMem_` allocation functions.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
