### PR TITLE
BUG: Fixup the quantile promotion fixup

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4576,7 +4576,7 @@ def _get_gamma(virtual_indexes, previous_indexes, method):
     gamma = method["fix_gamma"](gamma, virtual_indexes)
     # Ensure both that we have an array, and that we keep the dtype
     # (which may have been matched to the input array).
-    return np.asanyarray(gamma)
+    return np.asanyarray(gamma, dtype=virtual_indexes.dtype)
 
 
 def _lerp(a, b, t, out=None):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3941,6 +3941,9 @@ class TestPercentile:
         a = np.array([1, 2, 3, 4, 5], dtype=np.float32)
         value = np.percentile(a, np.float64(50), method=method)
         assert value.dtype == np.float64
+        # Check that we don't do accidental promotion either:
+        value = np.percentile(a, np.float32(50), method=method)
+        assert value.dtype == np.float32
 
 
 class TestQuantile:
@@ -4379,6 +4382,9 @@ class TestQuantile:
         a = np.array([1, 2, 3, 4, 5], dtype=np.float32)
         value = np.quantile(a, np.float64(0.5), method=method)
         assert value.dtype == np.float64
+        # Check that we don't do accidental promotion either:
+        value = np.quantile(a, np.float32(0.5), method=method)
+        assert value.dtype == np.float32
 
 
 class TestLerp:


### PR DESCRIPTION
Backport of #30710.

Sorry, I incorrectly reverted a line and made things maybe worse :(. Basically it now *always* returned float64 (at least for most methods).

I am surprised that we had not tests for this at all.

I suppose this needs backporting, which isn't great, but...

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
