### PR TITLE
DOC: Improve cross-links in thread safety documentation (#30373)

### DIFF
--- a/doc/neps/conf.py
+++ b/doc/neps/conf.py
@@ -39,10 +39,10 @@ extensions = [
 templates_path = ['../source/_templates/']
 
 # The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
+# You can specify multiple suffix as a dict mapping suffixes to parsers:
 #
-# source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+# source_suffix = {'.rst': 'restructuredtext', '.md': 'markdown'}
+source_suffix = {'.rst': 'restructuredtext'}
 
 # The master toctree document.
 master_doc = 'content'

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -114,7 +114,7 @@ for ext, warn in skippable_extensions:
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = {'.rst': 'restructuredtext'}
 
 # General substitutions.
 project = 'NumPy'

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -4272,6 +4272,8 @@ Memory management
 
     Returns 0 if nothing was done, -1 on error, and 1 if action was taken.
 
+.. _array.ndarray.capi.threading:
+
 Threading support
 ~~~~~~~~~~~~~~~~~
 

--- a/doc/source/reference/random/multithreading.rst
+++ b/doc/source/reference/random/multithreading.rst
@@ -9,6 +9,9 @@ well-behaved (writable and aligned). Under normal circumstances, arrays
 created using the common constructors such as :meth:`numpy.empty` will satisfy
 these requirements.
 
+.. seealso::
+   :ref:`thread_safety` for general information about thread safety in NumPy.
+
 This example makes use of :mod:`concurrent.futures` to fill an array using
 multiple threads.  Threads are long-lived so that repeated calls do not
 require any additional overheads from thread creation.

--- a/doc/source/reference/routines.err.rst
+++ b/doc/source/reference/routines.err.rst
@@ -1,7 +1,79 @@
+.. _fp_error_handling:
+
 Floating point error handling
 =============================
 
 .. currentmodule:: numpy
+
+Error handling settings are stored in :py:mod:`python:contextvars`
+allowing different threads or async tasks to have independent configurations.
+For more information, see :ref:`thread_safety`.
+
+.. _misc-error-handling:
+
+How numpy handles numerical exceptions
+--------------------------------------
+
+The default is to ``'warn'`` for ``invalid``, ``divide``, and ``overflow``
+and ``'ignore'`` for ``underflow``.  But this can be changed, and it can be
+set individually for different kinds of exceptions. The different behaviors
+are:
+
+- ``'ignore'`` : Take no action when the exception occurs.
+- ``'warn'``   : Print a :py:exc:`RuntimeWarning` (via the Python :py:mod:`warnings` module).
+- ``'raise'``  : Raise a :py:exc:`FloatingPointError`.
+- ``'call'``   : Call a specified function.
+- ``'print'``  : Print a warning directly to ``stdout``.
+- ``'log'``    : Record error in a Log object.
+
+These behaviors can be set for all kinds of errors or specific ones:
+
+- ``all``       : apply to all numeric exceptions
+- ``invalid``   : when NaNs are generated
+- ``divide``    : divide by zero (for integers as well!)
+- ``overflow``  : floating point overflows
+- ``underflow`` : floating point underflows
+
+Note that integer divide-by-zero is handled by the same machinery.
+
+The error handling mode can be configured :func:`numpy.errstate`
+context manager.
+
+Examples
+--------
+
+::
+
+    >>> with np.errstate(all='warn'):
+    ...     np.zeros(5, dtype=np.float32) / 0.0
+    <python-input-1>:2: RuntimeWarning: invalid value encountered in divide
+    array([nan, nan, nan, nan, nan], dtype=float32)
+
+::
+
+    >>> with np.errstate(under='ignore'):
+    ...     np.array([1.e-100])**10
+    array([0.])
+
+::
+
+    >>> with np.errstate(invalid='raise'):
+    ...     np.sqrt(np.array([-1.]))
+    ...
+    Traceback (most recent call last):
+      File "<python-input-1>", line 2, in <module>
+        np.sqrt(np.array([-1.]))
+        ~~~~~~~^^^^^^^^^^^^^^^^^
+    FloatingPointError: invalid value encountered in sqrt
+
+::
+
+    >>> def errorhandler(errstr, errflag):
+    ...     print("saw stupid error!")
+    >>> with np.errstate(call=errorhandler, all='call'):
+    ...     np.zeros(5, dtype=np.int32) / 0
+    saw stupid error!
+    array([nan, nan, nan, nan, nan])
 
 Setting and getting error handling
 ----------------------------------

--- a/doc/source/reference/routines.io.rst
+++ b/doc/source/reference/routines.io.rst
@@ -59,8 +59,15 @@ Memory mapping files
    memmap
    lib.format.open_memmap
 
+.. _text_formatting_options:
+
 Text formatting options
 -----------------------
+
+Text formatting settings are maintained in a :py:mod:`context variable <python:contextvars>`,
+allowing different threads or async tasks to have independent configurations.
+For more information, see :ref:`thread_safety`.
+
 .. autosummary::
    :toctree: generated/
 

--- a/doc/source/reference/thread_safety.rst
+++ b/doc/source/reference/thread_safety.rst
@@ -5,7 +5,7 @@ Thread Safety
 *************
 
 NumPy supports use in a multithreaded context via the `threading` module in the
-standard library. Many NumPy operations release the GIL, so unlike many
+standard library. Many NumPy operations release the :term:`python:GIL`, so unlike many
 situations in Python, it is possible to improve parallel performance by
 exploiting multithreaded parallelism in Python.
 
@@ -22,15 +22,27 @@ are not reproducible, let alone correct. It is also possible to crash the Python
 interpreter by, for example, resizing an array while another thread is reading
 from it to compute a ufunc operation.
 
-In the future, we may add locking to ndarray to make writing multithreaded
+In the future, we may add locking to :class:`~numpy.ndarray` to make writing multithreaded
 algorithms using NumPy arrays safer, but for now we suggest focusing on
 read-only access of arrays that are shared between threads, or adding your own
 locking if you need to mutation and multithreading.
 
 Note that operations that *do not* release the GIL will see no performance gains
 from use of the `threading` module, and instead might be better served with
-`multiprocessing`. In particular, operations on arrays with ``dtype=object`` do
-not release the GIL.
+`multiprocessing`. In particular, operations on arrays with ``dtype=np.object_``
+do not release the GIL.
+
+Context-local state
+-------------------
+
+NumPy maintains some state for ufuncs context-local basis, which means each
+thread in a multithreaded program or task in an asyncio program has its own
+independent configuration of the `numpy.errstate` (see
+:doc:`/reference/routines.err`), and of :ref:`text_formatting_options`.
+
+You can update state stored in a context variable by entering a context manager.
+As soon as the context manager exits, the state will be reset to its value
+before entering the context manager.
 
 Free-threaded Python
 --------------------
@@ -40,12 +52,27 @@ Free-threaded Python
 Starting with NumPy 2.1 and CPython 3.13, NumPy also has experimental support
 for python runtimes with the GIL disabled. See
 https://py-free-threading.github.io for more information about installing and
-using free-threaded Python, as well as information about supporting it in
-libraries that depend on NumPy.
+using :py:term:`free-threaded <python:free threading>` Python, as well as
+information about supporting it in libraries that depend on NumPy.
 
-Because free-threaded Python does not have a global interpreter lock to
-serialize access to Python objects, there are more opportunities for threads to
-mutate shared state and create thread safety issues. In addition to the
-limitations about locking of the ndarray object noted above, this also means
-that arrays with ``dtype=object`` are not protected by the GIL, creating data
-races for python objects that are not possible outside free-threaded python.
+Because free-threaded Python does not have a
+global interpreter lock to serialize access to Python objects, there are more
+opportunities for threads to mutate shared state and create thread safety
+issues. In addition to the limitations about locking of the
+:class:`~numpy.ndarray` object noted above, this also means that arrays with
+``dtype=np.object_`` are not protected by the GIL, creating data races for python
+objects that are not possible outside free-threaded python.
+
+C-API Threading Support
+-----------------------
+
+For developers writing C extensions that interact with NumPy, several parts of
+the :doc:`C-API array documentation </reference/c-api/array>` provide detailed
+information about multithreading considerations.
+
+See Also
+--------
+
+* :doc:`/reference/random/multithreading` - Practical example of using NumPy's
+  random number generators in a multithreaded context with
+  :mod:`concurrent.futures`.

--- a/doc/source/user/misc.rst
+++ b/doc/source/user/misc.rst
@@ -7,7 +7,7 @@ Miscellaneous
 IEEE 754 floating point special values
 --------------------------------------
 
-Special values defined in numpy: nan, inf,
+Special values defined in numpy: :data:`~numpy.nan`, :data:`~numpy.inf`
 
 NaNs can be used as a poor-man's mask (if you don't care what the
 original value was)
@@ -17,29 +17,39 @@ Note: cannot use equality to test NaNs. E.g.: ::
  >>> myarr = np.array([1., 0., np.nan, 3.])
  >>> np.nonzero(myarr == np.nan)
  (array([], dtype=int64),)
+
+::
+
  >>> np.nan == np.nan  # is always False! Use special numpy functions instead.
  False
+
+::
+
  >>> myarr[myarr == np.nan] = 0. # doesn't work
  >>> myarr
  array([  1.,   0.,  nan,   3.])
+
+::
+
  >>> myarr[np.isnan(myarr)] = 0. # use this instead find
  >>> myarr
  array([1.,  0.,  0.,  3.])
 
-Other related special value functions: ::
+Other related special value functions:
 
- isinf():    True if value is inf
- isfinite(): True if not nan or inf
- nan_to_num(): Map nan to 0, inf to max float, -inf to min float
+- :func:`~numpy.isnan` - True if value is nan
+- :func:`~numpy.isinf` - True if value is inf
+- :func:`~numpy.isfinite` - True if not nan or inf
+- :func:`~numpy.nan_to_num` - Map nan to 0, inf to max float, -inf to min float
 
 The following corresponds to the usual functions except that nans are excluded
-from the results: ::
+from the results:
 
- nansum()
- nanmax()
- nanmin()
- nanargmax()
- nanargmin()
+- :func:`~numpy.nansum`
+- :func:`~numpy.nanmax`
+- :func:`~numpy.nanmin`
+- :func:`~numpy.nanargmax`
+- :func:`~numpy.nanargmin`
 
  >>> x = np.arange(10.)
  >>> x[3] = np.nan
@@ -47,168 +57,3 @@ from the results: ::
  nan
  >>> np.nansum(x)
  42.0
-
-How numpy handles numerical exceptions
---------------------------------------
-
-The default is to ``'warn'`` for ``invalid``, ``divide``, and ``overflow``
-and ``'ignore'`` for ``underflow``.  But this can be changed, and it can be
-set individually for different kinds of exceptions. The different behaviors
-are:
-
- - 'ignore' : Take no action when the exception occurs.
- - 'warn'   : Print a `RuntimeWarning` (via the Python `warnings` module).
- - 'raise'  : Raise a `FloatingPointError`.
- - 'call'   : Call a function specified using the `seterrcall` function.
- - 'print'  : Print a warning directly to ``stdout``.
- - 'log'    : Record error in a Log object specified by `seterrcall`.
-
-These behaviors can be set for all kinds of errors or specific ones:
-
- - all       : apply to all numeric exceptions
- - invalid   : when NaNs are generated
- - divide    : divide by zero (for integers as well!)
- - overflow  : floating point overflows
- - underflow : floating point underflows
-
-Note that integer divide-by-zero is handled by the same machinery.
-These behaviors are set on a per-thread basis.
-
-Examples
---------
-
-::
-
- >>> oldsettings = np.seterr(all='warn')
- >>> np.zeros(5,dtype=np.float32)/0.
- Traceback (most recent call last):
- ...
- RuntimeWarning: invalid value encountered in divide
- >>> j = np.seterr(under='ignore')
- >>> np.array([1.e-100])**10
- array([0.])
- >>> j = np.seterr(invalid='raise')
- >>> np.sqrt(np.array([-1.]))
- Traceback (most recent call last):
- ...
- FloatingPointError: invalid value encountered in sqrt
- >>> def errorhandler(errstr, errflag):
- ...      print("saw stupid error!")
- >>> np.seterrcall(errorhandler)
- >>> j = np.seterr(all='call')
- >>> np.zeros(5, dtype=np.int32)/0
- saw stupid error!
- array([nan, nan, nan, nan, nan])
- >>> j = np.seterr(**oldsettings) # restore previous
- ...                              # error-handling settings
-
-Interfacing to C
-----------------
-Only a survey of the choices. Little detail on how each works.
-
-1) Bare metal, wrap your own C-code manually.
-
- - Plusses:
-
-   - Efficient
-   - No dependencies on other tools
-
- - Minuses:
-
-   - Lots of learning overhead:
-
-     - need to learn basics of Python C API
-     - need to learn basics of numpy C API
-     - need to learn how to handle reference counting and love it.
-
-   - Reference counting often difficult to get right.
-
-     - getting it wrong leads to memory leaks, and worse, segfaults
-
-2) Cython
-
- - Plusses:
-
-   - avoid learning C API's
-   - no dealing with reference counting
-   - can code in pseudo python and generate C code
-   - can also interface to existing C code
-   - should shield you from changes to Python C api
-   - has become the de-facto standard within the scientific Python community
-   - fast indexing support for arrays
-
- - Minuses:
-
-   - Can write code in non-standard form which may become obsolete
-   - Not as flexible as manual wrapping
-
-3) ctypes
-
- - Plusses:
-
-   - part of Python standard library
-   - good for interfacing to existing shareable libraries, particularly
-     Windows DLLs
-   - avoids API/reference counting issues
-   - good numpy support: arrays have all these in their ctypes
-     attribute: ::
-
-       a.ctypes.data
-       a.ctypes.data_as
-       a.ctypes.shape
-       a.ctypes.shape_as
-       a.ctypes.strides
-       a.ctypes.strides_as
-
- - Minuses:
-
-   - can't use for writing code to be turned into C extensions, only a wrapper
-     tool.
-
-4) SWIG (automatic wrapper generator)
-
- - Plusses:
-
-   - around a long time
-   - multiple scripting language support
-   - C++ support
-   - Good for wrapping large (many functions) existing C libraries
-
- - Minuses:
-
-   - generates lots of code between Python and the C code
-   - can cause performance problems that are nearly impossible to optimize
-     out
-   - interface files can be hard to write
-   - doesn't necessarily avoid reference counting issues or needing to know
-     API's
-
-5) Psyco
-
- - Plusses:
-
-   - Turns pure python into efficient machine code through jit-like
-     optimizations
-   - very fast when it optimizes well
-
- - Minuses:
-
-   - Only on intel (windows?)
-   - Doesn't do much for numpy?
-
-Interfacing to Fortran:
------------------------
-The clear choice to wrap Fortran code is
-`f2py <https://docs.scipy.org/doc/numpy/f2py/>`_.
-
-Pyfort is an older alternative, but not supported any longer.
-Fwrap is a newer project that looked promising but isn't being developed any
-longer.
-
-Interfacing to C++:
--------------------
- 1) Cython
- 2) CXX
- 3) Boost.python
- 4) SWIG
- 5) SIP (used mainly in PyQT)

