### PR TITLE
MAINT: silence unused variable warning

### DIFF
--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -466,6 +466,8 @@ array_dealloc(PyArrayObject *self)
 {
     // NPY_TRUE flags that errors are unraisable.
     int ret = _clear_array_attributes(self, NPY_TRUE);
+    // silence unused variable warning in release builds
+    (void)ret;
     assert(ret == 0);  // should always succeed if unraisable.
     // Only done on actual deallocation, nothing allocated by numpy.
     if (((PyArrayObject_fields *)self)->weakreflist != NULL) {


### PR DESCRIPTION
This change silence this compiler warning:

```
  [149/329] Compiling C object numpy/_core/_multiarray_umath.cpython-312-darwin.so.p/src_multiarray_arrayobject.c.o
  ../numpy/_core/src/multiarray/arrayobject.c:468:9: warning: unused variable 'ret' [-Wunused-variable]
    468 |     int ret = _clear_array_attributes(self, NPY_TRUE);
        |         ^~~
  1 warning generated.
```