### PR TITLE
DOC: Clarify matrix multiplication with 1D arrays

### DIFF
--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -84,6 +84,10 @@ class matrix(N.ndarray):
     .. note:: It is no longer recommended to use this class, even for linear
               algebra. Instead use regular arrays. The class may be removed
               in the future.
+              Matrix multiplication with 1D arrays is not supported and will raise a
+            ValueError. Vectors must be explicitly reshaped to 2D column or row
+            matrices before multiplication.
+
 
     Parameters
     ----------
@@ -112,6 +116,10 @@ class matrix(N.ndarray):
     >>> np.matrix([[1, 2], [3, 4]])
     matrix([[1, 2],
             [3, 4]])
+    >>> A = np.asmatrix(np.eye(2))
+    >>> v = np.ones((2, 1))
+    >>> A * v
+    matrix([[1.],[1.]])
 
     """
     __array_priority__ = 10.0


### PR DESCRIPTION
This PR clarifies matrix-specific multiplication behavior by documenting
that multiplying a `np.matrix` with a 1D array raises a ValueError and that
vectors must be reshaped to 2D before multiplication. This behavior is
currently enforced via regression tests but was not clearly stated in the
user-facing documentation.

