### PR TITLE
ENH: Pixi package definitions for downstream development

### DIFF
--- a/.github/workflows/pixi-packages.yml
+++ b/.github/workflows/pixi-packages.yml
@@ -1,0 +1,39 @@
+name: Pixi packages tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - maintenance/**
+    paths-ignore:
+      - '**.pyi'
+      - '**.md'
+      - '**.rst'
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  build_packages:
+    name: Build Pixi packages
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-latest, macos-15]
+        package_variant: [asan, default]
+    if: github.repository == 'numpy/numpy'
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        submodules: recursive
+        fetch-tags: true
+        persist-credentials: false
+
+    - uses: prefix-dev/setup-pixi@ba3bb36eb2066252b2363392b7739741bb777659 # v0.8.1
+      with:
+        pixi-version: v0.60.0
+        run-install: false
+
+    - name: Build
+      run: pixi build --path="pixi-packages/${{ matrix.package_variant }}"

--- a/doc/release/upcoming_changes/30381.new_feature.rst
+++ b/doc/release/upcoming_changes/30381.new_feature.rst
@@ -1,0 +1,11 @@
+Pixi package definitions
+------------------------
+Pixi package definitions have been added for different kinds
+of from-source builds of NumPy. These can be used in
+downstream Pixi workspaces via the ``pixi-build`` feature.
+
+Definitions for both ``default`` and AddressSanitizer-instrumented
+(``asan``) builds are available in the source code under the
+``pixi-packages/`` directory.
+
+``linux-64`` and ``osx-arm64`` platforms are supported.

--- a/pixi-packages/README.md
+++ b/pixi-packages/README.md
@@ -1,2 +1,37 @@
-- see https://github.com/scipy/scipy/pull/24066 for how these packages can be used in a Pixi workspace
-- combining directories blocked on https://github.com/prefix-dev/pixi/issues/2813
+# CPython Pixi packages
+
+This directory contains definitions for [Pixi packages](https://pixi.sh/latest/reference/pixi_manifest/#the-package-section)
+which can be built from the NumPy source code.
+
+Downstream developers can make use of these packages by adding them as Git dependencies in a
+[Pixi workspace](https://pixi.sh/latest/first_workspace/), like:
+
+```toml
+[dependencies]
+numpy = { git = "https://github.com/numpy/numpy", subdirectory = "pixi-packages/asan" }
+```
+
+This is particularly useful when developers need to build NumPy from source
+(for example, for an ASan-instrumented build), as it does not require any manual
+clone or build steps. Instead, Pixi will automatically handle both the build
+and installation of the package.
+
+See https://github.com/scipy/scipy/pull/24066 for a full example of downstream use.
+
+Each package definition is contained in a subdirectory.
+Currently defined package variants:
+
+- `default`
+- `asan`: ASan-instrumented build with `-Db_sanitize=address`
+
+## Maintenance
+
+- Keep host dependency requirements up to date
+- For dependencies on upstream CPython Pixi packages, keep the git revision at a compatible version
+
+## Opportunities for future improvement
+
+- More package variants (such as TSan, UBSan)
+- Support for Windows
+- Using a single `pixi.toml` for all package variants is blocked on https://github.com/prefix-dev/pixi/issues/2813
+- Consider pinning dependency versions to guard against upstream breakages over time

--- a/pixi-packages/README.md
+++ b/pixi-packages/README.md
@@ -1,0 +1,2 @@
+- see https://github.com/scipy/scipy/pull/24066 for how these packages can be used in a Pixi workspace
+- combining directories blocked on https://github.com/prefix-dev/pixi/issues/2813

--- a/pixi-packages/asan/pixi.toml
+++ b/pixi-packages/asan/pixi.toml
@@ -17,9 +17,9 @@ env.ASAN_OPTIONS = "detect_leaks=0:symbolize=1:strict_init_order=true:allocator_
 extra-args = ["-Csetup-args=-Db_sanitize=address", "-Csetup-args=-Dbuildtype=debug"] 
 
 [package.host-dependencies]
-python.git = "https://github.com/lucascolley/cpython"
+python.git = "https://github.com/python/cpython"
 python.subdirectory = "Tools/pixi-packages/asan"
-python.rev = "453e9eebd5e74ab58f3a0c43232e57d5e5e1020c"
+python.rev = "8bb5b6e8ce61da41b5affd5eb12d9cc46b5af448"
 
 meson-python = "*"
 cython = "*"

--- a/pixi-packages/asan/pixi.toml
+++ b/pixi-packages/asan/pixi.toml
@@ -1,0 +1,26 @@
+[workspace]
+channels = ["https://prefix.dev/conda-forge"]
+platforms = ["osx-arm64", "linux-64"]
+preview = ["pixi-build"]
+
+[package.build]
+source.path = "../.."
+
+[package.build.backend]
+name = "pixi-build-python"
+version = "*"
+
+[package.build.config]
+extra-input-globs = ["**/*.c.src"]
+compilers = ["c", "cxx"]
+env.ASAN_OPTIONS = "detect_leaks=0:symbolize=1:strict_init_order=true:allocator_may_return_null=1:use_sigaltstack=0"
+extra-args = ["-Csetup-args=-Db_sanitize=address", "-Csetup-args=-Dbuildtype=debug"] 
+
+[package.host-dependencies]
+python.git = "https://github.com/lucascolley/cpython"
+python.subdirectory = "Tools/pixi-packages/asan"
+python.rev = "375594b556fb6c41c0630c10b7e934fb89604712"
+
+meson-python = "*"
+cython = "*"
+uv = "*" # used to invoke the wheel build

