### PR TITLE
DEV: make `spin mypy` run `spin build`

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -544,6 +544,7 @@ def ipython(*, ipython_args, build_dir):
 def mypy(ctx):
     """🦆 Run Mypy tests for NumPy
     """
+    ctx.invoke(build)
     env = os.environ
     env['NPY_RUN_MYPY_IN_TESTSUITE'] = '1'
     ctx.params['pytest_args'] = [os.path.join('numpy', 'typing')]


### PR DESCRIPTION
For consistency with `spin test`. I wondered why `spin mypy` had been ignoring my changes and printing stale results.