### PR TITLE
ENH: optimizing np.searchsorted and adding benchmarks

### DIFF
--- a/benchmarks/benchmarks/bench_searchsorted.py
+++ b/benchmarks/benchmarks/bench_searchsorted.py
@@ -1,0 +1,29 @@
+import numpy as np
+from .common import Benchmark
+
+class SearchSortedInt64(Benchmark):
+    # Benchmark for np.searchsorted with int64 arrays
+    params = [
+        # 1B u64 is 8gb
+        [100, 10_000, 1_000_000, 1_000_000_000],       # array sizes
+        [1, 2, 100, 100_000],   # number of query elements
+        ['ordered', 'random'],        # query order
+        [42, 18122022]
+    ]
+    param_names = ['array_size', 'n_queries', 'query_order', 'seed']
+
+    def setup(self, array_size, n_queries, query_order, seed):
+        self.arr = np.arange(array_size, dtype=np.int64)
+
+        rng = np.random.default_rng(seed)
+
+        low = -array_size // 10
+        high = array_size + array_size // 10
+        self.queries = rng.integers(low, high, size=n_queries, dtype=np.int64)
+
+        # Generate queries
+        if query_order == 'ordered':
+            self.queries.sort()
+
+    def time_searchsorted(self, array_size, n_queries, query_order, seed):
+        np.searchsorted(self.arr, self.queries)

--- a/benchmarks/benchmarks/bench_searchsorted.py
+++ b/benchmarks/benchmarks/bench_searchsorted.py
@@ -1,5 +1,7 @@
 import numpy as np
+
 from .common import Benchmark
+
 
 class SearchSortedInt64(Benchmark):
     # Benchmark for np.searchsorted with int64 arrays

--- a/benchmarks/benchmarks/bench_searchsorted.py
+++ b/benchmarks/benchmarks/bench_searchsorted.py
@@ -8,7 +8,7 @@ class SearchSorted(Benchmark):
         [100, 10_000, 1_000_000, 100_000_000],  # array sizes
         [1, 10, 100_000],                       # number of query elements
         ['ordered', 'random'],                  # query order
-        [False, True],                          # use sorted
+        [False, True],                          # use sorter
         [42, 18122022],                         # seed
     ]
     param_names = ['array_size', 'n_queries', 'query_order', 'use_sorter', 'seed']

--- a/benchmarks/benchmarks/bench_searchsorted.py
+++ b/benchmarks/benchmarks/bench_searchsorted.py
@@ -10,7 +10,7 @@ class SearchSortedInt64(Benchmark):
         [100, 10_000, 1_000_000, 1_000_000_000],       # array sizes
         [1, 2, 100, 100_000],   # number of query elements
         ['ordered', 'random'],        # query order
-        [42, 18122022]
+        [42, 18122022],   # seed
     ]
     param_names = ['array_size', 'n_queries', 'query_order', 'seed']
 

--- a/benchmarks/benchmarks/bench_searchsorted.py
+++ b/benchmarks/benchmarks/bench_searchsorted.py
@@ -3,7 +3,7 @@ import numpy as np
 from .common import Benchmark
 
 
