### PR TITLE
DEP: remove ``_core.numerictypes.maximum_sctype``

### DIFF
--- a/doc/release/upcoming_changes/30462.expired.rst
+++ b/doc/release/upcoming_changes/30462.expired.rst
@@ -1,0 +1,1 @@
+* ``numpy._core.numerictypes.maximum_sctype`` has been removed (deprecated since 2.0)

--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -77,7 +77,6 @@ Exported symbols include:
 
 """
 import numbers
-import warnings
 
 from numpy._utils import set_module
 
@@ -106,7 +105,6 @@ __all__ = [
 # as numerictypes.bool, etc.
 from builtins import bool, bytes, complex, float, int, object, str  # noqa: F401, UP029
 
-from ._dtype import _kind_name
 from ._string_helpers import (  # noqa: F401
     LOWER_TABLE,
     UPPER_TABLE,
@@ -124,68 +122,6 @@ genericTypeRank = ['bool', 'int8', 'uint8', 'int16', 'uint16',
                    'float16', 'float32', 'float64', 'float96', 'float128',
                    'complex64', 'complex128', 'complex192', 'complex256',
                    'object']
-
-@set_module('numpy')
-def maximum_sctype(t):
-    """
-    Return the scalar type of highest precision of the same kind as the input.
-
-    .. deprecated:: 2.0
-        Use an explicit dtype like int64 or float64 instead.
-
-    Parameters
-    ----------
-    t : dtype or dtype specifier
-        The input data type. This can be a `dtype` object or an object that
-        is convertible to a `dtype`.
-
-    Returns
-    -------
-    out : dtype
-        The highest precision data type of the same kind (`dtype.kind`) as `t`.
-
-    See Also
-    --------
-    obj2sctype, mintypecode, sctype2char
-    dtype
-
-    Examples
-    --------
-    >>> from numpy._core.numerictypes import maximum_sctype
-    >>> maximum_sctype(int)
-    <class 'numpy.int64'>
-    >>> maximum_sctype(np.uint8)
-    <class 'numpy.uint64'>
-    >>> maximum_sctype(complex)
-    <class 'numpy.complex256'> # may vary
-
-    >>> maximum_sctype(str)
-    <class 'numpy.str_'>
-
-    >>> maximum_sctype('i2')
-    <class 'numpy.int64'>
-    >>> maximum_sctype('f4')
-    <class 'numpy.float128'> # may vary
-
-    """
-
-    # Deprecated in NumPy 2.0, 2023-07-11
-    warnings.warn(
-        "`maximum_sctype` is deprecated. Use an explicit dtype like int64 "
-        "or float64 instead. (deprecated in NumPy 2.0)",
-        DeprecationWarning,
-        stacklevel=2
-    )
-
-    g = obj2sctype(t)
-    if g is None:
-        return t
-    t = g
-    base = _kind_name(dtype(t))
-    if base in sctypes:
-        return sctypes[base][-1]
-    else:
-        return t
 
 
 @set_module('numpy')

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -275,7 +275,6 @@ class TestLibImports(_DeprecationTestCase):
     # Deprecated in Numpy 1.26.0, 2023-09
     def test_lib_functions_deprecation_call(self):
         from numpy import row_stack
-        from numpy._core.numerictypes import maximum_sctype
         from numpy.lib._npyio_impl import recfromcsv, recfromtxt
         from numpy.lib._shape_base_impl import get_array_wrap
         from numpy.lib._utils_impl import safe_eval
@@ -289,7 +288,6 @@ class TestLibImports(_DeprecationTestCase):
         self.assert_deprecated(lambda: recfromtxt(data_gen(), **kwargs))
 
         self.assert_deprecated(get_array_wrap)
-        self.assert_deprecated(lambda: maximum_sctype(int))
 
         self.assert_deprecated(lambda: row_stack([[]]))
         self.assert_deprecated(lambda: np.chararray)

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -5,7 +5,7 @@ import pytest
 
 import numpy as np
 import numpy._core.numerictypes as nt
-from numpy._core.numerictypes import issctype, maximum_sctype, sctype2char, sctypes
+from numpy._core.numerictypes import issctype, sctype2char, sctypes
 from numpy.testing import (
     IS_PYPY,
     assert_,
@@ -494,38 +494,6 @@ class TestSctypeDict:
         assert np._core.sctypeDict['ulong'] is np.ulong
         assert np.dtype(np.ulong) is np.dtype("ulong")
         assert np.dtype(np.ulong).itemsize == np.dtype(np.long).itemsize
-
-
-@pytest.mark.filterwarnings("ignore:.*maximum_sctype.*:DeprecationWarning")
-class TestMaximumSctype:
-
-    # note that parametrizing with sctype['int'] and similar would skip types
-    # with the same size (gh-11923)
-
-    @pytest.mark.parametrize(
-        't', [np.byte, np.short, np.intc, np.long, np.longlong]
-    )
-    def test_int(self, t):
-        assert_equal(maximum_sctype(t), np._core.sctypes['int'][-1])
-
-    @pytest.mark.parametrize(
-        't', [np.ubyte, np.ushort, np.uintc, np.ulong, np.ulonglong]
-    )
-    def test_uint(self, t):
-        assert_equal(maximum_sctype(t), np._core.sctypes['uint'][-1])
-
-    @pytest.mark.parametrize('t', [np.half, np.single, np.double, np.longdouble])
-    def test_float(self, t):
-        assert_equal(maximum_sctype(t), np._core.sctypes['float'][-1])
-
-    @pytest.mark.parametrize('t', [np.csingle, np.cdouble, np.clongdouble])
-    def test_complex(self, t):
-        assert_equal(maximum_sctype(t), np._core.sctypes['complex'][-1])
-
-    @pytest.mark.parametrize('t', [np.bool, np.object_, np.str_, np.bytes_,
-                                   np.void])
-    def test_other(self, t):
-        assert_equal(maximum_sctype(t), t)
 
 
 class Test_sctype2char:


### PR DESCRIPTION
towards #30440

Note that `numpy.maximum_sctype` was already removed in NumPy 2.0, so it was only accessible through `numpy._core.numerictypes`.