### PR TITLE
BUG: Add missing return status check of NpyIter_EnableExternalLoop() (#30404)

### DIFF
--- a/numpy/_core/src/multiarray/nditer_pywrap.c
+++ b/numpy/_core/src/multiarray/nditer_pywrap.c
@@ -1423,7 +1423,10 @@ npyiter_enable_external_loop(
         return NULL;
     }
 
-    NpyIter_EnableExternalLoop(self->iter);
+    if (NpyIter_EnableExternalLoop(self->iter) != NPY_SUCCEED) {
+        return NULL;
+    }
+
     /* EnableExternalLoop invalidates cached values */
     if (npyiter_cache_values(self) < 0) {
         return NULL;

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -3206,6 +3206,13 @@ def test_iter_too_large_with_multiindex():
             with assert_raises(ValueError):
                 _multiarray_tests.test_nditer_too_large(arrays, i * 2 + 1, mode)
 
+
+def test_invalid_call_of_enable_external_loop():
+    with pytest.raises(ValueError,
+                       match='Iterator flag EXTERNAL_LOOP cannot be used'):
+        np.nditer(([[1], [2]], [3, 4]), ['multi_index']).enable_external_loop()
+
+
 def test_writebacks():
     a = np.arange(6, dtype='f4')
     au = a.byteswap()


### PR DESCRIPTION
Backport of #30404.


Fix a small bug I just encountered:  calling `enable_external_loop()` on an `nditer` with `multi_index` enabled resulted in a `SystemError`.

Before this fix:

```
In [11]: np.nditer(([[10], [20]], [1, 2]), ['multi_index']).enable_external_loop()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
ValueError: Iterator flag EXTERNAL_LOOP cannot be used if an index or multi-index is being tracked

The above exception was the direct cause of the following exception:

SystemError                               Traceback (most recent call last)
Cell In[11], line 1
----> 1 np.nditer(([[10], [20]], [1, 2]), ['multi_index']).enable_external_loop()

SystemError: <method 'enable_external_loop' of 'numpy.nditer' objects> returned a result with an exception set
```

After:

```
In [1]: np.nditer(([[10], [20]], [1, 2]), ['multi_index']).enable_external_loop()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[1], line 1
----> 1 np.nditer(([[10], [20]], [1, 2]), ['multi_index']).enable_external_loop()

ValueError: Iterator flag EXTERNAL_LOOP cannot be used if an index or multi-index is being tracked
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
