### PR TITLE
DOC: add a page on CPU/SIMD support under "Building from source"

### DIFF
--- a/doc/source/building/cpu_simd.rst
+++ b/doc/source/building/cpu_simd.rst
@@ -1,0 +1,26 @@
+CPU support & SIMD
+==================
+
+NumPy supports a wide range of platforms and CPUs, and includes a significant
+amount of code optimized for specific CPUs. By default, NumPy targets a
+baseline with the minimum required SIMD instruction sets that are needed
+(e.g., SSE4.2 on x86-64 CPUs) and uses dynamic dispatch to use newer instruction
+sets (e.g., AVX2 and AVX512 on x86-64) when those are detected at runtime.
+
+There are a number of build options that can be used to modify that behavior.
+The default build settings are chosen for both portability and performance, and
+should be reasonably close to optimal for creating redistributable binaries as
+well as local installs. That said, there are reasons one may want to change the
+default behavior, for example to obtain smaller binaries, to install on very old
+hardware, to work around bugs, or for testing.
+
+To detect and uses all CPU features available on your local machine::
+
+    $ python -m pip install . -Csetup-args=-Dcpu-baseline="native" -Csetup-args=-Dcpu-dispatch="none"
+
+To use a lower baseline without any SIMD optimizations, useful for very old CPUs::
+
+    $ python -m pip install . -Csetup-args=-Dcpu-baseline="none"
+
+For more usage scenarios and more in-depth information about NumPy's SIMD support,
+see :ref:`cpu-build-options`.

--- a/doc/source/building/cpu_simd.rst
+++ b/doc/source/building/cpu_simd.rst
@@ -14,7 +14,7 @@ well as local installs. That said, there are reasons one may want to change the
 default behavior, for example to obtain smaller binaries, to install on very old
 hardware, to work around bugs, or for testing.
 
-To detect and uses all CPU features available on your local machine::
+To detect and use all CPU features available on your local machine::
 
     $ python -m pip install . -Csetup-args=-Dcpu-baseline="native" -Csetup-args=-Dcpu-dispatch="none"
 

--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -237,7 +237,7 @@ your system.
 
     First, install Microsoft Visual Studio - the 2022 Community Edition will
     work (see the `Visual Studio download site <https://visualstudio.microsoft.com/downloads/>`__).
-    Ensure that you have installed necessary Visual Studio components for building NumPy 
+    Ensure that you have installed necessary Visual Studio components for building NumPy
     on WoA from `here <https://gist.github.com/Mugundanmcw/c3bb93018d5da9311fb2b222f205ba19>`__.
 
     To use the flang compiler for Windows on ARM64, install Latest LLVM
@@ -515,6 +515,7 @@ Customizing builds
 
    compilers_and_options
    blas_lapack
+   cpu_simd
    cross_compilation
    redistributable_binaries
 

--- a/doc/source/reference/simd/build-options.rst
+++ b/doc/source/reference/simd/build-options.rst
@@ -1,3 +1,5 @@
+.. _cpu-build-options:
+
 *****************
 CPU Build Options
 *****************


### PR DESCRIPTION
Implements a suggestion made in gh-30492.