### PR TITLE
DOC, TYP: Expand the 2.3 ``numpy.typing`` deprecation docs

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -104,12 +104,44 @@ involving precision-based casting.
     >>> import numpy.typing as npt
 
     >>> T = TypeVar("T", bound=npt.NBitBase)
-    >>> def func(a: "np.floating[T]", b: "np.floating[T]") -> "np.floating[T]":
+    >>> def func(a: np.floating[T], b: np.floating[T]) -> np.floating[T]:
     ...     ...
 
 Consequently, the likes of `~numpy.float16`, `~numpy.float32` and
 `~numpy.float64` are still sub-types of `~numpy.floating`, but, contrary to
 runtime, they're not necessarily considered as sub-classes.
+
+.. deprecated:: 2.3
+    The :class:`~numpy.typing.NBitBase` helper is deprecated and will be
+    removed in a future release. Prefer expressing precision relationships via
+    ``typing.overload`` or ``TypeVar`` definitions bounded by concrete scalar
+    classes. For example:
+
+    .. code-block:: python
+
+        from typing import TypeVar
+        import numpy as np
+
+        S = TypeVar("S", bound=np.floating)
+
+        def func(a: S, b: S) -> S:
+            ...
+
+    or in the case of different input types mapping to different output types:
+
+   .. code-block:: python
+
+        from typing import overload
+        import numpy as np
+
+        @overload
+        def phase(x: np.complex64) -> np.float32: ...
+        @overload
+        def phase(x: np.complex128) -> np.float64: ...
+        @overload
+        def phase(x: np.clongdouble) -> np.longdouble: ...
+        def phase(x: np.complexfloating) -> np.floating:
+            ...
 
 Timedelta64
 ~~~~~~~~~~~

--- a/numpy/typing/mypy_plugin.py
+++ b/numpy/typing/mypy_plugin.py
@@ -18,6 +18,11 @@ Its functionality can be split into three distinct parts:
   .. versionadded:: 1.22
 
 .. deprecated:: 2.3
+    The :mod:`numpy.typing.mypy_plugin` entry-point is deprecated in favor of
+    platform-agnostic static type inference. Remove
+    ``numpy.typing.mypy_plugin`` from the ``plugins`` section of your mypy
+    configuration; if that surfaces new errors, please open an issue with a
+    minimal reproducer.
 
 Examples
 --------


### PR DESCRIPTION
Better late than never

- https://output.circle-artifacts.com/output/job/46bd4731-41e7-4455-88a7-a2f69b53f59b/artifacts/0/doc/build/html/reference/typing.html#mypy-plugin
- https://output.circle-artifacts.com/output/job/46bd4731-41e7-4455-88a7-a2f69b53f59b/artifacts/0/doc/build/html/reference/typing.html#number-precision