### PR TITLE
Fix ctypes conclusion list indentation in docs

### DIFF
--- a/doc/source/user/c-info.python-as-glue.rst
+++ b/doc/source/user/c-info.python-as-glue.rst
@@ -825,19 +825,13 @@ Conclusion
 Using ctypes is a powerful way to connect Python with arbitrary
 C-code. Its advantages for extending Python include
 
-- clean separation of C code from Python code
-
-    - no need to learn a new syntax except Python and C
-
-    - allows reuse of C code
-
-    - functionality in shared libraries written for other purposes can be
-      obtained with a simple Python wrapper and search for the library.
-
-
-- easy integration with NumPy through the ctypes attribute
-
-- full argument checking with the ndpointer class factory
+* clean separation of C code from Python code
+* no need to learn a new syntax except Python and C
+* allows reuse of C code
+* functionality in shared libraries written for other purposes can be
+  obtained with a simple Python wrapper and search for the library.
+* easy integration with NumPy through the ctypes attribute
+* full argument checking with the ndpointer class factory
 
 Its disadvantages include
 


### PR DESCRIPTION
Fix #30750 
## Summary
- fix incorrect indentation in the ctypes Conclusion list
- ensure the list renders as a single flat bullet list