### PR TITLE
DOC: Minor refine castbuf and DECREF explanation in ufuncs.rst

### DIFF
--- a/doc/ufuncs.rst
+++ b/doc/ufuncs.rst
@@ -78,10 +78,7 @@ If there are object arrays involved then loop->obj gets set to 1.  Then there ar
 	      loop, then "remainder" DECREF's are needed).
 
    Outputs:
-            - castbuf contains a new reference as the result of the function call.  This
-	      gets converted to the type of interest and.  This new reference in castbuf
-	      will be DECREF'd by later calls to the function.  Thus, only after the
-	      inner most loop do we need to DECREF the remaining references in castbuf.
+        - castbuf contains a new reference as the result of the function call. This is converted to the type of interest, and this new reference in castbuf                   will be DECREF'd (its reference count decreased) by later calls to the function. Thus, only after the innermost loop finishes do we need to DECREF                  the remaining references in castbuf.
 
 2) The loop function is of a different type:
 

--- a/doc/ufuncs.rst
+++ b/doc/ufuncs.rst
@@ -78,7 +78,11 @@ If there are object arrays involved then loop->obj gets set to 1.  Then there ar
 	      loop, then "remainder" DECREF's are needed).
 
    Outputs:
-        - castbuf contains a new reference as the result of the function call. This is converted to the type of interest, and this new reference in castbuf                   will be DECREF'd (its reference count decreased) by later calls to the function. Thus, only after the innermost loop finishes do we need to DECREF                  the remaining references in castbuf.
+        - castbuf contains a new reference as the result of the function call.
+          This is converted to the type of interest, and this new reference 
+          in castbuf will be DECREF'd (its reference count decreased) by
+          later calls to the function. Thus, only after the innermost loop
+          finishes do we need to DECREF the remaining references in castbuf.
 
 2) The loop function is of a different type:
 


### PR DESCRIPTION
This PR fixes a grammatical fragment in the ufuncs.rst documentation where a sentence ended abruptly with "and." Additionally, it adds brief clarifications for the term DECREF to assist developers less familiar with CPython reference counting. The logic remains unchanged, focusing only on improving readability and fixing documentation typos.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
