### PR TITLE
REL: Prepare for the NumPy 2.4.0 release (2)

### DIFF
--- a/numpy/_core/tests/test_multiprocessing.py
+++ b/numpy/_core/tests/test_multiprocessing.py
@@ -1,7 +1,9 @@
+import sys
+
 import pytest
 
 import numpy as np
-from numpy.testing import IS_WASM
+from numpy.testing import IS_PYPY, IS_WASM
 
 pytestmark = pytest.mark.thread_unsafe(
     reason="tests in this module are explicitly multi-processed"
@@ -28,6 +30,8 @@ def bool_array_reader(shm_name, n):
 
 @pytest.mark.skipif(IS_WASM,
                     reason="WASM does not support _posixshmem")
+@pytest.mark.skipif(IS_PYPY and sys.platform == "win32",
+                    reason="_winapi does not support UnmapViewOfFile")
 def test_read_write_bool_array():
     # See: gh-30389
     #


### PR DESCRIPTION
Don't run multiprocessing test for PyPy on Windows. PyPy uses _winapi which lacks UnmapViewOfFile. This is a known Python problem.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
