### PR TITLE
TYP: remove `_typing._FiniteNestedSequence`

### DIFF
--- a/numpy/_typing/__init__.py
+++ b/numpy/_typing/__init__.py
@@ -21,7 +21,6 @@ from ._array_like import (
     _ArrayLikeTD64_co as _ArrayLikeTD64_co,
     _ArrayLikeUInt_co as _ArrayLikeUInt_co,
     _ArrayLikeVoid_co as _ArrayLikeVoid_co,
-    _FiniteNestedSequence as _FiniteNestedSequence,
     _SupportsArray as _SupportsArray,
     _SupportsArrayFunc as _SupportsArrayFunc,
 )

--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -1,4 +1,4 @@
-from collections.abc import Buffer, Callable, Collection, Sequence
+from collections.abc import Buffer, Callable, Collection
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import numpy as np
@@ -35,15 +35,6 @@ class _SupportsArrayFunc(Protocol):
         kwargs: dict[str, Any],
     ) -> object: ...
 
-
-# TODO: Wait until mypy supports recursive objects in combination with typevars
-type _FiniteNestedSequence[T] = (
-    T
-    | Sequence[T]
-    | Sequence[Sequence[T]]
-    | Sequence[Sequence[Sequence[T]]]
-    | Sequence[Sequence[Sequence[Sequence[T]]]]
-)
 
 # A subset of `npt.ArrayLike` that can be parametrized w.r.t. `np.generic`
 type _ArrayLike[ScalarT: np.generic] = (

--- a/numpy/lib/_index_tricks_impl.pyi
+++ b/numpy/lib/_index_tricks_impl.pyi
@@ -23,7 +23,6 @@ from numpy._typing import (
     _AnyShape,
     _ArrayLike,
     _DTypeLike,
-    _FiniteNestedSequence,
     _HasDType,
     _NestedSequence,
     _SupportsArray,
@@ -61,7 +60,7 @@ class ndenumerate(Generic[_ScalarT_co]):  # noqa: UP046
     @overload
     def __init__[ScalarT: np.generic](
         self: ndenumerate[ScalarT],
-        arr: _FiniteNestedSequence[_SupportsArray[np.dtype[ScalarT]]],
+        arr: _NestedSequence[_SupportsArray[np.dtype[ScalarT]]] | _SupportsArray[np.dtype[ScalarT]],
     ) -> None: ...
     @overload
     def __init__(self: ndenumerate[np.str_], arr: str | _NestedSequence[str]) -> None: ...
@@ -232,7 +231,9 @@ class IndexExpression(Generic[_BoolT_co]):
     def __getitem__[T](self: IndexExpression[L[False]], item: T) -> T: ...
 
 @overload
-def ix_[DTypeT: np.dtype](*args: _FiniteNestedSequence[_HasDType[DTypeT]]) -> tuple[np.ndarray[_AnyShape, DTypeT], ...]: ...
+def ix_[DTypeT: np.dtype](
+    *args: _NestedSequence[_HasDType[DTypeT]] | _HasDType[DTypeT]
+) -> tuple[np.ndarray[_AnyShape, DTypeT], ...]: ...
 @overload
 def ix_(*args: str | _NestedSequence[str]) -> tuple[NDArray[np.str_], ...]: ...
 @overload


### PR DESCRIPTION
This time written by a human (grumble).