### PR TITLE
TYP: Fix return type of histogram2d

### DIFF
--- a/numpy/lib/_twodim_base_impl.pyi
+++ b/numpy/lib/_twodim_base_impl.pyi
@@ -57,7 +57,7 @@ type _ArrayLike1DNumber_co = _SupportsArray[np.dtype[_Number_co]] | Sequence[com
 type _MaskFunc[_T] = Callable[[NDArray[np.int_], _T], NDArray[_Number_co | np.timedelta64 | np.datetime64 | np.object_]]
 
 type _Indices2D = tuple[_Array1D[np.intp], _Array1D[np.intp]]
-type _Histogram2D[ScalarT: np.generic] = tuple[_Array1D[np.float64], _Array1D[ScalarT], _Array1D[ScalarT]]
+type _Histogram2D[ScalarT: np.generic] = tuple[_Array2D[np.float64], _Array1D[ScalarT], _Array1D[ScalarT]]
 
 @type_check_only
 class _HasShapeAndNDim(Protocol):

--- a/numpy/typing/tests/data/reveal/twodim_base.pyi
+++ b/numpy/typing/tests/data/reveal/twodim_base.pyi
@@ -108,7 +108,7 @@ assert_type(np.vander(_nd_obj), np.ndarray[_2D, np.dtype[np.object_]])
 assert_type(
     np.histogram2d(_to_1d_f64, _to_1d_f64),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.float64]],
     ],
@@ -116,7 +116,7 @@ assert_type(
 assert_type(
     np.histogram2d(_to_1d_c128, _to_1d_c128),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.complex128 | Any]],
         np.ndarray[_1D, np.dtype[np.complex128 | Any]],
     ],
@@ -124,7 +124,7 @@ assert_type(
 assert_type(
     np.histogram2d(_nd_i64, _nd_bool),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.float64]],
     ],
@@ -132,7 +132,7 @@ assert_type(
 assert_type(
     np.histogram2d(_nd_f64, _nd_i64),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.float64]],
     ],
@@ -140,7 +140,7 @@ assert_type(
 assert_type(
     np.histogram2d(_nd_i64, _nd_f64),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.float64]],
     ],
@@ -148,7 +148,7 @@ assert_type(
 assert_type(
     np.histogram2d(_nd_f64, _nd_c128, weights=_to_1d_bool),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.complex128]],
         np.ndarray[_1D, np.dtype[np.complex128]],
     ],
@@ -156,7 +156,7 @@ assert_type(
 assert_type(
     np.histogram2d(_nd_f64, _nd_c128, bins=8),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.complex128]],
         np.ndarray[_1D, np.dtype[np.complex128]],
     ],
@@ -164,7 +164,7 @@ assert_type(
 assert_type(
     np.histogram2d(_nd_c128, _nd_f64, bins=(8, 5)),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.complex128]],
         np.ndarray[_1D, np.dtype[np.complex128]],
     ],
@@ -172,7 +172,7 @@ assert_type(
 assert_type(
     np.histogram2d(_nd_c128, _nd_i64, bins=_nd_u64),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.uint64]],
         np.ndarray[_1D, np.dtype[np.uint64]],
     ],
@@ -180,7 +180,7 @@ assert_type(
 assert_type(
     np.histogram2d(_nd_c128, _nd_c128, bins=(_nd_u64, _nd_u64)),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.uint64]],
         np.ndarray[_1D, np.dtype[np.uint64]],
     ],
@@ -188,7 +188,7 @@ assert_type(
 assert_type(
     np.histogram2d(_nd_c128, _nd_c128, bins=(_nd_bool, 8)),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.complex128 | np.bool]],
         np.ndarray[_1D, np.dtype[np.complex128 | np.bool]],
     ],
@@ -196,7 +196,7 @@ assert_type(
 assert_type(
     np.histogram2d(_nd_c128, _nd_c128, bins=(_to_1d_f64, 8)),
     tuple[
-        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_2D, np.dtype[np.float64]],
         np.ndarray[_1D, np.dtype[np.complex128 | Any]],
         np.ndarray[_1D, np.dtype[np.complex128 | Any]],
     ],


### PR DESCRIPTION
Closes #30525

## Testing
- `spin mypy` passes with the updated tests
- `spin test -v` passes
- `python tools/linter.py` passes

Running the test in #30525 now results in the proper type information for the first `histogram2d` return value and the `.tolist()` of that np.array:
```
tests/minimal_numpy.py:10:17 - information: Type of "a" is "ndarray[tuple[Literal[2], Literal[2]], dtype[float64]]"
tests/minimal_numpy.py:11:17 - information: Type of "a[0]" is "Any"
tests/minimal_numpy.py:19:17 - information: Type of "al" is "list[list[float]]"
tests/minimal_numpy.py:20:17 - information: Type of "al[0]" is "list[float]"
```