### PR TITLE
BUG: Fixup the quantile promotion fixup (promoted to 64bit always)

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4576,7 +4576,7 @@ def _get_gamma(virtual_indexes, previous_indexes, method):
     gamma = method["fix_gamma"](gamma, virtual_indexes)
     # Ensure both that we have an array, and that we keep the dtype
     # (which may have been matched to the input array).
-    return np.asanyarray(gamma)
+    return np.asanyarray(gamma, dtype=virtual_indexes.dtype)
 
 
 def _lerp(a, b, t, out=None):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3946,6 +3946,9 @@ class TestPercentile:
         a = np.array([1, 2, 3, 4, 5], dtype=np.float32)
         value = np.percentile(a, np.float64(50), method=method)
         assert value.dtype == np.float64
+        # Check that we don't do accidental promotion either:
+        value = np.percentile(a, np.float32(50), method=method)
+        assert value.dtype == np.float32
 
 
 class TestQuantile:
@@ -4384,6 +4387,9 @@ class TestQuantile:
         a = np.array([1, 2, 3, 4, 5], dtype=np.float32)
         value = np.quantile(a, np.float64(0.5), method=method)
         assert value.dtype == np.float64
+        # Check that we don't do accidental promotion either:
+        value = np.quantile(a, np.float32(0.5), method=method)
+        assert value.dtype == np.float32
 
 
 class TestLerp:


### PR DESCRIPTION
Sorry, I incorrectly reverted a line and made things maybe worse :(. Basically it now *always* returned float64 (at least for most methods).

I am surprised that we had not tests for this at all.

I suppose this needs backporting, which isn't great, but...