### PR TITLE
DOC: Fix indentation in ctypes Conclusion section

### DIFF
--- a/doc/source/user/c-info.python-as-glue.rst
+++ b/doc/source/user/c-info.python-as-glue.rst
@@ -759,12 +759,12 @@ C-code. Its advantages for extending Python include
 
 - clean separation of C code from Python code
 
-    - no need to learn a new syntax except Python and C
+  - no need to learn a new syntax except Python and C
 
-    - allows reuse of C code
+  - allows reuse of C code
 
-    - functionality in shared libraries written for other purposes can be
-      obtained with a simple Python wrapper and search for the library.
+  - functionality in shared libraries written for other purposes can be
+    obtained with a simple Python wrapper and search for the library.
 
 
 - easy integration with NumPy through the ctypes attribute


### PR DESCRIPTION
Fix nested bullet point indentation in the 'Using Python as glue' documentation page. Nested list items were indented with 4 spaces instead of 2, causing improper rendering in the ctypes/Conclusion section.

Closes #30750