### PR TITLE
BUG: Fix build on s390x with clang (#30214)

### DIFF
--- a/numpy/_core/src/common/simd/vec/utils.h
+++ b/numpy/_core/src/common/simd/vec/utils.h
@@ -25,14 +25,16 @@
     #ifndef vec_neg
         #define vec_neg(a) (-(a))
     #endif
-    #ifndef vec_and
-        #define vec_and(a, b) ((a) & (b)) // Vector AND
-    #endif
-    #ifndef vec_or
-        #define vec_or(a, b) ((a) | (b)) // Vector OR
-    #endif
-    #ifndef vec_xor
-        #define vec_xor(a, b) ((a) ^ (b)) // Vector XOR
+    #if !(defined(__clang__) && __VEC__ >= 10305)
+        #ifndef vec_and
+            #define vec_and(a, b) ((a) & (b)) // Vector AND
+        #endif
+        #ifndef vec_or
+            #define vec_or(a, b) ((a) | (b)) // Vector OR
+        #endif
+        #ifndef vec_xor
+            #define vec_xor(a, b) ((a) ^ (b)) // Vector XOR
+        #endif
     #endif
     #ifndef vec_sl
         #define vec_sl(a, b) ((a) << (b)) // Vector Shift Left


### PR DESCRIPTION
Backport of #30214.

For clang 20+ (_VEC_ >= 10305), fallback check relied on macro definitions for vector operations, but clang provides regular functions instead. This caused the fallback to redefine them as macros, overriding the actual vector operation logic.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
