### PR TITLE
DOC: Add missing import in assert_array_equal docstring example

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1055,6 +1055,8 @@ def assert_array_equal(actual, desired, err_msg='', verbose=True, *,
 
     Examples
     --------
+    >>> import numpy as np
+
     The first assert does not raise an exception:
 
     >>> np.testing.assert_array_equal([1.0,2.33333,np.nan],


### PR DESCRIPTION
## Summary
Fixes #30509

The interactive example for `np.testing.assert_array_equal` in the web docs was raising a `NameError: name 'np' is not defined` because the `import numpy as np` statement was missing from the docstring examples.

## Changes
Added `>>> import numpy as np` at the beginning of the Examples section in `numpy/testing/_private/utils.py`.

## Test plan
- [x] Documentation change only - verified the example now runs correctly with the import