### PR TITLE
DOC: fix typos in RELEASE_WALKTHROUGH and NEP 43

### DIFF
--- a/doc/RELEASE_WALKTHROUGH.rst
+++ b/doc/RELEASE_WALKTHROUGH.rst
@@ -136,7 +136,7 @@ Test the wheel builds
 After the release PR is merged, go to the ``numpy-release`` repository in your
 browser and manually trigger the workflow on the ``maintenance/2.4.x`` branch
 using the ``Run workflow`` button in ``actions``.  Make sure that the upload
-target is ``none`` in the *evironment* dropdown. The wheels take about 1 hour
+target is ``none`` in the *environment* dropdown. The wheels take about 1 hour
 to build, but sometimes GitHub is very slow. If some wheel builds fail for
 unrelated reasons, you can re-run them as normal in the GitHub Actions UI with
 ``re-run failed``. After the wheels are built review the results, checking that
@@ -187,7 +187,7 @@ If you need to delete the tag due to error::
 Go to the ``numpy-release`` repository in your browser and manually trigger the
 workflow on the ``maintenance/2.4.x`` branch using the ``Run workflow`` button
 in ``actions``.  Make sure that the upload target is ``pypi`` in the
-*evironment* dropdown. The wheels take about 1 hour to build, but sometimes
+*environment* dropdown. The wheels take about 1 hour to build, but sometimes
 GitHub is very slow. If some wheel builds fail for unrelated reasons, you can
 re-run them as normal in the GitHub Actions UI with ``re-run failed``. After
 the wheels are built review the results, checking that the number of artifacts

--- a/doc/neps/nep-0043-extensible-ufuncs.rst
+++ b/doc/neps/nep-0043-extensible-ufuncs.rst
@@ -241,7 +241,7 @@ to define string equality, will be added to a ufunc.
         nin = 1
         nout = 1
         # DTypes are stored on the BoundArrayMethod and not on the internal
-        # ArrayMethod, to reference cyles.
+        # ArrayMethod, to reference cycles.
         DTypes = (String, String, Bool)
 
         def resolve_descriptors(self: ArrayMethod, DTypes, given_descrs):


### PR DESCRIPTION
This PR fixes a few small typos in the documentation.

<img width="946" height="312" alt="image" src="https://github.com/user-attachments/assets/583922a9-35fe-4636-baf0-22d10f928644" />

[Link to documentation](https://numpy.org/doc/stable/dev/releasing.html#test-the-wheel-builds)

<img width="956" height="319" alt="image" src="https://github.com/user-attachments/assets/bdea4633-8b63-4737-84fd-c28905a78bd4" />

[Link to documentation](https://numpy.org/neps/nep-0043-extensible-ufuncs.html#defining-a-new-ufunc-implementation)