### PR TITLE
TYP: Remove `_FiniteNestedSequence`, use `_NestedSequence` instead

### DIFF
--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -21,7 +21,6 @@ from ._array_like import (
     _ArrayLikeTD64_co as _ArrayLikeTD64_co,
     _ArrayLikeUInt_co as _ArrayLikeUInt_co,
     _ArrayLikeVoid_co as _ArrayLikeVoid_co,
-    _FiniteNestedSequence as _FiniteNestedSequence,
     _SupportsArray as _SupportsArray,
     _SupportsArrayFunc as _SupportsArrayFunc,
 )

--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -36,16 +36,6 @@ class _SupportsArrayFunc(Protocol):
     ) -> object: ...
 
 
-# TODO: Wait until mypy supports recursive objects in combination with typevars
-# Limited to 4 nesting levels - e.g. [[[[1]]]] works, [[[[[1]]]]] doesn't
-type _FiniteNestedSequence[T] = (
-    T
-    | Sequence[T]
-    | Sequence[Sequence[T]]
-    | Sequence[Sequence[Sequence[T]]]
-    | Sequence[Sequence[Sequence[Sequence[T]]]]
-)
-
 # A subset of `npt.ArrayLike` that can be parametrized w.r.t. `np.generic`
 type _ArrayLike[ScalarT: np.generic] = (
     _SupportsArray[np.dtype[ScalarT]]

--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -1,4 +1,4 @@
-from collections.abc import Buffer, Callable, Collection, Sequence
+from collections.abc import Buffer, Callable, Collection
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import numpy as np

--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -37,6 +37,7 @@ class _SupportsArrayFunc(Protocol):
 
 
 # TODO: Wait until mypy supports recursive objects in combination with typevars
+# Limited to 4 nesting levels - e.g. [[[[1]]]] works, [[[[[1]]]]] doesn't
 type _FiniteNestedSequence[T] = (
     T
     | Sequence[T]


### PR DESCRIPTION
Following up on feedback from @jorenham in #30721 - turns out _FiniteNestedSequence is barely used and can just be replaced with _NestedSequence.

Made the swap in the few places it was used (ndenumerate and ix_) and removed the type definition. Should be cleaner this way since we don't need the 4-level nesting restriction anymore.

Closes #30721