### PR TITLE
ENH: Remove unnecessary ValueError exception handler in trapezoid

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5019,13 +5019,7 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     slice2 = [slice(None)] * nd
     slice1[axis] = slice(1, None)
     slice2[axis] = slice(None, -1)
-    try:
-        ret = (d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0).sum(axis)
-    except ValueError:
-        # Operations didn't work, cast to ndarray
-        d = np.asarray(d)
-        y = np.asarray(y)
-        ret = add.reduce(d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0, axis)
+    ret = (d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0).sum(axis)
     return ret
 
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5019,7 +5019,14 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     slice2 = [slice(None)] * nd
     slice1[axis] = slice(1, None)
     slice2[axis] = slice(None, -1)
-    ret = (d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0).sum(axis)
+    try:
+        ret = (d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0).sum(axis)
+    except ValueError:
+        # Operations didn't work, cast to ndarray
+        # maybe a subclass like matrix?
+        d = np.asarray(d)
+        y = np.asarray(y)
+        ret = add.reduce(d * (y[tuple(slice1)] + y[tuple(slice2)]) / 2.0, axis)
     return ret
 
 


### PR DESCRIPTION
~Fix:~ Towards #30337
(edit: will not fix all the points in the issue, @mattip)
## What Changed

* Removed the unused `try/except ValueError` block in `numpy/lib/_function_base_impl.py`.

## Why Changed

The `ValueError` handler was never triggered by any valid input type, making it dead code.

## Comprehensive analysis shows:

1. **.sum(axis)** on NumPy arrays never raises ValueError 
2. **Broadcasting** is guaranteed by explicit reshape of d to match y's shape
(lines 5012-5014), so ValueError from broadcasting cannot occur
3. All **existing comprehensive tests** (including masked arrays, which are
the most likely to cause issues) pass without triggering the handler
4. The **fallback path does essentially the same computation as the normal
path** (converts to ndarray and uses add.reduce, which is what .sum()
uses internally anyway)

The handler appears to be defensive code added 'just in case' but handles
a case that doesn't occur with standard NumPy array types.