### PR TITLE
TST: Join threads in ``test_printoptions_thread_safety``

### DIFF
--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -122,6 +122,8 @@ def test_printoptions_thread_safety():
 
     task1.start()
     task2.start()
+    task1.join()
+    task2.join()
 
 
 def test_parallel_reduction():


### PR DESCRIPTION
The `test_printoptions_thread_safety` function spawns two `threading.Thread` objects but never calls `.join()` on them.

This causes multiple problems:
- The test function can return and be marked as "passed" by pytest **before** the assertions inside the threads have executed → intermittent failures or false positives.
- Threads are left running when the test process exits → thread leakage, occasional segmentation faults, and “daemon thread still running” warnings.
- Unnecessary non-determinism in an otherwise stable thread-safety regression test.

All other threading tests in the same file already join their threads properly (via `run_threaded` or `ThreadPoolExecutor`).

**Fix**  
Add the two missing lines:

```python
    task1.start()
    task2.start()
    task1.join()
    task2.join()