### PR TITLE
BUG: fix reduction issue in weighted quantile (#30070)

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -4228,6 +4228,17 @@ class TestQuantile:
                 )
         assert_allclose(q, q_res)
 
+        # axis is a tuple of all axes
+        q = np.quantile(y, alpha, weights=w, method=method, axis=(0, 1, 2))
+        q_res = np.quantile(y, alpha, weights=w, method=method, axis=None)
+        assert_allclose(q, q_res)
+
+        q = np.quantile(y, alpha, weights=w, method=method, axis=(1, 2))
+        q_res = np.zeros(shape=(2,))
+        for i in range(2):
+            q_res[i] = np.quantile(y[i], alpha, weights=w[i], method=method)
+        assert_allclose(q, q_res)
+
     @pytest.mark.parametrize("method", methods_supporting_weights)
     def test_quantile_weights_min_max(self, method):
         # Test weighted quantile at 0 and 1 with leading and trailing zero


### PR DESCRIPTION
Backport of #30070.

#### Related issues/PRs:

Fixes: https://github.com/numpy/numpy/issues/30069

#### How does this PR fixes the issue?

Handle `weights` in `_ureduce` the same way the main array `a` is handled.

Add tests that would have failed before the fix and now succeed (see for this [failed CI job](https://github.com/numpy/numpy/actions/runs/18786246946/job/53605130133) for instance)


* TST: Test weighted quantile with multiple axes reduction

* FIX: Fix weighted quantile reduction by handling weights in _ureduce

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
