### PR TITLE
MAINT: Replace %-formatting with f-strings in numpy/lib (UP031)

### DIFF
--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -838,9 +838,11 @@ def read_array(fp, allow_pickle=False, pickle_kwargs=None, *,
             array = pickle.load(fp, **pickle_kwargs)
         except UnicodeError as err:
             # Friendlier error message
-            raise UnicodeError("Unpickling a python object failed: %r\n"
-                               "You may need to pass the encoding= option "
-                               "to numpy.load" % (err,)) from err
+            raise UnicodeError(
+                f"Unpickling a python object failed: {err!r}\n"
+                "You may need to pass the encoding= option "
+                "to numpy.load"
+            ) from err
     else:
         if isfileobj(fp):
             # We can use the fast fromfile() function.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2190,17 +2190,17 @@ def _update_dim_sizes(dim_sizes, arg, core_dims):
     num_core_dims = len(core_dims)
     if arg.ndim < num_core_dims:
         raise ValueError(
-            '%d-dimensional argument does not have enough '
-            'dimensions for all core dimensions %r'
-            % (arg.ndim, core_dims))
+            f'{arg.ndim}-dimensional argument does not have enough '
+            f'dimensions for all core dimensions {core_dims!r}')
 
     core_shape = arg.shape[-num_core_dims:]
     for dim, size in zip(core_dims, core_shape):
         if dim in dim_sizes:
             if size != dim_sizes[dim]:
                 raise ValueError(
-                    'inconsistent size for core dimension %r: %r vs %r'
-                    % (dim, size, dim_sizes[dim]))
+                    f'inconsistent size for core dimension {dim!r}: {size!r} vs '
+                    f'{dim_sizes[dim]!r}'
+                )
         else:
             dim_sizes[dim] = size
 
@@ -2610,9 +2610,10 @@ class vectorize:
         input_core_dims, output_core_dims = self._in_and_out_core_dims
 
         if len(args) != len(input_core_dims):
-            raise TypeError('wrong number of positional arguments: '
-                            'expected %r, got %r'
-                            % (len(input_core_dims), len(args)))
+            raise TypeError(
+                'wrong number of positional arguments: '
+                f'expected {len(input_core_dims)!r}, got {len(args)!r}'
+            )
         args = tuple(asanyarray(arg) for arg in args)
 
         broadcast_shape, dim_sizes = _parse_input_dimensions(
@@ -2633,8 +2634,9 @@ class vectorize:
 
             if nout != n_results:
                 raise ValueError(
-                    'wrong number of outputs from pyfunc: expected %r, got %r'
-                    % (nout, n_results))
+                    f'wrong number of outputs from pyfunc: expected {nout!r}, '
+                    f'got {n_results!r}'
+                )
 
             if nout == 1:
                 results = (results,)

--- a/numpy/lib/_iotools.py
+++ b/numpy/lib/_iotools.py
@@ -373,7 +373,7 @@ class NameValidator:
                 item += '_'
             cnt = seen.get(item, 0)
             if cnt > 0:
-                validatednames.append(item + '_%d' % cnt)
+                validatednames.append(f"{item}_{cnt}")
             else:
                 validatednames.append(item)
             seen[item] = cnt + 1

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -765,7 +765,7 @@ def _savez(file, args, kwds, compress, allow_pickle=True, pickle_kwargs=None):
 
     namedict = kwds
     for i, val in enumerate(args):
-        key = 'arr_%d' % i
+        key = f'arr_{i}'
         if key in namedict.keys():
             raise ValueError(
                 f"Cannot use un-named variables and keyword {key}")
@@ -1561,7 +1561,7 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
         # Handle 1-dimensional arrays
         if X.ndim == 0 or X.ndim > 2:
             raise ValueError(
-                "Expected 1D or 2D array, got %dD array instead" % X.ndim)
+                f"Expected 1D or 2D array, got {X.ndim}D array instead")
         elif X.ndim == 1:
             # Common case -- 1d array of numbers
             if X.dtype.names is None:
@@ -1614,9 +1614,10 @@ def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
                 try:
                     v = format % tuple(row) + newline
                 except TypeError as e:
-                    raise TypeError("Mismatch between array dtype ('%s') and "
-                                    "format specifier ('%s')"
-                                    % (str(X.dtype), format)) from e
+                    raise TypeError(
+                        f"Mismatch between array dtype ('{str(X.dtype)}') and "
+                        f"format specifier ('{format}')"
+                    ) from e
                 fh.write(v)
 
         if len(footer) > 0:
@@ -1965,7 +1966,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     if not isinstance(user_converters, dict):
         raise TypeError(
             "The input argument 'converter' should be a valid dictionary "
-            "(got '%s' instead)" % type(user_converters))
+            f"(got '{type(user_converters)}' instead)"
+        )
 
     if encoding == 'bytes':
         encoding = None

--- a/numpy/lib/_polynomial_impl.py
+++ b/numpy/lib/_polynomial_impl.py
@@ -1323,9 +1323,9 @@ class poly1d:
             elif coefstr == '0':
                 newstr = ''
             elif coefstr == 'b':
