### PR TITLE
ENH: Add debug-only C-level function call tracing

### DIFF
--- a/ctrace_simple.py
+++ b/ctrace_simple.py
@@ -2,40 +2,48 @@
 """
 Simple NumPy C-Level Tracing Example
 
-Shows the complete call tree for a simple ufunc operation.
+Shows the complete call tree for a simple ufunc operation,
+including SIMD-optimized inner loops.
 
 Build: spin build -- -Denable-ctrace=true
 Run:   spin python ctrace_simple.py
 """
 
 import numpy as np
-from numpy._core._ctrace import CTrace, resolve_symbol, is_available
+from numpy._core._ctrace import CTrace, is_available
 
 if not is_available():
     print("Error: Build with -Denable-ctrace=true")
     exit(1)
 
-# Prepare arrays outside tracing
-a = np.array([2**i - 1 for i in range(16)])
+# Show CPU features
+try:
+    from numpy._core._multiarray_umath import __cpu_baseline__
+    print(f"CPU baseline: {__cpu_baseline__}")
+except ImportError:
+    pass
+print()
 
-# Trace np.add
-print("Tracing: np.bitwise_count(a)")
+# Prepare arrays outside tracing - use float64 for SIMD paths
+a = np.arange(5)
+
+# Trace np.sqrt which has SIMD-optimized paths
+print("Tracing: np.bitwise_count(a) - showing SIMD inner loop")
 print("=" * 60)
 
-def trace_callback(func, caller, depth, is_entry):
-    name = resolve_symbol(func) or f"0x{func:x}"
-    # Filter out noisy low-level helpers
-    skip = ["Py_TYPE", "Py_INCREF", "Py_DECREF", "Py_XINCREF", "Py_XDECREF",
-            "_Py_IsImmortal", "_Py_NewRef", "_ZL7Py_TYPE", "_ZL17PyType_Has",
-            "Py_SIZE", "PyType_HasFeature", "Py_IS_TYPE"]
-    if any(s in name for s in skip):
-       return
-    indent = "  " * min(depth, 20)
-    arrow = ">" if is_entry else "<"
-    print(f"{indent}{arrow} {name}")
-
-with CTrace(callback=trace_callback):
+with CTrace() as ct:
     result = np.bitwise_count(a)
 
+# Print the trace using utility methods
+ct.print_trace(show_exit=True)
+
 print("=" * 60)
-print(f"Result: {result}")
+print()
+
+# Print summary and hotspots
+ct.print_summary()
+print()
+ct.print_hotspots(top_n=5)
+
+print()
+print(f"Result[:5]: {result[:5]}")

--- a/ctrace_simple.py
+++ b/ctrace_simple.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Simple NumPy C-Level Tracing Example
+
+Shows the complete call tree for a simple ufunc operation.
+
+Build: spin build -- -Denable-ctrace=true
+Run:   spin python ctrace_simple.py
+"""
+
+import numpy as np
+from numpy._core._ctrace import CTrace, resolve_symbol, is_available
+
+if not is_available():
+    print("Error: Build with -Denable-ctrace=true")
+    exit(1)
+
+# Prepare arrays outside tracing
+a = np.array([2**i - 1 for i in range(16)])
+
+# Trace np.add
+print("Tracing: np.bitwise_count(a)")
+print("=" * 60)
+
+def trace_callback(func, caller, depth, is_entry):
+    name = resolve_symbol(func) or f"0x{func:x}"
+    # Filter out noisy low-level helpers
+    skip = ["Py_TYPE", "Py_INCREF", "Py_DECREF", "Py_XINCREF", "Py_XDECREF",
+            "_Py_IsImmortal", "_Py_NewRef", "_ZL7Py_TYPE", "_ZL17PyType_Has",
+            "Py_SIZE", "PyType_HasFeature", "Py_IS_TYPE"]
+    if any(s in name for s in skip):
+       return
+    indent = "  " * min(depth, 20)
+    arrow = ">" if is_entry else "<"
+    print(f"{indent}{arrow} {name}")
+
+with CTrace(callback=trace_callback):
+    result = np.bitwise_count(a)
+
+print("=" * 60)
+print(f"Result: {result}")

--- a/meson.options
+++ b/meson.options
@@ -51,3 +51,7 @@ option('test-simd', type: 'array',
        description: 'CPU SIMD feature sets to be tested by the NumPy SIMD test module')
 option('test-simd-args', type: 'string', value: '',
        description: 'Extra arguments passed to the internal `_simd` test module')
+
+# Debug / profiling
+option('enable-ctrace', type: 'boolean', value: false,
+       description: 'Enable debug-only C-level function call tracing (requires -finstrument-functions)')

--- a/numpy/_core/_ctrace.py
+++ b/numpy/_core/_ctrace.py
@@ -23,7 +23,7 @@ import contextlib
 import sys
 from typing import Callable, List, Optional
 
-__all__ = ['CTrace', 'is_available', 'enable', 'disable', 'dump_stack']
+__all__ = ['CTrace', 'TraceCollector', 'is_available', 'enable', 'disable', 'dump_stack']
 
 
 def _check_availability():
@@ -203,43 +203,86 @@ class CTrace:
     Context manager for C-level function call tracing.
 
     This class provides a convenient way to enable tracing for a specific
-    block of code.
+    block of code and access the collected traces via utility methods.
 
     Parameters
     ----------
     callback : callable, optional
-        Custom callback for trace events. If not provided, traces are
-        printed to stderr.
+        Custom callback for trace events. If provided, this callback is
+        called for each event AND traces are still collected internally.
     enabled : bool, optional
         Whether to actually enable tracing. Default is True. Set to False
         to create a no-op context manager.
+    max_events : int, optional
+        Maximum number of trace events to collect. Default is 100000.
+    filter_func : callable, optional
+        A function that takes (func_name, depth, is_entry) and returns
+        True to include the event, False to skip it.
 
     Examples
     --------
     >>> import numpy as np
     >>> from numpy._core._ctrace import CTrace
-    >>> with CTrace():
+    >>> with CTrace() as ct:
     ...     arr = np.array([1, 2, 3])
     ...     result = np.sum(arr)
+    >>> ct.print_trace()  # Print the collected trace
 
-    Using a custom callback:
-    >>> traces = []
-    >>> def my_callback(func, caller, depth, is_entry):
-    ...     traces.append((func, depth, is_entry))
-    >>> with CTrace(callback=my_callback):
+    Using filters:
+    >>> with CTrace(filter_func=lambda name, d, e: 'ufunc' in name) as ct:
     ...     np.zeros(10)
-    >>> print(f"Captured {len(traces)} trace events")
+    >>> ct.print_summary()
     """
+
+    # Common noisy symbols to filter out by default
+    DEFAULT_SKIP_PATTERNS = [
+        "Py_TYPE", "Py_INCREF", "Py_DECREF", "Py_XINCREF", "Py_XDECREF",
+        "_Py_IsImmortal", "_Py_NewRef", "_ZL7Py_TYPE", "_ZL17PyType_Has",
+        "Py_SIZE", "PyType_HasFeature", "Py_IS_TYPE", "_ZL9Py_INCREF",
+        "_ZL10Py_IS_TYPE", "_ZL9Py_DECREF", "_ZL10Py_XDECREF"
+    ]
 
     def __init__(
         self,
         callback: Optional[Callable[[int, int, int, bool], None]] = None,
-        enabled: bool = True
+        enabled: bool = True,
+        max_events: int = 100000,
+        filter_func: Optional[Callable[[str, int, bool], bool]] = None
     ):
-        self._callback = callback
+        self._user_callback = callback
         self._enabled = enabled and is_available()
         self._was_enabled = False
-        self._traces: List[tuple] = []
+        self._max_events = max_events
+        self._filter_func = filter_func
+        self._events: List[tuple] = []  # (func_addr, caller_addr, depth, is_entry, func_name)
+        self._max_depth = 0
+        self._symbol_cache: dict = {}
+
+    def _resolve_cached(self, addr: int) -> str:
+        """Resolve symbol with caching."""
+        if addr not in self._symbol_cache:
+            name = resolve_symbol(addr)
+            self._symbol_cache[addr] = name if name else f"0x{addr:x}"
+        return self._symbol_cache[addr]
+
+    def _internal_callback(self, func: int, caller: int, depth: int, is_entry: bool) -> None:
+        """Internal callback that collects traces."""
+        func_name = self._resolve_cached(func)
+
+        # Apply filter if provided
+        if self._filter_func is not None:
+            if not self._filter_func(func_name, depth, is_entry):
+                return
+
+        # Collect event
+        if len(self._events) < self._max_events:
+            self._events.append((func, caller, depth, is_entry, func_name))
+            if depth > self._max_depth:
+                self._max_depth = depth
+
+        # Call user callback if provided
+        if self._user_callback is not None:
+            self._user_callback(func, caller, depth, is_entry)
 
     def __enter__(self) -> 'CTrace':
         if not self._enabled:
@@ -247,12 +290,16 @@ class CTrace:
 
         impl = _get_impl()
 
+        # Clear previous data
+        self._events.clear()
+        self._max_depth = 0
+        self._symbol_cache.clear()
+
         # Save previous state
         self._was_enabled = impl.is_enabled()
 
-        # Set callback if provided
-        if self._callback is not None:
-            impl.set_callback(self._callback)
+        # Set our internal callback
+        impl.set_callback(self._internal_callback)
 
         # Enable tracing
         impl.enable()
@@ -270,8 +317,22 @@ class CTrace:
             impl.disable()
 
         # Reset callback to default
-        if self._callback is not None:
-            impl.set_callback(None)
+        impl.set_callback(None)
+
+    @property
+    def events(self) -> List[tuple]:
+        """List of (func_addr, caller_addr, depth, is_entry, func_name) tuples."""
+        return self._events
+
+    @property
+    def max_depth(self) -> int:
+        """Maximum call depth observed."""
+        return self._max_depth
+
+    @property
+    def event_count(self) -> int:
+        """Number of trace events collected."""
+        return len(self._events)
 
     def snapshot(self, max_size: int = 100) -> List[int]:
         """Take a snapshot of the current call stack."""
