### PR TITLE
MAINT: Fix E721 (type comparison) linter errors

### DIFF
--- a/numpy/_core/_dtype.py
+++ b/numpy/_core/_dtype.py
@@ -124,7 +124,7 @@ def _scalar_str(dtype, short):
         else:
             return "'%sU%d'" % (byteorder, dtype.itemsize / 4)
 
-    elif dtype.type == str:
+    elif dtype.type is str:
         return "'T'"
 
     elif not type(dtype)._legacy:

--- a/numpy/_core/tests/test_casting_unittests.py
+++ b/numpy/_core/tests/test_casting_unittests.py
@@ -274,8 +274,8 @@ class TestCasting:
                 for to_dt in [to_Dt(), to_Dt().newbyteorder()]:
                     casting, (from_res, to_res), view_off = (
                             cast._resolve_descriptors((from_dt, to_dt)))
-                    assert type(from_res) == from_Dt
-                    assert type(to_res) == to_Dt
+                    assert type(from_res) is from_Dt
+                    assert type(to_res) is to_Dt
                     if view_off is not None:
                         # If a view is acceptable, this is "no" casting
                         # and byte order must be matching.

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -778,7 +778,7 @@ class TestSubarray:
         arr = np.ones(3, dtype=[("f", "i", 3)])
         cast = arr.astype(object)
         for fields in cast:
-            assert type(fields) == tuple and len(fields) == 1
+            assert type(fields) is tuple and len(fields) == 1
             subarr = fields[0]
             assert subarr.base is None
             assert subarr.flags.owndata

--- a/numpy/_core/tests/test_nep50_promotions.py
+++ b/numpy/_core/tests/test_nep50_promotions.py
@@ -127,7 +127,7 @@ def test_nep50_complex_promotion():
     with pytest.warns(RuntimeWarning, match=".*overflow"):
         res = np.complex64(3) + complex(2**300)
 
-    assert type(res) == np.complex64
+    assert type(res) is np.complex64
 
 
 def test_nep50_integer_conversion_errors():

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3581,7 +3581,7 @@ class TestLikeFuncs:
         b = a[:, ::2]  # Ensure b is not contiguous.
         kwargs = {'fill_value': ''} if likefunc == np.full_like else {}
         result = likefunc(b, dtype=dtype, **kwargs)
-        if dtype == str:
+        if dtype is str:
             assert result.strides == (16, 4)
         else:
             # dtype is bytes

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -1055,7 +1055,7 @@ def test_subclass_deferral(sctype, __op__, __rop__, op, cmp):
 
     # inheritance has to override, or this is correctly lost:
     res = op(myf_simple1(1), myf_simple2(2))
-    assert type(res) == sctype or type(res) == np.bool
+    assert type(res) is sctype or type(res) is np.bool
     assert op(myf_simple1(1), myf_simple2(2)) == op(1, 2)  # inherited
 
     # Two independent subclasses do not really define an order.  This could
@@ -1092,7 +1092,7 @@ def test_pyscalar_subclasses(subtype, __op__, __rop__, op, cmp):
     assert op(myt(1), np.float64(2)) == __op__
     assert op(np.float64(1), myt(2)) == __rop__
 
-    if op in {operator.mod, operator.floordiv} and subtype == complex:
+    if op in {operator.mod, operator.floordiv} and subtype is complex:
         return  # module is not support for complex.  Do not test.
 
     if __rop__ == __op__:
@@ -1106,12 +1106,11 @@ def test_pyscalar_subclasses(subtype, __op__, __rop__, op, cmp):
     res = op(myt(1), np.float16(2))
     expected = op(behaves_like(1), np.float16(2))
     assert res == expected
-    assert type(res) == type(expected)
+    assert type(res) is type(expected)
     res = op(np.float32(2), myt(1))
     expected = op(np.float32(2), behaves_like(1))
     assert res == expected
-    assert type(res) == type(expected)
-
+    assert type(res) is type(expected)
     # Same check for longdouble (compare via dtype to accept float64 when
     # longdouble has the identical size), which is currently not perfectly
     # consistent.

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -217,25 +217,25 @@ class TestOut:
             if subok:
                 assert_(isinstance(r, ArrayWrap))
             else:
-                assert_(type(r) == np.ndarray)
+                assert_(type(r) is np.ndarray)
 
             r = np.add(a, 2, None, subok=subok)
             if subok:
                 assert_(isinstance(r, ArrayWrap))
             else:
-                assert_(type(r) == np.ndarray)
+                assert_(type(r) is np.ndarray)
 
             r = np.add(a, 2, out=None, subok=subok)
             if subok:
                 assert_(isinstance(r, ArrayWrap))
             else:
