### PR TITLE
DOC: Make the issue template clearer about what "context" means

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -67,7 +67,7 @@ body:
     label: "How does this issue affect you or how did you find it:"
     description: |
       Please explain how this issue concretely affects you or others.
-      Especiall if it does not impact you how did you find it?
+      Especially if it does not impact you how did you find it?
       (If an issue has no concrete impact this is also helpful to know.)
     placeholder: |
       << description of how the issue affects you >>

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -64,10 +64,12 @@ body:
 
 - type: textarea
   attributes:
-    label: "Context for the issue:"
+    label: "How does this issue affect you or how did you find it:"
     description: |
-      Please explain how this issue affects your work or why it should be prioritized.
+      Please explain how this issue concretely affects you or others.
+      Especiall if it does not impact you how did you find it?
+      (If an issue has no concrete impact this is also helpful to know.)
     placeholder: |
-      << your explanation here >>
+      << description of how the issue affects you >>
   validations:
     required: false


### PR DESCRIPTION
I like the "context", but more often than not, the context is not provided or filled with rather meaningless repititions of how it *might* affect someone.

So I think it may be good to be more blunt about what at least I would like to see here (i.e. concrete impact to the reporter).