### PR TITLE
MAINT, CI: avoid installing mypy in the ppc64le and armhf linux jobs

### DIFF
--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,7 +1,6 @@
 Cython
 wheel==0.38.1
-setuptools==65.5.1 ; python_version < '3.12'
-setuptools         ; python_version >= '3.12'
+setuptools
 hypothesis==6.142.2
 pytest==7.4.0
 pytest-cov==4.1.0
@@ -11,8 +10,9 @@ pytest-xdist
 pytest-timeout
 # For testing types. Notes on the restrictions:
 # - Mypy relies on C API features not present in PyPy
+# - Mypy requires librt, which has no PPC64LE or ARMv8l wheels, which would cause issues in CI
 # NOTE: Keep mypy in sync with environment.yml
-mypy==1.19.0; platform_python_implementation != "PyPy"
+mypy==1.19.0; platform_python_implementation != "PyPy" and platform_machine != "ppc64le" and platform_machine != "armv8l"
 typing_extensions>=4.5.0
 # for optional f2py encoding detection
 charset-normalizer


### PR DESCRIPTION
See e.g.:

- https://github.com/numpy/numpy/actions/runs/19978991810/job/57301923231?pr=30319
- https://github.com/numpy/numpy/actions/runs/19978991809/job/57301578333?pr=30319

Ref: https://github.com/numpy/numpy/pull/30319#issuecomment-3618965566