### PR TITLE
TYP: preserve type for split functions via structural Protocol

### DIFF
--- a/numpy/lib/_shape_base_impl.pyi
+++ b/numpy/lib/_shape_base_impl.pyi
@@ -66,16 +66,15 @@ class _SupportsArrayWrap(Protocol):
     def __array_wrap__(self) -> _ArrayWrap: ...
 
 # Protocol for array-like objects that preserve their type through split operations.
-# Requires shape (with __getitem__ for axis access), ndim for dimensional checks
-# in hsplit/vsplit/dsplit, swapaxes for axis manipulation, and __getitem__ for
-# slicing. Examples: pandas DataFrame, xarray DataArray.
+# Requires shape for size, ndim for dimensional checks in hsplit/vsplit/dsplit,
+# swapaxes for axis manipulation, and __getitem__ for slicing.
 @type_check_only
 class _SupportsSplitOps(Protocol):
     @property
     def shape(self) -> tuple[int, ...]: ...
     @property
     def ndim(self) -> int: ...
-    def swapaxes(self, axis1: SupportsIndex, axis2: SupportsIndex, /) -> Self: ...
+    def swapaxes(self, axis1: int, axis2: int, /) -> Self: ...
     def __getitem__(self, key: Any, /) -> Self: ...
 
 ###

--- a/numpy/lib/_shape_base_impl.pyi
+++ b/numpy/lib/_shape_base_impl.pyi
@@ -1,5 +1,13 @@
 from collections.abc import Callable, Sequence
