### PR TITLE
MAINT: avoid possible race condition by not touching `os.environ` on import

### DIFF
--- a/numpy/_core/__init__.py
+++ b/numpy/_core/__init__.py
@@ -13,9 +13,11 @@ from numpy.version import version as __version__
 # disables OpenBLAS affinity setting of the main thread that limits
 # python threads or processes to one core
 env_added = []
-for envkey in ['OPENBLAS_MAIN_FREE', 'GOTOBLAS_MAIN_FREE']:
+for envkey in ['OPENBLAS_MAIN_FREE']:
     if envkey not in os.environ:
-        os.environ[envkey] = '1'
+        # Note: using `putenv` (and `unsetenv` further down) instead of updating
+        # `os.environ` on purpose to avoid a race condition, see gh-30627.
+        os.putenv(envkey, '1')
         env_added.append(envkey)
 
 try:
@@ -83,7 +85,7 @@ Original error was: {exc}
     raise ImportError(msg) from exc
 finally:
     for envkey in env_added:
-        del os.environ[envkey]
+        os.unsetenv(envkey)
 del envkey
 del env_added
 del os


### PR DESCRIPTION
We need to set the `OPENBLAS_MAIN_FREE` environment variable before the OpenBLAS initialization runs, however we don't need to touch `os.environ` for that. Deleting a key from `os.environ` can lead to a race condition when numpy is imported in parallel in multiple threads (may lead to a `KeyError`), while `os.unsetenv` always succeeds. See gh-30627 for context.

Also clean up `GOTOBLAS_MAIN_FREE`, that's a deprecated env var that has the same function as `OPENBLAS_MAIN_FREE`. There won't be any GotoBLAS or early OpenBLAS versions in use anymore that only have the GOTOBLAS flavor.

Closes gh-30627
Closes gh-21223