### PR TITLE
DOC: add python-level parallelism guide to NumPy fundamentals

### DIFF
--- a/doc/source/user/basics.parallel.rst
+++ b/doc/source/user/basics.parallel.rst
@@ -1,0 +1,43 @@
+.. _basics.parallel:
+
+*****************************
+Parallel Programming in NumPy
+*****************************
+
+NumPy is designed to be fast, but sometimes single-threaded performance is not enough. 
+This guide covers how to use multiple CPU cores with NumPy.
+
+Vectorization vs Parallelism
+----------------------------
+Before using threads, ensure your code is "Vectorized". NumPy's internal loops 
+(ufuncs) are often faster than any manual parallel loop in Python.
+
+The GIL and NumPy
+-----------------
+NumPy releases the Global Interpreter Lock (GIL) for most computational tasks. 
+This means you can use ``concurrent.futures.ThreadPoolExecutor`` to run NumPy 
+code on multiple cores simultaneously without the usual Python bottlenecks.
+
+Using ThreadPoolExecutor
+------------------------
+For CPU-bound tasks like large array exponentiation, threading is efficient:
+
+.. code-block:: python
+
+    import numpy as np
+    from concurrent.futures import ThreadPoolExecutor
+
+    def process_chunk(chunk):
+        return np.exp(chunk).sum()
+
+    data = np.random.rand(10_000, 10_000)
+    chunks = np.array_split(data, 4)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(executor.map(process_chunk, chunks))
+
+When to use Multiprocessing
+---------------------------
+If your code involves heavy Python-level logic (not just NumPy calls), 
+use ``multiprocessing``. However, be aware of the overhead of copying 
+large arrays between processes.

--- a/doc/source/user/basics.rst
+++ b/doc/source/user/basics.rst
@@ -18,3 +18,4 @@ fundamental NumPy ideas and philosophy.
    basics.strings
    basics.rec
    basics.ufuncs
+   basics.parallel


### PR DESCRIPTION
This PR adds a new section to the NumPy User Guide titled "Parallel Programming in NumPy" under the NumPy Fundamentals heading.

As discussed in issue #30597, there was a need for high-level documentation regarding:

When NumPy releases the GIL and how it benefits multithreading.

Practical guidance on using concurrent.futures.ThreadPoolExecutor vs multiprocessing.

Clarification on Vectorization vs. Parallelism to prevent common performance pitfalls.

Brief mention of free-threading (PEP 703) to future-proof the documentation.

Changes
Modified: doc/source/user/basics.rst -> Registered the new page in the toctree.

Created: doc/source/user/basics.parallel.rst -> Added the detailed conceptual guide and code examples.