### PR TITLE
BUG: Set correct deprecation version for ndarray.resize

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2248,10 +2248,10 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def tolist(self, /) -> Any: ...
 
     @overload
-    @deprecated("Resizing a NumPy array inplace has been deprecated in NumPy 2.4")
+    @deprecated("Resizing a NumPy array inplace has been deprecated in NumPy 2.5")
     def resize(self, new_shape: _ShapeLike, /, *, refcheck: py_bool = True) -> None: ...
     @overload
-    @deprecated("Resizing a NumPy array inplace has been deprecated in NumPy 2.4")
+    @deprecated("Resizing a NumPy array inplace has been deprecated in NumPy 2.5")
     def resize(self, /, *new_shape: SupportsIndex, refcheck: py_bool = True) -> None: ...
 
     # keep in sync with `ma.MaskedArray.squeeze`


### PR DESCRIPTION
In https://github.com/numpy/numpy/pull/30181 an incorrect numpy version in the deprecation message for ndarray.resize was set. This PR sets the version to 2.5

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
