### PR TITLE
CI: have runtime jobs ignore ``tools/stubtest/**``

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -12,6 +12,7 @@ on:
       - '**.pyi'
       - '**.md'
       - '**.rst'
+      - 'tools/stubtest/**'
 
 defaults:
   run:

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -8,6 +8,7 @@ on:
       - '**.pyi'
       - '**.md'
       - '**.rst'
+      - 'tools/stubtest/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -9,6 +9,7 @@ on:
       - '**.pyi'
       - '**.md'
       - '**.rst'
+      - 'tools/stubtest/**'
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -9,6 +9,7 @@ on:
       - '**.pyi'
       - '**.md'
       - '**.rst'
+      - 'tools/stubtest/**'
   workflow_dispatch:
 
 permissions:
@@ -25,7 +26,7 @@ jobs:
     # For more details, see: https://github.com/numpy/numpy/issues/29125
     if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-24.04-ppc64le-p10
-  
+
     strategy:
       fail-fast: false
       matrix:
@@ -34,14 +35,14 @@ jobs:
             args: "-Dallow-noblas=false"
           - name: "clang"
             args: "-Dallow-noblas=false"
-    
+
     name: "${{ matrix.config.name }}"
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         submodules: recursive
         fetch-tags: true
-    
+
     - name: Install dependencies
       run: |
         sudo apt update

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,6 +18,7 @@ on:
       - '**.pyi'
       - '**.md'
       - '**.rst'
+      - 'tools/stubtest/**'
 
 defaults:
   run:

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -44,6 +44,7 @@ on:
       - '**.pyi'
       - '**.md'
       - '**.rst'
+      - 'tools/stubtest/**'
 
 defaults:
   run:

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -18,6 +18,7 @@ on:
       - '**.pyi'
       - '**.md'
       - '**.rst'
+      - 'tools/stubtest/**'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -35,6 +35,7 @@ on:
       - '**.pyi'
       - '**.md'
       - '**.rst'
+      - 'tools/stubtest/**'
 
 defaults:
   run:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,6 +9,7 @@ on:
       - '**.pyi'
       - '**.md'
       - '**.rst'
+      - 'tools/stubtest/**'
 
 permissions:
    contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,6 +13,7 @@ on:
       - '**.pyi'
       - '**.md'
       - '**.rst'
+      - 'tools/stubtest/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,7 @@ on:
       - '**.pyi'
       - '**.md'
       - '**.rst'
+      - 'tools/stubtest/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
This avoids unnecessary CI jobs from being run on changes to the stubtest config, like in e.g. #30456.