### PR TITLE
DOC: crosslinking and explanation for (g)ufuncs

### DIFF
--- a/doc/source/reference/c-api/generalized-ufuncs.rst
+++ b/doc/source/reference/c-api/generalized-ufuncs.rst
@@ -4,6 +4,9 @@
 Generalized universal function API
 ==================================
 
+.. seealso::
+  * :ref:`ufuncs`
+
 There is a general need for looping over not only functions on scalars
 but also over functions on vectors (or arrays).
 This concept is realized in NumPy by generalizing the universal functions

--- a/doc/source/reference/c-api/generalized-ufuncs.rst
+++ b/doc/source/reference/c-api/generalized-ufuncs.rst
@@ -4,8 +4,7 @@
 Generalized universal function API
 ==================================
 
-.. seealso::
-  * :ref:`ufuncs`
+.. seealso:: :ref:`ufuncs`
 
 There is a general need for looping over not only functions on scalars
 but also over functions on vectors (or arrays).

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -8,9 +8,7 @@
 Universal functions (:class:`ufunc`)
 ************************************
 
-.. seealso:: 
-  * :ref:`ufuncs-basics`
-  * :ref:`Generalized ufuncs (gufunc) <c-api.generalized-ufuncs>`
+.. seealso:: :ref:`ufuncs-basics`
 
 A universal function (or :term:`ufunc` for short) is a function that
 operates on :class:`ndarrays <numpy.ndarray>` in an element-by-element fashion,

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -8,7 +8,9 @@
 Universal functions (:class:`ufunc`)
 ************************************
 
-.. seealso:: :ref:`ufuncs-basics`
+.. seealso:: 
+  * :ref:`ufuncs-basics`
+  * :ref:`Generalized ufuncs (gufunc) <c-api.generalized-ufuncs>`
 
 A universal function (or :term:`ufunc` for short) is a function that
 operates on :class:`ndarrays <numpy.ndarray>` in an element-by-element fashion,
@@ -18,6 +20,10 @@ is, a ufunc is a ":term:`vectorized <vectorization>`" wrapper for a function
 that takes a fixed number of specific inputs and produces a fixed number of
 specific outputs. For detailed information on universal functions, see
 :ref:`ufuncs-basics`.
+
+
+There are also :ref:`generalized ufuncs <c-api.generalized-ufuncs>` which
+are functions over vectors (or arrays) instead of only scalars.
 
 :class:`ufunc`
 ==============

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -21,7 +21,7 @@ specific outputs. For detailed information on universal functions, see
 
 
 There are also :ref:`generalized ufuncs <c-api.generalized-ufuncs>` which
-are functions over vectors (or arrays) instead of only scalars.
+are functions over vectors (or arrays) instead of only single-element scalars.
 
 :class:`ufunc`
 ==============

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -6,9 +6,7 @@
 Universal functions (:class:`.ufunc`) basics
 ********************************************
 
-.. seealso::
-  * :ref:`ufuncs`
-  * :ref:`Generalized ufuncs (gufunc) <c-api.generalized-ufuncs>`
+.. seealso:: :ref:`ufuncs`
 
 .. index: ufunc, universal function, arithmetic, operation
 

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -6,7 +6,9 @@
 Universal functions (:class:`.ufunc`) basics
 ********************************************
 
-.. seealso:: :ref:`ufuncs`
+.. seealso::
+  * :ref:`ufuncs`
+  * :ref:`Generalized ufuncs (gufunc) <c-api.generalized-ufuncs>`
 
 .. index: ufunc, universal function, arithmetic, operation
 
