### PR TITLE
MAINT: Use RAII objects in unique.cpp to ensure safe resource management.

### DIFF
--- a/benchmarks/benchmarks/bench_lib.py
+++ b/benchmarks/benchmarks/bench_lib.py
@@ -2,6 +2,8 @@
 
 import string
 
+from asv_runner.benchmarks.mark import SkipNotImplemented
+
 import numpy as np
 
 from .common import Benchmark
@@ -185,6 +187,51 @@ class Unique(Benchmark):
 
     def time_unique_all(self, array_size, percent_nans,
                         percent_unique_values, dtype):
+        np.unique(self.arr, return_index=True,
+                  return_inverse=True, return_counts=True)
+
+
+class UniqueIntegers(Benchmark):
+    """Benchmark for np.unique with integer dtypes."""
+
+    param_names = ["array_size", "num_unique_values", "dtype"]
+    params = [
+        # sizes of the 1D arrays
+        [200, 100000, 1000000],
+        # number of unique values in arrays
+        [25, 125, 5000, 50000, 250000],
+        # dtypes of the arrays
+        [np.uint8, np.int16, np.uint32, np.int64],
+    ]
+
+    def setup(self, array_size, num_unique_values, dtype):
+        unique_array = np.arange(num_unique_values, dtype=dtype)
+        base_array = np.resize(unique_array, array_size)
+        rng = np.random.default_rng(121263137472525314065)
+        rng.shuffle(base_array)
+        self.arr = base_array
+
+    def time_unique_values(self, array_size, num_unique_values, dtype):
+        if num_unique_values >= np.iinfo(dtype).max or num_unique_values > array_size:
+            raise SkipNotImplemented("skipped")
+        np.unique(self.arr, return_index=False,
+                  return_inverse=False, return_counts=False)
+
+    def time_unique_counts(self, array_size, num_unique_values, dtype):
+        if num_unique_values >= np.iinfo(dtype).max or num_unique_values > array_size:
+            raise SkipNotImplemented("skipped")
+        np.unique(self.arr, return_index=False,
+                  return_inverse=False, return_counts=True,)
+
+    def time_unique_inverse(self, array_size, num_unique_values, dtype):
+        if num_unique_values >= np.iinfo(dtype).max or num_unique_values > array_size:
+            raise SkipNotImplemented("skipped")
+        np.unique(self.arr, return_index=False,
+                  return_inverse=True, return_counts=False)
+
+    def time_unique_all(self, array_size, num_unique_values, dtype):
+        if num_unique_values >= np.iinfo(dtype).max or num_unique_values > array_size:
+            raise SkipNotImplemented("skipped")
         np.unique(self.arr, return_index=True,
                   return_inverse=True, return_counts=True)
 

