### PR TITLE
ENH: add a variant of as_strided with bound checks.

### DIFF
--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -472,7 +472,10 @@ Glossary
 
        Strides are computed automatically from an array's dtype and
        shape, but can be directly specified using
-       :doc:`as_strided. <reference/generated/numpy.lib.stride_tricks.as_strided>`
+       :doc:`as_strided <reference/generated/numpy.lib.stride_tricks.as_strided>`
+       or
+       :doc:`as_strided_checked <reference/generated/numpy.lib.stride_tricks.as_strided_checked>`
+       (with bounds validation).
 
        For details, see
        :doc:`numpy.ndarray.strides <reference/generated/numpy.ndarray.strides>`.

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -472,10 +472,8 @@ Glossary
 
        Strides are computed automatically from an array's dtype and
        shape, but can be directly specified using
-       :doc:`as_strided <reference/generated/numpy.lib.stride_tricks.as_strided>`
-       or
-       :doc:`as_strided_checked <reference/generated/numpy.lib.stride_tricks.as_strided_checked>`
-       (with bounds validation).
+       :doc:`as_strided <reference/generated/numpy.lib.stride_tricks.as_strided>`.
+       Bounds validation can be enabled with the ``check_bounds`` parameter.
 
        For details, see
        :doc:`numpy.ndarray.strides <reference/generated/numpy.ndarray.strides>`.

