### PR TITLE
MAINT: remove ``lib._shape_base_impl._replace_zero_by_x_arrays``

### DIFF
--- a/numpy/lib/_shape_base_impl.py
+++ b/numpy/lib/_shape_base_impl.py
@@ -730,15 +730,6 @@ def dstack(tup):
     return _nx.concatenate(arrs, 2)
 
 
-def _replace_zero_by_x_arrays(sub_arys):
-    for i in range(len(sub_arys)):
-        if _nx.ndim(sub_arys[i]) == 0:
-            sub_arys[i] = _nx.empty(0, dtype=sub_arys[i].dtype)
-        elif _nx.sometrue(_nx.equal(_nx.shape(sub_arys[i]), 0)):
-            sub_arys[i] = _nx.empty(0, dtype=sub_arys[i].dtype)
-    return sub_arys
-
-
 def _array_split_dispatcher(ary, indices_or_sections, axis=None):
     return (ary, indices_or_sections)
 


### PR DESCRIPTION
It's not used or mentioned anywhere, and calls the removed `sometrue` function, so it wouldn't even work.