### PR TITLE
BUG: fix data race in `PyArray_DescrHash`

### DIFF
--- a/numpy/_core/src/common/npy_atomic.h
+++ b/numpy/_core/src/common/npy_atomic.h
@@ -79,6 +79,12 @@ npy_atomic_load_ptr(const void *obj) {
 #endif
 }
 
+static inline npy_hash_t
+npy_atomic_load_hash_t(const npy_hash_t *obj) {
+    assert(sizeof(npy_hash_t) == sizeof(void *));
+    return (npy_hash_t)npy_atomic_load_ptr((const void *)obj);
+}
+
 static inline void
 npy_atomic_store_uint8(npy_uint8 *obj, npy_uint8 value) {
 #ifdef STDC_ATOMICS
@@ -102,6 +108,12 @@ npy_atomic_store_ptr(void *obj, void *value)
 #elif defined(GCC_ATOMICS)
     __atomic_store_n((void **)obj, value, __ATOMIC_SEQ_CST);
 #endif
+}
+
+static inline void
+npy_atomic_store_hash_t(npy_hash_t *obj, npy_hash_t value) {
+    assert(sizeof(npy_hash_t) == sizeof(void *));
+    npy_atomic_store_ptr((void *)obj, (void *)value);
 }
 
 #undef MSC_ATOMICS

--- a/numpy/_core/src/multiarray/hashdescr.c
+++ b/numpy/_core/src/multiarray/hashdescr.c
@@ -259,7 +259,7 @@ static int _array_descr_walk(PyArray_Descr* descr, PyObject *l)
 /*
  * Return hash on success, -1 on failure
  */
-static int _PyArray_DescrHashImp(PyArray_Descr *descr)
+static npy_hash_t _PyArray_DescrHashImp(PyArray_Descr *descr)
 {
     PyObject *l, *tl;
     int st;

--- a/numpy/_core/src/multiarray/hashdescr.c
+++ b/numpy/_core/src/multiarray/hashdescr.c
@@ -6,6 +6,7 @@
 
 #include <numpy/arrayobject.h>
 
+#include "npy_atomic.h"
 #include "npy_config.h"
 
 
@@ -256,12 +257,13 @@ static int _array_descr_walk(PyArray_Descr* descr, PyObject *l)
 }
 
 /*
- * Return 0 if successful
+ * Return hash on success, -1 on failure
  */
-static int _PyArray_DescrHashImp(PyArray_Descr *descr, npy_hash_t *hash)
+static int _PyArray_DescrHashImp(PyArray_Descr *descr)
 {
     PyObject *l, *tl;
     int st;
+    npy_hash_t hash;
 
     l = PyList_New(0);
     if (l == NULL) {
@@ -283,25 +285,16 @@ static int _PyArray_DescrHashImp(PyArray_Descr *descr, npy_hash_t *hash)
     if (tl == NULL)
         return -1;
 
-    *hash = PyObject_Hash(tl);
+    hash = PyObject_Hash(tl);
     Py_DECREF(tl);
-    if (*hash == -1) {
-        /* XXX: does PyObject_Hash set an exception on failure ? */
-#if 0
-        PyErr_SetString(PyExc_SystemError,
-                "(Hash) Error while hashing final tuple");
-#endif
-        return -1;
-    }
-
-    return 0;
+    return hash;
 }
 
 NPY_NO_EXPORT npy_hash_t
 PyArray_DescrHash(PyObject* odescr)
 {
     PyArray_Descr *descr;
-    int st;
+    npy_hash_t hash;
 
     if (!PyArray_DescrCheck(odescr)) {
         PyErr_SetString(PyExc_ValueError,
@@ -310,12 +303,15 @@ PyArray_DescrHash(PyObject* odescr)
     }
     descr = (PyArray_Descr*)odescr;
 
-    if (descr->hash == -1) {
-        st = _PyArray_DescrHashImp(descr, &descr->hash);
-        if (st) {
+    hash = npy_atomic_load_hash_t(&descr->hash);
+
+    if (hash == -1) {
+        hash = _PyArray_DescrHashImp(descr);
+        if (hash == -1) {
             return -1;
         }
+        npy_atomic_store_hash_t(&descr->hash, hash);
     }
 
-    return descr->hash;
+    return hash;
 }


### PR DESCRIPTION
Relates https://github.com/numpy/numpy/issues/30085

This PR fixes data race in `PyArray_DescrHash` on `descr->hash`. The non-atomic load and store of hash can data race so it is now changed to use atomics. Relaxed ordering would be sufficient here but I  don't think it is worth it so  I have reused `npy_atomic_{load/store}_ptr` as the size of hash is same as pointer and uses seq-cst ordering. 




<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
