### PR TITLE
DOC: prefer passing scalar types to ``dtype=`` in examples

### DIFF
--- a/doc/neps/nep-0050-scalar-promotion.rst
+++ b/doc/neps/nep-0050-scalar-promotion.rst
@@ -509,9 +509,9 @@ will be ignored.  This means, that operations will never silently use the
 The user will have to write one of::
 
     np.array([3]) + np.array(2**100)
-    np.array([3]) + np.array(2**100, dtype=object)
+    np.array([3]) + np.array(2**100, dtype=np.object_)
 
-As such implicit conversion to ``object`` should be rare and the work-around
+As such implicit conversion to ``object_`` should be rare and the work-around
 is clear, we expect that the backwards compatibility concerns are fairly small.
 
 

--- a/doc/neps/nep-0055-string_dtype.rst
+++ b/doc/neps/nep-0055-string_dtype.rst
@@ -224,7 +224,7 @@ to fixed-width unicode arrays::
 
   In [3]: data = [str(i) * 10 for i in range(100_000)]
 
-  In [4]: %timeit arr_object = np.array(data, dtype=object)
+  In [4]: %timeit arr_object = np.array(data, dtype=np.object_)
   3.15 ms ± 74.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
 
   In [5]: %timeit arr_stringdtype = np.array(data, dtype=StringDType())
@@ -242,7 +242,7 @@ for strings, the string loading performance of ``StringDType`` should improve.
 
 String operations have similar performance::
 
-  In [7]: %timeit np.array([s.capitalize() for s in data], dtype=object)
+  In [7]: %timeit np.array([s.capitalize() for s in data], dtype=np.object_)
   31.6 ms ± 728 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
 
   In [8]: %timeit np.char.capitalize(arr_stringdtype)

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -479,16 +479,16 @@ Example:
 
   >>> import numpy as np
 
-  >>> a = np.memmap('newfile.dat', dtype=float, mode='w+', shape=1000)
+  >>> a = np.memmap('newfile.dat', dtype=np.float64, mode='w+', shape=1000)
   >>> a[10] = 10.0
   >>> a[30] = 30.0
   >>> del a
 
-  >>> b = np.fromfile('newfile.dat', dtype=float)
+  >>> b = np.fromfile('newfile.dat', dtype=np.float64)
   >>> print(b[10], b[30])
   10.0 30.0
 
-  >>> a = np.memmap('newfile.dat', dtype=float)
+  >>> a = np.memmap('newfile.dat', dtype=np.float64)
   >>> print(a[10], a[30])
   10.0 30.0
 

--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -124,10 +124,10 @@ datetime type with generic units.
 
     >>> import numpy as np
 
-    >>> np.array(['2007-07-13', '2006-01-13', '2010-08-13'], dtype='datetime64')
+    >>> np.array(['2007-07-13', '2006-01-13', '2010-08-13'], dtype=np.datetime64)
     array(['2007-07-13', '2006-01-13', '2010-08-13'], dtype='datetime64[D]')
 
-    >>> np.array(['2001-01-01T12:00', '2002-02-03T13:56:03.172'], dtype='datetime64')
+    >>> np.array(['2001-01-01T12:00', '2002-02-03T13:56:03.172'], dtype=np.datetime64)
     array(['2001-01-01T12:00:00.000', '2002-02-03T13:56:03.172'],
           dtype='datetime64[ms]')
 

--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -561,7 +561,7 @@ This equivalence can only be handled through ``==``, not through ``is``.
 
       >>> import numpy as np
 
-      >>> a = np.array([1, 2], dtype=float)
+      >>> a = np.array([1, 2], dtype=np.float64)
       >>> a.dtype == np.dtype(np.float64)
       True
       >>> a.dtype == np.float64

--- a/doc/source/reference/arrays.promotion.rst
+++ b/doc/source/reference/arrays.promotion.rst
@@ -79,10 +79,10 @@ their precision when determining the result dtype. This is often convenient.
 For instance, when working with arrays of a low precision dtype, it is usually
 desirable for simple operations with Python scalars to preserve the dtype.
 
-  >>> arr_float32 = np.array([1, 2.5, 2.1], dtype="float32")
+  >>> arr_float32 = np.array([1, 2.5, 2.1], dtype=np.float32)
   >>> arr_float32 + 10.0  # undesirable to promote to float64
   array([11. , 12.5, 12.1], dtype=float32)
-  >>> arr_int16 = np.array([3, 5, 7], dtype="int16")
+  >>> arr_int16 = np.array([3, 5, 7], dtype=np.int16)
   >>> arr_int16 + 10  # undesirable to promote to int64
   array([13, 15, 17], dtype=int16)
 
@@ -130,7 +130,7 @@ overflows:
   ... RuntimeWarning: overflow encountered in scalar add
 
 Note that NumPy warns when overflows occur for scalars, but not for arrays;
-e.g., ``np.array(100, dtype="uint8") + 100`` will *not* warn.
+e.g., ``np.array(100, dtype=np.uint8) + 100`` will *not* warn.
 
 Numerical promotion
 -------------------

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1786,9 +1786,9 @@ the functions that must be implemented for each slot.
    - ``0.0`` is the default for ``sum([])``.  But ``-0.0`` is the correct
      identity otherwise as it preserves the sign for ``sum([-0.0])``.
    - We use no identity for object, but return the default of ``0`` and
-     ``1`` for the empty ``sum([], dtype=object)`` and
-     ``prod([], dtype=object)``.
-     This allows ``np.sum(np.array(["a", "b"], dtype=object))`` to work.
+     ``1`` for the empty ``sum([], dtype=np.object_)`` and
+     ``prod([], dtype=np.object_)``.
+     This allows ``np.sum(np.array(["a", "b"], dtype=np.object_))`` to work.
    - ``-inf`` or ``INT_MIN`` for ``max`` is an identity, but at least
      ``INT_MIN`` not a good *default* when there are no items.
 

--- a/doc/source/reference/thread_safety.rst
+++ b/doc/source/reference/thread_safety.rst
@@ -29,8 +29,8 @@ locking if you need to mutation and multithreading.
 
 Note that operations that *do not* release the GIL will see no performance gains
 from use of the `threading` module, and instead might be better served with
-`multiprocessing`. In particular, operations on arrays with ``dtype=object`` do
-not release the GIL.
+`multiprocessing`. In particular, operations on arrays with ``dtype=np.object_``
+do not release the GIL.
 
 Free-threaded Python
 --------------------
@@ -47,5 +47,5 @@ Because free-threaded Python does not have a global interpreter lock to
 serialize access to Python objects, there are more opportunities for threads to
 mutate shared state and create thread safety issues. In addition to the
 limitations about locking of the ndarray object noted above, this also means
-that arrays with ``dtype=object`` are not protected by the GIL, creating data
+that arrays with ``dtype=np.object_`` are not protected by the GIL, creating data
 races for python objects that are not possible outside free-threaded python.

--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -779,7 +779,7 @@ You can add the arrays together with the plus sign.
 ::
 
   >>> data = np.array([1, 2])
-  >>> ones = np.ones(2, dtype=int)
+  >>> ones = np.ones(2, dtype=np.int_)
   >>> data + ones
   array([2, 3])
 

--- a/doc/source/user/basics.creation.rst
+++ b/doc/source/user/basics.creation.rst
@@ -20,7 +20,7 @@ There are 6 general mechanisms for creating arrays:
 6) Use of special library functions (e.g., random)
 
 You can use these methods to create ndarrays or :ref:`structured_arrays`.
-This document will cover general methods for ndarray creation. 
+This document will cover general methods for ndarray creation.
 
 1) Converting Python sequences to NumPy arrays
 ==============================================
@@ -29,8 +29,8 @@ NumPy arrays can be defined using Python sequences such as lists and
 tuples. Lists and tuples are defined using ``[...]`` and ``(...)``,
 respectively. Lists and tuples can define ndarray creation:
 
-* a list of numbers will create a 1D array, 
-* a list of lists will create a 2D array, 
+* a list of numbers will create a 1D array,
+* a list of lists will create a 2D array,
 * further nested lists will create higher-dimensional arrays. In general, any array object is called an **ndarray** in NumPy.
 
 ::
@@ -72,7 +72,7 @@ results, for example::
 
 Notice when you perform operations with two arrays of the same
 ``dtype``: ``uint32``, the resulting array is the same type. When you
-perform operations with different ``dtype``, NumPy will 
+perform operations with different ``dtype``, NumPy will
 assign a new type that satisfies all of the array elements involved in
 the computation, here ``uint32`` and ``int32`` can both be represented in
 as ``int64``.
@@ -88,7 +88,7 @@ you create the array.
 
 ..
   40 functions seems like a small number, but the routines.array-creation
-  has ~47. I'm sure there are more. 
+  has ~47. I'm sure there are more.
 
 NumPy has over 40 built-in functions for creating arrays as laid
 out in the :ref:`Array creation routines <routines.array-creation>`.
