### PR TITLE
BUG: default BLAS to LP64 and add Alpine preload smoke test

### DIFF
--- a/.github/alpine-musl-preload.Dockerfile
+++ b/.github/alpine-musl-preload.Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.20
+
+# Build dependencies and system BLAS/LAPACK
+RUN apk add --no-cache python3 py3-pip python3-dev build-base openblas-dev lapack-dev gfortran musl-dev git
+
+# Virtualenv to keep pip installs contained
+RUN python3 -m venv /opt/venv
+ENV PATH=/opt/venv/bin:$PATH
+
+# Copy source and install NumPy + test deps
+WORKDIR /src
+COPY . /src
+RUN pip install -U pip setuptools wheel \
+    && pip install -U cython meson-python pytest pytest-xdist \
+    && pip install -r requirements/test_requirements.txt \
+    && pip install .
+
+# Run tests from outside the source tree to avoid importing the checkout
+WORKDIR /tmp

--- a/.github/workflows/alpine_musl.yml
+++ b/.github/workflows/alpine_musl.yml
@@ -1,0 +1,32 @@
+name: Alpine musl BLAS preload
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  alpine-musl-smoke:
+    # Only runs when manually dispatched to avoid adding default CI load
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Build Alpine image
+        run: |
+          set -eux
+          docker build -t numpy-alpine -f .github/alpine-musl-preload.Dockerfile .
+
+      - name: Test on Alpine (no LD_PRELOAD)
+        run: |
+          set -eux
+          docker run --rm -w /tmp numpy-alpine /bin/sh -c 'PYTHONNOUSERSITE=1 python -c "import numpy, sys; print(\"NumPy\", numpy.__version__); sys.exit(0 if numpy.test(verbose=0, extra_argv=[\"-q\",\"-k\",\"not test_to_ctypes\"]) else 1)"'
+
+      - name: Test on Alpine (with LD_PRELOAD)
+        run: |
+          set -eux
+          docker run --rm -e LD_PRELOAD=/usr/lib/libopenblas.so.3 -w /tmp numpy-alpine /bin/sh -c 'PYTHONNOUSERSITE=1 python -c "import numpy, sys; print(\"NumPy\", numpy.__version__, \"(LD_PRELOAD openblas)\"); sys.exit(0 if numpy.test(verbose=0, extra_argv=[\"-q\",\"-k\",\"not test_to_ctypes\"]) else 1)"'

--- a/.github/workflows/alpine_musl.yml
+++ b/.github/workflows/alpine_musl.yml
@@ -8,25 +8,50 @@ permissions:
 
 jobs:
   alpine-musl-smoke:
-    # Only runs when manually dispatched to avoid adding default CI load
     runs-on: ubuntu-latest
+    container:
+      image: quay.io/pypa/musllinux_1_2_x86_64
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Build Alpine image
+      - name: Install system deps
         run: |
           set -eux
-          docker build -t numpy-alpine -f .github/alpine-musl-preload.Dockerfile .
+          apk update --quiet
+          apk add --no-cache python3 py3-pip python3-dev build-base openblas-dev lapack-dev gfortran musl-dev git
+          ln -sf /usr/bin/python3 /usr/bin/python
+
+      - name: Set up venv and install
+        run: |
+          set -eux
+          python -m venv /tmp/venv
+          . /tmp/venv/bin/activate
+          pip install -U pip setuptools wheel
+          pip install -U cython meson-python pytest pytest-xdist
+          pip install -r requirements/test_requirements.txt
+          pip install .
 
       - name: Test on Alpine (no LD_PRELOAD)
         run: |
           set -eux
-          docker run --rm -w /tmp numpy-alpine /bin/sh -c 'PYTHONNOUSERSITE=1 python -c "import numpy, sys; print(\"NumPy\", numpy.__version__); sys.exit(0 if numpy.test(verbose=0, extra_argv=[\"-q\",\"-k\",\"not test_to_ctypes\"]) else 1)"'
+          cd /tmp
+          PYTHONNOUSERSITE=1 /tmp/venv/bin/python - <<'PY'
+          import numpy, sys
+          print("NumPy", numpy.__version__)
+          res = numpy.test(verbose=0, extra_argv=["-q", "-k", "not test_to_ctypes"])
+          sys.exit(0 if res else 1)
+          PY
 
       - name: Test on Alpine (with LD_PRELOAD)
         run: |
           set -eux