-class SearchSortedInt64(Benchmark):
+class SearchSorted(Benchmark):
     params = [
         [100, 10_000, 1_000_000, 100_000_000],  # array sizes
         [1, 10, 100_000],                       # number of query elements

--- a/benchmarks/benchmarks/bench_searchsorted.py
+++ b/benchmarks/benchmarks/bench_searchsorted.py
@@ -4,28 +4,32 @@ from .common import Benchmark
 
 
 class SearchSortedInt64(Benchmark):
-    # Benchmark for np.searchsorted with int64 arrays
     params = [
-        # 1B u64 is 8gb
-        [100, 10_000, 1_000_000, 1_000_000_000],       # array sizes
-        [1, 2, 100, 100_000],   # number of query elements
-        ['ordered', 'random'],        # query order
-        [42, 18122022],   # seed
+        [100, 10_000, 1_000_000, 100_000_000],  # array sizes
+        [1, 10, 100_000],                       # number of query elements
+        ['ordered', 'random'],                  # query order
+        [False, True],                          # use sorted
+        [42, 18122022],                         # seed
     ]
-    param_names = ['array_size', 'n_queries', 'query_order', 'seed']
+    param_names = ['array_size', 'n_queries', 'query_order', 'use_sorter', 'seed']
 
-    def setup(self, array_size, n_queries, query_order, seed):
-        self.arr = np.arange(array_size, dtype=np.int64)
+    def setup(self, array_size, n_queries, query_order, use_sorter, seed):
+        self.arr = np.arange(array_size, dtype=np.int32)
 
         rng = np.random.default_rng(seed)
 
         low = -array_size // 10
         high = array_size + array_size // 10
-        self.queries = rng.integers(low, high, size=n_queries, dtype=np.int64)
 
-        # Generate queries
+        self.queries = rng.integers(low, high, size=n_queries, dtype=np.int32)
         if query_order == 'ordered':
             self.queries.sort()
 
-    def time_searchsorted(self, array_size, n_queries, query_order, seed):
-        np.searchsorted(self.arr, self.queries)
+        if use_sorter:
+            rng.shuffle(self.arr)
+            self.sorter = self.arr.argsort()
+        else:
+            self.sorter = None
+
+    def time_searchsorted(self, array_size, n_queries, query_order, use_sorter, seed):
+        np.searchsorted(self.arr, self.queries, sorter=self.sorter)

--- a/doc/release/upcoming_changes/30517.performance.rst
+++ b/doc/release/upcoming_changes/30517.performance.rst
@@ -1,0 +1,8 @@
+Improved performance of ``numpy.searchsorted``
+----------------------------------------------
+The C++ binary search implementation used by ``numpy.searchsorted`` now has
+a much better performance when searching for multiple keys. The new
+implementation batches binary search steps across all keys to leverage cache
+locality and out-of-order execution. Benchmarks show the new implementation can
+be up to 20 times faster for hundreds of thousands keys while single-key
+performance remains comparable to previous versions.

--- a/numpy/_core/src/npysort/binsearch.cpp
+++ b/numpy/_core/src/npysort/binsearch.cpp
@@ -65,7 +65,7 @@ binsearch(const char *arr, const char *key, char *ret, npy_intp arr_len,
     using T = typename Tag::type;
     auto cmp = side_to_cmp<Tag, side>::value;
 
-    // Let's handle this corner case first: if length is 0 we return all 0s
+    // If the array length is 0 we return all 0s
     if (arr_len <= 0) {
         for (npy_intp i = 0; i < key_len; ++i) {
             *(npy_intp *)(ret + i * ret_str) = 0;

--- a/numpy/_core/src/npysort/binsearch.cpp
+++ b/numpy/_core/src/npysort/binsearch.cpp
@@ -104,7 +104,7 @@ binsearch(const char *arr, const char *key, char *ret, npy_intp arr_len,
     - cmp(arr[i], key_val) == true  for all i < base
     - cmp(arr[i], key_val) == false for all i >= base + length
 
-    The insertion index candidates are i in range [base, base+length] and
+    The insertion index candidates are in range [base, base+length] and
     on each iteration we shrink the range into either
         [base, ceil(length / 2)]
     or
@@ -147,8 +147,8 @@ binsearch(const char *arr, const char *key, char *ret, npy_intp arr_len,
     }
 
     /*
-    At this point interval_length == 1, so the candidates are in interval
-    [base, base + 1].
+    At this point interval_length == 1, so the candidates are in the 
+    interval [base, base + 1].
 
     We have two options:
         If cmp(arr[base], key_val) == true, insertion index is base + 1


### PR DESCRIPTION

This PR optimizes C++ `binsearch` implementation used by `np.searchsorted` for primitive types and adds benchmarks. It results on up to 25x speedup when searching for hundred thousand items. It adds some overhead for the single-query&multiple-elements case (~40ns). The PR does not cover binary search for custom object with their own `cmp` method implemented in Python.

### Idea

The main idea is to express the binary search in terms of a range `[base, base+legth]` where the length halves on each iteration. This makes each key to only need a single `base` pointer for intermediate computations. The PR uses the `ret` array to store these intermediate computations so no extra memory is needed (base eventually becomes the result after the last iteration).

The lengths used are only dependent on the initial length of the array, which allows us to batch each intermediate step of the algorithm for all keys. Basically, each key is processed against the same set of lengths.

This ends up being faster for two reasons:

1. Cache locallity of pivots. In early iterations each key is compared against the same set of pivots. For example, in the first iteration all keys are compared against the median. In the second iteration, all keys end up being compared against 1st and 3rd quartiles.
2. Independent calculations for out-of-order execution. In the single-key version, step i+1 depends on computation of step i. Meaning that step i+1 must wait for step i to complete before proceeding. When batching multiple keys, we compute each step for all keys before continuing on the next step. All the computations at a given step are independent across different keys. Meaning that the CPU can execute multiple keys out-of-order in parallel.

### A numpy vectorized version

We could also implement this algorithm in Python by just relying on numpy array broadcasting:

```python
import numpy as np

def searchsorted_np(arr, keys, side="left"):
    N = arr.shape[0]
    K = keys.shape[0]

    result = np.zeros(K, dtype=np.intp)
    length = N

    if side == "left":
        cmp = np.less
    elif side == "right":
        cmp = np.less_equal

    while length > 1:
        half = length >> 1
        mid = result + half
        mid_val = arr[mid]
        move = cmp(mid_val, keys)
        result += move.astype(np.intp) * half
        length -= half

    mid_val = arr[result]
    move = cmp(mid_val, keys)
    result += move.astype(np.intp)

    return result
```

A quick benchmark shows this approach to be significantly faster than current implementation when quering multiple keys:

```python
import numpy as np
import timeit

np.random.seed(42)

N = 5_000_000
K = 100_000

arr = np.sort(np.random.randint(0, 10_000_000, size=N))
keys = np.random.randint(0, 10_000_000, size=K)

setup = """
import numpy as np
from __main__ import arr, keys, searchsorted_np
"""
number = 10

stmt_np = "np.searchsorted(arr, keys, side='left')"
stmt_my = "searchsorted_np(arr, keys, side='left')"

time_np = timeit.timeit(stmt=stmt_np, setup=setup, number=number)
time_my = timeit.timeit(stmt=stmt_my, setup=setup, number=number)

print((np.searchsorted(arr, keys, side='left') == searchsorted_np(arr, keys, side='left')).all())
print(f"np.searchsorted: {time_np/number:.4f}s per run")
print(f"searchsorted_np: {time_my/number:.4f}s per run")
```

```
True
np.searchsorted: 0.1160s per run
searchsorted_np: 0.0079s per run
```

Which is 15x faster (numpy beats numpy!). Although it does not beat the C++ implementation from the PR:

```
True
np.searchsorted: 0.0052s per run
searchsorted_np: 0.0081s per run
```

### Drawbacks

The main drawback of this approach is that we do `length = ceil(length / 2)` on each iteration. The PR algorithm always does exactly `ceil(log(lenght))` iterations whereas the current implementation might only require `floor(log(lenght))` in some cases. This extra overhead is what most-likely explains why PR's implementation is ~40ns slower for the single-key&big-array benchmarks. 

### Results

```
| Change   | Before [d9e70f6e] <main>   | After [2a94668d] <batched-binary-search>   |   Ratio | Benchmark (Parameter)                                                                                 |
|----------|----------------------------|--------------------------------------------|---------|-------------------------------------------------------------------------------------------------------|
| +        | 912±3ns                    | 1.01±0.01μs                                |    1.11 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 1, 'random', False, 18122022)       |
| +        | 873±2ns                    | 941±30ns                                   |    1.08 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 1, 'random', False, 18122022)           |
| +        | 987±10ns                   | 1.07±0.01μs                                |    1.08 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 1, 'random', True, 18122022)          |
| +        | 914±3ns                    | 990±2ns                                    |    1.08 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 1, 'random', False, 42)             |
| +        | 918±9ns                    | 978±4ns                                    |    1.07 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 1, 'ordered', False, 42)            |
| +        | 862±1ns                    | 918±10ns                                   |    1.06 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 1, 'ordered', False, 42)                |
| +        | 947±20ns                   | 1.01±0.01μs                                |    1.06 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 1, 'random', True, 18122022)            |
| +        | 887±1ns                    | 936±10ns                                   |    1.06 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 1, 'random', False, 18122022)         |
| +        | 872±9ns                    | 915±30ns                                   |    1.05 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 1, 'ordered', False, 18122022)          |
| +        | 981±8ns                    | 1.03±0.01μs                                |    1.05 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 1, 'ordered', True, 42)               |
| +        | 1.00±0.01μs                | 1.05±0.02μs                                |    1.05 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 1, 'random', True, 42)                |
| +        | 926±10ns                   | 976±4ns                                    |    1.05 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 1, 'ordered', False, 18122022)      |
| +        | 932±8ns                    | 967±7ns                                    |    1.04 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 1, 'ordered', True, 18122022)           |
| +        | 945±3ns                    | 985±20ns                                   |    1.04 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 1, 'ordered', True, 42)                 |
| +        | 870±2ns                    | 904±20ns                                   |    1.04 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 1, 'random', False, 42)                 |
| +        | 894±5ns                    | 928±3ns                                    |    1.04 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 1, 'ordered', False, 42)              |
| +        | 890±2ns                    | 929±8ns                                    |    1.04 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 1, 'random', False, 42)               |
| +        | 1.00±0.01μs                | 1.03±0.01μs                                |    1.02 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 1, 'ordered', True, 18122022)         |
| -        | 1.05±0μs                   | 950±8ns                                    |    0.91 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 10, 'ordered', False, 42)                 |
| -        | 1.07±0.01μs                | 950±4ns                                    |    0.89 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 10, 'random', False, 42)                  |
| -        | 1.07±0.01μs                | 943±4ns                                    |    0.88 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 10, 'ordered', False, 18122022)           |
| -        | 1.09±0.01μs                | 948±8ns                                    |    0.87 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 10, 'random', False, 18122022)            |
| -        | 1.23±0μs                   | 1.04±0μs                                   |    0.85 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 10, 'ordered', True, 42)                  |
| -        | 1.26±0μs                   | 1.06±0.02μs                                |    0.84 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 10, 'random', True, 42)                   |
| -        | 1.37±0.01μs                | 1.13±0.01μs                                |    0.83 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 10, 'ordered', False, 18122022)         |
| -        | 1.26±0.01μs                | 1.03±0.01μs                                |    0.82 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 10, 'ordered', True, 18122022)            |
| -        | 1.30±0.01μs                | 1.06±0.02μs                                |    0.81 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 10, 'random', True, 18122022)             |
| -        | 1.37±0.02μs                | 1.11±0.01μs                                |    0.81 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 10, 'ordered', False, 42)               |
| -        | 1.36±0μs                   | 1.10±0.01μs                                |    0.81 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 10, 'random', False, 42)                |
| -        | 1.38±0.01μs                | 1.10±0μs                                   |    0.8  | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 10, 'random', False, 18122022)          |
| -        | 1.68±0.01μs                | 1.25±0.01μs                                |    0.75 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 10, 'ordered', False, 42)             |
| -        | 1.69±0.06μs                | 1.25±0.01μs                                |    0.74 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 10, 'ordered', False, 18122022)       |
| -        | 1.72±0.02μs                | 1.23±0.01μs                                |    0.71 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 10, 'ordered', True, 18122022)          |
| -        | 1.74±0.02μs                | 1.23±0μs                                   |    0.71 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 10, 'random', False, 18122022)        |
| -        | 1.76±0.01μs                | 1.23±0.08μs                                |    0.7  | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 10, 'ordered', True, 42)                |
| -        | 1.74±0.01μs                | 1.20±0.01μs                                |    0.69 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 10, 'random', True, 42)                 |
| -        | 1.76±0.03μs                | 1.22±0μs                                   |    0.69 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 10, 'random', False, 42)              |
| -        | 1.75±0.03μs                | 1.19±0.02μs                                |    0.68 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 10, 'random', True, 18122022)           |
| -        | 2.13±0.03μs                | 1.42±0.03μs                                |    0.67 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 10, 'random', False, 18122022)      |
| -        | 2.18±0.02μs                | 1.44±0.03μs                                |    0.66 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 10, 'random', False, 42)            |
| -        | 2.19±0.03μs                | 1.39±0μs                                   |    0.64 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 10, 'ordered', False, 18122022)     |
| -        | 2.48±0.01μs                | 1.56±0.01μs                                |    0.63 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 10, 'ordered', True, 18122022)        |
| -        | 2.26±0.06μs                | 1.40±0.01μs                                |    0.62 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 10, 'ordered', False, 42)           |
| -        | 2.59±0.03μs                | 1.58±0.02μs                                |    0.61 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 10, 'ordered', True, 42)              |
| -        | 2.63±0.02μs                | 1.53±0.02μs                                |    0.58 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 10, 'random', True, 18122022)         |
| -        | 2.68±0.01μs                | 1.55±0.01μs                                |    0.58 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 10, 'random', True, 42)               |
| -        | 2.15±0.05ms                | 449±3μs                                    |    0.21 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 100000, 'ordered', False, 42)             |
| -        | 7.80±0.1ms                 | 1.61±0.06ms                                |    0.21 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 100000, 'ordered', False, 42)         |
| -        | 2.25±0.07ms                | 447±2μs                                    |    0.2  | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 100000, 'ordered', False, 18122022)       |
| -        | 4.67±0.01ms                | 876±2μs                                    |    0.19 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 100000, 'ordered', False, 42)           |
| -        | 7.98±0.08ms                | 1.51±0.01ms                                |    0.19 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 100000, 'ordered', False, 18122022)   |
| -        | 4.76±0.1ms                 | 867±3μs                                    |    0.18 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 100000, 'ordered', False, 18122022)     |
| -        | 3.48±0.06ms                | 591±20μs                                   |    0.17 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 100000, 'ordered', True, 18122022)        |
| -        | 2.81±0.03ms                | 469±10μs                                   |    0.17 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 100000, 'random', False, 18122022)        |
| -        | 3.45±0.1ms                 | 570±2μs                                    |    0.16 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 100000, 'ordered', True, 42)              |
| -        | 2.81±0.06ms                | 454±8μs                                    |    0.16 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 100000, 'random', False, 42)              |
| -        | 5.46±0.01ms                | 895±3μs                                    |    0.16 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 100000, 'random', False, 18122022)      |
| -        | 5.49±0.04ms                | 900±6μs                                    |    0.16 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 100000, 'random', False, 42)            |
| -        | 7.63±0.1ms                 | 1.12±0ms                                   |    0.15 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 100000, 'ordered', True, 18122022)      |
| -        | 7.47±0.1ms                 | 1.13±0.01ms                                |    0.15 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 100000, 'ordered', True, 42)            |
| -        | 26.4±4ms                   | 3.58±0.3ms                                 |    0.14 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 100000, 'ordered', True, 42)          |
| -        | 4.38±0.1ms                 | 584±10μs                                   |    0.13 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 100000, 'random', True, 18122022)         |
| -        | 4.48±0.08ms                | 593±20μs                                   |    0.13 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100, 100000, 'random', True, 42)               |
| -        | 8.75±0.04ms                | 1.15±0ms                                   |    0.13 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 100000, 'random', True, 18122022)       |
| -        | 8.77±0.04ms                | 1.17±0.02ms                                |    0.13 | bench_searchsorted.SearchSortedInt64.time_searchsorted(10000, 100000, 'random', True, 42)             |
| -        | 15.0±0.4ms                 | 1.80±0.04ms                                |    0.12 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 100000, 'random', False, 18122022)    |
| -        | 32.9±3ms                   | 3.60±0.3ms                                 |    0.11 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 100000, 'ordered', True, 18122022)    |
| -        | 16.0±0.3ms                 | 1.69±0.02ms                                |    0.11 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 100000, 'random', False, 42)          |
| -        | 52.1±6ms                   | 3.93±0.3ms                                 |    0.08 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 100000, 'random', True, 18122022)     |
| -        | 118±3ms                    | 9.08±0.1ms                                 |    0.08 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 100000, 'ordered', False, 18122022) |
| -        | 52.7±8ms                   | 3.94±0.3ms                                 |    0.07 | bench_searchsorted.SearchSortedInt64.time_searchsorted(1000000, 100000, 'random', True, 42)           |
| -        | 124±5ms                    | 8.30±0.1ms                                 |    0.07 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 100000, 'ordered', False, 42)       |
| -        | 427±1ms                    | 20.1±1ms                                   |    0.05 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 100000, 'ordered', True, 42)        |
| -        | 425±2ms                    | 17.6±0.2ms                                 |    0.04 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 100000, 'ordered', True, 18122022)  |
| -        | 212±5ms                    | 8.76±0.4ms                                 |    0.04 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 100000, 'random', False, 18122022)  |
| -        | 210±5ms                    | 8.83±0.3ms                                 |    0.04 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 100000, 'random', False, 42)        |
| -        | 522±5ms                    | 21.6±0ms                                   |    0.04 | bench_searchsorted.SearchSortedInt64.time_searchsorted(100000000, 100000, 'random', True, 42)         |
```
