### PR TITLE
use clang instead of gcc

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,6 +37,10 @@ jobs:
         buildplat:
           - [ubuntu-22.04, manylinux_x86_64, ""]
           - [ubuntu-22.04, musllinux_x86_64, ""]
+          - [ubuntu-22.04, manylinux_ppc64le, ""]
+          - [ubuntu-22.04, musllinux_ppc64le, ""]
+          - [ubuntu-22.04, manylinux_s390x, ""]
+          - [ubuntu-22.04, musllinux_s390x, ""]
           - [ubuntu-22.04-arm, manylinux_aarch64, ""]
           - [ubuntu-22.04-arm, musllinux_aarch64, ""]
           - [macos-15-intel, macosx_x86_64, openblas]
@@ -53,6 +57,12 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
+
+      - name: Setup QEMU
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
 
       - name: Setup MSVC (32-bit)
         if: ${{ matrix.buildplat[1] == 'win32' }}
@@ -97,6 +107,12 @@ jobs:
             DYLD="$DYLD_LIBRARY_PATH:/$PWD/.openblas/lib"
             echo "CIBW_ENVIRONMENT_MACOS=$CIBW PKG_CONFIG_PATH=$PKG_CONFIG_PATH DYLD_LIBRARY_PATH=$DYLD" >> "$GITHUB_ENV"
           fi
+
+      - name: Setup Linux
+        if: matrix.buildplat[0] == 'ubuntu-22.04' || matrix.buildplat[0] == 'ubuntu-22.04-arm'
+        run: |
+          policy=${{ matrix.buildplat[1] }}
+          echo "CIBW_ARCHS=${policy#*_}" >> "$GITHUB_ENV"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e  # v3.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,7 @@ tracker = "https://github.com/numpy/numpy/issues"
 # Note: the below skip command doesn't do much currently, the platforms to
 # build wheels for in CI are controlled in `.github/workflows/wheels.yml`.
 # universal2 wheels are not supported (see gh-21233), use `delocate-fuse` if you need them
-skip = ["*_i686", "*_ppc64le", "*_s390x", "*_universal2"]
+skip = ["*_i686", "*_universal2"]
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 before-test = "pip install -r {project}/requirements/test_requirements.txt"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
@@ -202,8 +202,12 @@ build-dir = "build"
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
+manylinux-ppc64le-image = "manylinux_2_28"
+manylinux-s390x-image = "manylinux_2_28"
 musllinux-x86_64-image = "musllinux_1_2"
 musllinux-aarch64-image = "musllinux_1_2"
+musllinux-ppc64le-image = "musllinux_1_2"
+musllinux-s390x-image = "musllinux_1_2"
 
 [tool.cibuildwheel.linux.environment]
 # RUNNER_OS is a GitHub Actions specific env var; define it here so it's
@@ -215,6 +219,14 @@ PKG_CONFIG_PATH="/project/.openblas"
 [tool.cibuildwheel.windows]
 config-settings = {setup-args = ["--vsenv", "-Dallow-noblas=false"], build-dir="build"}
 repair-wheel-command = "bash -el ./tools/wheels/repair_windows.sh {wheel} {dest_dir}"
+
+[[tool.cibuildwheel.overrides]]
+select = ["*-*linux*"]
+before-all = "./tools/install-static-clang.sh"
+inherit.environment = "append"
+environment = { CC = "/opt/clang/bin/clang", CXX = "/opt/clang/bin/clang++", LDFLAGS = "-fuse-ld=lld" }
+inherit.environment-pass = "append"
+environment-pass = ["RUNNER_ARCH"]
 
 [[tool.cibuildwheel.overrides]]
 select = ["*-win32"]

