### PR TITLE
BUG: unrelated error raised when a dtype's `__setstate__` is called with an invalid state tuple size

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -844,7 +844,7 @@ _try_convert_from_inherit_tuple(PyArray_Descr *type, PyObject *newobj)
         return (PyArray_Descr *)Py_NotImplemented;
     }
     if (!PyDataType_ISLEGACY(type) || !PyDataType_ISLEGACY(conv)) {
-        /* 
+        /*
          * This specification should probably be never supported, but
          * certainly not for new-style DTypes.
          */
@@ -1951,7 +1951,7 @@ NPY_NO_EXPORT PyArray_Descr *
 PyArray_DescrNew(PyArray_Descr *base_descr)
 {
     if (!PyDataType_ISLEGACY(base_descr)) {
-        /* 
+        /*
          * The main use of this function is mutating strings, so probably
          * disallowing this is fine in practice.
          */
@@ -2917,13 +2917,10 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
         }
         break;
     default:
-        /* raise an error */
-        if (PyTuple_GET_SIZE(PyTuple_GET_ITEM(args,0)) > 5) {
-            version = PyLong_AsLong(PyTuple_GET_ITEM(args, 0));
-        }
-        else {
-            version = -1;
-        }
+        PyErr_Format(PyExc_ValueError,
+                     "invalid tuple size %zd in numpy.dtype setstate",
+                     PyTuple_GET_SIZE(PyTuple_GET_ITEM(args, 0)));
+        return NULL;
     }
 
     /*

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2917,9 +2917,9 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
         }
         break;
     default:
-        PyErr_Format(PyExc_ValueError,
-                     "invalid input tuple size %zd in numpy.dtype setstate",
-                     PyTuple_GET_SIZE(PyTuple_GET_ITEM(args, 0)));
+        PyErr_SetString(PyExc_ValueError,
+                        "Invalid state while unpickling. Is the pickle corrupted "
+                        "or created with a newer NumPy version?");
         return NULL;
     }
 

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2918,7 +2918,7 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
         break;
     default:
         PyErr_Format(PyExc_ValueError,
-                     "invalid tuple size %zd in numpy.dtype setstate",
+                     "invalid input tuple size %zd in numpy.dtype setstate",
                      PyTuple_GET_SIZE(PyTuple_GET_ITEM(args, 0)));
         return NULL;
     }

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1341,6 +1341,29 @@ class TestPickling:
             assert roundtrip_dt == dt
             assert hash(roundtrip_dt) == pre_pickle_hash
 
+    @pytest.mark.parametrize('dt', [
+        np.dtype([('a', 'i4'), ('b', 'f8')]),
+        np.dtype('i4, i1', align=True),
+    ])
+    def test_setstate_invalid_tuple_size(self, dt):
+        # gh-30476
+        valid_state = dt.__reduce__()[2]
+        dt.__setstate__(valid_state)
+
+        for size in [1, 2, 3, 4]:
+            with pytest.raises(
+                ValueError, match=r"invalid tuple size \d+ in numpy.dtype setstate"
+            ):
+                dt.__setstate__(valid_state[:size])
+
+        min_extra = 10 - len(valid_state)
+        for extra in range(min_extra, min_extra + 5):
+            extended = valid_state + (None,) * extra
+            with pytest.raises(
+                ValueError, match=r"invalid tuple size \d+ in numpy.dtype setstate"
+            ):
+                dt.__setstate__(extended)
+
 
 class TestPromotion:
     """Test cases related to more complex DType promotions.  Further promotion

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1352,8 +1352,7 @@ class TestPickling:
 
         for size in [1, 2, 3, 4]:
             with pytest.raises(
-                ValueError,
-                match=r"invalid input tuple size \d+ in numpy.dtype setstate"
+                ValueError, match="Invalid state while unpickling"
             ):
                 dt.__setstate__(valid_state[:size])
 
@@ -1361,8 +1360,7 @@ class TestPickling:
         for extra in range(min_extra, min_extra + 5):
             extended = valid_state + (None,) * extra
             with pytest.raises(
-                ValueError,
-                match=r"invalid input tuple size \d+ in numpy.dtype setstate"
+                ValueError, match="Invalid state while unpickling"
             ):
                 dt.__setstate__(extended)
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1352,7 +1352,8 @@ class TestPickling:
 
         for size in [1, 2, 3, 4]:
             with pytest.raises(
-                ValueError, match=r"invalid tuple size \d+ in numpy.dtype setstate"
+                ValueError,
+                match=r"invalid input tuple size \d+ in numpy.dtype setstate"
             ):
                 dt.__setstate__(valid_state[:size])
 
@@ -1360,7 +1361,8 @@ class TestPickling:
         for extra in range(min_extra, min_extra + 5):
             extended = valid_state + (None,) * extra
             with pytest.raises(
-                ValueError, match=r"invalid tuple size \d+ in numpy.dtype setstate"
+                ValueError,
+                match=r"invalid input tuple size \d+ in numpy.dtype setstate"
             ):
                 dt.__setstate__(extended)
 


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/30476

My understanding here is that the switch statement checks only specific sizes of the input state tuple `PyTuple_GET_SIZE(PyTuple_GET_ITEM(args,0))`. If none of those sizes match, then it does this:
https://github.com/numpy/numpy/blob/60057c05a349a6d2281ffaf7a7627a1ae8732c63/numpy/_core/src/multiarray/descriptor.c#L2919-L2927
So if it's size is greater than 5, it tries to convert the tuple into a long with `PyLong_AsLong(PyTuple_GET_ITEM(args, 0))` which can't work right? `PyLong_AsLong` returns -1 on failure (the else block sets the version to -1 too) so we will get a `ValueError: can't handle version -1 of numpy.dtype pickle` from right below:
https://github.com/numpy/numpy/blob/60057c05a349a6d2281ffaf7a7627a1ae8732c63/numpy/_core/src/multiarray/descriptor.c#L2933-L2937

That appears like an unrelated error though and it looks to me like a proper error should be raised if the state tuple is not one of the acceptable sizes.

Before:
```py
>>> import numpy as np
>>> dt = np.dtype([('a', 'i4'), ('b', 'f8')])
>>> dt.__setstate__((6,7,8))
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    dt.__setstate__((6,7,8))
    ~~~~~~~~~~~~~~~^^^^^^^^^
ValueError: can't handle version -1 of numpy.dtype pickle
```
After:
```py
>>> import numpy as np
>>> dt = np.dtype([('a', 'i4'), ('b', 'f8')])
>>> dt.__setstate__((6,7,8))
Traceback (most recent call last):
  File "<python-input-4>", line 1, in <module>
    dt.__setstate__((6,7,8))
    ~~~~~~~~~~~~~~~^^^^^^^^^
ValueError: invalid input tuple size 3 in numpy.dtype setstate
```