### PR TITLE
MAINT: Fix typo 'paramterize' in test_multiarray.py

### DIFF
--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -5681,7 +5681,7 @@ class TestIO:
     def param_filename(self, request):
         # This fixtures returns string or path_obj
         # so that every test doesn't need to have the
-        # paramterize marker.
+        # parametrize marker.
         return request.param
 
     def test_nofile(self):


### PR DESCRIPTION
This PR fixes a typo in the comments of `test_multiarray.py`.
`paramterize` -> `parameterize`

This correction improves keyword searchability (grep) for the term "parameterize" within the codebase.