### PR TITLE
Add unit test for inv_mod function in matrixlib

### DIFF
--- a/numpy/matrixlib/tests/test_modular.py
+++ b/numpy/matrixlib/tests/test_modular.py
@@ -1,0 +1,7 @@
+import numpy as np
+import pytest
+
+def test_inv_mod_2x2():
+    A = np.array([[3, 3], [2, 5]])
+    inv = np.matrixlib.inv_mod(A, 26)
+    assert np.all((A @ inv) % 26 == np.eye(2) % 26)


### PR DESCRIPTION
Companion unit test for the inv_mod function defined in the matrixlib/modular.py