### PR TITLE
Corrected inv_mod with added test_cases, updated __inti__.py and __init__.pyi

### DIFF
--- a/numpy/matrixlib/__init__.py
+++ b/numpy/matrixlib/__init__.py
@@ -5,7 +5,7 @@ from . import defmatrix
 from .defmatrix import *
 from .modular import matrix_inv_mod
 
-__all__ = defmatrix.__all__ + ["matrix_inv_mod"]
+__all__ = defmatrix.__all__
 
 from numpy._pytesttester import PytestTester
 

--- a/numpy/matrixlib/__init__.py
+++ b/numpy/matrixlib/__init__.py
@@ -3,9 +3,9 @@
 """
 from . import defmatrix
 from .defmatrix import *
-from .modular import inv_mod
+from .modular import matrix_inv_mod
 
-__all__ = defmatrix.__all__ + ["inv_mod"]
+__all__ = defmatrix.__all__ + ["matrix_inv_mod"]
 
 from numpy._pytesttester import PytestTester
 

--- a/numpy/matrixlib/__init__.py
+++ b/numpy/matrixlib/__init__.py
@@ -3,8 +3,9 @@
 """
 from . import defmatrix
 from .defmatrix import *
+from .modular import inv_mod
 
-__all__ = defmatrix.__all__
+__all__ = defmatrix.__all__ + ["inv_mod"]
 
 from numpy._pytesttester import PytestTester
 

--- a/numpy/matrixlib/__init__.pyi
+++ b/numpy/matrixlib/__init__.pyi
@@ -1,3 +1,5 @@
 from .defmatrix import asmatrix, bmat, matrix
-from .modular import matrix_inv_mod
-__all__ = ["matrix", "bmat", "asmatrix","matrix_inv_mod"]
+
+def matrix_inv_mod(matrix, m): ...
+
+__all__ = ["matrix", "bmat", "asmatrix", "matrix_inv_mod"]

--- a/numpy/matrixlib/__init__.pyi
+++ b/numpy/matrixlib/__init__.pyi
@@ -2,4 +2,4 @@ from .defmatrix import asmatrix, bmat, matrix
 
 def matrix_inv_mod(matrix, m): ...
 
-__all__ = ["matrix", "bmat", "asmatrix", "matrix_inv_mod"]
+__all__ = ["matrix", "bmat", "asmatrix"]

--- a/numpy/matrixlib/__init__.pyi
+++ b/numpy/matrixlib/__init__.pyi
@@ -1,3 +1,3 @@
 from .defmatrix import asmatrix, bmat, matrix
-
-__all__ = ["matrix", "bmat", "asmatrix"]
+from .modular import inv_mod
+__all__ = ["matrix", "bmat", "asmatrix","inv_mod"]

--- a/numpy/matrixlib/__init__.pyi
+++ b/numpy/matrixlib/__init__.pyi
@@ -1,3 +1,3 @@
 from .defmatrix import asmatrix, bmat, matrix
-from .modular import inv_mod
-__all__ = ["matrix", "bmat", "asmatrix","inv_mod"]
+from .modular import matrix_inv_mod
+__all__ = ["matrix", "bmat", "asmatrix","matrix_inv_mod"]

--- a/numpy/matrixlib/modular.py
+++ b/numpy/matrixlib/modular.py
@@ -9,7 +9,7 @@ def inv_mod(A, m):
     if gcd(det, m) != 1:
         raise ValueError("Matrix not invertible modulo m")
 
-    det_inv = pow(det, -1, m)  # Python 3.8+
+    det_inv = pow(det, -1, m)
 
     cof = np.zeros((n, n), dtype=int)
     for i in range(n):

--- a/numpy/matrixlib/modular.py
+++ b/numpy/matrixlib/modular.py
@@ -1,0 +1,20 @@
+import numpy as np
+from math import gcd
+
+def inv_mod(A, m):
+    A = np.asarray(A, dtype=int)
+    n = A.shape[0]
+
+    det = int(round(np.linalg.det(A))) % m
+    if gcd(det, m) != 1:
+        raise ValueError("Matrix not invertible modulo m")
+
+    det_inv = pow(det, -1, m)  # Python 3.8+
+
+    cof = np.zeros((n, n), dtype=int)
+    for i in range(n):
+        for j in range(n):
+            minor = np.delete(np.delete(A, i, 0), j, 1)
+            cof[i, j] = ((-1)**(i+j)) * int(round(np.linalg.det(minor)))
+
+    return (det_inv * cof.T) % m

--- a/numpy/matrixlib/modular.py
+++ b/numpy/matrixlib/modular.py
@@ -1,7 +1,7 @@
 import numpy as np
 from math import gcd
 
-def inv_mod(A, m):
+def matrix_inv_mod(A, m):
     A = np.asarray(A, dtype=int)
     n = A.shape[0]
 

