### PR TITLE
MAINT: Fix np.interp to handle empty arrays

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1640,6 +1640,11 @@ def interp(x, xp, fp, left=None, right=None, period=None):
     """
 
     fp = np.asarray(fp)
+    x = np.asarray(x)
+
+    # handle empty arrays
+    if x.size == 0:
+        return x.astype(fp.dtype)
 
     if np.iscomplexobj(fp):
         interp_func = compiled_interp_complex


### PR DESCRIPTION
Fixes #30316

When calling np.interp with empty arrays, it now returns an empty array instead of failing. Simple fix - just check if x is empty and return early.

Tested:
- np.interp([], [], []) now returns array([])
- Works with period parameter too