### PR TITLE
ENH: use more fine-grained critical sections in array coercion internals

### DIFF
--- a/numpy/_core/src/common/npy_pycompat.h
+++ b/numpy/_core/src/common/npy_pycompat.h
@@ -34,7 +34,7 @@
         }                                                               \
     }
 #else
-#define NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original) {
+#define NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original) { do { (void)(original); } while (0)
 #define NPY_END_CRITICAL_SECTION_SEQUENCE_FAST() }
 #endif
 

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -1159,7 +1159,7 @@ PyArray_DiscoverDTypeAndShape_Recursive(
         return -1;
     }
 
-    int ret;
+    int ret = -1;
 
     NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(obj);
 
@@ -1182,7 +1182,6 @@ PyArray_DiscoverDTypeAndShape_Recursive(
 
     /* Allow keyboard interrupts. See gh issue 18117. */
     if (PyErr_CheckSignals() < 0) {
-        ret = -1;
         goto finish;
     }
 
@@ -1203,7 +1202,6 @@ PyArray_DiscoverDTypeAndShape_Recursive(
                 flags, copy);
 
         if (max_dims < 0) {
-            ret = -1;
             goto finish;
         }
     }

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -1209,7 +1209,7 @@ PyArray_DiscoverDTypeAndShape_Recursive(
     }
     ret = max_dims;
 
-  finish:
+  finish:;
 
     NPY_END_CRITICAL_SECTION_SEQUENCE_FAST();
 

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -1159,6 +1159,10 @@ PyArray_DiscoverDTypeAndShape_Recursive(
         return -1;
     }
 
+    int ret;
+
+    NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(obj);
+
     npy_intp size = PySequence_Fast_GET_SIZE(seq);
     PyObject **objects = PySequence_Fast_ITEMS(seq);
 
@@ -1166,17 +1170,20 @@ PyArray_DiscoverDTypeAndShape_Recursive(
                      out_shape, 1, &size, NPY_TRUE, flags) < 0) {
         /* But do update, if there this is a ragged case */
         *flags |= FOUND_RAGGED_ARRAY;
-        return max_dims;
+        ret = max_dims;
+        goto finish;
     }
     if (size == 0) {
         /* If the sequence is empty, this must be the last dimension */
         *flags |= MAX_DIMS_WAS_REACHED;
-        return curr_dims + 1;
+        ret = curr_dims + 1;
+        goto finish;
     }
 
     /* Allow keyboard interrupts. See gh issue 18117. */
     if (PyErr_CheckSignals() < 0) {
-        return -1;
+        ret = -1;
+        goto finish;
     }
 
     /*
@@ -1196,10 +1203,17 @@ PyArray_DiscoverDTypeAndShape_Recursive(
                 flags, copy);
 
         if (max_dims < 0) {
-            return -1;
+            ret = -1;
+            goto finish;
         }
     }
-    return max_dims;
+    ret = max_dims;
+
+  finish:
+
+    NPY_END_CRITICAL_SECTION_SEQUENCE_FAST();
+
+    return ret;
 }
 
 

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1571,8 +1571,6 @@ PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
         copy = 1;
     }
 
-    Py_BEGIN_CRITICAL_SECTION(op);
-
     ndim = PyArray_DiscoverDTypeAndShape(
             op, max_depth, dims, &cache, in_DType, in_descr, &dtype,
             copy, &was_copied_by__array__);
@@ -1741,7 +1739,6 @@ PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
 cleanup:;
 
     Py_XDECREF(dtype);
-    Py_END_CRITICAL_SECTION();
     return (PyObject *)ret;
 }
 

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -562,7 +562,8 @@ PyArray_AssignFromCache_Recursive(
             }
         }
 
-    finish_section:
+    finish_section:;
+
         NPY_END_CRITICAL_SECTION_SEQUENCE_FAST();
     }
     Py_DECREF(obj);

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -520,7 +520,7 @@ PyArray_AssignFromCache_Recursive(
         assert(depth != ndim);
         npy_intp orig_length = PyArray_DIMS(self)[0];
         for (npy_intp i = 0; i < orig_length; i++) {
-            int critical_section_error = 0;
+            int err = 0;
             // this macro takes *the argument* of PySequence_Fast, which is orig_seq;
             // not the object returned by PySequence_Fast, which is obj
             NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(orig_seq);
@@ -529,14 +529,14 @@ PyArray_AssignFromCache_Recursive(
                 PyErr_SetString(PyExc_RuntimeError,
                                 "Inconsistent object during array creation? "
                                 "Content of sequences changed (length inconsistent).");
-                critical_section_error = 1;
+                err = 1;
             }
             else {
                 Py_XSETREF(item_pyvalue, Py_NewRef(PySequence_Fast_GET_ITEM(obj, i)));
             }
             NPY_END_CRITICAL_SECTION_SEQUENCE_FAST();
 
-            if (critical_section_error) {
+            if (err) {
                 goto finish;
             }
 

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -522,7 +522,9 @@ PyArray_AssignFromCache_Recursive(
         for (npy_intp i = 0; i < orig_length; i++) {
             int err = 0;
             // this macro takes *the argument* of PySequence_Fast, which is orig_seq;
-            // not the object returned by PySequence_Fast, which is obj
+            // not the object returned by PySequence_Fast, which is a proxy object
+            // with its own per-object PyMutex lock.
+            // We want to lock the list object exposed to users, not the proxy.
             NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(orig_seq);
             npy_intp length = PySequence_Fast_GET_SIZE(obj);
             if (length != orig_length) {

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -495,8 +495,8 @@ PyArray_AssignFromCache_Recursive(
 {
     /* Consume first cache element by extracting information and freeing it */
     PyObject *obj = (*cache)->arr_or_sequence;
