### PR TITLE
PERF: Optimize string construction in array formatting functions

### DIFF
--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -962,8 +962,8 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
         # invoke the recursive part with an initial index and prefix
         res = recurser(index=(),
                         hanging_indent=next_line_prefix,
-                        curr_width=line_width)
-        
+curr_width=line_width)
+
         # If recurser returned a string, it means we had a 0-d array (scalar)
         # which didn't go through the list appending logic.
         if res is not None:

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -852,6 +852,8 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
     2. Summarized output
 
     """
+    s_list = []
+
     def recurser(index, hanging_indent, curr_width):
         """
         By using this local function, we don't need to recurse with all the
@@ -882,7 +884,7 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
             trailing_items = a_len
 
         # stringify the array with the hanging indent on the first line too
-        s_list = []
+        start_idx = len(s_list)
 
         # last axis (rows) - wrap elements if they would not fit on one line
         if axes_left == 1:
@@ -927,14 +929,12 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
 
         # other axes - insert newlines between rows
         else:
-            s_list = []
             line_sep = separator.rstrip() + '\n' * (axes_left - 1)
 
             for i in range(leading_items):
-                nested = recurser(
-                    index + (i,), next_hanging_indent, next_width
-                )
-                s_list.append(hanging_indent + nested + line_sep)
+                s_list.append(hanging_indent)
+                recurser(index + (i,), next_hanging_indent, next_width)
+                s_list.append(line_sep)
 
             if show_summary:
                 if legacy <= 113:
@@ -945,25 +945,29 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
                     s_list.append(hanging_indent + summary_insert + line_sep)
 
             for i in range(trailing_items, 1, -1):
-                nested = recurser(index + (-i,), next_hanging_indent,
+                s_list.append(hanging_indent)
+                recurser(index + (-i,), next_hanging_indent,
                                   next_width)
-                s_list.append(hanging_indent + nested + line_sep)
+                s_list.append(line_sep)
 
-            nested = recurser(index + (-1,), next_hanging_indent, next_width)
-            s_list.append(hanging_indent + nested)
-
-        s = "".join(s_list)
+            s_list.append(hanging_indent)
+            recurser(index + (-1,), next_hanging_indent, next_width)
 
         # remove the hanging indent, and wrap in []
-        s = '[' + s[len(hanging_indent):] + ']'
-        return s
+        current_first = s_list[start_idx]
+        s_list[start_idx] = '[' + current_first[len(hanging_indent):]
+        s_list.append(']')
 
     try:
         # invoke the recursive part with an initial index and prefix
-        return recurser(index=(),
+        recurser(index=(),
                         hanging_indent=next_line_prefix,
                         curr_width=line_width)
+        return "".join(s_list)
     finally:
+        # recursive closures have a cyclic reference to themselves, which
+        # requires gc to collect (gh-10620). To avoid this problem, for
+        # performance and PyPy friendliness, we break the cycle:
         recurser = None
 
 def _none_or_positive_arg(x, name):

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -960,9 +960,15 @@ def _formatArray(a, format_function, line_width, next_line_prefix,
 
     try:
         # invoke the recursive part with an initial index and prefix
-        recurser(index=(),
+        res = recurser(index=(),
                         hanging_indent=next_line_prefix,
                         curr_width=line_width)
+        
+        # If recurser returned a string, it means we had a 0-d array (scalar)
+        # which didn't go through the list appending logic.
+        if res is not None:
+            s_list.append(res)
+
         return "".join(s_list)
     finally:
         # recursive closures have a cyclic reference to themselves, which


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

This PR optimizes the string construction logic in `_extendLine`, `_extendLine_pretty`, and `_formatArray` by replacing incremental string concatenation (`s += ...`) with list accumulation and `.join()`.

The Issue: In Python, strings are immutable. The previous implementation used `+=` to append to the s string inside recursive calls and loops. This forces the interpreter to create a new string object and copy the entire content on every iteration, resulting in quadratic time complexity `O(N^2)`. This significantly degrades performance when formatting large arrays or deep structures.

The Solution: I refactored the functions to use a list (`s_list`) as an accumulator. Lines are appended to the list, and the final string is constructed once using `''.join(s_list)` at the end of the formatting process. This ensures linear time complexity `O(N)` regarding memory allocation.

This is in line with standard python performance recommendation: https://peps.python.org/pep-0008/#programming-recommendations