### PR TITLE
MAINT: remove some old work-arounds and test skips for PyPy

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -399,14 +399,7 @@ stringdtype_getitem(PyArray_StringDTypeObject *descr, char **dataptr)
         }
     }
     else {
-#ifndef PYPY_VERSION
         val_obj = PyUnicode_FromStringAndSize(sdata.buf, sdata.size);
-#else
-        // work around pypy issue #4046, can delete this when the fix is in
-        // a released version of pypy
-        val_obj = PyUnicode_FromStringAndSize(
-                sdata.buf == NULL ? "" : sdata.buf, sdata.size);
-#endif
         if (val_obj == NULL) {
             goto fail;
         }

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -12,7 +12,7 @@ from pytest import param
 import numpy as np
 import numpy._core._multiarray_umath as ncu
 from numpy._core._rational_tests import rational
-from numpy.testing import IS_64BIT, IS_PYPY, assert_array_equal
+from numpy.testing import IS_64BIT, assert_array_equal
 
 
 def arraylikes():
@@ -282,7 +282,6 @@ class TestScalarDiscovery:
         assert_array_equal(arr, arr3)
         assert_array_equal(arr, arr4)
 
-    @pytest.mark.xfail(IS_PYPY, reason="`int(np.complex128(3))` fails on PyPy")
     @pytest.mark.filterwarnings("ignore::numpy.exceptions.ComplexWarning")
     @pytest.mark.parametrize("cast_to", scalar_instances())
     def test_scalar_coercion_same_as_cast_and_assignment(self, cast_to):

--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -343,9 +343,6 @@ async def async_test_context_locality(get_module):
 
 
 def test_context_locality(get_module):
-    if (sys.implementation.name == 'pypy'
-            and sys.pypy_version_info[:3] < (7, 3, 6)):
-        pytest.skip('no context-locality support in PyPy < 7.3.6')
     asyncio.run(async_test_context_locality(get_module))
 
 
@@ -411,9 +408,6 @@ def test_new_policy(get_module):
     assert np._core.multiarray.get_handler_name(c) == orig_policy_name
 
 
-@pytest.mark.xfail(sys.implementation.name == "pypy",
-                   reason=("bad interaction between getenv and "
-                           "os.environ inside pytest"))
 @pytest.mark.parametrize("policy", ["0", "1", None])
 @pytest.mark.thread_unsafe(reason="modifies environment variables")
 def test_switch_owner(get_module, policy):

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -4017,7 +4017,7 @@ class TestBinop:
     #   - defer if other has __array_ufunc__ and it is None
     #           or other is not a subclass and has higher array priority
     #   - else, call ufunc
-    @pytest.mark.xfail(IS_PYPY, reason="Bug in pypy3.{9, 10}-v7.3.13, #24862")
+    @pytest.mark.xfail(IS_PYPY, reason="Bug in pypy, #24862")
     def test_ufunc_binop_interaction(self):
         # Python method name (without underscores)
         #   -> (numpy ufunc, has_in_place_version, preferred_dtype)
@@ -5928,7 +5928,6 @@ class TestIO:
                     np.fromfile, tmp_filename, dtype=x.dtype,
                     sep=",", offset=1)
 
-    @pytest.mark.skipif(IS_PYPY, reason="bug in PyPy's PyNumber_AsSsize_t")
     def test_fromfile_bad_dup(self, tmp_path, param_filename, monkeypatch):
         def dup_str(fd):
             return 'abc'
@@ -9822,9 +9821,6 @@ class TestFormat:
         # until gh-5543, ensure that the behaviour matches what it used to be
         a = np.array([np.pi])
         assert_raises(TypeError, '{:30}'.format, a)
-
-
-from numpy.testing import IS_PYPY
 
 
 class TestCTypes:

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -2291,8 +2291,6 @@ class TestRegression:
             new_shape = (2, 7, 7, 43826197)
         assert_raises(ValueError, a.reshape, new_shape)
 
-    @pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-            reason="PyPy bug in error formatting")
     def test_invalid_structured_dtypes(self):
         # gh-2865
         # mapping python objects to other dtypes

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -5,7 +5,7 @@ import pytest
 
 import numpy as np
 from numpy._core._exceptions import _UFuncNoLoopError
-from numpy.testing import IS_PYPY, assert_array_equal, assert_raises
+from numpy.testing import assert_array_equal, assert_raises
 from numpy.testing._private.utils import requires_memory
 
 COMPARISONS = [

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -19,8 +19,6 @@ COMPARISONS = [
 
 MAX = np.iinfo(np.int64).max
 
-IS_PYPY_LT_7_3_16 = IS_PYPY and sys.implementation.version < (7, 3, 16)
-
 @pytest.mark.parametrize(["op", "ufunc", "sym"], COMPARISONS)
 def test_mixed_string_comparison_ufuncs_fail(op, ufunc, sym):
     arr_string = np.array(["a", "b"], dtype="S")
@@ -1123,10 +1121,7 @@ class TestMethodsWithUnicode:
         '\U0001D7F6',
         '\U00011066',
         '\U000104A0',
-        pytest.param('\U0001F107', marks=pytest.mark.xfail(
-            sys.platform == 'win32' and IS_PYPY_LT_7_3_16,
-            reason="PYPY bug in Py_UNICODE_ISALNUM",
-            strict=True)),
+        '\U0001F107',),
     ])
     def test_isalnum_unicode(self, in_, dt):
         in_ = np.array(in_, dtype=dt)