--- a/numpy/lib/_stride_tricks_impl.py
+++ b/numpy/lib/_stride_tricks_impl.py
@@ -157,13 +157,13 @@ def as_strided(
         if view_low < base_low:
             raise ValueError(
                 f"Given shape and strides would access memory out of bounds. "
-                f"View starts {base_low - view_low} before starts"
+                f"View starts {base_low - view_low} bytes before lowest address"
             )
 
         if view_high > base_high:
             raise ValueError(
                 f"Given shape and strides would access memory out of bounds. "
-                f"View ends {view_high - base_high} after ends"
+                f"View ends {view_high - base_high} bytes after highest address"
             )
 
     return view

--- a/numpy/lib/_stride_tricks_impl.py
+++ b/numpy/lib/_stride_tricks_impl.py
@@ -35,67 +35,6 @@ def _maybe_view_as_subclass(original_array, new_array):
     return new_array
 
 
-def _compute_strided_offset_bounds(shape, strides):
-    """
-    Compute the minimum and maximum byte offsets for a strided array view.
-
-    Parameters
-    ----------
-    shape : tuple of int
-        The shape of the strided view.
-    strides : tuple of int
-        The strides (in bytes) of the view.
-
-    Returns
-    -------
-    min_offset : int
-        The minimum byte offset that would be accessed.
-    max_offset : int
-        The maximum byte offset that would be accessed (not including itemsize).
-
-    Notes
-    -----
-    This function computes the minimum and maximum byte offsets that could
-    be accessed by a strided view. For each dimension, the offset contribution
-    ranges from 0 to (shape[i] - 1) * strides[i] if strides[i] >= 0, or from
-    (shape[i] - 1) * strides[i] to 0 if strides[i] < 0.
-
-    Examples
-    --------
-    >>> shape = (5,)
-    >>> strides = (8,)
-    >>> _compute_strided_offset_bounds(shape, strides)
-    (0, 32)
-
-    >>> shape = (5,)
-    >>> strides = (-8,)
-    >>> _compute_strided_offset_bounds(shape, strides)
-    (-32, 0)
-
-    >>> shape = (2, 3)
-    >>> strides = (24, 8)
-    >>> _compute_strided_offset_bounds(shape, strides)
-    (0, 40)
-    """
-    min_offset = 0
-    max_offset = 0
-
-    for size, stride in zip(shape, strides):
-        if size == 0:
-            # Empty dimension, no access
-            continue
-
-        # The offset contribution from this dimension
-        contribution = (size - 1) * stride
-
-        if contribution > 0:
-            max_offset += contribution
-        else:
-            min_offset += contribution
-
-    return min_offset, max_offset
-
-
 @set_module("numpy.lib.stride_tricks")
 def as_strided_checked(x, shape=None, strides=None, subok=False, writeable=True):
     """

--- a/numpy/lib/_stride_tricks_impl.py
+++ b/numpy/lib/_stride_tricks_impl.py
@@ -157,13 +157,13 @@ def as_strided(
         if view_low < base_low:
             raise ValueError(
                 f"Given shape and strides would access memory out of bounds. "
-                f"View starts {base_low-view_low} before starts"
+                f"View starts {base_low - view_low} before starts"
             )
 
         if view_high > base_high:
             raise ValueError(
                 f"Given shape and strides would access memory out of bounds. "
-                f"View ends {view_high-base_high} after ends"
+                f"View ends {view_high - base_high} after ends"
             )
 
     return view

--- a/numpy/lib/_stride_tricks_impl.py
+++ b/numpy/lib/_stride_tricks_impl.py
@@ -148,7 +148,7 @@ def as_strided(
         view.flags.writeable = False
 
     if check_bounds:
-        while base.base is not None:
+        while isinstance(base.base, np.ndarray):
             base = base.base
 
         base_low, base_high = byte_bounds(base)

--- a/numpy/lib/_stride_tricks_impl.pyi
+++ b/numpy/lib/_stride_tricks_impl.pyi
@@ -22,6 +22,8 @@ def as_strided[ScalarT: np.generic](
     strides: Iterable[int] | None = None,
     subok: bool = False,
     writeable: bool = True,
+    *,
+    check_bounds: bool | None = None
 ) -> NDArray[ScalarT]: ...
 @overload
 def as_strided(
@@ -30,6 +32,8 @@ def as_strided(
     strides: Iterable[int] | None = None,
     subok: bool = False,
     writeable: bool = True,
+    *,
+    check_bounds: bool | None = None
 ) -> NDArray[Any]: ...
 
 @overload

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -1,1 +1,1 @@
-from ._stride_tricks_impl import __doc__, as_strided, sliding_window_view  # noqa: F401
+from ._stride_tricks_impl import __doc__, as_strided, as_strided_checked, sliding_window_view  # noqa: F401

--- a/numpy/lib/stride_tricks.py
+++ b/numpy/lib/stride_tricks.py
@@ -1,1 +1,1 @@
-from ._stride_tricks_impl import __doc__, as_strided, as_strided_checked, sliding_window_view  # noqa: F401
+from ._stride_tricks_impl import __doc__, as_strided, sliding_window_view  # noqa: F401

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -4,7 +4,9 @@ import numpy as np
 from numpy._core._rational_tests import rational
 from numpy.lib._stride_tricks_impl import (
     _broadcast_shape,
+    _compute_strided_offset_bounds,
     as_strided,
+    as_strided_checked,
     broadcast_arrays,
     broadcast_shapes,
     broadcast_to,
@@ -653,3 +655,307 @@ def test_reference_types():
 
     actual, _ = broadcast_arrays(input_array, np.ones(3))
     assert_array_equal(expected, actual)
+
+
+@pytest.mark.parametrize(
+    "shape,strides,expected_min,expected_max",
+    [
+        # Basic positive strides
+        ((5,), (8,), 0, 32),
+        ((10,), (4,), 0, 36),
+        ((3,), (16,), 0, 32),
+        # Basic negative strides
+        ((5,), (-8,), -32, 0),
+        ((10,), (-4,), -36, 0),
+        ((3,), (-16,), -32, 0),
+        # Zero strides (broadcasting)
+        ((5,), (0,), 0, 0),
+        ((10,), (0,), 0, 0),
+        ((100,), (0,), 0, 0),
+        # 2D arrays with positive strides
+        ((2, 3), (24, 8), 0, 40),
+        ((3, 4), (32, 8), 0, 88),
+        ((4, 5), (40, 8), 0, 152),
+        # 2D arrays with negative strides
+        ((2, 3), (-24, -8), -40, 0),
+        ((3, 4), (-32, -8), -88, 0),
+        # 2D arrays with mixed strides
+        ((2, 3), (24, -8), -16, 24),
+        ((3, 4), (-32, 8), -64, 24),
+        ((4, 3), (16, -8), -16, 48),
+        # 3D arrays
+        ((2, 3, 4), (96, 32, 8), 0, 184),
+        ((2, 2, 2), (32, 16, 8), 0, 56),
+        # Single element cases
+        ((1,), (8,), 0, 0),
+        ((1, 1), (8, 8), 0, 0),
+        ((1, 1, 1), (8, 8, 8), 0, 0),
+        # Empty dimensions
+        ((0,), (8,), 0, 0),
+        ((0, 5), (8, 8), 0, 32),
+        ((5, 0), (8, 8), 0, 32),
+        ((0, 0), (8, 8), 0, 0),
+        # Large dimensions
+        ((100,), (8,), 0, 792),
+        ((10, 10), (80, 8), 0, 792),
+        # Multiple zero strides
+        ((5, 3), (0, 0), 0, 0),
+        ((2, 3, 4), (0, 0, 0), 0, 0),
+        # Mixed zero and non-zero strides
+        ((5, 3), (8, 0), 0, 32),
+        ((3, 5), (0, 8), 0, 32),
+        ((2, 3, 4), (96, 0, 8), 0, 120),
+    ],
+)
+def test_compute_offset_bounds(shape, strides, expected_min, expected_max):
+    """Test offset bounds computation for various shape/stride combinations."""
+    min_offset, max_offset = _compute_strided_offset_bounds(shape, strides)
+    assert min_offset == expected_min
+    assert max_offset == expected_max
+
+
+@pytest.mark.parametrize(
+    "shape,strides",
+    [
+        # Verify that min <= max always holds
+        ((5,), (8,)),
+        ((5,), (-8,)),
+        ((3, 4), (32, -8)),
+        ((3, 4), (-32, 8)),
+        ((2, 3, 4), (96, -32, 8)),
+    ],
+)
+def test_compute_offset_bounds_min_max_relationship(shape, strides):
+    """Test that min_offset <= max_offset always."""
+    min_offset, max_offset = _compute_strided_offset_bounds(shape, strides)
+    assert min_offset <= max_offset
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.float32,
+        np.float64,
+        np.complex64,
+        np.complex128,
+    ],
+)
+def test_as_strided_checked_different_dtypes(dtype):
+    """Test as_strided_checked with different dtypes."""
+    x = np.arange(10, dtype=dtype)
+    y = as_strided_checked(x, shape=(5,), strides=(x.itemsize * 2,))
+    assert y.shape == (5,)
+    assert y.dtype == dtype
+
+
+@pytest.mark.parametrize(
+    "size,view_size,stride_mult",
+    [
+        (10, 5, 1),  # Contiguous view
+        (10, 5, 2),  # Every other element
+        (20, 10, 2),  # Every other element
+        (100, 10, 10),  # Every 10th element
+    ],
+)
+def test_as_strided_checked_1d_positive_strides(size, view_size, stride_mult):
+    """Test 1D arrays with positive strides."""
+    x = np.arange(size, dtype=np.int64)
+    itemsize = x.itemsize
+    y = as_strided_checked(x, shape=(view_size,), strides=(itemsize * stride_mult,))
+    assert y.shape == (view_size,)
+    # Verify data correctness
+    expected = x[::stride_mult][:view_size]
+    assert_array_equal(y, expected)
+
+
+@pytest.mark.parametrize(
+    "shape,window_shape",
+    [
+        ((10,), (3,)),
+        ((20,), (5,)),
+        ((100,), (10,)),
+    ],
+)
+def test_as_strided_checked_sliding_window_1d(shape, window_shape):
+    """Test sliding window views in 1D."""
+    x = np.arange(shape[0], dtype=np.int64)
+    itemsize = x.itemsize
+    n_windows = shape[0] - window_shape[0] + 1
+    view_shape = (n_windows, window_shape[0])
+    view_strides = (itemsize, itemsize)
+
+    y = as_strided_checked(x, shape=view_shape, strides=view_strides)
+    assert y.shape == view_shape
+    # Check first and last windows
+    assert_array_equal(y[0], x[: window_shape[0]])
+    assert_array_equal(y[-1], x[-window_shape[0] :])
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (3, 4),
+        (5, 6),
+        (10, 10),
+    ],
+)
+def test_as_strided_checked_2d_default_strides(shape):
+    """Test 2D arrays with default strides."""
+    x = np.arange(np.prod(shape), dtype=np.int64).reshape(shape)
+    y = as_strided_checked(x)  # Should use default shape and strides
+    assert_array_equal(y, x)
+
+
+@pytest.mark.parametrize("size", [0, 1, 2, 10, 100])
+def test_as_strided_checked_zero_stride_broadcasting(size):
+    """Test zero strides (broadcasting a single value)."""
+    x = np.array([42], dtype=np.int64)
+    y = as_strided_checked(x, shape=(size,), strides=(0,))
+    assert y.shape == (size,)
+    if size > 0:
+        assert_(np.all(y == 42))
+
+
+@pytest.mark.parametrize(
+    "size,shape,strides",
+    [
+        # Strides too large
+        (10, (5,), (32,)),
+        (10, (10,), (16,)),
+        (20, (15,), (16,)),
+        # Shape too large for strides
+        (10, (20,), (8,)),
+        (10, (100,), (8,)),
+        # 2D out of bounds cases
+        (20, (5, 5), (80, 8)),
+        (20, (3, 10), (64, 8)),  # Negative strides that go before array start
+        (10, (5,), (-8,)),
+        (10, (10,), (-8,)),
+        (20, (5,), (-16,)),
+        # ND negative strides
+        (10, (2, 3, 4), (96, 32, -8)),  # Negative stride in 3rd dim
+        (20, (3, 4), (64, -8)),  # Negative stride in 2nd dim
+        (30, (2, 3, 4), (-96, 32, 8)),  # Negative stride in 1st dim
+    ],
+)
+def test_as_strided_checked_out_of_bounds_positive_strides(size, shape, strides):
+    """Test that out-of-bounds positive strides raise ValueError."""
+    x = np.arange(size, dtype=np.int64)
+    with pytest.raises(ValueError, match="out of bounds"):
+        as_strided_checked(x, shape=shape, strides=strides)
+
+
+@pytest.mark.parametrize(
+    "input_data",
+    [
+        [1, 2, 3, 4, 5],  # List
+        (1, 2, 3, 4, 5),  # Tuple
+        [[1, 2], [3, 4]],  # Nested list
+    ],
+)
+def test_as_strided_checked_copy_required_inputs(input_data):
+    """Test that inputs requiring copy raise ValueError."""
+    with pytest.raises(ValueError):
+        as_strided_checked(input_data, shape=(2,), strides=(8,))
+
+
+def test_as_strided_checked_view_of_larger_array():
+    """Test that as_strided_checked considers the base array bounds, not just the view."""
+    a = np.arange(1000, dtype=np.int64)
+
+    b = a[:2]
+
+    # This should succeed because the underlying array has enough memory
+    y = as_strided_checked(b, shape=(2,), strides=(400,))
+    assert_equal(y.shape, (2,))
+    assert_equal(y[0], 0)
+    assert_equal(y[1], 50)
+
+
+def test_as_strided_checked_view_with_offset():
+    """Test as_strided_checked on a view that doesn't start at the beginning."""
+    a = np.arange(1000, dtype=np.int64)
+
+    # Create a view starting at element 100
+    b = a[100:102]
+
+    y = as_strided_checked(b, shape=(2,), strides=(80,))
+    assert_equal(y.shape, (2,))
+    assert_equal(y[0], 100)
+    assert_equal(y[1], 110)
+
+
+def test_as_strided_checked_view_out_of_bounds_negative():
+    """Test that negative strides on a view correctly detect out of bounds."""
+    a = np.arange(1000, dtype=np.int64)
+
+    b = a[5:7]
+
+    with pytest.raises(ValueError, match="out of bounds"):
+        as_strided_checked(b, shape=(2,), strides=(-48,))
+
+
+def test_as_strided_checked_view_out_of_bounds_positive():
+    """Test that positive strides on a view correctly detect out of bounds."""
+    a = np.arange(100, dtype=np.int64)  # 800 bytes total
+
+    b = a[95:97]
+
+    with pytest.raises(ValueError, match="out of bounds"):
+        as_strided_checked(b, shape=(2,), strides=(200,))
+
+
+def test_as_strided_checked_nested_views():
+    """Test as_strided_checked on a view of a view."""
+    a = np.arange(1000, dtype=np.int64)
+    b = a[10:100]
+    c = b[5:10]
+
+    y = as_strided_checked(c, shape=(2,), strides=(160,))
+    assert_equal(y.shape, (2,))
+    assert_equal(y[0], 15)
+    assert_equal(y[1], 35)  # 160 bytes / 8 bytes = 20 elements forward
+
+
+def test_as_strided_checked_sliced_array():
+    """Test various slicing scenarios."""
+    a = np.arange(200, dtype=np.int64)
+
+    b = a[10:20]
+    y = as_strided_checked(b, shape=(5,), strides=(16,))
+    assert_equal(y.shape, (5,))
+
+    c = a[::2]  # Every other element
+    y = as_strided_checked(c, shape=(10,), strides=(16,))
+    assert_equal(y.shape, (10,))
+
+
+@pytest.mark.parametrize(
+    "start,stop,stride_bytes,should_pass",
+    [
+        (0, 10, 160, True),
+        (0, 10, 800, True),
+        (90, 95, 320, True),
+        (95, 97, 200, False),
+        (5, 7, -48, False),
+    ],
+)
+def test_as_strided_checked_view_parametrized(start, stop, stride_bytes, should_pass):
+    """Parametrized test for various view and stride combinations."""
+    a = np.arange(100, dtype=np.int64)
+    b = a[start:stop]
+
+    if should_pass:
+        y = as_strided_checked(b, shape=(2,), strides=(stride_bytes,))
+        assert_equal(y.shape, (2,))
+    else:
+        with pytest.raises(ValueError, match="out of bounds"):
+            as_strided_checked(b, shape=(2,), strides=(stride_bytes,))

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -836,14 +836,15 @@ def test_as_strided_checked_zero_stride_broadcasting(size):
         (10, (100,), (8,)),
         # 2D out of bounds cases
         (20, (5, 5), (80, 8)),
-        (20, (3, 10), (64, 8)),  # Negative strides that go before array start
+        (20, (3, 10), (64, 8)),
+        # Negative strides that go before array start
         (10, (5,), (-8,)),
         (10, (10,), (-8,)),
         (20, (5,), (-16,)),
         # ND negative strides
-        (10, (2, 3, 4), (96, 32, -8)),  # Negative stride in 3rd dim
-        (20, (3, 4), (64, -8)),  # Negative stride in 2nd dim
-        (30, (2, 3, 4), (-96, 32, 8)),  # Negative stride in 1st dim
+        (10, (2, 3, 4), (96, 32, -8)),
+        (20, (3, 4), (64, -8)),
+        (30, (2, 3, 4), (-96, 32, 8)),
     ],
 )
 def test_as_strided_checked_out_of_bounds_positive_strides(size, shape, strides):
