### PR TITLE
DOC: Clarify docs and add examples for `np.negative` and `np.positive`

### DIFF
--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -3174,7 +3174,7 @@ add_newdoc('numpy._core.umath', 'multiply',
 
 add_newdoc('numpy._core.umath', 'negative',
     """
-    Element-wise numerical negation.
+    Numerical negation, element-wise.
 
     Parameters
     ----------
@@ -3193,19 +3193,6 @@ add_newdoc('numpy._core.umath', 'negative',
     >>> import numpy as np
     >>> np.negative([1.,-1.])
     array([-1.,  1.])
-
-    >>> x = np.array([[1, -2], [3, -4]])
-    >>> np.negative(x)
-    array([[-1,  2],
-           [-3,  4]])
-    
-    >>> np.negative([1, -1, np.nan])
-    array([-1.,  1.,  nan])
-
-    >>> a = np.array([1, -2, 3, -4])
-    >>> np.negative.at(a, [0, 1])
-    >>> a
-    array([-1,  2,  3, -4])
 
     The unary ``-`` operator can be used as a shorthand for ``np.negative`` on
     ndarrays.
@@ -3243,14 +3230,6 @@ add_newdoc('numpy._core.umath', 'positive',
     >>> x1 = np.array(([1., -1.]))
     >>> np.positive(x1)
     array([ 1., -1.])
-
-    >>> x = np.array([[1, -2], [3, -4]])
-    >>> np.positive(x)
-    array([[ 1., -2],
-           [ 3., -4]])
-    
-    >>> np.positive([1, -1, np.nan])
-    array([ 1., -1., nan])
 
     The unary ``+`` operator can be used as a shorthand for ``np.positive`` on
     ndarrays.

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -3174,7 +3174,7 @@ add_newdoc('numpy._core.umath', 'multiply',
 
 add_newdoc('numpy._core.umath', 'negative',
     """
-    Numerical negative, element-wise.
+    Element-wise numerical negation.
 
     Parameters
     ----------
@@ -3193,6 +3193,14 @@ add_newdoc('numpy._core.umath', 'negative',
     >>> import numpy as np
     >>> np.negative([1.,-1.])
     array([-1.,  1.])
+
+    >>> x = np.array([[1, -2], [3, -4]])
+    >>> np.negative(x)
+    array([[-1,  2],
+           [-3,  4]])
+    
+    >>> np.negative([1, -1, np.nan])
+    array([-1.,  1.,  nan])
 
     The unary ``-`` operator can be used as a shorthand for ``np.negative`` on
     ndarrays.
@@ -3230,6 +3238,14 @@ add_newdoc('numpy._core.umath', 'positive',
     >>> x1 = np.array(([1., -1.]))
     >>> np.positive(x1)
     array([ 1., -1.])
+
+    >>> x = np.array([[1, -2], [3, -4]])
+    >>> np.positive(x)
+    array([[ 1., -2],
+           [ 3., -4]])
+    
+    >>> np.positive([1, -1, np.nan])
+    array([ 1., -1., nan])
 
     The unary ``+`` operator can be used as a shorthand for ``np.positive`` on
     ndarrays.

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -3202,6 +3202,11 @@ add_newdoc('numpy._core.umath', 'negative',
     >>> np.negative([1, -1, np.nan])
     array([-1.,  1.,  nan])
 
+    >>> a = np.array([1, -2, 3, -4])
+    >>> np.negative.at(a, [0, 1])
+    >>> a
+    array([-1,  2,  3, -4])
+
     The unary ``-`` operator can be used as a shorthand for ``np.negative`` on
     ndarrays.
 


### PR DESCRIPTION
This PR modernizes and expands the documentation for `np.negative` and `np.positive`.

- Clarifies introductory wording
- Adds missing `.at` usage example for `np.negative`
- Aligns examples between both unary ufunc operators
- Maintains consistent ndarray formatting
- No behavior or API changes, documentation-only

Please let me know if any further adjustments are required.