-    PyObject *orig_obj = (*cache)->converted_obj;
     Py_INCREF(obj);
+    PyObject *orig_obj = (*cache)->converted_obj;
     npy_bool sequence = (*cache)->sequence;
     int depth = (*cache)->depth;
     int ret = 0;
@@ -514,7 +514,7 @@ PyArray_AssignFromCache_Recursive(
         assert(depth != ndim);
         // this macro thakes *the argument* of PySequence_Fast, which is orig_obj;
         // not the object returned by PySequence_Fast, which is obj
-        NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(orig_obj)
+        NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(orig_obj);
         npy_intp length = PySequence_Length(obj);
         if (length != PyArray_DIMS(self)[0]) {
             PyErr_SetString(PyExc_RuntimeError,

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -524,7 +524,7 @@ PyArray_AssignFromCache_Recursive(
             // this macro takes *the argument* of PySequence_Fast, which is orig_seq;
             // not the object returned by PySequence_Fast, which is obj
             NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(orig_seq);
-            npy_intp length = PySequence_Length(obj);
+            npy_intp length = PySequence_Fast_GET_SIZE(obj);
             if (length != orig_length) {
                 PyErr_SetString(PyExc_RuntimeError,
                                 "Inconsistent object during array creation? "

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -1354,7 +1354,7 @@ arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args,
     if (fast_seq == NULL) {
         return NULL;
     }
-    NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(args)
+    NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(args);
     n = PySequence_Fast_GET_SIZE(fast_seq);
     if (n > NPY_MAXARGS) {
         ret = multiiter_wrong_number_of_args();
@@ -1362,7 +1362,7 @@ arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args,
         ret = multiiter_new_impl(n, PySequence_Fast_ITEMS(fast_seq));
     }
     Py_DECREF(fast_seq);
-    NPY_END_CRITICAL_SECTION_SEQUENCE_FAST()
+    NPY_END_CRITICAL_SECTION_SEQUENCE_FAST();
     return ret;
 }
 

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -336,7 +336,6 @@ def test_arg_locking(kernel, outcome):
 
     def read_arrs(b):
         nonlocal done
-        nonlocal arrs
         b.wait()
         try:
             kernel(arrs)
@@ -344,8 +343,6 @@ def test_arg_locking(kernel, outcome):
             done += 1
 
     def contract_and_expand_list(b):
-        nonlocal done
-        nonlocal arrs
         b.wait()
         while done < 4:
             if len(arrs) > 10:
@@ -354,8 +351,6 @@ def test_arg_locking(kernel, outcome):
                 arrs.extend([np.array([1, 2, 3]) for _ in range(1000)])
 
     def replace_list_items(b):
-        nonlocal done
-        nonlocal arrs
         b.wait()
         rng = np.random.RandomState()
         rng.seed(0x4d3d3d3)
@@ -368,7 +363,7 @@ def test_arg_locking(kernel, outcome):
         try:
             with concurrent.futures.ThreadPoolExecutor(max_workers=5) as tpe:
                 tasks = [tpe.submit(read_arrs, b) for _ in range(4)]
-                tasks.append(tpe.submit(replace_list_items, b))
+                tasks.append(tpe.submit(mutation_func, b))
                 for t in tasks:
                     t.result()
         except RuntimeError as e:

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -376,7 +376,8 @@ def test_arg_locking(kernel, outcome):
                 if outcome == "success":
                     raise
                 assert "Inconsistent object during array creation?" in str(e)
-                assert mutation_func is contract_and_expand_list, "replace_list_items should not raise errors"
+                msg = "replace_list_items should not raise errors"
+                assert mutation_func is contract_and_expand_list, msg
             finally:
                 if len(tasks) < 5:
                     b.abort()

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -361,7 +361,6 @@ def test_arg_locking(kernel, outcome):
         rng.seed(0x4d3d3d3)
         while done < 4:
             data = rng.randint(0, 1000, size=4)
-            print(data)
             arrs[data[0]] = data[1:]
 
     for mutation_func in (replace_list_items, contract_and_expand_list):

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -325,12 +325,11 @@ def create_nditer(arrs):
     (
         (np_broadcast, "error"),
         (create_array, "error"),
-        (create_nditer, "success")
-    )
+        (create_nditer, "success"),
+    ),
 )
 def test_arg_locking(kernel, outcome):
     # should complete without triggering races but may error
-    # changing
 
     b = threading.Barrier(5)
     done = 0

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -364,20 +364,20 @@ def test_arg_locking(kernel, outcome):
             print(data)
             arrs[data[0]] = data[1:]
 
-        for mutation_func in (replace_list_items, contract_and_expand_list):
-            b = threading.Barrier(5)
-            try:
-                with concurrent.futures.ThreadPoolExecutor(max_workers=5) as tpe:
-                    tasks = [tpe.submit(read_arrs, b) for _ in range(4)]
-                    tasks.append(tpe.submit(replace_list_items, b))
-                    for t in tasks:
-                        t.result()
-            except RuntimeError as e:
-                if outcome == "success":
-                    raise
-                assert "Inconsistent object during array creation?" in str(e)
-                msg = "replace_list_items should not raise errors"
-                assert mutation_func is contract_and_expand_list, msg
-            finally:
-                if len(tasks) < 5:
-                    b.abort()
+    for mutation_func in (replace_list_items, contract_and_expand_list):
+        b = threading.Barrier(5)
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=5) as tpe:
+                tasks = [tpe.submit(read_arrs, b) for _ in range(4)]
+                tasks.append(tpe.submit(replace_list_items, b))
+                for t in tasks:
+                    t.result()
+        except RuntimeError as e:
+            if outcome == "success":
+                raise
+            assert "Inconsistent object during array creation?" in str(e)
+            msg = "replace_list_items should not raise errors"
+            assert mutation_func is contract_and_expand_list, msg
+        finally:
+            if len(tasks) < 5:
+                b.abort()

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -308,15 +308,15 @@ def test_nonzero(dtype):
 
 # These are all implemented using PySequence_Fast, which needs locking to be safe
 def np_broadcast(arrs):
-    for i in range(100):
+    for i in range(50):
         np.broadcast(arrs)
 
 def create_array(arrs):
-    for i in range(100):
+    for i in range(50):
         np.array(arrs)
 
 def create_nditer(arrs):
-    for i in range(1000):
+    for i in range(50):
         np.nditer(arrs)
 
 
@@ -331,19 +331,21 @@ def create_nditer(arrs):
 def test_arg_locking(kernel, outcome):
     # should complete without triggering races but may error
 
-    b = threading.Barrier(5)
     done = 0
-    arrs = []
+    arrs = [np.array([1, 2, 3]) for _ in range(1000)]
 
-    def read_arrs():
+    def read_arrs(b):
         nonlocal done
+        nonlocal arrs
         b.wait()
         try:
             kernel(arrs)
         finally:
             done += 1
 
-    def mutate_list():
+    def contract_and_expand_list(b):
+        nonlocal done
+        nonlocal arrs
         b.wait()
         while done < 4:
             if len(arrs) > 10:
@@ -351,14 +353,30 @@ def test_arg_locking(kernel, outcome):
             elif len(arrs) <= 10:
                 arrs.extend([np.array([1, 2, 3]) for _ in range(1000)])
 
-    arrs = [np.array([1, 2, 3]) for _ in range(1000)]
-    try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as tpe:
-            tasks = [tpe.submit(read_arrs) for _ in range(4)]
-            tasks.append(tpe.submit(mutate_list))
-            for t in tasks:
-                t.result()
-    except RuntimeError as e:
-        assert "Inconsistent object during array creation?" in str(e)
-        if outcome == "success":
-            raise
+    def replace_list_items(b):
+        nonlocal done
+        nonlocal arrs
+        b.wait()
+        rng = np.random.RandomState()
+        rng.seed(0x4d3d3d3)
+        while done < 4:
+            data = rng.randint(0, 1000, size=4)
+            print(data)
+            arrs[data[0]] = data[1:]
+
+        for mutation_func in (replace_list_items, contract_and_expand_list):
+            b = threading.Barrier(5)
+            try:
+                with concurrent.futures.ThreadPoolExecutor(max_workers=5) as tpe:
+                    tasks = [tpe.submit(read_arrs, b) for _ in range(4)]
+                    tasks.append(tpe.submit(replace_list_items, b))
+                    for t in tasks:
+                        t.result()
+            except RuntimeError as e:
+                if outcome == "success":
+                    raise
+                assert "Inconsistent object during array creation?" in str(e)
+                assert mutation_func is contract_and_expand_list, "replace_list_items should not raise errors"
+            finally:
+                if len(tasks) < 5:
+                    b.abort()


### PR DESCRIPTION
Towards addressing #30494. Right now the critical section I remove here in `PyArray_FromAny_int` shows up in the profile for the script in that issue.

I added the critical section in 5a031d9b8822551711973e6ae220cd00817c9523 and this partially reverts that change. On reflection, it's not a good idea to introduce a scaling bottleneck here in service of a sort of wonky thing to do: mutating the operand of `np.array()` while the array is being created.

Instead, we should error in those cases. Like we already do without the critical section!

I also needed to add new, more fine-grained critical sections, in `PyArray_DiscoverDTypeAndShape_Recursive` and `PyArray_AssignFromCache_Recursive` to avoid data races due to use of the `PySequence_Fast` API.

I also updated the tests for this to allow the cases affected by this to raise errors instead of succeeding, since that success relies on introducing scaling bottlenecks for valid read-only uses.

Here's a Samply profile output run using this PR on the script from #30494 - I no longer see a scaling bottleneck inside the array coercion routines: https://share.firefox.dev/44KLZxs