@@ -104,7 +104,7 @@ dimension of the array they create:
 
 The 1D array creation functions e.g. :func:`numpy.linspace` and
 :func:`numpy.arange` generally need at least two inputs, ``start`` and
-``stop``. 
+``stop``.
 
 :func:`numpy.arange` creates arrays with regularly incrementing values.
 Check the documentation for complete information and examples. A few
@@ -113,7 +113,7 @@ examples are shown::
  >>> import numpy as np
  >>> np.arange(10)
  array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
- >>> np.arange(2, 10, dtype=float)
+ >>> np.arange(2, 10, dtype=np.float64)
  array([2., 3., 4., 5., 6., 7., 8., 9.])
  >>> np.arange(2, 3, 0.1)
  array([2. , 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9])
@@ -121,8 +121,8 @@ examples are shown::
 Note: best practice for :func:`numpy.arange` is to use integer start, end, and
 step values. There are some subtleties regarding ``dtype``. In the second
 example, the ``dtype`` is defined. In the third example, the array is
-``dtype=float`` to accommodate the step size of ``0.1``. Due to roundoff error,
-the ``stop`` value is sometimes included. 
+``dtype=np.float64`` to accommodate the step size of ``0.1``. Due to roundoff error,
+the ``stop`` value is sometimes included.
 
 :func:`numpy.linspace` will create arrays with a specified number of elements, and
 spaced equally between the specified beginning and end values. For
@@ -140,7 +140,7 @@ number of elements and the starting and end point. The previous
 -------------------------------
 
 The 2D array creation functions e.g. :func:`numpy.eye`, :func:`numpy.diag`, and :func:`numpy.vander`
-define properties of special matrices represented as 2D arrays. 
+define properties of special matrices represented as 2D arrays.
 
 ``np.eye(n, m)`` defines a 2D identity matrix. The elements where i=j (row index and column index are equal) are 1
 and the rest are 0, as such::
@@ -159,7 +159,7 @@ and the rest are 0, as such::
 the diagonal *or* if given a 2D array returns a 1D array that is
 only the diagonal elements. The two array creation functions can be helpful while
 doing linear algebra, as such::
- 
+
  >>> import numpy as np
  >>> np.diag([1, 2, 3])
  array([[1, 0, 0],
@@ -197,7 +197,7 @@ routine is helpful in generating linear least squares models, as such::
         [ 8,  4,  2,  1],
         [27,  9,  3,  1],
         [64, 16,  4,  1]])
- 
+
 3 - general ndarray creation functions
 --------------------------------------
 
@@ -205,20 +205,20 @@ The ndarray creation functions e.g. :func:`numpy.ones`,
 :func:`numpy.zeros`, and :meth:`~numpy.random.Generator.random` define
 arrays based upon the desired shape.  The  ndarray creation functions
 can create arrays with any dimension by specifying how many dimensions
-and length along that dimension in a tuple or list. 
+and length along that dimension in a tuple or list.
 
 :func:`numpy.zeros` will create an array filled with 0 values with the
 specified shape. The default dtype is ``float64``::
 
  >>> import numpy as np
  >>> np.zeros((2, 3))