@@ -884,7 +885,6 @@ def test_as_strided_checked_view_with_offset():
     """Test as_strided_checked on a view that doesn't start at the beginning."""
     a = np.arange(1000, dtype=np.int64)
 
-    # Create a view starting at element 100
     b = a[100:102]
 
     y = as_strided_checked(b, shape=(2,), strides=(80,))
@@ -905,7 +905,7 @@ def test_as_strided_checked_view_out_of_bounds_negative():
 
 def test_as_strided_checked_view_out_of_bounds_positive():
     """Test that positive strides on a view correctly detect out of bounds."""
-    a = np.arange(100, dtype=np.int64)  # 800 bytes total
+    a = np.arange(100, dtype=np.int64)
 
     b = a[95:97]
 
@@ -922,7 +922,7 @@ def test_as_strided_checked_nested_views():
     y = as_strided_checked(c, shape=(2,), strides=(160,))
     assert_equal(y.shape, (2,))
     assert_equal(y[0], 15)
-    assert_equal(y[1], 35)  # 160 bytes / 8 bytes = 20 elements forward
+    assert_equal(y[1], 35)
 
 
 def test_as_strided_checked_sliced_array():
@@ -933,7 +933,7 @@ def test_as_strided_checked_sliced_array():
     y = as_strided_checked(b, shape=(5,), strides=(16,))
     assert_equal(y.shape, (5,))
 
