### PR TITLE
TST: Add regression test for genfromtxt ndmin argument (gh-25662)

### DIFF
--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2752,10 +2752,15 @@ def test_savez_nopickle():
     with temppath(suffix='.npz') as tmp:
         with pytest.raises(ValueError, match="Object arrays cannot be saved when.*"):
             np.savez_compressed(tmp, obj_array, allow_pickle=False)
+
+
 def test_genfromtxt_ndmin_regression():
-    from io import BytesIO          
-    import numpy as np              
-    
+    from io import BytesIO
+
+    import numpy as np
+
+   
     data = np.genfromtxt(BytesIO(b"1 2 3"), ndmin=2)
     assert data.ndim == 2
+    
     

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2753,9 +2753,9 @@ def test_savez_nopickle():
         with pytest.raises(ValueError, match="Object arrays cannot be saved when.*"):
             np.savez_compressed(tmp, obj_array, allow_pickle=False)
 def test_genfromtxt_ndmin_regression():
-    import numpy as np
-    from io import BytesIO
-    # Regression test for gh-25662
-    # Ensure ndmin argument is respected
+    from io import BytesIO          
+    import numpy as np              
+    
     data = np.genfromtxt(BytesIO(b"1 2 3"), ndmin=2)
     assert data.ndim == 2
+    

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2759,8 +2759,5 @@ def test_genfromtxt_ndmin_regression():
 
     import numpy as np
 
-   
     data = np.genfromtxt(BytesIO(b"1 2 3"), ndmin=2)
     assert data.ndim == 2
-    
-    

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2752,3 +2752,10 @@ def test_savez_nopickle():
     with temppath(suffix='.npz') as tmp:
         with pytest.raises(ValueError, match="Object arrays cannot be saved when.*"):
             np.savez_compressed(tmp, obj_array, allow_pickle=False)
+def test_genfromtxt_ndmin_regression():
+    import numpy as np
+    from io import BytesIO
+    # Regression test for gh-25662
+    # Ensure ndmin argument is respected
+    data = np.genfromtxt(BytesIO(b"1 2 3"), ndmin=2)
+    assert data.ndim == 2


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
This PR adds a regression test for issue #25662.

It appears that `genfromtxt` correctly respects the `ndmin` argument, but there was no explicit test coverage for this behavior. This test ensures that the functionality remains stable in the future.

**Changes:**
- Added `test_genfromtxt_ndmin_regression` to `numpy/lib/tests/test_io.py`.

**Verification:**
- Ran the new test locally using `spin test numpy/lib/tests/test_io.py` and confirmed it passes.
