### PR TITLE
TYP: ``histogram*``: shape-typing and dtype specialization

### DIFF
--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -8,6 +8,7 @@ from numpy._typing import (
     NDArray,
     _ArrayLike,
     _ArrayLikeComplex_co,
+    _ArrayLikeFloat64_co,
     _ArrayLikeFloat_co,
     _ArrayLikeInt_co,
     _ArrayLikeObject_co,
@@ -237,11 +238,36 @@ def histogram(
     weights: _WeightsLike,
 ) -> _HistogramResult[Incomplete, Incomplete]: ...
 
-#
+# unlike `histogram`, `weights` must be safe-castable to f64
+@overload  # dtype +float64
 def histogramdd(
-    sample: ArrayLike,
+    sample: _ArrayLikeInt_co | _NestedSequence[float] | _ArrayLikeObject_co,
     bins: SupportsIndex | ArrayLike = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
-    weights: ArrayLike | None = None,
-) -> tuple[NDArray[Any], tuple[NDArray[Any], ...]]: ...
+    weights: _ArrayLikeFloat64_co | None = None,
+) -> tuple[NDArray[np.float64], tuple[_Array1D[np.float64], ...]]: ...
+@overload  # dtype ~complex
+def histogramdd(
+    sample: _NestedList[complex],
+    bins: SupportsIndex | ArrayLike = 10,
+    range: Sequence[_Range] | None = None,
+    density: bool | None = None,
+    weights: _ArrayLikeFloat64_co | None = None,
+) -> tuple[NDArray[np.float64], tuple[_Array1D[np.complex128], ...]]: ...
+@overload  # dtype known
+def histogramdd[ScalarT: np.inexact](
+    sample: _ArrayLike[ScalarT],
+    bins: SupportsIndex | ArrayLike = 10,
+    range: Sequence[_Range] | None = None,
+    density: bool | None = None,
+    weights: _ArrayLikeFloat64_co | None = None,
+) -> tuple[NDArray[np.float64], tuple[_Array1D[ScalarT], ...]]: ...
+@overload  # dtype unknown
+def histogramdd(
+    sample: _ArrayLikeComplex_co,
+    bins: SupportsIndex | ArrayLike = 10,
+    range: Sequence[_Range] | None = None,
+    density: bool | None = None,
+    weights: _ArrayLikeFloat64_co | None = None,
+) -> tuple[NDArray[np.float64], tuple[_Array1D[Any], ...]]: ...

--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -7,8 +7,9 @@ from numpy._typing import (
     ArrayLike,
     NDArray,
     _ArrayLike,
+    _ArrayLikeComplex_co,
+    _ArrayLikeFloat_co,
     _ArrayLikeInt_co,
-    _ArrayLikeNumber_co,
     _ArrayLikeObject_co,
     _NestedSequence,
 )
@@ -19,54 +20,228 @@ __all__ = ["histogram", "histogramdd", "histogram_bin_edges"]
 
 type _BinKind = L["auto", "fd", "doane", "scott", "stone", "rice", "sturges", "sqrt"]
 
+type _Range = tuple[float, float]
+type _NestedList[T] = list[T] | _NestedSequence[list[T]]
+
+type _WeightsLike = _ArrayLikeComplex_co | _ArrayLikeObject_co
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
-type _WeightsLike = _ArrayLikeNumber_co | _ArrayLikeObject_co
+type _HistogramResult[HistT: np.generic, EdgeT: np.generic] = tuple[_Array1D[HistT], _Array1D[EdgeT]]
 
 ###
 
 # NOTE: The return type can also be complex or `object_`, not only floating like the docstring suggests.
-@overload  # +float64
+@overload  # dtype +float64
 def histogram_bin_edges(
     a: _ArrayLikeInt_co | _NestedSequence[float],
     bins: _BinKind | SupportsIndex | ArrayLike = 10,
-    range: tuple[float, float] | None = None,
+    range: _Range | None = None,
     weights: _WeightsLike | None = None,
 ) -> _Array1D[np.float64]: ...
