### PR TITLE
BUG: ``convolve``: fix incorrect error message for empty input

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -893,12 +893,12 @@ def convolve(a, v, mode='full'):
 
     """
     a, v = array(a, copy=None, ndmin=1), array(v, copy=None, ndmin=1)
-    if (len(v) > len(a)):
-        a, v = v, a
     if len(a) == 0:
         raise ValueError('a cannot be empty')
     if len(v) == 0:
         raise ValueError('v cannot be empty')
+    if len(v) > len(a):
+        a, v = v, a
     return multiarray.correlate(a, v[::-1], mode)
 
 

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3686,6 +3686,12 @@ class TestConvolve:
         with assert_raises(TypeError):
             np.convolve(d, k, mode=None)
 
+    def test_empty(self):
+        with assert_raises(ValueError, msg="a cannot be empty"):
+            np.convolve([], [1])
+        with assert_raises(ValueError, msg="b cannot be empty"):
+            np.convolve([1], [])
+
 
 class TestArgwhere:
 


### PR DESCRIPTION
Closes #30272

before:

```
In [1]: np.convolve(a=[], v=[1])
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[1], line 1
----> 1 np.convolve(a=[], v=[1])

File ~/.local/share/uv/tools/ipython/lib/python3.14/site-packages/numpy/_core/numeric.py:902, in convolve(a, v, mode)
    900     raise ValueError('a cannot be empty')
    901 if len(v) == 0:
--> 902     raise ValueError('v cannot be empty')
    903 return multiarray.correlate(a, v[::-1], mode)

ValueError: v cannot be empty
```

after:

```
In [1]: np.convolve(a=[], v=[1])
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[1], line 1
----> 1 np.convolve(a=[], v=[1])

File ~/Workspace/numpy/build-install/usr/lib/python3.11/site-packages/numpy/_core/numeric.py:897, in convolve(a, v, mode)
    895 a, v = array(a, copy=None, ndmin=1), array(v, copy=None, ndmin=1)
    896 if len(a) == 0:
--> 897     raise ValueError('a cannot be empty')
    898 if len(v) == 0:
    899     raise ValueError('v cannot be empty')

ValueError: a cannot be empty
```