### PR TITLE
MAINT: replace ob_type access with Py_TYPE in PyArray_CheckExact

### DIFF
--- a/numpy/_core/include/numpy/ndarrayobject.h
+++ b/numpy/_core/include/numpy/ndarrayobject.h
@@ -32,7 +32,7 @@ extern "C" {
 #define PyArray_DescrCheck(op) PyObject_TypeCheck(op, &PyArrayDescr_Type)
 
 #define PyArray_Check(op) PyObject_TypeCheck(op, &PyArray_Type)
-#define PyArray_CheckExact(op) (((PyObject*)(op))->ob_type == &PyArray_Type)
+#define PyArray_CheckExact(op) (Py_TYPE((PyObject*)(op)) == &PyArray_Type)
 
 #define PyArray_HasArrayInterfaceType(op, type, context, out)                 \
         ((((out)=PyArray_FromStructInterface(op)) != Py_NotImplemented) ||    \


### PR DESCRIPTION
Backport of #30705.

Directly accessing `ob_type` like this will not be possible in a future ABI where PyObject is opaque (https://github.com/numpy/numpy/issues/30704). Py_TYPE is in the stable ABI starting in Python 3.14 and has been available outside the stable ABI forever, so we can use that instead to avoid accessing CPython internal details.