### PR TITLE
DOC: Release notes for the runtime signature changes

### DIFF
--- a/doc/release/upcoming_changes/30208.highlight.rst
+++ b/doc/release/upcoming_changes/30208.highlight.rst
@@ -1,0 +1,2 @@
+* Runtime signature introspection support has been significantly improved. See the
+  corresponding improvement note for details.

--- a/doc/release/upcoming_changes/30208.improvement.rst
+++ b/doc/release/upcoming_changes/30208.improvement.rst
@@ -1,0 +1,12 @@
+Runtime signature introspection support has been significantly improved
+-----------------------------------------------------------------------
+Many NumPy functions, classes, and methods that previously raised ``ValueError`` when passed
+to ``inspect.signature()`` now return meaningful signatures. This improves support for runtime type
+checking, IDE autocomplete, documentation generation, and runtime introspection capabilities across
+the NumPy API.
+
+Over three hundred classes and functions have been updated in total, including, but not limited to,
+core classes such as `ndarray`, `generic`, `dtype`, `ufunc`, `broadcast`, `nditer`, etc.,
+most methods of `ndarray` and scalar types, array constructor functions (`array`, `empty`,
+`arange`, `fromiter`, etc.), and many other commonly used functions, including `dot`, `concat`,
+`where`, `bincount`, `can_cast`, and numerous others.


### PR DESCRIPTION
This covers the following PR's:

- #30091
- #30099
- #30104
- #30114
- #30121
- #30124
- #30126
- #30137
- #30138
- #30140
- #30143
- #30147
- #30155
- #30164
- #30169
- #30193

And here's the list of affected classes/methods/functions (although I'm probably forgetting a couple):

