### PR TITLE
BUG: Fix numpy.ma assert_almost_equal tolerance for arrays

### DIFF
--- a/numpy/ma/tests/test_assert_almost_equal.py
+++ b/numpy/ma/tests/test_assert_almost_equal.py
@@ -1,0 +1,9 @@
+import numpy as np
+import pytest
+from numpy.ma.testutils import assert_almost_equal
+
+def test_assert_almost_equal_decimal_6_fails():
+    actual = np.array([0.0])
+    desired = np.array([7.7e-7])
+    with pytest.raises(AssertionError):
+        assert_almost_equal(actual, desired, decimal=6)

--- a/numpy/ma/tests/test_assert_almost_equal.py
+++ b/numpy/ma/tests/test_assert_almost_equal.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from numpy.ma.testutils import assert_almost_equal
 
+
 def test_assert_almost_equal_decimal_6_fails():
     actual = np.array([0.0])
     desired = np.array([7.7e-7])

--- a/numpy/ma/tests/test_assert_almost_equal.py
+++ b/numpy/ma/tests/test_assert_almost_equal.py
@@ -1,5 +1,6 @@
-import numpy as np
 import pytest
+
+import numpy as np
 from numpy.ma.testutils import assert_almost_equal
 
 def test_assert_almost_equal_decimal_6_fails():

--- a/numpy/ma/testutils.py
+++ b/numpy/ma/testutils.py
@@ -83,7 +83,7 @@ def almost(a, b, decimal=6, fill_value=True):
         masked_array(d1, copy=False, mask=m), fill_value
     ).astype(np.float64)
     y = filled(masked_array(d2, copy=False, mask=m), 1).astype(np.float64)
-    d = np.around(np.abs(x - y), decimal) <= 10.0 ** (-decimal)
+    d = np.abs(x - y) < 0.5 * 10.0 ** (-decimal)
     return d.ravel()
 
 


### PR DESCRIPTION
Fixes #30258 
ready for review

The function `numpy.ma.testutils.assert_almost_equal` used a tolerance
implementation that did not match its docstring for arrays.

The previous code used:

    np.around(np.abs(x - y), decimal) <= 10**(-decimal)

which allows differences up to 1.5 * 10^(-decimal).

This PR updates the comparison to:

    np.abs(x - y) < 0.5 * 10**(-decimal)

and adds a test to ensure the correct behavior.
