### PR TITLE
DOC: relnotes for the ``numpy.ma`` typing improvements

### DIFF
--- a/doc/release/upcoming_changes/30566.typing.rst
+++ b/doc/release/upcoming_changes/30566.typing.rst
@@ -1,0 +1,5 @@
+``numpy.ma`` typing annotations
+-------------------------------
+The ``numpy.ma`` module is now fully covered by typing annotations.
+This includes annotations for masked arrays, masks, and various functions and methods.
+With this, NumPy has achieved 100% typing coverage across all its submodules.


### PR DESCRIPTION
See https://github.com/numpy/numpy/issues?q=is%3Apr%20state%3Aclosed%20label%3A%2241%20-%20Static%20typing%22%20label%3A%22component%3A%20numpy.ma%22 for the full list of PR's