### PR TITLE
ENH: enable `Py_TPFLAGS_SEQUENCE` for the ndarray object

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -155,4 +155,4 @@ jobs:
       if: ${{ matrix.version == '3.14t' && matrix.build_runner[0] == 'macos-14' }}
       run:  |
         pip install pytest-run-parallel==0.8.2
-        spin test -p 4 -- --timeout=600 --durations=10
+        spin test -p 4 -- -sv --timeout=600 --durations=10

--- a/doc/release/upcoming_changes/30653.new_feature.rst
+++ b/doc/release/upcoming_changes/30653.new_feature.rst
@@ -1,0 +1,5 @@
+``ndarray`` now supports structural pattern matching
+----------------------------------------------------
+`numpy.ndarray` and its subclasses now have the ``Py_TPFLAGS_SEQUENCE`` flag
+set, enabling structural pattern matching (PEP 634) with ``match``/``case``
+statements. This also enables Cython to optimize integer indexing operations.

--- a/doc/release/upcoming_changes/30653.new_feature.rst
+++ b/doc/release/upcoming_changes/30653.new_feature.rst
@@ -1,5 +1,6 @@
-``ndarray`` now supports structural pattern matching
-----------------------------------------------------
+``numpy.ndarray`` now supports structural pattern matching
+----------------------------------------------------------
 `numpy.ndarray` and its subclasses now have the ``Py_TPFLAGS_SEQUENCE`` flag
 set, enabling structural pattern matching (PEP 634) with ``match``/``case``
 statements. This also enables Cython to optimize integer indexing operations.
+See :ref:`arrays.ndarray.pattern-matching` for details.

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -641,5 +641,4 @@ Nested patterns work too, matching inner dimensions::
    ...         print(f"a={a}, b={b}, c={c}, d={d}")
    a=1, b=2, c=3, d=4
 
-This is enabled by the ``Py_TPFLAGS_SEQUENCE`` flag on the array type.
 All ndarray subclasses inherit this behavior.

--- a/doc/source/reference/arrays.ndarray.rst
+++ b/doc/source/reference/arrays.ndarray.rst
@@ -618,3 +618,28 @@ Utility method for typing:
    :toctree: generated/
 
    ndarray.__class_getitem__
+
+.. _arrays.ndarray.pattern-matching:
+
+Structural pattern matching
+===========================
+
+Arrays support :pep:`structural pattern matching <634>`. The array is matched
+as a sequence, so you can unpack arrays along the first dimension in
+``match``/``case`` statements::
+
+   >>> arr = np.array([[1, 2], [3, 4]])
+   >>> match arr:
+   ...     case [row1, row2]:
+   ...         print(f"row1={row1}, row2={row2}")
+   row1=[1 2], row2=[3 4]
+
+Nested patterns work too, matching inner dimensions::
+
+   >>> match arr:
+   ...     case [[a, b], [c, d]]:
+   ...         print(f"a={a}, b={b}, c={c}, d={d}")
+   a=1, b=2, c=3, d=4
+
+This is enabled by the ``Py_TPFLAGS_SEQUENCE`` flag on the array type.
+All ndarray subclasses inherit this behavior.

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -1232,7 +1232,7 @@ NPY_NO_EXPORT PyTypeObject PyArray_Type = {
     .tp_as_mapping = &array_as_mapping,
     .tp_str = (reprfunc)array_str,
     .tp_as_buffer = &array_as_buffer,
-    .tp_flags =(Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE),
+    .tp_flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_SEQUENCE),
 
     .tp_richcompare = (richcmpfunc)array_richcompare,
     .tp_weaklistoffset = offsetof(PyArrayObject_fields, weakreflist),

--- a/numpy/_core/tests/test_memmap.py
+++ b/numpy/_core/tests/test_memmap.py
@@ -245,3 +245,51 @@ class TestMemmap:
         memmap(self.tmpfp, shape=self.shape, mode='w+')
         memmap(self.tmpfp, shape=list(self.shape), mode='w+')
         memmap(self.tmpfp, shape=asarray(self.shape), mode='w+')