- `np.arange`
- `np.array`
- `np.asanyarray`
- `np.asarray`
- `np.ascontiguousarray`
- `np.asfortranarray`
- `np.bincount`
- `np.bool`
- `np.broadcast`
- `np.busday_count`
- `np.busday_offset`
- `np.busdaycalendar`
- `np.byte`
- `np.bytes_`
- `np.can_cast`
- `np.clongdouble`
- `np.complex64`
- `np.concat`
- `np.copyto`
- `np.datetime64`
- `np.datetime_as_string`
- `np.datetime_data`
- `np.dot`
- `np.dtype`
- `np.empty`
- `np.empty_like`
- `np.float128`
- `np.float16`
- `np.float32`
- `np.from_dlpack`
- `np.frombuffer`
- `np.fromfile`
- `np.fromiter`
- `np.frompyfunc`
- ~`np.fromstring`~  see [#30235](https://github.com/numpy/numpy/pull/30235)
- `np.inner`
- `np.int16`
- `np.int32`
- `np.int64`
- `np.is_busday`
- `np.lexsort`
- `np.longlong`
- `np.may_share_memory`
- `np.min_scalar_type`
- `np.ndarray`
- `np.nditer`
- `np.nested_iters`
- `np.object_`
- `np.packbits`
- `np.promote_types`
- `np.putmask`
- `np.ravel_multi_index`
- `np.record`
- `np.result_type`
- `np.shares_memory`
- `np.str_`
- `np.timedelta64`
- `np.ubyte`
- `np.uint`
- `np.uint16`
- `np.uint32`
- `np.ulonglong`
- `np.unpackbits`
- `np.unravel_index`
- `np.vdot`
- `np.void`
- `np.where`
- `np.zeros`
- `np.broadcast`
- `np.broadcast.reset`
- `np.flatiter.__array__`
- `np.flatiter.copy`
- `np.nditer`
- `np.nditer.remove_axis`
- `np.ndarray`
- `np.ndarray.__array__`
- `np.ndarray.__array_finalize__`
- `np.ndarray.__array_function__`
- `np.ndarray.__array_namespace__`
- `np.ndarray.__array_ufunc__`
- `np.ndarray.__array_wrap__`
- `np.ndarray.__complex__`
- `np.ndarray.__copy__`
- `np.ndarray.__dlpack__`
- `np.ndarray.__dlpack_device__`
- `np.ndarray.__format__`
- `np.ndarray.__sizeof__`
- `np.ndarray.__reduce_ex__`
- `np.ndarray.all`
- `np.ndarray.any`
- `np.ndarray.argmax`
- `np.ndarray.argmin`
- `np.ndarray.argpartition`
- `np.ndarray.argsort`
- `np.ndarray.astype`
- `np.ndarray.byteswap`
- `np.ndarray.choose`
- `np.ndarray.clip`
- `np.ndarray.compress`
- `np.ndarray.conj`
- `np.ndarray.conjugate`
- `np.ndarray.copy`
- `np.ndarray.cumprod`
- `np.ndarray.cumsum`
- `np.ndarray.diagonal`
- `np.ndarray.dot`
- `np.ndarray.dump`
- `np.ndarray.dumps`
- `np.ndarray.fill`
- `np.ndarray.flatten`
- `np.ndarray.getfield`
- `np.ndarray.item`
- `np.ndarray.max`
- `np.ndarray.mean`
- `np.ndarray.min`
- `np.ndarray.nonzero`
- `np.ndarray.partition`
- `np.ndarray.prod`
- `np.ndarray.put`
- `np.ndarray.ravel`
- `np.ndarray.repeat`
- `np.ndarray.reshape`
- `np.ndarray.resize`
- `np.ndarray.round`
- `np.ndarray.searchsorted`
- `np.ndarray.setfield`
- `np.ndarray.setflags`
- `np.ndarray.sort`
- `np.ndarray.squeeze`
- `np.ndarray.std`
- `np.ndarray.sum`
- `np.ndarray.swapaxes`
- `np.ndarray.take`
- `np.ndarray.to_device`
- `np.ndarray.tobytes`
- `np.ndarray.tofile`
- `np.ndarray.tolist`
- `np.ndarray.trace`
- `np.ndarray.transpose`
- `np.ndarray.var`
- `np.ndarray.view`
- `np.generic.__array_namespace__`
- `np.generic.__copy__`
- `np.generic.__deepcopy__`
- `np.generic.all`
- `np.generic.any`
- `np.generic.argmax`
- `np.generic.argmin`
- `np.generic.argsort`
- `np.generic.astype`
- `np.generic.byteswap`
- `np.generic.choose`
- `np.generic.clip`
- `np.generic.compress`
- `np.generic.conj`
- `np.generic.conjugate`
- `np.generic.copy`
- `np.generic.cumprod`
- `np.generic.cumsum`
- `np.generic.diagonal`
- `np.generic.dump`
- `np.generic.dumps`
- `np.generic.fill`
- `np.generic.flatten`
- `np.generic.getfield`
- `np.generic.item`
- `np.generic.max`
- `np.generic.mean`
- `np.generic.min`
- `np.generic.nonzero`
- `np.generic.prod`
- `np.generic.put`
- `np.generic.ravel`
- `np.generic.repeat`
- `np.generic.reshape`
- `np.generic.resize`
- `np.generic.round`
- `np.generic.searchsorted`
- `np.generic.setfield`
- `np.generic.setflags`
- `np.generic.sort`
- `np.generic.squeeze`
- `np.generic.std`
- `np.generic.sum`
- `np.generic.swapaxes`
- `np.generic.take`
- `np.generic.to_device`
- `np.generic.tobytes`
- `np.generic.tofile`
- `np.generic.tolist`
- `np.generic.tostring`
- `np.generic.trace`
- `np.generic.transpose`
- `np.generic.var`
- `np.generic.view`
- `np.void.getfield`
- `np.void.setfield`
- `np.ufunc.__call__`
- `np.ufunc.accumulate`
- `np.ufunc.at`
- `np.ufunc.outer`
- `np.ufunc.reduce`
- `np.ufunc.reduceat`
- `np.ufunc.resolve_dtypes`
- `np.dtypes.BoolDType`
- `np.dtypes.ByteDType`
- `np.dtypes.BytesDType`
- `np.dtypes.CLongDoubleDType`
- `np.dtypes.Complex128DType`
- `np.dtypes.Complex64DType`
- `np.dtypes.DateTime64DType`
- `np.dtypes.Float16DType`
- `np.dtypes.Float32DType`
- `np.dtypes.Float64DType`
- `np.dtypes.Int16DType`
- `np.dtypes.Int32DType`
- `np.dtypes.Int64DType`
- `np.dtypes.LongDoubleDType`
- `np.dtypes.LongLongDType`
- `np.dtypes.ObjectDType`
- `np.dtypes.StrDType`
- `np.dtypes.StringDType`
- `np.dtypes.TimeDelta64DType`
- `np.dtypes.UByteDType`
- `np.dtypes.UInt16DType`
- `np.dtypes.UInt32DType`
- `np.dtypes.UInt64DType`
- `np.dtypes.ULongLongDType`
- `np.dtypes.VoidDType`
- `np.dtype.newbyteorder`
- `np.char.compare_chararrays`
- `np.random.BitGenerator`
- `np.random.Generator`
- `np.random.MT19937`
- `np.random.PCG64`
- `np.random.PCG64DXSM`
- `np.random.Philox`
- `np.random.RandomState`
- `np.random.SFC64`
- `np.random.SeedSequence`
- `np.random.bit_generator.SeedlessSeedSequence`
- `np.ma.abs`
- `np.ma.absolute`
- `np.ma.all`
- `np.ma.angle`
- `np.ma.anom`
- `np.ma.anomalies`
- `np.ma.any`
- `np.ma.arange`
- `np.ma.arccos`
- `np.ma.arccosh`
- `np.ma.arcsin`
- `np.ma.arcsinh`
- `np.ma.arctan`
- `np.ma.arctanh`
- `np.ma.argmax`
- `np.ma.argmin`
- `np.ma.around`
- `np.ma.ceil`
- `np.ma.clip`
- `np.ma.compress`
- `np.ma.conjugate`
- `np.ma.copy`
- `np.ma.cos`
- `np.ma.cosh`
- `np.ma.count`
- `np.ma.cumprod`
- `np.ma.cumsum`
- `np.ma.diagonal`
- `np.ma.empty`
- `np.ma.empty_like`
- `np.ma.exp`
- `np.ma.fabs`
- `np.ma.floor`
- `np.ma.frombuffer`
- `np.ma.fromfunction`
- `np.ma.harden_mask`
- `np.ma.identity`
- `np.ma.ids`
- `np.ma.indices`
- `np.ma.log`
- `np.ma.log10`
- `np.ma.log2`
- `np.ma.logical_not`
- `np.ma.mean`
- `np.ma.negative`
- `np.ma.nonzero`
- `np.ma.ones`
- `np.ma.ones_like`
- `np.ma.prod`
- `np.ma.product`
- `np.ma.ravel`
- `np.ma.repeat`
- `np.ma.sin`
- `np.ma.sinh`
- `np.ma.soften_mask`
- `np.ma.sqrt`
- `np.ma.squeeze`
- `np.ma.std`
- `np.ma.sum`
- `np.ma.swapaxes`
- `np.ma.tan`
- `np.ma.tanh`
- `np.ma.trace`
- `np.ma.var`
- `np.ma.zeros`
- `np.ma.zeros_like`
- `np.ma.extras.AxisConcatenator.concatenate`
