### PR TITLE
BUG: C code generated by f2py is not C23 compliant

### DIFF
--- a/numpy/f2py/auxfuncs.py
+++ b/numpy/f2py/auxfuncs.py
@@ -699,7 +699,7 @@ def getcallstatement(rout):
 
 def getcallprotoargument(rout, cb_map={}):
     r = getmultilineblock(rout, 'callprotoargument', comment=0)
-    if r:
+    if r and r.strip():
         return r
     if hascallstatement(rout):
         outmess(


### PR DESCRIPTION
Fix #30167 

This PR  updates the condition to `if r and r.strip():`, the code now properly ignores empty or whitespace only blocks. This ensures that when no arguments are provided, F2PY correctly falls back to generating `void` as the argument list, producing a valid and C23-compliant function signature.

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou !