### PR TITLE
TST: skip deep recursion tests on TSAN and ASAN builds

### DIFF
--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -13,7 +13,6 @@ import numpy as np
 import numpy._core._multiarray_umath as ncu
 from numpy._core._rational_tests import rational
 from numpy.testing import IS_64BIT, IS_PYPY, assert_array_equal
-from numpy.testing._private.utils import requires_deep_recursion
 
 
 def arraylikes():
@@ -727,7 +726,6 @@ class TestArrayLikes:
             with pytest.raises(MemoryError):
                 np.array([arr])
 
-    @requires_deep_recursion
     @pytest.mark.parametrize("attribute",
         ["__array_interface__", "__array__", "__array_struct__"])
     @pytest.mark.parametrize("error", [RecursionError, MemoryError])
@@ -745,7 +743,6 @@ class TestArrayLikes:
         with pytest.raises(error):
             np.array(BadInterface())
 
-    @requires_deep_recursion
     @pytest.mark.parametrize("error", [RecursionError, MemoryError])
     def test_bad_array_like_bad_length(self, error):
         # RecursionError and MemoryError are considered "critical" in

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -13,6 +13,7 @@ import numpy as np
 import numpy._core._multiarray_umath as ncu
 from numpy._core._rational_tests import rational
 from numpy.testing import IS_64BIT, IS_PYPY, assert_array_equal
+from numpy.testing._private.utils import requires_deep_recursion
 
 
 def arraylikes():
@@ -726,6 +727,7 @@ class TestArrayLikes:
             with pytest.raises(MemoryError):
                 np.array([arr])
 
+    @requires_deep_recursion
     @pytest.mark.parametrize("attribute",
         ["__array_interface__", "__array__", "__array_struct__"])
     @pytest.mark.parametrize("error", [RecursionError, MemoryError])
@@ -743,6 +745,7 @@ class TestArrayLikes:
         with pytest.raises(error):
             np.array(BadInterface())
 
+    @requires_deep_recursion
     @pytest.mark.parametrize("error", [RecursionError, MemoryError])
     def test_bad_array_like_bad_length(self, error):
         # RecursionError and MemoryError are considered "critical" in

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -21,14 +21,12 @@ from numpy.testing import (
     HAS_REFCOUNT,
     IS_64BIT,
     IS_PYPY,
-    IS_PYSTON,
-    IS_WASM,
     assert_,
     assert_array_equal,
     assert_equal,
     assert_raises,
 )
-
+from numpy.testing._private.utils import requires_deep_recursion
 
 def assert_dtype_equal(a, b):
     assert_equal(a, b)
@@ -978,16 +976,14 @@ class TestMonsterType:
             ('yi', np.dtype((a, (3, 2))))])
         assert_dtype_equal(c, d)
 
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
-    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
+    @requires_deep_recursion
     def test_list_recursion(self):
         l = []
         l.append(('f', l))
         with pytest.raises(RecursionError):
             np.dtype(l)
 
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
-    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
+    @requires_deep_recursion
     def test_tuple_recursion(self):
         d = np.int32
         for i in range(100000):
@@ -997,8 +993,7 @@ class TestMonsterType:
         with contextlib.suppress(RecursionError):
             np.dtype(d)
 
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
-    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
+    @requires_deep_recursion
     def test_dict_recursion(self):
         d = {"names": ['self'], "formats": [None], "offsets": [0]}
         d['formats'][0] = d

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -28,6 +28,7 @@ from numpy.testing import (
 )
 from numpy.testing._private.utils import requires_deep_recursion
 
