### PR TITLE
BUG: Add missing `PyErr_Occurred()` check to fast-path

### DIFF
--- a/numpy/_core/src/umath/_umath_tests.c.src
+++ b/numpy/_core/src/umath/_umath_tests.c.src
@@ -460,6 +460,15 @@ addUfuncs(PyObject *dictionary) {
     }
     PyDict_SetItemString(dictionary, "always_error", f);
     Py_DECREF(f);
+    f = PyUFunc_FromFuncAndData(always_error_functions, always_error_data,
+            always_error_signatures, 1, 1, 1, PyUFunc_None, "always_error_unary",
+            "simply, broken, ufunc that sets an error (but releases the GIL).",
+            0);
+    if (f == NULL) {
+        return -1;
+    }
+    PyDict_SetItemString(dictionary, "always_error_unary", f);
+    Py_DECREF(f);
     f = PyUFunc_FromFuncAndDataAndSignature(always_error_functions,
             always_error_data, always_error_signatures, 1, 2, 1, PyUFunc_None,
             "always_error_gufunc",

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4379,6 +4379,10 @@ try_trivial_scalar_call(
     ret = strided_loop(&context, data, &n, strides, auxdata);
     NPY_AUXDATA_FREE(auxdata);
     if (ret == 0) {
+        if (PyErr_Occurred()) {
+            ret = -1;
+            goto bail;
+        }
         if (!(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
             // Check for any unmasked floating point errors (note: faster
             // than _check_ufunc_fperr as one doesn't need mask up front).

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4893,6 +4893,15 @@ def test_bad_legacy_ufunc_silent_errors():
         ncu_tests.always_error.at(arr, [0, 1, 2], arr)
 
 
+def test_bad_legacy_unary_ufunc_silent_errors():
+    # Unary has a special scalar path right now, so test it explicitly.
+    with pytest.raises(RuntimeError, match=r"How unexpected :\)!"):
+        ncu_tests.always_error_unary(np.arange(3).astype(np.float64))
+
+    with pytest.raises(RuntimeError, match=r"How unexpected :\)!"):
+        ncu_tests.always_error_unary(1.5)
+
+
 @pytest.mark.parametrize('x1', [np.arange(3.0), [0.0, 1.0, 2.0]])
 def test_bad_legacy_gufunc_silent_errors(x1):
     # Verify that an exception raised in a gufunc loop propagates correctly.


### PR DESCRIPTION
We could side-step this check unless it's a legacy ufunc, but there is little point as this is barely measureable.

Since someone would otherwise ask: No you can't move it into the legacy wrapping stuff because this has to happen at finalization when the GIL is held again.
