### PR TITLE
BUG: Ensure stable data address in scalar __array_interface__

### DIFF
--- a/doc/release/upcoming_changes/30538.change.rst
+++ b/doc/release/upcoming_changes/30538.change.rst
@@ -9,11 +9,10 @@ Users who need to convert scalar types to ctypes should first convert them to an
 (e.g., ``numpy.asarray``) before passing them to ``numpy.ctypeslib.as_ctypes``.
 
 
-``__ref`` value in ``__array_interface__`` for scalar types is removed
-------------------------------------------------------------------------
-Previously, scalar types in NumPy had a ``__ref`` entry in their ``__array_interface__``
-dictionary, which pointed to the temporary array created to hold the scalar value.
-This behavior has been removed to avoid the issue `gh-30354 <https://github.com/numpy/numpy/issues/30354>`__.
-Now, scalar types will not have a ``__ref`` entry in their ``__array_interface__``.
-Instead, ``data`` entry in ``__array_interface__`` will directly point to the memory location of the scalar value and
-will be marked as readonly.
+``__array_interface__`` changes on scalars
+------------------------------------------
+Scalars now export the ``__array_interface__`` directly rather than including
+an array copy as a ``__ref`` entry. This means that scalars are now exported
+as read-only while they previously exported as writeable.
+The path via ``__ref__`` was undocumented and not consistently used even
+within NumPy itself.

--- a/doc/release/upcoming_changes/30538.change.rst
+++ b/doc/release/upcoming_changes/30538.change.rst
@@ -1,0 +1,8 @@
+``numpy.ctypeslib.as_ctypes`` now does not support scalar types
+----------------------------------------------------------------
+The function ``numpy.ctypeslib.as_ctypes`` has been updated to only accept ``numpy.ndarray``.
+Passing a scalar type (e.g., ``numpy.int32(5)``) will now raise a ``TypeError``.
+This change was made to avoid the issue `gh-30354 <https://github.com/numpy/numpy/issues/30354>`__
+and to enforce the readonly nature of scalar types in NumPy.
+Users who need to convert scalar types to ctypes should first convert them to an array
+(e.g., ``numpy.asarray``) before passing them to ``numpy.ctypeslib.as_ctypes``.

--- a/doc/release/upcoming_changes/30538.change.rst
+++ b/doc/release/upcoming_changes/30538.change.rst
@@ -14,5 +14,5 @@ Users who need to convert scalar types to ctypes should first convert them to an
 Scalars now export the ``__array_interface__`` directly rather than including
 an array copy as a ``__ref`` entry. This means that scalars are now exported
 as read-only while they previously exported as writeable.
-The path via ``__ref__`` was undocumented and not consistently used even
+The path via ``__ref`` was undocumented and not consistently used even
 within NumPy itself.

--- a/doc/release/upcoming_changes/30538.change.rst
+++ b/doc/release/upcoming_changes/30538.change.rst
@@ -4,5 +4,16 @@ The function ``numpy.ctypeslib.as_ctypes`` has been updated to only accept ``num
 Passing a scalar type (e.g., ``numpy.int32(5)``) will now raise a ``TypeError``.
 This change was made to avoid the issue `gh-30354 <https://github.com/numpy/numpy/issues/30354>`__
 and to enforce the readonly nature of scalar types in NumPy.
+The previous behavior relied on undocumented implicit temporary arrays and was not well-defined.
 Users who need to convert scalar types to ctypes should first convert them to an array
 (e.g., ``numpy.asarray``) before passing them to ``numpy.ctypeslib.as_ctypes``.
+
+
+``__ref`` value in ``__array_interface__`` for scalar types is removed
+------------------------------------------------------------------------
+Previously, scalar types in NumPy had a ``__ref`` entry in their ``__array_interface__``
+dictionary, which pointed to the temporary array created to hold the scalar value.
+This behavior has been removed to avoid the issue `gh-30354 <https://github.com/numpy/numpy/issues/30354>`__.
+Now, scalar types will not have a ``__ref`` entry in their ``__array_interface__``.
+Instead, ``data`` entry in ``__array_interface__`` will directly point to the memory location of the scalar value and
+will be marked as readonly.

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -477,3 +477,61 @@ check_is_convertible_to_scalar(PyArrayObject *v)
             "only 0-dimensional arrays can be converted to Python scalars");
     return -1;
 }
