### PR TITLE
MAINT: Update circleci python to 3.12.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ _defaults: &defaults
   docker:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/developer/images/image/cimg/python
-    - image: cimg/python:3.11.13
+    - image: cimg/python:3.12.12
   working_directory: ~/repo
 
 
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: build NumPy
           command: |
-            python3.11 -m venv venv
+            python3.12 -m venv venv
             . venv/bin/activate
             pip install --progress-bar=off -r requirements/test_requirements.txt \
                -r requirements/build_requirements.txt \

--- a/doc/source/try_examples.json
+++ b/doc/source/try_examples.json
@@ -6,3 +6,4 @@
         "numpy.__array_namespace_info__.html*"
     ]
 }
+


### PR DESCRIPTION
We could go to 3.14, but I would prefer to let it settle a bit longer.

[skip actions] [skip cirrus]

NOTE: the build fails with Python 3.13, cannot parse `try_examples.json`. I suspect that maybe the environment needs an update.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
