### PR TITLE
TYP: move ``busdaycalendar`` stubs from ``__init__.pyi`` to ``_core/multiarray.pyi``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -316,6 +316,7 @@ from numpy._core.multiarray import (
     ascontiguousarray,
     asfortranarray,
     arange,
+    busdaycalendar,
     busday_count,
     busday_offset,
     datetime_as_string,
@@ -6062,19 +6063,6 @@ class broadcast:
     def __next__(self) -> tuple[Any, ...]: ...
     def __iter__(self) -> Self: ...
     def reset(self) -> None: ...
-
-@final
-class busdaycalendar:
-    def __init__(
-        self,
-        /,
-        weekmask: str | Sequence[int | bool_ | integer] | _SupportsArray[dtype[bool_ | integer]] = "1111100",
-        holidays: Sequence[dt.date | datetime64] | _SupportsArray[dtype[datetime64]] | None = None,
-    ) -> None: ...
-    @property
-    def weekmask(self) -> ndarray[tuple[int], dtype[bool_]]: ...
-    @property
-    def holidays(self) -> ndarray[tuple[int], dtype[datetime64[dt.date]]]: ...
 
 @final
 class nditer:

--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -25,7 +25,6 @@ from numpy import (  # type: ignore[attr-defined]  # Python >=3.12
     _OrderKACF,
     _SupportsFileMethods,
     broadcast,
-    busdaycalendar,
     complexfloating,
     correlate,
     count_nonzero,
@@ -1129,6 +1128,23 @@ def arange(
 #
 def datetime_data(dtype: str | _DTypeLike[datetime64 | timedelta64], /) -> tuple[str, int]: ...
 
+#
+@final
+class busdaycalendar:
+    __module__: ClassVar[L["numpy"]] = "numpy"  # type: ignore[misc]  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    def __init__(
+        self,
+        /,
+        weekmask: str | Sequence[_IntLike_co] | _SupportsArray[NDArray[np.bool | np.integer]] = "1111100",
+        holidays: Sequence[dt.date | np.datetime64[dt.date]] | _SupportsArray[NDArray[np.datetime64[dt.date]]] | None = None,
+    ) -> None: ...
+    @property
+    def weekmask(self) -> _Array1D[np.bool]: ...
+    @property
+    def holidays(self) -> _Array1D[np.datetime64[dt.date]]: ...
+
+#
 @overload
 def busday_count(
     begindates: _ScalarLike_co | dt.date,


### PR DESCRIPTION
See #29915 for the motivation