### PR TITLE
TYP: ``numpy.core`` stubs 

### DIFF
--- a/numpy/core/__init__.pyi
+++ b/numpy/core/__init__.pyi
@@ -1,0 +1,45 @@
+# deprecated module
+
+from types import ModuleType
+
+from . import (
+    _dtype,
+    _dtype_ctypes,
+    _internal,
+    arrayprint,
+    defchararray,
+    einsumfunc,
+    fromnumeric,
+    function_base,
+    getlimits,
+    multiarray,
+    numeric,
+    numerictypes,
+    overrides,
+    records,
+    shape_base,
+    umath,
+)
+
+__all__ = [
+    "_dtype",
+    "_dtype_ctypes",
+    "_internal",
+    "_multiarray_umath",
+    "arrayprint",
+    "defchararray",
+    "einsumfunc",
+    "fromnumeric",
+    "function_base",
+    "getlimits",
+    "multiarray",
+    "numeric",
+    "numerictypes",
+    "overrides",
+    "records",
+    "shape_base",
+    "umath",
+]
+
+# `numpy._core._multiarray_umath` has no stubs, so there's nothing to re-export
+_multiarray_umath: ModuleType

--- a/numpy/core/_internal.pyi
+++ b/numpy/core/_internal.pyi
@@ -1,0 +1,1 @@
+# deprecated module

--- a/numpy/core/arrayprint.pyi
+++ b/numpy/core/arrayprint.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.arrayprint import *
+from numpy._core.arrayprint import __all__ as __all__

--- a/numpy/core/defchararray.pyi
+++ b/numpy/core/defchararray.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.defchararray import *
+from numpy._core.defchararray import __all__ as __all__

--- a/numpy/core/einsumfunc.pyi
+++ b/numpy/core/einsumfunc.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.einsumfunc import *
+from numpy._core.einsumfunc import __all__ as __all__

--- a/numpy/core/fromnumeric.pyi
+++ b/numpy/core/fromnumeric.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.fromnumeric import *
+from numpy._core.fromnumeric import __all__ as __all__

--- a/numpy/core/function_base.pyi
+++ b/numpy/core/function_base.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.function_base import *
+from numpy._core.function_base import __all__ as __all__

--- a/numpy/core/getlimits.pyi
+++ b/numpy/core/getlimits.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.getlimits import *
+from numpy._core.getlimits import __all__ as __all__

--- a/numpy/core/multiarray.pyi
+++ b/numpy/core/multiarray.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.multiarray import *
+from numpy._core.multiarray import __all__ as __all__

--- a/numpy/core/numeric.pyi
+++ b/numpy/core/numeric.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.numeric import *
+from numpy._core.numeric import __all__ as __all__

--- a/numpy/core/numerictypes.pyi
+++ b/numpy/core/numerictypes.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.numerictypes import *
+from numpy._core.numerictypes import __all__ as __all__

--- a/numpy/core/records.pyi
+++ b/numpy/core/records.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.records import *
+from numpy._core.records import __all__ as __all__

--- a/numpy/core/shape_base.pyi
+++ b/numpy/core/shape_base.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.shape_base import *
+from numpy._core.shape_base import __all__ as __all__

--- a/numpy/core/umath.pyi
+++ b/numpy/core/umath.pyi
@@ -1,0 +1,4 @@
+# deprecated module
+
+from numpy._core.umath import *
+from numpy._core.umath import __all__ as __all__

--- a/tools/stubtest/allowlist.txt
+++ b/tools/stubtest/allowlist.txt
@@ -16,7 +16,7 @@ numpy\._core\._simd\.\w+
 
 # these are always either float96/complex192 or float128/complex256
 numpy\.__all__
-numpy\._?core\.__all__
+numpy\._core\.__all__
 numpy\._?core\.numeric\.__all__
 numpy\._?core\.numerictypes\.__all__
 numpy\.matlib\.__all__
@@ -43,22 +43,6 @@ numpy\.(\w+\.)*complexfloating\.__complex__
 numpy\.(\w+\.)*generic\.__hash__
 
 # intentionally missing deprecated module stubs
-numpy\.core\._dtype
-numpy\.core\._dtype_ctypes
-numpy\.core\._internal
-numpy\.core\._multiarray_umath.*
-numpy\.core\.arrayprint.*
-numpy\.core\.defchararray.*
-numpy\.core\.einsumfunc.*
-numpy\.core\.fromnumeric.*
-numpy\.core\.function_base.*
-numpy\.core\.getlimits.*
-numpy\.core\.multiarray.*
-numpy\.core\.numeric.*
-numpy\.core\.overrides
-numpy\.core\.records.*
-numpy\.core\.shape_base.*
-numpy\.core\.umath.*
 numpy\.typing\.mypy_plugin
 
 # false positive "... is not a Union" errors


### PR DESCRIPTION
This is needed to get the typing coverage score to 100%. It's just too bad that there exists no mechanism similar to `@warnings.deprecate`  that can be used to statically mark entire modules as deprecated, so we can't have the cake and eat it too.

The other option (which I'd prefer TBH), would be to get rid of `numpy.core`. It has been deprecated two years ago in NumPy 2.0, after all. So... should we? Because if so, then I'd happily close this and rip `numpy.core` out instead.