### PR TITLE
DOC: Fix typos in documentation

### DIFF
--- a/doc/source/dev/howto-docs.rst
+++ b/doc/source/dev/howto-docs.rst
@@ -229,7 +229,7 @@ XML files, which are  converted by Breathe_ into RST, which is used by Sphinx.
 -----------------------------
 
 Although there is still no commenting style set to follow, the Javadoc
-is more preferable than the others due to the similarities with the current
+is preferable to the others due to the similarities with the
 existing non-indexed comment blocks.
 
 .. note::

--- a/doc/source/dev/reviewer_guidelines.rst
+++ b/doc/source/dev/reviewer_guidelines.rst
@@ -70,7 +70,7 @@ Reviewer checklist
 
 For maintainers
 ---------------
-  
+
 - Make sure all automated CI tests pass before merging a PR, and that the
   :ref:`documentation builds <building-docs>` without any errors.
 - In case of merge conflicts, ask the PR submitter to :ref:`rebase on main

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -489,7 +489,7 @@ changed now that ``matmul`` is a ufunc and can be overridden using
 
 The scaling of the covariance matrix in ``np.polyfit`` is different
 -------------------------------------------------------------------
-So far, ``np.polyfit`` used a non-standard factor in the scaling of the the
+So far, ``np.polyfit`` used a non-standard factor in the scaling of the
 covariance matrix. Namely, rather than using the standard ``chisq/(M-N)``, it
 scaled it with ``chisq/(M-N-2)`` where M is the number of data points and N is the
 number of parameters.  This scaling is inconsistent with other fitting programs

--- a/doc/source/user/basics.indexing.rst
+++ b/doc/source/user/basics.indexing.rst
@@ -162,8 +162,8 @@ concepts to remember include:
 
 - Assume *n* is the number of elements in the dimension being
   sliced. Then, if *i* is not given it defaults to 0 for *k > 0* and
-  *n - 1* for *k < 0* . If *j* is not given it defaults to *n* for *k > 0*
-  and *-n-1* for *k < 0* . If *k* is not given it defaults to 1. Note that
+  *n - 1* for *k < 0*. If *j* is not given it defaults to *n* for *k > 0*
+  and *-n-1* for *k < 0*. If *k* is not given it defaults to 1. Note that
   ``::`` is the same as ``:`` and means select all indices along this
   axis.
   From the above example::
@@ -215,7 +215,7 @@ concepts to remember include:
   and used in the ``x[obj]`` notation. Slice objects can be used in
   the construction in place of the ``[start:stop:step]``
   notation. For example, ``x[1:10:5, ::-1]`` can also be implemented
-  as ``obj = (slice(1, 10, 5), slice(None, None, -1)); x[obj]`` . This
+  as ``obj = (slice(1, 10, 5), slice(None, None, -1)); x[obj]``. This
   can be useful for constructing generic code that works on arrays
   of arbitrary dimensions. See :ref:`dealing-with-variable-indices`
   for more information.

--- a/doc/source/user/c-info.how-to-extend.rst
+++ b/doc/source/user/c-info.how-to-extend.rst
@@ -36,7 +36,7 @@ into Python as if it were a standard python file. It will contain
 objects and methods that have been defined and compiled in C code. The
 basic steps for doing this in Python are well-documented and you can
 find more information in the documentation for Python itself available
-online at `www.python.org <https://www.python.org>`_ .
+online at `www.python.org <https://www.python.org>`_.
 
 In addition to the Python C-API, there is a full and rich C-API for NumPy
 allowing sophisticated manipulations on a C-level. However, for most

--- a/doc/source/user/c-info.how-to-extend.rst
+++ b/doc/source/user/c-info.how-to-extend.rst
@@ -20,7 +20,7 @@ Python, it is also designed to be general-purpose and satisfy a wide-
 variety of computational needs. As a result, if absolute speed is
 essential, there is no replacement for a well-crafted, compiled loop
 specific to your application and hardware. This is one of the reasons
-that numpy includes f2py so that an easy-to-use mechanisms for linking
+that numpy includes f2py so that an easy-to-use mechanism for linking
 (simple) C/C++ and (arbitrary) Fortran code directly into Python are
 available. You are encouraged to use and improve this mechanism. The
 purpose of this section is not to document this tool but to document

--- a/doc/source/user/how-to-how-to.rst
+++ b/doc/source/user/how-to-how-to.rst
@@ -82,7 +82,7 @@ Why write how-tos when there's Stack Overflow, Reddit, Gitter...?
 - We have authoritative answers.
 - How-tos make the site less forbidding to non-experts.
 - How-tos bring people into the site and help them discover other information
-  that's here .
+  that's here.
 - Creating how-tos helps us see NumPy usability through new eyes.
 
 ******************************************************************************


### PR DESCRIPTION
- Remove extra space before period in how-to-how-to.rst
- Fix subject-verb agreement: 'mechanisms' -> 'mechanism' in c-info.how-to-extend.rst

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
