### PR TITLE
BLD: use pykg-config on windows instead of pkgconfiglite

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,7 +62,7 @@ jobs:
       - name: pkg-config-for-win
         if: runner.os == 'windows'
         run: |
-		  python3 -m pip install pykg-config
+          python3 -m pip install pykg-config
           $CIBW = "${{ github.workspace }}/.openblas"
           # pkgconfig needs a complete path, and not just "./openblas since the
           # build is run in a tmp dir (?)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,7 +62,7 @@ jobs:
       - name: pkg-config-for-win
         if: runner.os == 'windows'
         run: |
-          choco install -y --no-progress --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
+		  python3 -m pip install pykg-config
           $CIBW = "${{ github.workspace }}/.openblas"
           # pkgconfig needs a complete path, and not just "./openblas since the
           # build is run in a tmp dir (?)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,7 +62,6 @@ jobs:
       - name: pkg-config-for-win
         if: runner.os == 'windows'
         run: |
-          python3 -m pip install pykg-config
           $CIBW = "${{ github.workspace }}/.openblas"
           # pkgconfig needs a complete path, and not just "./openblas since the
           # build is run in a tmp dir (?)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,16 +40,11 @@ jobs:
       run: |
         pip install -r requirements/build_requirements.txt
 
-    - name: Install pkg-config
-      run: |
-        python -m pip install pykg-config
-        echo "PKG_CONFIG_PATH=${{ github.workspace }}/.openblas" >> $env:GITHUB_ENV
-
     - name: Install NumPy (Clang-cl)
       run: |
         "[binaries]","c = 'clang-cl'","cpp = 'clang-cl'","ar = 'llvm-lib'","c_ld = 'lld-link'","cpp_ld = 'lld-link'" | Out-File $PWD/clang-cl-build.ini -Encoding ascii
         pip install -r requirements/ci_requirements.txt
-        spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini
+        spin build --with-scipy-openblas=32 -j2 -- --vsenv --native-file=$PWD/clang-cl-build.ini -Dpkg_config_path=$PWD/.openblas
 
     - name: Meson Log
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Install pkg-config
       run: |
-        choco install -y --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
+        python -m pip install pykg-config
         echo "PKG_CONFIG_PATH=${{ github.workspace }}/.openblas" >> $env:GITHUB_ENV
 
     - name: Install NumPy (Clang-cl)

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -13,9 +13,6 @@ steps:
 - script: python -m pip install -r requirements/test_requirements.txt
   displayName: 'Install dependencies; some are optional to avoid test skips'
 
-- script: python -m pip install pykg-config
-  displayName: 'Install utilities'
-
 - powershell: |
     # Note: ensure the `pip install .` command remains the last one here,
     # to avoid "green on failure" issues
@@ -25,13 +22,11 @@ steps:
     elseif ( Test-Path env:_USE_BLAS_ILP64 ) {
         pip install -r requirements/ci_requirements.txt
         spin config-openblas --with-scipy-openblas=64
-        $env:PKG_CONFIG_PATH="$pwd/.openblas"
-        python -m pip install . -v -Csetup-args="--vsenv"
+        python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Dpkg_config_path=$pwd/.openblas"
     } else {
         pip install -r requirements/ci_requirements.txt
         spin config-openblas --with-scipy-openblas=32
-        $env:PKG_CONFIG_PATH="$pwd/.openblas"
-        python -m pip install . -v -Csetup-args="--vsenv" 
+        python -m pip install . -v -Csetup-args="--vsenv" -Csetup-args="-Dpkg_config_path=$pwd/.openblas"
     }
   displayName: 'Build NumPy'
 

--- a/azure-steps-windows.yml
+++ b/azure-steps-windows.yml
@@ -13,8 +13,7 @@ steps:
 - script: python -m pip install -r requirements/test_requirements.txt
   displayName: 'Install dependencies; some are optional to avoid test skips'
 
-- powershell: |
-    choco install -y --stoponfirstfailure --checksum 6004DF17818F5A6DBF19CB335CC92702 pkgconfiglite
+- script: python -m pip install pykg-config
   displayName: 'Install utilities'
 
 - powershell: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ build-backend = "mesonpy"
 requires = [
     "meson-python>=0.18.0",
     "Cython>=3.0.6",  # keep in sync with version check in meson.build
+    "pykg-config ; platform_system == 'Windows'"
 ]
 
 [project]

--- a/requirements/build_requirements.txt
+++ b/requirements/build_requirements.txt
@@ -3,3 +3,4 @@ Cython>=3.0.6
 ninja
 spin==0.15
 build
+pypkg-config; sys_platform == 'win32'

--- a/requirements/build_requirements.txt
+++ b/requirements/build_requirements.txt
@@ -3,4 +3,4 @@ Cython>=3.0.6
 ninja
 spin==0.15
 build
-pypkg-config; sys_platform == 'win32'
+pykg-config; sys_platform == 'win32'


### PR DESCRIPTION
Fixes #30187 by using the pure-python pykg-config. A possible improvement would be to add pykg-config as a build requirement.