-@overload  # ~complex
+@overload  # dtype ~complex
 def histogram_bin_edges(
-    a: list[complex] | _NestedSequence[list[complex]],
+    a: _NestedList[complex],
     bins: _BinKind | SupportsIndex | ArrayLike = 10,
-    range: tuple[float, float] | None = None,
+    range: _Range | None = None,
     weights: _WeightsLike | None = None,
 ) -> _Array1D[np.complex128]: ...
-@overload  # ~inexact | object_
+@overload  # dtype known
 def histogram_bin_edges[ScalarT: np.inexact | np.object_](
     a: _ArrayLike[ScalarT],
     bins: _BinKind | SupportsIndex | ArrayLike = 10,
-    range: tuple[float, float] | None = None,
+    range: _Range | None = None,
     weights: _WeightsLike | None = None,
 ) -> _Array1D[ScalarT]: ...
-@overload  # fallback
+@overload  # dtype unknown
 def histogram_bin_edges(
-    a: _ArrayLikeNumber_co,
+    a: _ArrayLikeComplex_co,
     bins: _BinKind | SupportsIndex | ArrayLike = 10,
-    range: tuple[float, float] | None = None,
+    range: _Range | None = None,
     weights: _WeightsLike | None = None,
 ) -> _Array1D[Incomplete]: ...
 
