### PR TITLE
TYP: move the ``normalize_axis_*`` function definitions from ``lib`` to ``_core``

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -90,7 +90,6 @@ from numpy._typing._ufunc import (
     _PyFunc_Nin2_Nout1,
     _PyFunc_Nin3P_Nout1,
 )
-from numpy.lib._array_utils_impl import normalize_axis_index
 
 __all__ = [
     "_ARRAY_API",
@@ -537,6 +536,9 @@ def ravel_multi_index(
 def unravel_index(indices: _IntLike_co, shape: _ShapeLike, order: _OrderCF = "C") -> tuple[intp, ...]: ...
 @overload
 def unravel_index(indices: _ArrayLikeInt_co, shape: _ShapeLike, order: _OrderCF = "C") -> tuple[NDArray[intp], ...]: ...
+
+#
+def normalize_axis_index(axis: int, ndim: int, msg_prefix: str | None = None) -> int: ...
 
 # NOTE: Allow any sequence of array-like objects
 @overload

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete
 from builtins import bool as py_bool
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from typing import (
     Any,
     Final,
@@ -53,7 +53,6 @@ from numpy._typing import (
     _SupportsArrayFunc,
     _SupportsDType,
 )
-from numpy.lib._array_utils_impl import normalize_axis_tuple as normalize_axis_tuple
 
 from ._asarray import require
 from ._ufunc_config import (
@@ -1087,6 +1086,12 @@ def roll(a: ArrayLike, shift: _ShapeLike, axis: _ShapeLike | None = None) -> NDA
 #
 def rollaxis(a: _ArrayT, axis: int, start: int = 0) -> _ArrayT: ...
 def moveaxis(a: _ArrayT, source: _ShapeLike, destination: _ShapeLike) -> _ArrayT: ...
+def normalize_axis_tuple(
+    axis: int | Iterable[int],
+    ndim: int,
+    argname: str | None = None,
+    allow_duplicate: py_bool | None = False,
+) -> tuple[int, ...]: ...
 
 #
 @overload  # 0d, dtype=int (default), sparse=False (default)

--- a/numpy/lib/_array_utils_impl.pyi
+++ b/numpy/lib/_array_utils_impl.pyi
@@ -1,8 +1,5 @@
-from collections.abc import Iterable
-from typing import Any
-
-from numpy import generic
-from numpy.typing import NDArray
+import numpy as np
+from numpy._core.numeric import normalize_axis_index, normalize_axis_tuple
 
 __all__ = ["byte_bounds", "normalize_axis_tuple", "normalize_axis_index"]
 
@@ -10,17 +7,4 @@ __all__ = ["byte_bounds", "normalize_axis_tuple", "normalize_axis_index"]
 # implementing the `__array_interface__` protocol. The caveat is
 # that certain keys, marked as optional in the spec, must be present for
 #  `byte_bounds`. This concerns `"strides"` and `"data"`.
-def byte_bounds(a: generic | NDArray[Any]) -> tuple[int, int]: ...
-
-def normalize_axis_tuple(
-    axis: int | Iterable[int],
-    ndim: int,
-    argname: str | None = None,
-    allow_duplicate: bool | None = False,
-) -> tuple[int, ...]: ...
-
-def normalize_axis_index(
-    axis: int = ...,
-    ndim: int = ...,
-    msg_prefix: str | None = ...,
-) -> int: ...
+def byte_bounds(a: np.generic | np.ndarray) -> tuple[int, int]: ...


### PR DESCRIPTION
It more closely matches the runtime definitions this way, and helps with IDE code navigation.