### PR TITLE
BUG: Fix PPC64 native/POWER10 baseline builds

### DIFF
--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -25,26 +25,44 @@ jobs:
     # For more details, see: https://github.com/numpy/numpy/issues/29125
     if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-24.04-ppc64le-p10
-    name: "Native PPC64LE"
+  
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "default"
+            args: "-Dallow-noblas=false"
+          - name: "Power10/vsx4"
+            args: "-Dallow-noblas=false -Dcpu-baseline=vsx4 -Dcpu-dispatch=none"
+          - name: "clang"
+            args: "-Dallow-noblas=false"
+    
+    name: "${{ matrix.config.name }}"
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         submodules: recursive
         fetch-tags: true
-        persist-credentials: false
-
+    
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install -y python3 python3-pip python3-dev ninja-build gfortran \
+        sudo apt install -y python3.12 python3-pip python3-dev ninja-build gfortran \
                             build-essential libopenblas-dev liblapack-dev pkg-config
         pip install --upgrade pip
         pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         echo "/home/runner/.local/bin" >> $GITHUB_PATH
 
+    - name: Install clang
+      if: matrix.config.name == 'clang'
+      run: |
+        sudo apt install -y clang
+        export CC=clang
+        export CXX=clang++
+
     - name: Meson Build
       run: |
-        spin build -- -Dallow-noblas=false
+        spin build -- ${{ matrix.config.args }}
 
     - name: Meson Log
       if: always()

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -43,22 +43,6 @@ jobs:
       matrix:
         BUILD_PROP:
           - [
-              "ppc64le",
-              "powerpc64le-linux-gnu",
-              "ppc64le/ubuntu:22.04",
-              "-Dallow-noblas=true",
-              "test_kind or test_multiarray or test_simd or test_umath or test_ufunc",
-              "ppc64le"
-            ]
-          - [
-              "ppc64le - baseline(Power9)",
-              "powerpc64le-linux-gnu",
-              "ppc64le/ubuntu:22.04",
-              "-Dallow-noblas=true -Dcpu-baseline=vsx3",
-              "test_kind or test_multiarray or test_simd or test_umath or test_ufunc",
-              "ppc64le"
-            ]
-          - [
               "s390x",
               "s390x-linux-gnu",
               "s390x/ubuntu:22.04",

--- a/meson_cpu/ppc64/meson.build
+++ b/meson_cpu/ppc64/meson.build
@@ -3,17 +3,14 @@ mod_features = import('features')
 compiler_id = meson.get_compiler('c').get_id()
 
 VSX = mod_features.new(
-  'VSX', 1, args: '-mvsx',
+  'VSX', 1, args: ['-mvsx', '-DHWY_COMPILE_ONLY_STATIC', '-DHWY_DISABLE_ATTR'] + (compiler_id == 'clang' ? ['-maltivec'] : []),
   test_code: files(source_root + '/numpy/_core/src/_simd/checks/cpu_vsx.c')[0],
   extra_tests: {
     'VSX_ASM': files(source_root + '/numpy/_core/src/_simd/checks/extra_vsx_asm.c')[0]
   }
 )
-if compiler_id == 'clang'
-  VSX.update(args: ['-mvsx', '-maltivec'])
-endif
 VSX2 = mod_features.new(
-  'VSX2', 2, implies: VSX, args: {'val': '-mcpu=power8', 'match': '.*vsx'},
+  'VSX2', 2, implies: VSX, args: '-mcpu=power8',
   detect: {'val': 'VSX2', 'match': 'VSX'},
   test_code: files(source_root + '/numpy/_core/src/_simd/checks/cpu_vsx2.c')[0],
 )
@@ -23,7 +20,9 @@ if host_machine.endian() == 'little'
   VSX.update(implies: VSX2)
 endif
 VSX3 = mod_features.new(
-  'VSX3', 3, implies: VSX2, args: {'val': '-mcpu=power9', 'match': '.*(?:mcpu=|vsx).*'},
+  'VSX3', 3, implies: VSX2, args: [
+    {'val': '-mcpu=power9', 'match': '.*mcpu=.*'},
+  ],
   detect: {'val': 'VSX3', 'match': 'VSX.*'},
   test_code: files(source_root + '/numpy/_core/src/_simd/checks/cpu_vsx3.c')[0],
   extra_tests: {
@@ -31,7 +30,9 @@ VSX3 = mod_features.new(
   }
 )
 VSX4 = mod_features.new(
-  'VSX4', 4, implies: VSX3, args: {'val': '-mcpu=power10', 'match': '.*(?:mcpu=|vsx).*'},
+  'VSX4', 4, implies: VSX3, args: [
+    {'val': '-mcpu=power10', 'match': '.*mcpu=.*'},
+  ],
   detect: {'val': 'VSX4', 'match': 'VSX.*'},
   test_code: files(source_root + '/numpy/_core/src/_simd/checks/cpu_vsx4.c')[0],
   extra_tests: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ license-files = [
     'LICENSE.txt',                                       # BSD-3-Clause
     'numpy/_core/include/numpy/libdivide/LICENSE.txt',   # Zlib
     'numpy/_core/src/common/pythoncapi-compat/COPYING',  # 0BSD
-    'numpy/_core/src/highway/LICENSE-BSD3',              # BSD-3-Clause
+    'numpy/_core/src/highway/LICENSE',                   # Dual-licensed: Apache 2.0 or BSD 3-Clause
     'numpy/_core/src/multiarray/dragon4_LICENSE.txt',    # MIT
     'numpy/_core/src/npysort/x86-simd-sort/LICENSE.md',  # BSD-3-Clause
     'numpy/_core/src/umath/svml/LICENSE',                # BSD-3-Clause


### PR DESCRIPTION
Wide versions of GCC (≤13) produce ambiguous bugs with compiler target attributes when
`-mcpu/host` flags are provided via environment variables or via Meson build,
leading to an inability to raise the default baseline to POWER10.
This is fixed by enabling the newly added Highway option `-DHWY_DISABLE_ATTR` to address the issue,
as reported to Highway. This patch also fixes the Clang build bug reported by explicitly
adding `-mvsx` along with `-mcpu`.