### PR TITLE
Import inv_mod from modular in matrixlib

### DIFF
--- a/numpy/matrixlib/__init__.py
+++ b/numpy/matrixlib/__init__.py
@@ -3,6 +3,7 @@
 """
 from . import defmatrix
 from .defmatrix import *
+from .modular import inv_mod
 
 __all__ = defmatrix.__all__
 


### PR DESCRIPTION
Companion Pull Request for importing the inv_mod into __init__.py defined in the matrixlib/modular.py