@@ -284,58 +345,97 @@ class CTrace:
         if self._enabled:
             dump_stack()
 
+    def print_trace(
+        self,
+        file=None,
+        max_depth: Optional[int] = None,
+        skip_patterns: Optional[List[str]] = None,
+        show_exit: bool = True
+    ) -> None:
+        """
+        Print the collected trace as an indented call tree.
 
-class TraceCollector:
-    """
-    A trace collector that stores all trace events.
+        Parameters
+        ----------
+        file : file-like, optional
+            Output file. Defaults to sys.stdout.
+        max_depth : int, optional
+            Maximum depth to print. None means no limit.
+        skip_patterns : list of str, optional
+            List of substrings to filter out. If None, uses DEFAULT_SKIP_PATTERNS.
+            Pass empty list [] to disable filtering.
+        show_exit : bool, optional
+            Whether to show function exit events. Default is True.
+        """
+        if file is None:
+            file = sys.stdout
 
-    This is useful for post-hoc analysis of execution paths.
+        if skip_patterns is None:
+            skip_patterns = self.DEFAULT_SKIP_PATTERNS
 
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from numpy._core._ctrace import TraceCollector
-    >>> collector = TraceCollector()
-    >>> with collector:
-    ...     np.zeros(10)
-    >>> print(f"Max depth: {collector.max_depth}")
-    >>> for event in collector.events[:5]:
-    ...     print(event)
-    """
+        for func, caller, depth, is_entry, func_name in self._events:
+            # Apply skip patterns
+            if skip_patterns and any(s in func_name for s in skip_patterns):
+                continue
 
-    def __init__(self, max_events: int = 100000):
-        self._max_events = max_events
-        self._events: List[tuple] = []
-        self._max_depth = 0
-        self._ctrace: Optional[CTrace] = None
+            # Apply max depth filter
+            if max_depth is not None and depth > max_depth:
+                continue
 
-    def _callback(self, func: int, caller: int, depth: int, is_entry: bool) -> None:
-        if len(self._events) < self._max_events:
-            self._events.append((func, caller, depth, is_entry))
-            if depth > self._max_depth:
-                self._max_depth = depth
+            # Skip exit events if requested
+            if not show_exit and not is_entry:
+                continue
 
-    def __enter__(self) -> 'TraceCollector':
-        self._events.clear()
-        self._max_depth = 0
-        self._ctrace = CTrace(callback=self._callback)
-        self._ctrace.__enter__()
-        return self
+            indent = "  " * min(depth, 40)
+            arrow = ">" if is_entry else "<"
+            print(f"{indent}{arrow} {func_name}", file=file)
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        if self._ctrace:
-            self._ctrace.__exit__(exc_type, exc_val, exc_tb)
-            self._ctrace = None
+    def print_summary(self, file=None) -> None:
+        """
+        Print a summary of the collected traces.
 
-    @property
-    def events(self) -> List[tuple]:
-        """List of (func_addr, caller_addr, depth, is_entry) tuples."""
-        return self._events
+        Parameters
+        ----------
+        file : file-like, optional
+            Output file. Defaults to sys.stdout.
+        """
+        if file is None:
+            file = sys.stdout
 
-    @property
-    def max_depth(self) -> int:
-        """Maximum call depth observed."""
-        return self._max_depth
+        print(f"Trace Summary:", file=file)
+        print(f"  Total events: {len(self._events)}", file=file)
+        print(f"  Max depth: {self._max_depth}", file=file)
+
+        # Count unique functions
+        funcs = set(e[4] for e in self._events)  # func_name is at index 4
+        print(f"  Unique functions: {len(funcs)}", file=file)
+
+    def print_hotspots(self, top_n: int = 10, file=None) -> None:
+        """
+        Print the most frequently called functions.
+
+        Parameters
+        ----------
+        top_n : int, optional
+            Number of top functions to show. Default is 10.
+        file : file-like, optional
+            Output file. Defaults to sys.stdout.
+        """
+        if file is None:
+            file = sys.stdout
+
+        # Count entry events per function
+        counts: dict = {}
+        for func, caller, depth, is_entry, func_name in self._events:
+            if is_entry:
+                counts[func_name] = counts.get(func_name, 0) + 1
+
+        # Sort by count
+        sorted_funcs = sorted(counts.items(), key=lambda x: x[1], reverse=True)
+
+        print(f"Top {top_n} hotspots:", file=file)
+        for i, (name, count) in enumerate(sorted_funcs[:top_n], 1):
+            print(f"  {i:2d}. {count:6d} calls: {name}", file=file)
 
     def get_call_tree(self) -> dict:
         """
@@ -344,39 +444,49 @@ class TraceCollector:
         Returns
         -------
         dict
-            Nested dictionary representing the call tree.
+            Nested dictionary representing the call tree with keys:
+            'name', 'children', 'count'.
         """
-        root: dict = {'children': {}, 'count': 0}
+        root: dict = {'name': 'root', 'children': {}, 'count': 0}
         stack = [root]
 
-        for func, caller, depth, is_entry in self._events:
+        for func, caller, depth, is_entry, func_name in self._events:
             if is_entry:
                 # Ensure stack matches depth
                 while len(stack) > depth + 1:
                     stack.pop()
 
                 parent = stack[-1]
-                if func not in parent['children']:
-                    parent['children'][func] = {'children': {}, 'count': 0}
-                parent['children'][func]['count'] += 1
-                stack.append(parent['children'][func])
+                if func_name not in parent['children']:
+                    parent['children'][func_name] = {
+                        'name': func_name,
+                        'children': {},
+                        'count': 0
+                    }
+                parent['children'][func_name]['count'] += 1
+                stack.append(parent['children'][func_name])
             else:
                 if len(stack) > 1:
                     stack.pop()
 
         return root
 
-    def print_summary(self, file=None) -> None:
-        """Print a summary of the collected traces."""
-        if file is None:
-            file = sys.stderr
+    def get_flat_profile(self) -> List[tuple]:
+        """
+        Get a flat profile of function call counts.
 
-        print(f"Trace Summary:", file=file)
-        print(f"  Total events: {len(self._events)}", file=file)
-        print(f"  Max depth: {self._max_depth}", file=file)
+        Returns
+        -------
+        list of tuple
+            List of (func_name, call_count) sorted by count descending.
+        """
+        counts: dict = {}
+        for func, caller, depth, is_entry, func_name in self._events:
+            if is_entry:
+                counts[func_name] = counts.get(func_name, 0) + 1
 
-        # Count unique functions
-        funcs = set()
-        for func, caller, depth, is_entry in self._events:
-            funcs.add(func)
-        print(f"  Unique functions: {len(funcs)}", file=file)
+        return sorted(counts.items(), key=lambda x: x[1], reverse=True)
+
+
+# TraceCollector is now deprecated - use CTrace directly which has all the same functionality
+TraceCollector = CTrace  # Alias for backward compatibility

