### PR TITLE
DEP: remove ``'a'`` dtype alias (deprecated since 2.0)

### DIFF
--- a/doc/release/upcoming_changes/30613.expired.rst
+++ b/doc/release/upcoming_changes/30613.expired.rst
@@ -1,0 +1,1 @@
+* Data type alias ``'a'`` was removed in favor of ``'S'`` (deprecated since 2.0).

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -823,7 +823,6 @@ type _DTypeChar = L[
     "G",  # clongdouble
     "O",  # object
     "S",  # bytes_ (S0)
-    "a",  # bytes_ (deprecated)
     "U",  # str_
     "V",  # void
     "M",  # datetime64

--- a/numpy/_core/_type_aliases.py
+++ b/numpy/_core/_type_aliases.py
@@ -72,7 +72,6 @@ _extra_aliases = {
     "complex": "complex128",
     "object": "object_",
     "bytes": "bytes_",
-    "a": "bytes_",
     "int": "int_",
     "str": "str_",
     "unicode": "str_",

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -127,7 +127,6 @@ enum NPY_TYPECHAR {
         NPY_CLONGDOUBLELTR = 'G',
         NPY_OBJECTLTR = 'O',
         NPY_STRINGLTR = 'S',
-        NPY_DEPRECATED_STRINGLTR2 = 'a',
         NPY_UNICODELTR = 'U',
         NPY_VOIDLTR = 'V',
         NPY_DATETIMELTR = 'M',

--- a/numpy/_core/records.py
+++ b/numpy/_core/records.py
@@ -106,10 +106,10 @@ class format_parser:
     titles will simply not appear. If `names` is empty, default field names
     will be used.
 
-    >>> np.rec.format_parser(['f8', 'i4', 'a5'], ['col1', 'col2', 'col3'],
+    >>> np.rec.format_parser(['f8', 'i4', 'S5'], ['col1', 'col2', 'col3'],
     ...                      []).dtype
     dtype([('col1', '<f8'), ('col2', '<i4'), ('col3', '<S5')])
-    >>> np.rec.format_parser(['<f8', '<i4', '<a5'], [], []).dtype
+    >>> np.rec.format_parser(['<f8', '<i4', '<S5'], [], []).dtype
     dtype([('f0', '<f8'), ('f1', '<i4'), ('f2', 'S5')])
 
     """
@@ -861,7 +861,7 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
     Examples
     --------
     >>> from tempfile import TemporaryFile
-    >>> a = np.empty(10,dtype='f8,i4,a5')
+    >>> a = np.empty(10,dtype='f8,i4,S5')
     >>> a[5] = (0.5,10,'abcde')
     >>>
     >>> fd=TemporaryFile()
@@ -869,7 +869,7 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
     >>> a.tofile(fd)
     >>>
     >>> _ = fd.seek(0)
-    >>> r=np.rec.fromfile(fd, formats='f8,i4,a5', shape=10,
+    >>> r=np.rec.fromfile(fd, formats='f8,i4,S5', shape=10,
     ... byteorder='<')
     >>> print(r[5])
     (0.5, 10, b'abcde')

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -1332,20 +1332,6 @@ PyArray_TypestrConvert(int itemsize, int gentype)
             newtype = NPY_STRING;
             break;
 
-        case NPY_DEPRECATED_STRINGLTR2:
-        {
-            /*
-             * raise a deprecation warning, which might be an exception
-             * if warnings are errors, so leave newtype unset in that
-             * case
-             */
-            int ret = DEPRECATE("Data type alias 'a' was deprecated in NumPy 2.0. "
-                                "Use the 'S' alias instead.");
-            if (ret == 0) {
-                newtype = NPY_STRING;
-            }
-            break;
-        }
         case NPY_UNICODELTR:
             newtype = NPY_UNICODE;
             break;

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -669,7 +669,6 @@ dtype_kind_to_ordering(char kind)
             return 5;
         /* String kind */
         case 'S':
-        case 'a':
             return 6;
         /* Unicode kind */
         case 'U':

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1829,14 +1829,6 @@ _convert_from_str(PyObject *obj, int align)
                     check_num = NPY_STRING;
                     break;
 
-                case NPY_DEPRECATED_STRINGLTR2:
-                    if (DEPRECATE("Data type alias 'a' was deprecated in NumPy 2.0. "
-                                  "Use the 'S' alias instead.") < 0) {
-                        return NULL;
-                    }
-                    check_num = NPY_STRING;
-                    break;
-
                 /*
                  * When specifying length of UNICODE
                  * the number of characters is given to match
@@ -1905,13 +1897,6 @@ _convert_from_str(PyObject *obj, int align)
             }
 
             goto fail;
-        }
-
-        if (strcmp(type, "a") == 0) {
-            if (DEPRECATE("Data type alias 'a' was deprecated in NumPy 2.0. "
-                          "Use the 'S' alias instead.") < 0) {
-                return NULL;
-            }
         }
 
         /*

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -266,21 +266,11 @@ class TestMathAlias(_DeprecationTestCase):
 
 
 class TestDeprecatedDTypeAliases(_DeprecationTestCase):
-
-    def _check_for_warning(self, func):
-        with pytest.warns(DeprecationWarning,
-                          match="alias 'a' was deprecated in NumPy 2.0") as w:
-            func()
-        assert len(w) == 1
-
-    def test_a_dtype_alias(self):
-        for dtype in ["a", "a10"]:
-            f = lambda: np.dtype(dtype)
-            self._check_for_warning(f)
-            self.assert_deprecated(f)
-            f = lambda: np.array(["hello", "world"]).astype("a10")
-            self._check_for_warning(f)
-            self.assert_deprecated(f)
+    @pytest.mark.parametrize("dtype_code", ["a", "a10"])
+    def test_a_dtype_alias(self, dtype_code: str):
+        # Deprecated in 2.0, removed in 2.5, 2025-12
+        with pytest.raises(TypeError):
+            np.dtype(dtype_code)
 
 
 class TestDeprecatedArrayWrap(_DeprecationTestCase):

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -183,7 +183,6 @@ if HAVE_SCPDT:
                 "numpy.core",
                 "Importing from numpy.matlib",
                 "This function is deprecated.",    # random_integers
-                "Data type alias 'a'",     # numpy.rec.fromfile
                 "Arrays of 2-dimensional vectors",   # matlib.cross
                 "NumPy warning suppression and assertion utilities are deprecated."
         ]


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