@@ -1140,10 +1135,7 @@ class TestMethodsWithUnicode:
         ('\U0001F40D', False),
         ('\U0001F46F', False),
         ('\u2177', True),
-        pytest.param('\U00010429', True, marks=pytest.mark.xfail(
-            sys.platform == 'win32' and IS_PYPY_LT_7_3_16,
-            reason="PYPY bug in Py_UNICODE_ISLOWER",
-            strict=True)),
+        ('\U00010429', True),
         ('\U0001044E', True),
     ])
     def test_islower_unicode(self, in_, out, dt):
@@ -1158,10 +1150,7 @@ class TestMethodsWithUnicode:
         ('\U0001F40D', False),
         ('\U0001F46F', False),
         ('\u2177', False),
-        pytest.param('\U00010429', False, marks=pytest.mark.xfail(
-            sys.platform == 'win32' and IS_PYPY_LT_7_3_16,
-            reason="PYPY bug in Py_UNICODE_ISUPPER",
-            strict=True)),
+        ('\U00010429', False),
         ('\U0001044E', False),
     ])
     def test_isupper_unicode(self, in_, out, dt):
@@ -1171,15 +1160,9 @@ class TestMethodsWithUnicode:
     @pytest.mark.parametrize("in_,out", [
         ('\u1FFc', True),
         ('Greek \u1FFcitlecases ...', True),
-        pytest.param('\U00010401\U00010429', True, marks=pytest.mark.xfail(
-            sys.platform == 'win32' and IS_PYPY_LT_7_3_16,
-            reason="PYPY bug in Py_UNICODE_ISISTITLE",
-            strict=True)),
+        '\U00010401\U00010429', True),
         ('\U00010427\U0001044E', True),
-        pytest.param('\U00010429', False, marks=pytest.mark.xfail(
-            sys.platform == 'win32' and IS_PYPY_LT_7_3_16,
-            reason="PYPY bug in Py_UNICODE_ISISTITLE",
-            strict=True)),
+        ('\U00010429', False),
         ('\U0001044E', False),
         ('\U0001F40D', False),
         ('\U0001F46F', False),

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -1121,7 +1121,7 @@ class TestMethodsWithUnicode:
         '\U0001D7F6',
         '\U00011066',
         '\U000104A0',
-        '\U0001F107',),
+        '\U0001F107',
     ])
     def test_isalnum_unicode(self, in_, dt):
         in_ = np.array(in_, dtype=dt)
@@ -1160,7 +1160,7 @@ class TestMethodsWithUnicode:
     @pytest.mark.parametrize("in_,out", [
         ('\u1FFc', True),
         ('Greek \u1FFcitlecases ...', True),
-        '\U00010401\U00010429', True),
+        ('\U00010401\U00010429', True),
         ('\U00010427\U0001044E', True),
         ('\U00010429', False),
         ('\U0001044E', False),

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -1035,8 +1035,6 @@ def test_header_growth_axis():
         float, np.dtype({'names': ['c'], 'formats': [np.dtype(int, metadata={})]})
     ]}),
     ])
-@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-        reason="PyPy bug in error formatting")
 def test_metadata_dtype(dt):
     # gh-14142
     arr = np.ones(10, dtype=dt)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -843,8 +843,6 @@ class TestLoadTxt(LoadTxtBase):
         a = np.array([[1, 2, 3], [4, 5, 6]], int)
         assert_array_equal(x, a)
 
-    @pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                        reason="PyPy bug in error formatting")
     def test_comments_multi_chars(self):
         c = TextIO()
         c.write('/* comment\n1,2,3,5\n')
@@ -1061,8 +1059,6 @@ class TestLoadTxt(LoadTxtBase):
                 c, dtype=dt, converters=float.fromhex, encoding="latin1")
             assert_equal(res, tgt, err_msg=f"{dt}")
 
-    @pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                        reason="PyPy bug in error formatting")
     def test_default_float_converter_no_default_hex_conversion(self):
         """
         Ensure that fromhex is only used for values with the correct prefix and
@@ -1073,8 +1069,6 @@ class TestLoadTxt(LoadTxtBase):
                 match=".*convert string 'a' to float64 at row 0, column 1"):
             np.loadtxt(c)
 
-    @pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                        reason="PyPy bug in error formatting")
     def test_default_float_converter_exception(self):
         """
         Ensure that the exception message raised during failed floating point

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -204,8 +204,6 @@ def test_maxrows_no_blank_lines(dtype):
     assert_equal(res, np.array([["1.5", "2.5"], ["3.0", "4.0"]], dtype=dtype))
 
 
