### PR TITLE
ENH: Detect Fortran vs C order in array_assign_boolean_subscript

### DIFF
--- a/benchmarks/benchmarks/bench_indexing.py
+++ b/benchmarks/benchmarks/bench_indexing.py
@@ -94,11 +94,7 @@ class BooleanAssignmentOrder(Benchmark):
         # emulate gh-30156: boolean assignment into a sliced Fortran/C view
         self.view = self.base[1:-1, 1:-1, 1:-1]
         mask = np.random.RandomState(0).rand(*self.view.shape) > 0.5
-        if order == 'F':
-            mask = np.asfortranarray(mask)
-        else:
-            mask = np.ascontiguousarray(mask)
-        self.mask = mask
+        self.mask = mask.copy(order)
         self.value = np.uint32(7)
 
     def time_boolean_assign_scalar(self, order):

--- a/benchmarks/benchmarks/bench_indexing.py
+++ b/benchmarks/benchmarks/bench_indexing.py
@@ -84,6 +84,27 @@ class ScalarIndexing(Benchmark):
             arr[indx] = val
 
 
+class BooleanAssignmentOrder(Benchmark):
+    params = ['C', 'F']
+    param_names = ['order']
+
+    def setup(self, order):
+        shape = (64, 64, 64)
+        self.base = np.zeros(shape, dtype=np.uint32, order=order)
+        # emulate gh-30156: boolean assignment into a sliced Fortran/C view
+        self.view = self.base[1:-1, 1:-1, 1:-1]
+        mask = np.random.RandomState(0).rand(*self.view.shape) > 0.5
+        if order == 'F':
+            mask = np.asfortranarray(mask)
+        else:
+            mask = np.ascontiguousarray(mask)
+        self.mask = mask
+        self.value = np.uint32(7)
+
+    def time_boolean_assign_scalar(self, order):
+        self.view[self.mask] = self.value
+
+
 class IndexingSeparate(Benchmark):
     def setup(self):
         self.tmp_dir = mkdtemp()

--- a/benchmarks/benchmarks/bench_indexing.py
+++ b/benchmarks/benchmarks/bench_indexing.py
@@ -90,15 +90,14 @@ class BooleanAssignmentOrder(Benchmark):
 
     def setup(self, order):
         shape = (64, 64, 64)
+        # emulate gh-30156: boolean assignment into a Fortran/C array
         self.base = np.zeros(shape, dtype=np.uint32, order=order)
-        # emulate gh-30156: boolean assignment into a sliced Fortran/C view
-        self.view = self.base[1:-1, 1:-1, 1:-1]
-        mask = np.random.RandomState(0).rand(*self.view.shape) > 0.5
+        mask = np.random.RandomState(0).rand(*self.base.shape) > 0.5
         self.mask = mask.copy(order)
         self.value = np.uint32(7)
 
     def time_boolean_assign_scalar(self, order):
-        self.view[self.mask] = self.value
+        self.base[self.mask] = self.value
 
 
 class IndexingSeparate(Benchmark):

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1176,6 +1176,10 @@ array_assign_boolean_subscript(PyArrayObject *self,
     }
 
     v_data = PyArray_DATA(v);
+    if (v_stride == 0) {
+        /* Scalar/broadcast values benefit from KEEPORDER to match self layout */
+        order = NPY_KEEPORDER;
+    }
 
     /* Create an iterator for the data */
     int res = 0;

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1173,13 +1173,11 @@ array_assign_boolean_subscript(PyArrayObject *self,
     }
     else {
         v_stride = 0;
+        /* If the same value is repeated, iteration order does not matter */
+        order = NPY_KEEPORDER;
     }
 
     v_data = PyArray_DATA(v);
-    if (v_stride == 0) {
-        /* Scalar/broadcast values benefit from KEEPORDER to match self layout */
-        order = NPY_KEEPORDER;
-    }
 
     /* Create an iterator for the data */
     int res = 0;


### PR DESCRIPTION
This PR fixes #30156 by detecting when to set `KEEPORDER` order in `array_assign_boolean_subscript`.

On my machine, before this fix, using the benchmark I added:

```
[ 0.00%] ·· Benchmarking existing-py_Users_veitheller_.pyenv_versions_3.12.11_bin_python3.12
[50.00%] ··· Running (bench_indexing.BooleanAssignmentOrder.time_boolean_assign_scalar--).
[100.00%] ··· bench_indexing.BooleanAssignmentOrder.time_boolean_assign_scalar                                          ok
[100.00%] ··· ======= =============
               order
              ------- -------------
                 C       979±10μs
                 F     1.20±0.01ms
              ======= =============

[100.00%] ···· For parameters: 'C'
               NumPy CPU features: nothing enabled

               For parameters: 'F'
               NumPy CPU features: nothing enabled
```

And after:

```
[ 0.00%] ·· Benchmarking existing-py_Users_veitheller_.pyenv_versions_3.12.11_bin_python3.12
[50.00%] ··· Running (bench_indexing.BooleanAssignmentOrder.time_boolean_assign_scalar--).
[100.00%] ··· bench_indexing.BooleanAssignmentOrder.time_boolean_assign_scalar                                          ok
[100.00%] ··· ======= ==========
               order
              ------- ----------
                 C     974±10μs
                 F     984±10μs
              ======= ==========

[100.00%] ···· For parameters: 'C'
               NumPy CPU features: nothing enabled

               For parameters: 'F'
               NumPy CPU features: nothing enabled
```

I hope this is the fix we had in mind, I operated on the simple assumption that number_go_down==good.

Do we need a release note for this?

Cheers