### PR TITLE
BUG: avoid uninitialized variable access in dtype __setstate__

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2874,21 +2874,21 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
     int incref_names = 1;
     npy_int64 signed_dtypeflags = 0;
     npy_uint64 dtypeflags;
+if (PyTuple_GET_SIZE(args) != 1 ||
+        !PyTuple_Check(PyTuple_GET_ITEM(args, 0))) {
+    PyErr_BadInternalCall();
+    return NULL;
+}
 
-    if (!PyDataType_ISLEGACY(self)) {
-        PyErr_SetString(PyExc_RuntimeError,
-                "Cannot unpickle new style DType without custom methods.");
-        return NULL;
-    }
+PyObject *state = PyTuple_GET_ITEM(args, 0);
+Py_ssize_t n = PyTuple_GET_SIZE(state);
 
-    if (self->fields == Py_None) {
-        Py_RETURN_NONE;
-    }
-    if (PyTuple_GET_SIZE(args) != 1
-            || !(PyTuple_Check(PyTuple_GET_ITEM(args, 0)))) {
-        PyErr_BadInternalCall();
-        return NULL;
-    }
+/* Valid pickle state sizes are 5–9 */
+if (n < 5 || n > 9) {
+    PyErr_SetString(PyExc_ValueError,
+            "invalid numpy.dtype pickle state");
+    return NULL;
+}
     switch (PyTuple_GET_SIZE(PyTuple_GET_ITEM(args,0))) {
     case 9:
         if (!PyArg_ParseTuple(args, "(iOOOOnnkO):__setstate__",

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2880,14 +2880,20 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
 
     if (!PyDataType_ISLEGACY(self)) {
         PyErr_SetString(PyExc_RuntimeError,
-            "Cannot unpickle new style DType without custom methods.");
-            return NULL;
-        }
+                "Cannot unpickle new style DType without custom methods.");
+        return NULL;
+    }
+
+    if (self->fields == Py_None) {
+        Py_RETURN_NONE;
+    }
+
     if (PyTuple_GET_SIZE(args) != 1 ||
             !PyTuple_Check(PyTuple_GET_ITEM(args, 0))) {
         PyErr_BadInternalCall();
         return NULL;
     }
+
     PyObject *state = PyTuple_GET_ITEM(args, 0);
     Py_ssize_t n = PyTuple_GET_SIZE(state);
     
@@ -2897,56 +2903,57 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
                 "invalid numpy.dtype pickle state");
         return NULL;
     }