--- a/numpy/_core/_ctrace.py
+++ b/numpy/_core/_ctrace.py
@@ -1,0 +1,382 @@
+"""
+NumPy Debug-only C-Level Function Call Tracing - Python Interface
+
+This module provides a Python interface to the debug-only C-level function
+call tracing mechanism. It is only functional when NumPy is built with
+NUMPY_DEBUG_CTRACE defined.
+
+See numpy/prof.md for the full design document.
+
+Example usage:
+    >>> from numpy._core._ctrace import CTrace
+    >>> with CTrace() as tracer:
+    ...     # NumPy operations here will be traced
+    ...     arr = np.array([1, 2, 3])
+    ...     result = np.sum(arr)
+    >>> tracer.dump_stack()  # Print the call stack
+
+Note: This module is for debugging purposes only and is not part of the
+public NumPy API.
+"""
+
+import contextlib
+import sys
+from typing import Callable, List, Optional
+
+__all__ = ['CTrace', 'is_available', 'enable', 'disable', 'dump_stack']
+
+
+def _check_availability():
+    """Check if C-level tracing is available in this build."""
+    try:
+        from numpy._core import _ctrace_impl
+        return hasattr(_ctrace_impl, 'enable')
+    except ImportError:
+        return False
+
+
+_AVAILABLE = None
+
+
+def is_available() -> bool:
+    """
+    Check if C-level tracing is available.
+
+    Returns
+    -------
+    bool
+        True if tracing is available (NumPy built with NUMPY_DEBUG_CTRACE),
+        False otherwise.
+    """
+    global _AVAILABLE
+    if _AVAILABLE is None:
+        _AVAILABLE = _check_availability()
+    return _AVAILABLE
+
+
+def _get_impl():
+    """Get the implementation module, raising if unavailable."""
+    if not is_available():
+        raise RuntimeError(
+            "C-level tracing is not available. "
+            "NumPy must be built with NUMPY_DEBUG_CTRACE defined. "
+            "See numpy/prof.md for details."
+        )
+    from numpy._core import _ctrace_impl
+    return _ctrace_impl
+
+
+def enable() -> None:
+    """
+    Enable C-level tracing for the current thread.
+
+    Raises
+    ------
+    RuntimeError
+        If tracing is not available in this build.
+    """
+    _get_impl().enable()
+
+
+def disable() -> None:
+    """
+    Disable C-level tracing for the current thread.
+
+    Raises
+    ------
+    RuntimeError
+        If tracing is not available in this build.
+    """
+    _get_impl().disable()
+
+
+def is_enabled() -> bool:
+    """
+    Check if tracing is currently enabled for this thread.
+
+    Returns
+    -------
+    bool
+        True if tracing is enabled, False otherwise.
+
+    Raises
+    ------
+    RuntimeError
+        If tracing is not available in this build.
+    """
+    return _get_impl().is_enabled()
+
+
+def get_depth() -> int:
+    """
+    Get the current call stack depth.
+
+    Returns
+    -------
+    int
+        Current nesting depth (0 if at top level).
+
+    Raises
+    ------
+    RuntimeError
+        If tracing is not available in this build.
+    """
+    return _get_impl().get_depth()
+
+
+def snapshot(max_size: int = 100) -> List[int]:
+    """
+    Snapshot the current C call stack.
+
+    Parameters
+    ----------
+    max_size : int, optional
+        Maximum number of stack frames to capture. Default is 100.
+
+    Returns
+    -------
+    list of int
+        List of function addresses (as integers) from top to bottom.
+
+    Raises
+    ------
+    RuntimeError
+        If tracing is not available in this build.
+    """
+    return _get_impl().snapshot(max_size)
+
+
+def resolve_symbol(addr: int) -> Optional[str]:
+    """
+    Resolve a function address to a symbol name.
+
+    Parameters
+    ----------
+    addr : int
+        Function address to resolve.
+
+    Returns
+    -------
+    str or None
+        Symbol name if resolution succeeded, None otherwise.
+
+    Raises
+    ------
+    RuntimeError
+        If tracing is not available in this build.
+    """
+    return _get_impl().resolve_symbol(addr)
+
+
+def dump_stack() -> None:
+    """
+    Dump the current C call stack to stderr.
+
+    Raises
+    ------
+    RuntimeError
+        If tracing is not available in this build.
+    """
+    _get_impl().dump_stack()
+
+
+def set_callback(callback: Optional[Callable[[int, int, int, bool], None]]) -> None:
+    """
+    Set a custom callback for trace events.
+
+    Parameters
+    ----------
+    callback : callable or None
+        A function with signature (func_addr, caller_addr, depth, is_entry).
+        If None, the default callback (print to stderr) is used.
+
+    Raises
+    ------
+    RuntimeError
+        If tracing is not available in this build.
+    """
+    _get_impl().set_callback(callback)
+
+
+class CTrace:
+    """
+    Context manager for C-level function call tracing.
+
+    This class provides a convenient way to enable tracing for a specific
+    block of code.
+
+    Parameters
+    ----------
+    callback : callable, optional
+        Custom callback for trace events. If not provided, traces are
+        printed to stderr.
+    enabled : bool, optional
+        Whether to actually enable tracing. Default is True. Set to False
+        to create a no-op context manager.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from numpy._core._ctrace import CTrace
+    >>> with CTrace():
+    ...     arr = np.array([1, 2, 3])
+    ...     result = np.sum(arr)
+
+    Using a custom callback:
+    >>> traces = []
+    >>> def my_callback(func, caller, depth, is_entry):
+    ...     traces.append((func, depth, is_entry))
+    >>> with CTrace(callback=my_callback):
+    ...     np.zeros(10)
+    >>> print(f"Captured {len(traces)} trace events")
+    """
+
+    def __init__(
+        self,
+        callback: Optional[Callable[[int, int, int, bool], None]] = None,
+        enabled: bool = True
+    ):
+        self._callback = callback
+        self._enabled = enabled and is_available()
+        self._was_enabled = False
+        self._traces: List[tuple] = []
+
+    def __enter__(self) -> 'CTrace':
+        if not self._enabled:
+            return self
+
+        impl = _get_impl()
+
+        # Save previous state
+        self._was_enabled = impl.is_enabled()
+
+        # Set callback if provided
+        if self._callback is not None:
+            impl.set_callback(self._callback)
+
+        # Enable tracing
+        impl.enable()
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if not self._enabled:
+            return
+
+        impl = _get_impl()
+
+        # Restore previous state
+        if not self._was_enabled:
+            impl.disable()
+
+        # Reset callback to default
+        if self._callback is not None:
+            impl.set_callback(None)
+
+    def snapshot(self, max_size: int = 100) -> List[int]:
+        """Take a snapshot of the current call stack."""
+        if not self._enabled:
+            return []
+        return snapshot(max_size)
+
+    def dump_stack(self) -> None:
+        """Dump the current call stack to stderr."""
+        if self._enabled:
+            dump_stack()
+
+
+class TraceCollector:
+    """
+    A trace collector that stores all trace events.
+
+    This is useful for post-hoc analysis of execution paths.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from numpy._core._ctrace import TraceCollector
+    >>> collector = TraceCollector()
+    >>> with collector:
+    ...     np.zeros(10)
+    >>> print(f"Max depth: {collector.max_depth}")
+    >>> for event in collector.events[:5]:
+    ...     print(event)
+    """
+
+    def __init__(self, max_events: int = 100000):
+        self._max_events = max_events
+        self._events: List[tuple] = []
+        self._max_depth = 0
+        self._ctrace: Optional[CTrace] = None
+
+    def _callback(self, func: int, caller: int, depth: int, is_entry: bool) -> None:
+        if len(self._events) < self._max_events:
+            self._events.append((func, caller, depth, is_entry))
+            if depth > self._max_depth:
+                self._max_depth = depth
+
+    def __enter__(self) -> 'TraceCollector':
+        self._events.clear()
+        self._max_depth = 0
+        self._ctrace = CTrace(callback=self._callback)
+        self._ctrace.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._ctrace:
+            self._ctrace.__exit__(exc_type, exc_val, exc_tb)
+            self._ctrace = None
+
+    @property
+    def events(self) -> List[tuple]:
+        """List of (func_addr, caller_addr, depth, is_entry) tuples."""
+        return self._events
+
+    @property
+    def max_depth(self) -> int:
+        """Maximum call depth observed."""
+        return self._max_depth
+
+    def get_call_tree(self) -> dict:
+        """
+        Build a call tree from the collected events.
+
+        Returns
+        -------
+        dict
+            Nested dictionary representing the call tree.
+        """
+        root: dict = {'children': {}, 'count': 0}
+        stack = [root]
+
+        for func, caller, depth, is_entry in self._events:
+            if is_entry:
+                # Ensure stack matches depth
+                while len(stack) > depth + 1:
+                    stack.pop()
+
+                parent = stack[-1]
+                if func not in parent['children']:
+                    parent['children'][func] = {'children': {}, 'count': 0}
+                parent['children'][func]['count'] += 1
+                stack.append(parent['children'][func])
+            else:
+                if len(stack) > 1:
+                    stack.pop()
+
+        return root
+
+    def print_summary(self, file=None) -> None:
+        """Print a summary of the collected traces."""
+        if file is None:
+            file = sys.stderr
+
+        print(f"Trace Summary:", file=file)
+        print(f"  Total events: {len(self._events)}", file=file)
+        print(f"  Max depth: {self._max_depth}", file=file)
+
+        # Count unique functions
+        funcs = set()
+        for func, caller, depth, is_entry in self._events:
+            funcs.add(func)
+        print(f"  Unique functions: {len(funcs)}", file=file)

--- a/numpy/_core/config.h.in
+++ b/numpy/_core/config.h.in
@@ -110,6 +110,9 @@
 
 #mesondefine HAVE_EXTERNAL_LAPACK
 
