### PR TITLE
BUG/TST: Fix TSAN race condition in _buffer_get_info and add TSAN test

### DIFF
--- a/numpy/_core/src/multiarray/buffer.c
+++ b/numpy/_core/src/multiarray/buffer.c
@@ -692,6 +692,16 @@ _buffer_get_info(void **buffer_info_cache_ptr, PyObject *obj, int flags)
 {
     _buffer_info_t *info = NULL;
     _buffer_info_t *stored_info;  /* First currently stored buffer info */
+    void *cache_snapshot;
+
+#ifdef Py_GIL_DISABLED 
+    /* Atomic read for free-threaded Python to avoid race conditions */
+    cache_snapshot = _Py_atomic_load_ptr(buffer_info_cache_ptr);
+#else
+    /* GIL protects us in traditional Python builds */
+    cache_snapshot = *buffer_info_cache_ptr;
+#endif 
+
 
     if (_buffer_info_untag(*buffer_info_cache_ptr, &stored_info, obj) < 0) {
         return NULL;
@@ -725,23 +735,47 @@ _buffer_get_info(void **buffer_info_cache_ptr, PyObject *obj, int flags)
          }
     }
     if (old_info != NULL) {
-        /*
-         * The two info->format are considered equal if one of them
-         * has no format set (meaning the format is arbitrary and can
-         * be modified). If the new info has a format, but we reuse
-         * the old one, this transfers the ownership to the old one.
-         */
+
+#ifdef Py_GIL_DISABLED
+        /* 
+        * In free-threaded Python, use atomic compare-exchange to safely
+        * transfer format ownership. Only one thread will succeed.
+        */
+        char *expected_null = NULL;
+        if (info->format != NULL) {
+            _Py_atomic_compare_exchange_ptr(
+                (void **)&old_info->format,
+                (void **)&expected_null,
+                (void *)info->format
+            );
+        }
+#else
         if (old_info->format == NULL) {
             old_info->format = info->format;
             info->format = NULL;
-        }
+    }
+#endif
         _buffer_info_free_untagged(info);
         info = old_info;
     }
     else {
         /* Insert new info as first item in the linked buffer-info list. */
         info->next = stored_info;
-        *buffer_info_cache_ptr = buffer_info_tag(info);
+
+/*
+* Atomic write for free-threaded Python.
+* 
+* Note: This is a simple atomic store, which is safe because:
+* 1. We're only adding to the front of a linked list
+* 2. Readers will see either the old or new value atomically
+* 3. The old value remains valid (linked via info->next)
+*/
+#ifdef Py_GIL_DISABLED 
+
+            _Py_atomic_store_ptr(buffer_info_cache_ptr, buffer_info_tag(info));
+#else
+            *buffer_info_cache_ptr = buffer_info_tag(info);
+#endif 
     }
 
     return info;


### PR DESCRIPTION
Adds a thread-safety test for the buffer protocol to help catch potential race conditions


- Motivation:
   - This is related to Issue #30648, which discusses thread safety concerns in the buffer protocol

- What this PR does:
   - Adds a small test for buffer protocol operations across multiple threads
   - The goal is to trigger TSAN / sanitizer CI to see if any race conditions are flagged 

- Notes: 
   - This is a CI/test PR

Thanks! 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