-                assert_(type(r) == np.ndarray)
+                assert_(type(r) is np.ndarray)
 
             r = np.add(a, 2, out=(None,), subok=subok)
             if subok:
                 assert_(isinstance(r, ArrayWrap))
             else:
-                assert_(type(r) == np.ndarray)
+                assert_(type(r) is np.ndarray)
 
             d = ArrayWrap([5.7])
             o1 = np.empty((1,))
@@ -245,31 +245,31 @@ class TestOut:
             if subok:
                 assert_(isinstance(r2, ArrayWrap))
             else:
-                assert_(type(r2) == np.ndarray)
+                assert_(type(r2) is np.ndarray)
 
             r1, r2 = np.frexp(d, o1, None, subok=subok)
             if subok:
                 assert_(isinstance(r2, ArrayWrap))
             else:
-                assert_(type(r2) == np.ndarray)
+                assert_(type(r2) is np.ndarray)
 
             r1, r2 = np.frexp(d, None, o2, subok=subok)
             if subok:
                 assert_(isinstance(r1, ArrayWrap))
             else:
-                assert_(type(r1) == np.ndarray)
+                assert_(type(r1) is np.ndarray)
 
             r1, r2 = np.frexp(d, out=(o1, None), subok=subok)
             if subok:
                 assert_(isinstance(r2, ArrayWrap))
             else:
-                assert_(type(r2) == np.ndarray)
+                assert_(type(r2) is np.ndarray)
 
             r1, r2 = np.frexp(d, out=(None, o2), subok=subok)
             if subok:
                 assert_(isinstance(r1, ArrayWrap))
             else:
-                assert_(type(r1) == np.ndarray)
+                assert_(type(r1) is np.ndarray)
 
             with assert_raises(TypeError):
                 # Out argument must be tuple, since there are multiple outputs.
@@ -3702,7 +3702,7 @@ class TestSpecialMethods:
                 for obj in objs:
                     if isinstance(obj, cls):
                         obj = np.array(obj)
-                    elif type(obj) != np.ndarray:
+                    elif type(obj) is not np.ndarray:
                         return NotImplemented
                     result.append(obj)
                 return result

--- a/numpy/lib/_polynomial_impl.py
+++ b/numpy/lib/_polynomial_impl.py
@@ -5,7 +5,6 @@ Functions to operate on polynomials.
 __all__ = ['poly', 'roots', 'polyint', 'polyder', 'polyadd',
            'polysub', 'polymul', 'polydiv', 'polyval', 'poly1d',
            'polyfit']
-
 import functools
 import re
 import warnings
@@ -141,8 +140,7 @@ def poly(seq_of_zeros):
         seq_of_zeros = eigvals(seq_of_zeros)
     elif len(sh) == 1:
         dt = seq_of_zeros.dtype
-        # Let object arrays slip through, e.g. for arbitrary precision
-        if dt != object:
+        if dt.type is not NX.object_:
             seq_of_zeros = seq_of_zeros.astype(mintypecode(dt.char))
     else:
         raise ValueError("input must be 1d or non-empty square 2d array.")

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -637,46 +637,46 @@ class TestUnique:
         msg = base_msg.format('values', dt)
         v = unique(a)
         assert_array_equal(v, b, msg)
-        assert type(v) == type(b)
+        assert type(v) is type(b)
 
         msg = base_msg.format('return_index', dt)
         v, j = unique(a, True, False, False)
         assert_array_equal(v, b, msg)
         assert_array_equal(j, i1, msg)
-        assert type(v) == type(b)
+        assert type(v) is type(b)
 
         msg = base_msg.format('return_inverse', dt)
         v, j = unique(a, False, True, False)
         assert_array_equal(v, b, msg)
         assert_array_equal(j, i2, msg)
-        assert type(v) == type(b)
+        assert type(v) is type(b)
 
         msg = base_msg.format('return_counts', dt)
         v, j = unique(a, False, False, True)
         assert_array_equal(v, b, msg)
         assert_array_equal(j, c, msg)
-        assert type(v) == type(b)
+        assert type(v) is type(b)
 
         msg = base_msg.format('return_index and return_inverse', dt)
         v, j1, j2 = unique(a, True, True, False)
         assert_array_equal(v, b, msg)
         assert_array_equal(j1, i1, msg)
         assert_array_equal(j2, i2, msg)
-        assert type(v) == type(b)
+        assert type(v) is type(b)
 
         msg = base_msg.format('return_index and return_counts', dt)
         v, j1, j2 = unique(a, True, False, True)
         assert_array_equal(v, b, msg)
         assert_array_equal(j1, i1, msg)
         assert_array_equal(j2, c, msg)