@@ -17,6 +19,25 @@ casting <ufuncs.casting>`, and several other standard features. That
 is, a ufunc is a ":term:`vectorized <vectorization>`" wrapper for a function
 that takes a fixed number of specific inputs and produces a fixed number of
 specific outputs.
+
+There are also :ref:`generalized ufuncs <c-api.generalized-ufuncs>` which
+are functions over vectors (or arrays) instead of only scalars.
+For example, :func:`numpy.add` is a ufunc that operates element-by-element,
+while :func:`numpy.matmul` is a gufunc that operates on vectors/matrices::
+
+   >>> a = np.arange(6).reshape(3, 2)
+   >>> a
+   array([[0, 1],
+          [2, 3],
+          [4, 5]])
+   >>> np.add(a, a)  # element-wise addition
+   array([[ 0,  2],
+          [ 4,  6],
+          [ 8, 10]])
+   >>> np.matmul(a, a.T)  # matrix multiplication (3x2) @ (2x3) -> (3x3)
+   array([[ 1,  3,  5],
+          [ 3, 13, 23],
+          [ 5, 23, 41]])
 
 In NumPy, universal functions are instances of the
 :class:`numpy.ufunc` class. Many of the built-in functions are
@@ -35,11 +56,27 @@ One can also produce custom :class:`numpy.ufunc` instances using the
 Ufunc methods
 =============
 
-All ufuncs have four methods. They can be found at
-:ref:`ufuncs.methods`. However, these methods only make sense on scalar
+All ufuncs have 5 methods. 4 reduce-like methods
+(:meth:`~numpy.ufunc.reduce`, :meth:`~numpy.ufunc.accumulate`,
+:meth:`~numpy.ufunc.reduceat`, :meth:`~numpy.ufunc.outer`) and one
+for inplace operations (:meth:`~numpy.ufunc.at`).
+See :ref:`ufuncs.methods` for more. However, these methods only make sense on scalar
 ufuncs that take two input arguments and return one output argument.
 Attempting to call these methods on other ufuncs will cause a
 :exc:`ValueError`.
+
+For example, :func:`numpy.add` takes two inputs and returns one output,
+so its methods work::
+
+   >>> np.add.reduce([1, 2, 3])
+   6
+
+But :func:`numpy.divmod` returns two outputs (quotient and remainder),
+so calling its methods raises an error::
+
+   >>> np.divmod.reduce([1, 2, 3])
+       ...
+   ValueError: reduce only supported for functions returning a single value
 
 The reduce-like methods all take an *axis* keyword, a *dtype*
 keyword, and an *out* keyword, and the arrays must all have dimension >= 1.

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -75,6 +75,7 @@ But :func:`numpy.divmod` returns two outputs (quotient and remainder),
 so calling its methods raises an error::
 
    >>> np.divmod.reduce([1, 2, 3])
+   Traceback (most recent call last):
        ...
    ValueError: reduce only supported for functions returning a single value
 

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -19,7 +19,7 @@ that takes a fixed number of specific inputs and produces a fixed number of
 specific outputs.
 
 There are also :ref:`generalized ufuncs <c-api.generalized-ufuncs>` which
-are functions over vectors (or arrays) instead of only scalars.
+are functions over vectors (or arrays) instead of single-element scalars.
 For example, :func:`numpy.add` is a ufunc that operates element-by-element,
 while :func:`numpy.matmul` is a gufunc that operates on vectors/matrices::
 

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -58,8 +58,9 @@ All ufuncs have 5 methods. 4 reduce-like methods
 (:meth:`~numpy.ufunc.reduce`, :meth:`~numpy.ufunc.accumulate`,
 :meth:`~numpy.ufunc.reduceat`, :meth:`~numpy.ufunc.outer`) and one
 for inplace operations (:meth:`~numpy.ufunc.at`).
-See :ref:`ufuncs.methods` for more. However, these methods only make sense on scalar
-ufuncs that take two input arguments and return one output argument.
+See :ref:`ufuncs.methods` for more. However, these methods only make sense on 
+ufuncs that take two input arguments and return one output argument (so-called
+"scalar" ufuncs since the inner loop operates on a single scalar value).
 Attempting to call these methods on other ufuncs will cause a
 :exc:`ValueError`.
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
I recently did a deep dive learning about ufuncs and gufuncs. This PR aims to smooth over the parts where I found myself confused. In particular I spent quite a while confused by the statements in the ufunc guide about them being scalar only. I eventually discovered the numba guide to gufuncs, which led me to the numpy c-api page. There were also a few sections where I was slightly confused and felt an example would have helped me. So I have:

1 Added crosslinks between [gufunc](https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html) and ufunc pages to increase discoverability.
2. Added a note in the text about gufuncs
3. Expanded the examples in basics.ufuncs
4. Updated the statement about the number of methods ufuncs possess (4->5) plus some links and examples.

