### PR TITLE
BUG: validate contraction axes in tensordot

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1170,6 +1170,12 @@ def tensordot(a, b, axes=2):
         axes_b = [axes_b]
         nb = 1
 
+    if len(set(axes_a)) != len(axes_a):
+        raise ValueError("duplicate axes are not allowed in tensordot")
+    if len(set(axes_b)) != len(axes_b):
+        raise ValueError("duplicate axes are not allowed in tensordot")
+
+
     a, b = asarray(a), asarray(b)
     as_ = a.shape
     nda = a.ndim

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1022,7 +1022,8 @@ def tensordot(a, b, axes=2):
         * (2,) array_like
           Or, a list of axes to be summed over, first sequence applying to `a`,
           second to `b`. Both elements array_like must be of the same length.
-
+          Each axis may appear at most once; repeated axes are not allowed.
+          For example, ``axes=([1, 1], [0, 0])`` is invalid.
     Returns
     -------
     output : ndarray
@@ -1052,6 +1053,13 @@ def tensordot(a, b, axes=2):
     two sequences of the same length, with the first axis to sum over given
     first in both sequences, the second axis second, and so forth.
     The calculation can be referred to ``numpy.einsum``.
+
+    For example, if ``a.shape == (2, 3, 4)`` and ``b.shape == (3, 4, 5)``,
+    then ``axes=([1, 2], [0, 1])`` sums over the ``(3, 4)`` dimensions of
+    both arrays and produces an output of shape ``(2, 5)``.
+
+    Each summation axis corresponds to a distinct contraction index; repeating
+    an axis (for example ``axes=([1, 1], [0, 0])``) is invalid.
 
     The shape of the result consists of the non-contracted axes of the
     first tensor, followed by the non-contracted axes of the second.

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1175,7 +1175,6 @@ def tensordot(a, b, axes=2):
     if len(set(axes_b)) != len(axes_b):
         raise ValueError("duplicate axes are not allowed in tensordot")
 
-
     a, b = asarray(a), asarray(b)
     as_ = a.shape
     nda = a.ndim

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -4209,6 +4209,12 @@ class TestKeepdims:
 
 class TestTensordot:
 
+   def test_rejects_duplicate_axes(self):
+        a = np.ones((2, 3, 3))
+        b = np.ones((3, 3, 4))
+        with pytest.raises(ValueError):
+            np.tensordot(a, b, axes=([1, 1], [0, 0]))
+
     def test_zero_dimension(self):
         # Test resolution to issue #5663
         a = np.ndarray((3, 0))

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -4209,7 +4209,7 @@ class TestKeepdims:
 
 class TestTensordot:
 
-   def test_rejects_duplicate_axes(self):
+    def test_rejects_duplicate_axes(self):
         a = np.ones((2, 3, 3))
         b = np.ones((3, 3, 4))
         with pytest.raises(ValueError):


### PR DESCRIPTION
tensordot performs a tensor contraction where each axis corresponds to a distinct summation index. Duplicate contraction axes (e.g. axes=([1, 1], [0, 0])) are mathematically invalid but currently fail later during an internal transpose, raising ValueError: axes don't match array. This PR adds early validation to reject duplicate axes explicitly, aligning the behavior with the definition of tensor contraction and other NumPy axis-handling APIs.

Current behavior:
Supplying duplicate contraction axes (e.g. axes=([1, 1], [0, 0])) causes tensordot to fail later during an internal transpose, raising ValueError: axes don't match array.

Expected behavior:
Duplicate contraction axes should be rejected explicitly, since tensor contraction requires distinct summation axes, and a clear input-validation error should be raised before any internal reshaping or transposition.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
