### PR TITLE
ENH: Add mask comparison support to `assert_array_equal` and `assert_equal`

### DIFF
--- a/doc/release/upcoming_changes/30617.new_feature.rst
+++ b/doc/release/upcoming_changes/30617.new_feature.rst
@@ -1,0 +1,5 @@
+``equal_mask`` argument for masked array testing
+--------------------------------------------------
+A new ``equal_mask`` parameter has been added to `assert_equal`, `assert_array_equal`,
+and `assert_array_compare`. When ``True``, masks must match during comparison;
+masked positions are ignored. Default is ``False`` for backward compatibility.

--- a/doc/release/upcoming_changes/30617.new_feature.rst
+++ b/doc/release/upcoming_changes/30617.new_feature.rst
@@ -1,5 +1,5 @@
 ``equal_mask`` argument for masked array testing
---------------------------------------------------
+------------------------------------------------
 A new ``equal_mask`` parameter has been added to `assert_equal`, `assert_array_equal`,
 and `assert_array_compare`. When ``True``, masks must match during comparison;
 masked positions are ignored. Default is ``False`` for backward compatibility.

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -253,7 +253,8 @@ def build_err_msg(arrays, err_msg, header='Items are not equal:',
     return '\n'.join(msg)
 
 
-def assert_equal(actual, desired, err_msg='', verbose=True, *, strict=False):
+def assert_equal(actual, desired, err_msg='', verbose=True, *, strict=False,
+                 equal_mask=False):
     """
     Raises an AssertionError if two objects are not equal.
 
@@ -283,6 +284,13 @@ def assert_equal(actual, desired, err_msg='', verbose=True, *, strict=False):
         parameter has no effect.
 
         .. versionadded:: 2.0.0
+
+    equal_mask : bool, optional
+        If True, masked arrays must have matching masks. When False (default),
+        mask differences are ignored for backward compatibility. Only applies
+        when comparing masked arrays.
+
+        .. versionadded:: 2.2.0
 
     Raises
     ------
@@ -362,19 +370,19 @@ def assert_equal(actual, desired, err_msg='', verbose=True, *, strict=False):
             if k not in actual:
                 raise AssertionError(repr(k))
             assert_equal(actual[k], desired[k], f'key={k!r}\n{err_msg}',
-                         verbose)
+                         verbose, equal_mask=equal_mask)
         return
     if isinstance(desired, (list, tuple)) and isinstance(actual, (list, tuple)):
         assert_equal(len(actual), len(desired), err_msg, verbose)
         for k in range(len(desired)):
             assert_equal(actual[k], desired[k], f'item={k!r}\n{err_msg}',
-                         verbose)
+                         verbose, equal_mask=equal_mask)
         return
     from numpy import imag, iscomplexobj, real
     from numpy._core import isscalar, ndarray, signbit
     if isinstance(actual, ndarray) or isinstance(desired, ndarray):
         return assert_array_equal(actual, desired, err_msg, verbose,
-                                  strict=strict)
+                                  strict=strict, equal_mask=equal_mask)
     msg = build_err_msg([actual, desired], err_msg, verbose=verbose)
 
     # Handle complex numbers: separate into real/imag to handle
@@ -733,12 +741,50 @@ def assert_approx_equal(actual, desired, significant=7, err_msg='',
 
 def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
                          precision=6, equal_nan=True, equal_inf=True,
-                         *, strict=False, names=('ACTUAL', 'DESIRED')):
+                         *, strict=False, names=('ACTUAL', 'DESIRED'),
+                         equal_mask=False):
     __tracebackhide__ = True  # Hide traceback for py.test
     from numpy._core import all, array2string, errstate, inf, isnan, max, object_
 
     x = np.asanyarray(x)
     y = np.asanyarray(y)
+
+    mask_to_ignore = None
+    if equal_mask and (np.ma.isMaskedArray(x) or np.ma.isMaskedArray(y)):
+        mx = np.ma.getmaskarray(x)
+        my = np.ma.getmaskarray(y)
+        try:
+            mx, my = np.broadcast_arrays(mx, my)
+        except ValueError:
+            msg = build_err_msg([x, y], err_msg
+                                + '\nmask broadcast mismatch:',
+                                verbose=verbose, header=header,
+                                names=names, precision=precision)
+            raise AssertionError(msg)
+
+        mask_diff = mx != my
+        if np.any(mask_diff):
+            positions = np.argwhere(np.asarray(mask_diff))
+            details = ''
+            if positions.size:
+                s = "\n".join(
+                    [
+                        f" {p.tolist()}" for p in positions[:5]
+                    ]
+                )
+                if len(positions) == 1:
+                    details = f"\nMask mismatch at index:\n{s}"
+                elif len(positions) <= 5:
+                    details = f"\nMask mismatches at indices:\n{s}"
+                else:
+                    details = f"\nFirst 5 mask mismatches are at indices:\n{s}"
+
+            msg = build_err_msg([x, y], err_msg + '\nmask mismatch:' + details,
+                                verbose=verbose, header=header,
+                                names=names, precision=precision)
+            raise AssertionError(msg)
+
+        mask_to_ignore = mx
 
     # original array for output formatting
     ox, oy = x, y
@@ -878,6 +924,9 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
                     flagged = func_assert_same_pos(
                         x, y, func=isnan, hasval=x.dtype.na_object)
 
+        if mask_to_ignore is not None:
+            flagged = np.logical_or(flagged, mask_to_ignore)
+
         if flagged.ndim > 0:
             x, y = x[~flagged], y[~flagged]
             # Only do the comparison if actual values are left
@@ -993,7 +1042,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
 
 
 def assert_array_equal(actual, desired, err_msg='', verbose=True, *,
-                       strict=False):
+                       strict=False, equal_mask=False):
     """
     Raises an AssertionError if two array_like objects are not equal.
 
@@ -1034,6 +1083,13 @@ def assert_array_equal(actual, desired, err_msg='', verbose=True, *,
         handling for scalars mentioned in the Notes section is disabled.
 
         .. versionadded:: 1.24.0
+
+    equal_mask : bool, optional
+        If True, treat ``numpy.ma.MaskedArray`` mask positions as part of the
+        comparison: an AssertionError is raised when masks differ, and masked
+        positions are ignored when comparing the underlying data. When False
+        (default), mask differences are ignored and masked entries are filled
+        before comparison.
 
     Raises
     ------
@@ -1123,7 +1179,7 @@ def assert_array_equal(actual, desired, err_msg='', verbose=True, *,
     __tracebackhide__ = True  # Hide traceback for py.test
     assert_array_compare(operator.__eq__, actual, desired, err_msg=err_msg,
                          verbose=verbose, header='Arrays are not equal',
-                         strict=strict)
+                         strict=strict, equal_mask=equal_mask)
 
 
 def assert_array_almost_equal(actual, desired, decimal=6, err_msg='',

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -290,7 +290,7 @@ def assert_equal(actual, desired, err_msg='', verbose=True, *, strict=False,
         mask differences are ignored for backward compatibility. Only applies
         when comparing masked arrays.
 
-        .. versionadded:: 2.2.0
+        .. versionadded:: 2.5.0
 
     Raises
     ------
@@ -1091,6 +1091,7 @@ def assert_array_equal(actual, desired, err_msg='', verbose=True, *,
         (default), mask differences are ignored and masked entries are filled
         before comparison.
 
+        .. versionadded:: 2.5.0
     Raises
     ------
     AssertionError

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -194,6 +194,7 @@ def assert_equal(
     verbose: bool = True,
     *,
     strict: bool = False,
+    equal_mask: bool = False,
 ) -> None: ...
 
 def assert_almost_equal(
@@ -227,6 +228,7 @@ def assert_array_compare(
     *,
     strict: bool = False,
     names: tuple[str, str] = ("ACTUAL", "DESIRED"),
+    equal_mask: bool = False,
 ) -> None: ...
 
 #
@@ -237,6 +239,7 @@ def assert_array_equal(
     verbose: bool = True,
     *,
     strict: bool = False,
+    equal_mask: bool = False,
 ) -> None: ...
 
 #


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Fixes: #30564

I added `equal_mask` keyword arg to `assert_array_compare` allowing it to be passed in  `assert_array_equal` and `assert_equal`. I believe this should be done for other functions like `assert_array_almost_equal` which uses `assert_array_compare` internally, please let me know if this is required. 

Apologies in advance, I haven’t read the contribution guidelines yet. I’ll read them ASAP and make the necessary changes.