--- a/numpy/_core/src/common/raii_utils.hpp
+++ b/numpy/_core/src/common/raii_utils.hpp
@@ -25,6 +25,46 @@ NpyString_release_allocator(npy_string_allocator *allocator);
 namespace np { namespace raii {
 
 //
+// RAII for holding a Python reference.
+// This is a wrapper for Py_INCREF/Py_DECREF.
+//
+// In C++ code, use this at the beginning of a scope, e.g.
+//
+//     {
+//         np::raii::ScopedINCREF(obj);
+//         [code that requires holding a reference to obj]
+//     }
+//
+// instead of
+//
+//     Py_INCREF(obj);
+//     [code that requires holding a reference to obj]
+//     Py_DECREF(obj);
+//
+// This ensures that Py_DECREF(obj) is called, even if the wrapped
+// code throws an exception or executes a return or a goto.
+//
+class ScopedINCREF
+{
+    PyObject* _obj;
+
+public:
+
+    ScopedINCREF(PyObject *obj) : _obj(obj) {
+        Py_INCREF(_obj);
+    }
+
+    ~ScopedINCREF() {
+        Py_DECREF(_obj);
+    }
+
+    ScopedINCREF(const ScopedINCREF&) = delete;
+    ScopedINCREF(ScopedINCREF&& other) = delete;
+    ScopedINCREF& operator=(const ScopedINCREF&) = delete;
+    ScopedINCREF& operator=(ScopedINCREF&&) = delete;
+};
+
+//
 // RAII for PyGILState_* API.
 //
 // In C++ code, use this at the beginning of a scope, e.g.

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -370,9 +370,8 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
         std::invoke([&]() -> const set_type {
             PyArray_StringDTypeObject *descr =
                 reinterpret_cast<PyArray_StringDTypeObject *>(PyArray_DESCR(self));
-            np::raii::ScopedINCREF incref_descr(reinterpret_cast<PyObject *>(descr));
-            np::raii::SaveThreadState save_thread_state{};
             np::raii::NpyStringAcquireAllocator alloc(descr);
+            np::raii::SaveThreadState save_thread_state{};
 
             set_type hashset(std::min(isize, HASH_TABLE_INITIAL_BUCKETS), hash, equal);
 
@@ -407,9 +406,8 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
         reinterpret_cast<PyArray_StringDTypeObject *>(PyArray_DESCR(res_obj));
 
     {
-        np::raii::ScopedINCREF incref_res_descr(reinterpret_cast<PyObject *>(res_descr));
-        np::raii::SaveThreadState save_thread_state{};
         np::raii::NpyStringAcquireAllocator alloc(res_descr);
+        np::raii::SaveThreadState save_thread_state{};
 
         char *odata = PyArray_BYTES(res_obj);
         npy_intp ostride = PyArray_STRIDES(res_obj)[0];

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -58,10 +58,6 @@ empty_array_like(PyArrayObject *arr, npy_intp length)
                 NULL                    // obj
             )
         );
-    if (res_obj == NULL) {
-        Py_DECREF(descr);
-        return NULL;
-    }
     return res_obj;
 }
 

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -502,21 +502,23 @@ array__unique_hash(PyObject *NPY_UNUSED(module),
         return NULL;
     }
 
+    PyObject *result = NULL;
     try {
         auto type = PyArray_TYPE(arr);
         // we only support data types present in our unique_funcs map
         if (unique_funcs.find(type) == unique_funcs.end()) {
             Py_RETURN_NOTIMPLEMENTED;
         }
-
-        return unique_funcs[type](arr, equal_nan);
+        result = unique_funcs[type](arr, equal_nan);
     }
     catch (const std::bad_alloc &e) {
         PyErr_NoMemory();
-        return NULL;
+        result = NULL;
     }
     catch (const std::exception &e) {
         PyErr_SetString(PyExc_RuntimeError, e.what());
-        return NULL;
+        result = NULL;
     }
+    Py_DECREF(arr);
+    return result;
 }

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -224,7 +224,7 @@ unique_numeric(PyArrayObject *self, npy_bool equal_nan)
     // to manage resources.
     using set_type = std::unordered_set<T *, decltype(hash), decltype(equal)>;
     const set_type hashset =
-        std::invoke([&]() -> const set_type {
+        [&]() -> const set_type {
             np::raii::SaveThreadState save_thread_state{};
 
             // number of elements in the input array
@@ -236,7 +236,7 @@ unique_numeric(PyArrayObject *self, npy_bool equal_nan)
                 hashset.insert(reinterpret_cast<T *>(idata));
             }
             return hashset;
-        });
+        }();
 
     npy_intp length = hashset.size();
 
@@ -284,7 +284,7 @@ unique_string(PyArrayObject *self, npy_bool equal_nan)
     // to manage resources.
     using set_type = std::unordered_set<T *, decltype(hash), decltype(equal)>;
     const set_type hashset =
