### PR TITLE
DOC: move ``linalg.outer`` from "Decompositions" to "Matrix and vector products"

### DIFF
--- a/numpy/linalg/__init__.py
+++ b/numpy/linalg/__init__.py
@@ -31,12 +31,12 @@ Matrix and vector products
    matrix_power
    tensordot
    matmul
+   outer
 
 Decompositions
 --------------
 
    cholesky
-   outer
    qr
    svd
    svdvals


### PR DESCRIPTION
The outer *product* is, surprisingly, a product. And as far as I'm aware, it's not a decomposition.