### PR TITLE
BUG: Fix some bugs found via valgrind (#30680)

### DIFF
--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1371,7 +1371,6 @@ fail:
     if (needcopy) {
         PyArray_ClearBuffer(odescr, buffer, elsize, N, 1);
         PyDataMem_UserFREE(buffer, N * elsize, mem_handler);
-        Py_DECREF(odescr);
     }
     if (ret < 0 && !PyErr_Occurred()) {
         /* Out of memory during sorting or buffer creation */
@@ -1384,6 +1383,7 @@ fail:
     if (PyErr_Occurred() && ret == 0) {
         ret = -1;
     }
+    Py_XDECREF(odescr);
     Py_DECREF(it);
     Py_DECREF(mem_handler);
     NPY_cast_info_xfree(&to_cast_info);
@@ -1594,7 +1594,6 @@ fail:
     if (needcopy) {
         PyArray_ClearBuffer(odescr, valbuffer, elsize, N, 1);
         PyDataMem_UserFREE(valbuffer, N * elsize, mem_handler);
-        Py_DECREF(odescr);
     }
     PyDataMem_UserFREE(idxbuffer, N * sizeof(npy_intp), mem_handler);
     if (ret < 0) {
@@ -1605,6 +1604,7 @@ fail:
         Py_XDECREF(rop);
         rop = NULL;
     }
+    Py_XDECREF(odescr);
     Py_XDECREF(it);
     Py_XDECREF(rit);
     Py_DECREF(mem_handler);

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -2338,6 +2338,7 @@ array_fromstring(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds
     if (sep == NULL || strlen(sep) == 0) {
         PyErr_SetString(PyExc_ValueError,
             "The binary mode of fromstring is removed, use frombuffer instead");
+        Py_XDECREF(descr);
         return NULL;
     }
     return PyArray_FromString(data, (npy_intp)s, descr, (npy_intp)nin, sep);
@@ -2406,6 +2407,7 @@ array_fromfile(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *keywds)
     }
     if (npy_fseek(fp, offset, SEEK_CUR) != 0) {
         PyErr_SetFromErrno(PyExc_OSError);
+        Py_XDECREF(type);
         goto cleanup;
     }
     if (type == NULL) {

--- a/numpy/_core/src/multiarray/refcount.c
+++ b/numpy/_core/src/multiarray/refcount.c
@@ -124,7 +124,7 @@ PyArray_ZeroContiguousBuffer(
      * and only arrays which own their memory should clear it.
      */
     int aligned = PyArray_ISALIGNED(arr);
-    if (PyArray_ISCONTIGUOUS(arr)) {
+    if (PyArray_ISCONTIGUOUS(arr) || PyArray_IS_F_CONTIGUOUS(arr)) {
         return PyArray_ClearBuffer(
                 descr, PyArray_BYTES(arr), descr->elsize,
                 PyArray_SIZE(arr), aligned);
@@ -152,10 +152,12 @@ PyArray_ZeroContiguousBuffer(
         /* Process the innermost dimension */
         if (clear_info.func(NULL, clear_info.descr,
                 data_it, inner_shape, inner_stride, clear_info.auxdata) < 0) {
+            NPY_traverse_info_xfree(&clear_info);
             return -1;
         }
     } NPY_RAW_ITER_ONE_NEXT(idim, ndim, coord,
                             shape_it, data_it, strides_it);
+    NPY_traverse_info_xfree(&clear_info);
     return 0;
 }
 

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -955,7 +955,7 @@ datetimetype_repr(PyObject *self)
                 ret = PyUnicode_FromFormat("numpy.datetime64('%s')", iso);
             }
         }
-
+        Py_DECREF(meta);
     }
     else {
         PyObject *meta = metastr_to_unicode(&scal->obmeta, 1);

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -508,9 +508,11 @@ array__unique_hash(PyObject *NPY_UNUSED(module),
         auto type = PyArray_TYPE(arr);
         // we only support data types present in our unique_funcs map
         if (unique_funcs.find(type) == unique_funcs.end()) {
-            Py_RETURN_NOTIMPLEMENTED;
+            result = Py_NewRef(Py_NotImplemented);
         }
-        result = unique_funcs[type](arr, equal_nan);
+        else {
+            result = unique_funcs[type](arr, equal_nan);
+        }
     }
     catch (const std::bad_alloc &e) {
         PyErr_NoMemory();

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2738,8 +2738,9 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     else {
         fixed_strides[0] = PyArray_STRIDES(op[0])[axis];
         fixed_strides[1] = PyArray_STRIDES(op[1])[axis];
-        fixed_strides[2] = fixed_strides[0];
     }
+    // First argument is also passed as output (e.g. see dataptr below).
+    fixed_strides[2] = fixed_strides[0];
 
 
     NPY_ARRAYMETHOD_FLAGS flags = 0;
@@ -4524,7 +4525,7 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
                 "use the `out` keyword argument instead. If you hoped to work with "
                 "more than 2 inputs, combine them into a single array and get the extrema "
                 "for the relevant axis.") < 0) {
-                return NULL;
+                goto fail;
             }
         }
 

--- a/numpy/_core/tests/examples/cython/checks.pyx
+++ b/numpy/_core/tests/examples/cython/checks.pyx
@@ -248,6 +248,7 @@ def test_get_multi_index_iter_next(it: "nditer", cnp.ndarray[cnp.float64_t, ndim
         cnp.NpyIter_GetGetMultiIndex(cit, NULL)
     cdef cnp.NpyIter_IterNextFunc _iternext = \
         cnp.NpyIter_GetIterNext(cit, NULL)
+    cnp.NpyIter_Deallocate(cit)
     return 1
 
 


### PR DESCRIPTION
Backport of #30680.


A hodgepodge of reference leaks, mostly small or rather irrelevant stuff (although the unique one is large).

Maybe valgrind has it's ups, it did find a Python issue as well, of course that issue was already fixed in 3.14.2 :).

EDIT: Also note, I have not run valgrind on f2py tests here.

EDIT3: There is also a small leak in `numpy/_core/tests/test_dtype.py::TestUserDType::test_custom_structured_dtype_errors`. I am ignoring it (`names` is not cleaned up on the last error, because user dtypes are never fully cleaned up and it is too late, but I don't feel like hard-coding partial cleanup there, if would have to do the full cleanup there).

Since I have no shame, I used this ridiculous script to parallelize.  Your favorite LLM will write a prettier one though easily :).

<details>

```
#!/usr/bin/env python

"""
NOTE: To open the files with actual failures, try something like:

find . -type f ! -name "*valgrind-out.txt" | xargs -I {} sh -c "grep -q -E '(FAILURES|ERRORS)' {} && gnome-text-editor {} &"
"""

from concurrent.futures import ProcessPoolExecutor
import os
import subprocess

os.environ["PYTHONMALLOC"] = "malloc"  # for the spawned processes

test_files = []

DIR = os.getcwd()
FOLDER = "/home/sebastianb/forks/numpy/"

for root, dirs, files in os.walk(FOLDER + "numpy/"):
    files = [f for f in files if f.startswith("test_") and f.endswith(".py")]
    root = root.removeprefix(FOLDER + "numpy/")
    test_files.extend([root + "/" + f for f in files])

for f in test_files[:]:
    # These are particularly slow, so start early.
    if "test_multiarray" in f or "ma/test_core" in f:
        test_files.remove(f)
        test_files.insert(0, f)


setup = """
export PYTHONPATH="/home/sebastianb/forks/numpy/build-install/usr/lib/python3.14/site-packages"
/home/sebastianb/miniforge3/envs/numpy-dev/bin/python3.14 -P -c 'import numpy'
"""

cmd = "PYTHONMALLOC=malloc valgrind --errors-for-leak-kinds=definite --show-leak-kinds=definite --log-file={log_file} "
cmd += '''python -P -mpytest -vv {test_file} -m "not slow"'''
cmd += " --valgrind --valgrind-log={log_file}"


def process(file):
    # Yeah, should use proper pathlib paths :)
    os.chdir(DIR)
    output = os.path.abspath("output/" + file.replace("/", "_").replace(".py", ".txt"))
    log = output.replace(".txt", "-valgrind-out.txt")

    with open(output, "w") as out_file:
        os.chdir("/home/sebastianb/forks/numpy/build-install/usr/lib/python3.14/site-packages")
        actual_command = cmd.format(log_file=log, test_file="numpy/" + file, FOLDER=FOLDER)
        print(actual_command)
        subprocess.run(setup, shell=True)
        subprocess.run(actual_command, shell=True, stdout=out_file, stderr=out_file)
        print("    done file:", file)


def run():
    with ProcessPoolExecutor(16) as executor:
        result = executor.map(process, test_files)

    print(list(result))

if __name__ == "__main__":
    run()
```

