### PR TITLE
BUG: Undo result type change of quantile/percentile but keep ``q`` precision

### DIFF
--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3283,6 +3283,11 @@ quantile_methods = [
     'median_unbiased', 'normal_unbiased', 'nearest', 'lower', 'higher',
     'midpoint']
 
+# Note: Technically, averaged_inverted_cdf and midpoint are not interpolated.
+# but NumPy doesn't currently make a difference (at least w.r.t. to promotion).
+interpolating_quantile_methods = [
+    'averaged_inverted_cdf', 'interpolated_inverted_cdf', 'hazen', 'weibull',
+    'linear', 'median_unbiased', 'normal_unbiased', 'midpoint']
 
 methods_supporting_weights = ["inverted_cdf"]
 
@@ -3913,6 +3918,22 @@ class TestPercentile:
         assert z == one
         assert np.array(z).dtype == a.dtype
 
+    @pytest.mark.parametrize("method", interpolating_quantile_methods)
+    @pytest.mark.parametrize("q", [50, 10.0])
+    def test_q_weak_promotion(self, method, q):
+        a = np.array([1, 2, 3, 4, 5], dtype=np.float32)
+        value = np.percentile(a, q, method=method)
+        assert value.dtype == np.float32
+
+    @pytest.mark.parametrize("method", interpolating_quantile_methods)
+    def test_q_strong_promotion(self, method):
+        # For interpolating methods, the dtype should be float64, for
+        # discrete ones the original int8.  (technically, mid-point has no
+        # reason to take into account `q`, but does so anyway.)
+        a = np.array([1, 2, 3, 4, 5], dtype=np.float32)
+        value = np.percentile(a, np.float64(50), method=method)
+        assert value.dtype == np.float64
+
 
 class TestQuantile:
     # most of this is already tested by TestPercentile
@@ -4334,6 +4355,22 @@ class TestQuantile:
         value = np.quantile(a, q)
         assert value == q * 50_000
         assert value.dtype == np.float16
+
+    @pytest.mark.parametrize("method", interpolating_quantile_methods)
+    @pytest.mark.parametrize("q", [0.5, 1])
+    def test_q_weak_promotion(self, method, q):
+        a = np.array([1, 2, 3, 4, 5], dtype=np.float32)
+        value = np.quantile(a, q, method=method)
+        assert value.dtype == np.float32
+
+    @pytest.mark.parametrize("method", interpolating_quantile_methods)
+    def test_q_strong_promotion(self, method):
+        # For interpolating methods, the dtype should be float64, for
+        # discrete ones the original int8.  (technically, mid-point has no
+        # reason to take into account `q`, but does so anyway.)
+        a = np.array([1, 2, 3, 4, 5], dtype=np.float32)
+        value = np.quantile(a, np.float64(0.5), method=method)
+        assert value.dtype == np.float64
 
 
 class TestLerp:


### PR DESCRIPTION
Defer cast to input type to the end of the computation by passing through the `weak_q` information.

This fixes gh-30586, but I am not sure it is great to backport. Although, compared to the other PR it should just align the nan-functions fully and otherwise revert anything that isn't just a precision fix.


---

If we don't want to backport this, I would be tempted to just revert the original PR for 2.5, TBH.

**~This still needs tests, although~ it passes all tests added in gh-29105.**