### PR TITLE
ENH: use more fine-grained critical sections in array coercion internals (#30514)

### DIFF
--- a/numpy/_core/src/common/npy_pycompat.h
+++ b/numpy/_core/src/common/npy_pycompat.h
@@ -34,7 +34,7 @@
         }                                                               \
     }
 #else
-#define NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original) {
+#define NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original) { do { (void)(original); } while (0)
 #define NPY_END_CRITICAL_SECTION_SEQUENCE_FAST() }
 #endif
 

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -1354,7 +1354,7 @@ arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args,
     if (fast_seq == NULL) {
         return NULL;
     }
-    NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(args)
+    NPY_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(args);
     n = PySequence_Fast_GET_SIZE(fast_seq);
     if (n > NPY_MAXARGS) {
         ret = multiiter_wrong_number_of_args();
@@ -1362,7 +1362,7 @@ arraymultiter_new(PyTypeObject *NPY_UNUSED(subtype), PyObject *args,
         ret = multiiter_new_impl(n, PySequence_Fast_ITEMS(fast_seq));
     }
     Py_DECREF(fast_seq);
-    NPY_END_CRITICAL_SECTION_SEQUENCE_FAST()
+    NPY_END_CRITICAL_SECTION_SEQUENCE_FAST();
     return ret;
 }
 


### PR DESCRIPTION
Backport of #30514.

Towards addressing #30494. Right now the critical section I remove here in `PyArray_FromAny_int` shows up in the profile for the script in that issue.

I added the critical section in 5a031d9b8822551711973e6ae220cd00817c9523 and this partially reverts that change. On reflection, it's not a good idea to introduce a scaling bottleneck here in service of a sort of wonky thing to do: mutating the operand of `np.array()` while the array is being created.

Instead, we should error in those cases. Like we already do without the critical section!

I also needed to add new, more fine-grained critical sections, in `PyArray_DiscoverDTypeAndShape_Recursive` and `PyArray_AssignFromCache_Recursive` to avoid data races due to use of the `PySequence_Fast` API.

I also updated the tests for this to allow the cases affected by this to raise errors instead of succeeding, since that success relies on introducing scaling bottlenecks for valid read-only uses.

Here's a Samply profile output run using this PR on the script from #30494 - I no longer see a scaling bottleneck inside the array coercion routines: https://share.firefox.dev/44KLZxs

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
