### PR TITLE
BUG: Allow np.interp([], [], []) to return an empty array instead of error (GH-30316)

### DIFF
--- a/numpy/_core/_umath_tests.pyi
+++ b/numpy/_core/_umath_tests.pyi
@@ -1,0 +1,47 @@
+# undocumented internal testing module for ufunc features, defined in
+# numpy/_core/src/umath/_umath_tests.c.src
+
+from typing import Final, Literal as L, TypedDict, type_check_only
+
+import numpy as np
+from numpy._typing import _GUFunc_Nin2_Nout1, _UFunc_Nin1_Nout1, _UFunc_Nin2_Nout1
+
+@type_check_only
+class _TestDispatchResult(TypedDict):
+    func: str  # e.g. 'func_AVX2'
+    var: str  # e.g. 'var_AVX2'
+    func_xb: str  # e.g. 'func_AVX2'
+    var_xb: str  # e.g. 'var_AVX2'
+    all: list[str]  # e.g. ['func_AVX2', 'func_SSE41', 'func']
+
+###
+
+# undocumented
+def test_signature(
+    nin: int, nout: int, signature: str, /
+) -> tuple[
+    L[0, 1],  # core_enabled (0 for scalar ufunc; 1 for generalized ufunc)
+    tuple[int, ...] | None,  # core_num_dims
+    tuple[int, ...] | None,  # core_dim_ixs
+    tuple[int, ...] | None,  # core_dim_flags
+    tuple[int, ...] | None,  # core_dim_sizes
+]: ...
+
+# undocumented
+def test_dispatch() -> _TestDispatchResult: ...
+
+# undocumented ufuncs and gufuncs
+always_error: Final[_UFunc_Nin2_Nout1[L["always_error"], L[1], None]] = ...
+always_error_unary: Final[_UFunc_Nin1_Nout1[L["always_error_unary"], L[1], None]] = ...
+always_error_gufunc: Final[_GUFunc_Nin2_Nout1[L["always_error_gufunc"], L[1], None, L["(i),()->()"]]] = ...
+inner1d: Final[_GUFunc_Nin2_Nout1[L["inner1d"], L[2], None, L["(i),(i)->()"]]] = ...
+innerwt: Final[np.ufunc] = ...  # we have no specialized type for 3->1 gufuncs
+matrix_multiply: Final[_GUFunc_Nin2_Nout1[L["matrix_multiply"], L[3], None, L["(m,n),(n,p)->(m,p)"]]] = ...
+matmul: Final[_GUFunc_Nin2_Nout1[L["matmul"], L[3], None, L["(m?,n),(n,p?)->(m?,p?)"]]] = ...
+euclidean_pdist: Final[_GUFunc_Nin2_Nout1[L["euclidean_pdist"], L[2], None, L["(n,d)->(p)"]]] = ...
+cumsum: Final[np.ufunc] = ...  # we have no specialized type for 1->1 gufuncs
+inner1d_no_doc: Final[_GUFunc_Nin2_Nout1[L["inner1d_no_doc"], L[2], None, L["(i),(i)->()"]]] = ...
+cross1d: Final[_GUFunc_Nin2_Nout1[L["cross1d"], L[2], None, L["(3),(3)->(3)"]]] = ...
+_pickleable_module_global_ufunc: Final[np.ufunc] = ...  # 0->0 ufunc; segfaults if called
+indexed_negative: Final[_UFunc_Nin1_Nout1[L["indexed_negative"], L[0], L[0]]] = ...  # ntypes=0; can't be called
+conv1d_full: Final[_GUFunc_Nin2_Nout1[L["conv1d_full"], L[1], None, L["(m),(n)->(p)"]]] = ...

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -927,7 +927,7 @@ foreach gen_mtargets : [
     'loops_arithm_fp.dispatch.h',
     src_file.process('src/umath/loops_arithm_fp.dispatch.c.src'),
     [
-      X86_V3, X86_V2, 
+      X86_V3, X86_V2,
       ASIMD, NEON,
       VSX3, VSX2,
       VXE, VX,
@@ -960,7 +960,7 @@ foreach gen_mtargets : [
     'loops_exponent_log.dispatch.h',
     src_file.process('src/umath/loops_exponent_log.dispatch.c.src'),
     [
-      X86_V4, X86_V3, 
+      X86_V4, X86_V3,
     ]
   ],
   [
@@ -1403,6 +1403,7 @@ python_sources = [
   '_type_aliases.pyi',
   '_ufunc_config.py',
   '_ufunc_config.pyi',
+  '_umath_tests.pyi',
   'arrayprint.py',
   'arrayprint.pyi',
   'cversions.py',

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -574,7 +574,24 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t len_arg
                 NULL, NULL, NULL) < 0) {
         return NULL;
     }
+    /* Special case when x, xp and fp are all empty */
+    {
+        Py_ssize_t sx, sxp, sfp;
 
+        sx  = PySequence_Size(x);
+        if (sx < 0) { return NULL; }  /* error already set */
+
+        sxp = PySequence_Size(xp);
+        if (sxp < 0) { return NULL; }
+
+        sfp = PySequence_Size(fp);
+        if (sfp < 0) { return NULL; }
+
+        if (sx == 0 && sxp == 0 && sfp == 0) {
+            npy_intp dims[1] = {0};
+            return PyArray_SimpleNew(1, dims, NPY_DOUBLE);
+        }
+    }
     afp = (PyArrayObject *)PyArray_ContiguousFromAny(fp, NPY_DOUBLE, 1, 1);
     if (afp == NULL) {
         return NULL;

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3087,6 +3087,12 @@ class TestInterp:
         assert_raises(ValueError, interp, 0, [0, 1], [1, 2], period=0)
         assert_raises(ValueError, interp, 0, [], [], period=360)
         assert_raises(ValueError, interp, 0, [0], [1, 2], period=360)
+        
+    def test_empty_triple_case(self):
+        # New expected behavior: np.interp([], [], []) returns []
+        res = np.interp([], [], [])
+        assert_equal(res, np.array([]))
+        assert res.shape == (0,)
 
     def test_basic(self):
         x = np.linspace(0, 1, 5)

--- a/tools/stubtest/allowlist.txt
+++ b/tools/stubtest/allowlist.txt
@@ -59,7 +59,7 @@ numpy\.core\.shape_base.*
 numpy\.core\.umath.*
 numpy\.typing\.mypy_plugin
 
-# ufuncs
+# ufuncs, see https://github.com/python/mypy/issues/20223
 numpy\.(\w+\.)*abs
 numpy\.(\w+\.)*absolute
 numpy\.(\w+\.)*acos
@@ -177,7 +177,16 @@ numpy\.(\w+\.)*istitle
 numpy\.(\w+\.)*isupper
 numpy\.(\w+\.)*str_len
 numpy\._core\._methods\.umr_bitwise_count
-numpy\._core\._methods\.umr_bitwise_count
+numpy\._core\._umath_tests\.always_error
+numpy\._core\._umath_tests\.always_error_gufunc
+numpy\._core\._umath_tests\.always_error_unary
+numpy\._core\._umath_tests\.conv1d_full
+numpy\._core\._umath_tests\.cross1d
+numpy\._core\._umath_tests\.euclidean_pdist
+numpy\._core\._umath_tests\.indexed_negative
+numpy\._core\._umath_tests\.inner1d
+numpy\._core\._umath_tests\.inner1d_no_doc
+numpy\._core\._umath_tests\.matrix_multiply
 numpy\.linalg\._umath_linalg\.qr_complete
 numpy\.linalg\._umath_linalg\.qr_reduced
 numpy\.linalg\._umath_linalg\.solve


### PR DESCRIPTION
BUG: Fix np.interp([], [], []) returning ValueError (GH-30316)

When both `x` and `xp` are empty, np.interp previously raised
ValueError("array of sample points is empty"). This behavior is overly
strict, as empty input should naturally result in an empty output array
with the same shape as `x`.

This commit implements special handling for the case xp == [] and
x == [], returning an empty output array, while preserving all existing
error conditions:

* xp == [] and x non-empty → still raises ValueError
* len(fp) != len(xp) → still raises ValueError
* xp non-empty → normal interpolation

Tests are added to verify the corrected behavior.
Fixes GH-30316.