--- a/numpy/_core/_ufunc_config.py
+++ b/numpy/_core/_ufunc_config.py
@@ -57,6 +57,7 @@ def seterr(all=None, divide=None, over=None, under=None, invalid=None):
     seterrcall : Set a callback function for the 'call' mode.
     geterr, geterrcall, errstate
 
+
     Notes
     -----
     The floating-point exceptions are defined in the IEEE 754 standard [1]_:
@@ -67,6 +68,8 @@ def seterr(all=None, divide=None, over=None, under=None, invalid=None):
       was lost.
     - Invalid operation: result is not an expressible number, typically
       indicates that a NaN was produced.
+
+    **Concurrency note:** see  :ref:`fp_error_handling`
 
     .. [1] https://en.wikipedia.org/wiki/IEEE_754
 
@@ -127,6 +130,8 @@ def geterr():
     For complete documentation of the types of floating-point exceptions and
     treatment options, see `seterr`.
 
+    **Concurrency note:** see :doc:`/reference/routines.err`
+
     Examples
     --------
     >>> import numpy as np
@@ -172,6 +177,10 @@ def setbufsize(size):
     bufsize : int
         Previous size of ufunc buffer in bytes.
 
+    Notes
+    -----
+    **Concurrency note:** see :doc:`/reference/routines.err`
+
     Examples
     --------
     When exiting a `numpy.errstate` context manager the bufsize is restored:
