### PR TITLE
DOC: fix links for newly rebuilt numpy-tutorials site 

### DIFF
--- a/doc/source/user/how-to-how-to.rst
+++ b/doc/source/user/how-to-how-to.rst
@@ -105,7 +105,7 @@ deep dives intended to give understanding rather than immediate assistance,
 and *References*, which give complete, authoritative data on some concrete
 part of NumPy (like its API) but aren't obligated to paint a broader picture.
 
-For more on tutorials, see :doc:`numpy-tutorials:content/tutorial-style-guide`
+For more on tutorials, see :doc:`numpy-tutorials:tutorial-style-guide`
 
 ******************************************************************************
 Is this page an example of a how-to?

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -1479,4 +1479,4 @@ Further reading
 -  `SciPy Tutorial <https://docs.scipy.org/doc/scipy/tutorial/index.html>`__
 -  `SciPy Lecture Notes <https://scipy-lectures.org>`__
 -  A `matlab, R, IDL, NumPy/SciPy dictionary <https://mathesaurus.sourceforge.net/>`__
--  :doc:`tutorial-svd <numpy-tutorials:content/tutorial-svd>`
+-  :doc:`tutorial-svd <numpy-tutorials:tutorial-svd>`


### PR DESCRIPTION
Fixes #30212 

The numpy-tutorials site has been changed, so the links changed. cc @rossbar, @bsipocz. Are there other sites that link to the tutorials?