### PR TITLE
DOC: Correct an equation error in `numpy.random.Generator.pareto`

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -2083,7 +2083,7 @@ cdef class Generator:
         -----
         The probability density for the Pareto II distribution is
 
-        .. math:: p(x) = \\frac{a}{{x+1}^{a+1}} , x \ge 0
+        .. math:: p(x) = \\frac{a}{{(x+1)}^{a+1}} , x \ge 0
 
         where :math:`a > 0` is the shape.
 

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -2083,7 +2083,7 @@ cdef class Generator:
         -----
         The probability density for the Pareto II distribution is
 
-        .. math:: p(x) = \\frac{a}{{(x+1)}^{a+1}} , x \ge 0
+        .. math:: p(x) = \\frac{a}{(x+1)^{a+1}} , x \ge 0
 
         where :math:`a > 0` is the shape.
 


### PR DESCRIPTION
Correct an equation error in `numpy.random.Generator.pareto`
https://numpy.org/devdocs/reference/random/generated/numpy.random.Generator.pareto.html

<img width="322" height="127" alt="image" src="https://github.com/user-attachments/assets/6e04944f-8659-40a5-a9ed-41ace84b00f8" />

Replace "x + 1" with "( x + 1 )".