### PR TITLE
REV: Revert part of #30164

### DIFF
--- a/.github/check-warnings/msvc-allowed-warnings.txt
+++ b/.github/check-warnings/msvc-allowed-warnings.txt
@@ -15,7 +15,7 @@
 C:\a\numpy\numpy\numpy\random\src\pcg64\pcg64.h(342): warning C4146: unary minus operator applied to unsigned type, result still unsigned
 D:\a\numpy\numpy\numpy\random\src\pcg64\pcg64.h(342): warning C4146: unary minus operator applied to unsigned type, result still unsigned
 cl : Command line warning D9025 : overriding '/arch:SSE2' with '/arch:AVX2'
-numpy/random/_generator.cp312-win32.pyd.p/numpy/random/_generator.pyx.c(26329): warning C4244: 'function': conversion from 'int64_t' to 'double', possible loss of data
-numpy/random/_generator.cp312-win32.pyd.p/numpy/random/_generator.pyx.c(38353): warning C4244: 'function': conversion from 'int64_t' to 'double', possible loss of data
-numpy/random/_generator.cp312-win_arm64.pyd.p/numpy/random/_generator.pyx.c(26329): warning C4244: 'function': conversion from 'int64_t' to 'double', possible loss of data
-numpy/random/_generator.cp312-win_arm64.pyd.p/numpy/random/_generator.pyx.c(38353): warning C4244: 'function': conversion from 'int64_t' to 'double', possible loss of data
+numpy/random/_generator.cp312-win32.pyd.p/numpy/random/_generator.pyx.c(26345): warning C4244: 'function': conversion from 'int64_t' to 'double', possible loss of data
+numpy/random/_generator.cp312-win32.pyd.p/numpy/random/_generator.pyx.c(38369): warning C4244: 'function': conversion from 'int64_t' to 'double', possible loss of data
+numpy/random/_generator.cp312-win_arm64.pyd.p/numpy/random/_generator.pyx.c(26345): warning C4244: 'function': conversion from 'int64_t' to 'double', possible loss of data
+numpy/random/_generator.cp312-win_arm64.pyd.p/numpy/random/_generator.pyx.c(38369): warning C4244: 'function': conversion from 'int64_t' to 'double', possible loss of data

--- a/numpy/random/bit_generator.pxd
+++ b/numpy/random/bit_generator.pxd
@@ -33,3 +33,8 @@ cdef class SeedSequence():
 
 cdef class SeedlessSeedSequence:
     pass
+
+# NOTE: This has no implementation and should not be used. It purely exists for
+# backwards compatibility, see https://github.com/scipy/scipy/issues/24215.
+cdef class SeedlessSequence:
+    pass


### PR DESCRIPTION
The removal of this *unused* `SeedlessSequence` declaration (in #30164) broke every library that uses the `numpy.random` Cython API. Specifically, the wheels that were built against `numpy<2.4.0`. See https://github.com/scipy/scipy/issues/24215 for the full discussion.