### PR TITLE
REV: "MAINT: undo change to `fromstring` text signature for 2.4.0" for 2.5.0

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1482,9 +1482,11 @@ add_newdoc('numpy._core.multiarray', 'set_typeDict',
 
     """)
 
-# Signature can be updated for 2.5.0 release, see gh-30235 for details
 add_newdoc('numpy._core.multiarray', 'fromstring',
     """
+    fromstring(string, dtype=None, count=-1, *, sep, like=None)
+    --
+
     fromstring(string, dtype=float, count=-1, *, sep, like=None)
 
     A new 1-D array initialized from text data in a string.

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10982,6 +10982,7 @@ class TestTextSignatures:
         (np.fromfile, ("file", "dtype", "count", "sep", "offset", "like")),
         (np.fromiter, ("iter", "dtype", "count", "like")),
         (np.frompyfunc, ("func", "nin", "nout", "kwargs")),
+        (np.fromstring, ("string", "dtype", "count", "sep", "like")),
         (np.nested_iters, (
             "op", "axes", "flags", "op_flags", "op_dtypes", "order", "casting",
             "buffersize",


### PR DESCRIPTION
Reverts numpy/numpy#30235