### PR TITLE
ENH: New-style sorting for StringDType

### DIFF
--- a/numpy/_core/src/common/npy_sort.h.src
+++ b/numpy/_core/src/common/npy_sort.h.src
@@ -107,6 +107,29 @@ NPY_NO_EXPORT int npy_aheapsort(void *vec, npy_intp *ind, npy_intp cnt, void *ar
 NPY_NO_EXPORT int npy_amergesort(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
 NPY_NO_EXPORT int npy_atimsort(void *vec, npy_intp *ind, npy_intp cnt, void *arr);
 
+
+/*
+ *****************************************************************************
+ **                      GENERIC SORT IMPLEMENTATIONS                       **
+ *****************************************************************************
+ */
+
+typedef int (PyArray_SortImpl)(void *start, npy_intp num, void *varr,
+                               npy_intp elsize, PyArray_CompareFunc *cmp);
+typedef int (PyArray_ArgSortImpl)(void *vv, npy_intp *tosort, npy_intp n,
+                                  void *varr, npy_intp elsize,
+                                  PyArray_CompareFunc *cmp);
+
+NPY_NO_EXPORT int npy_quicksort_impl(void *start, npy_intp num, void *varr,
+                                     npy_intp elsize, PyArray_CompareFunc *cmp);
+NPY_NO_EXPORT int npy_mergesort_impl(void *start, npy_intp num, void *varr,
+                                     npy_intp elsize, PyArray_CompareFunc *cmp);
+NPY_NO_EXPORT int npy_aquicksort_impl(void *vv, npy_intp *tosort, npy_intp num, void *varr,
+                                      npy_intp elsize, PyArray_CompareFunc *cmp);
+NPY_NO_EXPORT int npy_amergesort_impl(void *v, npy_intp *tosort, npy_intp num, void *varr,
+                                      npy_intp elsize, PyArray_CompareFunc *cmp);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1226,8 +1226,8 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
     if (N <= 1 || PyArray_SIZE(op) == 0) {
         return 0;
     }
-    
-    if (method_flags != NULL) {
+
+    if (strided_loop != NULL) {
         needs_api = *method_flags & NPY_METH_REQUIRES_PYAPI;
     }
     else {
@@ -1441,7 +1441,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
     rstride = PyArray_STRIDE(rop, axis);
     needidxbuffer = rstride != sizeof(npy_intp);
 
-    if (method_flags != NULL) {
+    if (strided_loop != NULL) {
         needs_api = *method_flags & NPY_METH_REQUIRES_PYAPI;
     }
     else {
@@ -3142,7 +3142,7 @@ PyArray_Sort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
     PyArrayMethod_Context context = {0};
     PyArray_Descr *loop_descrs[2];
     NpyAuxData *auxdata = NULL;
-    NPY_ARRAYMETHOD_FLAGS *method_flags = NULL;
+    NPY_ARRAYMETHOD_FLAGS method_flags = 0;
 
     PyArray_SortFunc **sort_table = NULL;
     PyArray_SortFunc *sort = NULL;
@@ -3184,7 +3184,7 @@ PyArray_Sort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
         npy_intp strides[2] = {loop_descrs[0]->elsize, loop_descrs[1]->elsize};
 
         if (sort_method->get_strided_loop(
-            &context, 1, 0, strides, &strided_loop, &auxdata, method_flags) < 0) {
+            &context, 1, 0, strides, &strided_loop, &auxdata, &method_flags) < 0) {
             ret = -1;
             goto fail;
         }
@@ -3229,7 +3229,7 @@ PyArray_Sort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
     }
 
     ret = _new_sortlike(op, axis, sort, strided_loop,
-                        &context, auxdata, method_flags, NULL, NULL, 0);
+                        &context, auxdata, &method_flags, NULL, NULL, 0);
 
 fail:
     if (sort_method != NULL) {
@@ -3259,7 +3259,7 @@ PyArray_ArgSort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
     PyArrayMethod_Context context = {0};
     PyArray_Descr *loop_descrs[2];
     NpyAuxData *auxdata = NULL;
-    NPY_ARRAYMETHOD_FLAGS *method_flags = NULL;
+    NPY_ARRAYMETHOD_FLAGS method_flags = 0;
 
     PyArray_ArgSortFunc **argsort_table = NULL;
     PyArray_ArgSortFunc *argsort = NULL;
@@ -3295,7 +3295,7 @@ PyArray_ArgSort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
         npy_intp strides[2] = {loop_descrs[0]->elsize, loop_descrs[1]->elsize};
 
         if (argsort_method->get_strided_loop(
-            &context, 1, 0, strides, &strided_loop, &auxdata, method_flags) < 0) {
+            &context, 1, 0, strides, &strided_loop, &auxdata, &method_flags) < 0) {
             ret = NULL;
             goto fail;
         }
@@ -3346,7 +3346,7 @@ PyArray_ArgSort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
     }
 
     ret = _new_argsortlike(op2, axis, argsort, strided_loop,
-                           &context, auxdata, method_flags, NULL, NULL, 0);
+                           &context, auxdata, &method_flags, NULL, NULL, 0);
     Py_DECREF(op2);
 
 fail:

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -706,7 +706,6 @@ stringdtype_wrap_sort_loop(
  */
 static NPY_CASTING
 stringdtype_sort_resolve_descriptors(
-        PyArrayMethod_Context *context,
         PyArrayMethodObject *method,
         PyArray_DTypeMeta *const *dtypes,
         PyArray_Descr *const *input_descrs,
@@ -714,18 +713,19 @@ stringdtype_sort_resolve_descriptors(
         npy_intp *view_offset)
 {
     output_descrs[0] = NPY_DT_CALL_ensure_canonical(input_descrs[0]);
-    if (output_descrs[0] == NULL) {
+    if (NPY_UNLIKELY(output_descrs[0] == NULL)) {
         return -1;
     }
     output_descrs[1] = NPY_DT_CALL_ensure_canonical(input_descrs[1]);
-    if (output_descrs[1] == NULL) {
-        Py_DECREF(output_descrs[0]);
+    if (NPY_UNLIKELY(output_descrs[1] == NULL)) {
+        Py_XDECREF(output_descrs[0]);
         return -1;
     }
-    
+
+    // sorting cannot be a view
     *view_offset = 0;
-    
-    return NPY_NO_CASTING;
+
+    return method->casting;
 }
 
 int

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -460,17 +460,6 @@ compare(void *a, void *b, void *arr)
     return ret;
 }
 
-int
-_sort_compare(const void *a, const void *b, void *context)
-{
-    PyArrayMethod_Context *sort_context = (PyArrayMethod_Context *)context;
-    PyArray_StringDTypeObject *sdescr =
-        (PyArray_StringDTypeObject *)sort_context->descriptors[0];
-
-    int ret = _compare((void *)a, (void *)b, sdescr, sdescr);
-    return ret;
-}
-
 // We assume the allocator mutex is already held.
 int
 _compare(void *a, void *b, PyArray_StringDTypeObject *descr_a,
@@ -527,7 +516,18 @@ _compare(void *a, void *b, PyArray_StringDTypeObject *descr_a,
         }
     }
     return NpyString_cmp(&s_a, &s_b);
-    }
+}
+
+int
+_sort_compare(const void *a, const void *b, void *context)
+{
+    PyArrayMethod_Context *sort_context = (PyArrayMethod_Context *)context;
+    PyArray_StringDTypeObject *sdescr =
+        (PyArray_StringDTypeObject *)sort_context->descriptors[0];
+
+    int ret = _compare((void *)a, (void *)b, sdescr, sdescr);
+    return ret;
+}
 
 // PyArray_ArgFunc
 // The max element is the one with the highest unicode code point.

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -18,6 +18,7 @@
 #include "conversion_utils.h"
 #include "npy_import.h"
 #include "multiarraymodule.h"
+#include "npy_sort.h"
 
 /*
  * Internal helper to create new instances
@@ -460,6 +461,18 @@ compare(void *a, void *b, void *arr)
 }
 
 int
+_sort_compare(const void *a, const void *b, void *context)
+{
+    PyArrayMethod_Context *sort_context = (PyArrayMethod_Context *)context;
+    PyArray_StringDTypeObject *sdescr =
+        (PyArray_StringDTypeObject *)sort_context->descriptors[0];
+
+    int ret = _compare((void *)a, (void *)b, sdescr, sdescr);
+    return ret;
+}
+
+// We assume the allocator mutex is already held.
+int
 _compare(void *a, void *b, PyArray_StringDTypeObject *descr_a,
          PyArray_StringDTypeObject *descr_b)
 {
@@ -514,7 +527,7 @@ _compare(void *a, void *b, PyArray_StringDTypeObject *descr_a,
         }
     }
     return NpyString_cmp(&s_a, &s_b);
-}
+    }
 
 // PyArray_ArgFunc
 // The max element is the one with the highest unicode code point.
@@ -666,6 +679,165 @@ static PyType_Slot PyArray_StringDType_Slots[] = {
         {_NPY_DT_is_known_scalar_type, &stringdtype_is_known_scalar_type},
         {0, NULL}};
 
+
+/*
+ * Wrap the sort loop to acquire/release the string allocator.
+ */
+int
+stringdtype_wrap_sort_loop(
+        PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata, PyArray_SortImpl *sort_loop)
+{
+    PyArray_StringDTypeObject *sdescr =
+            (PyArray_StringDTypeObject *)context->descriptors[0];
+
+    npy_string_allocator *allocator = NpyString_acquire_allocator(sdescr);
+    int ret = sort_loop(
+            data[0], dimensions[0], context,
+            context->descriptors[0]->elsize, &_sort_compare);
+    NpyString_release_allocator(allocator);
+    return ret;
+}
+
+/* 
+ * This is currently required even though the default implementation would work,
+ * because the output, though enforced to be equal to the input, is parametric.
+ */
+static NPY_CASTING
+stringdtype_sort_resolve_descriptors(
+        PyArrayMethod_Context *context,
+        PyArrayMethodObject *method,
+        PyArray_DTypeMeta *const *dtypes,
+        PyArray_Descr *const *input_descrs,
+        PyArray_Descr **output_descrs,
+        npy_intp *view_offset)
+{
+    output_descrs[0] = NPY_DT_CALL_ensure_canonical(input_descrs[0]);
+    if (output_descrs[0] == NULL) {
+        return -1;
+    }
+    output_descrs[1] = NPY_DT_CALL_ensure_canonical(input_descrs[1]);
+    if (output_descrs[1] == NULL) {
+        Py_DECREF(output_descrs[0]);
+        return -1;
+    }
+    
+    *view_offset = 0;
+    
+    return NPY_NO_CASTING;
+}
+
+int
+stringdtype_wrap_argsort_loop(
+        PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata, PyArray_ArgSortImpl *argsort_loop)
+{
+    PyArray_StringDTypeObject *sdescr =
+            (PyArray_StringDTypeObject *)context->descriptors[0];
+
+    npy_string_allocator *allocator = NpyString_acquire_allocator(sdescr);
+    int ret = argsort_loop(
+            data[0], (npy_intp *)data[1], dimensions[0], context,
+            context->descriptors[0]->elsize, &_sort_compare);
+    NpyString_release_allocator(allocator);
+    return ret;
+}
+
+int
+stringdtype_defaultsort_loop(
+        PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata)
+{
+    return stringdtype_wrap_sort_loop(
+            context, data, dimensions, strides, transferdata,
+            &npy_quicksort_impl);
+}
+
+int
+stringdtype_stablesort_loop(
+        PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata)
+{
+    return stringdtype_wrap_sort_loop(
+            context, data, dimensions, strides, transferdata,
+            &npy_mergesort_impl);
+}
+
+int
+stringdtype_defaultargsort_loop(
+        PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata)
+{
+    return stringdtype_wrap_argsort_loop(
+            context, data, dimensions, strides, transferdata,
+            &npy_aquicksort_impl);
+}
+
+int
+stringdtype_stableargsort_loop(
+        PyArrayMethod_Context *context,
+        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
+        NpyAuxData *transferdata)
+{
+    return stringdtype_wrap_argsort_loop(
+            context, data, dimensions, strides, transferdata,
+            &npy_amergesort_impl);
+}
+
+int
+stringdtype_get_sort_loop(
+        PyArrayMethod_Context *context,
+        int aligned, int move_references,
+        const npy_intp *strides,
+        PyArrayMethod_StridedLoop **out_loop,
+        NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags)
+{
+    PyArrayMethod_SortParameters *parameters = (PyArrayMethod_SortParameters *)context->parameters;
+    *flags |= NPY_METH_NO_FLOATINGPOINT_ERRORS;
+
+    if (parameters->flags == NPY_SORT_STABLE) {
+        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_stablesort_loop;
+    }
+    else if (parameters->flags == NPY_SORT_DEFAULT) {
+        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_defaultsort_loop;
+    }
+    else {
+        PyErr_SetString(PyExc_RuntimeError, "unsupported sort kind");
+        return -1;
+    }
+    return 0;
+}
+
+int
+stringdtype_get_argsort_loop(
+        PyArrayMethod_Context *context,
+        int aligned, int move_references,
+        const npy_intp *strides,
+        PyArrayMethod_StridedLoop **out_loop,
+        NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags)
+{
+    PyArrayMethod_SortParameters *parameters = (PyArrayMethod_SortParameters *)context->parameters;
+    *flags |= NPY_METH_NO_FLOATINGPOINT_ERRORS;
+
+    if (parameters->flags == NPY_SORT_STABLE) {
+        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_stableargsort_loop;
+    }
+    else if (parameters->flags == NPY_SORT_DEFAULT) {
+        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_defaultargsort_loop;
+    }
+    else {
+        PyErr_SetString(PyExc_RuntimeError, "unsupported sort kind");
+        return -1;
+    }
+    return 0;
+}
 
 static PyObject *
 stringdtype_new(PyTypeObject *NPY_UNUSED(cls), PyObject *args, PyObject *kwds)
@@ -831,6 +1003,60 @@ PyArray_DTypeMeta PyArray_StringDType = {
         /* rest, filled in during DTypeMeta initialization */
 };
 
+int
+init_stringdtype_sorts(void)
+{
+    PyArray_DTypeMeta *stringdtype = &PyArray_StringDType;
+
+    PyArray_DTypeMeta *sort_dtypes[2] = {stringdtype, stringdtype};
+    PyType_Slot sort_slots[3] = {
+            {NPY_METH_resolve_descriptors, &stringdtype_sort_resolve_descriptors},
+            {NPY_METH_get_loop, &stringdtype_get_sort_loop},
+            {0, NULL}
+    };
+    PyArrayMethod_Spec sort_spec = {
+            .name = "stringdtype_sort",
+            .nin = 1,
+            .nout = 1,
+            .dtypes = sort_dtypes,
+            .slots = sort_slots,
+            .flags = NPY_METH_NO_FLOATINGPOINT_ERRORS,
+    };
+
+    PyBoundArrayMethodObject *sort_method = PyArrayMethod_FromSpec_int(
+            &sort_spec, 1);
+    if (sort_method == NULL) {
+        return -1;
+    }
+    NPY_DT_SLOTS(stringdtype)->sort_meth = sort_method->method;
+    Py_INCREF(sort_method->method);
+    Py_DECREF(sort_method);
+
+    PyArray_DTypeMeta *argsort_dtypes[2] = {stringdtype, &PyArray_IntpDType};
+    PyType_Slot argsort_slots[2] = {
+            {NPY_METH_get_loop, &stringdtype_get_argsort_loop},
+            {0, NULL}
+    };
+    PyArrayMethod_Spec argsort_spec = {
+            .name = "stringdtype_argsort",
+            .nin = 1,
+            .nout = 1,
+            .dtypes = argsort_dtypes,
+            .slots = argsort_slots,
+            .flags = NPY_METH_NO_FLOATINGPOINT_ERRORS,
+    };
+
+    PyBoundArrayMethodObject *argsort_method = PyArrayMethod_FromSpec_int(
+            &argsort_spec, 1);
+    if (argsort_method == NULL) {
+        return -1;
+    }
+    NPY_DT_SLOTS(stringdtype)->argsort_meth = argsort_method->method;
+    Py_INCREF(argsort_method->method);
+    Py_DECREF(argsort_method);
+    return 0;
+}
+
 NPY_NO_EXPORT int
 init_string_dtype(void)
 {
@@ -875,6 +1101,10 @@ init_string_dtype(void)
     }
 
     PyMem_Free(PyArray_StringDType_casts);
+
+    if (init_stringdtype_sorts() < 0) {
+        return -1;
+    }
 
     return 0;
 }

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -726,9 +726,6 @@ stringdtype_sort_resolve_descriptors(
         return -1;
     }
 
-    // sorting cannot be a view
-    *view_offset = 0;
-
     return method->casting;
 }
 

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -681,16 +681,20 @@ static PyType_Slot PyArray_StringDType_Slots[] = {
 
 
 /*
- * Wrap the sort loop to acquire/release the string allocator.
+ * Wrap the sort loop to acquire/release the string allocator,
+ * and pick the correct internal implementation.
  */
 int
 stringdtype_wrap_sort_loop(
         PyArrayMethod_Context *context,
         char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata, PyArray_SortImpl *sort_loop)
+        NpyAuxData *transferdata)
 {
     PyArray_StringDTypeObject *sdescr =
             (PyArray_StringDTypeObject *)context->descriptors[0];
+    PyArray_SortImpl *sort_loop =
+        ((PyArrayMethod_SortParameters *)context->parameters)->flags
+        == NPY_SORT_STABLE ? &npy_mergesort_impl : &npy_quicksort_impl;
 
     npy_string_allocator *allocator = NpyString_acquire_allocator(sdescr);
     int ret = sort_loop(
@@ -732,10 +736,13 @@ int
 stringdtype_wrap_argsort_loop(
         PyArrayMethod_Context *context,
         char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata, PyArray_ArgSortImpl *argsort_loop)
+        NpyAuxData *transferdata)
 {
     PyArray_StringDTypeObject *sdescr =
             (PyArray_StringDTypeObject *)context->descriptors[0];
+    PyArray_ArgSortImpl *argsort_loop =
+        ((PyArrayMethod_SortParameters *)context->parameters)
+        ->flags == NPY_SORT_STABLE ? &npy_amergesort_impl : &npy_aquicksort_impl;
 
     npy_string_allocator *allocator = NpyString_acquire_allocator(sdescr);
     int ret = argsort_loop(
@@ -743,32 +750,6 @@ stringdtype_wrap_argsort_loop(
             context->descriptors[0]->elsize, &_sort_compare);
     NpyString_release_allocator(allocator);
     return ret;
-}
-
-int
-stringdtype_sort_loop(
-        PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata)
-{
-    npy_bool stable = (((PyArrayMethod_SortParameters *)context->parameters)
-                       ->flags == NPY_SORT_STABLE);
-    return stringdtype_wrap_sort_loop(
-            context, data, dimensions, strides, transferdata,
-            stable ? &npy_mergesort_impl : &npy_quicksort_impl);
-}
-
-int
-stringdtype_argsort_loop(
-        PyArrayMethod_Context *context,
-        char *const *data, const npy_intp *dimensions, const npy_intp *strides,
-        NpyAuxData *transferdata)
-{
-    npy_bool stable = (((PyArrayMethod_SortParameters *)context->parameters)
-                       ->flags == NPY_SORT_STABLE);
-    return stringdtype_wrap_argsort_loop(
-            context, data, dimensions, strides, transferdata,
-            stable ? &npy_amergesort_impl : &npy_aquicksort_impl);
 }
 
 int
@@ -785,7 +766,7 @@ stringdtype_get_sort_loop(
 
     if ((parameters->flags == NPY_SORT_STABLE)
         || parameters->flags == NPY_SORT_DEFAULT) {
-        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_sort_loop;
+        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_wrap_sort_loop;
     }
     else {
         PyErr_SetString(PyExc_RuntimeError, "unsupported sort kind");
@@ -808,7 +789,7 @@ stringdtype_get_argsort_loop(
 
     if (parameters->flags == NPY_SORT_STABLE
         || parameters->flags == NPY_SORT_DEFAULT) {
-        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_argsort_loop;
+        *out_loop = (PyArrayMethod_StridedLoop *)stringdtype_wrap_argsort_loop;
     }
     else {
         PyErr_SetString(PyExc_RuntimeError, "unsupported sort kind");

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -684,7 +684,7 @@ static PyType_Slot PyArray_StringDType_Slots[] = {
  * Wrap the sort loop to acquire/release the string allocator,
  * and pick the correct internal implementation.
  */
-int
+static int
 stringdtype_wrap_sort_loop(
         PyArrayMethod_Context *context,
         char *const *data, const npy_intp *dimensions, const npy_intp *strides,
@@ -729,7 +729,7 @@ stringdtype_sort_resolve_descriptors(
     return method->casting;
 }
 
-int
+static int
 stringdtype_wrap_argsort_loop(
         PyArrayMethod_Context *context,
         char *const *data, const npy_intp *dimensions, const npy_intp *strides,
@@ -749,7 +749,7 @@ stringdtype_wrap_argsort_loop(
     return ret;
 }
 
-int
+static int
 stringdtype_get_sort_loop(
         PyArrayMethod_Context *context,
         int aligned, int move_references,
@@ -772,7 +772,7 @@ stringdtype_get_sort_loop(
     return 0;
 }
 
-int
+static int
 stringdtype_get_argsort_loop(
         PyArrayMethod_Context *context,
         int aligned, int move_references,
@@ -959,7 +959,7 @@ PyArray_DTypeMeta PyArray_StringDType = {
         /* rest, filled in during DTypeMeta initialization */
 };
 
-int
+NPY_NO_EXPORT int
 init_stringdtype_sorts(void)
 {
     PyArray_DTypeMeta *stringdtype = &PyArray_StringDType;

--- a/numpy/_core/src/npysort/mergesort.cpp
+++ b/numpy/_core/src/npysort/mergesort.cpp
@@ -386,7 +386,7 @@ npy_mergesort(void *start, npy_intp num, void *varr)
     void *arr = varr;
     npy_intp elsize;
     PyArray_CompareFunc *cmp;
-    fill_sort_data_with_array(arr, &elsize, &cmp);
+    get_sort_data_from_array(arr, &elsize, &cmp);
 
     return npy_mergesort_impl(start, num, varr, elsize, cmp);
 }
@@ -472,7 +472,7 @@ npy_amergesort(void *v, npy_intp *tosort, npy_intp num, void *varr)
     void *arr = varr;
     npy_intp elsize;
     PyArray_CompareFunc *cmp;
-    fill_sort_data_with_array(arr, &elsize, &cmp);
+    get_sort_data_from_array(arr, &elsize, &cmp);
 
     return npy_amergesort_impl(v, tosort, num, varr, elsize, cmp);
 }

--- a/numpy/_core/src/npysort/mergesort.cpp
+++ b/numpy/_core/src/npysort/mergesort.cpp
@@ -337,7 +337,7 @@ string_amergesort_(type *v, npy_intp *tosort, npy_intp num, void *varr)
 
 static void
 npy_mergesort0(char *pl, char *pr, char *pw, char *vp, npy_intp elsize,
-               PyArray_CompareFunc *cmp, PyArrayObject *arr)
+               PyArray_CompareFunc *cmp, void *arr)
 {
     char *pi, *pj, *pk, *pm;
 
@@ -381,11 +381,20 @@ npy_mergesort0(char *pl, char *pr, char *pw, char *vp, npy_intp elsize,
 }
 
 NPY_NO_EXPORT int
-npy_mergesort(void *start, npy_intp num, void *varr)
+npy_mergesort(void *start, npy_intp num, void *varr) {
+    void *arr = varr;
+    npy_intp elsize;
+    PyArray_CompareFunc *cmp;
+    fill_sort_data_with_array(arr, &elsize, &cmp);
+
+    return npy_mergesort_impl(start, num, varr, elsize, cmp);
+}
+
+NPY_NO_EXPORT int
+npy_mergesort_impl(void *start, npy_intp num, void *varr,
+                   npy_intp elsize, PyArray_CompareFunc *cmp)
 {
-    PyArrayObject *arr = (PyArrayObject *)varr;
-    npy_intp elsize = PyArray_ITEMSIZE(arr);
-    PyArray_CompareFunc *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
+    void *arr = varr;
     char *pl = (char *)start;
     char *pr = pl + num * elsize;
     char *pw;
@@ -413,7 +422,7 @@ npy_mergesort(void *start, npy_intp num, void *varr)
 
 static void
 npy_amergesort0(npy_intp *pl, npy_intp *pr, char *v, npy_intp *pw,
-                npy_intp elsize, PyArray_CompareFunc *cmp, PyArrayObject *arr)
+                npy_intp elsize, PyArray_CompareFunc *cmp, void *arr)
 {
     char *vp;
     npy_intp vi, *pi, *pj, *pk, *pm;
@@ -459,9 +468,19 @@ npy_amergesort0(npy_intp *pl, npy_intp *pr, char *v, npy_intp *pw,
 NPY_NO_EXPORT int
 npy_amergesort(void *v, npy_intp *tosort, npy_intp num, void *varr)
 {
-    PyArrayObject *arr = (PyArrayObject *)varr;
-    npy_intp elsize = PyArray_ITEMSIZE(arr);
-    PyArray_CompareFunc *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
+    void *arr = varr;
+    npy_intp elsize;
+    PyArray_CompareFunc *cmp;
+    fill_sort_data_with_array(arr, &elsize, &cmp);
+
+    return npy_amergesort_impl(v, tosort, num, varr, elsize, cmp);
+}
+
+NPY_NO_EXPORT int
+npy_amergesort_impl(void *v, npy_intp *tosort, npy_intp num, void *varr,
+                    npy_intp elsize, PyArray_CompareFunc *cmp)
+{
+    void *arr = varr;
     npy_intp *pl, *pr, *pw;
 
     /* Items that have zero size don't make sense to sort */

--- a/numpy/_core/src/npysort/mergesort.cpp
+++ b/numpy/_core/src/npysort/mergesort.cpp
@@ -381,7 +381,8 @@ npy_mergesort0(char *pl, char *pr, char *pw, char *vp, npy_intp elsize,
 }
 
 NPY_NO_EXPORT int
-npy_mergesort(void *start, npy_intp num, void *varr) {
+npy_mergesort(void *start, npy_intp num, void *varr)
+{
     void *arr = varr;
     npy_intp elsize;
     PyArray_CompareFunc *cmp;

--- a/numpy/_core/src/npysort/npysort_common.h
+++ b/numpy/_core/src/npysort/npysort_common.h
@@ -47,7 +47,7 @@ extern "C" {
  */
 
 static inline void
-fill_sort_data_with_array(void *varr, npy_intp *elsize, PyArray_CompareFunc **cmp)
+get_sort_data_from_array(void *varr, npy_intp *elsize, PyArray_CompareFunc **cmp)
 {
     PyArrayObject *arr = (PyArrayObject *)varr;
     *elsize = PyArray_ITEMSIZE(arr);

--- a/numpy/_core/src/npysort/npysort_common.h
+++ b/numpy/_core/src/npysort/npysort_common.h
@@ -41,6 +41,20 @@ extern "C" {
 #define INTP_SWAP(a,b) {npy_intp tmp = (b); (b)=(a); (a) = tmp;}
 
 /*
+ ******************************************************************************
+ **                        SORTING WRAPPERS                                  **
+ ******************************************************************************
+ */
+
+static inline void
+fill_sort_data_with_array(void *varr, npy_intp *elsize, PyArray_CompareFunc **cmp)
+{
+    PyArrayObject *arr = (PyArrayObject *)varr;
+    *elsize = PyArray_ITEMSIZE(arr);
+    *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
+}
+
+/*
  *****************************************************************************
  **                        COMPARISON FUNCTIONS                             **
  *****************************************************************************

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -508,9 +508,18 @@ string_aquicksort_(type *vv, npy_intp *tosort, npy_intp num, void *varr)
 NPY_NO_EXPORT int
 npy_quicksort(void *start, npy_intp num, void *varr)
 {
-    PyArrayObject *arr = (PyArrayObject *)varr;
-    npy_intp elsize = PyArray_ITEMSIZE(arr);
-    PyArray_CompareFunc *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
+    npy_intp elsize;
+    PyArray_CompareFunc *cmp;
+    fill_sort_data_with_array(varr, &elsize, &cmp);
+
+    return npy_quicksort_impl(start, num, varr, elsize, cmp);
+}
+
+NPY_NO_EXPORT int
+npy_quicksort_impl(void *start, npy_intp num, void *varr,
+                   npy_intp elsize, PyArray_CompareFunc *cmp)
+{
+    void *arr = varr;
     char *vp;
     char *pl = (char *)start;
     char *pr = pl + (num - 1) * elsize;
@@ -612,10 +621,19 @@ npy_quicksort(void *start, npy_intp num, void *varr)
 NPY_NO_EXPORT int
 npy_aquicksort(void *vv, npy_intp *tosort, npy_intp num, void *varr)
 {
+    npy_intp elsize;
+    PyArray_CompareFunc *cmp;
+    fill_sort_data_with_array(varr, &elsize, &cmp);
+
+    return npy_aquicksort_impl(vv, tosort, num, varr, elsize, cmp);
+}
+
+NPY_NO_EXPORT int
+npy_aquicksort_impl(void *vv, npy_intp *tosort, npy_intp num, void *varr,
+                   npy_intp elsize, PyArray_CompareFunc *cmp)
+{
+    void *arr = varr;
     char *v = (char *)vv;
-    PyArrayObject *arr = (PyArrayObject *)varr;
-    npy_intp elsize = PyArray_ITEMSIZE(arr);
-    PyArray_CompareFunc *cmp = PyDataType_GetArrFuncs(PyArray_DESCR(arr))->compare;
     char *vp;
     npy_intp *pl = tosort;
     npy_intp *pr = tosort + num - 1;

--- a/numpy/_core/src/npysort/quicksort.cpp
+++ b/numpy/_core/src/npysort/quicksort.cpp
@@ -510,7 +510,7 @@ npy_quicksort(void *start, npy_intp num, void *varr)
 {
     npy_intp elsize;
     PyArray_CompareFunc *cmp;
-    fill_sort_data_with_array(varr, &elsize, &cmp);
+    get_sort_data_from_array(varr, &elsize, &cmp);
 
     return npy_quicksort_impl(start, num, varr, elsize, cmp);
 }
@@ -623,7 +623,7 @@ npy_aquicksort(void *vv, npy_intp *tosort, npy_intp num, void *varr)
 {
     npy_intp elsize;
     PyArray_CompareFunc *cmp;
-    fill_sort_data_with_array(varr, &elsize, &cmp);
+    get_sort_data_from_array(varr, &elsize, &cmp);
 
     return npy_aquicksort_impl(vv, tosort, num, varr, elsize, cmp);
 }


### PR DESCRIPTION
Sorry, many PRs - I'm closing the other one (#30112). This should be much simpler.

Implements sorts and argsorts for StringDType using the feature introduced in #29737. The sorts allocate the mutex lock only once, thus fixes #26510. Some refactors of the npysort code were needed which should help with further work (e.g., descending sorts and moving the builtin dtype machinery).

Posting benchmarks below. ping @seberg @ngoldbaum @mhvk - thanks for reviewing!