### PR TITLE
MAINT: Add some pedantic Py_DECREFs

### DIFF
--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -1077,6 +1077,7 @@ test_as_c_array(PyObject *NPY_UNUSED(self), PyObject *args)
                     dims,
                     1,
                     descr) < 0) {
+                Py_DECREF(descr);
                 PyErr_SetString(PyExc_RuntimeError, "error converting 1D array");
                 return NULL;
             }
@@ -1090,6 +1091,7 @@ test_as_c_array(PyObject *NPY_UNUSED(self), PyObject *args)
                     dims,
                     2,
                     descr) < 0) {
+                Py_DECREF(descr);
                 PyErr_SetString(PyExc_RuntimeError, "error converting 2D array");
                 return NULL;
             }
@@ -1103,6 +1105,7 @@ test_as_c_array(PyObject *NPY_UNUSED(self), PyObject *args)
                     dims,
                     3,
                     descr) < 0) {
+                Py_DECREF(descr);
                 PyErr_SetString(PyExc_RuntimeError, "error converting 3D array");
                 return NULL;
             }

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -375,6 +375,7 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     values = (PyArrayObject *)PyArray_FromAny(values0, dtype,
                                     0, 0, NPY_ARRAY_CARRAY, NULL);
     if (values == NULL) {
+        Py_DECREF(dtype);
         goto fail;
     }
 

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -810,6 +810,7 @@ array_flat_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
     arr = (PyArrayObject *)PyArray_FromAny(val, typecode,
                   0, 0, NPY_ARRAY_FORCECAST | PyArray_FORTRAN_IF(self), NULL);
     if (arr == NULL) {
+        Py_DECREF(typecode);
         return -1;
     }
     arrit = (PyArrayIterObject *)PyArray_IterNew((PyObject *)arr);

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -15,7 +15,6 @@
 #include "npy_config.h"
 
 
-
 #include "npy_static_data.h"
 #include "common.h"
 #include "dtype_transfer.h"
@@ -283,6 +282,7 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
                                                     (PyObject *)self);
 
         if (obj == NULL) {
+            Py_DECREF(dtype);
             goto fail;
         }
 
@@ -313,6 +313,7 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
         Py_INCREF(dtype);
         obj = (PyArrayObject *)PyArray_FromArray(out, dtype, flags);
         if (obj == NULL) {
+            Py_DECREF(dtype);
             goto fail;
         }
     }
@@ -695,6 +696,7 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
     values = (PyArrayObject *)PyArray_FromAny(values0, dtype,
                                     0, 0, NPY_ARRAY_CARRAY, NULL);
     if (values == NULL) {
+        Py_DECREF(dtype);
         goto fail;
     }
     nv = PyArray_SIZE(values); /* zero if null array */

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -389,6 +389,7 @@ iter_subscript_Bool(PyArrayIterObject *self, PyArrayObject *ind,
                              NULL, NULL,
                              0, (PyObject *)self->ao);
     if (ret == NULL) {
+        Py_DECREF(dtype);
         return NULL;
     }
     if (count > 0) {
@@ -450,6 +451,7 @@ iter_subscript_int(PyArrayIterObject *self, PyArrayObject *ind,
                              NULL, NULL,
                              0, (PyObject *)self->ao);
     if (ret == NULL) {
+        Py_DECREF(dtype);
         return NULL;
     }
     optr = PyArray_DATA(ret);

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -974,6 +974,7 @@ array_boolean_subscript(PyArrayObject *self,
     ret = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type, dtype, 1, &size,
                                 NULL, NULL, 0, NULL);
     if (ret == NULL) {
+        Py_DECREF(dtype);
         return NULL;
     }
     /* not same as *dtype* if the DType class replaces dtypes */

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -122,6 +122,7 @@ PyArray_CopyInitialReduceValues(
             &PyArray_Type, descr, idim_out, shape, strides,
             PyArray_DATA(operand), 0, NULL);
     if (op_view == NULL) {
+        Py_DECREF(descr);
         return -1;
     }
 


### PR DESCRIPTION
A common pattern throughout the code is

    PyArray_Descr *descr = PyArray_DESCR(obj);
    Py_INCREF(descr);
    new_arr = PyArray_From[...](..., descr, ...)
    if (new_arr == NULL) {
        // Handle the failure.
    }

The array creation functions PyArray_From[...] steal a reference to descr, but if the function fails, the refcount of descr should be decreased. The Py_DECREF to do this was missing in many places.

This is not a high priority fix.  The array creation failure will end up as an exception in the calling code, and I doubt there are very many applications that will catch the exception *and keep going* long enough to notice a memory leak associated with the dtype.  So, as it says on the tin, *pedantic*...