### PR TITLE
DOC: Update legacy pareto documentation to match Pareto II

### DIFF
--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -2421,11 +2421,14 @@ cdef class RandomState:
 
         Notes
         -----
-        The probability density for the Pareto distribution is
+        The probability density for the Pareto II distribution is
 
-        .. math:: p(x) = \\frac{am^a}{x^{a+1}}
+        .. math:: p(x) = \\frac{a}{(x+1)^{a+1}} , x \ge 0
 
-        where :math:`a` is the shape and :math:`m` the scale.
+        where :math:`a > 0` is the shape.
+
+        The Pareto II distribution is a shifted and scaled version of the
+        Pareto I distribution, which can be found in `scipy.stats.pareto`.
 
         The Pareto distribution, named after the Italian economist
         Vilfredo Pareto, is a power law probability distribution


### PR DESCRIPTION
closes #30250 