+
+
+class TestPatternMatching:
+    """Tests for structural pattern matching support (PEP 634)."""
+
+    def test_match_sequence_pattern_1d(self):
+        with NamedTemporaryFile() as f:
+            arr = memmap(f, dtype='int64', mode='w+', shape=(3,))
+            arr[:] = [1, 2, 3]
+            match arr:
+                case [a, b, c]:
+                    assert a == 1
+                    assert b == 2
+                    assert c == 3
+                case _:
+                    raise AssertionError("1D memmap did not match sequence pattern")
+
+    def test_match_sequence_pattern_2d(self):
+        with NamedTemporaryFile() as f:
+            arr = memmap(f, dtype='int64', mode='w+', shape=(2, 2))
+            arr[:] = [[1, 2], [3, 4]]
+            match arr:
+                case [row1, row2]:
+                    assert_array_equal(row1, [1, 2])
+                    assert_array_equal(row2, [3, 4])
+                case _:
+                    raise AssertionError("2D memmap did not match sequence pattern")
+
+    def test_match_sequence_pattern_3d(self):
+        with NamedTemporaryFile() as f:
+            arr = memmap(f, dtype='int64', mode='w+', shape=(2, 2, 2))
+            arr[:] = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+            # outer matching
+            match arr:
+                case [plane1, plane2]:
+                    assert_array_equal(plane1, [[1, 2], [3, 4]])
+                    assert_array_equal(plane2, [[5, 6], [7, 8]])
+                case _:
+                    raise AssertionError("3D memmap did not match sequence pattern")
+            # inner matching
+            match arr:
+                case [[row1, row2], [row3, row4]]:
+                    assert_array_equal(row1, [1, 2])
+                    assert_array_equal(row2, [3, 4])
+                    assert_array_equal(row3, [5, 6])
+                    assert_array_equal(row4, [7, 8])
+                case _:
+                    raise AssertionError("3D memmap did not match sequence pattern")

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -11107,3 +11107,45 @@ class TestTextSignatures:
         sig = inspect.signature(func)
         assert sig.parameters
         assert tuple(sig.parameters) == parameter_names
+
+
+class TestPatternMatching:
+    """Tests for structural pattern matching support (PEP 634)."""
+
+    def test_match_sequence_pattern_1d(self):
+        arr = np.array([1, 2, 3])
+        match arr:
+            case [a, b, c]:
+                assert a == 1
+                assert b == 2
+                assert c == 3
+            case _:
+                raise AssertionError("1D ndarray did not match sequence pattern")
+
+    def test_match_sequence_pattern_2d(self):
+        arr = np.array([[1, 2], [3, 4]])
+        match arr:
+            case [row1, row2]:
+                assert_array_equal(row1, [1, 2])
+                assert_array_equal(row2, [3, 4])
+            case _:
+                raise AssertionError("2D ndarray did not match sequence pattern")
+
+    def test_match_sequence_pattern_3d(self):
+        arr = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+        # outer matching
+        match arr:
+            case [plane1, plane2]:
+                assert_array_equal(plane1, [[1, 2], [3, 4]])
+                assert_array_equal(plane2, [[5, 6], [7, 8]])
+            case _:
+                raise AssertionError("3D ndarray did not match sequence pattern")
+        # inner matching
+        match arr:
+            case [[row1, row2], [row3, row4]]:
+                assert_array_equal(row1, [1, 2])
+                assert_array_equal(row2, [3, 4])
+                assert_array_equal(row3, [5, 6])
+                assert_array_equal(row4, [7, 8])
+            case _:
+                raise AssertionError("3D ndarray did not match sequence pattern")

--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -542,3 +542,51 @@ def test_find_duplicate():
 
     l3 = [2, 2, 1, 4, 1, 6, 2, 3]
     assert_(np.rec.find_duplicate(l3) == [2, 1])
