### PR TITLE
TST: fix limited API example in tests for latest Cython

### DIFF
--- a/numpy/_core/tests/examples/limited_api/limited_api1.c
+++ b/numpy/_core/tests/examples/limited_api/limited_api1.c
@@ -1,5 +1,3 @@
-#define Py_LIMITED_API 0x03060000
-
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include <numpy/ufuncobject.h>

--- a/numpy/_core/tests/examples/limited_api/meson.build
+++ b/numpy/_core/tests/examples/limited_api/meson.build
@@ -1,4 +1,8 @@
-project('checks', 'c', 'cython')
+project(
+  'checks',
+  'c', 'cython',
+  meson_version: '>=1.8.3',
+)
 
 py = import('python').find_installation(pure: false)
 
@@ -31,7 +35,7 @@ py.extension_module(
       '-DNPY_NO_DEPRECATED_API=NPY_1_21_API_VERSION',
     ],
     include_directories: [npy_include_path],
-    limited_api: '3.6',
+    limited_api: '3.9',
 )
 
 py.extension_module(
@@ -55,5 +59,5 @@ py.extension_module(
       '-DCYTHON_LIMITED_API=1',
     ],
     include_directories: [npy_include_path],
-    limited_api: '3.7',
+    limited_api: '3.9',
 )


### PR DESCRIPTION
Cython 3.3 will require a minimum target of 3.9 for the limited API. There is no reason for us to still test 3.6/3.7

Remove `#define Py_LIMITED_API` from a C source file, that's not a good habit and it requires manually keeping the version in sync between the C file and the meson.build file.

Also fix warnings like these:
```
WARNING: Project specifies no minimum version but uses features which were added in versions:
 * 1.3.0: {'limited_api arg in python.extension_module'}
```
by requiring a recent Meson version.