### PR TITLE
BUG: np.einsum('i...->i', optimize=False) errored out when optimize=True didn't

### DIFF
--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -830,6 +830,19 @@ class TestEinsum:
             assert_equal(np.einsum('...lmn,lmno->...o', A, B,
                                    optimize=opt), ref)  # used to raise error
 
+    def test_einsum_broadcast_30349(self):
+        # Issue 30349 related to broadcasting with ellipsis
+        # np.einsum with optimize=True was not handling broadcasting
+        # correctly when ellipsis were involved (e.g. 'i...->i')
+        x = np.array([[[1,2,3],[1,2,3],[1,2,3]],
+                    [[1,2,3],[1,2,3],[1,2,3]],
+                    [[1,2,3],[1,2,3],[1,2,3]]])
+        
+        print(np.einsum("i...->i", x, optimize=False))
+
+        assert_equal(np.einsum("i...->i", x, optimize=False), np.array([18, 18, 18]))
+        assert_equal(np.einsum("i...->i", x, optimize=True), np.einsum("i...->i", x, optimize=False))
+
     def test_einsum_fixedstridebug(self):
         # Issue #4485 obscure einsum bug
         # This case revealed a bug in nditer where it reported a stride

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -832,18 +832,50 @@ class TestEinsum:
 
     def test_einsum_broadcast_30349(self):
         # Issue #30349 related to broadcasting with ellipsis
-        x = np.tile(np.array([1,2,3]), (3, 3, 1))
+        # Specific case that was failing
+        x = np.tile(np.array([1, 2, 3]), (3, 3, 1))
 
         assert_equal(np.einsum("i...->i", x, optimize=False), np.array([18, 18, 18]))
         assert_equal(np.einsum("i...->i", x, optimize=True), np.einsum("i...->i", x, optimize=False))
 
-        # Test other subscripts for same results with both paths
-        for subscript in {"...i->i", "ij...->i", "ij...->ij",
-                          "...ij->i", "...ij->ij", "i...j->i",
-                          "i...j->ij", "ijk->i", "ijk->ij", "ijk->ijk"}:
-            result = np.einsum(subscript, x, optimize=True)
-            expected = np.einsum(subscript, x, optimize=False)
-            assert_equal(result, expected)
+    @pytest.mark.parametrize(
+        "subscript",
+        [
+            ("...i->i"),
+            ("ij...->i"),
+            ("ij...->ij"),
+            ("...ij->i"),
+            ("...ij->ij"),
+            ("i...j->i"),
+            ("i...j->ij"),
+            ("ijk->i"),
+            ("ijk->ij"),
+            ("ijk->ijk")
+        ])
+    def test_einsum_ellipsis_30349_single_operand(self, subscript):
+        # Test other subscripts for same results with both optimized and unoptimized paths
+        x = np.tile(np.array([1, 2, 3]), (3, 3, 1))
+        result = np.einsum(subscript, x, optimize=True)
+        expected = np.einsum(subscript, x, optimize=False)
+        assert_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "subscript",
+        [
+            ("ij..., i...->i"),
+            ("j..., i...->j"),
+            ("j..., i...->"),
+            ("ijk, jk...->"),
+            ("ijk, k...->i"),
+            ("ijk, klm->k"),
+            ("ijk, jkl->ik")
+        ])
+    def test_einsum_ellipsis_30349_two_operands(self, subscript):
+        # Test other subscripts for same results with both optimized and unoptimized paths
+        x = np.tile(np.array([1, 2, 3]), (3, 3, 1))
+        result = np.einsum(subscript, x, x, optimize=True)
+        expected = np.einsum(subscript, x, x, optimize=False)
+        assert_equal(result, expected)
 
     def test_einsum_fixedstridebug(self):
         # Issue #4485 obscure einsum bug

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -834,10 +834,10 @@ class TestEinsum:
         # Issue 30349 related to broadcasting with ellipsis
         # np.einsum with optimize=True was not handling broadcasting
         # correctly when ellipsis were involved (e.g. 'i...->i')
-        x = np.array([[[1,2,3],[1,2,3],[1,2,3]],
-                    [[1,2,3],[1,2,3],[1,2,3]],
-                    [[1,2,3],[1,2,3],[1,2,3]]])
-        
+        x = np.array([[[1, 2, 3], [1, 2, 3], [1, 2, 3]],
+                    [[1, 2, 3], [1, 2, 3], [1, 2, 3]],
+                    [[1, 2, 3], [1, 2, 3], [1, 2, 3]]])
+
         print(np.einsum("i...->i", x, optimize=False))
 
         assert_equal(np.einsum("i...->i", x, optimize=False), np.array([18, 18, 18]))

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -831,17 +831,19 @@ class TestEinsum:
                                    optimize=opt), ref)  # used to raise error
 
     def test_einsum_broadcast_30349(self):
-        # Issue 30349 related to broadcasting with ellipsis
-        # np.einsum with optimize=True was not handling broadcasting
-        # correctly when ellipsis were involved (e.g. 'i...->i')
-        x = np.array([[[1, 2, 3], [1, 2, 3], [1, 2, 3]],
-                    [[1, 2, 3], [1, 2, 3], [1, 2, 3]],
-                    [[1, 2, 3], [1, 2, 3], [1, 2, 3]]])
-
-        print(np.einsum("i...->i", x, optimize=False))
+        # Issue #30349 related to broadcasting with ellipsis
+        x = np.tile(np.array([1,2,3]), (3, 3, 1))
 
         assert_equal(np.einsum("i...->i", x, optimize=False), np.array([18, 18, 18]))
         assert_equal(np.einsum("i...->i", x, optimize=True), np.einsum("i...->i", x, optimize=False))
+
+        # Test other subscripts for same results with both paths
+        for subscript in {"...i->i", "ij...->i", "ij...->ij",
+                          "...ij->i", "...ij->ij", "i...j->i",
+                          "i...j->ij", "ijk->i", "ijk->ij", "ijk->ijk"}:
+            result = np.einsum(subscript, x, optimize=True)
+            expected = np.einsum(subscript, x, optimize=False)
+            assert_equal(result, expected)
 
     def test_einsum_fixedstridebug(self):
         # Issue #4485 obscure einsum bug


### PR DESCRIPTION
Fixes #30349

`np.einsum('i...->i', x)` works as expected when optimize=True but throws a ValueError when optimize=False,
with `x = np.array([[[1,2,3], [1,2,3], [1,2,3]], [[1,2,3], [1,2,3], [1,2,3]], [[1,2,3], [1,2,3], [1,2,3]]])`.

## NB

np.einsum('ijk->i', x) worked as expected with optimize=False, indicating an error in broadcasting with ellipses.

## Error message

Traceback (most recent call last):
  File "<python-input-0>", line 5, in <module>
    np.einsum('i...->i', x)
    ~~~~~~~~~^^^^^^^^^^^^^^```
File "[...]/venv/lib/python3.13/site-packages/numpy/_core/einsumfunc.py", line 1423, in einsum
    return c_einsum(*operands, **kwargs)
ValueError: output has more dimensions than subscripts given in einstein sum, but no '...' ellipsis provided to broadcast the extra dimensions.

## Fix

Deleted errors thrown for valid syntax; added the infered broadcasted dimensions to the dimensions of the operands, with label '0', so that 'i...->' is effectively processed the same way as 'ijk->' and so that it can use the same accelerations.