-        std::invoke([&]() -> const set_type {
+        [&]() -> const set_type {
             np::raii::SaveThreadState save_thread_state{};
 
             // number of elements in the input array
@@ -296,7 +296,7 @@ unique_string(PyArrayObject *self, npy_bool equal_nan)
                 hashset.insert(reinterpret_cast<T *>(idata));
             }
             return hashset;
-        });
+        }();
 
     npy_intp length = hashset.size();
 
@@ -363,7 +363,7 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
     using set_type = std::unordered_set<npy_static_string *,
                                         decltype(hash), decltype(equal)>;
     const set_type hashset =
-        std::invoke([&]() -> const set_type {
+        [&]() -> const set_type {
             PyArray_StringDTypeObject *descr =
                 reinterpret_cast<PyArray_StringDTypeObject *>(PyArray_DESCR(self));
             np::raii::NpyStringAcquireAllocator alloc(descr);
@@ -389,7 +389,7 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
                 hashset.insert(&unpacked_strings[i]);
             }
             return hashset;
-        });
+        }();
 
     npy_intp length = hashset.size();
 

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -499,6 +499,7 @@ array__unique_hash(PyObject *NPY_UNUSED(module),
                             NULL, NULL, NULL
                             ) < 0
     ) {
+        Py_XDECREF(arr);
         return NULL;
     }
 

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -186,11 +186,8 @@ unique_numeric(PyArrayObject *self, npy_bool equal_nan)
     * Returns a new NumPy array containing the unique values of the input array of numeric (integer or complex).
     * This function uses hashing to identify uniqueness efficiently.
     */
-    NPY_ALLOW_C_API_DEF;
-    NPY_ALLOW_C_API;
     PyArray_Descr *descr = PyArray_DESCR(self);
     Py_INCREF(descr);
-    NPY_DISABLE_C_API;
 
     PyThreadState *_save1 = PyEval_SaveThread();
 
@@ -223,7 +220,6 @@ unique_numeric(PyArrayObject *self, npy_bool equal_nan)
     npy_intp length = hashset.size();
 
     PyEval_RestoreThread(_save1);
