### PR TITLE
MAINT: undo change to `fromstring` text signature for 2.4.0

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1482,11 +1482,9 @@ add_newdoc('numpy._core.multiarray', 'set_typeDict',
 
     """)
 
+# Signature can be updated for 2.5.0 release, see gh-30235 for details
 add_newdoc('numpy._core.multiarray', 'fromstring',
     """
-    fromstring(string, dtype=None, count=-1, *, sep, like=None)
-    --
-
     fromstring(string, dtype=float, count=-1, *, sep, like=None)
 
     A new 1-D array initialized from text data in a string.

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10982,7 +10982,6 @@ class TestTextSignatures:
         (np.fromfile, ("file", "dtype", "count", "sep", "offset", "like")),
         (np.fromiter, ("iter", "dtype", "count", "like")),
         (np.frompyfunc, ("func", "nin", "nout", "kwargs")),
-        (np.fromstring, ("string", "dtype", "count", "sep", "like")),
         (np.nested_iters, (
             "op", "axes", "flags", "op_flags", "op_dtypes", "order", "casting",
             "buffersize",


### PR DESCRIPTION
This reverts a very small part of gh-30147, because it broke Pythran (see [pythran#2368](https://github.com/serge-sans-paille/pythran/issues/2368)). While a new Pythran 0.18.1 release is available, that doesn't help for the SciPy 1.15.x releases which allow numpy<2.5 and pythran<0.18, see
https://github.com/scipy/scipy/blob/maintenance/1.15.x/pyproject.toml#L30-L41. So introducing this signature change only for 2.5.0 is much better, to avoid breaking SciPy 1.15.x for all users who need to build from source.

In addition, doing so doesn't leave us only a very narrow window with compatible NumPy and Pythran releases which would otherwise bite distro packagers as well.

We can reintroduce this change in `main` in a few weeks, after 2.4.x has branched.

Cc @serge-sans-paille @jorenham @charris for visibility.