### PR TITLE
TYP: ``from{buffer,string,file}`` shape-typing

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -858,30 +858,31 @@ def promote_types(__type1: DTypeLike, __type2: DTypeLike) -> dtype: ...
 def fromstring(
     string: str | bytes,
     dtype: None = None,
-    count: SupportsIndex = ...,
+    count: SupportsIndex = -1,
     *,
     sep: str,
-    like: _SupportsArrayFunc | None = ...,
-) -> NDArray[float64]: ...
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[float64]: ...
 @overload
 def fromstring[ScalarT: np.generic](
     string: str | bytes,
     dtype: _DTypeLike[ScalarT],
-    count: SupportsIndex = ...,
+    count: SupportsIndex = -1,
     *,
     sep: str,
-    like: _SupportsArrayFunc | None = ...,
-) -> NDArray[ScalarT]: ...
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[ScalarT]: ...
 @overload
 def fromstring(
     string: str | bytes,
-    dtype: DTypeLike | None = ...,
-    count: SupportsIndex = ...,
+    dtype: DTypeLike | None = None,
+    count: SupportsIndex = -1,
     *,
     sep: str,
-    like: _SupportsArrayFunc | None = ...,
-) -> NDArray[Any]: ...
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[Any]: ...
 
+#
 @overload
 def frompyfunc[ReturnT](
     func: Callable[[Any], ReturnT], /,
@@ -964,7 +965,7 @@ def fromfile(
     offset: SupportsIndex = ...,
     *,
     like: _SupportsArrayFunc | None = ...,
-) -> NDArray[float64]: ...
+) -> _Array1D[float64]: ...
 @overload
 def fromfile[ScalarT: np.generic](
     file: StrOrBytesPath | _SupportsFileMethods,
@@ -974,7 +975,7 @@ def fromfile[ScalarT: np.generic](
     offset: SupportsIndex = ...,
     *,
     like: _SupportsArrayFunc | None = ...,
-) -> NDArray[ScalarT]: ...
+) -> _Array1D[ScalarT]: ...
 @overload
 def fromfile(
     file: StrOrBytesPath | _SupportsFileMethods,
@@ -984,7 +985,7 @@ def fromfile(
     offset: SupportsIndex = ...,
     *,
     like: _SupportsArrayFunc | None = ...,
-) -> NDArray[Any]: ...
+) -> _Array1D[Any]: ...
 
 @overload
 def fromiter[ScalarT: np.generic](
@@ -1007,29 +1008,29 @@ def fromiter(
 def frombuffer(
     buffer: Buffer,
     dtype: None = None,
-    count: SupportsIndex = ...,
-    offset: SupportsIndex = ...,
+    count: SupportsIndex = -1,
+    offset: SupportsIndex = 0,
     *,
-    like: _SupportsArrayFunc | None = ...,
-) -> NDArray[float64]: ...
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[float64]: ...
 @overload
 def frombuffer[ScalarT: np.generic](
     buffer: Buffer,
     dtype: _DTypeLike[ScalarT],
-    count: SupportsIndex = ...,
-    offset: SupportsIndex = ...,
+    count: SupportsIndex = -1,
+    offset: SupportsIndex = 0,
     *,
-    like: _SupportsArrayFunc | None = ...,
-) -> NDArray[ScalarT]: ...
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[ScalarT]: ...
 @overload
 def frombuffer(
     buffer: Buffer,
-    dtype: DTypeLike | None = ...,
-    count: SupportsIndex = ...,
-    offset: SupportsIndex = ...,
+    dtype: DTypeLike | None = None,
+    count: SupportsIndex = -1,
+    offset: SupportsIndex = 0,
     *,
-    like: _SupportsArrayFunc | None = ...,
-) -> NDArray[Any]: ...
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[Any]: ...
 
 # keep in sync with ma.core.arange
 # NOTE: The `float64 | Any` return types needed to avoid incompatible overlapping overloads

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -92,27 +92,27 @@ assert_type(np.asfortranarray([1, 1.0]), npt.NDArray[Any])
 assert_type(np.asfortranarray(A, dtype=np.int64), npt.NDArray[np.int64])
 assert_type(np.asfortranarray(A, dtype="c16"), npt.NDArray[Any])
 
-assert_type(np.fromstring("1 1 1", sep=" "), npt.NDArray[np.float64])
-assert_type(np.fromstring(b"1 1 1", sep=" "), npt.NDArray[np.float64])
-assert_type(np.fromstring("1 1 1", dtype=np.int64, sep=" "), npt.NDArray[np.int64])
-assert_type(np.fromstring(b"1 1 1", dtype=np.int64, sep=" "), npt.NDArray[np.int64])
-assert_type(np.fromstring("1 1 1", dtype="c16", sep=" "), npt.NDArray[Any])
-assert_type(np.fromstring(b"1 1 1", dtype="c16", sep=" "), npt.NDArray[Any])
+assert_type(np.fromstring("1 1 1", sep=" "), _Array1D[np.float64])
+assert_type(np.fromstring(b"1 1 1", sep=" "), _Array1D[np.float64])
+assert_type(np.fromstring("1 1 1", dtype=np.int64, sep=" "), _Array1D[np.int64])
+assert_type(np.fromstring(b"1 1 1", dtype=np.int64, sep=" "), _Array1D[np.int64])
+assert_type(np.fromstring("1 1 1", dtype="c16", sep=" "), _Array1D[Any])
+assert_type(np.fromstring(b"1 1 1", dtype="c16", sep=" "), _Array1D[Any])
 
-assert_type(np.fromfile("test.txt", sep=" "), npt.NDArray[np.float64])
-assert_type(np.fromfile("test.txt", dtype=np.int64, sep=" "), npt.NDArray[np.int64])
-assert_type(np.fromfile("test.txt", dtype="c16", sep=" "), npt.NDArray[Any])
+assert_type(np.fromfile("test.txt", sep=" "), _Array1D[np.float64])
+assert_type(np.fromfile("test.txt", dtype=np.int64, sep=" "), _Array1D[np.int64])
+assert_type(np.fromfile("test.txt", dtype="c16", sep=" "), _Array1D[Any])
 with open("test.txt") as f:
-    assert_type(np.fromfile(f, sep=" "), npt.NDArray[np.float64])
-    assert_type(np.fromfile(b"test.txt", sep=" "), npt.NDArray[np.float64])
-    assert_type(np.fromfile(Path("test.txt"), sep=" "), npt.NDArray[np.float64])
+    assert_type(np.fromfile(f, sep=" "), _Array1D[np.float64])
+    assert_type(np.fromfile(b"test.txt", sep=" "), _Array1D[np.float64])
+    assert_type(np.fromfile(Path("test.txt"), sep=" "), _Array1D[np.float64])
 
 assert_type(np.fromiter("12345", np.float64), npt.NDArray[np.float64])
 assert_type(np.fromiter("12345", float), npt.NDArray[Any])
 
-assert_type(np.frombuffer(A), npt.NDArray[np.float64])
-assert_type(np.frombuffer(A, dtype=np.int64), npt.NDArray[np.int64])
-assert_type(np.frombuffer(A, dtype="c16"), npt.NDArray[Any])
+assert_type(np.frombuffer(A), _Array1D[np.float64])
+assert_type(np.frombuffer(A, dtype=np.int64), _Array1D[np.int64])
+assert_type(np.frombuffer(A, dtype="c16"), _Array1D[Any])
 
 _x_bool: bool
 _x_int: int


### PR DESCRIPTION
These three functions exclusively return 1d arrays, so let's put that in the stubs.