-          docker run --rm -e LD_PRELOAD=/usr/lib/libopenblas.so.3 -w /tmp numpy-alpine /bin/sh -c 'PYTHONNOUSERSITE=1 python -c "import numpy, sys; print(\"NumPy\", numpy.__version__, \"(LD_PRELOAD openblas)\"); sys.exit(0 if numpy.test(verbose=0, extra_argv=[\"-q\",\"-k\",\"not test_to_ctypes\"]) else 1)"'
+          cd /tmp
+          LD_PRELOAD=/usr/lib/libopenblas.so.3 PYTHONNOUSERSITE=1 /tmp/venv/bin/python - <<'PY'
+          import numpy, sys
+          print("NumPy", numpy.__version__, "(LD_PRELOAD openblas)")
+          res = numpy.test(verbose=0, extra_argv=["-q", "-k", "not test_to_ctypes"])
+          sys.exit(0 if res else 1)
+          PY

--- a/meson.options
+++ b/meson.options
@@ -10,6 +10,8 @@ option('lapack-order', type: 'array', value: ['auto'],
        description: 'Order of LAPACK libraries to search for. E.g.: mkl,openblas,lapack')
 option('use-ilp64', type: 'boolean', value: false,
        description: 'Use ILP64 (64-bit integer) BLAS and LAPACK interfaces')
+option('allow-ilp64-on-musl', type: 'boolean', value: false,
+       description: 'Allow ILP64 builds on musl (unsafe when mixing with system OpenBLAS)')
 option('blas-symbol-suffix', type: 'string', value: 'auto',
         description: 'BLAS and LAPACK symbol suffix to use, if any')
 option('mkl-threading', type: 'string', value: 'auto',

--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -67,6 +67,19 @@ else
   blas_interface = ['interface: lp64']
 endif
 
+is_glibc = cc.compiles('''
+  #include <features.h>
+  #ifndef __GLIBC__
+  #error "not glibc"
+  #endif
+  int main(void) { return 0; }
+''', name: 'glibc check', required: false)
+is_musl = host_machine.system() == 'linux' and not is_glibc
+if is_musl and use_ilp64 and not get_option('allow-ilp64-on-musl')
+  message('Disabling ILP64 on musl to avoid ABI mismatches with system OpenBLAS')
+  use_ilp64 = false
+  blas_interface = ['interface: lp64']
+endif
 
 blas_order = get_option('blas-order')
 if blas_order == ['auto']


### PR DESCRIPTION
Hello,

We recently hit a segfault on Alpine when importing NumPy in a process that had already loaded the system OpenBLAS. After some investigation, it seems Alpine’s system OpenBLAS is LP64 (32-bit BLAS ints) while the musllinux wheels default to ILP64 (64-bit BLAS ints), and mixing the two in one process can crash (seen via a reticulate workflow, https://github.com/rstudio/reticulate/issues/1858#issuecomment-3549517694). From what I can tell, most distro OpenBLAS packages (including Alpine) and MKL defaults are LP64, while manylinux wheels use ILP64 for large-array support, so this change tries to align musl builds with the system default, but please let me know if I’m missing a better precedent.

What changed

- Add a Meson option allow-ilp64-on-musl (default false).
- Detect musl at configure time and force LP64 BLAS/LAPACK unless the new flag is set; ILP64 stays opt-in. glibc/macOS/Windows unchanged.
- Add a manual workflow (alpine_musl.yml + Dockerfile) to smoke-test on Alpine with and without `LD_PRELOAD=/usr/lib/libopenblas.so.3`.

Testing

- macOS host: built from source, ran `numpy.test(verbose=0, extra_argv=['-q'])` from `/tmp` (pass).
- Alpine 3.20 (docker, aarch64 and x86_64) with system OpenBLAS: built from source and ran numpy.test(verbose=0, extra_argv=['-q', '-k', 'not test_to_ctypes']) both normally and with LD_PRELOAD=/usr/lib/libopenblas.so.3; all passed.

Happy to adjust anything. Thanks!