--- a/numpy/matrixlib/tests/test_modular.py
+++ b/numpy/matrixlib/tests/test_modular.py
@@ -1,13 +1,13 @@
 import numpy as np
 import pytest
 
-from numpy.matrixlib.modular import inv_mod
+from numpy.matrixlib.modular import matrix_inv_mod
 
 
 def test_inv_mod_2x2_mod26():
     A = np.array([[3, 3],
                   [2, 5]])
-    invA = inv_mod(A, 26)
+    invA = matrix_inv_mod(A, 26)
 
     I = np.eye(2, dtype=int)
     result = (A @ invA) % 26
@@ -20,7 +20,7 @@ def test_inv_mod_3x3_mod29():
                   [6, 3, 4],
                   [5, -2, -3]])
 
-    invA = inv_mod(A, 29)
+    invA = matrix_inv_mod(A, 29)
 
     I = np.eye(3, dtype=int)
     result = (A @ invA) % 29
@@ -30,7 +30,7 @@ def test_inv_mod_3x3_mod29():
 
 def test_inv_mod_identity():
     A = np.eye(4, dtype=int)
-    invA = inv_mod(A, 17)
+    invA = matrix_inv_mod(A, 17)
 
     assert np.array_equal(invA, A)
 
@@ -40,7 +40,7 @@ def test_inv_mod_non_invertible():
                   [1, 2]])
 
     with pytest.raises(ValueError):
-        inv_mod(A, 26)
+        matrix_inv_mod(A, 26)
 
 
 def test_inv_mod_non_square():
@@ -48,14 +48,14 @@ def test_inv_mod_non_square():
                   [4, 5, 6]])
 
     with pytest.raises(ValueError):
-        inv_mod(A, 11)
+        matrix_inv_mod(A, 11)
 
 
 def test_inv_mod_negative_entries():
     A = np.array([[1, -1],
                   [1,  2]])
 
-    invA = inv_mod(A, 7)
+    invA = matrix_inv_mod(A, 7)
 
     I = np.eye(2, dtype=int)
     result = (A @ invA) % 7

--- a/numpy/matrixlib/tests/test_modular.py
+++ b/numpy/matrixlib/tests/test_modular.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+from numpy.matrixlib.modular import inv_mod
+
+
+def test_inv_mod_2x2_mod26():
+    A = np.array([[3, 3],
+                  [2, 5]])
+    invA = inv_mod(A, 26)
+
+    I = np.eye(2, dtype=int)
+    result = (A @ invA) % 26
+
+    assert np.array_equal(result, I)
+
+
+def test_inv_mod_3x3_mod29():
+    A = np.array([[2, 5, 7],
+                  [6, 3, 4],
+                  [5, -2, -3]])
+
+    invA = inv_mod(A, 29)
+
+    I = np.eye(3, dtype=int)
+    result = (A @ invA) % 29
+
+    assert np.array_equal(result, I)
+
+
+def test_inv_mod_identity():
+    A = np.eye(4, dtype=int)
+    invA = inv_mod(A, 17)
+
+    assert np.array_equal(invA, A)
+
+
+def test_inv_mod_non_invertible():
+    A = np.array([[2, 4],
+                  [1, 2]])
+
+    with pytest.raises(ValueError):
+        inv_mod(A, 26)
+
+
+def test_inv_mod_non_square():
+    A = np.array([[1, 2, 3],
+                  [4, 5, 6]])
+
+    with pytest.raises(ValueError):
+        inv_mod(A, 11)
+
+
+def test_inv_mod_negative_entries():
+    A = np.array([[1, -1],
+                  [1,  2]])
+
+    invA = inv_mod(A, 7)
+
+    I = np.eye(2, dtype=int)
+    result = (A @ invA) % 7
+
+    assert np.array_equal(result, I)


### PR DESCRIPTION
This pull request adds modular matrix inversion functionality to the `numpy.matrixlib` module. The main changes include the implementation of the new `inv_mod` function, updates to the module's public API, and comprehensive tests to verify correctness and expected error handling.

**New functionality:**

* Added `inv_mod` function to `numpy/matrixlib/modular.py` for computing the modular inverse of integer matrices (`inv_mod(A, m)` returns the inverse of matrix `A` modulo `m`).

**API updates:**

* Exposed `inv_mod` in the public API by updating `__all__` in both `numpy/matrixlib/__init__.py` and `numpy/matrixlib/__init__.pyi`. [[1]](diffhunk://#diff-af30ec88fb248e146b781b306e4a141aa56ad466ecdf6c233787dc352ef49d6fR6-R8) [[2]](diffhunk://#diff-d8694d567e1bdb7525fa41b2d7bea210eae4173c0a6a338693103e50d54df4c6L2-R3)

**Testing:**

* Added `numpy/matrixlib/tests/test_modular.py` with tests for `inv_mod`, covering various cases including invertible matrices, identity matrix, non-invertible matrices, non-square matrices, and matrices with negative entries.