-#
+# There are 4 groups of 2 + 3 overloads (2 for density=True, 3 for density=False) = 20 in total
+@overload  # a: +float64, density: True (keyword), weights: +float | None (default)
 def histogram(
-    a: ArrayLike,
+    a: _ArrayLikeInt_co | _NestedSequence[float],
     bins: _BinKind | SupportsIndex | ArrayLike = 10,
-    range: tuple[float, float] | None = None,
-    density: bool | None = None,
-    weights: ArrayLike | None = None,
-) -> tuple[NDArray[Any], NDArray[Any]]: ...
+    range: _Range | None = None,
+    *,
+    density: L[True],
+    weights: _ArrayLikeFloat_co | None = None,
+) -> _HistogramResult[np.float64, np.float64]: ...
+@overload  # a: +float64, density: True (keyword), weights: +complex
+def histogram(
+    a: _ArrayLikeInt_co | _NestedSequence[float],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    *,
+    density: L[True],
+    weights: _ArrayLike[np.complexfloating] | _NestedList[complex],
+) -> _HistogramResult[np.complex128, np.float64]: ...
+@overload  # a: +float64, density: False (default), weights: ~int | None (default)
+def histogram(
+    a: _ArrayLikeInt_co | _NestedSequence[float],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    weights: _NestedSequence[int] | None = None,
+) -> _HistogramResult[np.intp, np.float64]: ...
+@overload  # a: +float64, density: False (default), weights: known (keyword)
+def histogram[WeightsT: np.bool | np.number | np.timedelta64](
+    a: _ArrayLikeInt_co | _NestedSequence[float],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    *,
+    weights: _ArrayLike[WeightsT],
+) -> _HistogramResult[WeightsT, np.float64]: ...
+@overload  # a: +float64, density: False (default), weights: unknown (keyword)
+def histogram(
+    a: _ArrayLikeInt_co | _NestedSequence[float],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    *,
+    weights: _WeightsLike,
+) -> _HistogramResult[Incomplete, np.float64]: ...
+@overload  # a: ~complex, density: True (keyword), weights: +float | None (default)
+def histogram(
+    a: _NestedList[complex],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    *,
+    density: L[True],
+    weights: _ArrayLikeFloat_co | None = None,
+) -> _HistogramResult[np.float64, np.complex128]: ...
+@overload  # a: ~complex, density: True (keyword), weights: +complex
+def histogram(
+    a: _NestedList[complex],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    *,
+    density: L[True],
+    weights: _ArrayLike[np.complexfloating] | _NestedList[complex],
+) -> _HistogramResult[np.complex128, np.complex128]: ...
+@overload  # a: ~complex, density: False (default), weights: ~int | None (default)
+def histogram(
+    a: _NestedList[complex],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    weights: _NestedSequence[int] | None = None,
+) -> _HistogramResult[np.intp, np.complex128]: ...
+@overload  # a: ~complex, density: False (default), weights: known (keyword)
+def histogram[WeightsT: np.bool | np.number | np.timedelta64](
+    a: _NestedList[complex],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    *,
+    weights: _ArrayLike[WeightsT],
+) -> _HistogramResult[WeightsT, np.complex128]: ...
+@overload  # a: ~complex, density: False (default), weights: unknown (keyword)
+def histogram(
+    a: _NestedList[complex],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    *,
+    weights: _WeightsLike,
+) -> _HistogramResult[Incomplete, np.complex128]: ...
+@overload  # a: known, density: True (keyword), weights: +float | None (default)
+def histogram[ScalarT: np.inexact | np.object_](
+    a: _ArrayLike[ScalarT],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    *,
+    density: L[True],
+    weights: _ArrayLikeFloat_co | None = None,
+) -> _HistogramResult[np.float64, ScalarT]: ...
+@overload  # a: known, density: True (keyword), weights: +complex
+def histogram[ScalarT: np.inexact | np.object_](
+    a: _ArrayLike[ScalarT],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    *,
+    density: L[True],
+    weights: _ArrayLike[np.complexfloating] | _NestedList[complex],
+) -> _HistogramResult[np.complex128, ScalarT]: ...
+@overload  # a: known, density: False (default), weights: ~int | None (default)
+def histogram[ScalarT: np.inexact | np.object_](
+    a: _ArrayLike[ScalarT],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    weights: _NestedSequence[int] | None = None,
+) -> _HistogramResult[np.intp, ScalarT]: ...
+@overload  # a: known, density: False (default), weights: known (keyword)
+def histogram[ScalarT: np.inexact | np.object_, WeightsT: np.bool | np.number | np.timedelta64](
+    a: _ArrayLike[ScalarT],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    *,
+    weights: _ArrayLike[WeightsT],
+) -> _HistogramResult[WeightsT, ScalarT]: ...
+@overload  # a: known, density: False (default), weights: unknown (keyword)
+def histogram[ScalarT: np.inexact | np.object_](
+    a: _ArrayLike[ScalarT],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    *,
+    weights: _WeightsLike,
+) -> _HistogramResult[Incomplete, ScalarT]: ...
+@overload  # a: unknown, density: True (keyword), weights: +float | None (default)
+def histogram(
+    a: _ArrayLikeComplex_co,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    *,
+    density: L[True],
+    weights: _ArrayLikeFloat_co | None = None,
+) -> _HistogramResult[np.float64, Incomplete]: ...
+@overload  # a: unknown, density: True (keyword), weights: +complex
+def histogram(
+    a: _ArrayLikeComplex_co,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    *,
+    density: L[True],
+    weights: _ArrayLike[np.complexfloating] | _NestedList[complex],
+) -> _HistogramResult[np.complex128, Incomplete]: ...
+@overload  # a: unknown, density: False (default), weights: int | None (default)
+def histogram(
+    a: _ArrayLikeComplex_co,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    weights: _NestedSequence[int] | None = None,
+) -> _HistogramResult[np.intp, Incomplete]: ...
+@overload  # a: unknown, density: False (default), weights: known (keyword)
+def histogram[WeightsT: np.bool | np.number | np.timedelta64](
+    a: _ArrayLikeComplex_co,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    *,
+    weights: _ArrayLike[WeightsT],
+) -> _HistogramResult[WeightsT, Incomplete]: ...
+@overload  # a: unknown, density: False (default), weights: unknown (keyword)
+def histogram(
+    a: _ArrayLikeComplex_co,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: _Range | None = None,
+    density: L[False] | None = None,
+    *,
+    weights: _WeightsLike,
+) -> _HistogramResult[Incomplete, Incomplete]: ...
 
