### PR TITLE
API: expose accessors for ufunc object members and use them internally

### DIFF
--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -1547,7 +1547,7 @@ def make_ufuncs(funcdict):
         mlist.append(fmt.format(**args))
         if uf.typereso is not None:
             mlist.append(
-                r"((PyUFuncObject *)f)->type_resolver = &%s;" % uf.typereso)
+                rf"PyUFunc_SET_TYPE_RESOLVER((PyUFuncObject *)f, &{uf.typereso});")
         for c in uf.indexed:
             # Handle indexed loops by getting the underlying ArrayMethodObject
             # from the list in f._loops and setting its field appropriately

--- a/numpy/_core/src/umath/_operand_flag_tests.c
+++ b/numpy/_core/src/umath/_operand_flag_tests.c
@@ -73,8 +73,8 @@ PyMODINIT_FUNC PyInit__operand_flag_tests(void)
      * Set flags to turn off buffering for first input operand,
      * so that result can be written back to input operand.
      */
-    ((PyUFuncObject*)ufunc)->op_flags[0] = NPY_ITER_READWRITE;
-    ((PyUFuncObject*)ufunc)->iter_flags = NPY_ITER_REDUCE_OK;
+    PyUFunc_SET_OP_FLAGS((PyUFuncObject*)ufunc, 0, NPY_ITER_READWRITE);
+    PyUFunc_SET_ITER_FLAGS((PyUFuncObject*)ufunc, NPY_ITER_REDUCE_OK);
     PyModule_AddObject(m, "inplace_add", (PyObject*)ufunc);
 
 #ifdef Py_GIL_DISABLED

--- a/numpy/_core/src/umath/_rational_tests.c
+++ b/numpy/_core/src/umath/_rational_tests.c
@@ -1209,10 +1209,10 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
         if (!ufunc) { \
             goto fail; \
         } \