@@ -204,6 +213,12 @@ def getbufsize():
     -------
     getbufsize : int
         Size of ufunc buffer in bytes.
+
+    Notes
+    -----
+
+    **Concurrency note:** see :doc:`/reference/routines.err`
+
 
     Examples
     --------
@@ -255,6 +270,11 @@ def seterrcall(func):
     See Also
     --------
     seterr, geterr, geterrcall
+
+    Notes
+    -----
+
+    **Concurrency note:** see :doc:`/reference/routines.err`
 
     Examples
     --------
@@ -331,6 +351,8 @@ def geterrcall():
     For complete documentation of the types of floating-point exceptions and
     treatment options, see `seterr`.
 
+    **Concurrency note:** see :ref:`fp_error_handling`
+
     Examples
     --------
     >>> import numpy as np
@@ -398,6 +420,8 @@ class errstate:
     -----
     For complete documentation of the types of floating-point exceptions and
     treatment options, see `seterr`.
+
+    **Concurrency note:** see :ref:`fp_error_handling`
 
     Examples
     --------

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -248,12 +248,15 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
     --------
     get_printoptions, printoptions, array2string
 
+
     Notes
     -----
 
     * ``formatter`` is always reset with a call to `set_printoptions`.
     * Use `printoptions` as a context manager to set the values temporarily.
     * These print options apply only to NumPy ndarrays, not to scalars.