+#
 def histogramdd(
     sample: ArrayLike,
     bins: SupportsIndex | ArrayLike = 10,
-    range: Sequence[tuple[float, float]] | None = None,
+    range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: ArrayLike | None = None,
 ) -> tuple[NDArray[Any], tuple[NDArray[Any], ...]]: ...

--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -1,28 +1,60 @@
+from _typeshed import Incomplete
 from collections.abc import Sequence
-from typing import Any, Literal as L, SupportsIndex
+from typing import Any, Literal as L, SupportsIndex, overload
 
-from numpy._typing import ArrayLike, NDArray
+import numpy as np
+from numpy._typing import (
+    ArrayLike,
+    NDArray,
+    _ArrayLike,
+    _ArrayLikeInt_co,
+    _ArrayLikeNumber_co,
+    _ArrayLikeObject_co,
+    _NestedSequence,
+)
 
 __all__ = ["histogram", "histogramdd", "histogram_bin_edges"]
 
-type _BinKind = L[
-    "stone",
-    "auto",
-    "doane",
-    "fd",
-    "rice",
-    "scott",
-    "sqrt",
-    "sturges",
-]
+###
 
+type _BinKind = L["auto", "fd", "doane", "scott", "stone", "rice", "sturges", "sqrt"]
+
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+type _WeightsLike = _ArrayLikeNumber_co | _ArrayLikeObject_co
+
+###
+
+# NOTE: The return type can also be complex or `object_`, not only floating like the docstring suggests.
+@overload  # +float64
 def histogram_bin_edges(
-    a: ArrayLike,
+    a: _ArrayLikeInt_co | _NestedSequence[float],
     bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: tuple[float, float] | None = None,
-    weights: ArrayLike | None = None,
-) -> NDArray[Any]: ...
+    weights: _WeightsLike | None = None,
+) -> _Array1D[np.float64]: ...
+@overload  # ~complex
+def histogram_bin_edges(
+    a: list[complex] | _NestedSequence[list[complex]],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: tuple[float, float] | None = None,
+    weights: _WeightsLike | None = None,
+) -> _Array1D[np.complex128]: ...
+@overload  # ~inexact | object_
+def histogram_bin_edges[ScalarT: np.inexact | np.object_](
+    a: _ArrayLike[ScalarT],
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: tuple[float, float] | None = None,
+    weights: _WeightsLike | None = None,
+) -> _Array1D[ScalarT]: ...
+@overload  # fallback
+def histogram_bin_edges(
+    a: _ArrayLikeNumber_co,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    range: tuple[float, float] | None = None,
+    weights: _WeightsLike | None = None,
+) -> _Array1D[Incomplete]: ...
 
+#
 def histogram(
     a: ArrayLike,
     bins: _BinKind | SupportsIndex | ArrayLike = 10,

--- a/numpy/typing/tests/data/reveal/histograms.pyi
+++ b/numpy/typing/tests/data/reveal/histograms.pyi
@@ -58,11 +58,12 @@ assert_type(np.histogram(AR_f4, weights=list_i), tuple[_Array1D[np.intp], _Array
 assert_type(np.histogram(AR_f4, weights=list_f), tuple[_Array1D[Any], _Array1D[np.float32]])
 assert_type(np.histogram(AR_f4, weights=list_c), tuple[_Array1D[Any], _Array1D[np.float32]])
 
-assert_type(np.histogramdd(AR_i8, bins=[1]),
-            tuple[npt.NDArray[Any], tuple[npt.NDArray[Any], ...]])
-assert_type(np.histogramdd(AR_i8, range=[(0, 3)]),
-            tuple[npt.NDArray[Any], tuple[npt.NDArray[Any], ...]])
-assert_type(np.histogramdd(AR_i8, weights=AR_f8),
-            tuple[npt.NDArray[Any], tuple[npt.NDArray[Any], ...]])
-assert_type(np.histogramdd(AR_f8, density=True),
-            tuple[npt.NDArray[Any], tuple[npt.NDArray[Any], ...]])
+assert_type(np.histogramdd(AR_i8, bins=[1]), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])
+assert_type(np.histogramdd(AR_i8, range=[(0, 3)]), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])
+assert_type(np.histogramdd(AR_i8, weights=AR_f8), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])
+assert_type(np.histogramdd(AR_f8, density=True), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])
+assert_type(np.histogramdd(AR_i4), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])
+assert_type(np.histogramdd(AR_i8), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])
+assert_type(np.histogramdd(AR_f4), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float32], ...]])
+assert_type(np.histogramdd(AR_c8), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.complex64], ...]])
+assert_type(np.histogramdd(AR_c16), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.complex128], ...]])

