### PR TITLE
DOC: ``numpy.select``: fix ``default`` parameter docstring

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -823,7 +823,7 @@ def select(condlist, choicelist, default=0):
     choicelist : list of ndarrays
         The list of arrays from which the output elements are taken. It has
         to be of the same length as `condlist`.
-    default : scalar, optional
+    default : array_like, optional
         The element inserted in `output` when all conditions evaluate to False.
 
     Returns


### PR DESCRIPTION
This indirectly led to the typing issue reported in #30497 that was introduce to #30246 (not to pass the blame; just trying to prevent it from happening again)