--- a/pixi-packages/asan/pixi.toml
+++ b/pixi-packages/asan/pixi.toml
@@ -19,7 +19,7 @@ extra-args = ["-Csetup-args=-Db_sanitize=address", "-Csetup-args=-Dbuildtype=deb
 [package.host-dependencies]
 python.git = "https://github.com/lucascolley/cpython"
 python.subdirectory = "Tools/pixi-packages/asan"
-python.rev = "54274f2c4e017ef58b5cd73ce45f9277ee5c52f5"
+python.rev = "453e9eebd5e74ab58f3a0c43232e57d5e5e1020c"
 
 meson-python = "*"
 cython = "*"

--- a/pixi-packages/asan/pixi.toml
+++ b/pixi-packages/asan/pixi.toml
@@ -19,7 +19,7 @@ extra-args = ["-Csetup-args=-Db_sanitize=address", "-Csetup-args=-Dbuildtype=deb
 [package.host-dependencies]
 python.git = "https://github.com/lucascolley/cpython"
 python.subdirectory = "Tools/pixi-packages/asan"
-python.rev = "375594b556fb6c41c0630c10b7e934fb89604712"
+python.rev = "54274f2c4e017ef58b5cd73ce45f9277ee5c52f5"
 
 meson-python = "*"
 cython = "*"

--- a/pixi-packages/default/pixi.toml
+++ b/pixi-packages/default/pixi.toml
@@ -1,0 +1,21 @@
+[workspace]
+channels = ["https://prefix.dev/conda-forge"]
+platforms = ["osx-arm64", "linux-64"]
+preview = ["pixi-build"]
+
+[package.build]
+source.path = "../.."
+
+[package.build.backend]
+name = "pixi-build-python"
+version = "*"
+
+[package.build.config]
+extra-input-globs = ["**/*.c.src"]
+compilers = ["c", "cxx"]
+
+[package.host-dependencies]
+python = "*"
+meson-python = "*"
+cython = "*"
+uv = "*" # used to invoke the wheel build


### PR DESCRIPTION
For https://github.com/scipy/scipy/pull/24066. cc @ngoldbaum @FFY00 @rgommers 

Depends on https://github.com/python/cpython/pull/142469.