### PR TITLE
TYP: ``_core._umath_tests`` module stubs

### DIFF
--- a/numpy/_core/_umath_tests.pyi
+++ b/numpy/_core/_umath_tests.pyi
@@ -1,0 +1,47 @@
+# undocumented internal testing module for ufunc features, defined in
+# numpy/_core/src/umath/_umath_tests.c.src
+
+from typing import Final, Literal as L, TypedDict, type_check_only
+
+import numpy as np
+from numpy._typing import _GUFunc_Nin2_Nout1, _UFunc_Nin1_Nout1, _UFunc_Nin2_Nout1
+
+@type_check_only
+class _TestDispatchResult(TypedDict):
+    func: str  # e.g. 'func_AVX2'
+    var: str  # e.g. 'var_AVX2'
+    func_xb: str  # e.g. 'func_AVX2'
+    var_xb: str  # e.g. 'var_AVX2'
+    all: list[str]  # e.g. ['func_AVX2', 'func_SSE41', 'func']
+
+###
+
+# undocumented
+def test_signature(
+    nin: int, nout: int, signature: str, /
+) -> tuple[
+    L[0, 1],  # core_enabled (0 for scalar ufunc; 1 for generalized ufunc)
+    tuple[int, ...] | None,  # core_num_dims
+    tuple[int, ...] | None,  # core_dim_ixs
+    tuple[int, ...] | None,  # core_dim_flags
+    tuple[int, ...] | None,  # core_dim_sizes
+]: ...
+
+# undocumented
+def test_dispatch() -> _TestDispatchResult: ...
+
+# undocumented ufuncs and gufuncs
+always_error: Final[_UFunc_Nin2_Nout1[L["always_error"], L[1], None]] = ...
+always_error_unary: Final[_UFunc_Nin1_Nout1[L["always_error_unary"], L[1], None]] = ...
+always_error_gufunc: Final[_GUFunc_Nin2_Nout1[L["always_error_gufunc"], L[1], None, L["(i),()->()"]]] = ...
+inner1d: Final[_GUFunc_Nin2_Nout1[L["inner1d"], L[2], None, L["(i),(i)->()"]]] = ...
+innerwt: Final[np.ufunc] = ...  # we have no specialized type for 3->1 gufuncs
+matrix_multiply: Final[_GUFunc_Nin2_Nout1[L["matrix_multiply"], L[3], None, L["(m,n),(n,p)->(m,p)"]]] = ...
+matmul: Final[_GUFunc_Nin2_Nout1[L["matmul"], L[3], None, L["(m?,n),(n,p?)->(m?,p?)"]]] = ...
+euclidean_pdist: Final[_GUFunc_Nin2_Nout1[L["euclidean_pdist"], L[2], None, L["(n,d)->(p)"]]] = ...
+cumsum: Final[np.ufunc] = ...  # we have no specialized type for 1->1 gufuncs
+inner1d_no_doc: Final[_GUFunc_Nin2_Nout1[L["inner1d_no_doc"], L[2], None, L["(i),(i)->()"]]] = ...
+cross1d: Final[_GUFunc_Nin2_Nout1[L["cross1d"], L[2], None, L["(3),(3)->(3)"]]] = ...
+_pickleable_module_global_ufunc: Final[np.ufunc] = ...  # 0->0 ufunc; segfaults if called
+indexed_negative: Final[_UFunc_Nin1_Nout1[L["indexed_negative"], L[0], L[0]]] = ...  # ntypes=0; can't be called
+conv1d_full: Final[_GUFunc_Nin2_Nout1[L["conv1d_full"], L[1], None, L["(m),(n)->(p)"]]] = ...

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -927,7 +927,7 @@ foreach gen_mtargets : [
     'loops_arithm_fp.dispatch.h',
     src_file.process('src/umath/loops_arithm_fp.dispatch.c.src'),
     [
-      X86_V3, X86_V2, 
+      X86_V3, X86_V2,
       ASIMD, NEON,
       VSX3, VSX2,
       VXE, VX,
@@ -960,7 +960,7 @@ foreach gen_mtargets : [
     'loops_exponent_log.dispatch.h',
     src_file.process('src/umath/loops_exponent_log.dispatch.c.src'),
     [
-      X86_V4, X86_V3, 
+      X86_V4, X86_V3,
     ]
   ],
   [
@@ -1403,6 +1403,7 @@ python_sources = [
   '_type_aliases.pyi',
   '_ufunc_config.py',
   '_ufunc_config.pyi',
+  '_umath_tests.pyi',
   'arrayprint.py',
   'arrayprint.pyi',
   'cversions.py',

--- a/tools/stubtest/allowlist.txt
+++ b/tools/stubtest/allowlist.txt
@@ -59,7 +59,7 @@ numpy\.core\.shape_base.*
 numpy\.core\.umath.*
 numpy\.typing\.mypy_plugin
 
-# ufuncs
+# ufuncs, see https://github.com/python/mypy/issues/20223
 numpy\.(\w+\.)*abs
 numpy\.(\w+\.)*absolute
 numpy\.(\w+\.)*acos
@@ -177,7 +177,16 @@ numpy\.(\w+\.)*istitle
 numpy\.(\w+\.)*isupper
 numpy\.(\w+\.)*str_len
 numpy\._core\._methods\.umr_bitwise_count
-numpy\._core\._methods\.umr_bitwise_count
+numpy\._core\._umath_tests\.always_error
+numpy\._core\._umath_tests\.always_error_gufunc
+numpy\._core\._umath_tests\.always_error_unary
+numpy\._core\._umath_tests\.conv1d_full
+numpy\._core\._umath_tests\.cross1d
+numpy\._core\._umath_tests\.euclidean_pdist
+numpy\._core\._umath_tests\.indexed_negative
+numpy\._core\._umath_tests\.inner1d
+numpy\._core\._umath_tests\.inner1d_no_doc
+numpy\._core\._umath_tests\.matrix_multiply
 numpy\.linalg\._umath_linalg\.qr_complete
 numpy\.linalg\._umath_linalg\.qr_reduced
 numpy\.linalg\._umath_linalg\.solve


### PR DESCRIPTION
This resolves a bunch of squiggly lines in `numpy/_core/tests/test_*.py`, and makes the process of working on these umath tests (in an IDE / with an LSP) a bit nicer in general :). It could also be viewed as a form of internal documentation.