### PR TITLE
MAINT: consistent ``__new__`` parameter naming

### DIFF
--- a/numpy/_core/defchararray.py
+++ b/numpy/_core/defchararray.py
@@ -543,7 +543,7 @@ class chararray(ndarray):
                [b'abc', b'abc', b'abc']], dtype='|S5')
 
     """
-    def __new__(subtype, shape, itemsize=1, unicode=False, buffer=None,
+    def __new__(cls, shape, itemsize=1, unicode=False, buffer=None,
                 offset=0, strides=None, order='C'):
         if unicode:
             dtype = str_
@@ -563,10 +563,10 @@ class chararray(ndarray):
             filler = None
 
         if buffer is None:
-            self = ndarray.__new__(subtype, shape, (dtype, itemsize),
+            self = ndarray.__new__(cls, shape, (dtype, itemsize),
                                    order=order)
         else:
-            self = ndarray.__new__(subtype, shape, (dtype, itemsize),
+            self = ndarray.__new__(cls, shape, (dtype, itemsize),
                                    buffer=buffer,
                                    offset=offset, strides=strides,
                                    order=order)

--- a/numpy/_core/defchararray.pyi
+++ b/numpy/_core/defchararray.pyi
@@ -89,7 +89,7 @@ type _StringDTypeSupportsArray = _SupportsArray[np.dtypes.StringDType]
 class chararray(ndarray[_ShapeT_co, _CharDTypeT_co]):
     @overload
     def __new__(
-        subtype,
+        cls,
         shape: _ShapeLike,
         itemsize: SupportsIndex | SupportsInt = 1,
         unicode: L[False] = False,
@@ -100,7 +100,7 @@ class chararray(ndarray[_ShapeT_co, _CharDTypeT_co]):
     ) -> _CharArray[bytes_]: ...
     @overload
     def __new__(
-        subtype,
+        cls,
         shape: _ShapeLike,
         itemsize: SupportsIndex | SupportsInt,
         unicode: L[True],
@@ -111,7 +111,7 @@ class chararray(ndarray[_ShapeT_co, _CharDTypeT_co]):
     ) -> _CharArray[str_]: ...
     @overload
     def __new__(
-        subtype,
+        cls,
         shape: _ShapeLike,
         itemsize: SupportsIndex | SupportsInt = 1,
         *,

--- a/numpy/_core/memmap.py
+++ b/numpy/_core/memmap.py
@@ -213,7 +213,7 @@ class memmap(ndarray):
 
     __array_priority__ = -100.0
 
-    def __new__(subtype, filename, dtype=uint8, mode='r+', offset=0,
+    def __new__(cls, filename, dtype=uint8, mode='r+', offset=0,
                 shape=None, order='C'):
         # Import here to minimize 'import numpy' overhead
         import mmap
@@ -290,7 +290,7 @@ class memmap(ndarray):
             array_offset = offset - start
             mm = mmap.mmap(fid.fileno(), bytes, access=acc, offset=start)
 
-            self = ndarray.__new__(subtype, shape, dtype=descr, buffer=mm,
+            self = ndarray.__new__(cls, shape, dtype=descr, buffer=mm,
                                    offset=array_offset, order=order)
             self._mmap = mm
             self.offset = offset

--- a/numpy/_core/memmap.pyi
+++ b/numpy/_core/memmap.pyi
@@ -39,7 +39,7 @@ class memmap(np.ndarray[_ShapeT_co, _DTypeT_co]):
 
     @overload
     def __new__[ScalarT: np.generic](
-        subtype,  # pyright: ignore[reportSelfClsParameterName]
+        cls,
         filename: StrOrBytesPath | _SupportsFileMethodsRW,
         dtype: _DTypeT_co,
         mode: _ToMode = "r+",
@@ -49,7 +49,7 @@ class memmap(np.ndarray[_ShapeT_co, _DTypeT_co]):
     ) -> Self: ...
     @overload
     def __new__(
-        subtype,  # pyright: ignore[reportSelfClsParameterName]
+        cls,
         filename: StrOrBytesPath | _SupportsFileMethodsRW,
         dtype: type[np.uint8] = ...,
         mode: _ToMode = "r+",
@@ -59,7 +59,7 @@ class memmap(np.ndarray[_ShapeT_co, _DTypeT_co]):
     ) -> memmap[_AnyShape, np.dtype[np.uint8]]: ...
     @overload
     def __new__[ScalarT: np.generic](
-        subtype,  # pyright: ignore[reportSelfClsParameterName]
+        cls,
         filename: StrOrBytesPath | _SupportsFileMethodsRW,
         dtype: _DTypeLike[ScalarT],
         mode: _ToMode = "r+",
@@ -69,7 +69,7 @@ class memmap(np.ndarray[_ShapeT_co, _DTypeT_co]):
     ) -> memmap[_AnyShape, np.dtype[ScalarT]]: ...
     @overload
     def __new__(
-        subtype,  # pyright: ignore[reportSelfClsParameterName]
+        cls,
         filename: StrOrBytesPath | _SupportsFileMethodsRW,
         dtype: DTypeLike,
         mode: _ToMode = "r+",

--- a/numpy/_core/records.py
+++ b/numpy/_core/records.py
@@ -383,7 +383,7 @@ class recarray(ndarray):
 
     """
 