-        assert type(v) == type(b)
+        assert type(v) is type(b)
 
         msg = base_msg.format('return_inverse and return_counts', dt)
         v, j1, j2 = unique(a, False, True, True)
         assert_array_equal(v, b, msg)
         assert_array_equal(j1, i2, msg)
         assert_array_equal(j2, c, msg)
-        assert type(v) == type(b)
+        assert type(v) is type(b)
 
         msg = base_msg.format(('return_index, return_inverse '
                                 'and return_counts'), dt)
@@ -685,9 +685,10 @@ class TestUnique:
         assert_array_equal(j1, i1, msg)
         assert_array_equal(j2, i2, msg)
         assert_array_equal(j3, c, msg)
-        assert type(v) == type(b)
+        assert type(v) is type(b)
 
     def get_types(self):
+
         types = []
         types.extend(np.typecodes['AllInteger'])
         types.extend(np.typecodes['AllFloat'])

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2441,9 +2441,9 @@ M   33  21.99
 
         assert_equal(test.dtype.names, ['f0', 'f1', 'f2'])
 
-        assert_(test.dtype['f0'] == float)
-        assert_(test.dtype['f1'] == np.int64)
-        assert_(test.dtype['f2'] == np.int_)
+        assert_(test.dtype['f0'].type is np.float64)
+        assert_(test.dtype['f1'].type is np.int64)
+        assert_(test.dtype['f2'].type is np.int_)
 
         assert_allclose(test['f0'], 73786976294838206464.)
         assert_equal(test['f1'], 17179869184)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1091,7 +1091,7 @@ class TestMatrixPower:
 
         for mat in self.rshft_all:
             tz(mat.astype(dt))
-            if dt != object:
+            if np.dtype(dt).type is not np.object_:
                 tz(self.stacked.astype(dt))
 
     def test_power_is_one(self, dt):
@@ -1102,7 +1102,7 @@ class TestMatrixPower:
 
         for mat in self.rshft_all:
             tz(mat.astype(dt))
-            if dt != object:
+            if np.dtype(dt).type is not np.object_:
                 tz(self.stacked.astype(dt))
 
     def test_power_is_two(self, dt):
@@ -1114,7 +1114,7 @@ class TestMatrixPower:
 
         for mat in self.rshft_all:
             tz(mat.astype(dt))
-            if dt != object:
+            if np.dtype(dt).type is not np.object_:
                 tz(self.stacked.astype(dt))
 
     def test_power_is_minus_one(self, dt):

--- a/numpy/random/tests/test_smoke.py
+++ b/numpy/random/tests/test_smoke.py
@@ -63,8 +63,8 @@ def comp_state(state1, state2):
     if isinstance(state1, dict):
         for key in state1:
             identical &= comp_state(state1[key], state2[key])
-    elif type(state1) != type(state2):
-        identical &= type(state1) == type(state2)
+    elif type(state1) is not type(state2):
+        identical &= type(state1) is type(state2)
     elif (isinstance(state1, (list, tuple, np.ndarray)) and isinstance(
             state2, (list, tuple, np.ndarray))):
         for s1, s2 in zip(state1, state2):
@@ -486,13 +486,13 @@ class RNG:
         rg = self._create_rng().rg
         pick = pickle.dumps(rg)
         unpick = pickle.loads(pick)
-        assert_(type(rg) == type(unpick))
+        assert_(type(rg) is type(unpick))
         assert_(comp_state(rg.bit_generator.state,
                            unpick.bit_generator.state))
 
         pick = pickle.dumps(rg)
         unpick = pickle.loads(pick)
-        assert_(type(rg) == type(unpick))
+        assert_(type(rg) is type(unpick))
         assert_(comp_state(rg.bit_generator.state,
                            unpick.bit_generator.state))
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -62,7 +62,6 @@ ignore = [
     "E302",    # TODO: Expected 2 blank lines, found 1
     "E402",    # Module level import not at top of file
     "E712",    # Avoid equality comparisons to `True` or `False`
-    "E721",    # TODO: Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance check
     "E731",    # Do not assign a `lambda` expression, use a `def`
     "E741",    # Ambiguous variable name
     # pyflakes


### PR DESCRIPTION
This PR removes the `E721` ignore rule from `ruff.toml` and fixes the resulting type comparison errors (~38 instances).

Most changes involve replacing `type(x) == Y` with `type(x) is Y` in test files.
Also fixed usage in `numpy/_core/_dtype.py` and `numpy/lib/_polynomial_impl.py`.

Verified locally with `spin lint`.

Closes gh-30663