### PR TITLE
CI: update debug CI to use more recent Python version

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -90,7 +90,7 @@ jobs:
         fetch-tags: true
         persist-credentials: false
     - name: Install debug Python
-      uses: deadsnakes/action@v3.2.0
+      uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
       with:
         python-version: '3.14'
         debug: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -89,23 +89,32 @@ jobs:
         submodules: recursive
         fetch-tags: true
         persist-credentials: false
-    - name: Install debug Python
+    - name: Set up pyenv
       run: |
-        sudo apt-get update
-        sudo apt-get install python3-dbg ninja-build
-    - name: Build NumPy and install into venv
+        git clone https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
+        PYENV_ROOT="$HOME/.pyenv"
+        PYENV_BIN="$PYENV_ROOT/bin"
+        PYENV_SHIMS="$PYENV_ROOT/shims"
+        echo "$PYENV_BIN" >> $GITHUB_PATH
+        echo "$PYENV_SHIMS" >> $GITHUB_PATH
+        echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
+    - name: Check pyenv is working
+      run:
+        pyenv --version
+    - name: Install Python debug build
       run: |
-        python3-dbg -m venv venv
-        source venv/bin/activate
+        CONFIGURE_OPTS="--with-pydebug" pyenv install 3.14
+        pyenv global 3.14
+    - name: Build and install NumPy
+      run: |
+        python --version
         pip install -U pip
         pip install . -v -Csetup-args=-Dbuildtype=debug -Csetup-args=-Dallow-noblas=true
     - name: Install test dependencies
       run: |
-        source venv/bin/activate
         pip install -r requirements/test_requirements.txt
     - name: Run test suite
       run: |
-        source venv/bin/activate
         cd tools
         pytest --timeout=600 --durations=10 --pyargs numpy -m "not slow"
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -89,22 +89,10 @@ jobs:
         submodules: recursive
         fetch-tags: true
         persist-credentials: false
-    - name: Set up pyenv
-      run: |
-        git clone https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
-        PYENV_ROOT="$HOME/.pyenv"
-        PYENV_BIN="$PYENV_ROOT/bin"
-        PYENV_SHIMS="$PYENV_ROOT/shims"
-        echo "$PYENV_BIN" >> $GITHUB_PATH
-        echo "$PYENV_SHIMS" >> $GITHUB_PATH
-        echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
-    - name: Check pyenv is working
-      run:
-        pyenv --version
-    - name: Install Python debug build
-      run: |
-        CONFIGURE_OPTS="--with-pydebug" pyenv install 3.14
-        pyenv global 3.14
+    - uses: deadsnakes/action@v3.2.0
+      with:
+        python-version: '3.14'
+        debug: true
     - name: Build and install NumPy
       run: |
         python --version

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -89,7 +89,8 @@ jobs:
         submodules: recursive
         fetch-tags: true
         persist-credentials: false
-    - uses: deadsnakes/action@v3.2.0
+    - name: Install debug Python
+      uses: deadsnakes/action@v3.2.0
       with:
         python-version: '3.14'
         debug: true


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Updates the debug CI to use Python 3.14. This has the added benefit of dumping C backtrace in case of a crash which is a new feature of faulthandler in 3.14.