### PR TITLE
BUG: Change return type of sign(timedelta64) to float64.

### DIFF
--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -526,8 +526,10 @@ defdict = {
 'sign':
     Ufunc(1, 1, None,
           docstrings.get('numpy._core.umath.sign'),
-          'PyUFunc_SimpleUniformOperationTypeResolver',
-          TD(nobool_or_datetime, dispatch=[('loops_autovec', ints)]),
+          'PyUFunc_SignTypeResolver',
+          TD(ints + flts, dispatch=[('loops_autovec', ints)]),
+          TD(timedeltaonly, out='d'),
+          TD(cmplx + O),
           ),
 'greater':
     Ufunc(2, 1, None,

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -688,7 +688,12 @@ TIMEDELTA_sign(char **args, npy_intp const *dimensions, npy_intp const *steps, v
 {
     UNARY_LOOP {
         const npy_timedelta in1 = *(npy_timedelta *)ip1;
-        *((npy_timedelta *)op1) = in1 > 0 ? 1 : (in1 < 0 ? -1 : 0);
+        if (in1 == NPY_DATETIME_NAT) {
+            *((npy_double *)op1) = NPY_NAN;
+        }
+        else {
+            *((npy_double *)op1) = in1 > 0 ? 1.0 : (in1 < 0 ? -1.0 : 0.0);
+        }
     }
 }
 

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -445,6 +445,9 @@ PyUFunc_SignTypeResolver(PyUFuncObject *ufunc,
 {
     if (PyArray_DESCR(operands[0])->type_num == NPY_TIMEDELTA) {
         out_dtypes[0] = NPY_DT_CALL_ensure_canonical(PyArray_DESCR(operands[0]));
+        if (out_dtypes[0] == NULL) {
+            return -1;
+        }
         out_dtypes[1] = PyArray_DescrFromType(NPY_DOUBLE);
         return 0;
     }
@@ -609,6 +612,9 @@ PyUFunc_SimpleUniformOperationTypeResolver(
             descr = PyArray_DESCR(operands[0]);
         }
         out_dtypes[0] = NPY_DT_CALL_ensure_canonical(descr);
+        if (out_dtypes[0] == NULL) {
+            return -1;
+        }
     }
 
     /* All types are the same - copy the first one to the rest */
@@ -675,6 +681,9 @@ PyUFunc_IsNaTTypeResolver(PyUFuncObject *ufunc,
     }
 
     out_dtypes[0] = NPY_DT_CALL_ensure_canonical(PyArray_DESCR(operands[0]));
+    if (out_dtypes[0] == NULL) {
+        return -1;
+    }
     out_dtypes[1] = PyArray_DescrFromType(NPY_BOOL);
 
     return 0;
@@ -694,6 +703,9 @@ PyUFunc_IsFiniteTypeResolver(PyUFuncObject *ufunc,
     }
 
     out_dtypes[0] = NPY_DT_CALL_ensure_canonical(PyArray_DESCR(operands[0]));
+    if (out_dtypes[0] == NULL) {
+        return -1;
+    }
     out_dtypes[1] = PyArray_DescrFromType(NPY_BOOL);
 
     return 0;

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -429,6 +429,31 @@ PyUFunc_NegativeTypeResolver(PyUFuncObject *ufunc,
     return ret;
 }
 
+/*
+ * This function applies special type resolution rules for the 'sign' ufunc.
+ * 'sign' converts timedelta64 to float64, so isn't covered by the simple
+ * unary type resolution.
+ *
+ * Returns 0 on success, -1 on error.
+ */
+NPY_NO_EXPORT int
+PyUFunc_SignTypeResolver(PyUFuncObject *ufunc,
+                         NPY_CASTING casting,
+                         PyArrayObject **operands,
+                         PyObject *type_tup,
+                         PyArray_Descr **out_dtypes)
+{
+    if (PyArray_DESCR(operands[0])->type_num == NPY_TIMEDELTA) {
+        out_dtypes[0] = NPY_DT_CALL_ensure_canonical(PyArray_DESCR(operands[0]));
+        out_dtypes[1] = PyArray_DescrFromType(NPY_DOUBLE);
+        return 0;
+    }
+    else {
+        return PyUFunc_SimpleUniformOperationTypeResolver(ufunc, casting,
+                    operands, type_tup, out_dtypes);
+    }
+}
+
 
 /*
  * The ones_like function shouldn't really be a ufunc, but while it

--- a/numpy/_core/src/umath/ufunc_type_resolution.h
+++ b/numpy/_core/src/umath/ufunc_type_resolution.h
@@ -20,6 +20,13 @@ PyUFunc_NegativeTypeResolver(PyUFuncObject *ufunc,
                              PyArray_Descr **out_dtypes);
 
 NPY_NO_EXPORT int
+PyUFunc_SignTypeResolver(PyUFuncObject *ufunc,
+                         NPY_CASTING casting,
+                         PyArrayObject **operands,
+                         PyObject *type_tup,
+                         PyArray_Descr **out_dtypes);
+
+NPY_NO_EXPORT int
 PyUFunc_OnesLikeTypeResolver(PyUFuncObject *ufunc,
                              NPY_CASTING casting,
                              PyArrayObject **operands,

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1124,6 +1124,10 @@ class TestDateTime:
         s = np.sign(x)
         assert_equal(s, np.array([-1.0, 0.0, 1.0, np.nan]), strict=True)
 
+    def test_timedelta64_sign_nat_scalar(self):
+        nat = np.timedelta64('nat', 'm')
+        assert_equal(np.sign(nat), np.nan)
+
     def test_datetime_add(self):
         for dta, dtb, dtc, dtnat, tda, tdb, tdc in \
                     [

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1080,21 +1080,18 @@ class TestDateTime:
         assert_equal(np.zeros_like(b).dtype, b.dtype)
         assert_equal(np.empty_like(b).dtype, b.dtype)
 
-    def test_datetime_unary(self):
-        for tda, tdb, tdzero, tdone, tdmone in \
+    def test_timedelta64_unary(self):
+        for tda, tdb, tdzero in \
                 [
                  # One-dimensional arrays
                  (np.array([3], dtype='m8[D]'),
                   np.array([-3], dtype='m8[D]'),
-                  np.array([0], dtype='m8[D]'),
-                  np.array([1], dtype='m8[D]'),
-                  np.array([-1], dtype='m8[D]')),
+                  np.array([0], dtype='m8[D]')),
                  # NumPy scalars
                  (np.timedelta64(3, '[D]'),
                   np.timedelta64(-3, '[D]'),
-                  np.timedelta64(0, '[D]'),
-                  np.timedelta64(1, '[D]'),
-                  np.timedelta64(-1, '[D]'))]:
+                  np.timedelta64(0, '[D]')),
+                ]:
             # negative ufunc
             assert_equal(-tdb, tda)
             assert_equal((-tdb).dtype, tda.dtype)
@@ -1112,13 +1109,20 @@ class TestDateTime:
             assert_equal(np.absolute(tdb).dtype, tda.dtype)
 
             # sign ufunc
-            assert_equal(np.sign(tda), tdone)
-            assert_equal(np.sign(tdb), tdmone)
-            assert_equal(np.sign(tdzero), tdzero)
-            assert_equal(np.sign(tda).dtype, tda.dtype)
+            assert_equal(np.sign(tda), np.ones_like(tda, dtype=np.float64),
+                         strict=True)
+            assert_equal(np.sign(tdb), -np.ones_like(tdb, dtype=np.float64),
+                         strict=True)
+            assert_equal(np.sign(tdzero), np.zeros_like(tdzero, dtype=np.float64),
+                         strict=True)
 
-            # The ufuncs always produce native-endian results
-            assert_
+    def test_timedelta64_sign_nat(self):
+        x = np.array([np.timedelta64(-123, 's'),
+                      np.timedelta64(0, 's'),
+                      np.timedelta64(88, 's'),
+                      np.timedelta64('NaT', 's')])
+        s = np.sign(x)
+        assert_equal(s, np.array([-1.0, 0.0, 1.0, np.nan]), strict=True)
 
     def test_datetime_add(self):
         for dta, dtb, dtc, dtnat, tda, tdb, tdc in \


### PR DESCRIPTION
With this PR, `sign(timedelta64)` returns a `float64`.  The ensures that the sign function has the basic property `x = np.sign(x)*np.abs(x)` when `x` has dtype `timedelta64`, including the case where `x` is `NaT`.

*The PR makes the change with no warnings and no deprecation.*

The issue was brought up on the mailing list: https://mail.python.org/archives/list/numpy-discussion@python.org/thread/7ELIJOAAZAMFIGNDAUMOCLXYBRYYKE2Z/

Closes gh-8463.
Closes gh-29496.

