### PR TITLE
MAINT: Enable linting with ruff E501

### DIFF
--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -277,12 +277,14 @@ class TestArray2String:
             # for issue #5692
             A = np.zeros(shape=10, dtype=[("A", "M8[s]")])
             A[5:].fill(np.datetime64('NaT'))
+            date_string = '1970-01-01T00:00:00'
+            none_string = 'NaT'
             assert_equal(
                 np.array2string(A),
-                textwrap.dedent("""\
-                [('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',)
-                 ('1970-01-01T00:00:00',) ('1970-01-01T00:00:00',) ('NaT',) ('NaT',)
-                 ('NaT',) ('NaT',) ('NaT',)]""")
+                textwrap.dedent(f"""\
+                [('{date_string}',) ('{date_string}',) ('{date_string}',)
+                 ('{date_string}',) ('{date_string}',) ('{none_string}',) ('{none_string}',)
+                 ('{none_string}',) ('{none_string}',) ('{none_string}',)]""")
             )
         finally:
             np.set_printoptions(legacy=False)

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -278,13 +278,12 @@ class TestArray2String:
             A = np.zeros(shape=10, dtype=[("A", "M8[s]")])
             A[5:].fill(np.datetime64('NaT'))
             date_string = '1970-01-01T00:00:00'
-            none_string = 'NaT'
             assert_equal(
                 np.array2string(A),
                 textwrap.dedent(f"""\
                 [('{date_string}',) ('{date_string}',) ('{date_string}',)
-                 ('{date_string}',) ('{date_string}',) ('{none_string}',) ('{none_string}',)
-                 ('{none_string}',) ('{none_string}',) ('{none_string}',)]""")
+                 ('{date_string}',) ('{date_string}',) ('NaT',) ('NaT',)
+                 ('NaT',) ('NaT',) ('NaT',)]""")
             )
         finally:
             np.set_printoptions(legacy=False)

--- a/numpy/_core/tests/test_cpu_dispatcher.py
+++ b/numpy/_core/tests/test_cpu_dispatcher.py
@@ -20,9 +20,9 @@ def test_dispatcher():
     highest_sfx = ""  # no suffix for the baseline
     all_sfx = []
     for feature in reversed(targets):
-        # skip baseline features, by the default `CCompilerOpt` do not generate separated objects
-        # for the baseline,  just one object combined all of them via 'baseline' option
-        # within the configuration statements.
+        # skip baseline features, by the default `CCompilerOpt` do not generate
+        # separated objects for the baseline, just one object combined all of them
+        # via 'baseline' option within the configuration statements.
         if feature in __cpu_baseline__:
             continue
         # check compiler and running machine support

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1836,7 +1836,12 @@ class TestFromCTypes:
             ]
         expected = np.dtype({
             "names": ['a', 'b', 'c', 'd'],
-            "formats": ['u1', np.uint16, np.uint32, [('one', 'u1'), ('two', np.uint32)]],
+            "formats": [
+                'u1',
+                np.uint16,
+                np.uint32,
+                [('one', 'u1'), ('two', np.uint32)],
+            ],
             "offsets": [0, 0, 0, 0],
             "itemsize": ctypes.sizeof(Union)
         })
@@ -1860,7 +1865,12 @@ class TestFromCTypes:
             ]
         expected = np.dtype({
             "names": ['a', 'b', 'c', 'd'],
-            "formats": ['u1', np.uint16, np.uint32, [('one', 'u1'), ('two', np.uint32)]],
+            "formats": [
+                'u1',
+                np.uint16,
+                np.uint32,
+                [('one', 'u1'), ('two', np.uint32)],
+            ],
             "offsets": [0, 0, 0, 0],
             "itemsize": ctypes.sizeof(Union)
         })
@@ -1892,7 +1902,15 @@ class TestFromCTypes:
                 ('g', ctypes.c_uint8)
                 ]
         expected = np.dtype({
-            "formats": [np.uint8, np.uint16, np.uint8, np.uint16, np.uint32, np.uint32, np.uint8],
+            "formats": [
+                np.uint8,
+                np.uint16,
+                np.uint8,
+                np.uint16,
+                np.uint32,
+                np.uint32,
+                np.uint8,
+            ],
             "offsets": [0, 2, 4, 6, 8, 12, 16],
             "names": ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
             "itemsize": 18})
@@ -1965,7 +1983,9 @@ class TestFromCTypes:
 
 class TestUserDType:
     @pytest.mark.leaks_references(reason="dynamically creates custom dtype.")
-    @pytest.mark.thread_unsafe(reason="crashes when GIL disabled, dtype setup is thread-unsafe")
+    @pytest.mark.thread_unsafe(
+        reason="crashes when GIL disabled, dtype setup is thread-unsafe",
+    )
     def test_custom_structured_dtype(self):
         class mytype:
             pass
@@ -1986,7 +2006,9 @@ class TestUserDType:
             del a
             assert sys.getrefcount(o) == startcount
 
-    @pytest.mark.thread_unsafe(reason="crashes when GIL disabled, dtype setup is thread-unsafe")
+    @pytest.mark.thread_unsafe(
+        reason="crashes when GIL disabled, dtype setup is thread-unsafe",
+    )
     def test_custom_structured_dtype_errors(self):
         class mytype:
             pass

--- a/ruff.toml
+++ b/ruff.toml
@@ -80,10 +80,7 @@ ignore = [
 "bench_*.py" = ["B015", "B018"]
 "test*.py" = ["B015", "B018", "E201", "E714"]
 
-"numpy/_core/tests/test_arrayprint.py" = ["E501"]
-"numpy/_core/tests/test_cpu_dispatcher.py" = ["E501"]
 "numpy/_core/tests/test_cpu_features.py" = ["E501"]
-"numpy/_core/tests/test_dtype.py" = ["E501"]
 "numpy/_core/tests/test_defchararray.py" = ["E501"]
 "numpy/_core/tests/test_einsum.py" = ["E501"]
 "numpy/_core/tests/test_multiarray.py" = ["E501"]


### PR DESCRIPTION
#28947 

This PR fixes the E501 (line too long) style errors in the following test files:

- numpy/_core/tests/test_arrayprint.py
- numpy/_core/tests/test_cpu_dispatcher.py
- numpy/_core/tests/test_dtype.py

No functional changes, only formatting improvements to comply with style guidelines.
