### PR TITLE
DOC: remove mention of 'skip azp' since we no longer use azure

### DIFF
--- a/doc/RELEASE_WALKTHROUGH.rst
+++ b/doc/RELEASE_WALKTHROUGH.rst
@@ -290,7 +290,7 @@ Update the ``version`` in ``pyproject.toml``::
     $ gvim pyproject.toml
 
 Commit the result, edit the commit message, note the files in the commit, and
-add a line ``[skip azp] [skip cirrus] [skip actions]``, then push::
+add a line ``[skip cirrus] [skip actions]``, then push::
 
     $ git commit -a -m"MAINT: Prepare 2.4.x for further development"
     $ git rebase -i HEAD^

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -205,13 +205,6 @@ these fragments in each commit message of a PR:
   settings.
   `See the configuration files for these checks. <https://github.com/numpy/numpy/tree/main/.github/workflows>`__
 
-* ``[skip azp]``: skip Azure jobs
-
-  `Azure <https://azure.microsoft.com/en-us/products/devops/pipelines>`__ is
-  where all comprehensive tests are run. This is an expensive run, and one you
-  could typically skip if you do documentation-only changes, for example.
-  `See the main configuration file for these checks. <https://github.com/numpy/numpy/blob/main/azure-pipelines.yml>`__
-
 * ``[skip circle]``: skip CircleCI jobs
 
   `CircleCI <https://circleci.com/>`__ is where we build the documentation and


### PR DESCRIPTION
Small cleanup PR after removal of azure CI runs.