### PR TITLE
BUG: raise BufferError when creating dlpack with wrong device tuple

### DIFF
--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -392,7 +392,8 @@ device_converter(PyObject *obj, DLDevice *result_device)
         return NPY_SUCCEED;
     }
 
-    PyErr_SetString(PyExc_ValueError, "unsupported device requested");
+    /* Must be a BufferError */
+    PyErr_SetString(PyExc_BufferError, "unsupported device requested");
     return NPY_FAIL;
 }
 

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -184,7 +184,7 @@ class TestDLPack:
         np.from_dlpack(x, device="cpu")
         np.from_dlpack(x, device=None)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(BufferError):
             x.__dlpack__(dl_device=(10, 0))
         with pytest.raises(ValueError):
             np.from_dlpack(x, device="gpu")


### PR DESCRIPTION
Fixes #30341

Raise compliant BufferError exception