### PR TITLE
BUG: Fix view semantics in user_array.container (slices returned copies)

### DIFF
--- a/numpy/lib/_user_array_impl.py
+++ b/numpy/lib/_user_array_impl.py
@@ -255,7 +255,7 @@ class container:
         if len(shape(a)) == 0:
             return a
         else:
-            return self.__class__(a)
+            return self.__class__(a, copy=False)
 
     def __array_wrap__(self, *args):
         return self.__class__(args[0])


### PR DESCRIPTION
Closes #30307

This PR fixes a critical logic bug in numpy.lib.user_array.container where slicing operations returned a deep copy of the data instead of a view. This behavior violated standard NumPy array semantics and caused in-place operations on slices (e.g., masking) to fail silently, as detailed in the issue user_array.container breaks view semantics: in-place slice modifications fail silently (#30307).

The Fix

Modified the internal _rc (return container) helper method in numpy/lib/_user_array_impl.py.

Before: return self.__class__(a) (Defaults to copy=True)

After: return self.__class__(a, copy=False)

Passing copy=False ensures that operations returning new container instances (like slicing) maintain a view of the original data rather than allocating new memory.