### PR TITLE
BUG: fix thread safety of `array_getbuffer` (#30667)

### DIFF
--- a/numpy/_core/src/multiarray/buffer.c
+++ b/numpy/_core/src/multiarray/buffer.c
@@ -793,8 +793,10 @@ array_getbuffer(PyObject *obj, Py_buffer *view, int flags)
     }
 
     /* Fill in information (and add it to _buffer_info if necessary) */
+    Py_BEGIN_CRITICAL_SECTION(self);
     info = _buffer_get_info(
             &((PyArrayObject_fields *)self)->_buffer_info, obj, flags);
+    Py_END_CRITICAL_SECTION();
     if (info == NULL) {
         goto fail;
     }
@@ -880,7 +882,10 @@ void_getbuffer(PyObject *self, Py_buffer *view, int flags)
      * to find the correct format.  This format must also be stored, since
      * at least in theory it can change (in practice it should never change).
      */
-    _buffer_info_t *info = _buffer_get_info(&scalar->_buffer_info, self, flags);
+    _buffer_info_t *info = NULL;
+    Py_BEGIN_CRITICAL_SECTION(scalar);
+    info = _buffer_get_info(&scalar->_buffer_info, self, flags);
+    Py_END_CRITICAL_SECTION();
     if (info == NULL) {
         Py_DECREF(self);
         return -1;

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -375,3 +375,29 @@ def test_arg_locking(kernel, outcome):
         finally:
             if len(tasks) < 5:
                 b.abort()
+
+def test_array__buffer__thread_safety():
+    import inspect
+    arr = np.arange(1000)
+    flags = [inspect.BufferFlags.STRIDED, inspect.BufferFlags.READ]
+
+    def func(b):
+        b.wait()
+        for i in range(100):
+            arr.__buffer__(flags[i % 2])
+
+    run_threaded(func, max_workers=8, pass_barrier=True)
+
+def test_void_dtype__buffer__thread_safety():
+    import inspect
+    dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])
+    x = np.array(('ndarray_scalar', (1.2, 3.0)), dtype=dt)[()]
+    assert isinstance(x, np.void)
+    flags = [inspect.BufferFlags.STRIDES, inspect.BufferFlags.READ]
+
+    def func(b):
+        b.wait()
+        for i in range(100):
+            x.__buffer__(flags[i % 2])
+
+    run_threaded(func, max_workers=8, pass_barrier=True)

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import sys
 import threading
 
 import pytest
@@ -376,6 +377,7 @@ def test_arg_locking(kernel, outcome):
             if len(tasks) < 5:
                 b.abort()
 
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Python >= 3.12 required")
 def test_array__buffer__thread_safety():
     import inspect
     arr = np.arange(1000)
@@ -388,6 +390,7 @@ def test_array__buffer__thread_safety():
 
     run_threaded(func, max_workers=8, pass_barrier=True)
 
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Python >= 3.12 required")
 def test_void_dtype__buffer__thread_safety():
     import inspect
     dt = np.dtype([('name', np.str_, 16), ('grades', np.float64, (2,))])


### PR DESCRIPTION
Backport of #30667.

Add critical sections around buffer info creation/mutation.

Fixes https://github.com/numpy/numpy/issues/30648

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