--- a/numpy/typing/tests/data/reveal/histograms.pyi
+++ b/numpy/typing/tests/data/reveal/histograms.pyi
@@ -3,12 +3,30 @@ from typing import Any, assert_type
 import numpy as np
 import numpy.typing as npt
 
-AR_i8: npt.NDArray[np.int64]
-AR_f8: npt.NDArray[np.float64]
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 
-assert_type(np.histogram_bin_edges(AR_i8, bins="auto"), npt.NDArray[Any])
-assert_type(np.histogram_bin_edges(AR_i8, bins="rice", range=(0, 3)), npt.NDArray[Any])
-assert_type(np.histogram_bin_edges(AR_i8, bins="scott", weights=AR_f8), npt.NDArray[Any])
+AR_i8: npt.NDArray[np.int64]
+AR_f4: npt.NDArray[np.float32]
+AR_f8: npt.NDArray[np.float64]
+AR_c8: npt.NDArray[np.complex64]
+AR_c16: npt.NDArray[np.complex128]
+
+list_i: list[int]
+list_f: list[float]
+list_c: list[complex]
+
+###
+
+assert_type(np.histogram_bin_edges(AR_i8, bins="auto"), _Array1D[np.float64])
+assert_type(np.histogram_bin_edges(AR_i8, bins="rice", range=(0, 3)), _Array1D[np.float64])
+assert_type(np.histogram_bin_edges(AR_i8, bins="scott", weights=AR_f8), _Array1D[np.float64])
+assert_type(np.histogram_bin_edges(AR_f4), _Array1D[np.float32])
+assert_type(np.histogram_bin_edges(AR_f8), _Array1D[np.float64])
+assert_type(np.histogram_bin_edges(AR_c8), _Array1D[np.complex64])
+assert_type(np.histogram_bin_edges(AR_c16), _Array1D[np.complex128])
+assert_type(np.histogram_bin_edges(list_i), _Array1D[np.float64])
+assert_type(np.histogram_bin_edges(list_f), _Array1D[np.float64])
+assert_type(np.histogram_bin_edges(list_c), _Array1D[np.complex128])
 
 assert_type(np.histogram(AR_i8, bins="auto"), tuple[npt.NDArray[Any], npt.NDArray[Any]])
 assert_type(np.histogram(AR_i8, bins="rice", range=(0, 3)), tuple[npt.NDArray[Any], npt.NDArray[Any]])

--- a/numpy/typing/tests/data/reveal/histograms.pyi
+++ b/numpy/typing/tests/data/reveal/histograms.pyi
@@ -5,6 +5,7 @@ import numpy.typing as npt
 
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 
+AR_i4: npt.NDArray[np.int32]
 AR_i8: npt.NDArray[np.int64]
 AR_f4: npt.NDArray[np.float32]
 AR_f8: npt.NDArray[np.float64]
@@ -28,10 +29,34 @@ assert_type(np.histogram_bin_edges(list_i), _Array1D[np.float64])
 assert_type(np.histogram_bin_edges(list_f), _Array1D[np.float64])
 assert_type(np.histogram_bin_edges(list_c), _Array1D[np.complex128])
 
