### PR TITLE
DOC: Fix duplicate `import pytest` in testing documentation example (Issue #30287)

### DIFF
--- a/doc/TESTS.rst
+++ b/doc/TESTS.rst
@@ -143,8 +143,6 @@ module called ``test_yyy.py``.  If you only need to test one aspect of
 More often, we need to group a number of tests together, so we create
 a test class::
 
-  import pytest
-
   # import xxx symbols
   from numpy.xxx.yyy import zzz
   import pytest

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -61,6 +61,7 @@ Other topics
    thread_safety
    global_state
    security
+   testing
    distutils_status_migration
    distutils_guide
    swig


### PR DESCRIPTION
## Description

Fixed a minor documentation issue in `doc/TESTS.rst` where `import pytest` appeared twice in the example code under the "Writing your own tests" section. This duplication could confuse new contributors who copy these examples directly.

Additionally, added a reference to the testing documentation in `doc/source/reference/index.rst` under "Other topics" to make the testing guidelines more discoverable, as suggested by @ngoldbaum .

## Changes Made

1. **Removed duplicate `import pytest`** in `doc/TESTS.rst` (line 146)
   
   The example now correctly shows:
   
   ```python
   # import xxx symbols
   from numpy.xxx.yyy import zzz
   import pytest
   
   class TestZzz:
       ...
   ```

2. **Added testing reference** in `doc/source/reference/index.rst`
   - Added `testing` to the "Other topics" section to improve discoverability

## Related Issue


Closes #30287

## Testing

- Verified the documentation builds correctly
- Confirmed no linting errors
- Checked that the example code is now clean and correct

## Checklist

- [x] Code/documentation follows NumPy style guidelines
- [x] Documentation updated
- [x] No new tests needed (documentation fix only)
- [x] Changes are backwards compatible