### PR TITLE
MAINT: remove duplicate byte decode in ``loadtxt``

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1365,9 +1365,6 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
             max_rows=max_rows
         )
 
-    if isinstance(delimiter, bytes):
-        delimiter.decode("latin1")
-
     if dtype is None:
         dtype = np.float64
 


### PR DESCRIPTION
`numpy/lib/_npyio_impl.py::loadtxt` had repeated code for decoding the `delimiter[bytes]`. This appears to have been a mistake and these lines can be safely removed.

Here is a permalink to main that shows both instances of the duplicated code:
https://github.com/camriddell/numpy/blob/a63efa60f04003da994caec9f4b1fe1071c105f1/numpy/lib/_npyio_impl.py#L1368-L1382

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
