### PR TITLE
BUG: Fix GH#30349 einsum explicit-output ellipsis reduction when optimize=False

### DIFF
--- a/numpy/_core/einsumfunc.py
+++ b/numpy/_core/einsumfunc.py
@@ -1607,6 +1607,11 @@ def einsum(*operands, out=None, optimize=False, **kwargs):
     if optimize is False:
         if specified_out:
             kwargs['out'] = out
+        # FIX:GH#30349 normalize ellipsis parsing via python parser ---
+        if operands and isinstance(operands[0], str) and "..." in operands[0]:
+            input_sub, output_sub, parsed_ops = _parse_einsum_input(operands)
+            subscripts = input_sub + "->" + output_sub
+            return c_einsum(subscripts, *parsed_ops, **kwargs)
         return c_einsum(*operands, **kwargs)
 
     # Check the kwargs to avoid a more cryptic error later, without having to

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -1349,3 +1349,16 @@ def test_einsum_chunking_precision():
 
     # At with GROWINNER 11 decimals succeed (larger will be less)
     assert_almost_equal(res, value, decimal=15)
+    
+def test_einsum_ellipsis_optimize_false_regression_30349():
+    x = np.array([[[1,2,3],[1,2,3],[1,2,3]],
+                  [[1,2,3],[1,2,3],[1,2,3]],
+                  [[1,2,3],[1,2,3],[1,2,3]]])
+
+    got = np.einsum("i...->i", x, optimize=False)
+    expected = np.array([18, 18, 18])
+    assert np.array_equal(got, expected)
+
+    # also ensure optimize=True matches
+    got_opt = np.einsum("i...->i", x, optimize=True)
+    assert np.array_equal(got_opt, expected)


### PR DESCRIPTION
## Summary

Fix `np.einsum` so that expressions with an ellipsis on the input and an explicit output that omits the ellipsis (e.g. `'i...->i'`) behave correctly when `optimize=False`. `optimize` should only affect performance, not correctness. This change makes
the non-optimized (`c_einsum`) path handle ellipsis-reduction the same way as the optimized path.

## Problem

For inputs like `x = np.ones((3, 3, 3), int)`, the expression:

```python
np.einsum("i...->i", x)
```

is expected to reduce (sum) over the ellipsis axes and return shape (3,). However, optimize=False raises an error, while optimize=True produces the correct result. This is a correctness bug because the optimize flag must not change semantics.

See: numpy/numpy#30349.

## What changed

Ensure the optimize=False path correctly parses/expands ellipsis for explicit-output expressions where the ellipsis is reduced away. Keep behavior identical between optimized and non-optimized execution paths.

Tests

Added/updated regression test covering `i...->i` with both `optimize=False` and `optimize=True`.
Fixes: numpy/numpy#30349
