### PR TITLE
TYP: `_core.*`: stubs for some private functions and constants

### DIFF
--- a/numpy/_core/shape_base.pyi
+++ b/numpy/_core/shape_base.pyi
@@ -15,6 +15,7 @@ __all__ = [
     "vstack",
 ]
 
+_T = TypeVar("_T")
 _ScalarT = TypeVar("_ScalarT", bound=generic)
 _ScalarT1 = TypeVar("_ScalarT1", bound=generic)
 _ScalarT2 = TypeVar("_ScalarT2", bound=generic)
@@ -63,6 +64,9 @@ def atleast_3d(a0: ArrayLike, /) -> NDArray[Any]: ...
 def atleast_3d(a0: ArrayLike, a1: ArrayLike, /) -> tuple[NDArray[Any], NDArray[Any]]: ...
 @overload
 def atleast_3d(a0: ArrayLike, a1: ArrayLike, /, *ai: ArrayLike) -> tuple[NDArray[Any], ...]: ...
+
+# used by numpy.lib._shape_base_impl
+def _arrays_for_stack_dispatcher(arrays: Sequence[_T]) -> tuple[_T, ...]: ...
 
 # keep in sync with `numpy.ma.extras.vstack`
 @overload

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -1,3 +1,9 @@
+import contextvars
+from _typeshed import SupportsWrite
+from collections.abc import Callable
+from typing import Any, Final, Literal, TypeAlias, TypedDict, Unpack, type_check_only
+from typing_extensions import CapsuleType
+
 from numpy import (
     absolute,
     add,
@@ -195,3 +201,30 @@ __all__ = [
     "vecdot",
     "vecmat",
 ]
+
+###
+
+_ErrKind: TypeAlias = Literal["ignore", "warn", "raise", "call", "print", "log"]
+_ErrCall: TypeAlias = Callable[[str, int], Any] | SupportsWrite[str]
+
+@type_check_only
+class _ExtOjbDict(TypedDict, total=False):
+    divide: _ErrKind
+    over: _ErrKind
+    under: _ErrKind
+    invalid: _ErrKind
+    call: _ErrCall | None
+    bufsize: int
+
+# re-exports from `_core._multiarray_umath` that are used by `_core._ufunc_config`
+
+NAN: Final[float] = float("nan")
+PINF: Final[float] = float("+inf")
+NINF: Final[float] = float("-inf")
+PZERO: Final[float] = +0.0
+NZERO: Final[float] = -0.0
+_UFUNC_API: Final[CapsuleType] = ...
+_extobj_contextvar: Final[contextvars.ContextVar[CapsuleType]] = ...
+
+def _get_extobj_dict() -> _ExtOjbDict: ...
+def _make_extobj(*, all: _ErrKind = ..., **kwargs: Unpack[_ExtOjbDict]) -> CapsuleType: ...


### PR DESCRIPTION
These were used in `_core/_ufunc_confg.py` and `lib/_shape_base_impl.py`, but because they had no stubs, they were causing errors to be reported by type-checkers. 
So this effectively gets rid of (almost) all of the annoying squiggly lines in those two modules.