+
+
+class TestPatternMatching:
+    """Tests for structural pattern matching support (PEP 634)."""
+
+    def test_match_sequence_pattern_1d(self):
+        dt = np.dtype([('x', 'i4'), ('y', 'f8')])
+        arr = np.array([(1, 1.5), (2, 2.5), (3, 3.5)], dtype=dt).view(np.recarray)
+        match arr:
+            case [a, b, c]:
+                assert a.x == 1 and a.y == 1.5
+                assert b.x == 2 and b.y == 2.5
+                assert c.x == 3 and c.y == 3.5
+            case _:
+                raise AssertionError("1D recarray did not match sequence pattern")
+
+    def test_match_sequence_pattern_2d(self):
+        dt = np.dtype([('x', 'i4'), ('y', 'f8')])
+        arr = np.array([[(1, 1.5), (2, 2.5)], [(3, 3.5), (4, 4.5)]],
+                       dtype=dt).view(np.recarray)
+        match arr:
+            case [row1, row2]:
+                assert_array_equal(row1.x, [1, 2])
+                assert_array_equal(row2.x, [3, 4])
+            case _:
+                raise AssertionError("2D recarray did not match sequence pattern")
+
+    def test_match_sequence_pattern_3d(self):
+        dt = np.dtype([('x', 'i4'), ('y', 'f8')])
+        arr = np.array([[[(1, 1.5), (2, 2.5)], [(3, 3.5), (4, 4.5)]],
+                        [[(5, 5.5), (6, 6.5)], [(7, 7.5), (8, 8.5)]]],
+                       dtype=dt).view(np.recarray)
+        # outer matching
+        match arr:
+            case [plane1, plane2]:
+                assert_array_equal(plane1.x, [[1, 2], [3, 4]])
+                assert_array_equal(plane2.x, [[5, 6], [7, 8]])
+            case _:
+                raise AssertionError("3D recarray did not match sequence pattern")
+        # inner matching
+        match arr:
+            case [[row1, row2], [row3, row4]]:
+                assert_array_equal(row1.x, [1, 2])
+                assert_array_equal(row2.x, [3, 4])
+                assert_array_equal(row3.x, [5, 6])
+                assert_array_equal(row4.x, [7, 8])
+            case _:
+                raise AssertionError("3D recarray did not match sequence pattern")

--- a/numpy/matrixlib/tests/test_defmatrix.py
+++ b/numpy/matrixlib/tests/test_defmatrix.py
@@ -451,3 +451,25 @@ class TestShape:
         expanded = np.expand_dims(a, axis=1)
         assert_equal(expanded.ndim, 3)
         assert_(not isinstance(expanded, np.matrix))
+
+
+class TestPatternMatching:
+    """Tests for structural pattern matching support (PEP 634)."""
+
+    def test_match_sequence_pattern_2d(self):
+        # matrix is always 2D, so rows are (1, N) matrices not 1D arrays
+        arr = matrix([[1, 2], [3, 4]])
+        # outer matching
+        match arr:
+            case [row1, row2]:
+                assert_array_equal(row1, [[1, 2]])
+                assert_array_equal(row2, [[3, 4]])
+            case _:
+                raise AssertionError("2D matrix did not match sequence pattern")
+        # inner matching - rows are still 2D matrices, not scalars
+        match arr:
+            case [[a], [b]]:
+                assert_array_equal(a, [[1, 2]])
+                assert_array_equal(b, [[3, 4]])
+            case _:
+                raise AssertionError("2D matrix did not match sequence pattern")


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/30519

I now get this locally which didn't match before
```
In [1]: import numpy as np
   ...:
   ...: array = np.array([1, 2, 3])
   ...:
   ...: match array:
   ...:   case [a, b, c]:
   ...:       print(f"Matched sequence: {a}, {b}, {c}")
   ...:   case _:
   ...:       print("No pattern matched")
   ...:
Matched sequence: 1, 2, 3

In [2]: import numpy as np
   ...:
   ...: array = np.ma.array([1, 2, 3])
   ...:
   ...: match array:
   ...:   case [a, b, c]:
   ...:       print(f"Matched sequence: {a}, {b}, {c}")
   ...:   case _:
   ...:       print("No pattern matched")
   ...:
Matched sequence: 1, 2, 3
```

I'm putting this up to see what CI says first