+
     switch (n) {
         case 9:
-        if (!PyArg_ParseTuple(args, "(iOOOOnnkO):__setstate__",
-                    &version, &endian_obj,
-                    &subarray, &names, &fields, &elsize,
-                    &alignment, &signed_dtypeflags, &metadata)) {
-            PyErr_Clear();
-            return NULL;
-        }
-        break;
-    case 8:
-        if (!PyArg_ParseTuple(args, "(iOOOOnnk):__setstate__",
-                    &version, &endian_obj,
-                    &subarray, &names, &fields, &elsize,
-                    &alignment, &signed_dtypeflags)) {
-            return NULL;
-        }
-        break;
-    case 7:
-        if (!PyArg_ParseTuple(args, "(iOOOOnn):__setstate__",
-                    &version, &endian_obj,
-                    &subarray, &names, &fields, &elsize,
-                    &alignment)) {
-            return NULL;
-        }
-        break;
-    case 6:
-        if (!PyArg_ParseTuple(args, "(iOOOnn):__setstate__",
-                    &version,
-                    &endian_obj, &subarray, &fields,
-                    &elsize, &alignment)) {
-            return NULL;
-        }
-        break;
-    case 5:
-        version = 0;
-        if (!PyArg_ParseTuple(args, "(OOOnn):__setstate__",
-                    &endian_obj, &subarray, &fields, &elsize,
-                    &alignment)) {
-            return NULL;
-        }
-        break;
-    default:
-        /* raise an error */
-        if (PyTuple_GET_SIZE(PyTuple_GET_ITEM(args,0)) > 5) {
-            version = PyLong_AsLong(PyTuple_GET_ITEM(args, 0));
-        }
-        else {
-            version = -1;
-        }
+            if (!PyArg_ParseTuple(args, "(iOOOOnnkO):__setstate__",
+                        &version, &endian_obj,
+                        &subarray, &names, &fields, &elsize,
+                        &alignment, &signed_dtypeflags, &metadata)) {
+                PyErr_Clear();
+                return NULL;
+            }
+            break;
+        case 8:
+            if (!PyArg_ParseTuple(args, "(iOOOOnnk):__setstate__",
+                        &version, &endian_obj,
+                        &subarray, &names, &fields, &elsize,
+                        &alignment, &signed_dtypeflags)) {
+                return NULL;
+            }
+            break;
+        case 7:
+            if (!PyArg_ParseTuple(args, "(iOOOOnn):__setstate__",
+                        &version, &endian_obj,
+                        &subarray, &names, &fields, &elsize,
+                        &alignment)) {
+                return NULL;
+            }
+            break;
+        case 6:
+            if (!PyArg_ParseTuple(args, "(iOOOnn):__setstate__",
+                        &version,
+                        &endian_obj, &subarray, &fields,
+                        &elsize, &alignment)) {
+                return NULL;
+            }
+            break;
+        case 5:
+            version = 0;
+            if (!PyArg_ParseTuple(args, "(OOOnn):__setstate__",
+                        &endian_obj, &subarray, &fields, &elsize,
+                        &alignment)) {
+                return NULL;
+            }
+            break;
+        default:
+            /* raise an error */
+            if (PyTuple_GET_SIZE(PyTuple_GET_ITEM(args,0)) > 5) {
+                version = PyLong_AsLong(PyTuple_GET_ITEM(args, 0));
+            }
+            else {
+                version = -1;
+            }
     }
 
     /*

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1640,6 +1640,12 @@ def interp(x, xp, fp, left=None, right=None, period=None):
     """
 
     fp = np.asarray(fp)
+    # Special-case fully empty input: np.interp([], [], [])
+    if period is None:
+        x_arr = np.asarray(x)
+        if x_arr.size == 0 and len(xp) == 0:
+            return x_arr.astype(fp.dtype, copy=False)
+
 
     if np.iscomplexobj(fp):
         interp_func = compiled_interp_complex

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1638,12 +1638,7 @@ def interp(x, xp, fp, left=None, right=None, period=None):
     array([0.+1.j , 1.+1.5j])
 
     """
-    fp = np.asarray(fp)
-    # Special-case fully empty input: np.interp([], [], [])
-    if period is None:
-        x_arr = np.asarray(x)
-        if x_arr.size == 0 and len(xp) == 0:
-            return x_arr.astype(fp.dtype, copy=False)
+
     if np.iscomplexobj(fp):
         interp_func = compiled_interp_complex
         input_dtype = np.complex128

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1638,15 +1638,12 @@ def interp(x, xp, fp, left=None, right=None, period=None):
     array([0.+1.j , 1.+1.5j])
 
     """
-
     fp = np.asarray(fp)
     # Special-case fully empty input: np.interp([], [], [])
     if period is None:
         x_arr = np.asarray(x)
         if x_arr.size == 0 and len(xp) == 0:
             return x_arr.astype(fp.dtype, copy=False)
-
-
     if np.iscomplexobj(fp):
         interp_func = compiled_interp_complex
         input_dtype = np.complex128

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3215,6 +3215,11 @@ class TestInterp:
         assert_equal(np.interp(0.5, [0, 1], sc([+np.inf,      10])), sc(+np.inf))
         assert_equal(np.interp(0.5, [0, 1], sc([-np.inf, -np.inf])), sc(-np.inf))
         assert_equal(np.interp(0.5, [0, 1], sc([+np.inf, +np.inf])), sc(+np.inf))
+        
+    def test_interp_empty_inputs(self):
+        result = np.interp([], [], [])
+        assert result.shape == (0,)
+
 
     def test_complex_interp(self):
         # test complex interpolation

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3215,11 +3215,10 @@ class TestInterp:
         assert_equal(np.interp(0.5, [0, 1], sc([+np.inf,      10])), sc(+np.inf))
         assert_equal(np.interp(0.5, [0, 1], sc([-np.inf, -np.inf])), sc(-np.inf))
         assert_equal(np.interp(0.5, [0, 1], sc([+np.inf, +np.inf])), sc(+np.inf))
-        
+
     def test_interp_empty_inputs(self):
         result = np.interp([], [], [])
         assert result.shape == (0,)
-
 
     def test_complex_interp(self):
         # test complex interpolation


### PR DESCRIPTION
Fix undefined behavior in arraydescr_setstate when unpickling malformed
numpy.dtype pickle states by ensuring invalid state sizes fail early.

This avoids access to uninitialized C variables and makes failures
deterministic at the Python level.

See gh-30476.