+/* Debug-only C-level function call tracing */
+#mesondefine NUMPY_DEBUG_CTRACE
+
 #ifndef __cplusplus
 /* #undef inline */
 #endif

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -864,8 +864,8 @@ foreach gen_mtargets : [
     baseline: CPU_BASELINE,
     prefix: 'NPY_',
     dependencies: [py_dep, np_core_dep],
-    c_args: c_args_common + max_opt,
-    cpp_args: cpp_args_common + max_opt,
+    c_args: c_args_common + max_opt + ctrace_instrument_args,
+    cpp_args: cpp_args_common + max_opt + ctrace_instrument_args,
     include_directories: [
       'include',
       'src/common',
@@ -926,8 +926,8 @@ foreach gen_mtargets : [
     # baseline: CPU_BASELINE, it doesn't provide baseline fallback
     prefix: 'NPY_',
     dependencies: [py_dep, np_core_dep, omp_dep],
-    c_args: c_args_common + max_opt,
-    cpp_args: cpp_args_common + max_opt,
+    c_args: c_args_common + max_opt + ctrace_instrument_args,
+    cpp_args: cpp_args_common + max_opt + ctrace_instrument_args,
     include_directories: [
       'include',
       'src/common',
@@ -1117,8 +1117,8 @@ foreach gen_mtargets : [
     baseline: CPU_BASELINE,
     prefix: 'NPY_',
     dependencies: [py_dep, np_core_dep],
-    c_args: c_args_common + max_opt,
-    cpp_args: cpp_args_common + max_opt,
+    c_args: c_args_common + max_opt + ctrace_instrument_args,
+    cpp_args: cpp_args_common + max_opt + ctrace_instrument_args,
     include_directories: [
       'include',
       'src/common',

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -137,6 +137,16 @@ endif
 
 use_openmp = get_option('enable-openmp') and not get_option('disable-threading')
 
+# C-level tracing (debug builds only)
+use_ctrace = get_option('enable-ctrace')
+if use_ctrace
+  if get_option('buildtype') != 'debug'
+    warning('C-level tracing is intended for debug builds only. ' +
+            'Performance will be severely impacted.')
+  endif
+  cdata.set10('NUMPY_DEBUG_CTRACE', true)
+endif
+
 # Setup openmp flags for x86-simd-sort:
 omp = []
 omp_dep = []
@@ -746,6 +756,52 @@ py.extension_module('_multiarray_tests',
   install_tag: 'tests'
 )
 
+# Build ctrace module (debug tracing)
+# ------------------------------------
+# The ctrace implementation is split into two parts:
+# 1. npy_ctrace.c - The main implementation, compiled into _ctrace_impl
+# 2. npy_ctrace_hooks.c - Thin hooks compiled into _multiarray_umath that
+#    forward to the main implementation via dlsym
+#
+# This separation is necessary because:
+# - The hooks must NOT be compiled with -finstrument-functions (infinite recursion)
+# - The main implementation needs its own thread-local state
+# - The instrumented code (_multiarray_umath) needs to call the hooks
+ctrace_instrument_args = []
+ctrace_hooks_lib = []
+ctrace_lib = []
+if use_ctrace
+  ctrace_instrument_args = ['-finstrument-functions', '-fno-inline', '-fno-inline-functions']
+  # Hooks library - compiled WITHOUT instrumentation to avoid recursion
+  ctrace_hooks_lib = static_library('npyctrace_hooks',
+    'src/common/npy_ctrace_hooks.c',
+    c_args: c_args_common,  # No instrumentation!
+    include_directories: ['src/common'],
+    dependencies: [py_dep, np_core_dep],
+    install: false,
+  )
+  # Main ctrace library for _ctrace_impl
+  ctrace_lib = static_library('npyctrace',
+    'src/common/npy_ctrace.c',
+    c_args: c_args_common,  # No instrumentation!
+    include_directories: ['src/common'],
+    dependencies: [py_dep, np_core_dep],
+    install: false,
+    gnu_symbol_visibility: 'default',
+  )
+endif
+
+py.extension_module('_ctrace_impl',
+  ['src/multiarray/_ctrace_impl.c'],
+  c_args: c_args_common,  # No instrumentation flags here!
+  include_directories: ['src/common'],
+  dependencies: [py_dep, np_core_dep],
+  link_with: ctrace_lib,
+  gnu_symbol_visibility: 'default',
+  install: true,
+  subdir: 'numpy/_core',
+)
+
 _umath_tests_mtargets = mod_features.multi_targets(
   '_umath_tests.dispatch.h',
   'src/umath/_umath_tests.dispatch.c',
@@ -1278,8 +1334,8 @@ py.extension_module('_multiarray_umath',
     npy_math_internal_h,
   ],
   objects: svml_objects,
-  c_args: c_args_common,
-  cpp_args: cpp_args_common,
+  c_args: c_args_common + ctrace_instrument_args,
+  cpp_args: cpp_args_common + ctrace_instrument_args,
   include_directories: [
     'include',
     'src/common',
@@ -1293,7 +1349,7 @@ py.extension_module('_multiarray_umath',
     npymath_lib,
     unique_hash_so,
     multiarray_umath_mtargets.static_lib('_multiarray_umath_mtargets')
-  ] + highway_lib,
+  ] + highway_lib + ctrace_hooks_lib,
   install: true,
   subdir: 'numpy/_core',
 )
@@ -1361,6 +1417,7 @@ python_sources = [
   '_add_newdocs_scalars.pyi',
   '_asarray.py',
   '_asarray.pyi',
+  '_ctrace.py',
   '_dtype.py',
   '_dtype.pyi',
   '_dtype_ctypes.py',

--- a/numpy/_core/src/common/npy_ctrace.c
+++ b/numpy/_core/src/common/npy_ctrace.c
@@ -1,0 +1,370 @@
+/*
+ * NumPy Debug-only C-Level Function Call Tracing - Implementation
+ *
+ * This file implements the debug-only C-level function call tracing mechanism
+ * described in numpy/prof.md.
+ *
+ * Key features:
+ * - Thread-local call stacks using _Thread_local
+ * - Fixed-size memory pools to avoid heap allocation in hot paths
+ * - Compiler instrumentation hooks (__cyg_profile_func_enter/exit)
+ * - Optional symbol resolution via dladdr()
+ *
+ * Build requirements:
+ * - Compile with -finstrument-functions
+ * - Define NUMPY_DEBUG_CTRACE
+ * - Use -O0 -g3 -fno-inline for best results
+ */
+
+#include "npy_config.h"
+
+#ifdef NUMPY_DEBUG_CTRACE
+
+#include "npy_ctrace.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Platform-specific includes for symbol resolution */
+#ifdef HAVE_DLFCN_H
+#include <dlfcn.h>
+#endif
+
+/*
+ * Thread-local storage for the call stack.
+ * We use a fixed-size pool to avoid malloc in the instrumentation hooks.
+ */
+typedef struct {
+    npy_trace_node_t pool[NPY_CTRACE_MAX_DEPTH];
+    npy_trace_node_t *head;      /* Top of the call stack */
+    npy_trace_node_t *free_list; /* Free nodes for reuse */
+    uint32_t depth;              /* Current stack depth */
+    int enabled;                 /* Tracing enabled flag */
+    int initialized;             /* Pool initialized flag */
+} npy_ctrace_tls_t;
+
+/* Check for thread-local storage support */
+#if defined(HAVE_THREAD_LOCAL)
+    #define NPY_TLS thread_local
+#elif defined(HAVE__THREAD_LOCAL)
+    #define NPY_TLS _Thread_local
+#elif defined(HAVE__THREAD)
+    #define NPY_TLS __thread
+#elif defined(HAVE___DECLSPEC_THREAD_)
+    #define NPY_TLS __declspec(thread)
+#elif defined(__GNUC__) || defined(__clang__)
+    #define NPY_TLS __thread
+#elif defined(_MSC_VER)
+    #define NPY_TLS __declspec(thread)
+#else
+    #error "No thread-local storage support detected"
+#endif
+
+/* Thread-local state */
+static NPY_TLS npy_ctrace_tls_t tls_state = {0};
+
+/* Global callback (shared across threads) */
+static npy_ctrace_callback_t g_callback = NULL;
+
+/* Global initialization flag */
+static int g_initialized = 0;
+
+/*
+ * Initialize the thread-local pool.
+ * Sets up the free list by linking all nodes.
+ */
+__attribute__((no_instrument_function))
+static void
+init_tls_pool(void)
+{
+    if (tls_state.initialized) {
+        return;
+    }
+
+    /* Link all nodes into the free list */
+    for (size_t i = 0; i < NPY_CTRACE_MAX_DEPTH - 1; i++) {
+        tls_state.pool[i].next = &tls_state.pool[i + 1];
+        tls_state.pool[i].prev = NULL;
+    }
+    tls_state.pool[NPY_CTRACE_MAX_DEPTH - 1].next = NULL;
+    tls_state.pool[NPY_CTRACE_MAX_DEPTH - 1].prev = NULL;
+
+    tls_state.free_list = &tls_state.pool[0];
+    tls_state.head = NULL;
+    tls_state.depth = 0;
+    tls_state.enabled = 0;
+    tls_state.initialized = 1;
+}
+
+/*
+ * Allocate a node from the free list.
+ * Returns NULL if the pool is exhausted.
+ */
+__attribute__((no_instrument_function))
+static npy_trace_node_t *
+alloc_node(void)
+{
+    if (!tls_state.free_list) {
+        return NULL;  /* Pool exhausted */
+    }
+
+    npy_trace_node_t *node = tls_state.free_list;
+    tls_state.free_list = node->next;
+    node->next = NULL;
+    node->prev = NULL;
+    return node;
+}
+
+/*
+ * Return a node to the free list.
+ */
+__attribute__((no_instrument_function))
+static void
+free_node(npy_trace_node_t *node)
+{
+    if (!node) {
+        return;
+    }
+    node->next = tls_state.free_list;
+    node->prev = NULL;
+    tls_state.free_list = node;
+}
+
+/*
+ * Default callback: prints entry/exit to stderr.
+ */
+__attribute__((no_instrument_function))
+static void
+default_callback(void *func, void *caller, uint32_t depth, int is_entry)
+{
+    /* Indent based on depth */
+    for (uint32_t i = 0; i < depth; i++) {
+        fprintf(stderr, "  ");
+    }
+
+    if (is_entry) {
+        fprintf(stderr, "-> %p (from %p)\n", func, caller);
+    }
+    else {
+        fprintf(stderr, "<- %p\n", func);
+    }
+}
+
+/* Public API implementation */
+
+__attribute__((no_instrument_function))
+void
+npy_ctrace_init(void)
+{
+    if (g_initialized) {
+        return;
+    }
+    g_callback = default_callback;
+    g_initialized = 1;
+}
+
+__attribute__((no_instrument_function))
+void
+npy_ctrace_shutdown(void)
+{
+    g_initialized = 0;
+    g_callback = NULL;
+}
+
+__attribute__((no_instrument_function))
+void
+npy_ctrace_enable(void)
+{
+    init_tls_pool();
+    tls_state.enabled = 1;
+}
+
+__attribute__((no_instrument_function))
+void
+npy_ctrace_disable(void)
+{
+    tls_state.enabled = 0;
+}
+
+__attribute__((no_instrument_function))
+int
+npy_ctrace_is_enabled(void)
+{
+    return tls_state.enabled;
+}
+
+__attribute__((no_instrument_function))
+void
+npy_ctrace_set_callback(npy_ctrace_callback_t callback)
+{
+    g_callback = callback ? callback : default_callback;
+}
+
+__attribute__((no_instrument_function))
+uint32_t
+npy_ctrace_get_depth(void)
+{
+    return tls_state.depth;
+}
+
+__attribute__((no_instrument_function))
+size_t
+npy_ctrace_snapshot(void **buffer, size_t max_size)
+{
+    if (!buffer || max_size == 0) {
+        return 0;
+    }
+
+    size_t count = 0;
+    npy_trace_node_t *node = tls_state.head;
+
+    while (node && count < max_size) {
+        buffer[count++] = node->func;
+        node = node->prev;
+    }
+
+    return count;
+}
+
+__attribute__((no_instrument_function))
+const char *
+npy_ctrace_resolve_symbol(void *addr, char *buf, size_t size)
+{
+    if (!addr || !buf || size == 0) {
+        return NULL;
+    }
+
+#ifdef HAVE_DLFCN_H
+    Dl_info info;
+    if (dladdr(addr, &info) && info.dli_sname) {
+        strncpy(buf, info.dli_sname, size - 1);
+        buf[size - 1] = '\0';
+        return buf;
+    }
+#endif
+
+    /* Fallback: just format the address */
+    snprintf(buf, size, "%p", addr);
+    return buf;
+}
+
+__attribute__((no_instrument_function))
+void
+npy_ctrace_dump_stack(void)
+{
+    char symbol_buf[256];
+
+    fprintf(stderr, "=== NumPy C Call Stack (depth=%u) ===\n", tls_state.depth);
+
+    npy_trace_node_t *node = tls_state.head;
+    uint32_t frame = 0;
+
+    while (node) {
+        const char *symbol = npy_ctrace_resolve_symbol(
+            node->func, symbol_buf, sizeof(symbol_buf));
+
+        fprintf(stderr, "#%u: %s (%p)\n", frame, symbol ? symbol : "???",
+                node->func);
+
+        node = node->prev;
+        frame++;
+    }
+
+    fprintf(stderr, "=== End Stack ===\n");
+}
+
+/*
+ * Compiler instrumentation hooks.
+ * These are called automatically by the compiler when -finstrument-functions
+ * is enabled. They must always be defined and exported so that instrumented
+ * code can link against them.
+ */
+
+void
+__cyg_profile_func_enter(void *func, void *caller)
+{
+    /* Skip if not initialized or not enabled */
+    if (!tls_state.initialized || !tls_state.enabled) {
+        return;
+    }
+
+    /* Allocate a node for this call */
+    npy_trace_node_t *node = alloc_node();
+    if (!node) {
+        /* Pool exhausted, silently drop */
+        return;
+    }
+
+    /* Fill in the node */
+    node->func = func;
+    node->caller = caller;
+    node->depth = tls_state.depth;
+
+    /* Push onto the stack */
+    node->prev = tls_state.head;
+    if (tls_state.head) {
+        tls_state.head->next = node;
+    }
+    tls_state.head = node;
+    tls_state.depth++;
+
+    /* Invoke callback */
+    if (g_callback) {
+        g_callback(func, caller, node->depth, 1);
+    }
+}
+
+void
+__cyg_profile_func_exit(void *func, void *caller)
+{
+    /* Skip if not initialized or not enabled */
+    if (!tls_state.initialized || !tls_state.enabled) {
+        return;
+    }
+
+    /* Pop from the stack */
+    npy_trace_node_t *node = tls_state.head;
+    if (!node) {
+        /* Stack underflow - shouldn't happen */
+        return;
+    }
+
+    /* Invoke callback before popping */
+    if (g_callback) {
+        g_callback(func, caller, node->depth, 0);
+    }
+
+    /* Update head */
+    tls_state.head = node->prev;
+    if (tls_state.head) {
+        tls_state.head->next = NULL;
+    }
+
+    /* Return node to free list */
+    free_node(node);
+
+    if (tls_state.depth > 0) {
+        tls_state.depth--;
+    }
+}
+
+/*
+ * Exported hook entry points for use by other modules.
+ * These are called by instrumented code in other shared libraries.
+ */
+__attribute__((visibility("default")))
+void
+npy_ctrace_hook_enter(void *func, void *caller)
+{
+    __cyg_profile_func_enter(func, caller);
+}
+
+__attribute__((visibility("default")))
+void
+npy_ctrace_hook_exit(void *func, void *caller)
+{
+    __cyg_profile_func_exit(func, caller);
+}
+
+#endif /* NUMPY_DEBUG_CTRACE */

--- a/numpy/_core/src/common/npy_ctrace.h
+++ b/numpy/_core/src/common/npy_ctrace.h
@@ -1,0 +1,167 @@
+/*
+ * NumPy Debug-only C-Level Function Call Tracing
+ *
+ * This header provides a debug-only mechanism to trace C-level function calls
+ * and call nesting executed during NumPy operations. It uses compiler-inserted
+ * function instrumentation via -finstrument-functions.
+ *
+ * This feature is ONLY enabled when NUMPY_DEBUG_CTRACE is defined.
+ * It is NOT intended for production use.
+ *
+ * See numpy/prof.md for the full design document.
+ */
+
+#ifndef NUMPY_CORE_SRC_COMMON_NPY_CTRACE_H_
+#define NUMPY_CORE_SRC_COMMON_NPY_CTRACE_H_
+
+#include "npy_config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef NUMPY_DEBUG_CTRACE
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Maximum depth of the call stack trace.
+ * Calls beyond this depth will be silently dropped.
+ */
+#ifndef NPY_CTRACE_MAX_DEPTH
+#define NPY_CTRACE_MAX_DEPTH 4096
+#endif
+
+/*
+ * Trace node structure for the thread-local call stack.
+ * Implemented as a doubly linked list for efficient push/pop.
+ */
+typedef struct npy_trace_node {
+    void *func;                     /* Function address */
+    void *caller;                   /* Caller address */
+    struct npy_trace_node *prev;    /* Previous node in stack */
+    struct npy_trace_node *next;    /* Next node (for free list) */
+    uint32_t depth;                 /* Current nesting depth */
+} npy_trace_node_t;
+
+/*
+ * Trace output callback type.
+ * Called on function entry/exit when tracing is enabled.
+ *
+ * Parameters:
+ *   func   - Address of the function being entered/exited
+ *   caller - Address of the calling function
+ *   depth  - Current nesting depth
+ *   is_entry - 1 for entry, 0 for exit
+ */
+typedef void (*npy_ctrace_callback_t)(void *func, void *caller,
+                                       uint32_t depth, int is_entry);
+
+/*
+ * Initialize the tracing subsystem.
+ * Must be called before any tracing operations.
+ * Thread-safe: can be called multiple times.
+ */
+__attribute__((no_instrument_function))
+void npy_ctrace_init(void);
+
+/*
+ * Shutdown the tracing subsystem and free resources.
+ * Thread-safe.
+ */
+__attribute__((no_instrument_function))
+void npy_ctrace_shutdown(void);
+
+/*
+ * Enable tracing for the current thread.
+ * Tracing is disabled by default.
+ */
+__attribute__((no_instrument_function))
+void npy_ctrace_enable(void);
+
+/*
+ * Disable tracing for the current thread.
+ */
+__attribute__((no_instrument_function))
+void npy_ctrace_disable(void);
+
+/*
+ * Check if tracing is enabled for the current thread.
+ * Returns: 1 if enabled, 0 if disabled
+ */
+__attribute__((no_instrument_function))
+int npy_ctrace_is_enabled(void);
+
+/*
+ * Set the trace output callback.
+ * If NULL, a default callback that prints to stderr is used.
+ *
+ * Parameters:
+ *   callback - The callback function, or NULL for default
+ */
+__attribute__((no_instrument_function))
+void npy_ctrace_set_callback(npy_ctrace_callback_t callback);
+
+/*
+ * Get the current call stack depth for this thread.
+ * Returns: Current depth (0 if at top level)
+ */
+__attribute__((no_instrument_function))
+uint32_t npy_ctrace_get_depth(void);
+
+/*
+ * Snapshot the current call stack.
+ * Copies function addresses into the provided buffer.
+ *
+ * Parameters:
+ *   buffer   - Array to store function addresses
+ *   max_size - Maximum number of entries to store
+ *
+ * Returns: Number of entries actually stored
+ */
+__attribute__((no_instrument_function))
+size_t npy_ctrace_snapshot(void **buffer, size_t max_size);
+
+/*
+ * Resolve a function address to a symbol name.
+ * Uses dladdr() if available, otherwise returns NULL.
+ *
+ * Parameters:
+ *   addr - Function address to resolve
+ *   buf  - Buffer to store the symbol name
+ *   size - Size of the buffer
+ *
+ * Returns: Pointer to buf on success, NULL on failure
+ */
+__attribute__((no_instrument_function))
+const char *npy_ctrace_resolve_symbol(void *addr, char *buf, size_t size);
+
+/*
+ * Dump the current call stack to stderr.
+ * Useful for debugging and diagnostics.
+ */
+__attribute__((no_instrument_function))
+void npy_ctrace_dump_stack(void);
+
+#else /* !NUMPY_DEBUG_CTRACE */
+
+/* No-op stubs when tracing is disabled */
+#define npy_ctrace_init()           ((void)0)
+#define npy_ctrace_shutdown()       ((void)0)
+#define npy_ctrace_enable()         ((void)0)
+#define npy_ctrace_disable()        ((void)0)
+#define npy_ctrace_is_enabled()     (0)
+#define npy_ctrace_set_callback(cb) ((void)0)
+#define npy_ctrace_get_depth()      (0)
+#define npy_ctrace_snapshot(b, s)   (0)
+#define npy_ctrace_resolve_symbol(a, b, s) (NULL)
+#define npy_ctrace_dump_stack()     ((void)0)
+
+#endif /* NUMPY_DEBUG_CTRACE */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NUMPY_CORE_SRC_COMMON_NPY_CTRACE_H_ */

--- a/numpy/_core/src/common/npy_ctrace_hooks.c
+++ b/numpy/_core/src/common/npy_ctrace_hooks.c
@@ -1,0 +1,76 @@
+/*
+ * NumPy C-Level Tracing Hooks for Instrumented Code
+ */
+
+#include "npy_config.h"
+
+#ifdef NUMPY_DEBUG_CTRACE
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+
+static void (*real_enter)(void *, void *) = NULL;
+static void (*real_exit)(void *, void *) = NULL;
+static int hooks_resolved = 0;
+static int hooks_failed = 0;
+static int resolve_attempted = 0;
+
+__attribute__((no_instrument_function))
+static void resolve_hooks(void) {
+    if (hooks_resolved || hooks_failed) return;
+    if (resolve_attempted) return;
+    resolve_attempted = 1;
+    
+    /* Try RTLD_DEFAULT first */
+    real_enter = (void (*)(void *, void *))dlsym(RTLD_DEFAULT, "npy_ctrace_hook_enter");
+    real_exit = (void (*)(void *, void *))dlsym(RTLD_DEFAULT, "npy_ctrace_hook_exit");
+    
+    if (real_enter && real_exit) {
+        hooks_resolved = 1;
+        return;
+    }
+    
+    /* On macOS, try to find _ctrace_impl library and load symbols from it */
+    Dl_info info;
+    if (dladdr((void*)resolve_hooks, &info) && info.dli_fname) {
+        /* Get the directory of this library */
+        char path[1024];
+        strncpy(path, info.dli_fname, sizeof(path) - 1);
+        path[sizeof(path) - 1] = '\0';
+        
+        /* Find last slash and replace filename */
+        char *last_slash = strrchr(path, '/');
+        if (last_slash) {
+            /* Try to find _ctrace_impl in the same directory */
+            strcpy(last_slash + 1, "_ctrace_impl.cpython-313-darwin.so");
+            
+            void *handle = dlopen(path, RTLD_NOW | RTLD_GLOBAL);
+            if (handle) {
+                real_enter = (void (*)(void *, void *))dlsym(handle, "npy_ctrace_hook_enter");
+                real_exit = (void (*)(void *, void *))dlsym(handle, "npy_ctrace_hook_exit");
+                
+                if (real_enter && real_exit) {
+                    hooks_resolved = 1;
+                    return;
+                }
+            }
+        }
+    }
+    
+    hooks_failed = 1;
+}
+
+__attribute__((no_instrument_function))
+void __cyg_profile_func_enter(void *func, void *caller) {
+    resolve_hooks();
+    if (real_enter) real_enter(func, caller);
+}
+
+__attribute__((no_instrument_function))
+void __cyg_profile_func_exit(void *func, void *caller) {
+    resolve_hooks();
+    if (real_exit) real_exit(func, caller);
+}
+
+#endif

--- a/numpy/_core/src/multiarray/_ctrace_impl.c
+++ b/numpy/_core/src/multiarray/_ctrace_impl.c
@@ -1,0 +1,280 @@
+/*
+ * NumPy Debug-only C-Level Function Call Tracing - Python Extension Module
+ *
+ * This module provides Python bindings for the C-level tracing functionality.
+ * It is only compiled when NUMPY_DEBUG_CTRACE is defined.
+ */
+
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#include <Python.h>
+#include "npy_config.h"
+
+#ifdef NUMPY_DEBUG_CTRACE
+
+#include "npy_ctrace.h"
+#include <stdint.h>
+
+/* Python callback storage */
+static PyObject *py_callback = NULL;
+
+/*
+ * Wrapper callback that invokes the Python callback.
+ */
+__attribute__((no_instrument_function))
+static void
+python_callback_wrapper(void *func, void *caller, uint32_t depth, int is_entry)
+{
+    if (!py_callback || py_callback == Py_None) {
+        return;
+    }
+
+    /* Acquire GIL - we might be called from a non-Python thread */
+    PyGILState_STATE gstate = PyGILState_Ensure();
+
+    PyObject *args = Py_BuildValue(
+        "(KKiO)",
+        (unsigned long long)(uintptr_t)func,
+        (unsigned long long)(uintptr_t)caller,
+        (int)depth,
+        is_entry ? Py_True : Py_False
+    );
+
+    if (args) {
+        PyObject *result = PyObject_CallObject(py_callback, args);
+        Py_DECREF(args);
+        if (result) {
+            Py_DECREF(result);
+        }
+        else {
+            /* Clear any exception - we can't propagate from here */
+            PyErr_Clear();
+        }
+    }
+
+    PyGILState_Release(gstate);
+}
+
+/*
+ * Python API: enable()
+ */
+static PyObject *
+ctrace_enable(PyObject *self, PyObject *args)
+{
+    npy_ctrace_enable();
+    Py_RETURN_NONE;
+}
+
+/*
+ * Python API: disable()
+ */
+static PyObject *
+ctrace_disable(PyObject *self, PyObject *args)
+{
+    npy_ctrace_disable();
+    Py_RETURN_NONE;
+}
+
+/*
+ * Python API: is_enabled()
+ */
+static PyObject *
+ctrace_is_enabled(PyObject *self, PyObject *args)
+{
+    if (npy_ctrace_is_enabled()) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+
+/*
+ * Python API: get_depth()
+ */
+static PyObject *
+ctrace_get_depth(PyObject *self, PyObject *args)
+{
+    return PyLong_FromUnsignedLong(npy_ctrace_get_depth());
+}
+
+/*
+ * Python API: snapshot(max_size)
+ */
+static PyObject *
+ctrace_snapshot(PyObject *self, PyObject *args)
+{
+    Py_ssize_t max_size = 100;
+
+    if (!PyArg_ParseTuple(args, "|n", &max_size)) {
+        return NULL;
+    }
+
+    if (max_size <= 0) {
+        return PyList_New(0);
+    }
+
+    /* Allocate buffer */
+    void **buffer = (void **)PyMem_Malloc(max_size * sizeof(void *));
+    if (!buffer) {
+        return PyErr_NoMemory();
+    }
+
+    /* Get snapshot */
+    size_t count = npy_ctrace_snapshot(buffer, (size_t)max_size);
+
+    /* Build Python list */
+    PyObject *result = PyList_New(count);
+    if (!result) {
+        PyMem_Free(buffer);
+        return NULL;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        PyObject *addr = PyLong_FromUnsignedLongLong(
+            (unsigned long long)(uintptr_t)buffer[i]);
+        if (!addr) {
+            Py_DECREF(result);
+            PyMem_Free(buffer);
+            return NULL;
+        }
+        PyList_SET_ITEM(result, i, addr);
+    }
+
+    PyMem_Free(buffer);
+    return result;
+}
+
+/*
+ * Python API: resolve_symbol(addr)
+ */
+static PyObject *
+ctrace_resolve_symbol(PyObject *self, PyObject *args)
+{
+    unsigned long long addr;
+
+    if (!PyArg_ParseTuple(args, "K", &addr)) {
+        return NULL;
+    }
+
+    char buf[512];
+    const char *symbol = npy_ctrace_resolve_symbol(
+        (void *)(uintptr_t)addr, buf, sizeof(buf));
+
+    if (symbol) {
+        return PyUnicode_FromString(symbol);
+    }
+
+    Py_RETURN_NONE;
+}
+
+/*
+ * Python API: dump_stack()
+ */
+static PyObject *
+ctrace_dump_stack(PyObject *self, PyObject *args)
+{
+    npy_ctrace_dump_stack();
+    Py_RETURN_NONE;
+}
+
+/*
+ * Python API: set_callback(callback)
+ */
+static PyObject *
+ctrace_set_callback(PyObject *self, PyObject *args)
+{
+    PyObject *callback;
+
+    if (!PyArg_ParseTuple(args, "O", &callback)) {
+        return NULL;
+    }
+
+    /* Clear old callback */
+    Py_XDECREF(py_callback);
+    py_callback = NULL;
+
+    if (callback == Py_None) {
+        /* Reset to default C callback */
+        npy_ctrace_set_callback(NULL);
+    }
+    else if (PyCallable_Check(callback)) {
+        /* Set Python callback */
+        Py_INCREF(callback);
+        py_callback = callback;
+        npy_ctrace_set_callback(python_callback_wrapper);
+    }
+    else {
+        PyErr_SetString(PyExc_TypeError, "callback must be callable or None");
+        return NULL;
+    }
+
+    Py_RETURN_NONE;
+}
+
+/* Method table */
+static PyMethodDef ctrace_methods[] = {
+    {"enable", ctrace_enable, METH_NOARGS,
+     "Enable C-level tracing for the current thread."},
+    {"disable", ctrace_disable, METH_NOARGS,
+     "Disable C-level tracing for the current thread."},
+    {"is_enabled", ctrace_is_enabled, METH_NOARGS,
+     "Check if tracing is enabled for the current thread."},
+    {"get_depth", ctrace_get_depth, METH_NOARGS,
+     "Get the current call stack depth."},
+    {"snapshot", ctrace_snapshot, METH_VARARGS,
+     "Snapshot the current C call stack."},
+    {"resolve_symbol", ctrace_resolve_symbol, METH_VARARGS,
+     "Resolve a function address to a symbol name."},
+    {"dump_stack", ctrace_dump_stack, METH_NOARGS,
+     "Dump the current C call stack to stderr."},
+    {"set_callback", ctrace_set_callback, METH_VARARGS,
+     "Set a custom callback for trace events."},
+    {NULL, NULL, 0, NULL}
+};
+
+/* Module definition */
+static struct PyModuleDef ctrace_module = {
+    PyModuleDef_HEAD_INIT,
+    "_ctrace_impl",
+    "NumPy C-level function call tracing (debug builds only)",
+    -1,
+    ctrace_methods,
+    NULL, NULL, NULL, NULL
+};
+
+/* Module initialization */
+PyMODINIT_FUNC
+PyInit__ctrace_impl(void)
+{
+    /* Initialize the tracing subsystem */
+    npy_ctrace_init();
+
+    return PyModule_Create(&ctrace_module);
+}
+
+#else /* !NUMPY_DEBUG_CTRACE */
+
+/*
+ * Stub module when tracing is disabled.
+ * This allows the Python code to check for availability.
+ */
+
+static PyMethodDef ctrace_methods[] = {
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef ctrace_module = {
+    PyModuleDef_HEAD_INIT,
+    "_ctrace_impl",
+    "NumPy C-level function call tracing (not available - build without NUMPY_DEBUG_CTRACE)",
+    -1,
+    ctrace_methods,
+    NULL, NULL, NULL, NULL
+};
+
+PyMODINIT_FUNC
+PyInit__ctrace_impl(void)
+{
+    return PyModule_Create(&ctrace_module);
+}
+
+#endif /* NUMPY_DEBUG_CTRACE */

--- a/numpy/_core/tests/test_ctrace.py
+++ b/numpy/_core/tests/test_ctrace.py
@@ -1,0 +1,317 @@
+"""
+Tests for the C-level function call tracing module.
+
+These tests verify the Python interface to the tracing functionality.
+Most tests are skipped if tracing is not available (i.e., NumPy was not
+built with NUMPY_DEBUG_CTRACE).
+"""
+
+import pytest
+import numpy as np
+from numpy._core._ctrace import (
+    is_available,
+    CTrace,
+    TraceCollector,
+)
+
+
+# Skip all tests if tracing is not available
+pytestmark = pytest.mark.skipif(
+    not is_available(),
+    reason="C-level tracing not available (build with NUMPY_DEBUG_CTRACE)"
+)
+
+
+class TestCTraceAvailability:
+    """Tests for availability checking."""
+
+    @pytest.mark.skipif(is_available(), reason="Only run when unavailable")
+    def test_is_available_false(self):
+        """Test that is_available returns False when not built with tracing."""
+        assert not is_available()
+
+    def test_is_available_true(self):
+        """Test that is_available returns True when built with tracing."""
+        assert is_available()
+
+
+class TestCTraceBasic:
+    """Basic tests for the CTrace context manager."""
+
+    def test_context_manager_enter_exit(self):
+        """Test that CTrace can be used as a context manager."""
+        with CTrace() as tracer:
+            assert tracer is not None
+
+    def test_enable_disable(self):
+        """Test enabling and disabling tracing."""
+        from numpy._core._ctrace import enable, disable, is_enabled
+
+        # Should start disabled
+        assert not is_enabled()
+
+        enable()
+        assert is_enabled()
+
+        disable()
+        assert not is_enabled()
+
+    def test_context_manager_enables_tracing(self):
+        """Test that CTrace enables tracing within the context."""
+        from numpy._core._ctrace import is_enabled
+
+        assert not is_enabled()
+
+        with CTrace():
+            assert is_enabled()
+
+        assert not is_enabled()
+
+    def test_nested_context_managers(self):
+        """Test nested CTrace context managers."""
+        from numpy._core._ctrace import is_enabled
+
+        with CTrace():
+            assert is_enabled()
+            with CTrace():
+                assert is_enabled()
+            assert is_enabled()
+
+        assert not is_enabled()
+
+    def test_disabled_context_manager(self):
+        """Test CTrace with enabled=False."""
+        from numpy._core._ctrace import is_enabled
+
+        with CTrace(enabled=False):
+            # Should not enable tracing
+            assert not is_enabled()
+
+
+class TestCTraceSnapshot:
+    """Tests for call stack snapshots."""
+
+    def test_snapshot_empty(self):
+        """Test snapshot when no calls are active."""
+        from numpy._core._ctrace import snapshot, enable, disable
+
+        enable()
+        result = snapshot()
+        disable()
+
+        # At the top level, stack should be minimal
+        assert isinstance(result, list)
+
+    def test_snapshot_max_size(self):
+        """Test snapshot with max_size parameter."""
+        from numpy._core._ctrace import snapshot, enable, disable
+
+        enable()
+        result = snapshot(max_size=5)
+        disable()
+
+        assert len(result) <= 5
+
+    def test_snapshot_returns_integers(self):
+        """Test that snapshot returns a list of integers (addresses)."""
+        from numpy._core._ctrace import snapshot, enable, disable
+
+        enable()
+        result = snapshot()
+        disable()
+
+        for addr in result:
+            assert isinstance(addr, int)
+
+
+class TestCTraceCallback:
+    """Tests for custom callbacks."""
+
+    def test_custom_callback(self):
+        """Test that custom callbacks are invoked."""
+        events = []
+
+        def callback(func, caller, depth, is_entry):
+            events.append((func, caller, depth, is_entry))
+
+        with CTrace(callback=callback):
+            # Do some NumPy operation
+            arr = np.array([1, 2, 3])
+            _ = np.sum(arr)
+
+        # Should have captured some events
+        # Note: exact count depends on build configuration
+        assert len(events) >= 0  # May be 0 if instrumentation not active
+
+    def test_callback_receives_correct_types(self):
+        """Test that callback receives correct argument types."""
+        type_checks = []
+
+        def callback(func, caller, depth, is_entry):
+            type_checks.append((
+                isinstance(func, int),
+                isinstance(caller, int),
+                isinstance(depth, int),
+                isinstance(is_entry, bool),
+            ))
+
+        with CTrace(callback=callback):
+            np.zeros(10)
+
+        for checks in type_checks:
+            assert all(checks), f"Type check failed: {checks}"
+
+
+class TestTraceCollector:
+    """Tests for the TraceCollector class."""
+
+    def test_collector_basic(self):
+        """Test basic TraceCollector usage."""
+        collector = TraceCollector()
+
+        with collector:
+            np.zeros(10)
+
+        # Check properties
+        assert isinstance(collector.events, list)
+        assert isinstance(collector.max_depth, int)
+        assert collector.max_depth >= 0
+
+    def test_collector_max_events(self):
+        """Test TraceCollector with max_events limit."""
+        collector = TraceCollector(max_events=10)
+
+        with collector:
+            # Do many operations
+            for _ in range(100):
+                np.zeros(10)
+
+        assert len(collector.events) <= 10
+
+    def test_collector_call_tree(self):
+        """Test TraceCollector.get_call_tree()."""
+        collector = TraceCollector()
+
+        with collector:
+            np.zeros(10)
+
+        tree = collector.get_call_tree()
+        assert isinstance(tree, dict)
+        assert 'children' in tree
+        assert 'count' in tree
+
+
+class TestCTraceSymbolResolution:
+    """Tests for symbol resolution."""
+
+    def test_resolve_symbol(self):
+        """Test resolving a function address to a symbol name."""
+        from numpy._core._ctrace import resolve_symbol
+
+        # Use a known function address (this is a bit tricky to test)
+        # We'll just verify the function doesn't crash
+        result = resolve_symbol(0)
+        # Result may be None or a string
+        assert result is None or isinstance(result, str)
+
+    def test_resolve_symbol_with_snapshot(self):
+        """Test resolving symbols from a snapshot."""
+        from numpy._core._ctrace import snapshot, resolve_symbol, enable, disable
+
+        enable()
+        addrs = snapshot()
+        disable()
+
+        for addr in addrs:
+            result = resolve_symbol(addr)
+            # Should return string or None
+            assert result is None or isinstance(result, str)
+
+
+class TestCTraceDepth:
+    """Tests for call depth tracking."""
+
+    def test_get_depth(self):
+        """Test getting the current call depth."""
+        from numpy._core._ctrace import get_depth, enable, disable
+
+        enable()
+        depth = get_depth()
+        disable()
+
+        assert isinstance(depth, int)
+        assert depth >= 0
+
+
+class TestCTraceDumpStack:
+    """Tests for stack dumping."""
+
+    def test_dump_stack_no_crash(self, capsys):
+        """Test that dump_stack doesn't crash."""
+        from numpy._core._ctrace import dump_stack, enable, disable
+
+        enable()
+        dump_stack()  # Should print to stderr
+        disable()
+
+        # Just verify it didn't crash
+        # Output goes to stderr
+
+
+class TestCTraceIntegration:
+    """Integration tests with NumPy operations."""
+
+    def test_trace_array_creation(self):
+        """Test tracing array creation."""
+        events = []
+
+        def callback(func, caller, depth, is_entry):
+            events.append(is_entry)
+
+        with CTrace(callback=callback):
+            np.array([1, 2, 3, 4, 5])
+
+        # Should have some entry/exit pairs
+        entries = sum(1 for e in events if e)
+        exits = sum(1 for e in events if not e)
+        # In a well-formed trace, entries should equal exits
+        # (though this may not hold if we start/stop mid-execution)
+
+    def test_trace_ufunc(self):
+        """Test tracing ufunc operations."""
+        collector = TraceCollector()
+
+        with collector:
+            a = np.array([1.0, 2.0, 3.0])
+            b = np.array([4.0, 5.0, 6.0])
+            _ = np.add(a, b)
+
+        # Should have captured some events
+        assert isinstance(collector.events, list)
+
+    def test_trace_linalg(self):
+        """Test tracing linear algebra operations."""
+        collector = TraceCollector()
+
+        with collector:
+            a = np.array([[1, 2], [3, 4]], dtype=float)
+            _ = np.linalg.det(a)
+
+        assert isinstance(collector.events, list)
+
+
+# Tests that should work even without tracing available
+class TestCTraceUnavailable:
+    """Tests for when tracing is unavailable."""
+
+    @pytest.mark.skipif(is_available(), reason="Only run when unavailable")
+    def test_ctrace_disabled_no_crash(self):
+        """Test that CTrace(enabled=False) works when unavailable."""
+        with CTrace(enabled=False) as tracer:
+            np.zeros(10)
+            # Should not crash
+
+    @pytest.mark.skipif(is_available(), reason="Only run when unavailable")
+    def test_is_available_returns_false(self):
+        """Test is_available returns False when not built with tracing."""
+        assert not is_available()


### PR DESCRIPTION
## Add debug-only C-level function call tracing

### Disclaimer: Built largely by prompting Claude model and fixing never ending list of problems

---

### Changes
Implements a debug-only mechanism to trace C-level function calls during NumPy operations using compiler instrumentation (-finstrument-functions).

This feature provides NumPy developers with deterministic visibility into C execution paths for debugging and diagnostics. It is NOT intended for production use and is only enabled when built with -Denable-ctrace=true.

Key features:
- Thread-local call stacks using fixed-size memory pools
- Compiler instrumentation hooks (__cyg_profile_func_enter/exit)
- Symbol resolution via dladdr()
- Python API with CTrace context manager and TraceCollector
- Configurable callbacks for custom trace handling

New files:
- numpy/_core/src/common/npy_ctrace.{h,c} - Core C implementation
- numpy/_core/src/common/npy_ctrace_hooks.c - Hooks for instrumented code
- numpy/_core/src/multiarray/_ctrace_impl.c - Python extension module
- numpy/_core/_ctrace.py - High-level Python API
- numpy/_core/tests/test_ctrace.py - Test suite

Build with: spin build -- -Denable-ctrace=true

---

### ToDo

- [ ] Mailing list
- [ ] Release Notes
- [ ] CI testing with dedicated stage compiled with flags
- [ ] Developer docs
- [ ] Typing

---

### Demo
<details><summary>Details</summary>
<p>

```
spin python ctrace_simple.py 2>&1
Invoking `build` prior to invoking Python:
$ /<>/os/np-test/bin/python3 vendored-meson/meson/meson.py compile -C build
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /<>/os/np-test/bin/ninja -C /<>/os/numpy/build
ninja: Entering directory `/<>/os/numpy/build'
[1/1] Generating numpy/generate-version with a custom command
Saving version to numpy/version.py
$ /<>/os/np-test/bin/python3 vendored-meson/meson/meson.py install --only-changed -C build --destdir ../build-install
$ export PYTHONPATH="/<>/os/numpy/build-install/usr/lib/python3.13/site-packages"
🐍 Launching Python with PYTHONPATH="/<>/os/numpy/build-install/usr/lib/python3.13/site-packages"
$ /<>/os/np-test/bin/python3 -P ctrace_simple.py
CPU baseline: ['NEON', 'NEON_FP16', 'NEON_VFPV4', 'ASIMD']

Tracing: np.bitwise_count(a) - showing SIMD inner loop
============================================================
> ufunc_generic_vectorcall
  > _PyVectorcall_NARGS
  < _PyVectorcall_NARGS
  > ufunc_generic_fastcall
    > PyObject_TypeCheck
    < PyObject_TypeCheck
    > _npy_init_workspace
    < _npy_init_workspace
    > PyArray_TupleFromItems
      > PyTuple_SET_ITEM
      < PyTuple_SET_ITEM
    < PyArray_TupleFromItems
    > PyUFunc_CheckOverride
      > get_array_ufunc_overrides
        > PyTuple_GET_SIZE
        < PyTuple_GET_SIZE
        > PyUFuncOverride_GetNonDefaultArrayUfunc
        < PyUFuncOverride_GetNonDefaultArrayUfunc
      < get_array_ufunc_overrides
    < PyUFunc_CheckOverride
    > _get_fixed_signature
    < _get_fixed_signature
    > convert_ufunc_arguments
      > PyObject_TypeCheck
      < PyObject_TypeCheck
      > PyArray_DESCR
      < PyArray_DESCR
    < convert_ufunc_arguments
    > promote_and_get_ufuncimpl
      > _ZL34promote_and_get_info_and_ufuncimplP17_tagPyUFuncObjectPKP16tagPyArrayObjectPP17PyArray_DTypeMetaS7_h
        > PyArrayIdentityHash_GetItem
          > find_item
            > find_item_buckets
              > identity_list_hash
              < identity_list_hash
            < find_item_buckets
          < find_item
        < PyArrayIdentityHash_GetItem
        > _ZL27resolve_implementation_infoP17_tagPyUFuncObjectPP17PyArray_DTypeMetahPP7_object
        < _ZL27resolve_implementation_infoP17_tagPyUFuncObjectPP17PyArray_DTypeMetahPP7_object
        > _ZL18PyObject_TypeCheckP7_objectP11_typeobject
        < _ZL18PyObject_TypeCheckP7_objectP11_typeobject
        > PyArrayIdentityHash_SetItemDefault
          > PyArrayIdentityHash_SetItemDefaultLockHeld
            > _resize_if_necessary
            < _resize_if_necessary
            > find_item
              > find_item_buckets
                > identity_list_hash
                < identity_list_hash
              < find_item_buckets
            < find_item
          < PyArrayIdentityHash_SetItemDefaultLockHeld
        < PyArrayIdentityHash_SetItemDefault
      < _ZL34promote_and_get_info_and_ufuncimplP17_tagPyUFuncObjectPKP16tagPyArrayObjectPP17PyArray_DTypeMetaS7_h
    < promote_and_get_ufuncimpl
    > resolve_descriptors
      > PyArray_DTYPE
      < PyArray_DTYPE
      > PyArray_FLAGS
      < PyArray_FLAGS
      > PyArray_CastDescrToDType
      < PyArray_CastDescrToDType
      > simple_legacy_resolve_descriptors
        > ensure_native_byteorder
        < ensure_native_byteorder
        > nonparametric_default_descr
        < nonparametric_default_descr
      < simple_legacy_resolve_descriptors
      > PyArray_MinCastSafety
      < PyArray_MinCastSafety
    < resolve_descriptors
    > PyUFunc_GenericFunctionInternal
      > _get_bufsize_errmask
        > _extract_pyvals
          > fetch_curr_extobj_state
          < fetch_curr_extobj_state
          > npy_extobj_clear
          < npy_extobj_clear
        < _extract_pyvals
      < _get_bufsize_errmask
      > _ufunc_setup_flags
      < _ufunc_setup_flags
      > NPY_context_init
      < NPY_context_init
      > check_for_trivial_loop
        > PyArray_CHKFLAGS
          > PyArray_FLAGS
          < PyArray_FLAGS
        < PyArray_CHKFLAGS
        > PyArray_DESCR
        < PyArray_DESCR
      < check_for_trivial_loop
      > try_trivial_single_output_loop
        > PyArray_NDIM
        < PyArray_NDIM
        > PyArray_SHAPE
        < PyArray_SHAPE
        > PyArray_STRIDES
        < PyArray_STRIDES
        > PyArray_NewFromDescr
          > PyArray_NewFromDescrAndBase
            > PyArray_NewFromDescr_int
              > PyDataType_SUBARRAY
              < PyDataType_SUBARRAY
              > NPY_traverse_info_init
              < NPY_traverse_info_init
              > npy_alloc_cache_dim
                > _ZL16_npy_alloc_cachemmjP12cache_bucketPFPvmE
                < _ZL16_npy_alloc_cachemmjP12cache_bucketPFPvmE
              < npy_alloc_cache_dim
              > npy_mul_sizes_with_overflow
              < npy_mul_sizes_with_overflow
              > _array_fill_strides
              < _array_fill_strides
              > PyDataType_FLAGS
              < PyDataType_FLAGS
              > PyDataMem_GetHandler
              < PyDataMem_GetHandler
              > PyDataMem_UserNEW
                > _ZL14default_mallocPvm
                  > _ZL16_npy_alloc_cachemmjP12cache_bucketPFPvmE
                    > indicate_hugepages
                    < indicate_hugepages
                  < _ZL16_npy_alloc_cachemmjP12cache_bucketPFPvmE
                < _ZL14default_mallocPvm
              < PyDataMem_UserNEW
              > PyArray_UpdateFlags
                > IsAligned
                  > PyArray_NDIM
                  < PyArray_NDIM
                  > PyArray_DIMS
                  < PyArray_DIMS
                  > PyArray_DATA
                  < PyArray_DATA
                  > PyArray_STRIDES
                  < PyArray_STRIDES
                  > PyArray_DESCR
                  < PyArray_DESCR
                  > raw_array_is_aligned
                  < raw_array_is_aligned
                < IsAligned
                > PyArray_ENABLEFLAGS
                < PyArray_ENABLEFLAGS
              < PyArray_UpdateFlags
              > NPY_traverse_info_xfree
              < NPY_traverse_info_xfree
            < PyArray_NewFromDescr_int
          < PyArray_NewFromDescrAndBase
        < PyArray_NewFromDescr
        > PyArray_MultiplyList
        < PyArray_MultiplyList
        > get_wrapped_legacy_ufunc_loop
          > PyObject_TypeCheck
          < PyObject_TypeCheck
          > PyUFunc_DefaultLegacyInnerLoopSelector
          < PyUFunc_DefaultLegacyInnerLoopSelector
          > get_new_loop_data
          < get_new_loop_data
        < get_wrapped_legacy_ufunc_loop
        > PyArray_BYTES
        < PyArray_BYTES
        > PyArray_BYTES
        < PyArray_BYTES
        > generic_wrapped_legacy_loop
          > LONG_bitwise_count
            > npy_popcountl
              > npy_popcountul
              < npy_popcountul
            < npy_popcountl
            > npy_popcountl
              > npy_popcountul
              < npy_popcountul
            < npy_popcountl
            > npy_popcountl
              > npy_popcountul
              < npy_popcountul
            < npy_popcountl
            > npy_popcountl
              > npy_popcountul
              < npy_popcountul
            < npy_popcountl
            > npy_popcountl
              > npy_popcountul
              < npy_popcountul
            < npy_popcountl
          < LONG_bitwise_count
        < generic_wrapped_legacy_loop
        > legacy_array_method_auxdata_free
        < legacy_array_method_auxdata_free
        > ufunc_get_name_cstr
        < ufunc_get_name_cstr
        > _check_ufunc_fperr
        < _check_ufunc_fperr
      < try_trivial_single_output_loop
    < PyUFunc_GenericFunctionInternal
    > replace_with_wrapped_result_and_return
      > npy_find_array_wrap
        > __npy_inff
        < __npy_inff
      < npy_find_array_wrap
      > PyArray_NDIM
      < PyArray_NDIM
      > npy_apply_wrap
      < npy_apply_wrap
    < replace_with_wrapped_result_and_return
    > _npy_free_workspace
    < _npy_free_workspace
  < ufunc_generic_fastcall
< ufunc_generic_vectorcall
============================================================

Trace Summary:
  Total events: 564
  Max depth: 10
  Unique functions: 97

Top 5 hotspots:
   1.     51 calls: _ZL7Py_TYPEP7_object
   2.     50 calls: _ZL17PyType_HasFeatureP11_typeobjectm
   3.     15 calls: Py_TYPE
   4.     13 calls: Py_DECREF
   5.     13 calls: _Py_IsImmortal

Result[:5]: [0 1 1 2 1]
```


</p>
</details> 

### Disclaimer
- Built largely by prompting Claude model and fixing never ending list of problems

### Related
resolves https://github.com/numpy/numpy/issues/27966 