--- a/tools/install-static-clang.sh
+++ b/tools/install-static-clang.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Stop at any error, show all commands
+set -exuo pipefail
+
+TOOLCHAIN_PATH=/opt/clang
+
+# Download static-clang
+DEFAULT_ARCH="$(uname -m)"
+if [ "${STATIC_CLANG_ARCH:-}" == "" ]; then
+	STATIC_CLANG_ARCH="${RUNNER_ARCH:-${DEFAULT_ARCH}}"
+fi
+case "${STATIC_CLANG_ARCH}" in
+	ARM64|aarch64|arm64|arm64/*) GO_ARCH=arm64;;
+	ARM|armv7l|armv8l|arm|arm/v7) GO_ARCH=arm;;  # assume arm/v7 for arm
+	X64|x86_64|amd64|amd64/*) GO_ARCH=amd64;;
+	X86|i686|386) GO_ARCH=386;;
+	loongarch64) GO_ARCH=loong64;;
+	ppc64le) GO_ARCH=ppc64le;;
+	riscv64) GO_ARCH=riscv64;;
+	s390x) GO_ARCH=s390x;;
+	*) echo "No static-clang toolchain for ${CLANG_ARCH}">2; exit 1;;
+esac
+STATIC_CLANG_VERSION=21.1.6.0
+STATIC_CLANG_FILENAME="static-clang-linux-${GO_ARCH}.tar.xz"
+STATIC_CLANG_URL="https://github.com/mayeut/static-clang-images/releases/download/v${STATIC_CLANG_VERSION}/${STATIC_CLANG_FILENAME}"
+pushd /tmp
+cat<<'EOF' | grep "${STATIC_CLANG_FILENAME}" > "${STATIC_CLANG_FILENAME}.sha256"
+3f92a131d27ca606dae8230550236a0c897a7f5990d61a293814e0abea8d0e1f  static-clang-linux-386.tar.xz
+3fc6a3500cb9514b2c3af6d4a95676842769c301f872b6cea8c15576a64e756c  static-clang-linux-amd64.tar.xz
+82ea0c148ec75f72a2f6f61cc877561efe9675c6e59a1a2c4d130f088f9dc868  static-clang-linux-arm.tar.xz
+9b5ad28877b6d56aff530164f7f88590e5d3441a1fddd7a73370539783056120  static-clang-linux-arm64.tar.xz
+2adccbcad99d033222c8a63872739919375a7aef2339ce2e8ab7dcfc938502b1  static-clang-linux-loong64.tar.xz
+5f551911ad73ecbbcf278e6d05a04bc68bd0dc4918a6a145352072f7734959c6  static-clang-linux-ppc64le.tar.xz
+90f5beda1004bec124607df1f9fc0a70c2b9f382b82ab1db2703ebd131c920ef  static-clang-linux-riscv64.tar.xz
+e4047765a5e64bace4be36f6aae4d859e96bc1298d3ff5ba6b7d6100ea7d23f7  static-clang-linux-s390x.tar.xz
+EOF
+curl -fsSLO "${STATIC_CLANG_URL}"
+sha256sum -c "${STATIC_CLANG_FILENAME}.sha256"
+tar -C /opt -xf "${STATIC_CLANG_FILENAME}"
+popd
+
+# configure target triple
+case "${AUDITWHEEL_POLICY}-${AUDITWHEEL_ARCH}" in
+	manylinux*-armv7l) TARGET_TRIPLE=armv7-unknown-linux-gnueabihf;;
+	musllinux*-armv7l) TARGET_TRIPLE=armv7-alpine-linux-musleabihf;;
+	manylinux*-ppc64le) TARGET_TRIPLE=powerpc64le-unknown-linux-gnu;;
+	musllinux*-ppc64le) TARGET_TRIPLE=powerpc64le-alpine-linux-musl;;
+	manylinux*-*) TARGET_TRIPLE=${AUDITWHEEL_ARCH}-unknown-linux-gnu;;
+	musllinux*-*) TARGET_TRIPLE=${AUDITWHEEL_ARCH}-alpine-linux-musl;;
+esac
+case "${AUDITWHEEL_POLICY}-${AUDITWHEEL_ARCH}" in
+	*-riscv64) M_ARCH="-march=rv64gc";;
+	*-x86_64) M_ARCH="-march=x86-64";;
+	*-armv7l) M_ARCH="-march=armv7a";;
+	manylinux*-i686) M_ARCH="-march=k8 -mtune=generic";;  # same as gcc manylinux2014 / manylinux_2_28
+	musllinux*-i686) M_ARCH="-march=pentium-m -mtune=generic";;  # same as gcc musllinux_1_2
+esac
+GCC_TRIPLE=$(gcc -dumpmachine)
+
+cat<<EOF >"${TOOLCHAIN_PATH}/bin/${AUDITWHEEL_PLAT}.cfg"
+	-target ${TARGET_TRIPLE}
+	${M_ARCH:-}
+	--gcc-toolchain=${DEVTOOLSET_ROOTPATH:-}/usr
+	--gcc-triple=${GCC_TRIPLE}
+EOF
+
+cat<<EOF >"${TOOLCHAIN_PATH}/bin/clang.cfg"
+	@${AUDITWHEEL_PLAT}.cfg
+EOF
+
+cat<<EOF >"${TOOLCHAIN_PATH}/bin/clang++.cfg"
+	@${AUDITWHEEL_PLAT}.cfg
+EOF
+
+cat<<EOF >"${TOOLCHAIN_PATH}/bin/clang-cpp.cfg"
+	@${AUDITWHEEL_PLAT}.cfg
+EOF
+
+# override entrypoint to add the toolchain to PATH
+mv /usr/local/bin/manylinux-entrypoint /usr/local/bin/manylinux-entrypoint-org
+cat<<EOF >/usr/local/bin/manylinux-entrypoint
+#!/bin/bash
+
+set -eu
+
+export PATH="${TOOLCHAIN_PATH}/bin:\${PATH}"
+exec /usr/local/bin/manylinux-entrypoint-org "\$@"
+EOF
+
+chmod +x /usr/local/bin/manylinux-entrypoint


### PR DESCRIPTION
This allows a speed-up of all QEMU targets by using a statically built clang that runs with the native architecture of the runner rather than calling gcc through QEMU.

Requirement:
- "scipy-openblas32>=0.3.30.359.2"

This PR is mostly used as a PoC for this trick and see wether it would see adoption, what are the limitations and how it could be improved.

Clang used in this PR is built & published in the following repo: https://github.com/mayeut/static-clang-images