+
 def assert_dtype_equal(a, b):
     assert_equal(a, b)
     assert_equal(hash(a), hash(b),

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -54,7 +54,11 @@ from numpy.testing import (
     runstring,
     temppath,
 )
-from numpy.testing._private.utils import _no_tracing, requires_memory, requires_deep_recursion
+from numpy.testing._private.utils import (
+    _no_tracing,
+    requires_deep_recursion,
+    requires_memory,
+)
 
 
 def assert_arg_sorted(arr, arg):

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -38,7 +38,6 @@ from numpy.testing import (
     HAS_REFCOUNT,
     IS_64BIT,
     IS_PYPY,
-    IS_PYSTON,
     IS_WASM,
     assert_,
     assert_allclose,
@@ -55,7 +54,7 @@ from numpy.testing import (
     runstring,
     temppath,
 )
-from numpy.testing._private.utils import _no_tracing, requires_memory
+from numpy.testing._private.utils import _no_tracing, requires_memory, requires_deep_recursion
 
 
 def assert_arg_sorted(arr, arg):
@@ -9349,6 +9348,7 @@ class TestConversion:
         assert_equal(bool(np.array([True])), True)
         assert_equal(bool(np.array([[42]])), True)
 
+    @requires_deep_recursion
     def test_to_bool_scalar_not_convertible(self):
 
         class NotConvertible:
@@ -9357,11 +9357,6 @@ class TestConversion:
 
         assert_raises(NotImplementedError, bool, np.array(NotConvertible()))
         assert_raises(NotImplementedError, bool, np.array([NotConvertible()]))
-        if IS_PYSTON:
-            pytest.skip("Pyston disables recursion checking")
-        if IS_WASM:
-            pytest.skip("Pyodide/WASM has limited stack size")
-
         self_containing = np.array([None])
         self_containing[0] = self_containing
 

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -27,7 +27,11 @@ from numpy.testing import (
     assert_raises,
     assert_raises_regex,
 )
-from numpy.testing._private.utils import _no_tracing, requires_memory, requires_deep_recursion
+from numpy.testing._private.utils import (
+    _no_tracing,
+    requires_deep_recursion,
+    requires_memory,
+)
 
 
 class TestRegression:

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -18,8 +18,6 @@ from numpy.testing import (
     HAS_REFCOUNT,
     IS_64BIT,
     IS_PYPY,
-    IS_PYSTON,
-    IS_WASM,
     _assert_valid_refcount,
     assert_,
     assert_almost_equal,
@@ -29,7 +27,7 @@ from numpy.testing import (
     assert_raises,
     assert_raises_regex,
 )
-from numpy.testing._private.utils import _no_tracing, requires_memory
+from numpy.testing._private.utils import _no_tracing, requires_memory, requires_deep_recursion
 
 
 class TestRegression:
@@ -1777,8 +1775,7 @@ class TestRegression:
         assert_(a.flags.f_contiguous)
         assert_(b.flags.c_contiguous)
 
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
-    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
+    @requires_deep_recursion
     def test_object_array_self_reference(self):
         # Object arrays with references to themselves can cause problems
         a = np.array(0, dtype=object)
@@ -1787,8 +1784,7 @@ class TestRegression:
         assert_raises(RecursionError, float, a)
         a[()] = None
 
-    @pytest.mark.skipif(IS_PYSTON, reason="Pyston disables recursion checking")
-    @pytest.mark.skipif(IS_WASM, reason="Pyodide/WASM has limited stack size")
+    @requires_deep_recursion
     def test_object_array_circular_reference(self):
         # Test the same for a circular reference.
         a = np.array(0, dtype=object)

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -18,6 +18,7 @@ from numpy.testing import (
     HAS_REFCOUNT,
     IS_64BIT,
     IS_PYPY,
+    IS_WASM,
     _assert_valid_refcount,
     assert_,
     assert_almost_equal,

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2830,3 +2830,29 @@ def run_threaded(func, max_workers=8, pass_count=False,
                     barrier.abort()
             for f in futures:
                 f.result()
+
+
+def requires_deep_recursion(func):
+    """Decorator to skip test if deep recursion is not supported."""
+    import pytest
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if IS_PYSTON:
+            pytest.skip("Pyston disables recursion checking")
+        if IS_WASM:
+            pytest.skip("WASM has limited stack size")
+        cflags = sysconfig.get_config_var('CFLAGS') or ''
+        config_args = sysconfig.get_config_var('CONFIG_ARGS') or ''
+        address_sanitizer = (
+            '-fsanitize=address' in cflags or
+            '--with-address-sanitizer' in config_args
+        )
+        thread_sanitizer = (
+            '-fsanitize=thread' in cflags or
+            '--with-thread-sanitizer' in config_args
+        )
+        if address_sanitizer or thread_sanitizer:
+            pytest.skip("AddressSanitizer and ThreadSanitizer do not support deep recursion")
+        return func(*args, **kwargs)
+    return wrapper

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2853,6 +2853,7 @@ def requires_deep_recursion(func):
             '--with-thread-sanitizer' in config_args
         )
         if address_sanitizer or thread_sanitizer:
-            pytest.skip("AddressSanitizer and ThreadSanitizer do not support deep recursion")
+            pytest.skip("AddressSanitizer and ThreadSanitizer do not support "
+                        "deep recursion")
         return func(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Relates #30085

Skip deep recursion tests which need large C stack on TSAN and ASAN builds, these tests would otherwise crash under sanitizers. 

cc @rgommers @ngoldbaum 