### PR TITLE
MAINT: update scipy-openblas to one with risc-V

### DIFF
--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.31.22.0
+scipy-openblas32==0.3.31.22.1

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.31.22.0
-scipy-openblas64==0.3.31.22.0
+scipy-openblas32==0.3.31.22.1
+scipy-openblas64==0.3.31.22.1


### PR DESCRIPTION
This version of scipy-openblas has risc-V wheels. Towards verfying NumPy on riscv64 (see #30216). `numpy-release` has already been updated.