### PR TITLE
Fix memory leak in np.eye (gh-30618)

### DIFF
--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -240,11 +240,15 @@ def eye(N, M=None, k=0, dtype=float, order='C', *, device=None, like=None):
     # a problem with inputs with type (for example) np.uint64.
     M = operator.index(M)
     k = operator.index(k)
+    # Compute diagonal indices explicitly to avoid flat iterator memory leak
     if k >= 0:
-        i = k
+        diag_len = min(N, M - k)
+        diag_indices = arange(k, k + diag_len * (M + 1), M + 1, dtype=intp)
     else:
-        i = (-k) * M
-    m[:M - k].flat[i::M + 1] = 1
+        diag_len = min(N + k, M)
+        start_idx = (-k) * M
+        diag_indices = arange(start_idx, start_idx + diag_len * (M + 1), M + 1, dtype=intp)
+    m.flat[diag_indices] = 1
     return m
 
 


### PR DESCRIPTION
Replace problematic flat iterator assignment m[:M-k].flat[i::M+1] = 1 with explicit index computation to avoid memory leak.

The fix computes diagonal indices explicitly using arange, similar to the approach used in diagflat function.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