+
+NPY_NO_EXPORT PyObject *
+build_array_interface(PyObject *dataptr, PyObject *descr, PyObject *strides,
+                      PyObject *typestr, PyObject *shape)
+{
+    PyObject *inter = NULL;
+    PyObject *version = NULL;
+    int ret;
+
+    inter = PyDict_New();
+    if (inter == NULL) {
+        goto fail;
+    }
+
+    ret = PyDict_SetItemString(inter, "data", dataptr);
+    if (ret < 0) {
+        goto fail;
+    }
+
+    ret = PyDict_SetItemString(inter, "strides", strides);
+    if (ret < 0) {
+        goto fail;
+    }
+
+    ret = PyDict_SetItemString(inter, "descr", descr);
+    if (ret < 0) {
+        goto fail;
+    }
+
+    ret = PyDict_SetItemString(inter, "typestr", typestr);
+    if (ret < 0) {
+        goto fail;
+    }
+
+    ret = PyDict_SetItemString(inter, "shape", shape);
+    if (ret < 0) {
+        goto fail;
+    }
+
+    version = PyLong_FromLong(3);
+    if (version == NULL) {
+        goto fail;
+    }
+
+    ret = PyDict_SetItemString(inter, "version", version);
+    if (ret < 0) {
+        goto fail;
+    }
+    Py_XDECREF(version);
+    return inter;
+
+
+fail:
+    Py_XDECREF(inter);
+    Py_XDECREF(version);
+    return NULL;
+
+}

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -22,6 +22,10 @@ extern "C" {
 #define error_converting(x)  (((x) == -1) && PyErr_Occurred())
 
 
+NPY_NO_EXPORT PyObject *
+build_array_interface(PyObject *dataptr, PyObject *descr, PyObject *strides,
+                      PyObject *typestr, PyObject *shape);
+
 NPY_NO_EXPORT PyArray_Descr *
 PyArray_DTypeFromObjectStringDiscovery(
         PyObject *obj, PyArray_Descr *last_dtype, int string_type);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -3804,7 +3804,7 @@ array_typestr_get(PyArray_Descr *self)
 }
 
 
-PyObject *
+NPY_NO_EXPORT PyObject *
 array_protocol_descr_get(PyArray_Descr *self)
 {
     PyObject *res;

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -3797,6 +3797,42 @@ descr_subscript(PyArray_Descr *self, PyObject *op)
     }
 }
 
+static PyObject *
+array_typestr_get(PyArray_Descr *self)
+{
+    return arraydescr_protocol_typestr_get(self, NULL);
+}
+
+
+PyObject *
+array_protocol_descr_get(PyArray_Descr *self)
+{
+    PyObject *res;
+    PyObject *dobj;
+
+    res = arraydescr_protocol_descr_get(self, NULL);
+    if (res) {
+        return res;
+    }
+    PyErr_Clear();
+
+    /* get default */
+    dobj = PyTuple_New(2);
+    if (dobj == NULL) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(dobj, 0, PyUnicode_FromString(""));
+    PyTuple_SET_ITEM(dobj, 1, array_typestr_get(self));
+    res = PyList_New(1);
+    if (res == NULL) {
+        Py_DECREF(dobj);
+        return NULL;
+    }
+    PyList_SET_ITEM(res, 0, dobj);
+    return res;
+}
+
+
 static PySequenceMethods descr_as_sequence = {
     (lenfunc) descr_length,                  /* sq_length */
     (binaryfunc) NULL,                       /* sq_concat */

--- a/numpy/_core/src/multiarray/descriptor.h
+++ b/numpy/_core/src/multiarray/descriptor.h
@@ -29,6 +29,8 @@ NPY_NO_EXPORT PyObject *arraydescr_protocol_typestr_get(
 NPY_NO_EXPORT PyObject *arraydescr_protocol_descr_get(
         PyArray_Descr *self, void *);
 
+NPY_NO_EXPORT PyObject *array_protocol_descr_get(PyArray_Descr *self);
+
 /*
  * offset:    A starting offset.
  * alignment: A power-of-two alignment.

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -201,44 +201,10 @@ array_priority_get(PyArrayObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 }
 
 static PyObject *
-array_typestr_get(PyArrayObject *self)
-{
-    return arraydescr_protocol_typestr_get(PyArray_DESCR(self), NULL);
-}
-
-static PyObject *
 array_descr_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     Py_INCREF(PyArray_DESCR(self));
     return (PyObject *)PyArray_DESCR(self);
-}
-
-static PyObject *
-array_protocol_descr_get(PyArrayObject *self)
-{
-    PyObject *res;
-    PyObject *dobj;
-
-    res = arraydescr_protocol_descr_get(PyArray_DESCR(self), NULL);
-    if (res) {
-        return res;
-    }
-    PyErr_Clear();
-
-    /* get default */
-    dobj = PyTuple_New(2);
-    if (dobj == NULL) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(dobj, 0, PyUnicode_FromString(""));
-    PyTuple_SET_ITEM(dobj, 1, array_typestr_get(self));
-    res = PyList_New(1);
-    if (res == NULL) {
-        Py_DECREF(dobj);
-        return NULL;
-    }
-    PyList_SET_ITEM(res, 0, dobj);
-    return res;
 }
 
 static PyObject *
@@ -307,7 +273,7 @@ array_interface_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
         return NULL;
     }
 
