### PR TITLE
DOC: clarify spin usage and add top-level reference

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -31,5 +31,3 @@ The ``spin`` tool provides a consistent interface for contributors working on
 NumPy itself, wrapping multiple underlying tools and configurations into a
 single command that follows NumPy’s development conventions.
 
-Most contributors will interact with ``spin`` when running tests locally,
-building the documentation, or preparing changes for review.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -17,6 +17,8 @@ For more, please read https://www.numpy.org/devdocs/dev/index.html
 
 Thank you for contributing, and happy coding!
 
+.. _spin_tool:
+
 Spin: NumPy’s developer tool
 ----------------------------
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -17,17 +17,3 @@ For more, please read https://www.numpy.org/devdocs/dev/index.html
 
 Thank you for contributing, and happy coding!
 
-.. _spin_tool:
-
-Spin: NumPy’s developer tool
-----------------------------
-
-NumPy uses a command-line tool called ``spin`` to support common development
-tasks such as building from source, running tests, building documentation, 
-and managing other
-developer workflows.
-
-The ``spin`` tool provides a consistent interface for contributors working on
-NumPy itself, wrapping multiple underlying tools and configurations into a
-single command that follows NumPy’s development conventions.
-

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -16,3 +16,17 @@ to all interactions, including issues and PRs.
 For more, please read https://www.numpy.org/devdocs/dev/index.html
 
 Thank you for contributing, and happy coding!
+
+Spin: NumPy’s developer tool
+----------------------------
+
+NumPy uses a command-line tool called ``spin`` to support common development
+tasks such as running tests, building documentation, and managing other
+developer workflows.
+
+The ``spin`` tool provides a consistent interface for contributors working on
+NumPy itself, wrapping multiple underlying tools and configurations into a
+single command that follows NumPy’s development conventions.
+
+Most contributors will interact with ``spin`` when running tests locally,
+building the documentation, or preparing changes for review.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -21,7 +21,8 @@ Spin: NumPy’s developer tool
 ----------------------------
 
 NumPy uses a command-line tool called ``spin`` to support common development
-tasks such as running tests, building documentation, and managing other
+tasks such as building from source, running tests, building documentation, 
+and managing other
 developer workflows.
 
 The ``spin`` tool provides a consistent interface for contributors working on

--- a/doc/TESTS.rst
+++ b/doc/TESTS.rst
@@ -63,11 +63,9 @@ example, the ``_core`` module, use the following::
 Running tests from the command line
 -----------------------------------
 
-If you want to build NumPy in order to work on NumPy itself, use the ``spin``
-utility.The spin utility is NumPy’s developer command-line tool used when 
-working with a local source checkout of NumPy. It provides convenient wrappers
-around common development tasks such as building NumPy, running tests, and
-checking documentation, ensuring the correct build environment is used. 
+If you want to build NumPy in order to work on NumPy itself, use the
+:ref:`spin utility <spin_tool>`.
+
 To run NumPy's full test suite::
 
   $ spin test -m full

--- a/doc/TESTS.rst
+++ b/doc/TESTS.rst
@@ -64,7 +64,11 @@ Running tests from the command line
 -----------------------------------
 
 If you want to build NumPy in order to work on NumPy itself, use the ``spin``
-utility. To run NumPy's full test suite::
+utility.The spin utility is NumPy’s developer command-line tool used when 
+working with a local source checkout of NumPy. It provides convenient wrappers
+around common development tasks such as building NumPy, running tests, and 
+checking documentation, ensuring the correct build environment is used. 
+To run NumPy's full test suite::
 
   $ spin test -m full
 

--- a/doc/TESTS.rst
+++ b/doc/TESTS.rst
@@ -66,7 +66,7 @@ Running tests from the command line
 If you want to build NumPy in order to work on NumPy itself, use the ``spin``
 utility.The spin utility is NumPy’s developer command-line tool used when 
 working with a local source checkout of NumPy. It provides convenient wrappers
-around common development tasks such as building NumPy, running tests, and 
+around common development tasks such as building NumPy, running tests, and
 checking documentation, ensuring the correct build environment is used. 
 To run NumPy's full test suite::
 

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -253,6 +253,7 @@ The rest of the story
    :maxdepth: 2
 
    development_environment
+   spin
    howto_build_docs
    development_workflow
    development_advanced_debugging

--- a/doc/source/dev/spin.rst
+++ b/doc/source/dev/spin.rst
@@ -11,7 +11,6 @@ developer workflows.
 The ``spin`` tool provides a consistent interface for contributors working on
 NumPy itself, wrapping multiple underlying tools and configurations into a
 single command that follows NumPy’s development conventions.
-
 Running the full test suite::
 
     $ spin test -m full

--- a/doc/source/dev/spin.rst
+++ b/doc/source/dev/spin.rst
@@ -1,0 +1,29 @@
+.. _spin_tool:
+
+Spin: NumPy’s developer tool
+----------------------------
+
+NumPy uses a command-line tool called ``spin`` to support common development
+tasks such as building from source, running tests, building documentation, 
+and managing other
+developer workflows.
+
+The ``spin`` tool provides a consistent interface for contributors working on
+NumPy itself, wrapping multiple underlying tools and configurations into a
+single command that follows NumPy’s development conventions.
+
+Running the full test suite::
+
+    $ spin test -m full
+
+Running a subset of tests::
+
+    $ spin test -t numpy/_core/tests
+
+Running tests with coverage::
+
+    $ spin test --coverage
+
+Building the documentation::
+
+    $ spin docs


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
### What does this PR do?

Adds a clearer, top-level description of the `spin` utility and links to it
instead of only describing it inside the testing documentation.

The contributing page summary is shortened to focus on NumPy-specific
workflow details, with a pointer to the `spin` explanation for general usage.

### Why is this needed?

During review of a previous PR, it was suggested that `spin` should not be
introduced only inside testing docs, as it is a general development tool.
This change follows that suggestion and improves discoverability for new
contributors.

### Related discussion
https://github.com/numpy/numpy/pull/30669#issuecomment-3766434862