### PR TITLE
TYP: ``{lin,log,geom}space`` shape-typing

### DIFF
--- a/numpy/_core/function_base.pyi
+++ b/numpy/_core/function_base.pyi
@@ -1,5 +1,5 @@
 from _typeshed import Incomplete
-from typing import Literal as L, SupportsIndex, overload
+from typing import Any, Literal as L, SupportsIndex, overload
 
 import numpy as np
 from numpy._typing import (
@@ -7,16 +7,31 @@ from numpy._typing import (
     NDArray,
     _ArrayLikeComplex_co,
     _ArrayLikeFloat_co,
+    _ComplexLike_co,
     _DTypeLike,
 )
 from numpy._typing._array_like import _DualArrayLike
 
 __all__ = ["geomspace", "linspace", "logspace"]
 
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+type _ToFloat64 = float | np.integer | np.bool  # `np.float64` is assignable to `float`
 type _ToArrayFloat64 = _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], float]
 
 ###
 
+@overload
+def linspace(
+    start: _ToFloat64,
+    stop: _ToFloat64,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    retstep: L[False] = False,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+    *,
+    device: L["cpu"] | None = None,
+) -> _Array1D[np.float64]: ...
 @overload
 def linspace(
     start: _ToArrayFloat64,
@@ -40,7 +55,19 @@ def linspace(
     axis: SupportsIndex = 0,
     *,
     device: L["cpu"] | None = None,
-) -> NDArray[np.floating]: ...
+) -> NDArray[np.float64 | Any]: ...
+@overload
+def linspace(
+    start: complex,
+    stop: complex,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    retstep: L[False] = False,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+    *,
+    device: L["cpu"] | None = None,
+) -> _Array1D[np.complex128 | Any]: ...
 @overload
 def linspace(
     start: _ArrayLikeComplex_co,
@@ -52,7 +79,31 @@ def linspace(
     axis: SupportsIndex = 0,
     *,
     device: L["cpu"] | None = None,
-) -> NDArray[np.complexfloating]: ...
+) -> NDArray[np.complex128 | Any]: ...
+@overload
+def linspace[ScalarT: np.generic](
+    start: _ComplexLike_co,
+    stop: _ComplexLike_co,
+    num: SupportsIndex,
+    endpoint: bool,
+    retstep: L[False],
+    dtype: _DTypeLike[ScalarT],
+    axis: SupportsIndex = 0,
+    *,
+    device: L["cpu"] | None = None,
+) -> _Array1D[ScalarT]: ...
+@overload
+def linspace[ScalarT: np.generic](
+    start: _ComplexLike_co,
+    stop: _ComplexLike_co,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    retstep: L[False] = False,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    axis: SupportsIndex = 0,
+    device: L["cpu"] | None = None,
+) -> _Array1D[ScalarT]: ...
 @overload
 def linspace[ScalarT: np.generic](
     start: _ArrayLikeComplex_co,
@@ -91,6 +142,18 @@ def linspace(
 ) -> NDArray[Incomplete]: ...
 @overload
 def linspace(
+    start: _ToFloat64,
+    stop: _ToFloat64,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    *,
+    retstep: L[True],
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+    device: L["cpu"] | None = None,
+) -> tuple[_Array1D[np.float64], np.float64]: ...
+@overload
+def linspace(
     start: _ToArrayFloat64,
     stop: _ToArrayFloat64,
     num: SupportsIndex = 50,
@@ -112,7 +175,19 @@ def linspace(
     dtype: None = None,
     axis: SupportsIndex = 0,
     device: L["cpu"] | None = None,
-) -> tuple[NDArray[np.floating], np.floating]: ...
+) -> tuple[NDArray[np.float64 | Any], np.float64 | Any]: ...
+@overload
+def linspace(
+    start: complex,
+    stop: complex,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    *,
+    retstep: L[True],
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+    device: L["cpu"] | None = None,
+) -> tuple[_Array1D[np.complex128 | Any], np.complex128 | Any]: ...
 @overload
 def linspace(
     start: _ArrayLikeComplex_co,
@@ -124,7 +199,19 @@ def linspace(
     dtype: None = None,
     axis: SupportsIndex = 0,
     device: L["cpu"] | None = None,
-) -> tuple[NDArray[np.complexfloating], np.complexfloating]: ...
+) -> tuple[NDArray[np.complex128 | Any], np.complex128 | Any]: ...
+@overload
+def linspace[ScalarT: np.generic](
+    start: _ComplexLike_co,
+    stop: _ComplexLike_co,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    *,
+    retstep: L[True],
+    dtype: _DTypeLike[ScalarT],
+    axis: SupportsIndex = 0,
+    device: L["cpu"] | None = None,
+) -> tuple[_Array1D[ScalarT], ScalarT]: ...
 @overload
 def linspace[ScalarT: np.generic](
     start: _ArrayLikeComplex_co,
@@ -150,6 +237,17 @@ def linspace(
     device: L["cpu"] | None = None,
 ) -> tuple[NDArray[Incomplete], Incomplete]: ...
 
+#
+@overload
+def logspace(
+    start: _ToFloat64,
+    stop: _ToFloat64,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    base: _ToFloat64 = 10.0,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+) -> _Array1D[np.float64]: ...
 @overload
 def logspace(
     start: _ToArrayFloat64,
@@ -169,7 +267,17 @@ def logspace(
     base: _ArrayLikeFloat_co = 10.0,
     dtype: None = None,
     axis: SupportsIndex = 0,
-) -> NDArray[np.floating]: ...
+) -> NDArray[np.float64 | Any]: ...
+@overload
+def logspace(
+    start: complex,
+    stop: complex,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    base: complex = 10.0,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+) -> _Array1D[np.complex128 | Any]: ...
 @overload
 def logspace(
     start: _ArrayLikeComplex_co,
@@ -179,7 +287,28 @@ def logspace(
     base: _ArrayLikeComplex_co = 10.0,
     dtype: None = None,
     axis: SupportsIndex = 0,
-) -> NDArray[np.complexfloating]: ...
+) -> NDArray[np.complex128 | Any]: ...
+@overload
+def logspace[ScalarT: np.generic](
+    start: _ComplexLike_co,
+    stop: _ComplexLike_co,
+    num: SupportsIndex,
+    endpoint: bool,
+    base: _ComplexLike_co,
+    dtype: _DTypeLike[ScalarT],
+    axis: SupportsIndex = 0,
+) -> _Array1D[ScalarT]: ...
+@overload
+def logspace[ScalarT: np.generic](
+    start: _ComplexLike_co,
+    stop: _ComplexLike_co,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    base: _ArrayLikeComplex_co = 10.0,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    axis: SupportsIndex = 0,
+) -> _Array1D[ScalarT]: ...
 @overload
 def logspace[ScalarT: np.generic](
     start: _ArrayLikeComplex_co,
@@ -212,6 +341,16 @@ def logspace(
     axis: SupportsIndex = 0,
 ) -> NDArray[Incomplete]: ...
 
+#
+@overload
+def geomspace(
+    start: _ToFloat64,
+    stop: _ToFloat64,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+) -> _Array1D[np.float64]: ...
 @overload
 def geomspace(
     start: _ToArrayFloat64,
@@ -229,7 +368,16 @@ def geomspace(
     endpoint: bool = True,
     dtype: None = None,
     axis: SupportsIndex = 0,
-) -> NDArray[np.floating]: ...
+) -> NDArray[np.float64 | Any]: ...
+@overload
+def geomspace(
+    start: complex,
+    stop: complex,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+) -> _Array1D[np.complex128 | Any]: ...
 @overload
 def geomspace(
     start: _ArrayLikeComplex_co,
@@ -238,7 +386,26 @@ def geomspace(
     endpoint: bool = True,
     dtype: None = None,
     axis: SupportsIndex = 0,
-) -> NDArray[np.complexfloating]: ...
+) -> NDArray[np.complex128 | Any]: ...
+@overload
+def geomspace[ScalarT: np.generic](
+    start: _ComplexLike_co,
+    stop: _ComplexLike_co,
+    num: SupportsIndex,
+    endpoint: bool,
+    dtype: _DTypeLike[ScalarT],
+    axis: SupportsIndex = 0,
+) -> _Array1D[ScalarT]: ...
+@overload
+def geomspace[ScalarT: np.generic](
+    start: _ComplexLike_co,
+    stop: _ComplexLike_co,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    axis: SupportsIndex = 0,
+) -> _Array1D[ScalarT]: ...
 @overload
 def geomspace[ScalarT: np.generic](
     start: _ArrayLikeComplex_co,
@@ -268,6 +435,7 @@ def geomspace(
     axis: SupportsIndex = 0,
 ) -> NDArray[Incomplete]: ...
 
+#
 def add_newdoc(
     place: str,
     obj: str,

--- a/numpy/_core/function_base.pyi
+++ b/numpy/_core/function_base.pyi
@@ -34,30 +34,6 @@ def linspace(
 ) -> _Array1D[np.float64]: ...
 @overload
 def linspace(
-    start: _ToArrayFloat64,
-    stop: _ToArrayFloat64,
-    num: SupportsIndex = 50,
-    endpoint: bool = True,
-    retstep: L[False] = False,
-    dtype: None = None,
-    axis: SupportsIndex = 0,
-    *,
-    device: L["cpu"] | None = None,
-) -> NDArray[np.float64]: ...
-@overload
-def linspace(
-    start: _ArrayLikeFloat_co,
-    stop: _ArrayLikeFloat_co,
-    num: SupportsIndex = 50,
-    endpoint: bool = True,
-    retstep: L[False] = False,
-    dtype: None = None,
-    axis: SupportsIndex = 0,
-    *,
-    device: L["cpu"] | None = None,
-) -> NDArray[np.float64 | Any]: ...
-@overload
-def linspace(
     start: complex,
     stop: complex,
     num: SupportsIndex = 50,
@@ -68,18 +44,6 @@ def linspace(
     *,
     device: L["cpu"] | None = None,
 ) -> _Array1D[np.complex128 | Any]: ...
-@overload
-def linspace(
-    start: _ArrayLikeComplex_co,
-    stop: _ArrayLikeComplex_co,
-    num: SupportsIndex = 50,
-    endpoint: bool = True,
-    retstep: L[False] = False,
-    dtype: None = None,
-    axis: SupportsIndex = 0,
-    *,
-    device: L["cpu"] | None = None,
-) -> NDArray[np.complex128 | Any]: ...
 @overload
 def linspace[ScalarT: np.generic](
     start: _ComplexLike_co,
@@ -104,6 +68,42 @@ def linspace[ScalarT: np.generic](
     axis: SupportsIndex = 0,
     device: L["cpu"] | None = None,
 ) -> _Array1D[ScalarT]: ...
+@overload
+def linspace(
+    start: _ToArrayFloat64,
+    stop: _ToArrayFloat64,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    retstep: L[False] = False,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+    *,
+    device: L["cpu"] | None = None,
+) -> NDArray[np.float64]: ...
+@overload
+def linspace(
+    start: _ArrayLikeFloat_co,
+    stop: _ArrayLikeFloat_co,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    retstep: L[False] = False,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+    *,
+    device: L["cpu"] | None = None,
+) -> NDArray[np.float64 | Any]: ...
+@overload
+def linspace(
+    start: _ArrayLikeComplex_co,
+    stop: _ArrayLikeComplex_co,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    retstep: L[False] = False,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+    *,
+    device: L["cpu"] | None = None,
+) -> NDArray[np.complex128 | Any]: ...
 @overload
 def linspace[ScalarT: np.generic](
     start: _ArrayLikeComplex_co,
@@ -154,6 +154,30 @@ def linspace(
 ) -> tuple[_Array1D[np.float64], np.float64]: ...
 @overload
 def linspace(
+    start: complex,
+    stop: complex,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    *,
+    retstep: L[True],
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+    device: L["cpu"] | None = None,
+) -> tuple[_Array1D[np.complex128 | Any], np.complex128 | Any]: ...
+@overload
+def linspace[ScalarT: np.generic](
+    start: _ComplexLike_co,
+    stop: _ComplexLike_co,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    *,
+    retstep: L[True],
+    dtype: _DTypeLike[ScalarT],
+    axis: SupportsIndex = 0,
+    device: L["cpu"] | None = None,
+) -> tuple[_Array1D[ScalarT], ScalarT]: ...
+@overload
+def linspace(
     start: _ToArrayFloat64,
     stop: _ToArrayFloat64,
     num: SupportsIndex = 50,
@@ -178,18 +202,6 @@ def linspace(
 ) -> tuple[NDArray[np.float64 | Any], np.float64 | Any]: ...
 @overload
 def linspace(
-    start: complex,
-    stop: complex,
-    num: SupportsIndex = 50,
-    endpoint: bool = True,
-    *,
-    retstep: L[True],
-    dtype: None = None,
-    axis: SupportsIndex = 0,
-    device: L["cpu"] | None = None,
-) -> tuple[_Array1D[np.complex128 | Any], np.complex128 | Any]: ...
-@overload
-def linspace(
     start: _ArrayLikeComplex_co,
     stop: _ArrayLikeComplex_co,
     num: SupportsIndex = 50,
@@ -200,18 +212,6 @@ def linspace(
     axis: SupportsIndex = 0,
     device: L["cpu"] | None = None,
 ) -> tuple[NDArray[np.complex128 | Any], np.complex128 | Any]: ...
-@overload
-def linspace[ScalarT: np.generic](
-    start: _ComplexLike_co,
-    stop: _ComplexLike_co,
-    num: SupportsIndex = 50,
-    endpoint: bool = True,
-    *,
-    retstep: L[True],
-    dtype: _DTypeLike[ScalarT],
-    axis: SupportsIndex = 0,
-    device: L["cpu"] | None = None,
-) -> tuple[_Array1D[ScalarT], ScalarT]: ...
 @overload
 def linspace[ScalarT: np.generic](
     start: _ArrayLikeComplex_co,
@@ -250,26 +250,6 @@ def logspace(
 ) -> _Array1D[np.float64]: ...
 @overload
 def logspace(
-    start: _ToArrayFloat64,
-    stop: _ToArrayFloat64,
-    num: SupportsIndex = 50,
-    endpoint: bool = True,
-    base: _ToArrayFloat64 = 10.0,
-    dtype: None = None,
-    axis: SupportsIndex = 0,
-) -> NDArray[np.float64]: ...
-@overload
-def logspace(
-    start: _ArrayLikeFloat_co,
-    stop: _ArrayLikeFloat_co,
-    num: SupportsIndex = 50,
-    endpoint: bool = True,
-    base: _ArrayLikeFloat_co = 10.0,
-    dtype: None = None,
-    axis: SupportsIndex = 0,
-) -> NDArray[np.float64 | Any]: ...
-@overload
-def logspace(
     start: complex,
     stop: complex,
     num: SupportsIndex = 50,
@@ -278,16 +258,6 @@ def logspace(
     dtype: None = None,
     axis: SupportsIndex = 0,
 ) -> _Array1D[np.complex128 | Any]: ...
-@overload
-def logspace(
-    start: _ArrayLikeComplex_co,
-    stop: _ArrayLikeComplex_co,
-    num: SupportsIndex = 50,
-    endpoint: bool = True,
-    base: _ArrayLikeComplex_co = 10.0,
-    dtype: None = None,
-    axis: SupportsIndex = 0,
-) -> NDArray[np.complex128 | Any]: ...
 @overload
 def logspace[ScalarT: np.generic](
     start: _ComplexLike_co,
@@ -309,6 +279,36 @@ def logspace[ScalarT: np.generic](
     dtype: _DTypeLike[ScalarT],
     axis: SupportsIndex = 0,
 ) -> _Array1D[ScalarT]: ...
+@overload
+def logspace(
+    start: _ToArrayFloat64,
+    stop: _ToArrayFloat64,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    base: _ToArrayFloat64 = 10.0,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+) -> NDArray[np.float64]: ...
+@overload
+def logspace(
+    start: _ArrayLikeFloat_co,
+    stop: _ArrayLikeFloat_co,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    base: _ArrayLikeFloat_co = 10.0,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+) -> NDArray[np.float64 | Any]: ...
+@overload
+def logspace(
+    start: _ArrayLikeComplex_co,
+    stop: _ArrayLikeComplex_co,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    base: _ArrayLikeComplex_co = 10.0,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+) -> NDArray[np.complex128 | Any]: ...
 @overload
 def logspace[ScalarT: np.generic](
     start: _ArrayLikeComplex_co,
@@ -353,24 +353,6 @@ def geomspace(
 ) -> _Array1D[np.float64]: ...
 @overload
 def geomspace(
-    start: _ToArrayFloat64,
-    stop: _ToArrayFloat64,
-    num: SupportsIndex = 50,
-    endpoint: bool = True,
-    dtype: None = None,
-    axis: SupportsIndex = 0,
-) -> NDArray[np.float64]: ...
-@overload
-def geomspace(
-    start: _ArrayLikeFloat_co,
-    stop: _ArrayLikeFloat_co,
-    num: SupportsIndex = 50,
-    endpoint: bool = True,
-    dtype: None = None,
-    axis: SupportsIndex = 0,
-) -> NDArray[np.float64 | Any]: ...
-@overload
-def geomspace(
     start: complex,
     stop: complex,
     num: SupportsIndex = 50,
@@ -378,15 +360,6 @@ def geomspace(
     dtype: None = None,
     axis: SupportsIndex = 0,
 ) -> _Array1D[np.complex128 | Any]: ...
-@overload
-def geomspace(
-    start: _ArrayLikeComplex_co,
-    stop: _ArrayLikeComplex_co,
-    num: SupportsIndex = 50,
-    endpoint: bool = True,
-    dtype: None = None,
-    axis: SupportsIndex = 0,
-) -> NDArray[np.complex128 | Any]: ...
 @overload
 def geomspace[ScalarT: np.generic](
     start: _ComplexLike_co,
@@ -406,6 +379,33 @@ def geomspace[ScalarT: np.generic](
     dtype: _DTypeLike[ScalarT],
     axis: SupportsIndex = 0,
 ) -> _Array1D[ScalarT]: ...
+@overload
+def geomspace(
+    start: _ToArrayFloat64,
+    stop: _ToArrayFloat64,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+) -> NDArray[np.float64]: ...
+@overload
+def geomspace(
+    start: _ArrayLikeFloat_co,
+    stop: _ArrayLikeFloat_co,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+) -> NDArray[np.float64 | Any]: ...
+@overload
+def geomspace(
+    start: _ArrayLikeComplex_co,
+    stop: _ArrayLikeComplex_co,
+    num: SupportsIndex = 50,
+    endpoint: bool = True,
+    dtype: None = None,
+    axis: SupportsIndex = 0,
+) -> NDArray[np.complex128 | Any]: ...
 @overload
 def geomspace[ScalarT: np.generic](
     start: _ArrayLikeComplex_co,

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -6,6 +6,8 @@ import numpy as np
 import numpy.typing as npt
 from numpy._typing import _AnyShape
 
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+
 class SubClass[ScalarT: np.generic](np.ndarray[_AnyShape, np.dtype[ScalarT]]): ...
 
 class IntoSubClass[ScalarT: np.generic]:
@@ -143,23 +145,23 @@ assert_type(np.require(B, requirements="W"), SubClass[np.float64])
 assert_type(np.require(B, requirements="A"), SubClass[np.float64])
 assert_type(np.require(C), npt.NDArray[Any])
 
-assert_type(np.linspace(0, 10), npt.NDArray[np.float64])
-assert_type(np.linspace(0, 10j), npt.NDArray[np.complexfloating])
-assert_type(np.linspace(0, 10, dtype=np.int64), npt.NDArray[np.int64])
+assert_type(np.linspace(0, 10), _Array1D[np.float64])
+assert_type(np.linspace(0, 10j), _Array1D[np.complex128 | Any])
+assert_type(np.linspace(0, 10, dtype=np.int64), _Array1D[np.int64])
 assert_type(np.linspace(0, 10, dtype=int), npt.NDArray[Any])
-assert_type(np.linspace(0, 10, retstep=True), tuple[npt.NDArray[np.float64], np.float64])
-assert_type(np.linspace(0j, 10, retstep=True), tuple[npt.NDArray[np.complexfloating], np.complexfloating])
-assert_type(np.linspace(0, 10, retstep=True, dtype=np.int64), tuple[npt.NDArray[np.int64], np.int64])
+assert_type(np.linspace(0, 10, retstep=True), tuple[_Array1D[np.float64], np.float64])
+assert_type(np.linspace(0j, 10, retstep=True), tuple[_Array1D[np.complex128 | Any], np.complex128 | Any])
+assert_type(np.linspace(0, 10, retstep=True, dtype=np.int64), tuple[_Array1D[np.int64], np.int64])
 assert_type(np.linspace(0j, 10, retstep=True, dtype=int), tuple[npt.NDArray[Any], Any])
 
-assert_type(np.logspace(0, 10), npt.NDArray[np.float64])
-assert_type(np.logspace(0, 10j), npt.NDArray[np.complexfloating])
-assert_type(np.logspace(0, 10, dtype=np.int64), npt.NDArray[np.int64])
+assert_type(np.logspace(0, 10), _Array1D[np.float64])
+assert_type(np.logspace(0, 10j), _Array1D[np.complex128 | Any])
+assert_type(np.logspace(0, 10, dtype=np.int64), _Array1D[np.int64])
 assert_type(np.logspace(0, 10, dtype=int), npt.NDArray[Any])
 
-assert_type(np.geomspace(0, 10), npt.NDArray[np.float64])
-assert_type(np.geomspace(0, 10j), npt.NDArray[np.complexfloating])
-assert_type(np.geomspace(0, 10, dtype=np.int64), npt.NDArray[np.int64])
+assert_type(np.geomspace(0, 10), _Array1D[np.float64])
+assert_type(np.geomspace(0, 10j), _Array1D[np.complex128 | Any])
+assert_type(np.geomspace(0, 10, dtype=np.int64), _Array1D[np.int64])
 assert_type(np.geomspace(0, 10, dtype=int), npt.NDArray[Any])
 
 assert_type(np.zeros_like(A), npt.NDArray[np.float64])


### PR DESCRIPTION
... for the (most commonly used) 1-d cases, that is. 

This also makes the return dtypes for the non-`float64` cases a bit more user-friendly (`floating` and `complexfloating` can be annoying to work with).