### PR TITLE
BUG: always ignore FPE when Accelerate is the BLAS backend

### DIFF
--- a/numpy/_core/src/common/blas_utils.c
+++ b/numpy/_core/src/common/blas_utils.c
@@ -14,8 +14,13 @@
 #if NPY_BLAS_CHECK_FPE_SUPPORT
 /*
  * Static variable to cache runtime check of BLAS FPE support.
+ * Will always be false (ignore all FPE) when accelerate is the compiled backend
  */
+  #if defined(ACCELERATE_NEW_LAPACK)
+static bool blas_supports_fpe = false;
+  #else
 static bool blas_supports_fpe = true;
+  #endif // ACCELERATE_NEW_LAPACK
 
 #endif // NPY_BLAS_CHECK_FPE_SUPPORT
 


### PR DESCRIPTION
Fixes #30162 which seems to be a regression in Accelerate. It started  happening when we moved to a newer macOS image in CI (not an M4 machine) and was independently reported by @neutrinoceros on macOS 15.7.1 with an M2 machine. 

Continuation of #30102. Set the default `blas_supports_fpe=false` when compiling with Accelerate to "ignore all FPE in calls to BLAS". #30102 added a check when importing NumPy to see if a simple matmul triggers an FPE. If so, then `blas_supports_fpe` is set to `false`. But since the check is flaky it does not reliably set the value to `false` and we see FPE warnings.

Downstream packagers like conda that allow switching out the blas support from Accelerate to OpenBLAS to MKL and others will have to develop a patch to deal with the flaky Accelerate library and FPEs. The available handles are:
- at compile time they could choose to always set `blas_supports_fpe=false` and never see the warnings, at the cost of not knowing when overflow/underflow/divide-by-zero occurs
- at runtime, they could call `numpy._core._multiarray_umath._blas_supports_fpe(False)` when Accelerate is swapped in, to work around the flaky FPE false-positives.