### PR TITLE
TYP: ``__numpy_dtype__``

### DIFF
--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -98,6 +98,7 @@ from ._dtype_like import (
     _DTypeLikeTD64 as _DTypeLikeTD64,
     _DTypeLikeUInt as _DTypeLikeUInt,
     _DTypeLikeVoid as _DTypeLikeVoid,
+    _HasDType as _HasDType,
     _SupportsDType as _SupportsDType,
     _VoidDTypeLike as _VoidDTypeLike,
 )

--- a/numpy/_typing/_dtype_like.py
+++ b/numpy/_typing/_dtype_like.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence  # noqa: F811
-from typing import Any, Protocol, TypeAlias, TypedDict, TypeVar, runtime_checkable
+from typing import Any, Protocol, TypeAlias, TypedDict, TypeVar
 
 import numpy as np
 
@@ -19,6 +19,7 @@ from ._char_codes import (
 )
 
 _ScalarT = TypeVar("_ScalarT", bound=np.generic)
+_DTypeT = TypeVar("_DTypeT", bound=np.dtype)
 _DTypeT_co = TypeVar("_DTypeT_co", bound=np.dtype, covariant=True)
 
 _DTypeLikeNested: TypeAlias = Any  # TODO: wait for support for recursive types
@@ -40,11 +41,17 @@ class _DTypeDict(_DTypeDictBase, total=False):
     aligned: bool
 
 
-# A protocol for anything with the dtype attribute
-@runtime_checkable
-class _SupportsDType(Protocol[_DTypeT_co]):
+class _HasDType(Protocol[_DTypeT_co]):
     @property
     def dtype(self) -> _DTypeT_co: ...
+
+
+class _HasNumPyDType(Protocol[_DTypeT_co]):
+    @property
+    def __numpy_dtype__(self, /) -> _DTypeT_co: ...
+
+
+_SupportsDType: TypeAlias = _HasDType[_DTypeT] | _HasNumPyDType[_DTypeT]
 
 
 # A subset of `npt.DTypeLike` that can be parametrized w.r.t. `np.generic`

--- a/numpy/lib/_index_tricks_impl.pyi
+++ b/numpy/lib/_index_tricks_impl.pyi
@@ -24,9 +24,9 @@ from numpy._typing import (
     _ArrayLike,
     _DTypeLike,
     _FiniteNestedSequence,
+    _HasDType,
     _NestedSequence,
     _SupportsArray,
-    _SupportsDType,
 )
 
 __all__ = [  # noqa: RUF022
@@ -235,7 +235,7 @@ class IndexExpression(Generic[_BoolT_co]):
     def __getitem__(self: IndexExpression[L[False]], item: _T) -> _T: ...
 
 @overload
-def ix_(*args: _FiniteNestedSequence[_SupportsDType[_DTypeT]]) -> tuple[np.ndarray[_AnyShape, _DTypeT], ...]: ...
+def ix_(*args: _FiniteNestedSequence[_HasDType[_DTypeT]]) -> tuple[np.ndarray[_AnyShape, _DTypeT], ...]: ...
 @overload
 def ix_(*args: str | _NestedSequence[str]) -> tuple[NDArray[np.str_], ...]: ...
 @overload

--- a/numpy/typing/tests/data/reveal/dtype.pyi
+++ b/numpy/typing/tests/data/reveal/dtype.pyi
@@ -125,3 +125,8 @@ assert_type(dtype_V["f0"], np.dtype)
 assert_type(dtype_V[0], np.dtype)
 assert_type(dtype_V[["f0", "f1"]], np.dtype[np.void])
 assert_type(dtype_V[["f0"]], np.dtype[np.void])
+
+class _D:
+    __numpy_dtype__: np.dtype[np.int8]
+
+assert_type(np.dtype(_D()), np.dtype[np.int8])

--- a/numpy/typing/tests/test_runtime.py
+++ b/numpy/typing/tests/test_runtime.py
@@ -93,7 +93,6 @@ def test_keys() -> None:
 
 
 PROTOCOLS: dict[str, tuple[type[Any], object]] = {
-    "_SupportsDType": (_npt._SupportsDType, np.int64(1)),
     "_SupportsArray": (_npt._SupportsArray, np.arange(10)),
     "_SupportsArrayFunc": (_npt._SupportsArrayFunc, np.arange(10)),
     "_NestedSequence": (_npt._NestedSequence, [1]),
@@ -107,9 +106,5 @@ class TestRuntimeProtocol:
         assert not isinstance(None, cls)
 
     def test_issubclass(self, cls: type[Any], obj: object) -> None:
-        if cls is _npt._SupportsDType:
-            pytest.xfail(
-                "Protocols with non-method members don't support issubclass()"
-            )
         assert issubclass(type(obj), cls)
         assert not issubclass(type(None), cls)


### PR DESCRIPTION
Following #30179, this adds support for `__numpy_dtype__` to `numpy.typing.DTypeLike` and `numpy._typing._DTypeLike`. 