- array([[0., 0., 0.], 
+ array([[0., 0., 0.],
         [0., 0., 0.]])
  >>> np.zeros((2, 3, 2))
  array([[[0., 0.],
          [0., 0.],
          [0., 0.]],
- <BLANKLINE>        
+ <BLANKLINE>
         [[0., 0.],
          [0., 0.],
          [0., 0.]]])
@@ -228,7 +228,7 @@ specified shape. The default dtype is ``float64``::
 
  >>> import numpy as np
  >>> np.ones((2, 3))
- array([[1., 1., 1.], 
+ array([[1., 1., 1.],
         [1., 1., 1.]])
  >>> np.ones((2, 3, 2))
  array([[[1., 1.],
@@ -265,11 +265,11 @@ dimension::
 
  >>> import numpy as np
  >>> np.indices((3,3))
- array([[[0, 0, 0], 
-         [1, 1, 1], 
-         [2, 2, 2]], 
-        [[0, 1, 2], 
-         [0, 1, 2], 
+ array([[[0, 0, 0],
+         [1, 1, 1],
+         [2, 2, 2]],
+        [[0, 1, 2],
+         [0, 1, 2],
          [0, 1, 2]]])
 
 This is particularly useful for evaluating functions of multiple dimensions on
@@ -322,7 +322,7 @@ arrays into a 4-by-4 array using ``block``::
         [ 0.,  0.,  0., -4.]])
 
 Other routines use similar syntax to join ndarrays. Check the
-routine's documentation for further examples and syntax. 
+routine's documentation for further examples and syntax.
 
 4) Reading arrays from disk, either from standard or custom formats
 ===================================================================
@@ -330,7 +330,7 @@ routine's documentation for further examples and syntax.
 This is the most common case of large array creation. The details depend
 greatly on the format of data on disk. This section gives general pointers on
 how to handle various formats. For more detailed examples of IO look at
-:ref:`How to Read and Write files <how-to-io>`. 
+:ref:`How to Read and Write files <how-to-io>`.
 
 Standard binary formats
 -----------------------
@@ -397,4 +397,4 @@ knowledge to interface with C or C++.
 NumPy is the fundamental library for array containers in the Python Scientific Computing
 stack. Many Python libraries, including SciPy, Pandas, and OpenCV, use NumPy ndarrays
 as the common format for data exchange, These libraries can create,
-operate on, and work with NumPy arrays. 
+operate on, and work with NumPy arrays.

--- a/doc/source/user/basics.io.genfromtxt.rst
+++ b/doc/source/user/basics.io.genfromtxt.rst
@@ -201,16 +201,16 @@ The main way to control how the sequences of strings we have read from the
 file are converted to other types is to set the ``dtype`` argument.
 Acceptable values for this argument are:
 
-* a single type, such as ``dtype=float``.
+* a single type, such as ``dtype=np.float64``.
   The output will be 2D with the given dtype, unless a name has been
   associated with each column with the use of the ``names`` argument
-  (see below).  Note that ``dtype=float`` is the default for
+  (see below).  Note that ``dtype=np.float64`` is the default for
   :func:`~numpy.genfromtxt`.
-* a sequence of types, such as ``dtype=(int, float, float)``.
+* a sequence of types, such as ``dtype=(np.int_, np.float64, np.float64)``.
 * a comma-separated string, such as ``dtype="i4,f8,|U3"``.
 * a dictionary with two keys ``'names'`` and ``'formats'``.
 * a sequence of tuples ``(name, type)``, such as
-  ``dtype=[('A', int), ('B', float)]``.
+  ``dtype=[('A', np.int_), ('B', np.float64)]``.
 * an existing :class:`numpy.dtype` object.
 * the special value ``None``.
   In that case, the type of the columns will be determined from the data
@@ -243,7 +243,7 @@ each column.  A first possibility is to use an explicit structured dtype,
 as mentioned previously::
 
    >>> data = StringIO("1 2 3\n 4 5 6")
-   >>> np.genfromtxt(data, dtype=[(_, int) for _ in "abc"])
+   >>> np.genfromtxt(data, dtype=[(_, np.int_) for _ in "abc"])
    array([(1, 2, 3), (4, 5, 6)],
          dtype=[('a', '<i8'), ('b', '<i8'), ('c', '<i8')])
 
@@ -255,7 +255,7 @@ sequence of strings or a comma-separated string::
    array([(1., 2., 3.), (4., 5., 6.)],
          dtype=[('A', '<f8'), ('B', '<f8'), ('C', '<f8')])
 
-In the example above, we used the fact that by default, ``dtype=float``.
+In the example above, we used the fact that by default, ``dtype=np.float64``.
 By giving a sequence of names, we are forcing the output to a structured
 dtype.
 
@@ -274,7 +274,7 @@ value to the keyword, the new names will overwrite the field names we may
 have defined with the dtype::
 
    >>> data = StringIO("1 2 3\n 4 5 6")
-   >>> ndtype=[('a',int), ('b', float), ('c', int)]
+   >>> ndtype=[('a', np.int_), ('b', np.float64), ('c', np.int_)]
    >>> names = ["A", "B", "C"]
    >>> np.genfromtxt(data, names=names, dtype=ndtype)
    array([(1, 2., 3), (4, 5., 6)],
@@ -289,7 +289,7 @@ with the standard NumPy default of ``"f%i"``, yielding names like ``f0``,
 ``f1`` and so forth::
 
    >>> data = StringIO("1 2 3\n 4 5 6")
-   >>> np.genfromtxt(data, dtype=(int, float, int))
+   >>> np.genfromtxt(data, dtype=(np.int_, np.float64, np.int_))
    array([(1, 2., 3), (4, 5., 6)],
          dtype=[('f0', '<i8'), ('f1', '<f8'), ('f2', '<i8')])
 
@@ -297,7 +297,7 @@ In the same way, if we don't give enough names to match the length of the
 dtype, the missing names will be defined with this default template::
 
    >>> data = StringIO("1 2 3\n 4 5 6")
-   >>> np.genfromtxt(data, dtype=(int, float, int), names="a")
+   >>> np.genfromtxt(data, dtype=(np.int_, np.float64, np.int_), names="a")
    array([(1, 2., 3), (4, 5., 6)],
          dtype=[('a', '<i8'), ('f0', '<f8'), ('f1', '<i8')])
 
@@ -305,7 +305,7 @@ We can overwrite this default with the ``defaultfmt`` argument, that
 takes any format string::
 
    >>> data = StringIO("1 2 3\n 4 5 6")
-   >>> np.genfromtxt(data, dtype=(int, float, int), defaultfmt="var_%02i")
+   >>> np.genfromtxt(data, dtype=(np.int_, np.float64, np.int_), defaultfmt="var_%02i")
    array([(1, 2., 3), (4, 5., 6)],
          dtype=[('var_00', '<i8'), ('var_01', '<f8'), ('var_02', '<i8')])
 
@@ -374,7 +374,7 @@ representing a percentage to a float between 0 and 1::
    array([(1., nan, 45.), (6., nan, 0.)],
          dtype=[('i', '<f8'), ('p', '<f8'), ('n', '<f8')])
 
-We need to keep in mind that by default, ``dtype=float``.  A float is
+We need to keep in mind that by default, ``dtype=np.float64``.  A float is
 therefore expected for the second column.  However, the strings ``' 2.3%'``
 and ``' 78.9%'`` cannot be converted to float and we end up having
 ``np.nan`` instead.  Let's now use a converter::
@@ -481,7 +481,7 @@ and second column, and to -999 if they occur in the last column::
 
     >>> data = "N/A, 2, 3\n4, ,???"
     >>> kwargs = dict(delimiter=",",
-    ...               dtype=int,
+    ...               dtype=np.int_,
     ...               names="a,b,c",
     ...               missing_values={0:"N/A", 'b':" ", 2:"???"},
     ...               filling_values={0:0, 'b':0, 2:-999})

--- a/doc/source/user/basics.subclassing.rst
+++ b/doc/source/user/basics.subclassing.rst
@@ -346,7 +346,7 @@ Simple example - adding an extra attribute to ndarray
 
   class InfoArray(np.ndarray):
 
-      def __new__(subtype, shape, dtype=float, buffer=None, offset=0,
+      def __new__(subtype, shape, dtype=np.float64, buffer=None, offset=0,
                   strides=None, order=None, info=None):
           # Create the ndarray instance of our type, given the usual
           # ndarray input arguments.  This will call the standard
@@ -779,5 +779,3 @@ your function's signature should accept ``**kwargs``. For example:
 This object is now compatible with ``np.sum`` again because any extraneous arguments
 (i.e. keywords that are not ``axis`` or ``dtype``) will be hidden away in the
 ``**unused_kwargs`` parameter.
-
-

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -76,7 +76,7 @@ an integer (or Boolean) data-type and smaller than the size of the
 
    >>> x.dtype
    dtype('int64')
-   >>> np.multiply.reduce(x, dtype=float)
+   >>> np.multiply.reduce(x, dtype=np.float64)
    array([ 0., 28., 80.])
 
 Finally, the *out* keyword allows you to
@@ -84,10 +84,10 @@ provide an output array (or a tuple of output arrays for multi-output ufuncs).
 If *out* is given, the *dtype* argument is only used for the internal computations.
 Considering ``x`` from the previous example::
 
-   >>> y = np.zeros(3, dtype=int)
+   >>> y = np.zeros(3, dtype=np.int_)
    >>> y
    array([0, 0, 0])
-   >>> np.multiply.reduce(x, dtype=float, out=y)
+   >>> np.multiply.reduce(x, dtype=np.float64, out=y)
    array([ 0, 28, 80])
 
 Ufuncs also have a fifth method, :func:`numpy.ufunc.at`, that allows in place

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -608,7 +608,7 @@ After the above has been installed, it can be imported and used as follows.
 >>> import npufunc
 >>> npufunc.logit(0.5)
 np.float64(0.0)
->>> a = np.linspace(0, 1, 5, dtype="f4")
+>>> a = np.linspace(0, 1, 5, dtype=np.float32)
 >>> npufunc.logit(a)
 <python-input-4>:1: RuntimeWarning: divide by zero encountered in logit
 array([      -inf, -1.0986123,  0.       ,  1.0986123,        inf],

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -163,7 +163,7 @@ The type of the array can also be explicitly specified at creation time:
 
 ::
 
-    >>> c = np.array([[1, 2], [3, 4]], dtype=complex)
+    >>> c = np.array([[1, 2], [3, 4]], dtype=np.complex128)
     >>> c
     array([[1.+0.j, 2.+0.j],
            [3.+0.j, 4.+0.j]])
@@ -346,7 +346,7 @@ existing array rather than create a new one.
 ::
 
     >>> rg = np.random.default_rng(1)  # create instance of default random number generator
-    >>> a = np.ones((2, 3), dtype=int)
+    >>> a = np.ones((2, 3), dtype=np.int_)
     >>> b = rg.random((2, 3))
     >>> a *= 3
     >>> a
@@ -535,7 +535,7 @@ are given in a tuple separated by commas::
     >>> def f(x, y):
     ...     return 10 * x + y
     ...
-    >>> b = np.fromfunction(f, (5, 4), dtype=int)
+    >>> b = np.fromfunction(f, (5, 4), dtype=np.int_)
     >>> b
     array([[ 0,  1,  2,  3],
            [10, 11, 12, 13],
@@ -1256,7 +1256,7 @@ set <https://en.wikipedia.org/wiki/Mandelbrot_set>`__:
     ...     A, B = np.meshgrid(x, y)
     ...     C = A + B*1j
     ...     z = np.zeros_like(C)
-    ...     divtime = maxit + np.zeros(z.shape, dtype=int)
+    ...     divtime = maxit + np.zeros(z.shape, dtype=np.int_)
     ...
     ...     for i in range(maxit):
     ...         z = z**2 + C

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -418,11 +418,11 @@ add_newdoc('numpy._core', 'nditer',
     original data when the :meth:`~object.__exit__` function is called
     but not before:
 
-    >>> a = np.arange(6, dtype='i4')[::-2]
+    >>> a = np.arange(6, dtype=np.int32)[::-2]
     >>> with np.nditer(a, [],
     ...        [['writeonly', 'updateifcopy']],
     ...        casting='unsafe',
-    ...        op_dtypes=[np.dtype('f4')]) as i:
+    ...        op_dtypes=[np.dtype(np.float32)]) as i:
     ...    x = i.operands[0]
     ...    x[:] = [-1, -2, -3]
     ...    # a still unchanged here
@@ -939,7 +939,7 @@ add_newdoc('numpy._core.multiarray', 'array',
         ``NPY_MAXDIMS``).
         Setting ``ndmax`` stops recursion at the specified depth, preserving
         deeper nested structures as objects instead of promoting them to
-        higher-dimensional arrays. In this case, ``dtype=object`` is required.
+        higher-dimensional arrays. In this case, ``dtype=np.object_`` is required.
 
         .. versionadded:: 2.4.0
     ${ARRAY_FUNCTION_LIKE}
@@ -994,7 +994,7 @@ add_newdoc('numpy._core.multiarray', 'array',
 
     Type provided:
 
-    >>> np.array([1, 2, 3], dtype=complex)
+    >>> np.array([1, 2, 3], dtype=np.complex128)
     array([ 1.+0.j,  2.+0.j,  3.+0.j])
 
     Data-type consisting of more than one element:
@@ -1015,14 +1015,14 @@ add_newdoc('numpy._core.multiarray', 'array',
 
     Limiting the maximum dimensions with ``ndmax``:
 
-    >>> a = np.array([[1, 2], [3, 4]], dtype=object, ndmax=2)
+    >>> a = np.array([[1, 2], [3, 4]], dtype=np.object_, ndmax=2)
     >>> a
     array([[1, 2],
            [3, 4]], dtype=object)
     >>> a.shape
     (2, 2)
 
-    >>> b = np.array([[1, 2], [3, 4]], dtype=object, ndmax=1)
+    >>> b = np.array([[1, 2], [3, 4]], dtype=np.object_, ndmax=1)
     >>> b
     array([list([1, 2]), list([3, 4])], dtype=object)
     >>> b.shape
@@ -1389,7 +1389,7 @@ add_newdoc('numpy._core.multiarray', 'empty',
     array([[ -9.74499359e+001,   6.69583040e-309],
            [  2.13182611e-314,   3.06959433e-309]])         #uninitialized
 
-    >>> np.empty([2, 2], dtype=int)
+    >>> np.empty([2, 2], dtype=np.int_)
     array([[-1073741821, -1067949133],
            [  496041986,    19249760]])                     #uninitialized
 
@@ -1455,7 +1455,7 @@ add_newdoc('numpy._core.multiarray', 'zeros',
     >>> np.zeros(5)
     array([ 0.,  0.,  0.,  0.,  0.])
 
-    >>> np.zeros((5,), dtype=int)
+    >>> np.zeros((5,), dtype=np.int_)
     array([0, 0, 0, 0, 0])
 
     >>> np.zeros((2, 1))
@@ -1487,7 +1487,7 @@ add_newdoc('numpy._core.multiarray', 'fromstring',
     fromstring(string, dtype=None, count=-1, *, sep, like=None)
     --
 
-    fromstring(string, dtype=float, count=-1, *, sep, like=None)
+    fromstring(string, dtype=np.float64, count=-1, *, sep, like=None)
 
     A new 1-D array initialized from text data in a string.
 
@@ -1538,9 +1538,9 @@ add_newdoc('numpy._core.multiarray', 'fromstring',
     Examples
     --------
     >>> import numpy as np
-    >>> np.fromstring('1 2', dtype=int, sep=' ')
+    >>> np.fromstring('1 2', dtype=np.int_, sep=' ')
     array([1, 2])
-    >>> np.fromstring('1, 2', dtype=int, sep=',')
+    >>> np.fromstring('1, 2', dtype=np.int_, sep=',')
     array([1, 2])
 
     """)
@@ -1649,7 +1649,7 @@ add_newdoc('numpy._core.multiarray', 'fromfile',
     fromfile(file, dtype=None, count=-1, sep='', offset=0, *, like=None)
     --
 
-    fromfile(file, dtype=float, count=-1, sep='', offset=0, *, like=None)
+    fromfile(file, dtype=np.float64, count=-1, sep='', offset=0, *, like=None)
 
     Construct an array from data in a text or binary file.
 
@@ -1737,7 +1737,7 @@ add_newdoc('numpy._core.multiarray', 'frombuffer',
     frombuffer(buffer, dtype=None, count=-1, offset=0, *, like=None)
     --
 
-    frombuffer(buffer, dtype=float, count=-1, offset=0, *, like=None)
+    frombuffer(buffer, dtype=np.float64, count=-1, offset=0, *, like=None)
 
     Interpret a buffer as a 1-dimensional array.
 
@@ -1770,7 +1770,7 @@ add_newdoc('numpy._core.multiarray', 'frombuffer',
     If the buffer has data that is not in machine byte-order, this should
     be specified as part of the data-type, e.g.::
 
-      >>> dt = np.dtype(int)
+      >>> dt = np.dtype(np.int_)
       >>> dt = dt.newbyteorder('>')
       >>> np.frombuffer(buf, dtype=dt) # doctest: +SKIP
 
@@ -1925,9 +1925,9 @@ add_newdoc('numpy._core.multiarray', 'arange',
     `start` is much larger than `step`. This can lead to unexpected
     behaviour. For example::
 
-      >>> np.arange(0, 5, 0.5, dtype=int)
+      >>> np.arange(0, 5, 0.5, dtype=np.int_)
       array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-      >>> np.arange(-3, 3, 0.5, dtype=int)
+      >>> np.arange(-3, 3, 0.5, dtype=np.int_)
       array([-3, -2, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8])
 
     In such cases, the use of `numpy.linspace` should be preferred.
@@ -2030,16 +2030,16 @@ add_newdoc('numpy._core.multiarray', 'promote_types',
     Examples
     --------
     >>> import numpy as np
-    >>> np.promote_types('f4', 'f8')
+    >>> np.promote_types(np.float32, np.float64)
     dtype('float64')
 
-    >>> np.promote_types('i8', 'f4')
+    >>> np.promote_types(np.int64, np.float32)
     dtype('float64')
 
     >>> np.promote_types('>i8', '<c8')
     dtype('complex128')
 
-    >>> np.promote_types('i4', 'S8')
+    >>> np.promote_types(np.int32, 'S8')
     dtype('S11')
 
     An example of a non-associative case:
@@ -2376,7 +2376,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray',
     ndarray(shape, dtype=None, buffer=None, offset=0, strides=None, order=None)
     --
 
-    ndarray(shape, dtype=float, buffer=None, offset=0, strides=None, order=None)
+    ndarray(shape, dtype=np.float64, buffer=None, offset=0, strides=None, order=None)
 
     An array object represents a multidimensional, homogeneous array
     of fixed-size items.  An associated data-type object describes the
@@ -2485,7 +2485,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray',
     First mode, `buffer` is None:
 
     >>> import numpy as np
-    >>> np.ndarray(shape=(2,2), dtype=float, order='F')
+    >>> np.ndarray(shape=(2,2), dtype=np.float64, order='F')
     array([[0.0e+000, 0.0e+000], # random
            [     nan, 2.5e-323]])
 
@@ -2493,7 +2493,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray',
 
     >>> np.ndarray((2,), buffer=np.array([1,2,3]),
     ...            offset=np.int_().itemsize,
-    ...            dtype=int) # offset = 1*itemsize, i.e. skip first element
+    ...            dtype=np.int_) # offset = 1*itemsize, i.e. skip first element
     array([2, 3])
 
     """)
@@ -3573,15 +3573,15 @@ _array_method_doc('astype', "dtype, order='K', casting='unsafe', subok=True, cop
     >>> x
     array([1. ,  2. ,  2.5])
 
-    >>> x.astype(int)
+    >>> x.astype(np.int_)
     array([1, 2, 2])
 
-    >>> x.astype(int, casting="same_value")
+    >>> x.astype(np.int_, casting="same_value")
     Traceback (most recent call last):
     ...
     ValueError: could not cast 'same_value' double to long
 
-    >>> x[:2].astype(int, casting="same_value")
+    >>> x[:2].astype(np.int_, casting="same_value")
     array([1, 2])
     """)
 
@@ -3751,12 +3751,12 @@ _array_method_doc('copy', "order='C'",
     >>> y.flags['C_CONTIGUOUS']
     True
 
-    For arrays containing Python objects (e.g. dtype=object),
+    For arrays containing Python objects (e.g. dtype=np.object_),
     the copy is a shallow one. The new array will contain the
     same object which may lead to surprises if that object can
     be modified (is mutable):
 
-    >>> a = np.array([1, 'm', [2, 3, 4]], dtype=object)
+    >>> a = np.array([1, 'm', [2, 3, 4]], dtype=np.object_)
     >>> b = a.copy()
     >>> b[2][0] = 10
     >>> a
@@ -3766,7 +3766,7 @@ _array_method_doc('copy', "order='C'",
     use `copy.deepcopy`:
 
     >>> import copy
-    >>> a = np.array([1, 'm', [2, 3, 4]], dtype=object)
+    >>> a = np.array([1, 'm', [2, 3, 4]], dtype=np.object_)
     >>> c = copy.deepcopy(a)
     >>> c[2][0] = 10
     >>> c
@@ -3868,7 +3868,7 @@ _array_method_doc('fill', "value",
     to a single array element.  The following is a rare example where this
     distinction is important:
 
-    >>> a = np.array([None, None], dtype=object)
+    >>> a = np.array([None, None], dtype=np.object_)
     >>> a[0] = np.array(3)
     >>> a
     array([array(3), None], dtype=object)
@@ -4020,7 +4020,7 @@ _array_method_doc('item', "*args",
 
     For an array with object dtype, elements are returned as-is.
 
-    >>> a = np.array([np.int64(1)], dtype=object)
+    >>> a = np.array([np.int64(1)], dtype=np.object_)
     >>> a.item() #return np.int64
     np.int64(1)
     """)
@@ -4780,7 +4780,7 @@ _array_method_doc('view', "*args, **kwargs",
     .. note::
         Passing None for ``dtype`` is different from omitting the parameter,
         since the former invokes ``dtype(None)`` which is an alias for
-        ``dtype('float64')``.
+        ``dtype(np.float64)``.
 
     Parameters
     ----------
@@ -5867,8 +5867,8 @@ add_newdoc('numpy._core', 'ufunc', ('resolve_dtypes',
     This API requires passing dtypes, define them for convenience:
 
     >>> import numpy as np
-    >>> int32 = np.dtype("int32")
-    >>> float32 = np.dtype("float32")
+    >>> int32 = np.dtype(np.int32)
+    >>> float32 = np.dtype(np.float32)
 
     The typical ufunc call does not pass an output dtype.  `numpy.add` has two
     inputs and one output, so leave the output as ``None`` (not provided):
@@ -6095,11 +6095,11 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('alignment',
     --------
 
     >>> import numpy as np
-    >>> x = np.dtype('i4')
+    >>> x = np.dtype(np.int32)
     >>> x.alignment
     4
 
-    >>> x = np.dtype(float)
+    >>> x = np.dtype(np.float64)
     >>> x.alignment
     8
 
@@ -6124,11 +6124,11 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('byteorder',
     --------
 
     >>> import numpy as np
-    >>> dt = np.dtype('i2')
+    >>> dt = np.dtype(np.int16)
     >>> dt.byteorder
     '='
     >>> # endian is not relevant for 8 bit numbers
-    >>> np.dtype('i1').byteorder
+    >>> np.dtype(np.int8).byteorder
     '|'
     >>> # or ASCII strings
     >>> np.dtype('S2').byteorder
@@ -6274,13 +6274,13 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('isbuiltin',
     --------
 
     >>> import numpy as np
-    >>> dt = np.dtype('i2')
+    >>> dt = np.dtype(np.int16)
     >>> dt.isbuiltin
     1
-    >>> dt = np.dtype('f8')
+    >>> dt = np.dtype(np.float64)
     >>> dt.isbuiltin
     1
-    >>> dt = np.dtype([('field1', 'f8')])
+    >>> dt = np.dtype([('field1', np.float64)])
     >>> dt.isbuiltin
     0
 
@@ -6348,13 +6348,13 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('kind',
     --------
 
     >>> import numpy as np
-    >>> dt = np.dtype('i4')
+    >>> dt = np.dtype(np.int32)
     >>> dt.kind
     'i'
-    >>> dt = np.dtype('f8')
+    >>> dt = np.dtype(np.float64)
     >>> dt.kind
     'f'
-    >>> dt = np.dtype([('field1', 'f8')])
+    >>> dt = np.dtype([('field1', np.float64)])
     >>> dt.kind
     'V'
 
@@ -6520,7 +6520,7 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('subdtype',
     >>> x.subdtype
     (dtype('float32'), (8,))
 
-    >>> x =  np.dtype('i2')
+    >>> x =  np.dtype(np.int16)
     >>> x.subdtype
     >>>
 
@@ -6542,7 +6542,7 @@ add_newdoc('numpy._core.multiarray', 'dtype', ('base',
     >>> x.base
     dtype('float32')
 
-    >>> x =  np.dtype('i2')
+    >>> x = np.dtype(np.int16)
     >>> x.base
     dtype('int16')
 

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -917,7 +917,7 @@ add_newdoc('numpy._core.umath', 'cos',
     array([  1.00000000e+00,   6.12303177e-17,  -1.00000000e+00])
     >>>
     >>> # Example of providing the optional output parameter
-    >>> out1 = np.array([0], dtype='d')
+    >>> out1 = np.array([0], dtype=np.float64)
     >>> out2 = np.cos([0.1], out1)
     >>> out2 is out1
     True
@@ -1145,7 +1145,7 @@ add_newdoc('numpy._core.umath', 'equal',
     -------
     out : ndarray or scalar
         Output array, element-wise comparison of `x1` and `x2`.
-        Typically of type bool, unless ``dtype=object`` is passed.
+        Typically of type bool, unless ``dtype=np.object_`` is passed.
         $OUT_SCALAR_2
 
     See Also
@@ -1506,7 +1506,7 @@ add_newdoc('numpy._core.umath', 'greater',
     -------
     out : ndarray or scalar
         Output array, element-wise comparison of `x1` and `x2`.
-        Typically of type bool, unless ``dtype=object`` is passed.
+        Typically of type bool, unless ``dtype=np.object_`` is passed.
         $OUT_SCALAR_2
 
 
@@ -1545,7 +1545,7 @@ add_newdoc('numpy._core.umath', 'greater_equal',
     -------
     out : bool or ndarray of bool
         Output array, element-wise comparison of `x1` and `x2`.
-        Typically of type bool, unless ``dtype=object`` is passed.
+        Typically of type bool, unless ``dtype=np.object_`` is passed.
         $OUT_SCALAR_2
 
     See Also
@@ -1957,7 +1957,7 @@ add_newdoc('numpy._core.umath', 'less',
     -------
     out : ndarray or scalar
         Output array, element-wise comparison of `x1` and `x2`.
-        Typically of type bool, unless ``dtype=object`` is passed.
+        Typically of type bool, unless ``dtype=np.object_`` is passed.
         $OUT_SCALAR_2
 
     See Also
@@ -1994,7 +1994,7 @@ add_newdoc('numpy._core.umath', 'less_equal',
     -------
     out : ndarray or scalar
         Output array, element-wise comparison of `x1` and `x2`.
-        Typically of type bool, unless ``dtype=object`` is passed.
+        Typically of type bool, unless ``dtype=np.object_`` is passed.
         $OUT_SCALAR_2
 
     See Also
@@ -3255,7 +3255,7 @@ add_newdoc('numpy._core.umath', 'not_equal',
     -------
     out : ndarray or scalar
         Output array, element-wise comparison of `x1` and `x2`.
-        Typically of type bool, unless ``dtype=object`` is passed.
+        Typically of type bool, unless ``dtype=np.object_`` is passed.
         $OUT_SCALAR_2
 
     See Also
@@ -3373,9 +3373,9 @@ add_newdoc('numpy._core.umath', 'power',
     >>> p
     array([nan, nan])
 
-    To get complex results, give the argument ``dtype=complex``.
+    To get complex results, give the argument ``dtype=np.complex128``.
 
-    >>> np.power(x3, 1.5, dtype=complex)
+    >>> np.power(x3, 1.5, dtype=np.complex128)
     array([-1.83697020e-16-1.j, -1.46957616e-15-8.j])
 
     """)
@@ -3452,9 +3452,9 @@ add_newdoc('numpy._core.umath', 'float_power',
     >>> p
     array([nan, nan])
 
-    To get complex results, give the argument ``dtype=complex``.
+    To get complex results, give the argument ``dtype=np.complex128``.
 
-    >>> np.float_power(x3, 1.5, dtype=complex)
+    >>> np.float_power(x3, 1.5, dtype=np.complex128)
     array([-1.83697020e-16-1.j, -1.46957616e-15-8.j])
 
     """)
@@ -4055,7 +4055,7 @@ add_newdoc('numpy._core.umath', 'sinh',
     >>> # Discrepancy due to vagaries of floating point arithmetic.
 
     >>> # Example of providing the optional output parameter
-    >>> out1 = np.array([0], dtype='d')
+    >>> out1 = np.array([0], dtype=np.float64)
     >>> out2 = np.sinh([0.1], out1)
     >>> out2 is out1
     True
@@ -4256,7 +4256,7 @@ add_newdoc('numpy._core.umath', 'tan',
     >>>
     >>> # Example of providing the optional output parameter illustrating
     >>> # that what is returned is a reference to said parameter
-    >>> out1 = np.array([0], dtype='d')
+    >>> out1 = np.array([0], dtype=np.float64)
     >>> out2 = np.cos([0.1], out1)
     >>> out2 is out1
     True
@@ -4309,7 +4309,7 @@ add_newdoc('numpy._core.umath', 'tanh',
 
     >>> # Example of providing the optional output parameter illustrating
     >>> # that what is returned is a reference to said parameter
-    >>> out1 = np.array([0], dtype='d')
+    >>> out1 = np.array([0], dtype=np.float64)
     >>> out2 = np.tanh([0.1], out1)
     >>> out2 is out1
     True

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -2026,7 +2026,7 @@ def nonzero(a):
     Notes
     -----
     While the nonzero values can be obtained with ``a[nonzero(a)]``, it is
-    recommended to use ``x[x.astype(bool)]`` or ``x[x != 0]`` instead, which
+    recommended to use ``x[x.astype(np.bool)]`` or ``x[x != 0]`` instead, which
     will correctly handle 0-d arrays.
 
     Examples
@@ -2385,7 +2385,7 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     more precise approach to summation.
     Especially when summing a large number of lower precision floating point
     numbers, such as ``float32``, numerical errors can become significant.
-    In such cases it can be advisable to use `dtype="float64"` to use a higher
+    In such cases it can be advisable to use `dtype=np.float64` to use a higher
     precision for the output.
 
     Examples
@@ -2721,7 +2721,7 @@ def cumulative_prod(x, /, *, axis=None, dtype=None, out=None,
     ...                        # total product 1*2*3 = 6
     array([1, 2, 6])
     >>> a = np.array([1, 2, 3, 4, 5, 6])
-    >>> np.cumulative_prod(a, dtype=float) # specify type of output
+    >>> np.cumulative_prod(a, dtype=np.float64)  # specify type of output
     array([   1.,    2.,    6.,   24.,  120.,  720.])
 
     The cumulative product for each column (i.e., over the rows) of ``b``:
@@ -2808,7 +2808,7 @@ def cumulative_sum(x, /, *, axis=None, dtype=None, out=None,
     array([1, 2, 3, 4, 5, 6])
     >>> np.cumulative_sum(a)
     array([ 1,  3,  6, 10, 15, 21])
-    >>> np.cumulative_sum(a, dtype=float)  # specifies type of output value(s)
+    >>> np.cumulative_sum(a, dtype=np.float64)  # specifies type of output value(s)
     array([  1.,   3.,   6.,  10.,  15.,  21.])
 
     >>> b = np.array([[1, 2, 3], [4, 5, 6]])
@@ -2892,7 +2892,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
            [4, 5, 6]])
     >>> np.cumsum(a)
     array([ 1,  3,  6, 10, 15, 21])
-    >>> np.cumsum(a, dtype=float)     # specifies type of output value(s)
+    >>> np.cumsum(a, dtype=np.float64)  # specifies type of output value(s)
     array([  1.,   3.,   6.,  10.,  15.,  21.])
 
     >>> np.cumsum(a,axis=0)      # sum over rows for each of the 3 columns
@@ -3096,7 +3096,7 @@ def max(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     array([1, 3])
     >>> np.max(a, where=[False, True], initial=-1, axis=0)
     array([-1,  3])
-    >>> b = np.arange(5, dtype=float)
+    >>> b = np.arange(5, dtype=np.float64)
     >>> b[2] = np.nan
     >>> np.max(b)
     np.float64(nan)
@@ -3235,7 +3235,7 @@ def min(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     >>> np.min(a, where=[False, True], initial=10, axis=0)
     array([10,  1])
 
-    >>> b = np.arange(5, dtype=float)
+    >>> b = np.arange(5, dtype=np.float64)
     >>> b[2] = np.nan
     >>> np.min(b)
     np.float64(nan)
@@ -3456,7 +3456,7 @@ def cumprod(a, axis=None, dtype=None, out=None):
     ...               # total product 1*2*3 = 6
     array([1, 2, 6])
     >>> a = np.array([[1, 2, 3], [4, 5, 6]])
-    >>> np.cumprod(a, dtype=float) # specify type of output
+    >>> np.cumprod(a, dtype=np.float64)  # specify type of output
     array([   1.,    2.,    6.,   24.,  120.,  720.])
 
     The cumulative product for each column (i.e., over the rows) of `a`:

--- a/numpy/_core/function_base.py
+++ b/numpy/_core/function_base.py
@@ -38,7 +38,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
     .. versionchanged:: 1.20.0
         Values are rounded towards ``-inf`` instead of ``0`` when an
         integer ``dtype`` is specified. The old behavior can
-        still be obtained with ``np.linspace(start, stop, num).astype(int)``
+        still be obtained with ``np.linspace(start, stop, num).astype(np.int_)``
 
     Parameters
     ----------
@@ -375,9 +375,9 @@ def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
 
     Note that the above may not produce exact integers:
 
-    >>> np.geomspace(1, 256, num=9, dtype=int)
+    >>> np.geomspace(1, 256, num=9, dtype=np.int_)
     array([  1,   2,   4,   7,  16,  32,  63, 127, 256])
-    >>> np.around(np.geomspace(1, 256, num=9)).astype(int)
+    >>> np.around(np.geomspace(1, 256, num=9)).astype(np.int_)
     array([  1,   2,   4,   8,  16,  32,  64, 128, 256])
 
     Negative, decreasing, and complex inputs are allowed:

--- a/numpy/_core/memmap.py
+++ b/numpy/_core/memmap.py
@@ -130,7 +130,7 @@ class memmap(ndarray):
     Examples
     --------
     >>> import numpy as np
-    >>> data = np.arange(12, dtype='float32')
+    >>> data = np.arange(12, dtype=np.float32)
     >>> data.resize((3,4))
 
     This example uses a temporary file so that doctest doesn't write
@@ -142,7 +142,7 @@ class memmap(ndarray):
 
     Create a memmap with dtype and shape that matches our data:
 
-    >>> fp = np.memmap(filename, dtype='float32', mode='w+', shape=(3,4))
+    >>> fp = np.memmap(filename, dtype=np.float32, mode='w+', shape=(3,4))
     >>> fp
     memmap([[0., 0., 0., 0.],
             [0., 0., 0., 0.],
@@ -165,7 +165,7 @@ class memmap(ndarray):
 
     Load the memmap and verify data was stored:
 
-    >>> newfp = np.memmap(filename, dtype='float32', mode='r', shape=(3,4))
+    >>> newfp = np.memmap(filename, dtype=np.float32, mode='r', shape=(3,4))
     >>> newfp
     memmap([[  0.,   1.,   2.,   3.],
             [  4.,   5.,   6.,   7.],
@@ -173,13 +173,13 @@ class memmap(ndarray):
 
     Read-only memmap:
 
-    >>> fpr = np.memmap(filename, dtype='float32', mode='r', shape=(3,4))
+    >>> fpr = np.memmap(filename, dtype=np.float32, mode='r', shape=(3,4))
     >>> fpr.flags.writeable
     False
 
     Copy-on-write memmap:
 
-    >>> fpc = np.memmap(filename, dtype='float32', mode='c', shape=(3,4))
+    >>> fpc = np.memmap(filename, dtype=np.float32, mode='c', shape=(3,4))
     >>> fpc.flags.writeable
     True
 
@@ -205,7 +205,7 @@ class memmap(ndarray):
 
     Offset into a memmap:
 
-    >>> fpo = np.memmap(filename, dtype='float32', mode='r', offset=16)
+    >>> fpo = np.memmap(filename, dtype=np.float32, mode='r', offset=16)
     >>> fpo
     memmap([  4.,   5.,   6.,   7.,   8.,   9.,  10.,  11.], dtype=float32)
 

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -700,7 +700,7 @@ def min_scalar_type(a, /):
     >>> np.min_scalar_type(1e50)
     dtype('float64')
 
-    >>> np.min_scalar_type(np.arange(4,dtype='f8'))
+    >>> np.min_scalar_type(np.arange(4, dtype=np.float64))
     dtype('float64')
 
     """
@@ -732,10 +732,10 @@ def result_type(*arrays_and_dtypes):
     Examples
     --------
     >>> import numpy as np
-    >>> np.result_type(3, np.arange(7, dtype='i1'))
+    >>> np.result_type(3, np.arange(7, dtype=np.int8))
     dtype('int8')
 
-    >>> np.result_type('i4', 'c8')
+    >>> np.result_type(np.int32, np.complex64)
     dtype('complex128')
 
     >>> np.result_type(3.0, -2)
@@ -961,7 +961,7 @@ def bincount(x, /, weights=None, minlength=0):
     The input array needs to be of integer dtype, otherwise a
     TypeError is raised:
 
-    >>> np.bincount(np.arange(5, dtype=float))
+    >>> np.bincount(np.arange(5, dtype=np.float64))
     Traceback (most recent call last):
       ...
     TypeError: Cannot cast array data from dtype('float64') to dtype('int64')

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -151,7 +151,7 @@ def zeros_like(
     array([[0, 0, 0],
            [0, 0, 0]])
 
-    >>> y = np.arange(3, dtype=float)
+    >>> y = np.arange(3, dtype=np.float64)
     >>> y
     array([0., 1., 2.])
     >>> np.zeros_like(y)
@@ -211,7 +211,7 @@ def ones(shape, dtype=None, order='C', *, device=None, like=None):
     >>> np.ones(5)
     array([1., 1., 1., 1., 1.])
 
-    >>> np.ones((5,), dtype=int)
+    >>> np.ones((5,), dtype=np.int_)
     array([1, 1, 1, 1, 1])
 
     >>> np.ones((2, 1))
@@ -300,7 +300,7 @@ def ones_like(
     array([[1, 1, 1],
            [1, 1, 1]])
 
-    >>> y = np.arange(3, dtype=float)
+    >>> y = np.arange(3, dtype=np.float64)
     >>> y
     array([0., 1., 2.])
     >>> np.ones_like(y)
@@ -448,21 +448,21 @@ def full_like(
     Examples
     --------
     >>> import numpy as np
-    >>> x = np.arange(6, dtype=int)
+    >>> x = np.arange(6, dtype=np.int_)
     >>> np.full_like(x, 1)
     array([1, 1, 1, 1, 1, 1])
     >>> np.full_like(x, 0.1)
     array([0, 0, 0, 0, 0, 0])
-    >>> np.full_like(x, 0.1, dtype=np.double)
+    >>> np.full_like(x, 0.1, dtype=np.float64)
     array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
-    >>> np.full_like(x, np.nan, dtype=np.double)
+    >>> np.full_like(x, np.nan, dtype=np.float64)
     array([nan, nan, nan, nan, nan, nan])
 
-    >>> y = np.arange(6, dtype=np.double)
+    >>> y = np.arange(6, dtype=np.float64)
     >>> np.full_like(y, 0.1)
     array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
 
-    >>> y = np.zeros([2, 2, 3], dtype=int)
+    >>> y = np.zeros([2, 2, 3], dtype=np.int_)
     >>> np.full_like(y, [0, 0, 255])
     array([[[  0,   0, 255],
             [  0,   0, 255]],
@@ -982,7 +982,7 @@ def outer(a, b, out=None):
 
     An example using a "vector" of letters:
 
-    >>> x = np.array(['a', 'b', 'c'], dtype=object)
+    >>> x = np.array(['a', 'b', 'c'], dtype=np.object_)
     >>> np.outer(x, [1, 2, 3])
     array([['a', 'aa', 'aaa'],
            ['b', 'bb', 'bbb'],
@@ -1107,7 +1107,7 @@ def tensordot(a, b, axes=2):
     An extended example taking advantage of the overloading of + and \\*:
 
     >>> a = np.array(range(1, 9)).reshape((2, 2, 2))
-    >>> A = np.array(('a', 'b', 'c', 'd'), dtype=object)
+    >>> A = np.array(('a', 'b', 'c', 'd'), dtype=np.object_)
     >>> A = A.reshape((2, 2))
     >>> a; A
     array([[[1, 2],
@@ -1922,20 +1922,20 @@ def fromfunction(function, shape, *, dtype=float, like=None, **kwargs):
     Examples
     --------
     >>> import numpy as np
-    >>> np.fromfunction(lambda i, j: i, (2, 2), dtype=float)
+    >>> np.fromfunction(lambda i, j: i, (2, 2), dtype=np.float64)
     array([[0., 0.],
            [1., 1.]])
 
-    >>> np.fromfunction(lambda i, j: j, (2, 2), dtype=float)
+    >>> np.fromfunction(lambda i, j: j, (2, 2), dtype=np.float64)
     array([[0., 1.],
            [0., 1.]])
 
-    >>> np.fromfunction(lambda i, j: i == j, (3, 3), dtype=int)
+    >>> np.fromfunction(lambda i, j: i == j, (3, 3), dtype=np.int_)
     array([[ True, False, False],
            [False,  True, False],
            [False, False,  True]])
 
-    >>> np.fromfunction(lambda i, j: i + j, (3, 3), dtype=int)
+    >>> np.fromfunction(lambda i, j: i + j, (3, 3), dtype=np.int_)
     array([[0, 1, 2],
            [1, 2, 3],
            [2, 3, 4]])

--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -220,7 +220,7 @@ def issctype(rep):
 
     Strings are also a scalar type:
 
-    >>> issctype(np.dtype('str'))
+    >>> issctype(np.dtype(np.str_))
     True
 
     """

--- a/numpy/ctypeslib/_ctypeslib.py
+++ b/numpy/ctypeslib/_ctypeslib.py
@@ -502,7 +502,7 @@ if ctypes is not None:
         --------
         Converting a simple dtype:
 
-        >>> dt = np.dtype('int8')
+        >>> dt = np.dtype(np.int8)
         >>> ctype = np.ctypeslib.as_ctypes_type(dt)
         >>> ctype
         <class 'ctypes.c_byte'>

--- a/numpy/doc/ufuncs.py
+++ b/numpy/doc/ufuncs.py
@@ -113,7 +113,7 @@ use more convenient operator notation in expressions). Note that when the
 output argument is used, the ufunc still returns a reference to the result.
 
  >>> x = np.arange(2)
- >>> np.add(np.arange(2, dtype=float), np.arange(2, dtype=float), x,
+ >>> np.add(np.arange(2, dtype=np.float64), np.arange(2, dtype=np.float64), x,
  ...        casting='unsafe')
  array([0, 2])
  >>> x

--- a/numpy/fft/_helper.py
+++ b/numpy/fft/_helper.py
@@ -156,7 +156,7 @@ def fftfreq(n, d=1.0, device=None):
     Examples
     --------
     >>> import numpy as np
-    >>> signal = np.array([-2, 8, 6, 4, 1, 0, 3, 5], dtype=float)
+    >>> signal = np.array([-2, 8, 6, 4, 1, 0, 3, 5], dtype=np.float64)
     >>> fourier = np.fft.fft(signal)
     >>> n = signal.size
     >>> timestep = 0.1
@@ -215,7 +215,7 @@ def rfftfreq(n, d=1.0, device=None):
     Examples
     --------
     >>> import numpy as np
-    >>> signal = np.array([-2, 8, 6, 4, 1, 0, 3, 5, -3, 4], dtype=float)
+    >>> signal = np.array([-2, 8, 6, 4, 1, 0, 3, 5, -3, 4], dtype=np.float64)
     >>> fourier = np.fft.rfft(signal)
     >>> n = signal.size
     >>> sample_rate = 100

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -302,7 +302,7 @@ def ifft(a, n=None, axis=-1, norm=None, out=None):
 
     >>> import matplotlib.pyplot as plt
     >>> t = np.arange(400)
-    >>> n = np.zeros((400,), dtype=complex)
+    >>> n = np.zeros((400,), dtype=np.complex128)
     >>> n[40:60] = np.exp(1j*np.random.uniform(0, 2*np.pi, (20,)))
     >>> s = np.fft.ifft(n)
     >>> plt.plot(t, s.real, label='real')
@@ -1005,7 +1005,7 @@ def ifftn(a, s=None, axes=None, norm=None, out=None):
     Create and plot an image with band-limited frequency content:
 
     >>> import matplotlib.pyplot as plt
-    >>> n = np.zeros((200,200), dtype=complex)
+    >>> n = np.zeros((200,200), dtype=np.complex128)
     >>> n[60:80, 20:40] = np.exp(1j*np.random.uniform(0, 2*np.pi, (20, 20)))
     >>> im = np.fft.ifftn(n).real
     >>> plt.imshow(im)

--- a/numpy/lib/_array_utils_impl.py
+++ b/numpy/lib/_array_utils_impl.py
@@ -30,7 +30,7 @@ def byte_bounds(a):
     Examples
     --------
     >>> import numpy as np
-    >>> I = np.eye(2, dtype='f'); I.dtype
+    >>> I = np.eye(2, dtype=np.float32); I.dtype
     dtype('float32')
     >>> low, high = np.lib.array_utils.byte_bounds(I)
     >>> high - low == I.size*I.itemsize

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -654,7 +654,7 @@ def asarray_chkfinite(a, dtype=None, order=None):
     ``asarray_chkfinite`` is identical to ``asarray``.
 
     >>> a = [1, 2]
-    >>> np.asarray_chkfinite(a, dtype=float)
+    >>> np.asarray_chkfinite(a, dtype=np.float64)
     array([1., 2.])
 
     Raises ValueError if array_like contains Nans or Infs.
@@ -5239,7 +5239,7 @@ def delete(arr, obj, axis=None):
     Often it is preferable to use a boolean mask. For example:
 
     >>> arr = np.arange(12) + 1
-    >>> mask = np.ones(len(arr), dtype=bool)
+    >>> mask = np.ones(len(arr), dtype=np.bool)
     >>> mask[[0,2,4]] = False
     >>> result = arr[mask,...]
 
@@ -5622,7 +5622,7 @@ def append(arr, values, axis=None):
     the array at index 0 has 2 dimension(s) and the array at index 1 has 1
     dimension(s)
 
-    >>> a = np.array([1, 2], dtype=int)
+    >>> a = np.array([1, 2], dtype=np.int_)
     >>> c = np.append(a, [])
     >>> c
     array([1., 2.])

--- a/numpy/lib/_index_tricks_impl.py
+++ b/numpy/lib/_index_tricks_impl.py
@@ -977,7 +977,7 @@ def diag_indices(n, ndim=2):
 
     And use it to set the diagonal of an array of zeros to 1:
 
-    >>> a = np.zeros((2, 2, 2), dtype=int)
+    >>> a = np.zeros((2, 2, 2), dtype=np.int_)
     >>> a[d3] = 1
     >>> a
     array([[[1, 0],

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1343,7 +1343,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
     single escaped character:
 
     >>> s = StringIO('"Hello, my name is ""Monty""!"')
-    >>> np.loadtxt(s, dtype="U", delimiter=",", quotechar='"')
+    >>> np.loadtxt(s, dtype=np.str_, delimiter=",", quotechar='"')
     array('Hello, my name is "Monty"!', dtype='<U26')
 
     Read subset of columns when all rows do not contain equal number of values:

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -217,7 +217,7 @@ def eye(N, M=None, k=0, dtype=float, order='C', *, device=None, like=None):
     Examples
     --------
     >>> import numpy as np
-    >>> np.eye(2, dtype=int)
+    >>> np.eye(2, dtype=np.int_)
     array([[1, 0],
            [0, 1]])
     >>> np.eye(3, k=1)
@@ -418,7 +418,7 @@ def tri(N, M=None, k=0, dtype=float, *, like=None):
     Examples
     --------
     >>> import numpy as np
-    >>> np.tri(3, 5, 2, dtype=int)
+    >>> np.tri(3, 5, 2, dtype=np.int_)
     array([[1, 1, 1, 0, 0],
            [1, 1, 1, 1, 0],
            [1, 1, 1, 1, 1]])

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -240,26 +240,26 @@ def isreal(x):
     Examples
     --------
     >>> import numpy as np
-    >>> a = np.array([1+1j, 1+0j, 4.5, 3, 2, 2j], dtype=complex)
+    >>> a = np.array([1+1j, 1+0j, 4.5, 3, 2, 2j], dtype=np.complex128)
     >>> np.isreal(a)
     array([False,  True,  True,  True,  True, False])
 
     The function does not work on string arrays.
 
-    >>> a = np.array([2j, "a"], dtype="U")
+    >>> a = np.array([2j, "a"], dtype=np.str_)
     >>> np.isreal(a)  # Warns about non-elementwise comparison
     False
 
-    Returns True for all elements in input array of ``dtype=object`` even if
+    Returns True for all elements in input array of ``dtype=np.object_`` even if
     any of the elements is complex.
 
-    >>> a = np.array([1, "2", 3+4j], dtype=object)
+    >>> a = np.array([1, "2", 3+4j], dtype=np.object_)
     >>> np.isreal(a)
     array([ True,  True,  True])
 
     isreal should not be used with object arrays
 
-    >>> a = np.array([1+2j, 2+1j], dtype=object)
+    >>> a = np.array([1+2j, 2+1j], dtype=np.object_)
     >>> np.isreal(a)
     array([ True,  True])
 

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -938,7 +938,7 @@ def outer(x1, x2, /):
 
     An example using a "vector" of letters:
 
-    >>> x = np.array(['a', 'b', 'c'], dtype=object)
+    >>> x = np.array(['a', 'b', 'c'], dtype=np.object_)
     >>> np.linalg.outer(x, [1, 2, 3])
     array([['a', 'aa', 'aaa'],
            ['b', 'bb', 'bbb'],
@@ -1764,7 +1764,7 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
     ((9, 9), (6,), (6, 6))
     >>> np.allclose(a, np.dot(U[:, :6] * S, Vh))
     True
-    >>> smat = np.zeros((9, 6), dtype=complex)
+    >>> smat = np.zeros((9, 6), dtype=np.complex128)
     >>> smat[:6, :6] = np.diag(S)
     >>> np.allclose(a, np.dot(U, np.dot(smat, Vh)))
     True

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2277,7 +2277,7 @@ def masked_object(x, value, copy=True, shrink=True):
     --------
     >>> import numpy as np
     >>> import numpy.ma as ma
-    >>> food = np.array(['green_eggs', 'ham'], dtype=object)
+    >>> food = np.array(['green_eggs', 'ham'], dtype=np.object_)
     >>> # don't eat spoiled food
     >>> eat = ma.masked_object(food, 'green_eggs')
     >>> eat
@@ -2286,7 +2286,7 @@ def masked_object(x, value, copy=True, shrink=True):
            fill_value='green_eggs',
                 dtype=object)
     >>> # plain ol` ham is boring
-    >>> fresh_food = np.array(['cheese', 'ham', 'pineapple'], dtype=object)
+    >>> fresh_food = np.array(['cheese', 'ham', 'pineapple'], dtype=np.object_)
     >>> eat = ma.masked_object(fresh_food, 'green_eggs')
     >>> eat
     masked_array(data=['cheese', 'ham', 'pineapple'],
@@ -2403,7 +2403,7 @@ def masked_invalid(a, copy=True):
     --------
     >>> import numpy as np
     >>> import numpy.ma as ma
-    >>> a = np.arange(5, dtype=float)
+    >>> a = np.arange(5, dtype=np.float64)
     >>> a[2] = np.nan
     >>> a[3] = np.inf
     >>> a

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1078,7 +1078,7 @@ def mask_rowcols(a, axis=None):
     Examples
     --------
     >>> import numpy as np
-    >>> a = np.zeros((3, 3), dtype=int)
+    >>> a = np.zeros((3, 3), dtype=np.int_)
     >>> a[1, 1] = 1
     >>> a
     array([[0, 0, 0],
@@ -1135,7 +1135,7 @@ def mask_rows(a, axis=np._NoValue):
     Examples
     --------
     >>> import numpy as np
-    >>> a = np.zeros((3, 3), dtype=int)
+    >>> a = np.zeros((3, 3), dtype=np.int_)
     >>> a[1, 1] = 1
     >>> a
     array([[0, 0, 0],
@@ -1186,7 +1186,7 @@ def mask_cols(a, axis=np._NoValue):
     Examples
     --------
     >>> import numpy as np
-    >>> a = np.zeros((3, 3), dtype=int)
+    >>> a = np.zeros((3, 3), dtype=np.int_)
     >>> a[1, 1] = 1
     >>> a
     array([[0, 0, 0],

--- a/numpy/matlib.py
+++ b/numpy/matlib.py
@@ -56,7 +56,7 @@ def empty(shape, dtype=None, order='C'):
     >>> np.matlib.empty((2, 2))    # filled with random data
     matrix([[  6.76425276e-320,   9.79033856e-307], # random
             [  7.39337286e-309,   3.22135945e-309]])
-    >>> np.matlib.empty((2, 2), dtype=int)
+    >>> np.matlib.empty((2, 2), dtype=np.int_)
     matrix([[ 6600475,        0], # random
             [ 6586976, 22740995]])
 
@@ -177,7 +177,7 @@ def identity(n, dtype=None):
     Examples
     --------
     >>> import numpy.matlib
-    >>> np.matlib.identity(3, dtype=int)
+    >>> np.matlib.identity(3, dtype=np.int_)
     matrix([[1, 0, 0],
             [0, 1, 0],
             [0, 0, 1]])
@@ -222,7 +222,7 @@ def eye(n, M=None, k=0, dtype=float, order='C'):
     Examples
     --------
     >>> import numpy.matlib
-    >>> np.matlib.eye(3, k=1, dtype=float)
+    >>> np.matlib.eye(3, k=1, dtype=np.float64)
     matrix([[0.,  1.,  0.],
             [0.,  0.,  1.],
             [0.,  0.,  0.]])

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -315,11 +315,11 @@ class matrix(N.ndarray):
         >>> x.sum(axis=1)
         matrix([[3],
                 [7]])
-        >>> x.sum(axis=1, dtype='float')
+        >>> x.sum(axis=1, dtype=np.float64)
         matrix([[3.],
                 [7.]])
-        >>> out = np.zeros((2, 1), dtype='float')
-        >>> x.sum(axis=1, dtype='float', out=np.asmatrix(out))
+        >>> out = np.zeros((2, 1), dtype=np.float64)
+        >>> x.sum(axis=1, dtype=np.float64, out=np.asmatrix(out))
         matrix([[3.],
                 [7.]])
 

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -793,7 +793,7 @@ cdef class Generator:
         than the optimized sampler even if each element of ``p`` is 1 / len(a).
 
         ``p`` must sum to 1 when cast to ``float64``. To ensure this, you may wish
-        to normalize using ``p = p / np.sum(p, dtype=float)``.
+        to normalize using ``p = p / np.sum(p, dtype=np.float64)``.
 
         When passing ``a`` as an integer type and ``size`` is not specified, the return
         type is a native Python ``int``.

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -719,7 +719,14 @@ cdef class RandomState:
             single value is returned.
         dtype : dtype, optional
             Desired dtype of the result. Byteorder must be native.
-            The default value is intp.
+            The default value is long.
+
+            .. warning::
+              This function defaults to the C-long dtype, which is 32bit on windows
+              and otherwise 64bit on 64bit platforms (and 32bit on 32bit ones).
+              Since NumPy 2.0, NumPy's default integer is 32bit on 32bit platforms
+              and 64bit on 64bit platforms.  Which corresponds to `np.intp`.
+              (`dtype=int` is not the same as in most NumPy functions.)
 
         Returns
         -------

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -719,14 +719,7 @@ cdef class RandomState:
             single value is returned.
         dtype : dtype, optional
             Desired dtype of the result. Byteorder must be native.
-            The default value is long.
-
-            .. warning::
-              This function defaults to the C-long dtype, which is 32bit on windows
-              and otherwise 64bit on 64bit platforms (and 32bit on 32bit ones).
-              Since NumPy 2.0, NumPy's default integer is 32bit on 32bit platforms
-              and 64bit on 64bit platforms.  Which corresponds to `np.intp`.
-              (`dtype=int` is not the same as in most NumPy functions.)
+            The default value is intp.
 
         Returns
         -------


### PR DESCRIPTION
Besides the obvious advantages of consistent docs, passing scalar-types as `dtype=` is beneficial for static typing purposes, because in case of strings or builtin types the dtype can usually not be statically determined.