### PR TITLE
BUG: Fix the crash in spawn() with negative n_children

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -294,8 +294,6 @@ cdef class Generator:
         >>> nested_spawn = child_rng1.spawn(20)
 
         """                                                                                                                                                                                                                                                                                                                                                                                                                                        
-        if n_children < 0:
-            raise ValueError("n_children must be non-negative")
         return [type(self)(g) for g in self._bit_generator.spawn(n_children)]
 
     def random(self, size=None, dtype=np.float64, out=None):

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -293,7 +293,9 @@ cdef class Generator:
         >>> more_child_rngs = rng.spawn(20)
         >>> nested_spawn = child_rng1.spawn(20)
 
-        """
+        """                                                                                                                                                                                                                                                                                                                                                                                                                                        
+        if n_children < 0:
+            raise ValueError("n_children must be non-negative")
         return [type(self)(g) for g in self._bit_generator.spawn(n_children)]
 
     def random(self, size=None, dtype=np.float64, out=None):

--- a/numpy/random/tests/test_seed_sequence.py
+++ b/numpy/random/tests/test_seed_sequence.py
@@ -77,3 +77,11 @@ def test_zero_padding():
         np.not_equal,
         SeedSequence(42, spawn_key=(0,)).generate_state(4),
         expected42)
+
+
+def test_spawn_negative_argument():
+    import pytest
+    # Regression test for gh-30577
+    ss = SeedSequence(12345)
+    with pytest.raises(ValueError, match="n_children must be non-negative"):
+        ss.spawn(-1)


### PR DESCRIPTION
Fixes #30577 
Added a check to raise a ValueError if n_children is negative, preventing the OverflowError

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
