### PR TITLE
DOC: clarify nesting limit of _FiniteNestedSequence

### DIFF
--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -37,6 +37,7 @@ class _SupportsArrayFunc(Protocol):
 
 
 # TODO: Wait until mypy supports recursive objects in combination with typevars
+# Limited to 4 nesting levels - e.g. [[[[1]]]] works, [[[[[1]]]]] doesn't
 type _FiniteNestedSequence[T] = (
     T
     | Sequence[T]


### PR DESCRIPTION
While using _FiniteNestedSequence, I ran into confusing behavior with deeply nested lists not being accepted by type checkers.

Reading the alias definition shows that it is intentionally limited to four levels of nesting, but this limitation is not documented. This PR adds a short comment to make that constraint explicit so users don’t have to infer it from the source.

No behavior changes, documentation only.
