### PR TITLE
TYP: move ``memmap`` stubs to ``_core.memmap``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -289,7 +289,7 @@ from numpy._core.getlimits import (
     finfo,
     iinfo,
 )
-
+from numpy._core.memmap import memmap
 from numpy._core.multiarray import (
     array,
     empty_like,
@@ -922,13 +922,6 @@ type _NDIterFlagsOp = L[
     "writemasked",
 ]
 
-type _MemMapModeKind = L[
-    "readonly", "r",
-    "copyonwrite", "c",
-    "readwrite", "r+",
-    "write", "w+",
-]  # fmt: skip
-
 type _DT64Item = dt.date | int | None
 type _TD64Item = dt.timedelta | int | None
 
@@ -985,9 +978,6 @@ class _SupportsFileMethods(SupportsFlush, Protocol):
     def fileno(self) -> SupportsIndex: ...
     def tell(self) -> SupportsIndex: ...
     def seek(self, offset: int, whence: int, /) -> object: ...
-
-@type_check_only
-class _SupportsFileMethodsRW(SupportsWrite[bytes], _SupportsFileMethods, Protocol): ...
 
 @type_check_only
 class _SupportsDLPack[StreamT](Protocol):
@@ -6171,50 +6161,6 @@ class nditer:
     def shape(self) -> tuple[int, ...]: ...
     @property
     def value(self) -> tuple[NDArray[Any], ...]: ...
-
-class memmap(ndarray[_ShapeT_co, _DTypeT_co]):
-    __array_priority__: ClassVar[float] = 100.0  # pyright: ignore[reportIncompatibleMethodOverride]
-    filename: str | None
-    offset: int
-    mode: str
-    @overload
-    def __new__(
-        subtype,
-        filename: StrOrBytesPath | _SupportsFileMethodsRW,
-        dtype: type[uint8] = ...,
-        mode: _MemMapModeKind = "r+",
-        offset: int = 0,
-        shape: int | tuple[int, ...] | None = None,
-        order: _OrderKACF = "C",
-    ) -> memmap[Any, dtype[uint8]]: ...
-    @overload
-    def __new__[ScalarT: generic](
-        subtype,
-        filename: StrOrBytesPath | _SupportsFileMethodsRW,
-        dtype: _DTypeLike[ScalarT],
-        mode: _MemMapModeKind = "r+",
-        offset: int = 0,
-        shape: int | tuple[int, ...] | None = None,
-        order: _OrderKACF = "C",
-    ) -> memmap[Any, dtype[ScalarT]]: ...
-    @overload
-    def __new__(
-        subtype,
-        filename: StrOrBytesPath | _SupportsFileMethodsRW,
-        dtype: DTypeLike,
-        mode: _MemMapModeKind = "r+",
-        offset: int = 0,
-        shape: int | tuple[int, ...] | None = None,
-        order: _OrderKACF = "C",
-    ) -> memmap[Any, dtype]: ...
-    def __array_finalize__(self, obj: object) -> None: ...
-    def __array_wrap__(  # type: ignore[override]
-        self,
-        array: memmap[_ShapeT_co, _DTypeT_co],
-        context: tuple[ufunc, tuple[Any, ...], int] | None = None,
-        return_scalar: py_bool = False,
-    ) -> Any: ...
-    def flush(self) -> None: ...
 
 class poly1d:
     @property

--- a/numpy/_core/memmap.pyi
+++ b/numpy/_core/memmap.pyi
@@ -1,3 +1,94 @@
-from numpy import memmap
+from _typeshed import StrOrBytesPath, SupportsWrite
+from typing import (
+    Any,
+    ClassVar,
+    Final,
+    Literal,
+    Protocol,
+    Self,
+    overload,
+    override,
+    type_check_only,
+)
+from typing_extensions import TypeVar
+
+import numpy as np
+from numpy import _OrderKACF, _SupportsFileMethods
+from numpy._typing import DTypeLike, _AnyShape, _DTypeLike, _Shape
 
 __all__ = ["memmap"]
+
+_ShapeT_co = TypeVar("_ShapeT_co", bound=_Shape, default=_AnyShape, covariant=True)
+_DTypeT_co = TypeVar("_DTypeT_co", bound=np.dtype[Any], default=np.dtype[Any], covariant=True)
+
+type _Mode = Literal["r", "c", "r+", "w+"]
+type _ToMode = Literal[_Mode, "readonly", "copyonwrite", "readwrite", "write"]
+
+@type_check_only
+class _SupportsFileMethodsRW(SupportsWrite[bytes], _SupportsFileMethods, Protocol): ...
+
+###
+
+class memmap(np.ndarray[_ShapeT_co, _DTypeT_co]):
+    __module__: Literal["numpy"] = "numpy"
+    __array_priority__: ClassVar[float] = 100.0  # pyright: ignore[reportIncompatibleMethodOverride]
+
+    filename: Final[str | None]
+    offset: Final[int]
+    mode: Final[_Mode]
+
+    @overload
+    def __new__[ScalarT: np.generic](
+        subtype,  # pyright: ignore[reportSelfClsParameterName]
+        filename: StrOrBytesPath | _SupportsFileMethodsRW,
+        dtype: _DTypeT_co,
+        mode: _ToMode = "r+",
+        offset: int = 0,
+        shape: int | tuple[int, ...] | None = None,
+        order: _OrderKACF = "C",
+    ) -> Self: ...
+    @overload
+    def __new__(
+        subtype,  # pyright: ignore[reportSelfClsParameterName]
+        filename: StrOrBytesPath | _SupportsFileMethodsRW,
+        dtype: type[np.uint8] = ...,
+        mode: _ToMode = "r+",
+        offset: int = 0,
+        shape: int | tuple[int, ...] | None = None,
+        order: _OrderKACF = "C",
+    ) -> memmap[_AnyShape, np.dtype[np.uint8]]: ...
+    @overload
+    def __new__[ScalarT: np.generic](
+        subtype,  # pyright: ignore[reportSelfClsParameterName]
+        filename: StrOrBytesPath | _SupportsFileMethodsRW,
+        dtype: _DTypeLike[ScalarT],
+        mode: _ToMode = "r+",
+        offset: int = 0,
+        shape: int | tuple[int, ...] | None = None,
+        order: _OrderKACF = "C",
+    ) -> memmap[_AnyShape, np.dtype[ScalarT]]: ...
+    @overload
+    def __new__(
+        subtype,  # pyright: ignore[reportSelfClsParameterName]
+        filename: StrOrBytesPath | _SupportsFileMethodsRW,
+        dtype: DTypeLike,
+        mode: _ToMode = "r+",
+        offset: int = 0,
+        shape: int | tuple[int, ...] | None = None,
+        order: _OrderKACF = "C",
+    ) -> memmap: ...
+
+    #
+    @override
+    def __array_finalize__(self, obj: object, /) -> None: ...
+    @override
+    def __array_wrap__(  # type: ignore[override]
+        self,
+        /,
+        array: memmap[_ShapeT_co, _DTypeT_co],
+        context: tuple[np.ufunc, tuple[Any, ...], int] | None = None,
+        return_scalar: bool = False,
+    ) -> Any: ...
+
+    #
+    def flush(self) -> None: ...

--- a/numpy/typing/tests/data/reveal/memmap.pyi
+++ b/numpy/typing/tests/data/reveal/memmap.pyi
@@ -1,19 +1,21 @@
-from typing import Any, assert_type
+from typing import Any, Literal, assert_type
 
 import numpy as np
 
-memmap_obj: np.memmap[Any, np.dtype[np.str_]]
+type _Memmap[ScalarT: np.generic] = np.memmap[tuple[Any, ...], np.dtype[ScalarT]]
+
+memmap_obj: _Memmap[np.str_]
 
 assert_type(np.memmap.__array_priority__, float)
 assert_type(memmap_obj.__array_priority__, float)
 assert_type(memmap_obj.filename, str | None)
 assert_type(memmap_obj.offset, int)
-assert_type(memmap_obj.mode, str)
+assert_type(memmap_obj.mode, Literal["r", "r+", "w+", "c"])
 assert_type(memmap_obj.flush(), None)
 
-assert_type(np.memmap("file.txt", offset=5), np.memmap[Any, np.dtype[np.uint8]])
-assert_type(np.memmap(b"file.txt", dtype=np.float64, shape=(10, 3)), np.memmap[Any, np.dtype[np.float64]])
+assert_type(np.memmap("file.txt", offset=5), _Memmap[np.uint8])
+assert_type(np.memmap(b"file.txt", dtype=np.float64, shape=(10, 3)), _Memmap[np.float64])
 with open("file.txt", "rb") as f:
-    assert_type(np.memmap(f, dtype=float, order="K"), np.memmap[Any, np.dtype])
+    assert_type(np.memmap(f, dtype=float, order="K"), np.memmap)
 
 assert_type(memmap_obj.__array_finalize__(object()), None)


### PR DESCRIPTION
This also narrows the generic shape type-parameter default to the gradual "any shape" type, and makes the constructor transparent w.r.t. passed `dtype` instances. The attributes have also been made final and slightly narrower in case of `mode`.