### PR TITLE
BUG: fix meshgrid return type

### DIFF
--- a/doc/release/upcoming_changes/30707.change.rst
+++ b/doc/release/upcoming_changes/30707.change.rst
@@ -1,0 +1,4 @@
+``meshgrid`` now always returns a tuple
+---------------------------------------------
+``np.meshgrid`` previously used to return a list when ``sparse`` was true and ``copy`` was false.
+Now, it always returns a tuple regardless of the arguments.

--- a/doc/release/upcoming_changes/30707.change.rst
+++ b/doc/release/upcoming_changes/30707.change.rst
@@ -1,4 +1,4 @@
 ``meshgrid`` now always returns a tuple
----------------------------------------------
+---------------------------------------
 ``np.meshgrid`` previously used to return a list when ``sparse`` was true and ``copy`` was false.
 Now, it always returns a tuple regardless of the arguments.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5195,6 +5195,9 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     if copy:
         output = tuple(x.copy() for x in output)
 
+    if sparse and copy == False:
+        return tuple(output)
+
     return output
 
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5195,7 +5195,7 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     if copy:
         output = tuple(x.copy() for x in output)
 
-    if sparse and copy == False:
+    if sparse and not copy:
         return tuple(output)
 
     return output

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2803,13 +2803,10 @@ class TestMeshgrid:
         assert_array_equal(Y, np.array([[4], [5], [6], [7]]))
 
     def test_always_tuple(self):
-        [A, B] = meshgrid([1, 2], [3, 4], sparse=True, copy=False)
-        C = (np.array([[1, 2]]))
-        D = (np.array([[3], [4]]))
-        assert_array_equal(A, C)
-        assert_array_equal(B, D)
-        assert_equal(type(A), type(C))
-        assert_equal(type(B), type(D))
+        A = meshgrid([1, 2, 3], [4, 5, 6, 7], sparse=True, copy=False)
+        B = meshgrid([], sparse=True, copy=False)
+        assert_equal(isinstance(A, tuple), True)
+        assert_equal(isinstance(B, tuple), True)
 
     def test_invalid_arguments(self):
         # Test that meshgrid complains about invalid arguments

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2799,11 +2799,17 @@ class TestMeshgrid:
 
     def test_sparse(self):
         [X, Y] = meshgrid([1, 2, 3], [4, 5, 6, 7], sparse=True)
-        [A, B] = meshgrid([1, 2, 3, 4], [4, 5, 6], sparse=True, copy=False)
         assert_array_equal(X, np.array([[1, 2, 3]]))
         assert_array_equal(Y, np.array([[4], [5], [6], [7]]))
-        assert_array_equal(A, np.array([[1, 2, 3, 4]]))
-        assert_array_equal(B, np.array([[4], [5], [6]]))
+
+    def test_always_tuple(self):
+        [A, B] = meshgrid([1, 2], [3, 4], sparse=True, copy=False)
+        C = (np.array([[1, 2]]))
+        D = (np.array([[3], [4]]))
+        assert_array_equal(A, C)
+        assert_array_equal(B, D)
+        assert_equal(type(A), type(C))
+        assert_equal(type(B), type(D))
 
     def test_invalid_arguments(self):
         # Test that meshgrid complains about invalid arguments

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2799,8 +2799,11 @@ class TestMeshgrid:
 
     def test_sparse(self):
         [X, Y] = meshgrid([1, 2, 3], [4, 5, 6, 7], sparse=True)
+        [A, B] = meshgrid([1, 2, 3, 4], [4, 5, 6], sparse=True, copy=False)
         assert_array_equal(X, np.array([[1, 2, 3]]))
         assert_array_equal(Y, np.array([[4], [5], [6], [7]]))
+        assert_array_equal(A, np.array([[1, 2, 3, 4]]))
+        assert_array_equal(B, np.array([[4], [5], [6]]))
 
     def test_invalid_arguments(self):
         # Test that meshgrid complains about invalid arguments

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2805,8 +2805,8 @@ class TestMeshgrid:
     def test_always_tuple(self):
         A = meshgrid([1, 2, 3], [4, 5, 6, 7], sparse=True, copy=False)
         B = meshgrid([], sparse=True, copy=False)
-        assert_equal(isinstance(A, tuple), True)
-        assert_equal(isinstance(B, tuple), True)
+        assert isinstance(A, tuple)
+        assert isinstance(B, tuple)
 
     def test_invalid_arguments(self):
         # Test that meshgrid complains about invalid arguments


### PR DESCRIPTION
resolves #30641 

This PR is to make sure that `np.meshgrid` always returns a tuple regardless of the values of `copy` and `sparse`.