-    c = a[::2]  # Every other element
+    c = a[::2]
     y = as_strided_checked(c, shape=(10,), strides=(16,))
     assert_equal(y.shape, (10,))
 
@@ -941,11 +941,12 @@ def test_as_strided_checked_sliced_array():
 @pytest.mark.parametrize(
     "start,stop,stride_bytes,should_pass",
     [
-        (0, 10, 160, True),
-        (0, 10, 800, True),
-        (90, 95, 320, True),
-        (95, 97, 200, False),
-        (5, 7, -48, False),
+        (0, 10, 552, True),
+        (0, 10, 552 + 1, True),
+        (90, 95, 72, True),
+        (90, 95, 72 + 1, False),
+        (5, 7, -40, True),
+        (5, 7, -40 - 1, False),
     ],
 )
 def test_as_strided_checked_view_parametrized(start, stop, stride_bytes, should_pass):

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -781,7 +781,12 @@ def test_as_strided_checked_out_of_bounds_positive_strides(size, shape, strides)
 
 
 def test_as_strided_checked_view_of_larger_array():
-    """Test that as_strided with check_bounds=True considers the base array bounds, not just the view."""
+    """Test as_strided
+
+    - with check_bounds=True
+    - considers the base array bounds, not just the view.
+
+    """
     a = np.arange(1000, dtype=np.int64)
 
     b = a[:2]
