### PR TITLE
MAINT: consistent ``sys.version_info`` checks

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1337,35 +1337,7 @@ class dtype(Generic[_ScalarT_co], metaclass=_DTypeMeta):  # noqa: UP046
     ) -> dtype[longdouble]: ...
 
     # `complexfloating` string-based representations and ctypes
-    if sys.version_info >= (3, 14) and sys.platform != "win32":
-        @overload
-        def __new__(
-            cls,
-            dtype: _Complex64Codes | type[ct.c_float_complex],
-            align: py_bool = False,
-            copy: py_bool = False,
-            *,
-            metadata: dict[str, Any] = ...,
-        ) -> dtype[complex64]: ...
-        @overload
-        def __new__(
-            cls,
-            dtype: _Complex128Codes | type[ct.c_double_complex],
-            align: py_bool = False,
-            copy: py_bool = False,
-            *,
-            metadata: dict[str, Any] = ...,
-        ) -> dtype[complex128]: ...
-        @overload
-        def __new__(
-            cls,
-            dtype: _CLongDoubleCodes | type[ct.c_longdouble_complex],
-            align: py_bool = False,
-            copy: py_bool = False,
-            *,
-            metadata: dict[str, Any] = ...,
-        ) -> dtype[clongdouble]: ...
-    else:
+    if sys.version_info < (3, 14) or sys.platform == "win32":
         @overload
         def __new__(
             cls,
@@ -1388,6 +1360,34 @@ class dtype(Generic[_ScalarT_co], metaclass=_DTypeMeta):  # noqa: UP046
         def __new__(
             cls,
             dtype: _CLongDoubleCodes,
+            align: py_bool = False,
+            copy: py_bool = False,
+            *,
+            metadata: dict[str, Any] = ...,
+        ) -> dtype[clongdouble]: ...
+    else:
+        @overload
+        def __new__(
+            cls,
+            dtype: _Complex64Codes | type[ct.c_float_complex],
+            align: py_bool = False,
+            copy: py_bool = False,
+            *,
+            metadata: dict[str, Any] = ...,
+        ) -> dtype[complex64]: ...
+        @overload
+        def __new__(
+            cls,
+            dtype: _Complex128Codes | type[ct.c_double_complex],
+            align: py_bool = False,
+            copy: py_bool = False,
+            *,
+            metadata: dict[str, Any] = ...,
+        ) -> dtype[complex128]: ...
+        @overload
+        def __new__(
+            cls,
+            dtype: _CLongDoubleCodes | type[ct.c_longdouble_complex],
             align: py_bool = False,
             copy: py_bool = False,
             *,

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -64,9 +64,7 @@ except importlib.metadata.PackageNotFoundError:
 else:
     IS_INSTALLED = True
     try:
-        if sys.version_info >= (3, 13):
-            IS_EDITABLE = np_dist.origin.dir_info.editable
-        else:
+        if sys.version_info < (3, 13):
             # Backport importlib.metadata.Distribution.origin
             import json  # noqa: E401
             import types
@@ -75,6 +73,8 @@ else:
                 object_hook=lambda data: types.SimpleNamespace(**data),
             )
             IS_EDITABLE = origin.dir_info.editable
+        else:
+            IS_EDITABLE = np_dist.origin.dir_info.editable
     except AttributeError:
         IS_EDITABLE = False
 


### PR DESCRIPTION
This will make it easier to drop Python versions in the future. I went with `<` because it was used more often than `>=`.