### PR TITLE
ENH: Return rank 0 for empty matrices in matrix_rank

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2131,10 +2131,6 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     if A.ndim < 2:
         return int(not all(A == 0))
 
-    # Handle empty matrices - rank is 0 for matrices with 0 rows or 0 columns
-    if A.size == 0:
-        return 0
-
     S = svd(A, compute_uv=False, hermitian=hermitian)
 
     if tol is None:
@@ -2142,7 +2138,7 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
             rtol = max(A.shape[-2:]) * finfo(S.dtype).eps
         else:
             rtol = asarray(rtol)[..., newaxis]
-        tol = S.max(axis=-1, keepdims=True) * rtol
+        tol = S.max(axis=-1, keepdims=True, initial = 0) * rtol
     else:
         tol = asarray(tol)[..., newaxis]
 

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2138,7 +2138,7 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
             rtol = max(A.shape[-2:]) * finfo(S.dtype).eps
         else:
             rtol = asarray(rtol)[..., newaxis]
-        tol = S.max(axis=-1, keepdims=True, initial = 0) * rtol
+        tol = S.max(axis=-1, keepdims=True, initial=0) * rtol
     else:
         tol = asarray(tol)[..., newaxis]
 

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2130,6 +2130,11 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     A = asarray(A)
     if A.ndim < 2:
         return int(not all(A == 0))
+
+    # Handle empty matrices - rank is 0 for matrices with 0 rows or 0 columns
+    if A.size == 0:
+        return 0
+
     S = svd(A, compute_uv=False, hermitian=hermitian)
 
     if tol is None:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2459,3 +2459,4 @@ def test_empty_matrix_rank():
     result = matrix_rank(np.zeros((2, 3, 0, 4)))
     assert_equal(result.shape, (2, 3))
     assert_equal(result, np.zeros((2, 3), dtype=np.intp))
+

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2441,13 +2441,21 @@ def test_vector_norm_empty():
         assert_equal(np.linalg.vector_norm(x, ord=2), 0)
         assert_equal(np.linalg.vector_norm(x, ord=np.inf), 0)
 
-def test_matrix_rank_all_empty_cases():
-    cases = [
-        np.zeros((0, 0)),
-        np.zeros((0, 5)),
-        np.zeros((5, 0)),
-    ]
+def test_empty_matrix_rank():
+    assert_equal(matrix_rank(np.zeros((0, 0))), 0)
+    assert_equal(matrix_rank(np.zeros((0, 5))), 0)
+    assert_equal(matrix_rank(np.zeros((5, 0))), 0)
 
-    for A in cases:
-        rank = np.linalg.matrix_rank(A)
-        assert rank == 0, f"Rank of shape {A.shape} should be 0, got {rank}" 
+    result = matrix_rank(np.zeros((0, 5, 5)))
+    assert_equal(result.shape, (0,))
+    assert_equal(result.dtype, np.intp)
+
+    result = matrix_rank(np.zeros((3, 0, 5)))
+    assert_equal(result, np.array([0, 0, 0]))
+
+    result = matrix_rank(np.zeros((2, 5, 0)))
+    assert_equal(result, np.array([0, 0]))
+
+    result = matrix_rank(np.zeros((2, 3, 0, 4)))
+    assert_equal(result.shape, (2, 3))
+    assert_equal(result, np.zeros((2, 3), dtype=np.intp))

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2459,4 +2459,3 @@ def test_empty_matrix_rank():
     result = matrix_rank(np.zeros((2, 3, 0, 4)))
     assert_equal(result.shape, (2, 3))
     assert_equal(result, np.zeros((2, 3), dtype=np.intp))
-

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2440,3 +2440,14 @@ def test_vector_norm_empty():
         assert_equal(np.linalg.vector_norm(x, ord=1), 0)
         assert_equal(np.linalg.vector_norm(x, ord=2), 0)
         assert_equal(np.linalg.vector_norm(x, ord=np.inf), 0)
+
+def test_matrix_rank_all_empty_cases():
+    cases = [
+        np.zeros((0, 0)),
+        np.zeros((0, 5)),
+        np.zeros((5, 0)),
+    ]
+
+    for A in cases:
+        rank = np.linalg.matrix_rank(A)
+        assert rank == 0, f"Rank of shape {A.shape} should be 0, got {rank}" 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2450,4 +2450,4 @@ def test_matrix_rank_all_empty_cases():
 
     for A in cases:
         rank = np.linalg.matrix_rank(A)
-        assert rank == 0, f"Rank of shape {A.shape} should be 0, got {rank}" 
+        assert rank == 0


### PR DESCRIPTION
This PR fixes a bug in `np.linalg.matrix_rank` where empty matrices
(previously with 0 rows or 0 columns) would raise a ValueError due to 
attempting a reduction operation on a zero-size array.

Changes include:
- Return 0 for all empty matrices in `matrix_rank`.
- Added tests covering all empty matrix shapes to ensure the correct behavior.

Files modified:
- `numpy/linalg/_linalg.py`
- `numpy/linalg/tests/test_linalg.py`

Closes #30421