### PR TITLE
DEP: remove `numpy.chararray`

### DIFF
--- a/doc/release/upcoming_changes/30604.expired.rst
+++ b/doc/release/upcoming_changes/30604.expired.rst
@@ -1,0 +1,1 @@
+* The ``numpy.chararray`` re-export of ``numpy.char.chararray`` has been removed (deprecated since 2.0).

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -766,14 +766,6 @@ else:
                 name=None
             )
 
-        if attr == "chararray":
-            warnings.warn(
-                "`np.chararray` is deprecated and will be removed from "
-                "the main namespace in the future. Use an array with a string "
-                "or bytes dtype instead.", DeprecationWarning, stacklevel=2)
-            import numpy.char as char
-            return char.chararray
-
         raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
 
     def __dir__():

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -265,12 +265,6 @@ class TestMathAlias(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.lib.math)
 
 
-class TestLibImports(_DeprecationTestCase):
-    # Deprecated in Numpy 1.26.0, 2023-09
-    def test_lib_functions_deprecation_call(self):
-        self.assert_deprecated(lambda: np.chararray)
-
-
 class TestDeprecatedDTypeAliases(_DeprecationTestCase):
 
     def _check_for_warning(self, func):


### PR DESCRIPTION
This was decided in today's triage meeting.

See #30605 for the *actual* deprecation of `chararray` itself.