### PR TITLE
MAINT: don't assert RecursionError in monster dtype test

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -118,7 +118,7 @@ jobs:
         build_runner:
           - [ macos-15-intel, "macos_x86_64" ]
           - [ macos-14, "macos_arm64" ]
-        version: ["3.12", "3.14.0t"]
+        version: ["3.12", "3.14t"]
 
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -991,8 +991,12 @@ class TestMonsterType:
         d = np.int32
         for i in range(100000):
             d = (d, (1,))
-        with pytest.raises(RecursionError):
+        # depending on OS and Python version, this might succeed
+        # see gh-30370 and cpython issue #142253
+        try:
             np.dtype(d)
+        except RecursionError:
+            pass
 
     @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
     @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1,3 +1,4 @@
+import contextlib
 import ctypes
 import gc
 import inspect
@@ -993,10 +994,8 @@ class TestMonsterType:
             d = (d, (1,))
         # depending on OS and Python version, this might succeed
         # see gh-30370 and cpython issue #142253
-        try:
+        with contextlib.suppress(RecursionError):
             np.dtype(d)
-        except RecursionError:
-            pass
 
     @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
     @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")


### PR DESCRIPTION
Fixes #30370.

Newer CPython versions can recurse more deeply without raising a RecursionError and blowing out the stack. It happens that on x86_64 MacOS the `np.dtype` call succeeds and no error is raised. IMO it's fine if there's no error, the test was simply checking for the observed behavior of CPython and verifying that the case doesn't lead to a seg fault. See https://github.com/numpy/numpy/commit/bb76bff17f86e468ca9fbc5071d95782dc932c10 for context.