### PR TITLE
MAINT: avoid passing ints to functions that take double

### DIFF
--- a/numpy/random/_common.pxd
+++ b/numpy/random/_common.pxd
@@ -26,12 +26,15 @@ cdef enum ConstraintType:
     LEGACY_CONS_NON_NEGATIVE_INBOUNDS_LONG
 
 ctypedef ConstraintType constraint_type
+ctypedef fused double_or_int64:
+    double
+    int64_t
 
 cdef object benchmark(bitgen_t *bitgen, object lock, Py_ssize_t cnt, object method)
 cdef object random_raw(bitgen_t *bitgen, object lock, object size, object output)
 cdef object prepare_cffi(bitgen_t *bitgen)
 cdef object prepare_ctypes(bitgen_t *bitgen)
-cdef int check_constraint(double val, object name, constraint_type cons) except -1
+cdef int check_constraint(double_or_int64 val, object name, constraint_type cons) except -1
 cdef int check_array_constraint(np.ndarray val, object name, constraint_type cons) except -1
 
 cdef extern from "include/aligned_malloc.h":

--- a/numpy/random/_common.pyx
+++ b/numpy/random/_common.pyx
@@ -427,10 +427,10 @@ cdef int check_array_constraint(np.ndarray val, object name, constraint_type con
 
 cdef int check_constraint(double_or_int64 val, object name, constraint_type cons) except -1:
     if cons == CONS_NON_NEGATIVE:
-        if not isnan(val) and signbit(val):
+        if double_or_int64 is double and not isnan(val) and signbit(val):
             raise ValueError(f"{name} < 0")
     elif cons == CONS_POSITIVE or cons == CONS_POSITIVE_NOT_NAN:
-        if cons == CONS_POSITIVE_NOT_NAN and isnan(val):
+        if cons == CONS_POSITIVE_NOT_NAN and double_or_int64 is double and isnan(val):
             raise ValueError(f"{name} must not be NaN")
         elif val <= 0:
             raise ValueError(f"{name} <= 0")

--- a/numpy/random/_common.pyx
+++ b/numpy/random/_common.pyx
@@ -427,7 +427,8 @@ cdef int check_array_constraint(np.ndarray val, object name, constraint_type con
 
 cdef int check_constraint(double_or_int64 val, object name, constraint_type cons) except -1:
     if cons == CONS_NON_NEGATIVE:
-        if double_or_int64 is double and not isnan(val) and signbit(val):
+        if ((double_or_int64 is double and not isnan(val) and signbit(val)) or
+            (double_or_int64 is int64_t and val < 0)):
             raise ValueError(f"{name} < 0")
     elif cons == CONS_POSITIVE or cons == CONS_POSITIVE_NOT_NAN:
         if cons == CONS_POSITIVE_NOT_NAN and double_or_int64 is double and isnan(val):

--- a/numpy/random/_common.pyx
+++ b/numpy/random/_common.pyx
@@ -425,7 +425,7 @@ cdef int check_array_constraint(np.ndarray val, object name, constraint_type con
     return 0
 
 
-cdef int check_constraint(double val, object name, constraint_type cons) except -1:
+cdef int check_constraint(double_or_int64 val, object name, constraint_type cons) except -1:
     if cons == CONS_NON_NEGATIVE:
         if not isnan(val) and signbit(val):
             raise ValueError(f"{name} < 0")

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -955,7 +955,7 @@ cdef class Generator:
                     cutoff = 20
                 if pop_size_i > 10000 and (size_i > (pop_size_i // cutoff)):
                     # Tail shuffle size elements
-                    idx = np.PyArray_Arange(0, pop_size_i, 1, np.NPY_INT64)
+                    idx = np.arange(0, pop_size_i, dtype=np.int64)
                     idx_data = <int64_t*>(<np.ndarray>idx).data
                     with self.lock, nogil:
                         _shuffle_int(&self._bitgen, pop_size_i,


### PR DESCRIPTION
Fixes #30578 

See https://cython.readthedocs.io/en/latest/src/userguide/fusedtypes.html#type-checking-specializations if you're unfamiliar with the fused types specialization syntax I'm using.