### PR TITLE
CI: build numpy with 2 jobs for faster sanitizers CI

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -69,7 +69,7 @@ jobs:
         pip uninstall -y pytest-xdist
     - name: Build
       run:
-        python -m spin build -j4 -- -Db_sanitize=address,undefined -Db_lundef=false
+        python -m spin build -j2 -- -Db_sanitize=address,undefined -Db_lundef=false
     - name: Test
       run: |
         # pass -s to pytest to see ASAN errors and warnings, otherwise pytest captures them
@@ -99,7 +99,7 @@ jobs:
         run: pip install -U spin
 
       - name: Build NumPy with ThreadSanitizer
-        run: python -m spin build -j4 -- -Db_sanitize=thread
+        run: python -m spin build -j2 -- -Db_sanitize=thread
 
       - name: Run tests under prebuilt TSAN container
         run: |

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -69,7 +69,7 @@ jobs:
         pip uninstall -y pytest-xdist
     - name: Build
       run:
-        python -m spin build -- -Db_sanitize=address,undefined -Db_lundef=false
+        python -m spin build -j4 -- -Db_sanitize=address,undefined -Db_lundef=false
     - name: Test
       run: |
         # pass -s to pytest to see ASAN errors and warnings, otherwise pytest captures them
@@ -99,7 +99,7 @@ jobs:
         run: pip install -U spin
 
       - name: Build NumPy with ThreadSanitizer
-        run: python -m spin build -- -Db_sanitize=thread
+        run: python -m spin build -j4 -- -Db_sanitize=thread
 
       - name: Run tests under prebuilt TSAN container
         run: |


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This reduces the build time by 1-2 mins, not a lot but overtime this would save a lot of CI time. 