### PR TITLE
BUG: fix remaining data races in mtrand.pyx (#30426)

### DIFF
--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -222,12 +222,13 @@ cdef class RandomState:
                              "be instantized.")
         self._bitgen = (<bitgen_t *> PyCapsule_GetPointer(capsule, name))[0]
         self._aug_state.bit_generator = &self._bitgen
-        self._reset_gauss()
         self.lock = bit_generator.lock
+        self._reset_gauss()
 
     cdef _reset_gauss(self):
-        self._aug_state.has_gauss = 0
-        self._aug_state.gauss = 0.0
+        with self.lock:
+            self._aug_state.has_gauss = 0
+            self._aug_state.gauss = 0.0
 
     def seed(self, seed=None):
         """
@@ -301,8 +302,9 @@ cdef class RandomState:
                           'MT19937 BitGenerator. To silence this warning, '
                           'set `legacy` to False.', RuntimeWarning)
             legacy = False
-        st['has_gauss'] = self._aug_state.has_gauss
-        st['gauss'] = self._aug_state.gauss
+        with self.lock:
+            st['has_gauss'] = self._aug_state.has_gauss
+            st['gauss'] = self._aug_state.gauss
         if legacy and not isinstance(self._bit_generator, _MT19937):
             raise ValueError(
                 "legacy can only be True when the underlying bitgenerator is "


### PR DESCRIPTION
Backport of #30426.

This PR fixes the remaining data races in `mtrand.pyx`, mostly adding by using `self.lock` which is used in other places. 
This was missed in https://github.com/numpy/numpy/issues/30085#issuecomment-3642955400 as I had done testing on x86-64 but it is reproducible on arm64.

```console
WARNING: ThreadSanitizer: data race (pid=50513)
  Write of size 4 at 0x000127d2a878 by thread T1515:
    #0 mt19937_seed mt19937.c:10 (_mt19937.cpython-314t-darwin.so:arm64+0x165a4)
    #1 __pyx_pf_5numpy_6random_8_mt19937_7MT19937_2_legacy_seeding _mt19937.pyx.c:5787 (_mt19937.cpython-314t-darwin.so:arm64+0xde88)
    #2 __pyx_pw_5numpy_6random_8_mt19937_7MT19937_3_legacy_seeding _mt19937.pyx.c:5446 (_mt19937.cpython-314t-darwin.so:arm64+0xae08)
    #3 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS _mt19937.pyx.c:12586 (_mt19937.cpython-314t-darwin.so:arm64+0x164f0)
    #4 PyObject_VectorcallMethod call.c:856 (libpython3.14t.dylib:arm64+0x8cc24)
    #5 __pyx_pw_5numpy_6random_6mtrand_11RandomState_13seed mtrand.pyx.c:7832 (mtrand.cpython-314t-darwin.so:arm64+0x18fcc)
    #6 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS mtrand.pyx.c:35313 (mtrand.cpython-314t-darwin.so:arm64+0x67e84)
    #7 __Pyx_PyObject_FastCallDict mtrand.pyx.c:31122 (mtrand.cpython-314t-darwin.so:arm64+0xfdc8)
    #8 __pyx_pw_5numpy_6random_6mtrand_1seed mtrand.pyx.c:26433 (mtrand.cpython-314t-darwin.so:arm64+0x68788)
    #9 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS mtrand.pyx.c:35313 (mtrand.cpython-314t-darwin.so:arm64+0x67e84)
    #10 PyObject_Vectorcall call.c:327 (libpython3.14t.dylib:arm64+0x8af00)
    #11 _PyEval_EvalFrameDefault generated_cases.c.h:1619 (libpython3.14t.dylib:arm64+0x27cc00)
    #12 gen_send_ex2 genobject.c:259 (libpython3.14t.dylib:arm64+0xbf558)
    #13 gen_iternext genobject.c:635 (libpython3.14t.dylib:arm64+0xbce28)
    #14 builtin_next bltinmodule.c:1687 (libpython3.14t.dylib:arm64+0x2733a4)
    #15 _PyEval_EvalFrameDefault generated_cases.c.h:2263 (libpython3.14t.dylib:arm64+0x27eb1c)
    #16 _PyEval_Vector ceval.c:2083 (libpython3.14t.dylib:arm64+0x278928)
    #17 _PyFunction_Vectorcall call.c (libpython3.14t.dylib:arm64+0x8b54c)
    #18 method_vectorcall classobject.c:73 (libpython3.14t.dylib:arm64+0x8f9c0)
    #19 _PyObject_Call call.c:348 (libpython3.14t.dylib:arm64+0x8b1c0)
    #20 PyObject_Call call.c:373 (libpython3.14t.dylib:arm64+0x8b234)
    #21 _PyEval_EvalFrameDefault generated_cases.c.h:2654 (libpython3.14t.dylib:arm64+0x27f9b0)
    #22 _PyEval_Vector ceval.c:2083 (libpython3.14t.dylib:arm64+0x278928)
    #23 _PyFunction_Vectorcall call.c (libpython3.14t.dylib:arm64+0x8b54c)
    #24 method_vectorcall classobject.c:73 (libpython3.14t.dylib:arm64+0x8f9c0)
    #25 context_run context.c:728 (libpython3.14t.dylib:arm64+0x2c3d18)
    #26 _PyEval_EvalFrameDefault generated_cases.c.h:3744 (libpython3.14t.dylib:arm64+0x282c64)
    #27 _PyEval_Vector ceval.c:2083 (libpython3.14t.dylib:arm64+0x278928)
    #28 _PyFunction_Vectorcall call.c (libpython3.14t.dylib:arm64+0x8b54c)
    #29 method_vectorcall classobject.c:73 (libpython3.14t.dylib:arm64+0x8f9c0)
    #30 _PyObject_Call call.c:348 (libpython3.14t.dylib:arm64+0x8b1c0)
    #31 PyObject_Call call.c:373 (libpython3.14t.dylib:arm64+0x8b234)
    #32 thread_run _threadmodule.c:359 (libpython3.14t.dylib:arm64+0x419b3c)
    #33 pythread_wrapper thread_pthread.h:242 (libpython3.14t.dylib:arm64+0x369a20)

  Previous read of size 4 at 0x000127d2a878 by thread T1514:
    #0 __pyx_getprop_5numpy_6random_8_mt19937_7MT19937_state _mt19937.pyx.c:7269 (_mt19937.cpython-314t-darwin.so:arm64+0x13110)
    #1 getset_get descrobject.c:194 (libpython3.14t.dylib:arm64+0xa10dc)
    #2 _PyObject_GenericGetAttrWithDict object.c:1709 (libpython3.14t.dylib:arm64+0x139114)
    #3 PyObject_GenericGetAttr object.c:1795 (libpython3.14t.dylib:arm64+0x138f34)
    #4 __pyx_pw_5numpy_6random_6mtrand_11RandomState_15get_state mtrand.pyx.c:8173 (mtrand.cpython-314t-darwin.so:arm64+0x1a034)
    #5 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS mtrand.pyx.c:35313 (mtrand.cpython-314t-darwin.so:arm64+0x67e84)
    #6 PyObject_Vectorcall call.c:327 (libpython3.14t.dylib:arm64+0x8af00)
    #7 _PyEval_EvalFrameDefault generated_cases.c.h:1619 (libpython3.14t.dylib:arm64+0x27cc00)
    #8 gen_send_ex2 genobject.c:259 (libpython3.14t.dylib:arm64+0xbf558)
    #9 gen_iternext genobject.c:635 (libpython3.14t.dylib:arm64+0xbce28)
    #10 builtin_next bltinmodule.c:1687 (libpython3.14t.dylib:arm64+0x2733a4)
    #11 _PyEval_EvalFrameDefault generated_cases.c.h:2263 (libpython3.14t.dylib:arm64+0x27eb1c)
    #12 _PyEval_Vector ceval.c:2083 (libpython3.14t.dylib:arm64+0x278928)
    #13 _PyFunction_Vectorcall call.c (libpython3.14t.dylib:arm64+0x8b54c)
    #14 method_vectorcall classobject.c:73 (libpython3.14t.dylib:arm64+0x8f9c0)
    #15 _PyObject_Call call.c:348 (libpython3.14t.dylib:arm64+0x8b1c0)
    #16 PyObject_Call call.c:373 (libpython3.14t.dylib:arm64+0x8b234)
    #17 _PyEval_EvalFrameDefault generated_cases.c.h:2654 (libpython3.14t.dylib:arm64+0x27f9b0)
    #18 _PyEval_Vector ceval.c:2083 (libpython3.14t.dylib:arm64+0x278928)
    #19 _PyFunction_Vectorcall call.c (libpython3.14t.dylib:arm64+0x8b54c)
    #20 method_vectorcall classobject.c:73 (libpython3.14t.dylib:arm64+0x8f9c0)
    #21 context_run context.c:728 (libpython3.14t.dylib:arm64+0x2c3d18)
    #22 _PyEval_EvalFrameDefault generated_cases.c.h:3744 (libpython3.14t.dylib:arm64+0x282c64)
    #23 _PyEval_Vector ceval.c:2083 (libpython3.14t.dylib:arm64+0x278928)
    #24 _PyFunction_Vectorcall call.c (libpython3.14t.dylib:arm64+0x8b54c)
    #25 method_vectorcall classobject.c:73 (libpython3.14t.dylib:arm64+0x8f9c0)
    #26 _PyObject_Call call.c:348 (libpython3.14t.dylib:arm64+0x8b1c0)
    #27 PyObject_Call call.c:373 (libpython3.14t.dylib:arm64+0x8b234)
    #28 thread_run _threadmodule.c:359 (libpython3.14t.dylib:arm64+0x419b3c)
    #29 pythread_wrapper thread_pthread.h:242 (libpython3.14t.dylib:arm64+0x369a20)

```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
