### PR TITLE
MAINT: avoid unused variable warnings in dtype tests

### DIFF
--- a/numpy/_core/src/umath/_scaled_float_dtype.c
+++ b/numpy/_core/src/umath/_scaled_float_dtype.c
@@ -787,8 +787,7 @@ sfloat_stable_sort_loop(
 {
     assert(data[0] == data[1]);
     assert(strides[0] == sizeof(npy_float64) && strides[1] == sizeof(npy_float64));
-    PyArrayMethod_SortParameters *parameters = (PyArrayMethod_SortParameters *)context->parameters;
-    assert(parameters->flags == NPY_SORT_STABLE);
+    assert(((PyArrayMethod_SortParameters *)context->parameters)->flags == NPY_SORT_STABLE);
 
     npy_intp N = dimensions[0];
     char *in = data[0];
@@ -807,8 +806,7 @@ sfloat_default_sort_loop(
 {
     assert(data[0] == data[1]);
     assert(strides[0] == sizeof(npy_float64) && strides[1] == sizeof(npy_float64));
-    PyArrayMethod_SortParameters *parameters = (PyArrayMethod_SortParameters *)context->parameters;
-    assert(parameters->flags == NPY_SORT_DEFAULT);
+    assert(((PyArrayMethod_SortParameters *)context->parameters)->flags == NPY_SORT_DEFAULT);
 
     npy_intp N = dimensions[0];
     char *in = data[0];
@@ -874,8 +872,7 @@ sfloat_stable_argsort_loop(
         const npy_intp *strides,
         NpyAuxData *NPY_UNUSED(auxdata))
 {
-    PyArrayMethod_SortParameters *parameters = (PyArrayMethod_SortParameters *)context->parameters;
-    assert(parameters->flags == NPY_SORT_STABLE);
+    assert(((PyArrayMethod_SortParameters *)context->parameters)->flags == NPY_SORT_STABLE);
     assert(strides[0] == sizeof(npy_float64));
     assert(strides[1] == sizeof(npy_intp));
 
@@ -895,8 +892,7 @@ sfloat_default_argsort_loop(
         const npy_intp *strides,
         NpyAuxData *NPY_UNUSED(auxdata))
 {
-    PyArrayMethod_SortParameters *parameters = (PyArrayMethod_SortParameters *)context->parameters;
-    assert(parameters->flags == NPY_SORT_DEFAULT);
+    assert(((PyArrayMethod_SortParameters *)context->parameters)->flags == NPY_SORT_DEFAULT);
     assert(strides[0] == sizeof(npy_float64));
     assert(strides[1] == sizeof(npy_intp));
 


### PR DESCRIPTION
If `NDEBUG` is defined then asserts are no-ops and the `parameters` pointer is unused.

ping @MaanasArora 