-    NPY_ALLOW_C_API;
     PyObject *res_obj = PyArray_NewFromDescr(
         &PyArray_Type,
         descr,
@@ -239,7 +235,6 @@ unique_numeric(PyArrayObject *self, npy_bool equal_nan)
     if (res_obj == NULL) {
         return NULL;
     }
-    NPY_DISABLE_C_API;
     PyThreadState *_save2 = PyEval_SaveThread();
     auto save2_dealloc = finally([&]() {
         PyEval_RestoreThread(_save2);
@@ -263,11 +258,8 @@ unique_string(PyArrayObject *self, npy_bool equal_nan)
     * Returns a new NumPy array containing the unique values of the input array of fixed size strings.
     * This function uses hashing to identify uniqueness efficiently.
     */
-    NPY_ALLOW_C_API_DEF;
-    NPY_ALLOW_C_API;
     PyArray_Descr *descr = PyArray_DESCR(self);
     Py_INCREF(descr);
-    NPY_DISABLE_C_API;
 
     PyThreadState *_save1 = PyEval_SaveThread();
 
@@ -303,7 +295,6 @@ unique_string(PyArrayObject *self, npy_bool equal_nan)
     npy_intp length = hashset.size();
 
     PyEval_RestoreThread(_save1);
-    NPY_ALLOW_C_API;
     PyObject *res_obj = PyArray_NewFromDescr(
         &PyArray_Type,
         descr,
@@ -319,7 +310,6 @@ unique_string(PyArrayObject *self, npy_bool equal_nan)
     if (res_obj == NULL) {
         return NULL;
     }
-    NPY_DISABLE_C_API;
     PyThreadState *_save2 = PyEval_SaveThread();
     auto save2_dealloc = finally([&]() {
         PyEval_RestoreThread(_save2);
@@ -342,11 +332,8 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
     * Returns a new NumPy array containing the unique values of the input array.
     * This function uses hashing to identify uniqueness efficiently.
     */
-    NPY_ALLOW_C_API_DEF;
-    NPY_ALLOW_C_API;
     PyArray_Descr *descr = PyArray_DESCR(self);
     Py_INCREF(descr);
-    NPY_DISABLE_C_API;
 
     PyThreadState *_save1 = PyEval_SaveThread();
 
@@ -412,7 +399,6 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
     npy_intp length = hashset.size();
 
     PyEval_RestoreThread(_save1);
-    NPY_ALLOW_C_API;
     PyObject *res_obj = PyArray_NewFromDescr(
         &PyArray_Type,
         descr,
@@ -429,7 +415,6 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
     }
     PyArray_Descr *res_descr = PyArray_DESCR((PyArrayObject *)res_obj);
     Py_INCREF(res_descr);
-    NPY_DISABLE_C_API;
 
     PyThreadState *_save2 = PyEval_SaveThread();
     auto save2_dealloc = finally([&]() {

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -1,13 +1,13 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 
-#define HASH_TABLE_INITIAL_BUCKETS 1024
 #include <Python.h>
 
 #include <algorithm>
 #include <complex>
 #include <cstring>
 #include <functional>
+#include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -15,6 +15,7 @@
 #include <numpy/npy_common.h>
 #include "numpy/arrayobject.h"
 #include "gil_utils.h"
+#include "raii_utils.hpp"
 extern "C" {
     #include "fnv.h"
     #include "npy_argparse.h"
@@ -22,6 +23,16 @@ extern "C" {
     #include "numpy/halffloat.h"
 }
 
+// HASH_TABLE_INITIAL_BUCKETS is the reserve hashset capacity used in the
+// std::unordered_set instances in the various unique_* functions.
+// We use min(input_size, HASH_TABLE_INITIAL_BUCKETS) as the initial bucket
+// count:
+// - Reserving for all elements (isize) may over-allocate when there are few
+//   unique values.
+// - Using a moderate upper bound HASH_TABLE_INITIAL_BUCKETS(1024) keeps
+//   memory usage reasonable (4 KiB for pointers).
+// See https://github.com/numpy/numpy/pull/28767#discussion_r2064267631
+const npy_intp HASH_TABLE_INITIAL_BUCKETS = 1024;
 
 //
 // Create a 1-d array with the given length that has the same
@@ -52,20 +63,6 @@ empty_array_like(PyArrayObject *arr, npy_intp length)
         return NULL;
     }
     return res_obj;
-}
-
-// This is to use RAII pattern to handle cpp exceptions while avoiding memory leaks.
-// Adapted from https://stackoverflow.com/a/25510879/2536294
-template <typename F>
-struct FinalAction {
-    FinalAction(F f) : clean_{f} {}
-    ~FinalAction() { clean_(); }
-  private:
-    F clean_;
-};
-template <typename F>
-FinalAction<F> finally(F f) {
-    return FinalAction<F>(f);
 }
 
 template <typename T>
@@ -215,13 +212,10 @@ static PyObject*
 unique_numeric(PyArrayObject *self, npy_bool equal_nan)
 {
     /*
-    * Returns a new NumPy array containing the unique values of the input array of numeric (integer or complex).
-    * This function uses hashing to identify uniqueness efficiently.
-    */
-    PyThreadState *_save1 = PyEval_SaveThread();
-
-    // number of elements in the input array
-    npy_intp isize = PyArray_SIZE(self);
+     * Returns a new NumPy array containing the unique values of the input
+     * array of numeric (integer or complex).
+     * This function uses hashing to identify uniqueness efficiently.
+     */
 
     auto hash = [equal_nan](const T *value) -> size_t {
         return hash_func(value, equal_nan);
@@ -230,41 +224,39 @@ unique_numeric(PyArrayObject *self, npy_bool equal_nan)
         return equal_func(lhs, rhs, equal_nan);
     };
 
-    // Reserve hashset capacity in advance to minimize reallocations and collisions.
-    // We use min(isize, HASH_TABLE_INITIAL_BUCKETS) as the initial bucket count:
-    // - Reserving for all elements (isize) may over-allocate when there are few unique values.
-    // - Using a moderate upper bound HASH_TABLE_INITIAL_BUCKETS(1024) keeps memory usage reasonable (4 KiB for pointers).
-    // See discussion: https://github.com/numpy/numpy/pull/28767#discussion_r2064267631
-    std::unordered_set<T *, decltype(hash), decltype(equal)> hashset(
-        std::min(isize, (npy_intp)HASH_TABLE_INITIAL_BUCKETS), hash, equal
-    );
+    // Create hashset within the scope of a lambda to allow RAII objects
+    // to manage resources.
+    using set_type = std::unordered_set<T *, decltype(hash), decltype(equal)>;
+    const set_type hashset =
+        std::invoke([&]() -> const set_type {
+            np::raii::SaveThreadState save_thread_state{};
 
-    // Input array is one-dimensional, enabling efficient iteration using strides.
-    char *idata = PyArray_BYTES(self);
-    npy_intp istride = PyArray_STRIDES(self)[0];
-    for (npy_intp i = 0; i < isize; i++, idata += istride) {
-        hashset.insert((T *)idata);
-    }
+            // number of elements in the input array
+            npy_intp isize = PyArray_SIZE(self);
+            set_type hashset(std::min(isize, HASH_TABLE_INITIAL_BUCKETS), hash, equal);
+            char *idata = PyArray_BYTES(self);
+            npy_intp istride = PyArray_STRIDES(self)[0];
+            for (npy_intp i = 0; i < isize; i++, idata += istride) {
+                hashset.insert(reinterpret_cast<T *>(idata));
+            }
+            return hashset;
+        });
 
     npy_intp length = hashset.size();
-
-    PyEval_RestoreThread(_save1);
 
     PyArrayObject *res_obj = empty_array_like(self, length);
     if (res_obj == NULL) {
         return NULL;
     }
 
-    PyThreadState *_save2 = PyEval_SaveThread();
-    auto save2_dealloc = finally([&]() {
-        PyEval_RestoreThread(_save2);
-    });
+    {
+        np::raii::SaveThreadState save_thread_state{};
 
-    char *odata = PyArray_BYTES(res_obj);
-    npy_intp ostride = PyArray_STRIDES(res_obj)[0];
-    // Output array is one-dimensional, enabling efficient iteration using strides.
-    for (auto it = hashset.begin(); it != hashset.end(); it++, odata += ostride) {
-        copy_func(odata, *it);
+        char *odata = PyArray_BYTES(res_obj);
+        npy_intp ostride = PyArray_STRIDES(res_obj)[0];
+        for (auto it = hashset.begin(); it != hashset.end(); it++, odata += ostride) {
+            copy_func(odata, *it);
+        }
     }
 
     return reinterpret_cast<PyObject *>(res_obj);
@@ -275,20 +267,16 @@ static PyObject*
 unique_string(PyArrayObject *self, npy_bool equal_nan)
 {
     /*
-    * Returns a new NumPy array containing the unique values of the input array of fixed size strings.
-    * This function uses hashing to identify uniqueness efficiently.
-    */
+     * Returns a new NumPy array containing the unique values of the input
+     * array of fixed size strings.
+     * This function uses hashing to identify uniqueness efficiently.
+     */
+
     PyArray_Descr *descr = PyArray_DESCR(self);
-    Py_INCREF(descr);
-
-    PyThreadState *_save1 = PyEval_SaveThread();
-
-    // number of elements in the input array
-    npy_intp isize = PyArray_SIZE(self);
-
     // variables for the string
     npy_intp itemsize = descr->elsize;
     npy_intp num_chars = itemsize / sizeof(T);
+
     auto hash = [num_chars](const T *value) -> size_t {
         return npy_fnv1a(value, num_chars * sizeof(T));
     };
@@ -296,41 +284,39 @@ unique_string(PyArrayObject *self, npy_bool equal_nan)
         return std::memcmp(lhs, rhs, itemsize) == 0;
     };
 
-    // Reserve hashset capacity in advance to minimize reallocations and collisions.
-    // We use min(isize, HASH_TABLE_INITIAL_BUCKETS) as the initial bucket count:
-    // - Reserving for all elements (isize) may over-allocate when there are few unique values.
-    // - Using a moderate upper bound HASH_TABLE_INITIAL_BUCKETS(1024) keeps memory usage reasonable (4 KiB for pointers).
-    // See discussion: https://github.com/numpy/numpy/pull/28767#discussion_r2064267631
-    std::unordered_set<T *, decltype(hash), decltype(equal)> hashset(
-        std::min(isize, (npy_intp)HASH_TABLE_INITIAL_BUCKETS), hash, equal
-    );
+    // Create hashset within the scope of a lambda to allow RAII objects
+    // to manage resources.
+    using set_type = std::unordered_set<T *, decltype(hash), decltype(equal)>;
+    const set_type hashset =
+        std::invoke([&]() -> const set_type {
+            np::raii::SaveThreadState save_thread_state{};
 
-    // Input array is one-dimensional, enabling efficient iteration using strides.
-    char *idata = PyArray_BYTES(self);
-    npy_intp istride = PyArray_STRIDES(self)[0];
-    for (npy_intp i = 0; i < isize; i++, idata += istride) {
-        hashset.insert((T *)idata);
-    }
+            // number of elements in the input array
+            npy_intp isize = PyArray_SIZE(self);
+            set_type hashset(std::min(isize, HASH_TABLE_INITIAL_BUCKETS), hash, equal);
+            char *idata = PyArray_BYTES(self);
+            npy_intp istride = PyArray_STRIDES(self)[0];
+            for (npy_intp i = 0; i < isize; i++, idata += istride) {
+                hashset.insert(reinterpret_cast<T *>(idata));
+            }
+            return hashset;
+        });
 
     npy_intp length = hashset.size();
-
-    PyEval_RestoreThread(_save1);
 
     PyArrayObject *res_obj = empty_array_like(self, length);
     if (res_obj == NULL) {
         return NULL;
     }
 
-    PyThreadState *_save2 = PyEval_SaveThread();
-    auto save2_dealloc = finally([&]() {
-        PyEval_RestoreThread(_save2);
-    });
+    {
+        np::raii::SaveThreadState save_thread_state{};
 
-    char *odata = PyArray_BYTES(res_obj);
-    npy_intp ostride = PyArray_STRIDES(res_obj)[0];
-    // Output array is one-dimensional, enabling efficient iteration using strides.
-    for (auto it = hashset.begin(); it != hashset.end(); it++, odata += ostride) {
-        std::memcpy(odata, *it, itemsize);
+        char *odata = PyArray_BYTES(res_obj);
+        npy_intp ostride = PyArray_STRIDES(res_obj)[0];
+        for (auto it = hashset.begin(); it != hashset.end(); it++, odata += ostride) {
+            std::memcpy(odata, *it, itemsize);
+        }
     }
 
     return reinterpret_cast<PyObject *>(res_obj);
@@ -340,19 +326,10 @@ static PyObject*
 unique_vstring(PyArrayObject *self, npy_bool equal_nan)
 {
     /*
-    * Returns a new NumPy array containing the unique values of the input array.
-    * This function uses hashing to identify uniqueness efficiently.
-    */
-    PyArray_Descr *descr = PyArray_DESCR(self);
-    Py_INCREF(descr);
+     * Returns a new NumPy array containing the unique values of the input array.
+     * This function uses hashing to identify uniqueness efficiently.
+     */
 
-    PyThreadState *_save1 = PyEval_SaveThread();
-
-    // number of elements in the input array
-    npy_intp isize = PyArray_SIZE(self);
-
-    // variables for the vstring
-    npy_string_allocator *in_allocator = NpyString_acquire_allocator((PyArray_StringDTypeObject *)descr);
     auto hash = [equal_nan](const npy_static_string *value) -> size_t {
         if (value->buf == NULL) {
             if (equal_nan) {
@@ -380,72 +357,78 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
         return std::memcmp(lhs->buf, rhs->buf, lhs->size) == 0;
     };
 
-    // Reserve hashset capacity in advance to minimize reallocations and collisions.
-    // We use min(isize, HASH_TABLE_INITIAL_BUCKETS) as the initial bucket count:
-    // - Reserving for all elements (isize) may over-allocate when there are few unique values.
-    // - Using a moderate upper bound HASH_TABLE_INITIAL_BUCKETS(1024) keeps memory usage reasonable (4 KiB for pointers).
-    // See discussion: https://github.com/numpy/numpy/pull/28767#discussion_r2064267631
-    std::unordered_set<npy_static_string *, decltype(hash), decltype(equal)> hashset(
-        std::min(isize, (npy_intp)HASH_TABLE_INITIAL_BUCKETS), hash, equal
-    );
-
-    // Input array is one-dimensional, enabling efficient iteration using strides.
-    char *idata = PyArray_BYTES(self);
-    npy_intp istride = PyArray_STRIDES(self)[0];
-    // unpacked_strings need to be allocated outside of the loop because of the lifetime problem.
+    npy_intp isize = PyArray_SIZE(self);
+    // unpacked_strings must be allocated outside of the scope used to create
+    // hashset because of the lifetime problem.
     std::vector<npy_static_string> unpacked_strings(isize, {0, NULL});
-    for (npy_intp i = 0; i < isize; i++, idata += istride) {
-        npy_packed_static_string *packed_string = (npy_packed_static_string *)idata;
-        int is_null = NpyString_load(in_allocator, packed_string, &unpacked_strings[i]);
-        if (is_null == -1) {
-            npy_gil_error(PyExc_RuntimeError,
-                "Failed to load string from packed static string. ");
-            return NULL;
-        }
-        hashset.insert(&unpacked_strings[i]);
-    }
 
-    NpyString_release_allocator(in_allocator);
+    // Create hashset within the scope of a lambda to allow RAII objects
+    // to manage resources.
+    using set_type = std::unordered_set<npy_static_string *,
+                                        decltype(hash), decltype(equal)>;
+    const set_type hashset =
+        std::invoke([&]() -> const set_type {
+            PyArray_StringDTypeObject *descr =
+                reinterpret_cast<PyArray_StringDTypeObject *>(PyArray_DESCR(self));
+            np::raii::ScopedINCREF incref_descr(reinterpret_cast<PyObject *>(descr));
+            np::raii::SaveThreadState save_thread_state{};
+            np::raii::NpyStringAcquireAllocator alloc(descr);
+
+            set_type hashset(std::min(isize, HASH_TABLE_INITIAL_BUCKETS), hash, equal);
+
+            char *idata = PyArray_BYTES(self);
+            npy_intp istride = PyArray_STRIDES(self)[0];
+
+            for (npy_intp i = 0; i < isize; i++, idata += istride) {
+                npy_packed_static_string *packed_string =
+                    reinterpret_cast<npy_packed_static_string *>(idata);
+                int is_null = NpyString_load(alloc.allocator(), packed_string,
+                                             &unpacked_strings[i]);
+                if (is_null == -1) {
+                    // Unexpected error. Throw a C++ exception that will be caught
+                    // by the caller of unique_vstring() and converted into a Python
+                    // RuntimeError.
+                    throw std::runtime_error("Failed to load string from packed "
+                                             "static string.");
+                }
+                hashset.insert(&unpacked_strings[i]);
+            }
+            return hashset;
+        });
 
     npy_intp length = hashset.size();
-
-    PyEval_RestoreThread(_save1);
 
     PyArrayObject *res_obj = empty_array_like(self, length);
     if (res_obj == NULL) {
         return NULL;
     }
 
-    PyArray_Descr *res_descr = PyArray_DESCR(res_obj);
-    Py_INCREF(res_descr);
+    PyArray_StringDTypeObject *res_descr =
+        reinterpret_cast<PyArray_StringDTypeObject *>(PyArray_DESCR(res_obj));
 
-    PyThreadState *_save2 = PyEval_SaveThread();
-    auto save2_dealloc = finally([&]() {
-        PyEval_RestoreThread(_save2);
-    });
+    {
+        np::raii::ScopedINCREF incref_res_descr(reinterpret_cast<PyObject *>(res_descr));
+        np::raii::SaveThreadState save_thread_state{};
+        np::raii::NpyStringAcquireAllocator alloc(res_descr);
 
-    npy_string_allocator *out_allocator = NpyString_acquire_allocator((PyArray_StringDTypeObject *)res_descr);
-    auto out_allocator_dealloc = finally([&]() {
-        NpyString_release_allocator(out_allocator);
-    });
-
-    char *odata = PyArray_BYTES(res_obj);
-    npy_intp ostride = PyArray_STRIDES(res_obj)[0];
-    // Output array is one-dimensional, enabling efficient iteration using strides.
-    for (auto it = hashset.begin(); it != hashset.end(); it++, odata += ostride) {
-        npy_packed_static_string *packed_string = (npy_packed_static_string *)odata;
-        int pack_status = 0;
-        if ((*it)->buf == NULL) {
-            pack_status = NpyString_pack_null(out_allocator, packed_string);
-        } else {
-            pack_status = NpyString_pack(out_allocator, packed_string, (*it)->buf, (*it)->size);
-        }
-        if (pack_status == -1) {
-            // string packing failed
-            return NULL;
+        char *odata = PyArray_BYTES(res_obj);
+        npy_intp ostride = PyArray_STRIDES(res_obj)[0];
+        for (auto it = hashset.begin(); it != hashset.end(); it++, odata += ostride) {
+            npy_packed_static_string *packed_string =
+                reinterpret_cast<npy_packed_static_string *>(odata);
+            int pack_status = 0;
+            if ((*it)->buf == NULL) {
+                pack_status = NpyString_pack_null(alloc.allocator(), packed_string);
+            } else {
+                pack_status = NpyString_pack(alloc.allocator(), packed_string,
+                                             (*it)->buf, (*it)->size);
+            }
+            if (pack_status == -1) {
+                // string packing failed
+                return NULL;
+            }
         }
     }
-
     return reinterpret_cast<PyObject *>(res_obj);
 }
 


### PR DESCRIPTION
The functions `unique_numeric()`, `unique_string()` and `unique_vstring()` in `unique.cpp` are updated to ensure that if an exception is thrown during processing of the `std::unordered_set()` (e.g. throwing `std::bad_alloc`), the GIL, refcounts, and NpyString allocators are properly restored.

<strike>Another RAII object is added, ScopedINCREF, that increments the refcount of an object that must be used for the duration of a scope. The refcount is decreased when the scope is exited.</strike>

This addresses the issue about `unique()` reported in https://github.com/numpy/numpy/issues/30177.

This PR replaces https://github.com/numpy/numpy/pull/30180.  I mentioned over there that I would add handling of `datetime64` and `timedelta64`, but those changes didn't make it into this PR.  I scaled back the scope so that this PR should preserve the existing behavior.  `datetime64` and `timedelta64` can be handled in a follow-up PR.