### PR TITLE
BUG: fix alloc tls destruction on gcc

### DIFF
--- a/numpy/_core/src/multiarray/alloc.cpp
+++ b/numpy/_core/src/multiarray/alloc.cpp
@@ -51,6 +51,12 @@ typedef struct {
     void * ptrs[NCACHE];
 } cache_bucket;
 
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61991
+// gcc has a bug where if the thread_local variable is unused
+// then its destructor may not get called at thread exit.
+// to work around this we define consolidate both datacache
+// and dimcache into a single thread_local variable so
+// that there is no issue of unused thread_local variables.
 typedef struct thread_local_cache {
     cache_bucket datacache[NBUCKETS];
     cache_bucket dimcache[NBUCKETS_DIM];

--- a/numpy/_core/src/multiarray/alloc.cpp
+++ b/numpy/_core/src/multiarray/alloc.cpp
@@ -54,6 +54,17 @@ typedef struct {
 static NPY_TLS cache_bucket _datacache[NBUCKETS];
 static NPY_TLS cache_bucket _dimcache[NBUCKETS_DIM];
 
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61991
+// gcc has a bug where if the thread local variable
+// is unused then in some cases it's destructor may not get
+// called at thread exit. So to workaround this, we access the
+// datacache and dimcache through this struct so that
+// cache_destructor gets initialized and used, ensuring that
+// the destructor gets called properly at thread exit.
+// The datacache and dimcache are not embedded in this struct
+// because that would make this struct very large and certain
+// platforms like armhf can crash while allocating that large
+// TLS block.
 typedef struct cache_destructor {
     cache_bucket *dimcache;
     cache_bucket *datacache;

--- a/numpy/_core/src/multiarray/alloc.cpp
+++ b/numpy/_core/src/multiarray/alloc.cpp
@@ -60,6 +60,16 @@ typedef struct {
 typedef struct thread_local_cache {
     cache_bucket datacache[NBUCKETS];
     cache_bucket dimcache[NBUCKETS_DIM];
+
+    thread_local_cache() {
+        for (npy_uint i = 0; i < NBUCKETS; ++i) {
+            datacache[i].available = 0;
+        }
+        for (npy_uint i = 0; i < NBUCKETS_DIM; ++i) {
+            dimcache[i].available = 0;
+        }
+    }
+
     ~thread_local_cache() {
         for (npy_uint i = 0; i < NBUCKETS; ++i) {
             while (datacache[i].available > 0) {


### PR DESCRIPTION
Addresses the issue discussed at https://github.com/numpy/numpy/pull/30499#issuecomment-3765645237