### PR TITLE
DOC: clarify when `genfromtxt` produces a structured array

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1758,8 +1758,10 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         in a list or produced by a generator are treated as lines.
     dtype : dtype, optional
         Data type of the resulting array.
-        If None, the dtypes will be determined by the contents of each
-        column, individually.
+        If a structured dtype, the output array will be 1D and structured where
+        each field corresponds to one column. If None, the output array will be
+        structured, and the dtype of each field will be determined by the
+        contents of each column, individually.
     comments : str, optional
         The character used to indicate the start of a comment.
         All the characters occurring on a line after a comment are discarded.
@@ -1788,13 +1790,15 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         Which columns to read, with 0 being the first.  For example,
         ``usecols = (1, 4, 5)`` will extract the 2nd, 5th and 6th columns.
     names : {None, True, str, sequence}, optional
-        If `names` is True, the field names are read from the first line after
-        the first `skip_header` lines. This line can optionally be preceded
-        by a comment delimiter. Any content before the comment delimiter is
-        discarded. If `names` is a sequence or a single-string of
-        comma-separated names, the names will be used to define the field
-        names in a structured dtype. If `names` is None, the names of the
-        dtype fields will be used, if any.
+        If `names` is True, the output will be a structured array whose field
+        names are read from the first line after the first `skip_header` lines.
+        This line can optionally be preceded by a comment delimiter. Any content
+        before the comment delimiter is discarded.
+        If `names` is a sequence or a single-string of comma-separated names,
+        the output is a structured array whose field names are taken from
+        `names`.
+        If `names` is None, the output is structured only if `dtype` is
+        structured, in which case the field names are taken from `dtype`.
     excludelist : sequence, optional
         A list of names to exclude. This list is appended to the default list
         ['return','file','print']. Excluded names are appended with an

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1759,9 +1759,10 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     dtype : dtype, optional
         Data type of the resulting array.
         If a structured dtype, the output array will be 1D and structured where
-        each field corresponds to one column. If None, the output array will be
-        structured, and the dtype of each field will be determined by the
-        contents of each column, individually.
+        each field corresponds to one column.
+        If None, the dtype of each column will be inferred automatically, and
+        the output array will be structured only if either the dtypes are not
+        all the same or if `names` is not None.
     comments : str, optional
         The character used to indicate the start of a comment.
         All the characters occurring on a line after a comment are discarded.

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1795,7 +1795,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         names are read from the first line after the first `skip_header` lines.
         This line can optionally be preceded by a comment delimiter. Any content
         before the comment delimiter is discarded.
-        If `names` is a sequence or a single-string of comma-separated names,
+        If `names` is a sequence or a single string of comma-separated names,
         the output is a structured array whose field names are taken from
         `names`.
         If `names` is None, the output is structured only if `dtype` is


### PR DESCRIPTION
The docstring for `genfromtxt` didn't make it clear when the output would be a structured array.  It kind of made it sound like it was only if when `names` is a sequence or a string, but in reality it's whenever `dtype` is structured _or_ `names` is not None.  Now it is stated how the structured outputs behave and when the output is and is not structured.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
