### PR TITLE
DOC: fix missing numpy import in emath documentation example

### DIFF
--- a/doc/source/reference/routines.emath.rst
+++ b/doc/source/reference/routines.emath.rst
@@ -15,6 +15,7 @@ domains of the input.
 For example, for functions like `log` with branch cuts, the versions in this
 module provide the mathematically valid answers in the complex plane::
 
+  >>> import numpy as np
   >>> import math
   >>> np.emath.log(-math.exp(1)) == (1+1j*math.pi)
   True


### PR DESCRIPTION
Adds the missing NumPy import to the numpy.emath documentation example.
Without this import, the example raises a NameError when executed.

