### PR TITLE
SIMD, BLD: Fix Highway target attribute build failure on ppc64

### DIFF
--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -25,26 +25,42 @@ jobs:
     # For more details, see: https://github.com/numpy/numpy/issues/29125
     if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-24.04-ppc64le-p10
-    name: "Native PPC64LE"
+  
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "GCC"
+            args: "-Dallow-noblas=false"
+          - name: "clang"
+            args: "-Dallow-noblas=false"
+    
+    name: "${{ matrix.config.name }}"
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         submodules: recursive
         fetch-tags: true
-        persist-credentials: false
-
+    
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install -y python3 python3-pip python3-dev ninja-build gfortran \
+        sudo apt install -y python3.12 python3-pip python3-dev ninja-build gfortran \
                             build-essential libopenblas-dev liblapack-dev pkg-config
         pip install --upgrade pip
         pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         echo "/home/runner/.local/bin" >> $GITHUB_PATH
 
+    - name: Install clang
+      if: matrix.config.name == 'clang'
+      run: |
+        sudo apt install -y clang
+        export CC=clang
+        export CXX=clang++
+
     - name: Meson Build
       run: |
-        spin build -- -Dallow-noblas=false
+        spin build -- ${{ matrix.config.args }}
 
     - name: Meson Log
       if: always()

--- a/meson_cpu/ppc64/meson.build
+++ b/meson_cpu/ppc64/meson.build
@@ -3,15 +3,13 @@ mod_features = import('features')
 compiler_id = meson.get_compiler('c').get_id()
 
 VSX = mod_features.new(
-  'VSX', 1, args: '-mvsx',
+  'VSX', 1, args: ['-mvsx', '-DHWY_COMPILE_ONLY_STATIC', '-DHWY_DISABLE_ATTR'] +
+                  (compiler_id == 'clang' ? ['-maltivec'] : []),
   test_code: files(source_root + '/numpy/_core/src/_simd/checks/cpu_vsx.c')[0],
   extra_tests: {
     'VSX_ASM': files(source_root + '/numpy/_core/src/_simd/checks/extra_vsx_asm.c')[0]
   }
 )
-if compiler_id == 'clang'
-  VSX.update(args: ['-mvsx', '-maltivec'])
-endif
 VSX2 = mod_features.new(
   'VSX2', 2, implies: VSX, args: {'val': '-mcpu=power8', 'match': '.*vsx'},
   detect: {'val': 'VSX2', 'match': 'VSX'},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ license-files = [
     'LICENSE.txt',                                       # BSD-3-Clause
     'numpy/_core/include/numpy/libdivide/LICENSE.txt',   # Zlib
     'numpy/_core/src/common/pythoncapi-compat/COPYING',  # 0BSD
-    'numpy/_core/src/highway/LICENSE-BSD3',              # BSD-3-Clause
+    'numpy/_core/src/highway/LICENSE',                   # Dual-licensed: Apache 2.0 or BSD 3-Clause
     'numpy/_core/src/multiarray/dragon4_LICENSE.txt',    # MIT
     'numpy/_core/src/npysort/x86-simd-sort/LICENSE.md',  # BSD-3-Clause
     'numpy/_core/src/umath/svml/LICENSE',                # BSD-3-Clause


### PR DESCRIPTION
On GCC < 13, compiler target attributes cause a build failure with the `power9/vsx3` feature enabled:
```
from ../numpy/_core/src/umath/loops_trigonometric.dispatch.cpp:5:
hwy/ops/ppc_vsx-inl.h: In function ‘np::simd::{anonymous}::Vec<TLane> np::simd::{anonymous}::LoadN(const TLane*, size_t) [with TLane = float]’:
hwy/ops/ppc_vsx-inl.h:1200:19: error: inlining failed in call to ‘always_inline’ ‘hwy::N_PPC10::VFromD<D>
1200 | HWY_API VFromD<D> LoadN(D d, const T* HWY_RESTRICT p,
```

To fix this issue, a new Highway option `HWY_DISABLE_ATTR` has been introduced in Highway to explicitly disable compiler target attributes, as we rely on a source-based CPU dispatcher. Therefore, this patch updates to the latest Highway main. This patch also extends the native CI ppc64 build to include Clang and and sets testing against Python 3.12.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
