### PR TITLE
TYP: ``dtype``: unit-based ``datetime64``/``timedelta64`` specialization

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -97,7 +97,6 @@ from numpy._typing import (  # type: ignore[deprecated]
     _ULongLongCodes,
     _LongDoubleCodes,
     _CLongDoubleCodes,
-    _DT64Codes,
     _TD64Codes,
     _StrCodes,
     _BytesCodes,
@@ -117,6 +116,12 @@ from numpy._typing import (  # type: ignore[deprecated]
     _UFunc_Nin1_Nout2,
     _UFunc_Nin2_Nout2,
     _GUFunc_Nin2_Nout1,
+)
+from numpy._typing._char_codes import (
+    _DT64Codes_any,
+    _DT64Codes_date,
+    _DT64Codes_datetime,
+    _DT64Codes_int,
 )
 
 # NOTE: Numpy's mypy plugin is used for removing the types unavailable to the specific platform
@@ -1393,8 +1398,46 @@ class dtype(Generic[_ScalarT_co], metaclass=_DTypeMeta):  # noqa: UP046
             metadata: dict[str, Any] = ...,
         ) -> dtype[clongdouble]: ...
 
-    # Miscellaneous string-based representations and ctypes
-    @overload
+    # datetime64
+    @overload  # datetime64[{Y,M,W,D}]
+    def __new__(
+        cls,
+        dtype: _DT64Codes_date,
+        align: py_bool = False,
+        copy: py_bool = False,
+        *,
+        metadata: dict[str, Any] = ...,
+    ) -> dtype[datetime64[dt.date]]: ...
+    @overload  # datetime64[{h,m,s,ms,us}]
+    def __new__(
+        cls,
+        dtype: _DT64Codes_datetime,
+        align: py_bool = False,
+        copy: py_bool = False,
+        *,
+        metadata: dict[str, Any] = ...,
+    ) -> dtype[datetime64[dt.datetime]]: ...
+    @overload  # datetime64[{ns,ps,fs,as}]
+    def __new__(
+        cls,
+        dtype: _DT64Codes_int,
+        align: py_bool = False,
+        copy: py_bool = False,
+        *,
+        metadata: dict[str, Any] = ...,
+    ) -> dtype[datetime64[int]]: ...
+    @overload  # datetime64[?]
+    def __new__(
+        cls,
+        dtype: _DT64Codes_any,
+        align: py_bool = False,
+        copy: py_bool = False,
+        *,
+        metadata: dict[str, Any] = ...,
+    ) -> dtype[datetime64]: ...
+
+    # timedelta64
+    @overload  # timedelta64[?]
     def __new__(
         cls,
         dtype: _TD64Codes,
@@ -1403,15 +1446,6 @@ class dtype(Generic[_ScalarT_co], metaclass=_DTypeMeta):  # noqa: UP046
         *,
         metadata: dict[str, Any] = ...,
     ) -> dtype[timedelta64]: ...
-    @overload
-    def __new__(
-        cls,
-        dtype: _DT64Codes,
-        align: py_bool = False,
-        copy: py_bool = False,
-        *,
-        metadata: dict[str, Any] = ...,
-    ) -> dtype[datetime64]: ...
 
     # `StringDType` requires special treatment because it has no scalar type
     @overload

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -122,6 +122,9 @@ from numpy._typing._char_codes import (
     _DT64Codes_date,
     _DT64Codes_datetime,
     _DT64Codes_int,
+    _TD64Codes_any,
+    _TD64Codes_int,
+    _TD64Codes_timedelta,
 )
 
 # NOTE: Numpy's mypy plugin is used for removing the types unavailable to the specific platform
@@ -1437,10 +1440,28 @@ class dtype(Generic[_ScalarT_co], metaclass=_DTypeMeta):  # noqa: UP046
     ) -> dtype[datetime64]: ...
 
     # timedelta64
