### PR TITLE
DOC:clarify fromnumeric wrapper behaviour

### DIFF
--- a/numpy/core/fromnumeric.py
+++ b/numpy/core/fromnumeric.py
@@ -1,3 +1,11 @@
+"""
+This module provides the Python-level wrappers for many NumPy functions
+such as ``sum``, ``mean``, and ``argmax``.
+
+Most functions here forward calls to lower-level implementations in NumPy
+core. Accessing these functions via ``np.<function>`` may trigger warnings
+that guide users toward the recommended APIs.
+"""
 def __getattr__(attr_name):
     from numpy._core import fromnumeric
 


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This PR adds a short explanation to the module-level docstring in
`numpy/_core/fromnumeric.py` to clarify how wrapper functions are exposed
and why warnings may be emitted when accessing them via `np.<function>`.
No functional changes are made.