@@ -794,7 +799,11 @@ def test_as_strided_checked_view_of_larger_array():
 
 
 def test_as_strided_checked_view_with_offset():
-    """Test as_strided with check_bounds=True on a view that doesn't start at the beginning."""
+    """Test as_strided
+
+    - with check_bounds=True
+    - on a view that doesn't start at the beginning.
+    """
     a = np.arange(1000, dtype=np.int64)
 
     b = a[100:102]

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy._core._rational_tests import rational
 from numpy.lib._stride_tricks_impl import (
     _broadcast_shape,
-    _compute_strided_offset_bounds,
     as_strided,
     as_strided_checked,
     broadcast_arrays,
@@ -655,80 +654,6 @@ def test_reference_types():
 
     actual, _ = broadcast_arrays(input_array, np.ones(3))
     assert_array_equal(expected, actual)
-
-
-@pytest.mark.parametrize(
-    "shape,strides,expected_min,expected_max",
-    [
-        # Basic positive strides
-        ((5,), (8,), 0, 32),
-        ((10,), (4,), 0, 36),
-        ((3,), (16,), 0, 32),
-        # Basic negative strides
-        ((5,), (-8,), -32, 0),
-        ((10,), (-4,), -36, 0),
-        ((3,), (-16,), -32, 0),
-        # Zero strides (broadcasting)
-        ((5,), (0,), 0, 0),
-        ((10,), (0,), 0, 0),
-        ((100,), (0,), 0, 0),
-        # 2D arrays with positive strides
-        ((2, 3), (24, 8), 0, 40),
-        ((3, 4), (32, 8), 0, 88),
-        ((4, 5), (40, 8), 0, 152),
-        # 2D arrays with negative strides
-        ((2, 3), (-24, -8), -40, 0),
-        ((3, 4), (-32, -8), -88, 0),
-        # 2D arrays with mixed strides
-        ((2, 3), (24, -8), -16, 24),
-        ((3, 4), (-32, 8), -64, 24),
-        ((4, 3), (16, -8), -16, 48),
-        # 3D arrays
-        ((2, 3, 4), (96, 32, 8), 0, 184),
-        ((2, 2, 2), (32, 16, 8), 0, 56),
-        # Single element cases
-        ((1,), (8,), 0, 0),
-        ((1, 1), (8, 8), 0, 0),
-        ((1, 1, 1), (8, 8, 8), 0, 0),
-        # Empty dimensions
-        ((0,), (8,), 0, 0),
-        ((0, 5), (8, 8), 0, 32),
-        ((5, 0), (8, 8), 0, 32),
-        ((0, 0), (8, 8), 0, 0),
-        # Large dimensions
-        ((100,), (8,), 0, 792),
-        ((10, 10), (80, 8), 0, 792),
-        # Multiple zero strides
-        ((5, 3), (0, 0), 0, 0),
-        ((2, 3, 4), (0, 0, 0), 0, 0),
-        # Mixed zero and non-zero strides
-        ((5, 3), (8, 0), 0, 32),
-        ((3, 5), (0, 8), 0, 32),
-        ((2, 3, 4), (96, 0, 8), 0, 120),
-    ],
-)
-def test_compute_offset_bounds(shape, strides, expected_min, expected_max):
-    """Test offset bounds computation for various shape/stride combinations."""
-    min_offset, max_offset = _compute_strided_offset_bounds(shape, strides)
-    assert min_offset == expected_min
-    assert max_offset == expected_max
-
-
-@pytest.mark.parametrize(
-    "shape,strides",
-    [
-        # Verify that min <= max always holds
-        ((5,), (8,)),
-        ((5,), (-8,)),
-        ((3, 4), (32, -8)),
-        ((3, 4), (-32, 8)),
-        ((2, 3, 4), (96, -32, 8)),
-    ],
-)
-def test_compute_offset_bounds_min_max_relationship(shape, strides):
-    """Test that min_offset <= max_offset always."""
-    min_offset, max_offset = _compute_strided_offset_bounds(shape, strides)
-    assert min_offset <= max_offset
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is a bit safer than as_strided, and can allow to catch typoes or mistake.

This also tries to lookup both the base array when using on a view; I'm not sure we want to do that; but it's easy; this comes from an internal discussion at work, so I include it – I can ask for the actual use case if necessary.


Consider this Pull request more a proof of concept for discussion, as
this could also be flag for as_strided, that either `skip checks | raise a warning | error`

I found #8315 from 10 years ago, but did not found any discussion on the ML.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
