### PR TITLE
DOC: Fix some broken refs and Typos.

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -784,7 +784,7 @@ cannot not be accessed directly.
     Allows setting of the itemsize, this is *only* relevant for string/bytes
     datatypes as it is the current pattern to define one with a new size.
 
-.. c:function:: npy_intp PyDataType_ALIGNENT(PyArray_Descr *descr)
+.. c:function:: npy_intp PyDataType_ALIGNMENT(PyArray_Descr *descr)
 
     The alignment of the datatype.
 

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -365,7 +365,7 @@ PyArrayDescr_Type and PyArray_Descr
        places an item of this type: ``offsetof(struct {char c; type v;},
        v)``
 
-       See `PyDataType_ALIGNMENT` for a way to access this field in a NumPy 1.x
+       See :c:func:`PyDataType_ALIGNMENT` for a way to access this field in a NumPy 1.x
        compatible way.
 
    .. c:member:: PyObject *metadata

--- a/doc/source/user/c-info.beyond-basics.rst
+++ b/doc/source/user/c-info.beyond-basics.rst
@@ -268,7 +268,7 @@ specifies your data-type. This type number should be stored and made
 available by your module so that other modules can use it to recognize
 your data-type.
 
-Note that this API is inherently thread-unsafe. See `thread_safety` for more
+Note that this API is inherently thread-unsafe. See :ref:`thread_safety` for more
 details about thread safety in NumPy.
 
 


### PR DESCRIPTION
The default role is set to autolink (which fallbacks to emphasis if not resolved) And I believe there is typo in ALIGNMENT vs ALIGNENT.

I would suggest moving away from autolink for default role, and have it raise an error if not resolved.
This would also make sure users use double backticks for code.