### PR TITLE
DOC: Fix formatting in random module documentation index

### DIFF
--- a/doc/source/reference/random/index.rst
+++ b/doc/source/reference/random/index.rst
@@ -168,9 +168,9 @@ Features
 
    Parallel Applications <parallel>
    Multithreaded Generation <multithreading>
-   new-or-different
+   New or Different <new-or-different>
    Comparing Performance <performance>
-   c-api
+   C API <c-api>
    Examples of using Numba, Cython, CFFI <extending>
 
 Original Source of the Generator and BitGenerators


### PR DESCRIPTION
Fixes minor formatting inconsistencies in the random module documentation index. No functional changes.
