### PR TITLE
ENH: Change `assert_allclose` to accept `numpy.timedelta64` as `atol`

### DIFF
--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -2748,6 +2748,17 @@ class TestDateTime:
         results = inputs / divisor
         assert_array_equal(results, expected)
 
+    @pytest.mark.parametrize(
+        "atol", [np.timedelta64(1, "s"), np.timedelta64(1, "ms")]
+    )
+    def test_assert_all_close_with_timedelta_atol(
+        self, atol: np.timedelta64 | datetime.timedelta
+    ):
+        # gh-30382
+        a = np.array([1, 2], dtype="m8[s]")
+        b = np.array([3, 4], dtype="m8[s]")
+        with pytest.raises(AssertionError):
+            np.testing.assert_allclose(a, b, atol=atol)
 
 class TestDateTimeData:
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1687,7 +1687,7 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=True,
         Array desired.
     rtol : float, optional
         Relative tolerance.
-    atol : float, optional
+    atol : float | np.timedelta64, optional
         Absolute tolerance.
     equal_nan : bool, optional.
         If True, NaNs will compare equal.

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1766,7 +1766,11 @@ def assert_allclose(actual, desired, rtol=1e-7, atol=0, equal_nan=True,
                                        equal_nan=equal_nan)
 
     actual, desired = np.asanyarray(actual), np.asanyarray(desired)
-    header = f'Not equal to tolerance rtol={rtol:g}, atol={atol:g}'
+    if isinstance(atol, np.timedelta64):
+        atol_str = str(atol)
+    else:
+        atol_str = f"{atol:g}"
+    header = f'Not equal to tolerance rtol={rtol:g}, atol={atol_str}'
     assert_array_compare(compare, actual, desired, err_msg=str(err_msg),
                          verbose=verbose, header=header, equal_nan=equal_nan,
                          strict=strict)

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -319,7 +319,7 @@ def assert_allclose(
     actual: _ArrayLikeTD64_co,
     desired: _ArrayLikeTD64_co,
     rtol: float = 1e-7,
-    atol: float = 0,
+    atol: float | np.timedelta64 = 0,
     equal_nan: bool = True,
     err_msg: object = "",
     verbose: bool = True,


### PR DESCRIPTION
Closes #30382 

The `:g` float formatting caused a TypeError when `atol` was a `numpy.timedelta64` scalar. This patch falls back to default string formatting for `numpy.timedelta64` scalar. 

