### PR TITLE
BUG: Handle empty x array in np.interp

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1638,8 +1638,16 @@ def interp(x, xp, fp, left=None, right=None, period=None):
     array([0.+1.j , 1.+1.5j])
 
     """
-
+    x = np.asarray(x)
+    xp = np.asarray(xp)
     fp = np.asarray(fp)
+
+    # Handle empty x array: return empty array with appropriate dtype
+    if x.size == 0:
+        if np.iscomplexobj(fp):
+            return np.empty(x.shape, dtype=np.complex128)
+        else:
+            return np.empty(x.shape, dtype=np.float64)
 
     if np.iscomplexobj(fp):
         interp_func = compiled_interp_complex


### PR DESCRIPTION
## Summary

- Fixes `np.interp([], [], [])` raising `ValueError` instead of returning an empty array
- Adds early check for empty `x` arrays and returns empty array with appropriate dtype

## Details

When `np.interp` is called with empty arrays (e.g., `np.interp([], [], [])`), it currently raises:

```
ValueError: array of sample points is empty
```

However, the correct behavior should be to return an empty array (which is clearly the expected result for interpolating zero points).

## Fix

The fix adds an early check at the beginning of the function:

```python
x = np.asarray(x)
xp = np.asarray(xp)
fp = np.asarray(fp)

# Handle empty x array: return empty array with appropriate dtype
if x.size == 0:
    if np.iscomplexobj(fp):
        return np.empty(x.shape, dtype=np.complex128)
    else:
        return np.empty(x.shape, dtype=np.float64)
```

This preserves the shape of `x` while returning an empty array with the correct dtype.

## Test plan

- [x] `np.interp([], [], [])` now returns `array([], dtype=float64)` instead of raising an error
- [x] Complex interpolation: `np.interp([], [], [1j])` returns `array([], dtype=complex128)`

Fixes #30316

🤖 Generated with [Claude Code](https://claude.com/claude-code)