### PR TITLE
MAINT: update OpenBLAS

### DIFF
--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.30.0.7
+scipy-openblas32==0.3.31.22.0

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.30.0.7
-scipy-openblas64==0.3.30.0.7
+scipy-openblas32==0.3.31.22.0
+scipy-openblas64==0.3.31.22.0


### PR DESCRIPTION
OpenBLAS released 0.3.31, and I created scipy-openblas-0.3.31.22.0. Let's try it out. Note that scipy/scipy#24342 with 0.3.30.443 (some 20 commits behind this one) seems to have some problem with 32-bit linux. Not clear whether that is an OpenBLAS problem or a SciPy problem.