+    @overload  # timedelta64[{W,D,h,m,s,ms,us}]
+    def __new__(
+        cls,
+        dtype: _TD64Codes_timedelta,
+        align: py_bool = False,
+        copy: py_bool = False,
+        *,
+        metadata: dict[str, Any] = ...,
+    ) -> dtype[timedelta64[dt.timedelta]]: ...
+    @overload  # timedelta64[{Y,M,ns,ps,fs,as}]
+    def __new__(
+        cls,
+        dtype: _TD64Codes_int,
+        align: py_bool = False,
+        copy: py_bool = False,
+        *,
+        metadata: dict[str, Any] = ...,
+    ) -> dtype[timedelta64[int]]: ...
     @overload  # timedelta64[?]
     def __new__(
         cls,
-        dtype: _TD64Codes,
+        dtype: _TD64Codes_any,
         align: py_bool = False,
         copy: py_bool = False,
         *,

--- a/numpy/typing/tests/data/reveal/dtype.pyi
+++ b/numpy/typing/tests/data/reveal/dtype.pyi
@@ -68,6 +68,23 @@ assert_type(np.dtype("l"), np.dtype[np.int32 | np.int64])
 assert_type(np.dtype("longlong"), np.dtype[np.longlong])
 assert_type(np.dtype(">g"), np.dtype[np.longdouble])
 assert_type(np.dtype(cs_integer), np.dtype[np.integer])
+# char-codes - datetime64
+assert_type(np.dtype("datetime64[Y]"), np.dtype[np.datetime64[dt.date]])
+assert_type(np.dtype("datetime64[M]"), np.dtype[np.datetime64[dt.date]])
+assert_type(np.dtype("datetime64[W]"), np.dtype[np.datetime64[dt.date]])
+assert_type(np.dtype("datetime64[D]"), np.dtype[np.datetime64[dt.date]])
+assert_type(np.dtype("datetime64[h]"), np.dtype[np.datetime64[dt.datetime]])
+assert_type(np.dtype("datetime64[m]"), np.dtype[np.datetime64[dt.datetime]])
+assert_type(np.dtype("datetime64[s]"), np.dtype[np.datetime64[dt.datetime]])
+assert_type(np.dtype("datetime64[ms]"), np.dtype[np.datetime64[dt.datetime]])
+assert_type(np.dtype("datetime64[us]"), np.dtype[np.datetime64[dt.datetime]])
+assert_type(np.dtype("datetime64[ns]"), np.dtype[np.datetime64[int]])
+assert_type(np.dtype("datetime64[ps]"), np.dtype[np.datetime64[int]])
+assert_type(np.dtype("datetime64[fs]"), np.dtype[np.datetime64[int]])
+assert_type(np.dtype("datetime64[as]"), np.dtype[np.datetime64[int]])
+assert_type(np.dtype("datetime64"), np.dtype[np.datetime64])
+assert_type(np.dtype("M8"), np.dtype[np.datetime64])
+assert_type(np.dtype("M"), np.dtype[np.datetime64])
 
 # ctypes
 assert_type(np.dtype(ct.c_double), np.dtype[np.float64])  # see numpy/numpy#29155

--- a/numpy/typing/tests/data/reveal/dtype.pyi
+++ b/numpy/typing/tests/data/reveal/dtype.pyi
@@ -85,6 +85,23 @@ assert_type(np.dtype("datetime64[as]"), np.dtype[np.datetime64[int]])
 assert_type(np.dtype("datetime64"), np.dtype[np.datetime64])
 assert_type(np.dtype("M8"), np.dtype[np.datetime64])
 assert_type(np.dtype("M"), np.dtype[np.datetime64])
+# char-codes - timedelta64
+assert_type(np.dtype("timedelta64[Y]"), np.dtype[np.timedelta64[int]])
+assert_type(np.dtype("timedelta64[M]"), np.dtype[np.timedelta64[int]])
+assert_type(np.dtype("timedelta64[W]"), np.dtype[np.timedelta64[dt.timedelta]])
+assert_type(np.dtype("timedelta64[D]"), np.dtype[np.timedelta64[dt.timedelta]])
+assert_type(np.dtype("timedelta64[h]"), np.dtype[np.timedelta64[dt.timedelta]])
+assert_type(np.dtype("timedelta64[m]"), np.dtype[np.timedelta64[dt.timedelta]])
+assert_type(np.dtype("timedelta64[s]"), np.dtype[np.timedelta64[dt.timedelta]])
+assert_type(np.dtype("timedelta64[ms]"), np.dtype[np.timedelta64[dt.timedelta]])
+assert_type(np.dtype("timedelta64[us]"), np.dtype[np.timedelta64[dt.timedelta]])
+assert_type(np.dtype("timedelta64[ns]"), np.dtype[np.timedelta64[int]])
+assert_type(np.dtype("timedelta64[ps]"), np.dtype[np.timedelta64[int]])
+assert_type(np.dtype("timedelta64[fs]"), np.dtype[np.timedelta64[int]])
+assert_type(np.dtype("timedelta64[as]"), np.dtype[np.timedelta64[int]])
+assert_type(np.dtype("timedelta64"), np.dtype[np.timedelta64])
+assert_type(np.dtype("m8"), np.dtype[np.timedelta64])
+assert_type(np.dtype("m"), np.dtype[np.timedelta64])
 
 # ctypes
 assert_type(np.dtype(ct.c_double), np.dtype[np.float64])  # see numpy/numpy#29155


### PR DESCRIPTION
This adds dtype constructor overloads for `datetime64` and `timedelta64` strings with specific units. Type-checkers will now infer `dtype("datetime64[Y]")` as `dtype[datetime64[date]]` (previously `dtype[datetime64[Any]]`) and `dtype("timedelta64[ns]")` as `dtype[timedelta64[int]]` (previously `dtype[timedelta64[Any]]`). This can help improve type-safety in case mixed units are used. It's also helpful to know which internal representation will be used for a particular unit by hovering the dtype variable in your IDE.

This already happens in the scalar-type constructors, btw.