### PR TITLE
TYP: move ``vectorize`` stubs to ``lib._function_base_impl``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -468,6 +468,7 @@ from numpy.lib._function_base_impl import (  # type: ignore[deprecated]
     append,
     interp,
     quantile,
+    vectorize,
 )
 
 from numpy.lib._histograms_impl import (
@@ -6103,27 +6104,6 @@ class memmap(ndarray[_ShapeT_co, _DTypeT_co]):
         return_scalar: builtins.bool = False,
     ) -> Any: ...
     def flush(self) -> None: ...
-
-# TODO: Add a mypy plugin for managing functions whose output type is dependent
-# on the literal value of some sort of signature (e.g. `einsum` and `vectorize`)
-class vectorize:
-    pyfunc: Callable[..., Any]
-    cache: builtins.bool
-    signature: LiteralString | None
-    otypes: LiteralString | None
-    excluded: set[int | str]
-    __doc__: str | None
-    def __init__(
-        self,
-        /,
-        pyfunc: Callable[..., Any] | _NoValueType = ...,  # = _NoValue
-        otypes: str | Iterable[DTypeLike] | None = None,
-        doc: str | None = None,
-        excluded: Iterable[int | str] | None = None,
-        cache: builtins.bool = False,
-        signature: str | None = None,
-    ) -> None: ...
-    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 class poly1d:
     @property

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -16,7 +16,7 @@ from typing import (
 from typing_extensions import TypeIs, TypeVar
 
 import numpy as np
-from numpy import _OrderKACF, vectorize
+from numpy import _OrderKACF
 from numpy._core.multiarray import bincount
 from numpy._globals import _NoValueType
 from numpy._typing import (
@@ -189,6 +189,27 @@ class _SizedIterable(Protocol[_T_co]):
     def __len__(self) -> int: ...
 
 ###
+
+class vectorize:
+    __doc__: str | None
+    __module__: L["numpy"] = "numpy"
+    pyfunc: Callable[..., Incomplete]
+    cache: bool
+    signature: str | None
+    otypes: str | None
+    excluded: set[int | str]
+
+    def __init__(
+        self,
+        /,
+        pyfunc: Callable[..., Incomplete] | _NoValueType = ...,  # = _NoValue
+        otypes: str | Iterable[DTypeLike] | None = None,
+        doc: str | None = None,
+        excluded: Iterable[int | str] | None = None,
+        cache: bool = False,
+        signature: str | None = None,
+    ) -> None: ...
+    def __call__(self, /, *args: Incomplete, **kwargs: Incomplete) -> Incomplete: ...
 
 @overload
 def rot90(m: _ArrayT, k: int = 1, axes: tuple[int, int] = (0, 1)) -> _ArrayT: ...


### PR DESCRIPTION
related to #29776 and #29915