### PR TITLE
DOC: Add more examples for numpy.sum

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -2413,6 +2413,10 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
 
     >>> np.sum([10], initial=5)
     15
+    >>> np.sum([1, 2, 3, 4], where=[True, False, True, False])
+    4
+    >>> np.sum([1, 2, 3], initial=10)
+    16
     """
     if isinstance(a, _gentype):
         # 2018-02-25, 1.15.0


### PR DESCRIPTION
This PR adds two additional examples to the numpy.sum documentation:
	•	An example demonstrating the use of the where parameter
	•	An example demonstrating the use of the initial parameter

These examples make the optional arguments easier to understand for beginners and improve the clarity of the documentation.