### PR TITLE
BUG: fix heap overflow in fixed-width string multiply

### DIFF
--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -177,9 +177,11 @@ string_multiply(Buffer<enc> buf1, npy_int64 reps, Buffer<enc> out)
     }
 
     size_t width = out.buffer_width();
+    // we know this is positive
+    size_t reps_ = (size_t)reps;
 
     if (len1 == 1) {
-        size_t end_index = reps > width ? width : reps;
+        size_t end_index = reps_ > width ? width : reps_;
         out.buffer_memset(*buf1, end_index);
         out.buffer_fill_with_zeros_after_index(end_index);
         return 0;

--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -176,9 +176,12 @@ string_multiply(Buffer<enc> buf1, npy_int64 reps, Buffer<enc> out)
         return 0;
     }
 
+    size_t width = out.buffer_width();
+
     if (len1 == 1) {
-        out.buffer_memset(*buf1, reps);
-        out.buffer_fill_with_zeros_after_index(reps);
+        size_t end_index = reps > width ? width : reps;
+        out.buffer_memset(*buf1, end_index);
+        out.buffer_fill_with_zeros_after_index(end_index);
         return 0;
     }
 
@@ -188,7 +191,6 @@ string_multiply(Buffer<enc> buf1, npy_int64 reps, Buffer<enc> out)
     }
 
     size_t pad = 0;
-    size_t width = out.buffer_width();
     if (width < newlen) {
         reps = width / len1;
         pad = width % len1;

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -192,6 +192,14 @@ def test_large_string_cast():
         a.astype("U")
 
 
+@pytest.mark.parametrize("dt", ["S1", "U1"])
+def test_in_place_mutiply_no_overflow(dt):
+    # see gh-30495
+    a = np.array("a", dtype=dt)
+    a *= 20
+    assert_array_equal(a, np.array("a", dtype=dt))
+
+
 @pytest.mark.parametrize("dt", ["S", "U", "T"])
 class TestMethods:
 


### PR DESCRIPTION
Fixes #30495.

I missed this case working on https://github.com/numpy/numpy/pull/29060.