### PR TITLE
TYP: ``_core.overrides.set_module`` implicit re-export

### DIFF
--- a/numpy/_core/overrides.pyi
+++ b/numpy/_core/overrides.pyi
@@ -1,6 +1,8 @@
 from collections.abc import Callable, Iterable
 from typing import Any, Final, NamedTuple, ParamSpec, TypeAlias, TypeVar
 
+from numpy._utils import set_module as set_module
+
 _T = TypeVar("_T")
 _Tss = ParamSpec("_Tss")
 _FuncLikeT = TypeVar("_FuncLikeT", bound=type | Callable[..., object])


### PR DESCRIPTION
This fixes mypy errors in e.g. `numpy/fft/_helper.py`, which imports `set_module` from `numpy._core.overrides`.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
