### PR TITLE
BUG: fix data race in `wrapping_auxdata_freelist` by making it thread-local

### DIFF
--- a/numpy/_core/src/umath/wrapping_array_method.c
+++ b/numpy/_core/src/umath/wrapping_array_method.c
@@ -83,8 +83,8 @@ typedef struct {
 
 
 #define WRAPPING_AUXDATA_FREELIST_SIZE 5
-static int wrapping_auxdata_freenum = 0;
-static wrapping_auxdata *wrapping_auxdata_freelist[WRAPPING_AUXDATA_FREELIST_SIZE] = {NULL};
+static NPY_TLS int wrapping_auxdata_freenum = 0;
+static NPY_TLS wrapping_auxdata *wrapping_auxdata_freelist[WRAPPING_AUXDATA_FREELIST_SIZE] = {NULL};
 
 
 static void


### PR DESCRIPTION
Relates #30085

This PR fixes the data race in `wrapping_auxdata_freelist` by making the freelist thread-local. 

Without this PR, `numpy/_core/tests/test_custom_dtypes.py::TestSFloat::test_wrapped_and_wrapped_reductions` produces the following data races when run with `pytest-run-parallel` under TSAN:

```console
==================
WARNING: ThreadSanitizer: data race (pid=21377)
  Read of size 4 at 0x000120a0c6e8 by thread T129:
    #0 wrapping_method_get_loop wrapping_array_method.c:154 (_multiarray_umath.cpython-314t-darwin.so:arm64+0x34c72c)
    #1 PyUFunc_GenericFunctionInternal ufunc_object.c:2242 (_multiarray_umath.cpython-314t-darwin.so:arm64+0x307b40)
    #2 ufunc_generic_fastcall ufunc_object.c:4702 (_multiarray_umath.cpython-314t-darwin.so:arm64+0x30473c)
    #3 ufunc_generic_vectorcall ufunc_object.c:4766 (_multiarray_umath.cpython-314t-darwin.so:arm64+0x301910)
    #4 PyObject_Vectorcall <null> (libpython3.14t.dylib:arm64+0x8ab8c)
    #5 _PyEval_EvalFrameDefault <null> (libpython3.14t.dylib:arm64+0x27ce94)
    #6 _PyEval_Vector <null> (libpython3.14t.dylib:arm64+0x278c90)
    #7 _PyFunction_Vectorcall <null> (libpython3.14t.dylib:arm64+0x8b1cc)
    #8 method_vectorcall <null> (libpython3.14t.dylib:arm64+0x8f638)
    #9 _PyObject_Call <null> (libpython3.14t.dylib:arm64+0x8ae40)
    #10 PyObject_Call <null> (libpython3.14t.dylib:arm64+0x8aeb4)
    #11 _PyEval_EvalFrameDefault <null> (libpython3.14t.dylib:arm64+0x27fbc0)
    #12 _PyEval_Vector <null> (libpython3.14t.dylib:arm64+0x278c90)
    #13 _PyFunction_Vectorcall <null> (libpython3.14t.dylib:arm64+0x8b1cc)
    #14 method_vectorcall <null> (libpython3.14t.dylib:arm64+0x8f638)
    #15 context_run <null> (libpython3.14t.dylib:arm64+0x2c3eec)
    #16 _PyEval_EvalFrameDefault <null> (libpython3.14t.dylib:arm64+0x283168)
    #17 _PyEval_Vector <null> (libpython3.14t.dylib:arm64+0x278c90)
    #18 _PyFunction_Vectorcall <null> (libpython3.14t.dylib:arm64+0x8b1cc)
    #19 method_vectorcall <null> (libpython3.14t.dylib:arm64+0x8f638)
    #20 _PyObject_Call <null> (libpython3.14t.dylib:arm64+0x8ae40)
    #21 PyObject_Call <null> (libpython3.14t.dylib:arm64+0x8aeb4)
    #22 thread_run <null> (libpython3.14t.dylib:arm64+0x416b08)
    #23 pythread_wrapper <null> (libpython3.14t.dylib:arm64+0x368cac)

  Previous write of size 4 at 0x000120a0c6e8 by thread T132:
    #0 wrapping_auxdata_free wrapping_array_method.c:99 (_multiarray_umath.cpython-314t-darwin.so:arm64+0x34cbe0)
    #1 PyUFunc_GenericFunctionInternal ufunc_object.c:2242 (_multiarray_umath.cpython-314t-darwin.so:arm64+0x307d60)
    #2 ufunc_generic_fastcall ufunc_object.c:4702 (_multiarray_umath.cpython-314t-darwin.so:arm64+0x30473c)
    #3 ufunc_generic_vectorcall ufunc_object.c:4766 (_multiarray_umath.cpython-314t-darwin.so:arm64+0x301910)
    #4 PyObject_Vectorcall <null> (libpython3.14t.dylib:arm64+0x8ab8c)
    #5 _PyEval_EvalFrameDefault <null> (libpython3.14t.dylib:arm64+0x27ce94)
    #6 _PyEval_Vector <null> (libpython3.14t.dylib:arm64+0x278c90)
    #7 _PyFunction_Vectorcall <null> (libpython3.14t.dylib:arm64+0x8b1cc)
    #8 method_vectorcall <null> (libpython3.14t.dylib:arm64+0x8f638)
    #9 _PyObject_Call <null> (libpython3.14t.dylib:arm64+0x8ae40)
    #10 PyObject_Call <null> (libpython3.14t.dylib:arm64+0x8aeb4)
    #11 _PyEval_EvalFrameDefault <null> (libpython3.14t.dylib:arm64+0x27fbc0)
    #12 _PyEval_Vector <null> (libpython3.14t.dylib:arm64+0x278c90)
    #13 _PyFunction_Vectorcall <null> (libpython3.14t.dylib:arm64+0x8b1cc)
    #14 method_vectorcall <null> (libpython3.14t.dylib:arm64+0x8f638)
    #15 context_run <null> (libpython3.14t.dylib:arm64+0x2c3eec)
    #16 _PyEval_EvalFrameDefault <null> (libpython3.14t.dylib:arm64+0x283168)
    #17 _PyEval_Vector <null> (libpython3.14t.dylib:arm64+0x278c90)
    #18 _PyFunction_Vectorcall <null> (libpython3.14t.dylib:arm64+0x8b1cc)
    #19 method_vectorcall <null> (libpython3.14t.dylib:arm64+0x8f638)
    #20 _PyObject_Call <null> (libpython3.14t.dylib:arm64+0x8ae40)
    #21 PyObject_Call <null> (libpython3.14t.dylib:arm64+0x8aeb4)
    #22 thread_run <null> (libpython3.14t.dylib:arm64+0x416b08)
    #23 pythread_wrapper <null> (libpython3.14t.dylib:arm64+0x368cac)

SUMMARY: ThreadSanitizer: data race wrapping_array_method.c:154 in wrapping_method_get_loop
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