-                newstr = '%s**%d' % (var, power,)
+                newstr = f'{var}**{power}'
             else:
-                newstr = '%s %s**%d' % (coefstr, var, power)
+                newstr = f'{coefstr} {var}**{power}'
 
             if k > 0:
                 if newstr != '':

--- a/numpy/lib/_utils_impl.py
+++ b/numpy/lib/_utils_impl.py
@@ -348,7 +348,7 @@ def info(object=None, maxwidth=76, output=None, toplevel='numpy'):
             print(f"Help for {object} not found.", file=output)
         else:
             print("\n     "
-                  "*** Total of %d references found. ***" % numfound,
+                  f"*** Total of {numfound} references found. ***",
                   file=output
                   )
 

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -1532,9 +1532,9 @@ def join_by(key, r1, r2, jointype='inner', r1postfix='1', r2postfix='2',
     # Check jointype
     if jointype not in ('inner', 'outer', 'leftouter'):
         raise ValueError(
-                "The 'jointype' argument should be in 'inner', "
-                "'outer' or 'leftouter' (got '%s' instead)" % jointype
-                )
+            "The 'jointype' argument should be in 'inner', "
+            f"'outer' or 'leftouter' (got '{jointype}' instead)"
+        )
     # If we have a single key, put it in a tuple
     if isinstance(key, str):
         key = (key,)

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -675,7 +675,7 @@ def test_descr_to_dtype(dt):
 def test_version_2_0():
     f = BytesIO()
     # requires more than 2 byte for header
-    dt = [(("%d" % i) * 100, float) for i in range(500)]
+    dt = [(f"{i}" * 100, float) for i in range(500)]
     d = np.ones(1000, dtype=dt)
 
     format.write_array(f, d, version=(2, 0))
@@ -700,7 +700,7 @@ def test_version_2_0():
 @pytest.mark.skipif(IS_WASM, reason="memmap doesn't work correctly")
 def test_version_2_0_memmap(tmpdir):
     # requires more than 2 byte for header
-    dt = [(("%d" % i) * 100, float) for i in range(500)]
+    dt = [(f"{i}" * 100, float) for i in range(500)]
     d = np.ones(1000, dtype=dt)
     tf1 = os.path.join(tmpdir, 'version2_01.npy')
     tf2 = os.path.join(tmpdir, 'version2_02.npy')

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -185,7 +185,7 @@ class RoundtripTest:
 
     @pytest.mark.slow
     def test_format_2_0(self):
-        dt = [(("%d" % i) * 100, float) for i in range(500)]
+        dt = [(f"{i}" * 100, float) for i in range(500)]
         a = np.ones(1000, dtype=dt)
         with warnings.catch_warnings(record=True):
             warnings.filterwarnings('always', '', UserWarning)
@@ -205,7 +205,7 @@ class TestSavezLoad(RoundtripTest):
         arr, arr_reloaded = RoundtripTest.roundtrip(self, np.savez, *args, **kwargs)
         try:
             for n, a in enumerate(arr):
-                reloaded = arr_reloaded['arr_%d' % n]
+                reloaded = arr_reloaded[f'arr_{n}']
                 assert_equal(a, reloaded)
                 assert_equal(a.dtype, reloaded.dtype)
                 assert_equal(a.flags.fnc, reloaded.flags.fnc)
@@ -623,7 +623,7 @@ class TestSaveTxt:
         np.savetxt(s, a, fmt="%f")
         s.seek(0)
         if iotype is StringIO:
-            assert_equal(s.read(), "%f\n" % 1.)
+            assert_equal(s.read(), f"{1.:f}\n")
         else:
             assert_equal(s.read(), b"%f\n" % 1.)
 
@@ -1179,7 +1179,7 @@ class TestLoadTxt(LoadTxtBase):
     def test_generator_source(self):
         def count():
             for i in range(10):
-                yield "%d" % i
+                yield f"{i}"
 
         res = np.loadtxt(count())
         assert_array_equal(res, np.arange(10))
@@ -2419,7 +2419,7 @@ M   33  21.99
         # gft doesn't work with unicode.
         def count():
             for i in range(10):
-                yield asbytes("%d" % i)
+                yield asbytes(f"{i}")
 
         res = np.genfromtxt(count())
         assert_array_equal(res, np.arange(10))


### PR DESCRIPTION
**Motivation**
Rule `UP031` (printf-string-formatting) is currently globally ignored in `ruff.toml` with a `# TODO`. This PR applies fixes for this rule specifically within the `numpy/lib` submodule to incrementally clear this technical debt.

**Changes**
- **Refactor:** Converted `%`-formatting to f-strings throughout `numpy/lib`.
- **Manual Adjustments:** Preserved `.format(*args)` in `test_io.py` as tuple unpacking is cleaner than f-strings in those specific cases.

**Verification**
Manually checked multi-line string scopes and verified with `spin test -v -- numpy/lib`.