-    obj = array_protocol_descr_get(self);
+    obj = array_protocol_descr_get(PyArray_DESCR(self));
     ret = PyDict_SetItemString(dict, "descr", obj);
     Py_DECREF(obj);
     if (ret < 0) {

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -246,65 +246,49 @@ array_ctypes_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 static PyObject *
 array_interface_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
-    PyObject *dict;
-    PyObject *obj;
+    PyObject *dataptr = NULL;
+    PyObject *strides = NULL;
+    PyObject *shape = NULL;
+    PyObject *descr = NULL;
+    PyObject *typestr = NULL;
+    PyObject *dict = NULL;
 
-    dict = PyDict_New();
-    if (dict == NULL) {
-        return NULL;
+    dataptr = array_dataptr_get(self, NULL);
+    if (dataptr == NULL) {
+        goto finish;
     }
 
-    int ret;
-
-    /* dataptr */
-    obj = array_dataptr_get(self, NULL);
-    ret = PyDict_SetItemString(dict, "data", obj);
-    Py_DECREF(obj);
-    if (ret < 0) {
-        Py_DECREF(dict);
-        return NULL;
+    strides = array_protocol_strides_get(self);
+    if (strides == NULL) {
+        goto finish;
     }
 
-    obj = array_protocol_strides_get(self);
-    ret = PyDict_SetItemString(dict, "strides", obj);
-    Py_DECREF(obj);
-    if (ret < 0) {
-        Py_DECREF(dict);
-        return NULL;
+    descr = array_protocol_descr_get(PyArray_DESCR(self));
+    if (descr == NULL) {
+        goto finish;
     }
 
-    obj = array_protocol_descr_get(PyArray_DESCR(self));
-    ret = PyDict_SetItemString(dict, "descr", obj);
-    Py_DECREF(obj);
-    if (ret < 0) {
-        Py_DECREF(dict);
-        return NULL;
+    typestr = arraydescr_protocol_typestr_get(PyArray_DESCR(self), NULL);
+    if (typestr == NULL) {
+        goto finish;
     }
 
-    obj = arraydescr_protocol_typestr_get(PyArray_DESCR(self), NULL);
-    ret = PyDict_SetItemString(dict, "typestr", obj);
-    Py_DECREF(obj);
-    if (ret < 0) {
-        Py_DECREF(dict);
-        return NULL;
+    shape = array_shape_get(self, NULL);
+    if (shape == NULL) {
+        goto finish;
     }
 
-    obj = array_shape_get(self, NULL);
-    ret = PyDict_SetItemString(dict, "shape", obj);
-    Py_DECREF(obj);
-    if (ret < 0) {
-        Py_DECREF(dict);
-        return NULL;
-    }
+    dict = build_array_interface(
+        dataptr, descr, strides, typestr, shape
+    );
+    goto finish;
 
-    obj = PyLong_FromLong(3);
-    ret = PyDict_SetItemString(dict, "version", obj);
-    Py_DECREF(obj);
-    if (ret < 0) {
-        Py_DECREF(dict);
-        return NULL;
-    }
-
+finish:
+    Py_XDECREF(dataptr);
+    Py_XDECREF(strides);
+    Py_XDECREF(shape);
+    Py_XDECREF(descr);
+    Py_XDECREF(typestr);
     return dict;
 }
 

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1812,7 +1812,6 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
     inter = PyObject_GetAttrString((PyObject *)arr, "__array_interface__");
     if (inter == NULL) {
         Py_DECREF(arr);
-        Py_DECREF(inter);
         return NULL;        
     }
 

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1788,6 +1788,18 @@ gentype_shape_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 
 
 static PyObject *
+gentype_dataptr_get(PyObject *self, int flags, void *NPY_UNUSED(ignored))
+{
+    int _flags = flags;
+    _flags &= ~(NPY_ARRAY_WRITEBACKIFCOPY | NPY_ARRAY_OWNDATA);
+    _flags |= NPY_ARRAY_NOTSWAPPED;
+
+    return Py_BuildValue(
+            "NO", PyLong_FromVoidPtr(scalar_value(self, NULL)),
+            ((flags & PyBUF_WRITEABLE) == PyBUF_WRITEABLE) ? Py_False : Py_True);
+}
+
+static PyObject *
 gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArrayObject *arr;
@@ -1798,12 +1810,27 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
         return NULL;
     }
     inter = PyObject_GetAttrString((PyObject *)arr, "__array_interface__");
-    if (inter != NULL) {
-        PyDict_SetItemString(inter, "__ref", (PyObject *)arr);
+    Py_DECREF(arr);
+    if (inter == NULL) {
+        Py_DECREF(inter);
+        return NULL;        
     }
+
+    // Overwrite the 'data' field to point to the scalar's data
+    PyObject *obj;
+    int ret;
+    /* dataptr */
+    int flags = PyArray_FLAGS(arr);
+    obj = gentype_dataptr_get(self, flags, NULL);
+    ret = PyDict_SetItemString(inter, "data", obj);
+    Py_DECREF(obj);
+    if (ret < 0) {
+        Py_DECREF(inter);
+        return NULL;
+    }
+
     return inter;
 }
-
 
 
 static PyObject *

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1802,96 +1802,60 @@ gentype_dataptr_get(PyObject *self)
 static PyObject *
 gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
+    PyObject *dataptr = NULL;
+    PyObject *strides = NULL;
+    PyObject *shape = NULL;
+    PyObject *descr = NULL;
+    PyObject *typestr = NULL;
+    PyArray_Descr *array_descr = NULL;
     PyObject *inter = NULL;
-    PyObject *obj = NULL;
-    PyArray_Descr *descr = NULL;
-    int ret;
 
-    inter = PyDict_New();
-    if (inter == NULL) {
-        goto fail;
-    }
 
-    descr = PyArray_DescrFromScalar(self);
-    if (descr == NULL) {
-        goto fail;
+    array_descr = PyArray_DescrFromScalar(self);
+    if (array_descr == NULL) {
+        goto finish;
     }
 
     /* dataptr */
-    obj = gentype_dataptr_get(self);
-    if (obj == NULL) {
-        goto fail;
-    }
-    ret = PyDict_SetItemString(inter, "data", obj);
-    Py_CLEAR(obj);
-    if (ret < 0) {
-        goto fail;
+    dataptr = gentype_dataptr_get(self);
+    if (dataptr == NULL) {
+        goto finish;
     }
 
     /* strides */
-    obj = gentype_shape_get(self, NULL);
-    if (obj == NULL) {
-        goto fail;
-    }
-    ret = PyDict_SetItemString(inter, "strides", obj);
-    Py_CLEAR(obj);
-    if (ret < 0) {
-        goto fail;
+    strides = gentype_shape_get(self, NULL);
+    if (strides == NULL) {
+        goto finish;
     }
     
-    /* shape */
-    obj = array_protocol_descr_get(descr);
-    if (obj == NULL) {
-        goto fail;
-    }
-    ret = PyDict_SetItemString(inter, "descr", obj);
-    Py_CLEAR(obj);
-    if (ret < 0) {
-        goto fail;
+    /* descr */
+    descr = array_protocol_descr_get(array_descr);
+    if (descr == NULL) {
+        goto finish;
     }
 
     /* typestr */
-    obj = arraydescr_protocol_typestr_get(descr, NULL);
-    if (obj == NULL) {
-        goto fail;
-    }
-    ret = PyDict_SetItemString(inter, "typestr", obj);
-    Py_CLEAR(obj);
-    if (ret < 0) {
-        goto fail;
+    typestr = arraydescr_protocol_typestr_get(array_descr, NULL);
+    if (typestr == NULL) {
+        goto finish;
     }
 
     /* shape */
-    obj = gentype_shape_get(self, NULL);
-    if (obj == NULL) {
-        goto fail;
-    }
-    ret = PyDict_SetItemString(inter, "shape", obj);
-    Py_CLEAR(obj);
-    if (ret < 0) {
-        goto fail;
+    shape = gentype_shape_get(self, NULL);
+    if (shape == NULL) {
+        goto finish;
     }
 
-    /* version */
-    obj = PyLong_FromLong(3);
-    if (obj == NULL) {
-        goto fail;
-    }
-    ret = PyDict_SetItemString(inter, "version", obj);
-    Py_CLEAR(obj);
-    if (ret < 0) {
-        goto fail;
-    }
-    goto finish;
-
-fail:
-    Py_XDECREF(inter);
-    inter = NULL;
+    inter = build_array_interface(dataptr, descr, strides, typestr, shape);
     goto finish;
 
 finish:
     Py_XDECREF(descr);
-    Py_XDECREF(obj);
+    Py_XDECREF(dataptr);
+    Py_XDECREF(strides);
+    Py_XDECREF(shape);
+    Py_XDECREF(typestr);
+    Py_XDECREF(array_descr);
     return inter;
 }
 

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1802,64 +1802,96 @@ gentype_dataptr_get(PyObject *self)
 static PyObject *
 gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
-    PyObject *inter;
-    PyObject *obj;
+    PyObject *inter = NULL;
+    PyObject *obj = NULL;
+    PyArray_Descr *descr = NULL;
     int ret;
 
     inter = PyDict_New();
     if (inter == NULL) {
-        return NULL;
+        goto fail;
+    }
+
+    descr = PyArray_DescrFromScalar(self);
+    if (descr == NULL) {
+        goto fail;
     }
 
     /* dataptr */
     obj = gentype_dataptr_get(self);
+    if (obj == NULL) {
+        goto fail;
+    }
     ret = PyDict_SetItemString(inter, "data", obj);
-    Py_DECREF(obj);
+    Py_CLEAR(obj);
     if (ret < 0) {
-        Py_DECREF(inter);
-        return NULL;
+        goto fail;
     }
 
+    /* strides */
     obj = gentype_shape_get(self, NULL);
+    if (obj == NULL) {
+        goto fail;
+    }
     ret = PyDict_SetItemString(inter, "strides", obj);
-    Py_DECREF(obj);
+    Py_CLEAR(obj);
     if (ret < 0) {
-        Py_DECREF(inter);
-        return NULL;
+        goto fail;
     }
-
-    obj = array_protocol_descr_get(PyArray_DescrFromScalar(self));
+    
+    /* shape */
+    obj = array_protocol_descr_get(descr);
+    if (obj == NULL) {
+        goto fail;
+    }
     ret = PyDict_SetItemString(inter, "descr", obj);
-    Py_DECREF(obj);
+    Py_CLEAR(obj);
     if (ret < 0) {
-        Py_DECREF(inter);
-        return NULL;
+        goto fail;
     }
 
-    obj = arraydescr_protocol_typestr_get(PyArray_DescrFromScalar(self), NULL);
+    /* typestr */
+    obj = arraydescr_protocol_typestr_get(descr, NULL);
+    if (obj == NULL) {
+        goto fail;
+    }
     ret = PyDict_SetItemString(inter, "typestr", obj);
-    Py_DECREF(obj);
+    Py_CLEAR(obj);
     if (ret < 0) {
-        Py_DECREF(inter);
-        return NULL;
+        goto fail;
     }
 
+    /* shape */
     obj = gentype_shape_get(self, NULL);
+    if (obj == NULL) {
+        goto fail;
+    }
     ret = PyDict_SetItemString(inter, "shape", obj);
-    Py_DECREF(obj);
+    Py_CLEAR(obj);
     if (ret < 0) {
-        Py_DECREF(inter);
-        return NULL;
+        goto fail;
     }
 
+    /* version */
     obj = PyLong_FromLong(3);
-    ret = PyDict_SetItemString(inter, "version", obj);
-    Py_DECREF(obj);
-    if (ret < 0) {
-        Py_DECREF(inter);
-        return NULL;
+    if (obj == NULL) {
+        goto fail;
     }
+    ret = PyDict_SetItemString(inter, "version", obj);
+    Py_CLEAR(obj);
+    if (ret < 0) {
+        goto fail;
+    }
+    goto finish;
 
+fail:
+    Py_XDECREF(inter);
+    inter = NULL;
+    goto finish;
+
+finish:
+    Py_XDECREF(descr);
+    Py_XDECREF(obj);
     return inter;
 }
 

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1791,24 +1791,11 @@ gentype_shape_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 static PyObject *
 gentype_dataptr_get(PyObject *self)
 {
-    PyArrayObject *arr;
-    arr = (PyArrayObject *)PyArray_FromScalar(self, NULL);
-
-    if (arr == NULL) {
-        return NULL;
-    }
-
-    /* NOTE: sclar array is always readonly, but we need writable flags
-     * to use `ctypeslib.as_ctyps` via `__array_interface__`.
-     * So, we set the flag borrowing from the temporary array. 
-     */
-    PyObject* ptr = Py_BuildValue(
-        "NO", PyLong_FromVoidPtr(scalar_value(self, NULL)),
-        (PyArray_FLAGS(arr) & NPY_ARRAY_WRITEABLE) ? Py_False : Py_True
+    return Py_BuildValue(
+        "NO",
+        PyLong_FromVoidPtr(scalar_value(self, NULL)),
+        Py_True
     );
-
-    Py_DECREF(arr);
-    return ptr;
 }
 
 static PyObject *

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1810,8 +1810,8 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
         return NULL;
     }
     inter = PyObject_GetAttrString((PyObject *)arr, "__array_interface__");
-    Py_DECREF(arr);
     if (inter == NULL) {
+        Py_DECREF(arr);
         Py_DECREF(inter);
         return NULL;        
     }
@@ -1823,7 +1823,9 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
     int flags = PyArray_FLAGS(arr);
     obj = gentype_dataptr_get(self, flags, NULL);
     ret = PyDict_SetItemString(inter, "data", obj);
+    Py_DECREF(arr);
     Py_DECREF(obj);
+
     if (ret < 0) {
         Py_DECREF(inter);
         return NULL;

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -20,6 +20,7 @@
 #include "mapping.h"
 #include "ctors.h"
 #include "dtypemeta.h"
+#include "descriptor.h" 
 #include "usertypes.h"
 #include "number.h"
 #include "numpyos.h"
@@ -1788,43 +1789,120 @@ gentype_shape_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 
 
 static PyObject *
-gentype_dataptr_get(PyObject *self, int flags, void *NPY_UNUSED(ignored))
+gentype_dataptr_get(PyObject *self)
 {
-    int _flags = flags;
-    _flags &= ~(NPY_ARRAY_WRITEBACKIFCOPY | NPY_ARRAY_OWNDATA);
-    _flags |= NPY_ARRAY_NOTSWAPPED;
+    PyArrayObject *arr;
+    arr = (PyArrayObject *)PyArray_FromScalar(self, NULL);
 
-    return Py_BuildValue(
-            "NO", PyLong_FromVoidPtr(scalar_value(self, NULL)),
-            ((flags & PyBUF_WRITEABLE) == PyBUF_WRITEABLE) ? Py_False : Py_True);
+    if (arr == NULL) {
+        return NULL;
+    }
+
+    /* NOTE: sclar array is always readonly, but we need writable flags
+     * to use `ctypeslib.as_ctyps` via `__array_interface__`.
+     * So, we set the flag borrowing from the temporary array. 
+     */
+    PyObject* ptr = Py_BuildValue(
+        "NO", PyLong_FromVoidPtr(scalar_value(self, NULL)),
+        (PyArray_FLAGS(arr) & NPY_ARRAY_WRITEABLE) ? Py_False : Py_True
+    );
+
+    Py_DECREF(arr);
+    return ptr;
 }
+
+static PyObject *
+gentype_typestr_get(PyObject *self)
+{
+    return arraydescr_protocol_typestr_get(PyArray_DescrFromScalar(self), NULL);
+}
+
+
+static PyObject *
+gentype_protocol_descr_get(PyObject *self)
+{
+    PyObject *res;
+    PyObject *dobj;
+
+    res = arraydescr_protocol_descr_get(PyArray_DescrFromScalar(self), NULL);
+    if (res) {
+        return res;
+    }
+    PyErr_Clear();
+
+    /* get default */
+    dobj = PyTuple_New(2);
+    if (dobj == NULL) {
+        return NULL;
+    }
+    PyTuple_SET_ITEM(dobj, 0, PyUnicode_FromString(""));
+    PyTuple_SET_ITEM(dobj, 1, gentype_typestr_get(self));
+    res = PyList_New(1);
+    if (res == NULL) {
+        Py_DECREF(dobj);
+        return NULL;
+    }
+    PyList_SET_ITEM(res, 0, dobj);
+    return res;
+}
+
 
 static PyObject *
 gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
-    PyArrayObject *arr;
     PyObject *inter;
-
-    arr = (PyArrayObject *)PyArray_FromScalar(self, NULL);
-    if (arr == NULL) {
-        return NULL;
-    }
-    inter = PyObject_GetAttrString((PyObject *)arr, "__array_interface__");
-    if (inter == NULL) {
-        Py_DECREF(arr);
-        return NULL;        
-    }
-
-    // Overwrite the 'data' field to point to the scalar's data
     PyObject *obj;
     int ret;
-    /* dataptr */
-    int flags = PyArray_FLAGS(arr);
-    obj = gentype_dataptr_get(self, flags, NULL);
-    ret = PyDict_SetItemString(inter, "data", obj);
-    Py_DECREF(arr);
-    Py_DECREF(obj);
 
+    inter = PyDict_New();
+    if (inter == NULL) {
+        return NULL;
+    }
+
+    /* dataptr */
+    obj = gentype_dataptr_get(self);
+    ret = PyDict_SetItemString(inter, "data", obj);
+    Py_DECREF(obj);
+    if (ret < 0) {
+        Py_DECREF(inter);
+        return NULL;
+    }
+
+    obj = gentype_shape_get(self, NULL);
+    ret = PyDict_SetItemString(inter, "strides", obj);
+    Py_DECREF(obj);
+    if (ret < 0) {
+        Py_DECREF(inter);
+        return NULL;
+    }
+
+    obj = gentype_protocol_descr_get(self);
+    ret = PyDict_SetItemString(inter, "descr", obj);
+    Py_DECREF(obj);
+    if (ret < 0) {
+        Py_DECREF(inter);
+        return NULL;
+    }
+
+    obj = gentype_typestr_get(self);
+    ret = PyDict_SetItemString(inter, "typestr", obj);
+    Py_DECREF(obj);
+    if (ret < 0) {
+        Py_DECREF(inter);
+        return NULL;
+    }
+
+    obj = gentype_shape_get(self, NULL);
+    ret = PyDict_SetItemString(inter, "shape", obj);
+    Py_DECREF(obj);
+    if (ret < 0) {
+        Py_DECREF(inter);
+        return NULL;
+    }
+
+    obj = PyLong_FromLong(3);
+    ret = PyDict_SetItemString(inter, "version", obj);
+    Py_DECREF(obj);
     if (ret < 0) {
         Py_DECREF(inter);
         return NULL;

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1798,41 +1798,6 @@ gentype_dataptr_get(PyObject *self)
     );
 }
 
-static PyObject *
-gentype_typestr_get(PyObject *self)
-{
-    return arraydescr_protocol_typestr_get(PyArray_DescrFromScalar(self), NULL);
-}
-
-
-static PyObject *
-gentype_protocol_descr_get(PyObject *self)
-{
-    PyObject *res;
-    PyObject *dobj;
-
-    res = arraydescr_protocol_descr_get(PyArray_DescrFromScalar(self), NULL);
-    if (res) {
-        return res;
-    }
-    PyErr_Clear();
-
-    /* get default */
-    dobj = PyTuple_New(2);
-    if (dobj == NULL) {
-        return NULL;
-    }
-    PyTuple_SET_ITEM(dobj, 0, PyUnicode_FromString(""));
-    PyTuple_SET_ITEM(dobj, 1, gentype_typestr_get(self));
-    res = PyList_New(1);
-    if (res == NULL) {
-        Py_DECREF(dobj);
-        return NULL;
-    }
-    PyList_SET_ITEM(res, 0, dobj);
-    return res;
-}
-
 
 static PyObject *
 gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
@@ -1863,7 +1828,7 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
         return NULL;
     }
 
-    obj = gentype_protocol_descr_get(self);
+    obj = array_protocol_descr_get(PyArray_DescrFromScalar(self));
     ret = PyDict_SetItemString(inter, "descr", obj);
     Py_DECREF(obj);
     if (ret < 0) {
@@ -1871,7 +1836,7 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
         return NULL;
     }
 
-    obj = gentype_typestr_get(self);
+    obj = arraydescr_protocol_typestr_get(PyArray_DescrFromScalar(self), NULL);
     ret = PyDict_SetItemString(inter, "typestr", obj);
     Py_DECREF(obj);
     if (ret < 0) {

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1801,7 +1801,6 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
     if (inter != NULL) {
         PyDict_SetItemString(inter, "__ref", (PyObject *)arr);
     }
-    Py_DECREF(arr);
     return inter;
 }
 

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -413,7 +413,13 @@ class TestAsCtypesType:
 
     @pytest.mark.parametrize(
         "numpy_scalar",
-        [(np.str_("aaa")), (np.datetime64("2026-01-01")), (np.timedelta64(100, "s"))],
+        [
+            (np.str_("aaa")),
+            (np.datetime64("2026-01-01")),
+            (np.timedelta64(100, "s")),
+            (np.complex64(1 + 2j)),
+            (np.complex128(1 + 2j)),
+        ],
     )
     def test_cannot_convert_to_ctypes(self, numpy_scalar: np.generic):
         with pytest.raises(

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -382,13 +382,41 @@ class TestAsCtypesType:
         })
         assert_raises(NotImplementedError, np.ctypeslib.as_ctypes_type, dt)
 
-    def test_retrieve_same_value(self):
+    @pytest.mark.parametrize("numpy_scalar_type, value1, value2", [
+        (np.int8, 10, 100),
+        (np.int16, 10, 100),
+        (np.int32, 10, 100),
+        (np.int64, 10, 100),
+        (np.uint8, 10, 100),
+        (np.uint16, 10, 100),
+        (np.uint32, 10, 100),
+        (np.uint64, 10, 100),
+        (np.float32, 1.5, 2.5),
+        (np.float64, 1.5, 2.5),
+        (np.bool, True, False),
+    ])
+    def test_retrieve_same_scalar_value(
+        self,
+        numpy_scalar_type: np.generic,
+        value1: int | float | bool,
+        value2: int | float | bool,
+    ):
         # gh-30354
-        a = np.int64(10)
-        b = np.int64(100)
+        a = numpy_scalar_type(value1)
+        b = numpy_scalar_type(value2)
 
         s1 = np.ctypeslib.as_ctypes(a)
         s2 = np.ctypeslib.as_ctypes(b)
 
-        assert s1.value == 10
-        assert s2.value == 100
+        assert s1.value == value1
+        assert s2.value == value2
+
+    @pytest.mark.parametrize(
+        "numpy_scalar",
+        [(np.str_("aaa")), (np.datetime64("2026-01-01")), (np.timedelta64(100, "s"))],
+    )
+    def test_cannot_convert_to_ctypes(self, numpy_scalar: np.generic):
+        with pytest.raises(
+            NotImplementedError, match="Converting dtype.* to a ctypes type"
+        ):
+            np.ctypeslib.as_ctypes(numpy_scalar)

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -381,3 +381,14 @@ class TestAsCtypesType:
             'formats': [np.uint32, np.uint32]
         })
         assert_raises(NotImplementedError, np.ctypeslib.as_ctypes_type, dt)
+
+    def test_retrieve_same_value(self):
+        # gh-30354
+        a = np.int64(10)
+        b = np.int64(100)
+
+        s1 = np.ctypeslib.as_ctypes(a)
+        s2 = np.ctypeslib.as_ctypes(b)
+
+        assert s1.value == 10
+        assert s2.value == 100


### PR DESCRIPTION
### Changes

* Implement `__array_interface__` for NumPy scalar types to avoid creating a temporary array.
* Set the read-only flag in the `__array_interface__` dict for NumPy scalars.

As a consequence of this change, ``numpy.ctypeslib.as_ctypes`` now raises ``TypeError`` when NumPy scalar types are passed directly.

Closes #30354
