### PR TITLE
MAINT: Simplify array setstate by using general deallocation code

### DIFF
--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -442,12 +442,6 @@ _clear_array_attributes(PyArrayObject *self, npy_bool unraisable)
         }
         /* mem_handler can be absent if NPY_ARRAY_OWNDATA arbitrarily set */
         if (fa->mem_handler == NULL) {
-            /* For non-dealloc case, we simply error */
-            if (!unraisable) {
-                PyErr_SetString(PyExc_RuntimeError,
-                                "no memory handler found but OWNDATA flag set");
-                return -1;
-            }
             if (npy_global_state.warn_if_no_mem_policy) {
                 char const *msg = "Trying to dealloc data, but a memory policy "
                     "is not set. If you take ownership of the data, you must "

--- a/numpy/_core/src/multiarray/arrayobject.h
+++ b/numpy/_core/src/multiarray/arrayobject.h
@@ -20,6 +20,13 @@ NPY_NO_EXPORT int
 array_might_be_written(PyArrayObject *obj);
 
 /*
+ * For use in __setstate__, where pickle gives us an instance on which we
+ * have to replace all the actual data. Returns 0 on success, -1 on error.
+ */
+NPY_NO_EXPORT int
+clear_array_attributes(PyArrayObject *self);
+
+/*
  * This flag is used to mark arrays which we would like to, in the future,
  * turn into views. It causes a warning to be issued on the first attempt to
  * write to the array (but the write is allowed to succeed).

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -2073,17 +2073,6 @@ array_setstate(PyArrayObject *self, PyObject *args)
         return NULL;
     }
 
-    /*
-     * Reassigning fa->descr messes with the reallocation strategy,
-     * since fa could be a 0-d or scalar, and then
-     * PyDataMem_UserFREE will be confused
-     */
-    size_t n_tofree = PyArray_NBYTES(self);
-    if (n_tofree == 0) {
-        n_tofree = 1;
-    }
-    Py_XDECREF(PyArray_DESCR(self));
-    fa->descr = typecode;
     Py_INCREF(typecode);
     nd = PyArray_IntpFromSequence(shape, dimensions, NPY_MAXDIMS);
     if (nd < 0) {
@@ -2097,7 +2086,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
      *    copy from the pickled data (may not match allocation currently if 0).
      * Compare with `PyArray_NewFromDescr`, raise MemoryError for simplicity.
      */
-    nbytes = PyArray_ITEMSIZE(self);
+    nbytes = typecode->elsize;
     for (int i = 0; i < nd; i++) {
         if (dimensions[i] < 0) {
             PyErr_SetString(PyExc_TypeError,
@@ -2152,32 +2141,13 @@ array_setstate(PyArrayObject *self, PyObject *args)
             return NULL;
         }
     }
-
-    if ((PyArray_FLAGS(self) & NPY_ARRAY_OWNDATA)) {
-        /*
-         * Allocation will never be 0, see comment in ctors.c
-         * line 820
-         */
-        PyObject *handler = PyArray_HANDLER(self);
-        if (handler == NULL) {
-            /* This can happen if someone arbitrarily sets NPY_ARRAY_OWNDATA */
-            PyErr_SetString(PyExc_RuntimeError,
-                            "no memory handler found but OWNDATA flag set");
-            return NULL;
-        }
-        PyDataMem_UserFREE(PyArray_DATA(self), n_tofree, handler);
-        PyArray_CLEARFLAGS(self, NPY_ARRAY_OWNDATA);
+    /*
+     * Get rid of everything on self, and then populate with pickle data.
+     */
+    if (clear_array_attributes(self) < 0) {
+        return NULL;
     }
-    Py_XDECREF(PyArray_BASE(self));
-    fa->base = NULL;
-
-    PyArray_CLEARFLAGS(self, NPY_ARRAY_WRITEBACKIFCOPY);
-
-    if (PyArray_DIMS(self) != NULL) {
-        npy_free_cache_dim_array(self);
-        fa->dimensions = NULL;
-    }
-
+    fa->descr = typecode;
     fa->flags = NPY_ARRAY_DEFAULT;
 
     fa->nd = nd;
@@ -2207,11 +2177,8 @@ array_setstate(PyArrayObject *self, PyObject *args)
             if (num == 0) {
                 num = 1;
             }
-            /* Store the handler in case the default is modified */
-            Py_XDECREF(fa->mem_handler);
             fa->mem_handler = PyDataMem_GetHandler();
             if (fa->mem_handler == NULL) {
-                Py_CLEAR(fa->mem_handler);
                 Py_DECREF(rawdata);
                 return NULL;
             }
@@ -2259,7 +2226,6 @@ array_setstate(PyArrayObject *self, PyObject *args)
         }
         else {
             /* The handlers should never be called in this case */
-            Py_XDECREF(fa->mem_handler);
             fa->mem_handler = NULL;
             fa->data = datastr;
             if (PyArray_SetBaseObject(self, rawdata) < 0) {
@@ -2273,9 +2239,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
         if (num == 0) {
             num = 1;
         }
-
         /* Store the functions in case the default handler is modified */
-        Py_XDECREF(fa->mem_handler);
         fa->mem_handler = PyDataMem_GetHandler();
         if (fa->mem_handler == NULL) {
             return NULL;

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -69,6 +69,7 @@ intern_strings(void)
     INTERN_STRING(copy, "copy");
     INTERN_STRING(dl_device, "dl_device");
     INTERN_STRING(max_version, "max_version");
+    INTERN_STRING(array_dealloc, "array_dealloc");
     return 0;
 }
 

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -48,6 +48,7 @@ typedef struct npy_interned_str_struct {
     PyObject *copy;
     PyObject *dl_device;
     PyObject *max_version;
+    PyObject *array_dealloc;
 } npy_interned_str_struct;
 
 /*


### PR DESCRIPTION
In preparation for (perhaps) having the array not necessarily allocate separate memory for sizes+strides and data, this simplifies one of the places where `ndarray` instance hacking takes place, viz., `__setstate__`. Here, one has to replace all bits from initialization of a new instance by pickle with the data actually stored in the pickle. Since that replacement requires what most of what deallocation does, with the exception of deallocating `self` itself, this PR splits off that bit in `arrayobject` and uses it in `methods`.

As part of the above, I made a few other simplifications in `__setstate__` (first commit).