### PR TITLE
MAINT: Towards removing `SeedlessSequence`

### DIFF
--- a/numpy/random/bit_generator.pxd
+++ b/numpy/random/bit_generator.pxd
@@ -33,8 +33,3 @@ cdef class SeedSequence():
 
 cdef class SeedlessSeedSequence:
     pass
-
-# NOTE: This has no implementation and should not be used. It purely exists for
-# backwards compatibility, see https://github.com/scipy/scipy/issues/24215.
-cdef class SeedlessSequence:
-    pass

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -709,3 +709,8 @@ cdef class BitGenerator:
         if self._cffi is None:
             self._cffi = prepare_cffi(&self._bitgen)
         return self._cffi
+
+# NOTE: This has no implementation and should not be used. It purely exists for
+# backwards compatibility, see https://github.com/scipy/scipy/issues/24215.
+cdef class SeedlessSequence:
+    pass


### PR DESCRIPTION
This is an alternative fix for https://github.com/scipy/scipy/issues/24215 that, unlike #30500, will allow us to *eventually* remove the non-existent `SeedSequence`  class from the `numpy.random` Cython API.

---

Is this what you meant in  https://github.com/numpy/numpy/pull/30500#issuecomment-3682508883 @seberg?