### PR TITLE
STY: fix ``ma.MaskedAArray.tolist`` docstring indentation

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6653,14 +6653,14 @@ class mvoid(MaskedArray):
 
     def tolist(self):
         """
-    Transforms the mvoid object into a tuple.
+        Transforms the mvoid object into a tuple.
 
-    Masked fields are replaced by None.
+        Masked fields are replaced by None.
 
-    Returns
-    -------
-    returned_tuple
-        Tuple of fields
+        Returns
+        -------
+        returned_tuple
+            Tuple of fields
         """
         _mask = self._mask
         if _mask is nomask:


### PR DESCRIPTION
i.e. by selecting it and then pressing <kbd>tab</kbd>