### PR TITLE
DEP: deprecate numpy.typename

### DIFF
--- a/doc/release/upcoming_changes/30774.deprecation.rst
+++ b/doc/release/upcoming_changes/30774.deprecation.rst
@@ -1,0 +1,4 @@
+``typename`` is deprecated
+--------------------------
+``numpy.typename`` is deprecated because the names returned by it were outdated and inconsistent.
+``numpy.dtype.name`` can be used as a replacement.

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -347,3 +347,11 @@ class TestTooManyArgsExtremum(_DeprecationTestCase):
     @pytest.mark.parametrize("ufunc", [np.minimum, np.maximum])
     def test_extremem_3_args(self, ufunc):
         self.assert_deprecated(ufunc, args=(np.ones(1), np.zeros(1), np.empty(1)))
+
+
+class TestTypenameDeprecation(_DeprecationTestCase):
+    # Deprecation in Numpy 2.5, 2026-02
+
+    def test_typename_emits_deprecation_warning(self):
+        self.assert_deprecated(lambda: np.typename("S1"))
+        self.assert_deprecated(lambda: np.typename("h"))

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -185,6 +185,7 @@ if HAVE_SCPDT:
                 "NumPy warning suppression and assertion utilities are deprecated.",
                 "numpy.fix is deprecated",  # fix -> trunc
                 "The chararray class is deprecated",  # char.chararray
+                "numpy.typename is deprecated",  # typename -> dtype.name
         ]
         msg = "|".join(msgs)
 

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -185,7 +185,6 @@ if HAVE_SCPDT:
                 "NumPy warning suppression and assertion utilities are deprecated.",
                 "numpy.fix is deprecated",  # fix -> trunc
                 "The chararray class is deprecated",  # char.chararray
-                "numpy.typename is deprecated",  # typename -> dtype.name
         ]
         msg = "|".join(msgs)
 

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -637,6 +637,7 @@ def typename(char):
     q  :  long long integer
 
     """
+    # Deprecated in NumPy 2.5, 2026-02-03
     warnings.warn(
         "numpy.typename is deprecated. Use numpy.dtype.name instead.",
         DeprecationWarning,

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -642,8 +642,7 @@ def typename(char):
     warnings.warn(
         "numpy.typename is deprecated. Use numpy.dtype.name instead.",
         DeprecationWarning,
-        skip_file_prefixes=(os.path.dirname(__file__),),
-        stacklevel=2,
+        skip_file_prefixes=(os.path.dirname(__file__),)
     )
     return _namefromtype[char]
 

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -2,6 +2,7 @@
 
 """
 import functools
