### PR TITLE
BLD: Avoiding conflict with pygit2 for static build

### DIFF
--- a/numpy/_core/src/umath/_rational_tests.c
+++ b/numpy/_core/src/umath/_rational_tests.c
@@ -1097,7 +1097,7 @@ rational_ufunc_test_add_rationals(char** args, npy_intp const *dimensions,
 }
 
 
-PyMethodDef module_methods[] = {
+static PyMethodDef module_methods[] = {
     {0} /* sentinel */
 };
 


### PR DESCRIPTION
`pygit2` also defines this symbol - https://github.com/libgit2/pygit2/blob/master/src/pygit2.c#L411

If you build statically, there will be a name conflict. Common practice is to write `static PyMethodDef module_methods[] = ...`.

Related https://github.com/libgit2/pygit2/pull/1446