### PR TITLE
BUG: np.take out dtype

### DIFF
--- a/doc/release/upcoming_changes/30615.deprecation.rst
+++ b/doc/release/upcoming_changes/30615.deprecation.rst
@@ -1,0 +1,7 @@
+* `numpy.take` now correctly checks if the result can be cast to
+  the provided ``out=out`` under the same-kind rule.
+  A ``DeprecationWarning`` is given now when this check fails.
+  Previously, ``take`` incorrectly checked if ``out`` could be cast to
+  the result (the wrong direction).
+  This deprecation also affects ``compress`` and possibly other functions.
+  (Future versions of NumPy may tighten the casting check further.)

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -312,9 +312,9 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
         dtype = PyArray_DESCR(self);
         Py_INCREF(dtype);
         out_dtype = PyArray_DESCR(out);
+        Py_INCREF(out_dtype);
         if (dtype == out_dtype) {
-            obj = (PyArrayObject *)out;
-            Py_INCREF(obj);
+            obj = (PyArrayObject *)PyArray_FromArray(out, dtype, flags);
         }
         else {
             if (PyArray_CanCastTypeTo(dtype, out_dtype, NPY_SAME_KIND_CASTING) == 0) {
@@ -329,7 +329,6 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
             }
             flags |= NPY_ARRAY_FORCECAST;
             obj = (PyArrayObject *)PyArray_FromArray(out, dtype, flags);
-            Py_INCREF(obj);
         }
         if (obj == NULL) {
             goto fail;

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -312,12 +312,11 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
         dtype = PyArray_DESCR(self);
         out_dtype = PyArray_DESCR(out);
         if (dtype != out_dtype) {
-            /*Deprecated NumPy 2.5, 2026-01*/
-            if (PyArray_CanCastTypeTo(dtype, out_dtype, NPY_SAME_KIND_CASTING) == 0) {
+            /* Deprecated NumPy 2.5, 2026-01 */
+            if (!PyArray_CanCastTypeTo(dtype, out_dtype, NPY_SAME_KIND_CASTING)) {
                 if (DEPRECATE(
-                            "Implicit casting of output to a different kind is "
-                            "deprecated. "
-                            "In a future version, this will result in an error. (Deprecated NumPy 2.5)") <
+                        "Implicit casting of output to a different kind is deprecated."
+                        "In a future version, this will result in an error. (Deprecated NumPy 2.5)") <
                     0) {
                     goto fail;
                 }
@@ -325,7 +324,6 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
             flags |= NPY_ARRAY_FORCECAST;
         }
         Py_INCREF(dtype);
-        Py_INCREF(out_dtype);
         obj = (PyArrayObject *)PyArray_FromArray(out, dtype, flags);
         if (obj == NULL) {
             goto fail;

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -310,26 +310,23 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
             flags |= NPY_ARRAY_ENSURECOPY;
         }
         dtype = PyArray_DESCR(self);
-        Py_INCREF(dtype);
         out_dtype = PyArray_DESCR(out);
-        Py_INCREF(out_dtype);
-        if (dtype == out_dtype) {
-            obj = (PyArrayObject *)PyArray_FromArray(out, dtype, flags);
-        }
-        else {
+        if (dtype != out_dtype) {
+            /*Deprecated NumPy 2.5, 2026-01*/
             if (PyArray_CanCastTypeTo(dtype, out_dtype, NPY_SAME_KIND_CASTING) == 0) {
                 if (DEPRECATE(
                             "Implicit casting of output to a different kind is "
                             "deprecated. "
-                            "In a future version, this will result in an error. Please "
-                            "ensure the output has the same-kind type as the input.") <
+                            "In a future version, this will result in an error. (Deprecated NumPy 2.5)") <
                     0) {
                     goto fail;
                 }
             }
             flags |= NPY_ARRAY_FORCECAST;
-            obj = (PyArrayObject *)PyArray_FromArray(out, dtype, flags);
         }
+        Py_INCREF(dtype);
+        Py_INCREF(out_dtype);
+        obj = (PyArrayObject *)PyArray_FromArray(out, dtype, flags);
         if (obj == NULL) {
             goto fail;
         }

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -315,7 +315,7 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
             /* Deprecated NumPy 2.5, 2026-01 */
             if (!PyArray_CanCastTypeTo(dtype, out_dtype, NPY_SAME_KIND_CASTING)) {
                 if (DEPRECATE(
-                        "Implicit casting of output to a different kind is deprecated."
+                        "Implicit casting of output to a different kind is deprecated. "
                         "In a future version, this will result in an error. (Deprecated NumPy 2.5)") <
                     0) {
                     goto fail;
@@ -3183,7 +3183,7 @@ PyArray_Sort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
         PyArray_Descr *given_descrs[2] = {descr, descr};
         // Sort cannot be a view, so view_offset is unused
         npy_intp view_offset = 0;
-        
+
         if (sort_method->resolve_descriptors(
             sort_method, dtypes, given_descrs, loop_descrs, &view_offset) < 0) {
             PyErr_SetString(PyExc_RuntimeError,
@@ -3293,7 +3293,7 @@ PyArray_ArgSort(PyArrayObject *op, int axis, NPY_SORTKIND flags)
         PyArray_Descr *given_descrs[2] = {descr, odescr};
         // we can ignore the view_offset for sorting
         npy_intp view_offset = 0;
-        
+
         int resolve_ret = argsort_method->resolve_descriptors(
             argsort_method, dtypes, given_descrs, loop_descrs, &view_offset);
         Py_DECREF(odescr);

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -366,6 +366,7 @@ class TestRoundDeprecation(_DeprecationTestCase):
     def test_round_emits_deprecation_warning_scalar(self):
         self.assert_deprecated(lambda: np.ma.round_(3.14))
 
+
 class TestTriDeprecationWithNonInteger(_DeprecationTestCase):
     # Deprecation in NumPy 2.5, 2026-03
 
@@ -392,3 +393,17 @@ class TestTriDeprecationWithNonInteger(_DeprecationTestCase):
            [ 8,  9, 10, 11],
            [12, 13, 14, 15]])
         self.assert_deprecated(lambda: np.tril_indices_from(a, k=9.8))
+
+
+class TestTakeOutDtype(_DeprecationTestCase):
+    # Deprecated in Numpy 2.5, 2026-01
+    message = "Implicit casting of output to a different kind."
+
+    def test_out_dtype_deprecated(self):
+        a = np.arange(3).astype(np.int32)
+        indices = np.arange(2)
+        diffrent_dtype_out = np.zeros_like(indices, dtype=np.uint32)
+
+        self.assert_deprecated(
+            np.take, args=(a, indices), kwargs={"out": diffrent_dtype_out}
+        )

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -402,8 +402,6 @@ class TestTakeOutDtype(_DeprecationTestCase):
     def test_out_dtype_deprecated(self):
         a = np.arange(3).astype(np.int32)
         indices = np.arange(2)
-        diffrent_dtype_out = np.zeros_like(indices, dtype=np.uint32)
+        different_dtype_out = np.zeros_like(indices, dtype=np.uint32)
 
-        self.assert_deprecated(
-            np.take, args=(a, indices), kwargs={"out": diffrent_dtype_out}
-        )
+        self.assert_deprecated(lambda: np.take(a, indices, out=different_dtype_out))

--- a/numpy/_core/tests/test_item_selection.py
+++ b/numpy/_core/tests/test_item_selection.py
@@ -81,6 +81,17 @@ class TestTake:
 
         assert_array_equal(a, a_original)
 
+    def test_out_dtype(self):
+        # In reference to github issue #25588
+        a = np.arange(3).astype(np.int32)
+        indices = np.arange(2)
+        out = np.zeros_like(indices, dtype=np.int64)
+        np.take(a, indices, out=out)
+        assert_array_equal(a[indices], out)
+        diffrent_dtype_out = np.zeros_like(indices, dtype=np.uint32)
+        with pytest.warns(DeprecationWarning):
+            np.take(a, indices, out=diffrent_dtype_out)
+
     def test_empty_argpartition(self):
         # In reference to github issue #6530
         a = np.array([0, 2, 4, 6, 8, 10])

--- a/numpy/_core/tests/test_item_selection.py
+++ b/numpy/_core/tests/test_item_selection.py
@@ -88,9 +88,6 @@ class TestTake:
         out = np.zeros_like(indices, dtype=np.int64)
         np.take(a, indices, out=out)
         assert_array_equal(a[indices], out)
-        diffrent_dtype_out = np.zeros_like(indices, dtype=np.uint32)
-        with pytest.warns(DeprecationWarning):
-            np.take(a, indices, out=diffrent_dtype_out)
 
     def test_empty_argpartition(self):
         # In reference to github issue #6530

--- a/numpy/_core/tests/test_item_selection.py
+++ b/numpy/_core/tests/test_item_selection.py
@@ -81,11 +81,14 @@ class TestTake:
 
         assert_array_equal(a, a_original)
 
-    def test_out_dtype(self):
+    @pytest.mark.parametrize("dtype",
+            [np.int8, np.int16, np.int32, np.int64,
+             np.float16, np.float32, np.float64, np.longdouble])
+    def test_out_dtype(self, dtype):
         # In reference to github issue #25588
         a = np.arange(3).astype(np.int32)
         indices = np.arange(2)
-        out = np.zeros_like(indices, dtype=np.int64)
+        out = np.zeros_like(indices, dtype=dtype)
         np.take(a, indices, out=out)
         assert_array_equal(a[indices], out)
 

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1101,9 +1101,7 @@ class TestRegression:
         b = np.zeros((2, 1), dtype=np.single)
         try:
             a.compress([True, False], axis=1, out=b)
-            raise AssertionError("compress with an out which cannot be "
-                                 "safely casted should not return "
-                                 "successfully")
+            assert_equal(b, np.array([[1.0], [3.0]]))
         except TypeError:
             pass
 

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1093,16 +1093,24 @@ class TestRegression:
         assert_(xp.__array_interface__['data'][0] !=
                 xpd.__array_interface__['data'][0])
 
+    @pytest.mark.filterwarnings(
+        "error:Implicit casting of output.*:DeprecationWarning",
+    )
     def test_compress_small_type(self):
         # Ticket #789, changeset 5217.
         # compress with out argument segfaulted if cannot cast safely
         import numpy as np
         a = np.array([[1, 2], [3, 4]])
         b = np.zeros((2, 1), dtype=np.single)
+        a.compress([True, False], axis=1, out=b)
+        assert_equal(b, np.array([[1.0], [3.0]]))
         try:
-            a.compress([True, False], axis=1, out=b)
-            assert_equal(b, np.array([[1.0], [3.0]]))
-        except TypeError:
+            # Previously the above already failed (and that is OK) but take
+            # currently allows same-kind casting for the output.
+            a.compress([True, False], axis=1, out=np.empty((2, 1), dtype=bool))
+            raise AssertionError("Expected TypeError due to unsafe out cast")
+        except DeprecationWarning:
+            # After deprecation remove TypeError the warnings filter.
             pass
 
     def test_attributes(self):


### PR DESCRIPTION
### Description
This PR addresses the issue in `np.take` where an error was raised when input and output dtypes were different during casting. 

Key changes:
- Allows 'same-kind' casting to proceed in `np.take`.
- Emits a `DeprecationWarning` for other casting types to maintain backward compatibility while signaling future changes.

This is my first contribution to NumPy, so I'm opening this as a **draft** to ensure the implementation and formatting align with the project's standards. I'd appreciate any feedback on the code or the CI results.

### Fixes
Closes #25588

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
