### PR TITLE
REV: Revert part of #30164 (#30500)

### DIFF
--- a/numpy/random/bit_generator.pxd
+++ b/numpy/random/bit_generator.pxd
@@ -33,3 +33,8 @@ cdef class SeedSequence():
 
 cdef class SeedlessSeedSequence:
     pass
+
+# NOTE: This has no implementation and should not be used. It purely exists for
+# backwards compatibility, see https://github.com/scipy/scipy/issues/24215.
+cdef class SeedlessSequence:
+    pass


### PR DESCRIPTION
Backport of #30500.

The removal of this unused SeedlessSequence declaration (in https://github.com/numpy/numpy/pull/30164) broke every library that uses the numpy.random Cython API. Specifically, the wheels that were built against numpy<2.4.0. See https://github.com/scipy/scipy/issues/24215 for the full discussion.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
