### PR TITLE
DOC: __array_namespace__info__: set_module not __module__

### DIFF
--- a/numpy/_array_api_info.py
+++ b/numpy/_array_api_info.py
@@ -24,8 +24,10 @@ from numpy._core import (
     uint32,
     uint64,
 )
+from numpy._utils import set_module
 
 
+@set_module('numpy')
 class __array_namespace_info__:
     """
     Get the array API inspection namespace for NumPy.
@@ -57,8 +59,6 @@ class __array_namespace_info__:
      'indexing': numpy.int64}
 
     """
-
-    __module__ = 'numpy'
 
     def capabilities(self):
         """


### PR DESCRIPTION
`inspect.getsource(np.__array_namespace__info)` should raise `OSError` not `TokenError` for Sphinx. `set_module` correctly removes `__firstlineno__`, while `__module__` doesn't. See #28645.

Fixes: #30674