-from typing import Any, Concatenate, Protocol, SupportsIndex, overload, type_check_only
+from typing import (
+    Any,
+    Concatenate,
+    Protocol,
+    Self,
+    SupportsIndex,
+    overload,
+    type_check_only,
+)
 
 import numpy as np
 from numpy import (
@@ -57,6 +65,19 @@ class _SupportsArrayWrap(Protocol):
     @property
     def __array_wrap__(self) -> _ArrayWrap: ...
 
+# Protocol for array-like objects that preserve their type through split operations.
+# Requires shape (with __getitem__ for axis access), ndim for dimensional checks
+# in hsplit/vsplit/dsplit, swapaxes for axis manipulation, and __getitem__ for
+# slicing. Examples: pandas DataFrame, xarray DataArray.
+@type_check_only
+class _SupportsSplitOps(Protocol):
+    @property
+    def shape(self) -> tuple[int, ...]: ...
+    @property
+    def ndim(self) -> int: ...
+    def swapaxes(self, axis1: SupportsIndex, axis2: SupportsIndex, /) -> Self: ...
+    def __getitem__(self, key: Any, /) -> Self: ...
+
 ###
 
 def take_along_axis[ScalarT: np.generic](
@@ -113,6 +134,12 @@ def dstack[ScalarT: np.generic](tup: Sequence[_ArrayLike[ScalarT]]) -> NDArray[S
 def dstack(tup: Sequence[ArrayLike]) -> NDArray[Any]: ...
 
 @overload
+def array_split[SplitableT: _SupportsSplitOps](
+    ary: SplitableT,
+    indices_or_sections: _ShapeLike,
+    axis: SupportsIndex = 0,
+) -> list[SplitableT]: ...
+@overload
 def array_split[ScalarT: np.generic](
     ary: _ArrayLike[ScalarT],
     indices_or_sections: _ShapeLike,
@@ -125,6 +152,12 @@ def array_split(
     axis: SupportsIndex = 0,
 ) -> list[NDArray[Any]]: ...
 
+@overload
+def split[SplitableT: _SupportsSplitOps](
+    ary: SplitableT,
+    indices_or_sections: _ShapeLike,
+    axis: SupportsIndex = 0,
+) -> list[SplitableT]: ...
 @overload
 def split[ScalarT: np.generic](
     ary: _ArrayLike[ScalarT],
@@ -140,6 +173,11 @@ def split(
 
 # keep in sync with `numpy.ma.extras.hsplit`
 @overload
+def hsplit[SplitableT: _SupportsSplitOps](
+    ary: SplitableT,
+    indices_or_sections: _ShapeLike,
+) -> list[SplitableT]: ...
+@overload
 def hsplit[ScalarT: np.generic](
     ary: _ArrayLike[ScalarT],
     indices_or_sections: _ShapeLike,
@@ -151,6 +189,11 @@ def hsplit(
 ) -> list[NDArray[Any]]: ...
 
 @overload
+def vsplit[SplitableT: _SupportsSplitOps](
+    ary: SplitableT,
+    indices_or_sections: _ShapeLike,
+) -> list[SplitableT]: ...
+@overload
 def vsplit[ScalarT: np.generic](
     ary: _ArrayLike[ScalarT],
     indices_or_sections: _ShapeLike,
@@ -161,6 +204,11 @@ def vsplit(
     indices_or_sections: _ShapeLike,
 ) -> list[NDArray[Any]]: ...
 
+@overload
+def dsplit[SplitableT: _SupportsSplitOps](
+    ary: SplitableT,
+    indices_or_sections: _ShapeLike,
+) -> list[SplitableT]: ...
 @overload
 def dsplit[ScalarT: np.generic](
     ary: _ArrayLike[ScalarT],

--- a/numpy/typing/tests/data/reveal/shape_base.pyi
+++ b/numpy/typing/tests/data/reveal/shape_base.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Self, SupportsIndex, assert_type
+from typing import Any, Self, assert_type
 
 import numpy as np
 import numpy.typing as npt
@@ -16,7 +16,7 @@ AR_LIKE_f8: list[float]
 class _SplitableArray:
     shape: tuple[int, ...]
     ndim: int
-    def swapaxes(self, axis1: SupportsIndex, axis2: SupportsIndex, /) -> Self: ...
+    def swapaxes(self, axis1: int, axis2: int, /) -> Self: ...
     def __getitem__(self, key: Any, /) -> Self: ...
 
 splitable: _SplitableArray

--- a/numpy/typing/tests/data/reveal/shape_base.pyi
+++ b/numpy/typing/tests/data/reveal/shape_base.pyi
@@ -1,4 +1,4 @@
-from typing import Any, assert_type
+from typing import Any, Self, SupportsIndex, assert_type
 
 import numpy as np
 import numpy.typing as npt
@@ -11,6 +11,15 @@ AR_i8: npt.NDArray[np.int64]
 AR_f8: npt.NDArray[np.float64]
 
 AR_LIKE_f8: list[float]
+
+# Duck-typed class implementing _SupportsSplitOps protocol for testing
+class _SplitableArray:
+    shape: tuple[int, ...]
+    ndim: int
+    def swapaxes(self, axis1: SupportsIndex, axis2: SupportsIndex, /) -> Self: ...
+    def __getitem__(self, key: Any, /) -> Self: ...
+
+splitable: _SplitableArray
 
 assert_type(np.take_along_axis(AR_f8, AR_i8, axis=1), npt.NDArray[np.float64])
 assert_type(np.take_along_axis(f8, AR_i8, axis=None), npt.NDArray[np.float64])
@@ -28,18 +37,23 @@ assert_type(np.dstack([AR_LIKE_f8]), npt.NDArray[Any])
 
 assert_type(np.array_split(AR_i8, [3, 5, 6, 10]), list[npt.NDArray[np.int64]])
 assert_type(np.array_split(AR_LIKE_f8, [3, 5, 6, 10]), list[npt.NDArray[Any]])
+assert_type(np.array_split(splitable, 2), list[_SplitableArray])
 
 assert_type(np.split(AR_i8, [3, 5, 6, 10]), list[npt.NDArray[np.int64]])
 assert_type(np.split(AR_LIKE_f8, [3, 5, 6, 10]), list[npt.NDArray[Any]])
+assert_type(np.split(splitable, 2), list[_SplitableArray])
 
 assert_type(np.hsplit(AR_i8, [3, 5, 6, 10]), list[npt.NDArray[np.int64]])
 assert_type(np.hsplit(AR_LIKE_f8, [3, 5, 6, 10]), list[npt.NDArray[Any]])
+assert_type(np.hsplit(splitable, 2), list[_SplitableArray])
 
 assert_type(np.vsplit(AR_i8, [3, 5, 6, 10]), list[npt.NDArray[np.int64]])
 assert_type(np.vsplit(AR_LIKE_f8, [3, 5, 6, 10]), list[npt.NDArray[Any]])
+assert_type(np.vsplit(splitable, 2), list[_SplitableArray])
 
 assert_type(np.dsplit(AR_i8, [3, 5, 6, 10]), list[npt.NDArray[np.int64]])
 assert_type(np.dsplit(AR_LIKE_f8, [3, 5, 6, 10]), list[npt.NDArray[Any]])
+assert_type(np.dsplit(splitable, 2), list[_SplitableArray])
 
 assert_type(np.kron(AR_b, AR_b), npt.NDArray[np.bool])
 assert_type(np.kron(AR_b, AR_i8), npt.NDArray[np.signedinteger])


### PR DESCRIPTION
add overloads for `array_split`, `split`, `hsplit`, `vsplit`, and `dsplit` that preserve the input type when the input implements `swapaxes` and `__getitem__`.

this uses structural typing (Protocol) based on the methods actually used by these split functions internally - not `__array_function__`. the Protocol is:

```python
@type_check_only
class _SupportsSplitOps(Protocol):
    def swapaxes(self, axis1: Any, axis2: Any, copy: Any = ...) -> Any: ...
    def __getitem__(self, key: Any, /) -> Any: ...
```

objects like `pandas.DataFrame` that implement these methods (and return `Self` from them) will have their type preserved through split operations.

### example

```python
import numpy as np
import pandas as pd

df = pd.DataFrame({"a": [1, 2, 3, 4]})
splits = np.array_split(df, 2)
splits[0].columns  # before: error (ndarray has no attr "columns"), after: works
```

### why this works

the split functions use `swapaxes` and slicing (`__getitem__`) internally. for objects like DataFrame that return their own type from these operations, the split result preserves the type. this is pure duck-typing, not `__array_function__` dispatch.

closes #23005