### PR TITLE
TYP: ``linalg.multi_dot``: improved dtype specialization

### DIFF
--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -897,12 +897,33 @@ def tensordot(
     a: _ArrayLikeComplex_co, b: _ArrayLikeComplex_co, /, *, axes: int | tuple[_ShapeLike, _ShapeLike] = 2
 ) -> NDArray[np.complex128 | Any]: ...
 
-# TODO: Returns a scalar or array
-def multi_dot(
-    arrays: Iterable[_ArrayLikeComplex_co | _ArrayLikeObject_co | _ArrayLikeTD64_co],
-    *,
-    out: NDArray[Any] | None = None,
-) -> Any: ...
+#
+@overload
+def multi_dot[ArrayT: np.ndarray](
+    arrays: Iterable[_ArrayLikeComplex_co | _ArrayLikeObject_co | _ArrayLikeTD64_co], *, out: ArrayT,
+) -> ArrayT: ...
+@overload
+def multi_dot[
+    AnyScalarT: (
+        np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64,
+        np.float16, np.float32, np.float64, np.longdouble, np.complex64, np.complex128, np.clongdouble,
+        np.object_, np.timedelta64,
+    ),
+](arrays: Sequence[_ArrayLike[AnyScalarT]], *, out: None = None) -> NDArray[AnyScalarT]: ...
+@overload
+def multi_dot(arrays: Sequence[_ArrayLikeBool_co], *, out: None = None) -> NDArray[np.bool]: ...
+@overload
+def multi_dot(arrays: Sequence[_ArrayLikeInt_co], *, out: None = None) -> NDArray[np.int64 | Any]: ...
+@overload
+def multi_dot(arrays: Sequence[_ArrayLikeFloat_co], *, out: None = None) -> NDArray[np.float64 | Any]: ...
+@overload
+def multi_dot(arrays: Sequence[_ArrayLikeComplex_co], *, out: None = None) -> NDArray[np.complex128 | Any]: ...
+@overload
+def multi_dot(arrays: Sequence[_ArrayLikeTD64_co], *, out: None = None) -> NDArray[np.timedelta64 | Any]: ...
+@overload
+def multi_dot[ScalarT: np.number | np.object_ | np.timedelta64](
+    arrays: Sequence[_ArrayLike[ScalarT]], *, out: None = None
+) -> NDArray[ScalarT]: ...
 
 #
 @overload  # workaround for microsoft/pyright#10232

--- a/numpy/typing/tests/data/fail/linalg.pyi
+++ b/numpy/typing/tests/data/fail/linalg.pyi
@@ -45,4 +45,4 @@ np.linalg.det(AR_O)  # type: ignore[arg-type]
 
 np.linalg.norm(AR_f8, ord="bob")  # type: ignore[call-overload]
 
-np.linalg.multi_dot([AR_M])  # type: ignore[list-item]
+np.linalg.multi_dot([AR_M])  # type: ignore[type-var]

--- a/numpy/typing/tests/data/reveal/linalg.pyi
+++ b/numpy/typing/tests/data/reveal/linalg.pyi
@@ -365,11 +365,14 @@ assert_type(np.linalg.tensordot(AR_c16, AR_c16), npt.NDArray[np.complex128])
 assert_type(np.linalg.tensordot(AR_m, AR_m), npt.NDArray[np.timedelta64])
 assert_type(np.linalg.tensordot(AR_O, AR_O), npt.NDArray[np.object_])
 
-assert_type(np.linalg.multi_dot([AR_i8, AR_i8]), Any)
-assert_type(np.linalg.multi_dot([AR_i8, AR_f8]), Any)
-assert_type(np.linalg.multi_dot([AR_f8, AR_c16]), Any)
-assert_type(np.linalg.multi_dot([AR_O, AR_O]), Any)
-assert_type(np.linalg.multi_dot([AR_m, AR_m]), Any)
+assert_type(np.linalg.multi_dot([AR_i8, AR_i8]), npt.NDArray[np.int64])
+assert_type(np.linalg.multi_dot([AR_f8, AR_f8]), npt.NDArray[np.float64])
+assert_type(np.linalg.multi_dot([AR_c16, AR_c16]), npt.NDArray[np.complex128])
+assert_type(np.linalg.multi_dot([AR_O, AR_O]), npt.NDArray[np.object_])
+# Mypy incorrectly infers `ndarray[Any, Any]`, but pyright behaves correctly.
+assert_type(np.linalg.multi_dot([AR_i8, AR_f8]), npt.NDArray[np.float64 | Any])  # type: ignore[assert-type]
+assert_type(np.linalg.multi_dot([AR_f8, AR_c16]), npt.NDArray[np.complex128 | Any])  # type: ignore[assert-type]
+assert_type(np.linalg.multi_dot([AR_m, AR_m]), npt.NDArray[np.timedelta64])  # type: ignore[assert-type]
 
 # Mypy incorrectly infers `ndarray[Any, Any]`, but pyright behaves correctly.
 assert_type(np.linalg.diagonal(AR_any), np.ndarray)  # type: ignore[assert-type]


### PR DESCRIPTION
This is the last `numpy.linalg` function that needed improving, towards #30405.

I'll write a release note for these improvements in a follow-up.