+import warnings
 
 __all__ = ['iscomplexobj', 'isrealobj', 'imag', 'iscomplex',
            'isreal', 'nan_to_num', 'real', 'real_if_close',
@@ -587,6 +588,9 @@ def typename(char):
     """
     Return a description for the given data type code.
 
+    .. deprecated:: 2.5
+        `numpy.typename` is deprecated. Use `numpy.dtype.name` instead.
+
     Parameters
     ----------
     char : str
@@ -633,6 +637,11 @@ def typename(char):
     q  :  long long integer
 
     """
+    warnings.warn(
+        "numpy.typename is deprecated. Use numpy.dtype.name instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _namefromtype[char]
 
 #-----------------------------------------------------------------------------

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -2,7 +2,6 @@
 
 """
 import functools
-import os
 import warnings
 
 __all__ = ['iscomplexobj', 'isrealobj', 'imag', 'iscomplex',
@@ -642,7 +641,7 @@ def typename(char):
     warnings.warn(
         "numpy.typename is deprecated. Use numpy.dtype.name instead.",
         DeprecationWarning,
-        skip_file_prefixes=(os.path.dirname(__file__),)
+        stacklevel=2
     )
     return _namefromtype[char]
 

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -2,6 +2,7 @@
 
 """
 import functools
+import os
 import warnings
 
 __all__ = ['iscomplexobj', 'isrealobj', 'imag', 'iscomplex',
@@ -641,6 +642,7 @@ def typename(char):
     warnings.warn(
         "numpy.typename is deprecated. Use numpy.dtype.name instead.",
         DeprecationWarning,
+        skip_file_prefixes=(os.path.dirname(__file__),),
         stacklevel=2,
     )
     return _namefromtype[char]

--- a/numpy/lib/_type_check_impl.pyi
+++ b/numpy/lib/_type_check_impl.pyi
@@ -1,6 +1,7 @@
 from _typeshed import Incomplete
 from collections.abc import Container, Iterable
 from typing import Any, Literal as L, Protocol, overload, type_check_only
+from typing_extensions import deprecated
 
 import numpy as np
 from numpy._typing import (
@@ -148,48 +149,70 @@ def real_if_close(a: ArrayLike, tol: float = 100) -> NDArray[Any]: ...
 
 #
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["S1"]) -> L["character"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["?"]) -> L["bool"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["b"]) -> L["signed char"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["B"]) -> L["unsigned char"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["h"]) -> L["short"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["H"]) -> L["unsigned short"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["i"]) -> L["integer"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["I"]) -> L["unsigned integer"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["l"]) -> L["long integer"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["L"]) -> L["unsigned long integer"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["q"]) -> L["long long integer"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["Q"]) -> L["unsigned long long integer"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["f"]) -> L["single precision"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["d"]) -> L["double precision"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["g"]) -> L["long precision"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["F"]) -> L["complex single precision"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["D"]) -> L["complex double precision"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["G"]) -> L["complex long double precision"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["S"]) -> L["string"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["U"]) -> L["unicode"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["V"]) -> L["void"]: ...
 @overload
+@deprecated("numpy.typename is deprecated. Use numpy.dtype.name instead.")
 def typename(char: L["O"]) -> L["object"]: ...
 
 # NOTE: The [overload-overlap] mypy errors are false positives

--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -478,9 +478,7 @@ class TestTypenameDeprecation:
     """Test that numpy.typename emits a DeprecationWarning."""
 
     def test_typename_emits_deprecation_warning(self):
-        a = ['S1', '?', 'B', 'D', 'G', 'F', 'I', 'H', 'L', 'O', 'Q',
-             'S', 'U', 'V', 'b', 'd', 'g', 'f', 'i', 'h', 'l', 'q']
-
-        for c in a:
-            with pytest.warns(DeprecationWarning, match="numpy.typename is deprecated"):
-                np.typename(c)
+        with pytest.warns(DeprecationWarning, match="numpy.typename is deprecated"):
+            np.typename("S1")
+        with pytest.warns(DeprecationWarning, match="numpy.typename is deprecated"):
+            np.typename("h")

--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -1,3 +1,5 @@
+import pytest
+
 import numpy as np
 from numpy import (
     common_type,
@@ -471,3 +473,14 @@ class TestRealIfClose:
         assert_all(iscomplexobj(b))
         b = real_if_close(a + 1e-7j, tol=1e-6)
         assert_all(isrealobj(b))
+
+class TestTypenameDeprecation:
+    """Test that numpy.typename emits a DeprecationWarning."""
+
+    def test_typename_emits_deprecation_warning(self):
+        a = ['S1', '?', 'B', 'D', 'G', 'F', 'I', 'H', 'L', 'O', 'Q',
+             'S', 'U', 'V', 'b', 'd', 'g', 'f', 'i', 'h', 'l', 'q']
+
+        for c in a:
+            with pytest.warns(DeprecationWarning, match="numpy.typename is deprecated"):
+                np.typename(c)

--- a/numpy/lib/tests/test_type_check.py
+++ b/numpy/lib/tests/test_type_check.py
@@ -1,5 +1,3 @@
-import pytest
-
 import numpy as np
 from numpy import (
     common_type,
@@ -473,12 +471,3 @@ class TestRealIfClose:
         assert_all(iscomplexobj(b))
         b = real_if_close(a + 1e-7j, tol=1e-6)
         assert_all(isrealobj(b))
-
-class TestTypenameDeprecation:
-    """Test that numpy.typename emits a DeprecationWarning."""
-
-    def test_typename_emits_deprecation_warning(self):
-        with pytest.warns(DeprecationWarning, match="numpy.typename is deprecated"):
-            np.typename("S1")
-        with pytest.warns(DeprecationWarning, match="numpy.typename is deprecated"):
-            np.typename("h")

--- a/numpy/typing/tests/data/reveal/type_check.pyi
+++ b/numpy/typing/tests/data/reveal/type_check.pyi
@@ -54,10 +54,10 @@ assert_type(np.real_if_close(AR_c16), npt.NDArray[np.float64 | np.complex128])
 assert_type(np.real_if_close(AR_c8), npt.NDArray[np.float32 | np.complex64])
 assert_type(np.real_if_close(AR_LIKE_f), npt.NDArray[Any])
 
-assert_type(np.typename("h"), Literal["short"])
-assert_type(np.typename("B"), Literal["unsigned char"])
-assert_type(np.typename("V"), Literal["void"])
-assert_type(np.typename("S1"), Literal["character"])
+assert_type(np.typename("h"), Literal["short"])  # type: ignore[deprecated]
+assert_type(np.typename("B"), Literal["unsigned char"])  # type: ignore[deprecated]
+assert_type(np.typename("V"), Literal["void"])  # type: ignore[deprecated]
+assert_type(np.typename("S1"), Literal["character"])  # type: ignore[deprecated]
 
 assert_type(np.common_type(AR_i4), type[np.float64])
 assert_type(np.common_type(AR_f2), type[np.float16])


### PR DESCRIPTION
resolves #30762 

This PR deprecates `numpy.typename` in favor of `numpy.dtype.name`.
