### PR TITLE
API: Make PyArrayObject opaque on internal builds

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -829,6 +829,8 @@ typedef struct tagPyArrayObject_fields {
  * PyArrayObject field access is deprecated as of NumPy 1.7.
  */
 typedef PyArrayObject_fields PyArrayObject;
+#elif defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD
+typedef struct tagPyArrayObject PyArrayObject;
 #else
 typedef struct tagPyArrayObject {
         PyObject_HEAD


### PR DESCRIPTION
Towards fixing https://github.com/numpy/numpy/issues/30704.

After #30705 we don't access any fields in the PyObject header, so it's safe to make this opaque. Only doing it for internal builds for now but in a future PR I'll also do this for opaque PyObject builds.

In the future we can also make the public definition opaque and deprecate the old definition.