### PR TITLE
ENH,MAINT: rewrite np.fix to use np.trunc internally

### DIFF
--- a/numpy/lib/_ufunclike_impl.py
+++ b/numpy/lib/_ufunclike_impl.py
@@ -56,15 +56,7 @@ def fix(x, out=None):
     array([ 2.,  2., -2., -2.])
 
     """
-    # promote back to an array if flattened
-    res = nx.ceil(x, out=... if out is None else out)
-    res = nx.floor(x, out=res, where=nx.greater_equal(x, 0))
-
-    # when no out argument is passed and no subclasses are involved, flatten
-    # scalars
-    if out is None and type(res) is nx.ndarray:
-        res = res[()]
-    return res
+    return nx.trunc(x, out=out)
 
 
 @array_function_dispatch(_dispatcher, verify=False, module='numpy')

--- a/numpy/typing/tests/data/pass/ufunclike.py
+++ b/numpy/typing/tests/data/pass/ufunclike.py
@@ -12,6 +12,9 @@ class Object:
     def __floor__(self) -> Object:
         return self
 
+    def __trunc__(self) -> Object:
+        return self
+
     def __ge__(self, value: object) -> bool:
         return True
 


### PR DESCRIPTION
As discussed in #30098, this PR is a break-out PR to rewrite `np.fix` to use `np.trunc` internally. @seberg I hope I understood your comment in https://github.com/numpy/numpy/pull/30098#issuecomment-3516011752 correctly.

This PR should have no observable effects except maybe a speed-up of `np.fix`.

Cheers