### PR TITLE
BUG: fix numpy.quantile for integer inputs

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4794,6 +4794,11 @@ def _quantile(
                                method_props, gtype)
             result_shape = virtual_indexes.shape + (1,) * (arr.ndim - 1)
             gamma = gamma.reshape(result_shape)
+            if arr.dtype.kind in ("i", "u"):
+                # as documented, if the inputs are integers, return float64
+                # cast before _lerp to avoid overflows
+                previous = np.astype(previous, np.float64)
+                next = np.astype(next, np.float64)
             result = _lerp(previous,
                         next,
                         gamma,


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
As mentioned in #29315 (see https://github.com/numpy/numpy/issues/29315#issuecomment-3033546960), `numpy.quantile` currently can overflow for integer inputs in spite of returning a float:

```python
>>> np.quantile(np.array([32767, -1], dtype=np.int16), 0.5)
np.float64(49151.0)
```

This can be fixed by casting integers to floats, before interpolating.
This yields the correct result:
```python
>>> np.quantile(np.array([32767, -1], dtype=np.int16), 0.5)
np.float64(16383.0)
```
We ensure a consistent behavior by adding a property test:

```python
quantile = np.quantile(a, q)
assert np.min(a) <= quantile
assert quantile <= np.max(a)
```

So far, this is just a quick fix, I haven't check if all paths are correct.

We probably need to parameterize by the additional parameters of `np.quantile`.
I just wanted to first cross-check if this is the right approach to fix the issue.

At this point, we still incorrectly get:

```python
>>> np.quantile([1], 0)
np.int64(1)
```
While the documentation ensures us that we should get `np.float64(0.0)`.
Currently, the return type depends on the value of `q`:

```python
>>> np.quantile([1], 0.5)
np.float64(1.0)
```

which is undesired behavior.
I can add the return type to the property test.
We also haven't looked into the second part of the documentation: "If the input contains ... floats smaller than float64, the output data-type is float64."

-----

Another point worth discussing is using `np.int64` with values bigger than can be exactly represented by `np.float64` (i.e. integers larger than 2⁵³).
I am not quite sure, if we might lose accuracy in this case.
On the other hand, it is clearly documented that we cat `np.float64`, so we should expect a loss of accuracy for integers outside the representable range.