+
+    **Concurrency note:** see :ref:`text_formatting_options`
 
     Examples
     --------
@@ -357,6 +360,8 @@ def get_printoptions():
     -----
     These print options apply only to NumPy ndarrays, not to scalars.
 
+    **Concurrency note:** see :ref:`text_formatting_options`
+
     See Also
     --------
     set_printoptions, printoptions
@@ -418,6 +423,8 @@ def printoptions(*args, **kwargs):
     Notes
     -----
     These print options apply only to NumPy ndarrays, not to scalars.
+
+    **Concurrency note:** see :ref:`text_formatting_options`
 
     """
     token = _set_printoptions(*args, **kwargs)


### PR DESCRIPTION
Backport of #30373.

Those are mostly cosmetic changes and extra cross-links to improve the documentation. In particular I'd like to use this page as an example of good top-level documentation for threading/freethreading in the py-threading-guide https://py-free-threading.github.io/

This also does a number of updates to the misc.rst file which was basically too indented, and missing a bunch of links. I think many of the info misc.rst on how to interop with C/C++ could be removed, and likely all the information on seterr/geterr moved to routines.err.rst but I don't want to include this moves as part of this PR as it's likely more subject to discussion.

There are minor updates in conf.py to avoid 1 sphinx warnings, and I know the thread safety backlink in geterr/seterr/...etc, are a bit overkill, but as numpy will be used as an example and in general is referred to as one of the core scientific Python project I thinks it's OK go go a bit further than usual.

[skip actions]
[skip cirrus]