-assert_type(np.histogram(AR_i8, bins="auto"), tuple[npt.NDArray[Any], npt.NDArray[Any]])
-assert_type(np.histogram(AR_i8, bins="rice", range=(0, 3)), tuple[npt.NDArray[Any], npt.NDArray[Any]])
-assert_type(np.histogram(AR_i8, bins="scott", weights=AR_f8), tuple[npt.NDArray[Any], npt.NDArray[Any]])
-assert_type(np.histogram(AR_f8, bins=1, density=True), tuple[npt.NDArray[Any], npt.NDArray[Any]])
+assert_type(np.histogram(AR_i8, bins="auto"), tuple[_Array1D[np.intp], _Array1D[np.float64]])
+assert_type(np.histogram(AR_i8, bins="rice", range=(0, 3)), tuple[_Array1D[np.intp], _Array1D[np.float64]])
+assert_type(np.histogram(AR_i8, bins="scott", weights=AR_f8), tuple[_Array1D[np.float64], _Array1D[np.float64]])
+assert_type(np.histogram(AR_f8, bins=1, density=True), tuple[_Array1D[np.float64], _Array1D[np.float64]])
+assert_type(np.histogram(AR_f4), tuple[_Array1D[np.intp], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f8), tuple[_Array1D[np.intp], _Array1D[np.float64]])
+assert_type(np.histogram(AR_c8), tuple[_Array1D[np.intp], _Array1D[np.complex64]])
+assert_type(np.histogram(AR_c16), tuple[_Array1D[np.intp], _Array1D[np.complex128]])
+assert_type(np.histogram(list_i), tuple[_Array1D[np.intp], _Array1D[np.float64]])
+assert_type(np.histogram(list_f), tuple[_Array1D[np.intp], _Array1D[np.float64]])
+assert_type(np.histogram(list_c), tuple[_Array1D[np.intp], _Array1D[np.complex128]])
+assert_type(np.histogram(AR_f4, density=True), tuple[_Array1D[np.float64], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, density=True, weights=AR_i4), tuple[_Array1D[np.float64], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, density=True, weights=AR_f4), tuple[_Array1D[np.float64], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, density=True, weights=AR_f8), tuple[_Array1D[np.float64], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, density=True, weights=AR_c8), tuple[_Array1D[np.complex128], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, density=True, weights=AR_c16), tuple[_Array1D[np.complex128], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, density=True, weights=list_i), tuple[_Array1D[np.float64], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, density=True, weights=list_f), tuple[_Array1D[np.float64], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, density=True, weights=list_c), tuple[_Array1D[np.complex128], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, weights=AR_i4), tuple[_Array1D[np.int32], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, weights=AR_f4), tuple[_Array1D[np.float32], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, weights=AR_f8), tuple[_Array1D[np.float64], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, weights=AR_c8), tuple[_Array1D[np.complex64], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, weights=AR_c16), tuple[_Array1D[np.complex128], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, weights=list_i), tuple[_Array1D[np.intp], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, weights=list_f), tuple[_Array1D[Any], _Array1D[np.float32]])
+assert_type(np.histogram(AR_f4, weights=list_c), tuple[_Array1D[Any], _Array1D[np.float32]])
 
 assert_type(np.histogramdd(AR_i8, bins=[1]),
             tuple[npt.NDArray[Any], tuple[npt.NDArray[Any], ...]])


### PR DESCRIPTION
The histogram function stubs were mostly incomplete, giving little type-safety. This adds (many) overloads for `histogram_bin_edges`, `histogram`, and `histogramdd` for specific input combinations to return specialized dtypes. This additionally changes the returned array types to include their (often 1d) shape-types.

Don't let the many overloads scare you; because just like with death metal, once you can get past the machine-gun blastbeats and gutteral pig-squealing, then you'll find that there are actually a couple of notes hidden in there. So static typing is basically the death metal of Python (in a good way). I guess that must be why I like it then 🤔.