### PR TITLE
ENH: Use descriptor rather than custom `tp_getattro`

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -4966,7 +4966,18 @@ _multiarray_umath_exec(PyObject *m) {
         return -1;
     }
 
+    /* Set __signature__ to None on the type (the instance has a property) */
+    s = npy_import("numpy._globals", "_SignatureDescriptor");
+    if (s == NULL) {
+        return -1;
+    }
+    PyUFunc_Type.tp_dict = Py_BuildValue(
+        "{ON}", npy_interned_str.__signature__, s);
+    if (PyUFunc_Type.tp_dict == NULL) {
+        return -1;
+    }
     if (PyType_Ready(&PyUFunc_Type) < 0) {
+        Py_CLEAR(PyUFunc_Type.tp_dict);
         return -1;
     }
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -4967,7 +4967,7 @@ _multiarray_umath_exec(PyObject *m) {
     }
 
     /* Set __signature__ to None on the type (the instance has a property) */
-    s = npy_import("numpy._globals", "_SignatureDescriptor");
+    s = npy_import("numpy._globals", "_signature_descriptor");
     if (s == NULL) {
         return -1;
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -6755,6 +6755,7 @@ static PyGetSetDef ufunc_getset[] = {
     {"signature",
         (getter)ufunc_get_signature,
         NULL, NULL, NULL},
+    // __signature__ stored in `__dict__`, see `_globals._SignatureDescriptor`
     {NULL, NULL, NULL, NULL, NULL},  /* Sentinel */
 };
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -6646,57 +6646,6 @@ ufunc_set_doc(PyUFuncObject *ufunc, PyObject *doc, void *NPY_UNUSED(ignored))
 }
 
 static PyObject *
-ufunc_get_inspect_signature(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
-{
-    PyObject *signature;
-
-    // If there is a __signature__ in the instance __dict__, use it.
-    int result = PyDict_GetItemRef(ufunc->dict, npy_interned_str.__signature__,
-                                   &signature);
-    if (result == -1) {
-        return NULL;
-    }
-    else if (result == 1) {
-        return signature;
-    }
-
-    if (npy_cache_import_runtime(
-            "numpy._core._internal", "_ufunc_inspect_signature_builder",
-            &npy_runtime_imports._ufunc_inspect_signature_builder) == -1) {
-        return NULL;
-    }
-
-    signature = PyObject_CallFunctionObjArgs(
-            npy_runtime_imports._ufunc_inspect_signature_builder,
-            (PyObject *)ufunc, NULL);
-    if (signature == NULL) {
-        return NULL;
-    }
-
-    // Cache the result in the instance dict for next time
-    if (PyDict_SetItem(ufunc->dict, npy_interned_str.__signature__,
-                       signature) < 0) {
-        Py_DECREF(signature);
-        return NULL;
-    }
-
-    return signature;
-}
-
-static PyObject *
-ufunc_getattro(PyObject *obj, PyObject *name)
-{
-    // __signature__ special-casing to prevent class attribute access
-    if (PyUnicode_Check(name) &&
-        PyUnicode_Compare(name, npy_interned_str.__signature__) == 0) {
-        return ufunc_get_inspect_signature((PyUFuncObject *)obj, NULL);
-    }
-    
-    // For all other attributes, use default behavior
-    return PyObject_GenericGetAttr(obj, name);
-}
-
-static PyObject *
 ufunc_get_nin(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
 {
     return PyLong_FromLong(ufunc->nin);
@@ -6840,7 +6789,7 @@ NPY_NO_EXPORT PyTypeObject PyUFunc_Type = {
     .tp_traverse = (traverseproc)ufunc_traverse,
     .tp_methods = ufunc_methods,
     .tp_getset = ufunc_getset,
-    .tp_getattro = ufunc_getattro,
+    .tp_getattro = PyObject_GenericGetAttr,
     .tp_setattro = PyObject_GenericSetAttr,
     // TODO when Python 3.12 is the minimum supported version,
     // use Py_TPFLAGS_MANAGED_DICT

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4048,6 +4048,7 @@ class TestSpecialMethods:
         assert_array_equal(res, a + a)
 
     @pytest.mark.thread_unsafe(reason="modifies global module")
+    @pytest.mark.skipif(IS_PYPY, reason="__signature__ descriptor dance fails")
     def test_ufunc_docstring(self):
         original_doc = np.add.__doc__
         new_doc = "new docs"

--- a/numpy/_globals.py
+++ b/numpy/_globals.py
@@ -94,3 +94,28 @@ class _CopyMode(enum.Enum):
             return False
 
         raise ValueError(f"{self} is neither True nor False.")
+
+
+class _SignatureDescriptorClass:
+    # A descriptor to store on the ufunc __dict__ that avoids definig a
+    # signature for the ufunc class/type but allows the instance to have one.
+    # This is needed because inspect.signature() chokes on normal properties
+    # (as of 3.14 at least).
+    # We could also set __signature__ on the instance but this allows deferred
+    # computation of the signature.
+    def __get__(self, obj, objtype=None):
+        # Delay import, not a critical path but need to avoid circular import.
+        from numpy._core._internal import _ufunc_inspect_signature_builder
+
+        if obj is None:
+            # could also return None, which is accepted as "not set" by
+            # inspect.signature().
+            raise AttributeError(
+                "type object 'numpy.ufunc' has no attribute '__signature__'")
+
+        # Store on the instance, after this the descriptor won't be used.
+        obj.__signature__ = _ufunc_inspect_signature_builder(obj)
+        return obj.__signature__
+
+
+_SignatureDescriptor = _SignatureDescriptorClass()

--- a/numpy/_globals.py
+++ b/numpy/_globals.py
@@ -96,7 +96,7 @@ class _CopyMode(enum.Enum):
         raise ValueError(f"{self} is neither True nor False.")
 
 
-class _SignatureDescriptorClass:
+class _SignatureDescriptor:
     # A descriptor to store on the ufunc __dict__ that avoids definig a
     # signature for the ufunc class/type but allows the instance to have one.
     # This is needed because inspect.signature() chokes on normal properties
@@ -118,4 +118,4 @@ class _SignatureDescriptorClass:
         return obj.__signature__
 
 
-_SignatureDescriptor = _SignatureDescriptorClass()
+_signature_descriptor = _SignatureDescriptor()


### PR DESCRIPTION
To me a custom `tp_getattro` feels a bit wrong, so instead use a descriptor protocol to solve this.
That is unfortunately slightly annoying/complex.  Static types do however have a `tp_dict` (a fact that I had missed...).

So while normal properties don't behave well enough for signatures putting a `__signature__` into the `__dict__` does work perfectly fine, although admittedly it is bit awkward to set up.

This should ensure that fast-paths that rely on the default getattr not being replaced should remain active.