### PR TITLE
BUG: Raise ValueError when spawn() called with negative n_children

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -294,6 +294,8 @@ cdef class Generator:
         >>> nested_spawn = child_rng1.spawn(20)
 
         """
+        if n_children < 0:
+            raise ValueError("n_children must be non-negative")
         return [type(self)(g) for g in self._bit_generator.spawn(n_children)]
 
     def random(self, size=None, dtype=np.float64, out=None):

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -241,6 +241,8 @@ cdef class SeedlessSeedSequence:
         raise NotImplementedError('seedless SeedSequences cannot generate state')
 
     def spawn(self, n_children):
+        if n_children < 0:
+            raise ValueError("n_children must be non-negative")
         return [self] * n_children
 
 
@@ -476,6 +478,9 @@ cdef class SeedSequence:
         """
         cdef uint32_t i
 
+        if n_children < 0:
+            raise ValueError("n_children must be non-negative")
+
         seqs = []
         for i in range(self.n_children_spawned,
                        self.n_children_spawned + n_children):
@@ -626,6 +631,8 @@ cdef class BitGenerator:
             Equivalent method on the generator and seed sequence.
 
         """
+        if n_children < 0:
+            raise ValueError("n_children must be non-negative")
         if not isinstance(self._seed_seq, ISpawnableSeedSequence):
             raise TypeError(
                 "The underlying SeedSequence does not implement spawning.")

--- a/numpy/random/tests/test_direct.py
+++ b/numpy/random/tests/test_direct.py
@@ -183,6 +183,31 @@ def test_generator_spawning():
     assert new_rngs[0].uniform() != new_rngs[1].uniform()
 
 
+def test_spawn_negative_n_children():
+    """Test that spawn raises ValueError for negative n_children."""
+    from numpy.random.bit_generator import SeedlessSeedSequence
+
+    rng = np.random.default_rng(42)
+    seq = rng.bit_generator.seed_seq
+
+    # Test SeedSequence.spawn
+    with pytest.raises(ValueError, match="n_children must be non-negative"):
+        seq.spawn(-1)
+
+    # Test SeedlessSeedSequence.spawn
+    seedless = SeedlessSeedSequence()
+    with pytest.raises(ValueError, match="n_children must be non-negative"):
+        seedless.spawn(-1)
+
+    # Test BitGenerator.spawn
+    with pytest.raises(ValueError, match="n_children must be non-negative"):
+        rng.bit_generator.spawn(-1)
+
+    # Test Generator.spawn
+    with pytest.raises(ValueError, match="n_children must be non-negative"):
+        rng.spawn(-1)
+
+
 def test_non_spawnable():
     from numpy.random.bit_generator import ISeedSequence
 


### PR DESCRIPTION
Fixes #30577

This PR adds validation to reject negative n_children arguments in all spawn() methods which previously caused erratic behavior:
* SeedSequence.spawn()
* SeedlessSeedSequence.spawn()
* BitGenerator.spawn()
* Generator.spawn()

**Changes:**

Added if n_children < 0: raise ValueError("n_children must be non-negative") to
* SeedSequence.spawn()
* SeedlessSeedSequence.spawn()
* BitGenerator.spawn()
* Generator.spawn()

Added test_spawn_negative_n_children() test to verify all spawn methods correctly reject negative arguments

**Test and results:**

spin test -t numpy/random/tests/test_direct.py::test_spawn_negative_n_children -v

<img width="801" height="237" alt="Screenshot 2026-01-14 at 3 54 57 PM" src="https://github.com/user-attachments/assets/171919e8-a0a7-4d56-a740-70edf1580054" />