-    def __new__(subtype, shape, dtype=None, buf=None, offset=0, strides=None,
+    def __new__(cls, shape, dtype=None, buf=None, offset=0, strides=None,
                 formats=None, names=None, titles=None,
                 byteorder=None, aligned=False, order='C'):
 
@@ -395,12 +395,10 @@ class recarray(ndarray):
             ).dtype
 
         if buf is None:
-            self = ndarray.__new__(
-                subtype, shape, (record, descr), order=order
-            )
+            self = ndarray.__new__(cls, shape, (record, descr), order=order)
         else:
             self = ndarray.__new__(
-                subtype, shape, (record, descr), buffer=buf,
+                cls, shape, (record, descr), buffer=buf,
                 offset=offset, strides=strides, order=order
             )
         return self

--- a/numpy/_core/records.pyi
+++ b/numpy/_core/records.pyi
@@ -75,7 +75,7 @@ class recarray(np.ndarray[_ShapeT_co, _DTypeT_co]):
 
     @overload
     def __new__(
-        subtype,
+        cls,
         shape: _ShapeLike,
         dtype: None = None,
         buf: Buffer | None = None,
@@ -91,7 +91,7 @@ class recarray(np.ndarray[_ShapeT_co, _DTypeT_co]):
     ) -> _RecArray[record]: ...
     @overload
     def __new__(
-        subtype,
+        cls,
         shape: _ShapeLike,
         dtype: DTypeLike | None,
         buf: Buffer | None = None,

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4482,8 +4482,8 @@ class TestSubclass:
     def test_subclass_op(self):
 
         class simple(np.ndarray):
-            def __new__(subtype, shape):
-                self = np.ndarray.__new__(subtype, shape, dtype=object)
+            def __new__(cls, shape):
+                self = np.ndarray.__new__(cls, shape, dtype=object)
                 self.fill(0)
                 return self
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6530,11 +6530,11 @@ class mvoid(MaskedArray):
     Fake a 'void' object to use for masked array with structured dtypes.
     """
 
-    def __new__(self, data, mask=nomask, dtype=None, fill_value=None,
+    def __new__(cls, data, mask=nomask, dtype=None, fill_value=None,
                 hardmask=False, copy=False, subok=True):
         copy = None if not copy else True
         _data = np.array(data, copy=copy, subok=subok, dtype=dtype)
-        _data = _data.view(self)
+        _data = _data.view(cls)
         _data._hardmask = hardmask
         if mask is not nomask:
             if isinstance(mask, np.void):

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -2563,7 +2563,7 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
 
 class mvoid(MaskedArray[_ShapeT_co, _DTypeT_co]):
     def __new__(
-        self,  # pyright: ignore[reportSelfClsParameterName]
+        cls,
         data,
         mask=...,
         dtype=...,

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -116,7 +116,7 @@ class matrix(N.ndarray):
     """
     __array_priority__ = 10.0
 
-    def __new__(subtype, data, dtype=None, copy=True):
+    def __new__(cls, data, dtype=None, copy=True):
         warnings.warn('the matrix subclass is not the recommended way to '
                       'represent matrices or deal with linear algebra (see '
                       'https://docs.scipy.org/doc/numpy/user/'
@@ -136,7 +136,7 @@ class matrix(N.ndarray):
                 intype = data.dtype
             else:
                 intype = N.dtype(dtype)
-            new = data.view(subtype)
+            new = data.view(cls)
             if intype != data.dtype:
                 return new.astype(intype)
             if copy:
@@ -166,9 +166,7 @@ class matrix(N.ndarray):
         if not (order or arr.flags.contiguous):
             arr = arr.copy()
 
-        ret = N.ndarray.__new__(subtype, shape, arr.dtype,
-                                buffer=arr,
-                                order=order)
+        ret = N.ndarray.__new__(cls, shape, arr.dtype, buffer=arr, order=order)
         return ret
 
     def __array_finalize__(self, obj):

--- a/numpy/matrixlib/defmatrix.pyi
+++ b/numpy/matrixlib/defmatrix.pyi
@@ -30,12 +30,7 @@ type _ToIndex2 = tuple[_ToIndex1, _ToIndex1 | SupportsIndex] | tuple[_ToIndex1 |
 class matrix(np.ndarray[_ShapeT_co, _DTypeT_co]):
     __array_priority__: ClassVar[float] = 10.0  # pyright: ignore[reportIncompatibleMethodOverride]
 
-    def __new__(
-        subtype,  # pyright: ignore[reportSelfClsParameterName]
-        data: ArrayLike,
-        dtype: DTypeLike | None = None,
-        copy: bool = True,
-    ) -> _Matrix[Incomplete]: ...
+    def __new__(cls, data: ArrayLike, dtype: DTypeLike | None = None, copy: bool = True) -> _Matrix[Incomplete]: ...
 
     #
     @overload  # type: ignore[override]


### PR DESCRIPTION
Pyright, for example, complains about ``__new__`` methods whose first parameter isn't named ``cls``.