-@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                    reason="PyPy bug in error formatting")
 @pytest.mark.parametrize("dtype", (np.dtype("f8"), np.dtype("i2")))
 def test_exception_message_bad_values(dtype):
     txt = StringIO("1,2\n3,XXX\n5,6")
@@ -393,8 +391,6 @@ def test_bool():
     assert_array_equal(res.view(np.uint8), [[1, 0], [1, 1]])
 
 
-@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                    reason="PyPy bug in error formatting")
 @pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])
 @pytest.mark.filterwarnings("error:.*integer via a float.*:DeprecationWarning")
 def test_integer_signs(dtype):
@@ -411,8 +407,6 @@ def test_integer_signs(dtype):
             np.loadtxt([f"{sign}2\n"], dtype=dtype)
 
 
-@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                    reason="PyPy bug in error formatting")
 @pytest.mark.parametrize("dtype", np.typecodes["AllInteger"])
 @pytest.mark.filterwarnings("error:.*integer via a float.*:DeprecationWarning")
 def test_implicit_cast_float_to_int_fails(dtype):
@@ -483,8 +477,6 @@ def test_object_cleanup_on_read_error():
     assert sys.getrefcount(sentinel) == 2
 
 
-@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                    reason="PyPy bug in error formatting")
 def test_character_not_bytes_compatible():
     """Test exception when a character cannot be encoded as 'S'."""
     data = StringIO("–")  # == \u2013
@@ -502,8 +494,6 @@ def test_invalid_converter(conv):
         np.loadtxt(StringIO("1 2\n3 4"), converters=conv)
 
 
-@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                    reason="PyPy bug in error formatting")
 def test_converters_dict_raises_non_integer_key():
     with pytest.raises(TypeError, match="keys of the converters dict"):
         np.loadtxt(StringIO("1 2\n3 4"), converters={"a": int})
@@ -569,8 +559,6 @@ def test_quote_support_default():
     assert_array_equal(res, expected)
 
 
-@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                    reason="PyPy bug in error formatting")
 def test_quotechar_multichar_error():
     txt = StringIO("1,2\n3,4")
     msg = r".*must be a single unicode character or None"
@@ -730,8 +718,6 @@ def test_unicode_whitespace_stripping_complex(dtype):
     assert_array_equal(res, np.array([[1, 2 + 3j, 4 + 5j, 6 - 7j, 8j, 9j]] * 2))
 
 
-@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                    reason="PyPy bug in error formatting")
 @pytest.mark.parametrize("dtype", "FD")
 @pytest.mark.parametrize("field",
         ["1 +2j", "1+ 2j", "1+2 j", "1+-+3", "(1j", "(1", "(1+2j", "1+2j)"])
@@ -740,8 +726,6 @@ def test_bad_complex(dtype, field):
         np.loadtxt([field + "\n"], dtype=dtype, delimiter=",")
 
 
-@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                    reason="PyPy bug in error formatting")
 @pytest.mark.parametrize("dtype",
             np.typecodes["AllInteger"] + "efgdFDG" + "?")
 def test_nul_character_error(dtype):
@@ -753,8 +737,6 @@ def test_nul_character_error(dtype):
         np.loadtxt(["1\000"], dtype=dtype, delimiter=",", quotechar='"')
 
 
-@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                    reason="PyPy bug in error formatting")
 @pytest.mark.parametrize("dtype",
         np.typecodes["AllInteger"] + "efgdFDG" + "?")
 def test_no_thousands_support(dtype):
@@ -1022,8 +1004,6 @@ def test_str_dtype_unit_discovery_with_converter():
     assert_equal(a, expected)
 
 
-@pytest.mark.skipif(IS_PYPY and sys.implementation.version <= (7, 3, 8),
-                    reason="PyPy bug in error formatting")
 def test_control_character_empty():
     with pytest.raises(TypeError, match="Text reading control character must"):
         np.loadtxt(StringIO("1 2 3"), delimiter="")

--- a/numpy/lib/tests/test_loadtxt.py
+++ b/numpy/lib/tests/test_loadtxt.py
@@ -13,7 +13,7 @@ import pytest
 
 import numpy as np
 from numpy.ma.testutils import assert_equal
-from numpy.testing import HAS_REFCOUNT, IS_PYPY, assert_array_equal
+from numpy.testing import HAS_REFCOUNT, assert_array_equal
 
 
 def test_scientific_notation():


### PR DESCRIPTION
Related to #30416. Clean up some old PyPy work-arounds no longer needed since those versions have not been supported for more than two years.

Note these are no longer tested in CI, but I tested them locally.