### PR TITLE
DOC: Update Sphinx to 9.0.4 and numpydoc to >=1.10.0

### DIFF
--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -1,6 +1,6 @@
 # doxygen required, use apt-get or dnf
-sphinx==7.2.6
-numpydoc==1.10.0
+sphinx==9.0.4
+numpydoc>=1.10.0
 pydata-sphinx-theme>=0.15.2
 sphinx-copybutton
 sphinx-design


### PR DESCRIPTION
## Summary
Updates the pinned versions of Sphinx and Numpydoc in the documentation requirements to prevent the documentation build configuration from becoming outdated.

Closes #30684

## Changes
**File modified:** [requirements/doc_requirements.txt](cci:7://file:///c:/Users/param/OneDrive/Desktop/gsoc%202026%20contributor/numpy/numpy/requirements/doc_requirements.txt:0:0-0:0)
- Update Sphinx from `7.2.6` (2023) to `9.0.4` (2025)
- Update numpydoc from `==1.10.0` to `>=1.10.0`
## Rationale
### Sphinx Update
- Current version (7.2.6) is from 2023 and risks bitrot
- Sphinx 9.0.4 is the latest version compatible with Python 3.11
- Sphinx 9.1.0 (absolute latest) requires Python 3.12+, which NumPy doesn't yet require
- This represents a 2 major version upgrade while maintaining compatibility
### Numpydoc Update
- Changed from pinned (`==1.10.0`) to minimum version (`>=1.10.0`)
- Allows automatic updates to compatible patch versions
- Reduces maintenance burden while ensuring minimum version requirements
## Testing
- [x] All documentation dependencies install successfully without conflicts
- [x] Verified Sphinx 9.0.4 and Numpydoc 1.10.0 install correctly
- [x] No breaking changes in dependency tree
- [ ] CI/CD (CircleCI) will verify documentation builds successfully
## Notes
- The CircleCI documentation build uses `SPHINXOPTS="-W -n"` (warnings as errors)
- Some warnings may appear with the newer Sphinx version due to stricter validation
- Any critical warnings will be addressed in follow-up PRs if needed
- This change prevents the documentation tooling from becoming hopelessly outdated
## Checklist
- [x] Commit message follows NumPy guidelines (starts with DOC:)
- [x] Changes are minimal and focused
- [x] No code changes, only dependency version updates
- [x] Ready for CI/CD testing