### PR TITLE
BUG: Return first NaN occurence in np.unique for complex arrays

### DIFF
--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -773,9 +773,9 @@ class TestUnique:
         # test for ticket 2111 - complex
         a = [2.0 - 1j, np.nan, 1.0 + 1j, complex(0.0, np.nan), complex(1.0, np.nan)]
         ua = [1.0 + 1j, 2.0 - 1j, complex(0.0, np.nan)]
-        ua_idx = [2, 0, 3]
-        ua_inv = [1, 2, 0, 2, 2]
-        ua_cnt = [1, 1, 3]
+        ua_idx = [2, 0, 1]
+        ua_inv = [1, 2, 0, 1, 1]
+        ua_cnt = [1, 3, 1]
         # order of unique values is not guaranteed
         assert_equal(np.sort(np.unique(a)), np.sort(ua))
         assert_equal(np.unique(a, return_index=True), (ua, ua_idx))
@@ -1195,13 +1195,20 @@ class TestUnique:
         msg = "Unique's return_counts=True failed with axis=1"
         assert_array_equal(cnt, np.array([2, 1, 1]), msg)
 
-    def test_unique_nanequals(self):
+    def test_complex_nanequal_unique(self):
         # issue 20326
         a = np.array([1, 1, np.nan, np.nan, np.nan])
         unq = np.unique(a)
         not_unq = np.unique(a, equal_nan=False)
         assert_array_equal(unq, np.array([1, np.nan]))
         assert_array_equal(not_unq, np.array([1, np.nan, np.nan, np.nan]))
+
+        # issue 30113
+        a = np.array([1 + 1j, 1 + 1j,
+                      np.nan, complex(0.0, np.nan), complex(0.0, np.nan)])
+        unq, indices = np.unique(a, return_index=True, equal_nan=True)
+        assert_array_equal(unq, np.array([1 + 1j, np.nan]))
+        assert_array_equal(indices, np.array([0, 2]))
 
     def test_unique_array_api_functions(self):
         arr = np.array(


### PR DESCRIPTION
Fixes #30113.

This is somewhat an experiment, because while it works, there is a clear performance deficit if there are many NaNs or when indices are not needed. That said, since sorting doesn't preserve nan order, I couldn't find a way yet to avoid this much... perhaps we can just wait for #30110 to finish if this is not critical.

There is some history in #2111 it seems, too, and a test had to be changed.

I'll add a release note if we decide to do this. Thanks for reviewing!