-        if (sizeof(_types)/sizeof(int)!=ufunc->nargs) { \
+        if (sizeof(_types)/sizeof(int)!=PyUFunc_NARGS(ufunc)) {   \
             PyErr_Format(PyExc_AssertionError, \
                          "ufunc %s takes %d arguments, our loop takes %lu", \
-                         #name, ufunc->nargs, (unsigned long) \
+                         #name, PyUFunc_NARGS(ufunc), (unsigned long) \
                          (sizeof(_types)/sizeof(int))); \
             Py_DECREF(ufunc); \
             goto fail; \

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -395,7 +395,7 @@ minimum_maximum_strided_loop(PyArrayMethod_Context *context, char *const data[],
                      npy_intp const dimensions[], npy_intp const strides[],
                      NpyAuxData *NPY_UNUSED(auxdata))
 {
-    const char *ufunc_name = ((PyUFuncObject *)context->caller)->name;
+    const char *ufunc_name = PyUFunc_NAME((PyUFuncObject *)context->caller);
     npy_bool invert = *(npy_bool *)context->method->static_data; // true for maximum
     PyArray_StringDTypeObject *in1_descr =
             ((PyArray_StringDTypeObject *)context->descriptors[0]);
@@ -462,7 +462,7 @@ string_comparison_strided_loop(PyArrayMethod_Context *context, char *const data[
                             npy_intp const strides[],
                             NpyAuxData *NPY_UNUSED(auxdata))
 {
-    const char *ufunc_name = ((PyUFuncObject *)context->caller)->name;
+    const char *ufunc_name = PyUFunc_NAME((PyUFuncObject *)context->caller);
     npy_bool res_for_eq = ((npy_bool *)context->method->static_data)[0];
     npy_bool res_for_lt = ((npy_bool *)context->method->static_data)[1];
     npy_bool res_for_gt = ((npy_bool *)context->method->static_data)[2];
@@ -638,7 +638,7 @@ string_bool_output_unary_strided_loop(
         npy_intp const strides[],
         NpyAuxData *NPY_UNUSED(auxdata))
 {
-    const char *ufunc_name = ((PyUFuncObject *)context->caller)->name;
+    const char *ufunc_name = PyUFunc_NAME((PyUFuncObject *)context->caller);
     utf8_buffer_method is_it = *(utf8_buffer_method *)(context->method->static_data);
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)context->descriptors[0];
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
@@ -870,7 +870,7 @@ string_findlike_strided_loop(PyArrayMethod_Context *context,
                          npy_intp const strides[],
                          NpyAuxData *auxdata)
 {
-    const char *ufunc_name = ((PyUFuncObject *)context->caller)->name;
+    const char *ufunc_name = PyUFunc_NAME((PyUFuncObject *)context->caller);
     find_like_function *function = *(find_like_function *)(context->method->static_data);
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)context->descriptors[0];
 
@@ -946,7 +946,7 @@ string_startswith_endswith_strided_loop(PyArrayMethod_Context *context,
                                npy_intp const strides[],
                                NpyAuxData *auxdata)
 {
-    const char *ufunc_name = ((PyUFuncObject *)context->caller)->name;
+    const char *ufunc_name = PyUFunc_NAME((PyUFuncObject *)context->caller);
     STARTPOSITION startposition = *(STARTPOSITION *)context->method->static_data;
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)context->descriptors[0];
 
@@ -1062,7 +1062,7 @@ string_lrstrip_chars_strided_loop(
         npy_intp const strides[],
         NpyAuxData *auxdata)
 {
-    const char *ufunc_name = ((PyUFuncObject *)context->caller)->name;
+    const char *ufunc_name = PyUFunc_NAME((PyUFuncObject *)context->caller);
     STRIPTYPE striptype = *(STRIPTYPE *)context->method->static_data;
     PyArray_StringDTypeObject *s1descr = (PyArray_StringDTypeObject *)context->descriptors[0];
     int has_null = s1descr->na_object != NULL;
@@ -1188,7 +1188,7 @@ string_lrstrip_whitespace_strided_loop(
         char *const data[], npy_intp const dimensions[],
         npy_intp const strides[], NpyAuxData *NPY_UNUSED(auxdata))
 {
-    const char *ufunc_name = ((PyUFuncObject *)context->caller)->name;
+    const char *ufunc_name = PyUFunc_NAME((PyUFuncObject *)context->caller);
     STRIPTYPE striptype = *(STRIPTYPE *)context->method->static_data;
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)context->descriptors[0];
     int has_null = descr->na_object != NULL;
@@ -1688,7 +1688,7 @@ center_ljust_rjust_strided_loop(PyArrayMethod_Context *context,
     npy_string_allocator *oallocator = allocators[3];
 
     JUSTPOSITION pos = *(JUSTPOSITION *)(context->method->static_data);
-    const char* ufunc_name = ((PyUFuncObject *)context->caller)->name;
+    const char* ufunc_name = PyUFunc_NAME((PyUFuncObject *)context->caller);
 
     while (N--) {
         const npy_packed_static_string *ps1 = (npy_packed_static_string *)in1;
@@ -2015,14 +2015,14 @@ string_partition_strided_loop(
 
         if (i1_isnull == -1 || i2_isnull == -1) {
             npy_gil_error(PyExc_MemoryError, "Failed to load string in %s",
-                          ((PyUFuncObject *)context->caller)->name);
+                          PyUFunc_NAME((PyUFuncObject *)context->caller));
             goto fail;
         }
         else if (NPY_UNLIKELY(i1_isnull || i2_isnull)) {
             if (!has_string_na) {
                 npy_gil_error(PyExc_ValueError,
                               "Null values are not supported in %s",
-                              ((PyUFuncObject *)context->caller)->name);
+                              PyUFunc_NAME((PyUFuncObject *)context->caller));
                 goto fail;
             }
             else {
@@ -2069,15 +2069,15 @@ string_partition_strided_loop(
         npy_static_string o3s = {0, NULL};
 
         if (load_new_string(o1ps, &o1s, out1_size, out1allocator,
-                            ((PyUFuncObject *)context->caller)->name) == -1) {
+                            PyUFunc_NAME((PyUFuncObject *)context->caller)) == -1) {
             goto fail;
         }
         if (load_new_string(o2ps, &o2s, out2_size, out2allocator,
-                            ((PyUFuncObject *)context->caller)->name) == -1) {
+                            PyUFunc_NAME((PyUFuncObject *)context->caller)) == -1) {
             goto fail;
         }
         if (load_new_string(o3ps, &o3s, out3_size, out3allocator,
-                            ((PyUFuncObject *)context->caller)->name) == -1) {
+                            PyUFunc_NAME((PyUFuncObject *)context->caller)) == -1) {
             goto fail;
         }
 
@@ -2121,7 +2121,7 @@ string_inputs_promoter(
 {
     PyUFuncObject *ufunc = (PyUFuncObject *)ufunc_obj;
     /* set all input operands to final_dtype */
-    for (int i = 0; i < ufunc->nin; i++) {
+    for (int i = 0; i < PyUFunc_NIN(ufunc); i++) {
         PyArray_DTypeMeta *tmp = final_dtype;
         if (signature[i]) {
             tmp = signature[i]; /* never replace a fixed one. */
@@ -2130,7 +2130,7 @@ string_inputs_promoter(
         new_op_dtypes[i] = tmp;
     }
     /* don't touch output dtypes if they are set */
-    for (int i = ufunc->nin; i < ufunc->nargs; i++) {
+    for (int i = PyUFunc_NIN(ufunc); i < PyUFunc_NARGS(ufunc); i++) {
         if (op_dtypes[i] != NULL) {
             Py_INCREF(op_dtypes[i]);
             new_op_dtypes[i] = op_dtypes[i];
@@ -2423,7 +2423,7 @@ string_multiply_promoter(PyObject *ufunc_obj,
                          PyArray_DTypeMeta *new_op_dtypes[])
 {
     PyUFuncObject *ufunc = (PyUFuncObject *)ufunc_obj;
-    for (int i = 0; i < ufunc->nin; i++) {
+    for (int i = 0; i < PyUFunc_NIN(ufunc); i++) {
         PyArray_DTypeMeta *tmp = NULL;
         if (signature[i]) {
             tmp = signature[i];
@@ -2441,7 +2441,7 @@ string_multiply_promoter(PyObject *ufunc_obj,
         new_op_dtypes[i] = tmp;
     }
     /* don't touch output dtypes if they are set */
-    for (int i = ufunc->nin; i < ufunc->nargs; i++) {
+    for (int i = PyUFunc_NIN(ufunc); i < PyUFunc_NARGS(ufunc); i++) {
         if (op_dtypes[i]) {
             Py_INCREF(op_dtypes[i]);
             new_op_dtypes[i] = op_dtypes[i];

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -48,7 +48,7 @@ object_ufunc_type_resolver(PyUFuncObject *ufunc,
                                 PyObject *type_tup,
                                 PyArray_Descr **out_dtypes)
 {
-    int i, nop = ufunc->nin + ufunc->nout;
+    int i, nop = PyUFunc_NIN(ufunc) + PyUFunc_NOUT(ufunc);
 
     out_dtypes[0] = PyArray_DescrFromType(NPY_OBJECT);
     if (out_dtypes[0] == NULL) {
@@ -154,10 +154,9 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds) {
         return NULL;
     }
     Py_INCREF(function);
-    self->obj = function;
-    self->ptr = ptr;
-
-    self->type_resolver = &object_ufunc_type_resolver;
+    PyUFunc_SET_OBJ(self, function);
+    PyUFunc_SET_PTR(self, ptr);
+    PyUFunc_SET_TYPE_RESOLVER(self, &object_ufunc_type_resolver);
     PyObject_GC_Track(self);
 
     return (PyObject *)self;

--- a/numpy/_core/src/umath/wrapping_array_method.c
+++ b/numpy/_core/src/umath/wrapping_array_method.c
@@ -243,13 +243,13 @@ PyUFunc_AddWrappingLoop(PyObject *ufunc_obj,
     }
 
     wrapped_dt_tuple = PyArray_TupleFromItems(
-            ufunc->nargs, (PyObject **)wrapped_dtypes, 1);
+            PyUFunc_NARGS(ufunc), (PyObject **)wrapped_dtypes, 1);
     if (wrapped_dt_tuple == NULL) {
         goto finish;
     }
 
     PyArrayMethodObject *wrapped_meth = NULL;
-    PyObject *loops = ufunc->_loops;
+    PyObject *loops = PyUFunc__LOOPS(ufunc);
     Py_ssize_t length = PyList_Size(loops);
     for (Py_ssize_t i = 0; i < length; i++) {
         PyObject *item = PyList_GetItemRef(loops, i);
@@ -304,7 +304,7 @@ PyUFunc_AddWrappingLoop(PyObject *ufunc_obj,
     Py_SETREF(bmeth, NULL);
 
     /* Finalize the "wrapped" part of the new ArrayMethod */
-    meth->wrapped_dtypes = PyMem_Malloc(ufunc->nargs * sizeof(PyArray_DTypeMeta *));
+    meth->wrapped_dtypes = PyMem_Malloc(PyUFunc_NARGS(ufunc) * sizeof(PyArray_DTypeMeta *));
     if (meth->wrapped_dtypes == NULL) {
         goto finish;
     }
@@ -313,13 +313,13 @@ PyUFunc_AddWrappingLoop(PyObject *ufunc_obj,
     meth->wrapped_meth = wrapped_meth;
     meth->translate_given_descrs = translate_given_descrs;
     meth->translate_loop_descrs = translate_loop_descrs;
-    for (int i = 0; i < ufunc->nargs; i++) {
+    for (int i = 0; i < PyUFunc_NARGS(ufunc); i++) {
         Py_XINCREF(wrapped_dtypes[i]);
         meth->wrapped_dtypes[i] = wrapped_dtypes[i];
     }
 
     new_dt_tuple = PyArray_TupleFromItems(
-            ufunc->nargs, (PyObject **)new_dtypes, 1);
+            PyUFunc_NARGS(ufunc), (PyObject **)new_dtypes, 1);
     if (new_dt_tuple == NULL) {
         goto finish;
     }

--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -604,20 +604,22 @@ static inline void
 dump_ufunc_object(PyUFuncObject* ufunc)
 {
     TRACE_TXT("\n\n%s '%s' (%d input(s), %d output(s), %d specialization(s).\n",
-              ufunc->core_enabled? "generalized ufunc" : "scalar ufunc",
-              ufunc->name, ufunc->nin, ufunc->nout, ufunc->ntypes);
-    if (ufunc->core_enabled) {
+              PyUFunc_CORE_ENABLED(ufunc) ? "generalized ufunc" : "scalar ufunc",
+              PyUFunc_NAME(ufunc), PyUFunc_NIN(ufunc),
+              PyUFunc_NOUT(ufunc), PyUFunc_NTYPES(ufunc));
+    if (PyUFunc_CORE_ENABLED(ufunc)) {
         int arg;
         int dim;
         TRACE_TXT("\t%s (%d dimension(s) detected).\n",
-                  ufunc->core_signature, ufunc->core_num_dim_ix);
+                  PyUFunc_CORE_SIGNATURE(ufunc),
+                  PyUFunc_CORE_NUM_DIM_IX(ufunc);
 
-        for (arg = 0; arg < ufunc->nargs; arg++){
-            int * arg_dim_ix = ufunc->core_dim_ixs + ufunc->core_offsets[arg];
+        for (arg = 0; arg < PyUFunc_NARGS(ufunc); arg++){
+            int * arg_dim_ix = PyUFunc_CORE_DIM_IXS(ufunc) + PyUFunc_CORE_OFFSETS(ufunc)[arg];
             TRACE_TXT("\t\targ %d (%s) has %d dimension(s): (",
-                      arg, arg < ufunc->nin? "INPUT" : "OUTPUT",
-                      ufunc->core_num_dims[arg]);
-            for (dim = 0; dim < ufunc->core_num_dims[arg]; dim ++) {
+                      arg, arg < PyUFunc_NIN(ufunc)? "INPUT" : "OUTPUT",
+                      PyUFunc_CORE_NUM_DIMS(ufunc)[arg]);
+            for (dim = 0; dim < PyUFunc_CORE_NUM_DIMS(ufunc)[arg]; dim ++) {
                 TRACE_TXT(" %d", arg_dim_ix[dim]);
             }
             TRACE_TXT(" )\n");


### PR DESCRIPTION
Towards fixing #30704. Also see #30744.

Opening as a draft because docs and discussion are still TODO.

This makes `PyUFuncObject` an opaque pointer internally, moves the fields to a new `PyUFunc_fields` struct, and exposes accessor macros for all fields and setter macros for a subset of fields needed by the NumPy implementation. I also added `PyUFunc_GET_ITEM_DATA` to get the fields struct. We may decide to simply expose `GET_ITEM_DATA` instead of the setters. We also probably don't need to expose getters for members we deem to be private.

Opening for initial review and as a basis for a performance test on Windows.