### PR TITLE
BUG: Ensure summed weights returned by np.average always are correct class (#30522)

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -594,7 +594,7 @@ def average(a, axis=None, weights=None, returned=False, *,
 
     if returned:
         if scl.shape != avg_as_array.shape:
-            scl = np.broadcast_to(scl, avg_as_array.shape).copy()
+            scl = np.broadcast_to(scl, avg_as_array.shape, subok=True).copy()
         return avg, scl
     else:
         return avg

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -497,6 +497,14 @@ class TestAverage:
 
         assert_equal(type(np.average(a)), subclass)
         assert_equal(type(np.average(a, weights=w)), subclass)
+        # Ensure a possibly returned sum of weights is correct too.
+        ra, rw = np.average(a, weights=w, returned=True)
+        assert_equal(type(ra), subclass)
+        assert_equal(type(rw), subclass)
+        # Even if it needs to be broadcast.
+        ra, rw = np.average(a, weights=w[0], axis=1, returned=True)
+        assert_equal(type(ra), subclass)
+        assert_equal(type(rw), subclass)
 
     def test_upcasting(self):
         typs = [('i4', 'i4', 'f8'), ('i4', 'f4', 'f8'), ('f4', 'i4', 'f8'),


### PR DESCRIPTION
Backport of #30522.

Over at astropy, it was noticed that if one passes in a `Quantity` weight to `np.average`, and asks for the summed weight to be returned, then the unit can be lost if the shapes of the weights and input array do not match (see https://github.com/astropy/astropy/issues/19054). This is because of a missing `subok=True` in a final broadcast -- which this PR fixes (how I wish I had insisted more that that would be default for `subok` when it was introduced...).


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
