### PR TITLE
API: make array scalars opaque internally and expose accessors

### DIFF
--- a/numpy/_core/code_generators/genapi.py
+++ b/numpy/_core/code_generators/genapi.py
@@ -402,7 +402,7 @@ class BoolValuesApi:
 
     def internal_define(self):
         astr = """\
-extern NPY_NO_EXPORT PyBoolScalarObject _PyArrayScalar_BoolValues[2];
+extern NPY_NO_EXPORT PyBoolScalarObject_fields _PyArrayScalar_BoolValues[2];
 """
         return astr
 

--- a/numpy/_core/code_generators/generate_numpy_api.py
+++ b/numpy/_core/code_generators/generate_numpy_api.py
@@ -13,10 +13,15 @@ h_template = r"""
 typedef struct {
         PyObject_HEAD
         npy_bool obval;
-} PyBoolScalarObject;
+} PyBoolScalarObject_fields;
+#if !defined(NPY_INTERNAL_BUILD) || (!NPY_INTERNAL_BUILD)
+typedef PyBoolScalarObject_fields PyBoolScalarObject;
+#else
+typedef struct PyBoolScalarObject PyBoolScalarObject;
+#endif
 
 extern NPY_NO_EXPORT PyTypeObject PyArrayNeighborhoodIter_Type;
-extern NPY_NO_EXPORT PyBoolScalarObject _PyArrayScalar_BoolValues[2];
+extern NPY_NO_EXPORT PyBoolScalarObject_fields _PyArrayScalar_BoolValues[2];
 
 %s
 

--- a/numpy/_core/include/numpy/arrayscalars.h
+++ b/numpy/_core/include/numpy/arrayscalars.h
@@ -5,137 +5,139 @@
 typedef struct {
         PyObject_HEAD
         npy_bool obval;
-} PyBoolScalarObject;
+} PyBoolScalarObject_fields;
 #endif
 
 
 typedef struct {
         PyObject_HEAD
         signed char obval;
-} PyByteScalarObject;
+} PyByteScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         short obval;
-} PyShortScalarObject;
+} PyShortScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         int obval;
-} PyIntScalarObject;
+} PyIntScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         long obval;
-} PyLongScalarObject;
+} PyLongScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         npy_longlong obval;
-} PyLongLongScalarObject;
+} PyLongLongScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         unsigned char obval;
-} PyUByteScalarObject;
+} PyUByteScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         unsigned short obval;
-} PyUShortScalarObject;
+} PyUShortScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         unsigned int obval;
-} PyUIntScalarObject;
+} PyUIntScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         unsigned long obval;
-} PyULongScalarObject;
+} PyULongScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         npy_ulonglong obval;
-} PyULongLongScalarObject;
+} PyULongLongScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         npy_half obval;
-} PyHalfScalarObject;
+} PyHalfScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         float obval;
-} PyFloatScalarObject;
+} PyFloatScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         double obval;
-} PyDoubleScalarObject;
+} PyDoubleScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         npy_longdouble obval;
-} PyLongDoubleScalarObject;
+} PyLongDoubleScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         npy_cfloat obval;
-} PyCFloatScalarObject;
+} PyCFloatScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         npy_cdouble obval;
-} PyCDoubleScalarObject;
+} PyCDoubleScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         npy_clongdouble obval;
-} PyCLongDoubleScalarObject;
+} PyCLongDoubleScalarObject_fields;
 
 
 typedef struct {
         PyObject_HEAD
         PyObject * obval;
-} PyObjectScalarObject;
+} PyObjectScalarObject_fields;
 
 typedef struct {
         PyObject_HEAD
         npy_datetime obval;
         PyArray_DatetimeMetaData obmeta;
-} PyDatetimeScalarObject;
+} PyDatetimeScalarObject_fields;
 
 typedef struct {
         PyObject_HEAD
         npy_timedelta obval;
         PyArray_DatetimeMetaData obmeta;
-} PyTimedeltaScalarObject;
-
+} PyTimedeltaScalarObject_fields;
 
 typedef struct {
         PyObject_HEAD
         char obval;
-} PyScalarObject;
+} PyScalarObject_fields;
+
+// PyUnicodeObject and PyBytesObject are not exposed in the limited API
+#ifndef Py_LIMITED_API
 
 #define PyStringScalarObject PyBytesObject
-#ifndef Py_LIMITED_API
+
 typedef struct {
         /* note that the PyObject_HEAD macro lives right here */
         PyUnicodeObject base;
@@ -143,9 +145,9 @@ typedef struct {
     #if NPY_FEATURE_VERSION >= NPY_1_20_API_VERSION
         char *buffer_fmt;
     #endif
-} PyUnicodeScalarObject;
-#endif
+} PyUnicodeScalarObject_fields;
 
+#endif // Py_LIMITED_API
 
 typedef struct {
         PyObject_VAR_HEAD
@@ -161,7 +163,78 @@ typedef struct {
     #if NPY_FEATURE_VERSION >= NPY_1_20_API_VERSION
         void *_buffer_info;  /* private buffer info, tagged to allow warning */
     #endif
-} PyVoidScalarObject;
+} PyVoidScalarObject_fields;
+
+/* The exposed objects.
+ *
+ * A future NumPy release will likely make these objects
+ * opaque and require accessing the fields via PyArrayScalar_VAL
+ * and other acesors defined for specific types above.
+ *
+ */
+
+#if defined(NPY_INTERNAL_BUILD) && (NPY_INTERNAL_BUILD)
+// all these structs are opaque internally
+#ifndef _MULTIARRAYMODULE
+typedef struct PyBoolScalarObject PyBoolScalarObject;
+#endif
+typedef struct PyByteScalarObject PyByteScalarObject;
+typedef struct PyShortScalarObject PyShortScalarObject;
+typedef struct PyIntScalarObject PyIntScalarObject;
+typedef struct PyLongScalarObject PyLongScalarObject;
+typedef struct PyLongLongScalarObject PyLongLongScalarObject;
+typedef struct PyUByteScalarObject PyUByteScalarObject;
+typedef struct PyUShortScalarObject PyUShortScalarObject;
+typedef struct PyUIntScalarObject PyUIntScalarObject;
+typedef struct PyULongScalarObject PyULongScalarObject;
+typedef struct PyULongLongScalarObject PyULongLongScalarObject;
+typedef struct PyHalfScalarObject PyHalfScalarObject;
+typedef struct PyFloatScalarObject PyFloatScalarObject;
+typedef struct PyDoubleScalarObject PyDoubleScalarObject;
+typedef struct PyLongDoubleScalarObject PyLongDoubleScalarObject;
+typedef struct PyCFloatScalarObject PyCFloatScalarObject;
+typedef struct PyCDoubleScalarObject PyCDoubleScalarObject;
+typedef struct PyCLongDoubleScalarObject PyCLongDoubleScalarObject;
+typedef struct PyObjectScalarObject PyObjectScalarObject;
+typedef struct PyDatetimeScalarObject PyDatetimeScalarObject;
+typedef struct PyTimedeltaScalarObject PyTimedeltaScalarObject;
+typedef struct PyScalarObject PyScalarObject;
+#ifndef Py_LIMITED_API
+typedef struct PyUnicodeScalarObject PyUnicodeScalarObject;
+#endif
+typedef struct PyVoidScalarObject PyVoidScalarObject;
+#else
+#ifndef _MULTIARRAYMODULE
+typedef PyBoolScalarObject_fields PyBoolScalarObject;
+#endif
+typedef PyByteScalarObject_fields PyByteScalarObject;
+typedef PyShortScalarObject_fields PyShortScalarObject;
+typedef PyIntScalarObject_fields PyIntScalarObject;
+typedef PyLongScalarObject_fields PyLongScalarObject;
+typedef PyLongLongScalarObject_fields PyLongLongScalarObject;
+typedef PyUByteScalarObject_fields PyUByteScalarObject;
+typedef PyUShortScalarObject_fields PyUShortScalarObject;
+typedef PyUIntScalarObject_fields PyUIntScalarObject;
+typedef PyULongScalarObject_fields PyULongScalarObject;
+typedef PyULongLongScalarObject_fields PyULongLongScalarObject;
+typedef PyHalfScalarObject_fields PyHalfScalarObject;
+typedef PyFloatScalarObject_fields PyFloatScalarObject;
+typedef PyDoubleScalarObject_fields PyDoubleScalarObject;
+typedef PyLongDoubleScalarObject_fields PyLongDoubleScalarObject;
+typedef PyCFloatScalarObject_fields PyCFloatScalarObject;
+typedef PyCDoubleScalarObject_fields PyCDoubleScalarObject;
+typedef PyCLongDoubleScalarObject_fields PyCLongDoubleScalarObject;
+typedef PyObjectScalarObject_fields PyObjectScalarObject;
+typedef PyDatetimeScalarObject_fields PyDatetimeScalarObject;
+typedef PyTimedeltaScalarObject_fields PyTimedeltaScalarObject;
+typedef PyScalarObject_fields PyScalarObject;
+#ifndef Py_LIMITED_API
+typedef PyUnicodeScalarObject_fields PyUnicodeScalarObject;
+#endif
+typedef PyVoidScalarObject_fields PyVoidScalarObject;
+
+
+#endif
 
 /* Macros
      Py<Cls><bitsize>ScalarObject
@@ -190,9 +263,78 @@ typedef struct {
 #ifndef Py_LIMITED_API
 /* For the limited API, use PyArray_ScalarAsCtype instead */
 #define PyArrayScalar_VAL(obj, cls)             \
-        ((Py##cls##ScalarObject *)obj)->obval
+        ((Py##cls##ScalarObject_fields *)obj)->obval
 #define PyArrayScalar_ASSIGN(obj, cls, val) \
         PyArrayScalar_VAL(obj, cls) = val
+#endif
+
+static inline PyVoidScalarObject_fields *
+PyVoidScalar_GET_ITEM_DATA(PyVoidScalarObject *scalar)
+{
+    return (PyVoidScalarObject_fields *)scalar;
+}
+
+#if defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD
+static inline _PyArray_LegacyDescr *
+#else
+static inline PyArray_Descr *
+#endif
+PyVoidScalar_DESCR(PyVoidScalarObject *scalar)
+{
+    return PyVoidScalar_GET_ITEM_DATA(scalar)->descr;
+}
+
+static inline int
+PyVoidScalar_FLAGS(PyVoidScalarObject *scalar)
+{
+    return PyVoidScalar_GET_ITEM_DATA(scalar)->flags;
+}
+
+static inline PyObject *
+PyVoidScalar_BASE(PyVoidScalarObject *scalar)
+{
+    return PyVoidScalar_GET_ITEM_DATA(scalar)->base;
+}
+
+static inline PyDatetimeScalarObject_fields *
+PyDatetimeScalar_GET_ITEM_DATA(PyDatetimeScalarObject *scalar)
+{
+    return (PyDatetimeScalarObject_fields *)scalar;
+}
+
+static inline PyArray_DatetimeMetaData *
+PyDatetimeScalar_OBMETA(PyDatetimeScalarObject *scalar) {
+    return &(PyDatetimeScalar_GET_ITEM_DATA(scalar)->obmeta);
+}
+
+static inline PyTimedeltaScalarObject_fields *
+PyTimedeltaScalar_GET_ITEM_DATA(PyTimedeltaScalarObject *scalar)
+{
+    return (PyTimedeltaScalarObject_fields *)scalar;
+}
+
+static inline PyArray_DatetimeMetaData *
+PyTimedeltaScalar_OBMETA(PyTimedeltaScalarObject *scalar) {
+    return &(PyTimedeltaScalar_GET_ITEM_DATA(scalar)->obmeta);
+}
+
+#ifndef Py_LIMITED_API
+
+static inline PyUnicodeScalarObject_fields *
+PyUnicodeScalar_GET_ITEM_DATA(PyUnicodeScalarObject *scalar)
+{
+    return (PyUnicodeScalarObject_fields *)scalar;
+}
+
+#if NPY_FEATURE_VERSION >= NPY_1_20_API_VERSION
+static inline char *
+PyUnicodeScalar_BUFFER_FMT(PyUnicodeScalarObject *scalar)
+{
+    return PyUnicodeScalar_GET_ITEM_DATA(scalar)->buffer_fmt;
+}
+
+#endif
+
 #endif
 
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY_ARRAYSCALARS_H_ */

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -590,7 +590,7 @@ corrupt_or_fix_bufferinfo(PyObject *dummy, PyObject *obj)
         buffer_info_ptr = &((PyArrayObject_fields *)obj)->_buffer_info;
     }
     else if (PyArray_IsScalar(obj, Void)) {
-        buffer_info_ptr = &((PyVoidScalarObject *)obj)->_buffer_info;
+        buffer_info_ptr = &((PyVoidScalarObject_fields *)obj)->_buffer_info;
     }
     else {
         PyErr_SetString(PyExc_TypeError,

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1054,8 +1054,8 @@ VOID_setitem(PyArray_Descr *descr_, PyObject *op, char *ip)
                                     PyArray_DESCR(oparr), PyArray_DATA(oparr));
         }
         else if (PyArray_IsScalar(op, Void)) {
-            PyArray_Descr *srcdescr = (PyArray_Descr *)((PyVoidScalarObject *)op)->descr;
-            char *srcdata = ((PyVoidScalarObject *)op)->obval;
+            PyArray_Descr *srcdescr = (PyArray_Descr *)PyVoidScalar_DESCR((PyVoidScalarObject *)op);
+            char *srcdata = PyArrayScalar_VAL((PyVoidScalarObject *)op, Void);
             return _copy_and_return_void_setitem(descr, ip, srcdescr, srcdata);
         }
         else if (PyTuple_Check(op)) {

--- a/numpy/_core/src/multiarray/buffer.c
+++ b/numpy/_core/src/multiarray/buffer.c
@@ -859,17 +859,19 @@ void_getbuffer(PyObject *self, Py_buffer *view, int flags)
         return -1;
     }
 
+    PyVoidScalarObject_fields *fields = PyVoidScalar_GET_ITEM_DATA(scalar);
+
     view->ndim = 0;
     view->shape = NULL;
     view->strides = NULL;
     view->suboffsets = NULL;
-    view->len = scalar->descr->elsize;
-    view->itemsize = scalar->descr->elsize;
+    view->len = fields->descr->elsize;
+    view->itemsize = fields->descr->elsize;
     view->readonly = 1;
     view->suboffsets = NULL;
     Py_INCREF(self);
     view->obj = self;
-    view->buf = scalar->obval;
+    view->buf = fields->obval;
 
     if (((flags & PyBUF_FORMAT) != PyBUF_FORMAT)) {
         /* It is unnecessary to find the correct format */
@@ -884,7 +886,7 @@ void_getbuffer(PyObject *self, Py_buffer *view, int flags)
      */
     _buffer_info_t *info = NULL;
     Py_BEGIN_CRITICAL_SECTION(scalar);
-    info = _buffer_get_info(&scalar->_buffer_info, self, flags);
+    info = _buffer_get_info(&fields->_buffer_info, self, flags);
     Py_END_CRITICAL_SECTION();
     if (info == NULL) {
         Py_DECREF(self);

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1642,7 +1642,7 @@ PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
         goto cleanup;
     }
     else if (cache == NULL && PyArray_IsScalar(op, Void) &&
-            !(((PyVoidScalarObject *)op)->flags & NPY_ARRAY_OWNDATA) &&
+            !(PyVoidScalar_FLAGS((PyVoidScalarObject *)op) & NPY_ARRAY_OWNDATA) &&
              ((in_descr == NULL) && (in_DType == NULL))) {
         /*
          * Special case, we return a *view* into void scalars, mainly to
@@ -1659,8 +1659,8 @@ PyArray_FromAny_int(PyObject *op, PyArray_Descr *in_descr,
         ret = (PyArrayObject *)PyArray_NewFromDescrAndBase(
                 &PyArray_Type, dtype,
                 0, NULL, NULL,
-                ((PyVoidScalarObject *)op)->obval,
-                ((PyVoidScalarObject *)op)->flags,
+                PyArrayScalar_VAL((PyVoidScalarObject *)op, Void),
+                PyVoidScalar_FLAGS((PyVoidScalarObject *)op),
                 NULL, op);
         goto cleanup;
     }

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2379,26 +2379,28 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
     /* Datetime scalar */
     else if (PyArray_IsScalar(obj, Datetime)) {
         PyDatetimeScalarObject *dts = (PyDatetimeScalarObject *)obj;
+        PyArray_DatetimeMetaData *obmeta = PyDatetimeScalar_OBMETA(dts);
+        npy_datetime obval = PyArrayScalar_VAL(dts, Datetime);
 
         /* Copy the scalar directly if units weren't specified */
         if (meta->base == NPY_FR_ERROR) {
-            *meta = dts->obmeta;
-            *out = dts->obval;
+            *meta = *obmeta;
+            *out = obval;
 
             return 0;
         }
         /* Otherwise do a casting transformation */
         else {
             /* Allow NaT (not-a-time) values to slip through any rule */
-            if (dts->obval != NPY_DATETIME_NAT &&
+            if (obval != NPY_DATETIME_NAT &&
                         raise_if_datetime64_metadata_cast_error(
                                 "NumPy timedelta64 scalar",
-                                &dts->obmeta, meta, casting) < 0) {
+                                obmeta, meta, casting) < 0) {
                 return -1;
             }
             else {
-                return cast_datetime_to_datetime(&dts->obmeta, meta,
-                                                    dts->obval, out);
+                return cast_datetime_to_datetime(obmeta, meta,
+                                                    obval, out);
             }
         }
     }
@@ -2580,26 +2582,28 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
     /* Timedelta scalar */
     else if (PyArray_IsScalar(obj, Timedelta)) {
         PyTimedeltaScalarObject *dts = (PyTimedeltaScalarObject *)obj;
+        PyArray_DatetimeMetaData *obmeta = PyTimedeltaScalar_OBMETA(dts);
+        npy_timedelta obval = PyArrayScalar_VAL(dts, Timedelta);
 
         /* Copy the scalar directly if units weren't specified */
         if (meta->base == NPY_FR_ERROR) {
-            *meta = dts->obmeta;
-            *out = dts->obval;
+            *meta = *obmeta;
+            *out = obval;
 
             return 0;
         }
         /* Otherwise do a casting transformation */
         else {
             /* Allow NaT (not-a-time) values to slip through any rule */
-            if (dts->obval != NPY_DATETIME_NAT &&
+            if (obval != NPY_DATETIME_NAT &&
                         raise_if_timedelta64_metadata_cast_error(
                                 "NumPy timedelta64 scalar",
-                                &dts->obmeta, meta, casting) < 0) {
+                                obmeta, meta, casting) < 0) {
                 return -1;
             }
             else {
-                return cast_timedelta_to_timedelta(&dts->obmeta, meta,
-                                                    dts->obval, out);
+                return cast_timedelta_to_timedelta(obmeta, meta,
+                                                    obval, out);
             }
         }
     }
@@ -3676,10 +3680,11 @@ find_object_datetime64_meta(PyObject *obj, PyArray_DatetimeMetaData *meta)
 {
     if (PyArray_IsScalar(obj, Datetime)) {
         PyDatetimeScalarObject *dts = (PyDatetimeScalarObject *)obj;
+        PyArray_DatetimeMetaData *obmeta = PyDatetimeScalar_OBMETA(dts);
 
         /* Combine it with 'meta' */
         if (compute_datetime_metadata_greatest_common_divisor(meta,
-                        &dts->obmeta, meta, 0, 0) < 0) {
+                        obmeta, meta, 0, 0) < 0) {
             return -1;
         }
 
@@ -3784,10 +3789,11 @@ find_object_timedelta64_meta(PyObject *obj, PyArray_DatetimeMetaData *meta)
     /* Datetime scalar -> use its metadata */
     if (PyArray_IsScalar(obj, Timedelta)) {
         PyTimedeltaScalarObject *dts = (PyTimedeltaScalarObject *)obj;
+        PyArray_DatetimeMetaData *obmeta = PyTimedeltaScalar_OBMETA(dts);
 
         /* Combine it with 'meta' */
         if (compute_datetime_metadata_greatest_common_divisor(meta,
-                        &dts->obmeta, meta, 1, 1) < 0) {
+                        obmeta, meta, 1, 1) < 0) {
             return -1;
         }
 

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -544,8 +544,8 @@ void_discover_descr_from_pyobject(
 {
     if (PyArray_IsScalar(obj, Void)) {
         PyVoidScalarObject *void_obj = (PyVoidScalarObject *)obj;
-        Py_INCREF(void_obj->descr);
-        return (PyArray_Descr *)void_obj->descr;
+        Py_INCREF(PyVoidScalar_DESCR(void_obj));
+        return (PyArray_Descr *)PyVoidScalar_DESCR(void_obj);
     }
     if (PyBytes_Check(obj)) {
         PyArray_Descr *descr = PyArray_DescrNewFromType(NPY_VOID);

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -220,13 +220,13 @@ PyArray_FromScalar(PyObject *scalar, PyArray_Descr *outcode)
         return NULL;
     }
     if ((typecode->type_num == NPY_VOID) &&
-            !(((PyVoidScalarObject *)scalar)->flags & NPY_ARRAY_OWNDATA) &&
+            !(PyVoidScalar_FLAGS((PyVoidScalarObject *)scalar) & NPY_ARRAY_OWNDATA) &&
             outcode == NULL) {
         return PyArray_NewFromDescrAndBase(
                 &PyArray_Type, typecode,
                 0, NULL, NULL,
-                ((PyVoidScalarObject *)scalar)->obval,
-                ((PyVoidScalarObject *)scalar)->flags,
+                PyArrayScalar_VAL((PyVoidScalarObject *)scalar, Void),
+                PyVoidScalar_FLAGS((PyVoidScalarObject *)scalar),
                 NULL, (PyObject *)scalar);
     }
 
@@ -406,7 +406,7 @@ PyArray_DescrFromScalar(PyObject *sc)
     PyArray_Descr *descr;
 
     if (PyArray_IsScalar(sc, Void)) {
-        descr = (PyArray_Descr *)((PyVoidScalarObject *)sc)->descr;
+        descr = (PyArray_Descr *)PyVoidScalar_DESCR((PyVoidScalarObject *)sc);
         Py_INCREF(descr);
         return descr;
     }
@@ -425,7 +425,7 @@ PyArray_DescrFromScalar(PyObject *sc)
             return NULL;
         }
         dt_data = &(((PyArray_DatetimeDTypeMetaData *)((_PyArray_LegacyDescr *)descr)->c_metadata)->meta);
-        memcpy(dt_data, &((PyDatetimeScalarObject *)sc)->obmeta,
+        memcpy(dt_data, PyDatetimeScalar_OBMETA((PyDatetimeScalarObject *)sc),
                sizeof(PyArray_DatetimeMetaData));
 
         return descr;
@@ -575,7 +575,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
         PyArray_DatetimeMetaData *dt_data;
 
         dt_data = &(((PyArray_DatetimeDTypeMetaData *)((_PyArray_LegacyDescr *)descr)->c_metadata)->meta);
-        memcpy(&(((PyDatetimeScalarObject *)obj)->obmeta), dt_data,
+        memcpy(PyDatetimeScalar_OBMETA(((PyDatetimeScalarObject *)obj)), dt_data,
                sizeof(PyArray_DatetimeMetaData));
     }
     if (PyTypeNum_ISFLEXIBLE(type_num)) {
@@ -585,7 +585,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
             return obj;
         }
         else {
-            PyVoidScalarObject *vobj = (PyVoidScalarObject *)obj;
+            PyVoidScalarObject_fields *vobj = (PyVoidScalarObject_fields *)obj;
             vobj->base = NULL;
             vobj->descr = (_PyArray_LegacyDescr *)descr;
             Py_INCREF(descr);

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -54,7 +54,7 @@ npy_alloc_cache_zero(size_t nmemb, size_t size);
 NPY_NO_EXPORT void
 npy_free_cache(void * p, npy_uintp sz);
 
-NPY_NO_EXPORT PyBoolScalarObject _PyArrayScalar_BoolValues[] = {
+NPY_NO_EXPORT PyBoolScalarObject_fields _PyArrayScalar_BoolValues[] = {
     {PyObject_HEAD_INIT(&PyBoolArrType_Type) 0},
     {PyObject_HEAD_INIT(&PyBoolArrType_Type) 1},
 };
@@ -609,7 +609,7 @@ static PyObject *
 genbool_type_str(PyObject *self)
 {
     return PyUnicode_FromString(
-            ((PyBoolScalarObject *)self)->obval ? "True" : "False");
+            PyArrayScalar_VAL((PyBoolScalarObject *)self, Bool) ? "True" : "False");
 }
 
 static PyObject *
@@ -623,7 +623,7 @@ genbool_type_repr(PyObject *self)
         return genbool_type_str(self);
     }
     return PyUnicode_FromString(
-            ((PyBoolScalarObject *)self)->obval ? "np.True_" : "np.False_");
+            PyArrayScalar_VAL((PyBoolScalarObject *)self, Bool) ? "np.True_" : "np.False_");
 }
 
 /*
@@ -876,7 +876,7 @@ static PyObject *
 voidtype_repr(PyObject *self)
 {
     PyVoidScalarObject *s = (PyVoidScalarObject*) self;
-    if (PyDataType_HASFIELDS(s->descr)) {
+    if (PyDataType_HASFIELDS(PyVoidScalar_DESCR(s))) {
         /* Python helper checks for the legacy mode printing */
         return _void_scalar_to_string(self, 1);
     }
@@ -885,10 +885,10 @@ voidtype_repr(PyObject *self)
         return NULL;
     }
     if (legacy_print_mode > 125) {
-        return _void_to_hex(s->obval, s->descr->elsize, "np.void(b'", "\\x", "')");
+        return _void_to_hex(PyArrayScalar_VAL(s, Void), PyVoidScalar_DESCR(s)->elsize, "np.void(b'", "\\x", "')");
     }
     else {
-        return _void_to_hex(s->obval, s->descr->elsize, "void(b'", "\\x", "')");
+        return _void_to_hex(PyArrayScalar_VAL(s, Void), PyVoidScalar_DESCR(s)->elsize, "void(b'", "\\x", "')");
     }
 }
 
@@ -896,10 +896,10 @@ static PyObject *
 voidtype_str(PyObject *self)
 {
     PyVoidScalarObject *s = (PyVoidScalarObject*) self;
-    if (PyDataType_HASFIELDS(s->descr)) {
+    if (PyDataType_HASFIELDS(PyVoidScalar_DESCR(s))) {
         return _void_scalar_to_string(self, 0);
     }
-    return _void_to_hex(s->obval, s->descr->elsize, "b'", "\\x", "'");
+    return _void_to_hex(PyArrayScalar_VAL(s, Void), PyVoidScalar_DESCR(s)->elsize, "b'", "\\x", "'");
 }
 
 static PyObject *
@@ -918,13 +918,14 @@ datetimetype_repr(PyObject *self)
     }
 
     scal = (PyDatetimeScalarObject *)self;
+    PyArray_DatetimeMetaData *obmeta = PyDatetimeScalar_OBMETA(scal);
+    npy_datetime obval = PyArrayScalar_VAL(scal, Datetime);
 
-    if (NpyDatetime_ConvertDatetime64ToDatetimeStruct(&scal->obmeta,
-                scal->obval, &dts) < 0) {
+    if (NpyDatetime_ConvertDatetime64ToDatetimeStruct(obmeta, obval, &dts) < 0) {
         return NULL;
     }
 
-    unit = scal->obmeta.base;
+    unit = obmeta->base;
     if (NpyDatetime_MakeISO8601Datetime(&dts, iso, sizeof(iso), 0, 0,
                             unit, -1, NPY_SAFE_CASTING) < 0) {
         return NULL;
@@ -934,15 +935,15 @@ datetimetype_repr(PyObject *self)
      * For straight units or generic units, the unit will be deduced
      * from the string, so it's not necessary to specify it.
      */
-    if ((scal->obmeta.num == 1 && scal->obmeta.base != NPY_FR_h) ||
-            scal->obmeta.base == NPY_FR_GENERIC) {
+    if ((obmeta->num == 1 && obmeta->base != NPY_FR_h) ||
+            obmeta->base == NPY_FR_GENERIC) {
         int legacy_print_mode = get_legacy_print_mode();
         if (legacy_print_mode == -1) {
             return NULL;
         }
 
-        PyObject *meta = metastr_to_unicode(&scal->obmeta, 1);
-        if((scal->obval == NPY_DATETIME_NAT) && (meta != NULL)){
+        PyObject *meta = metastr_to_unicode(obmeta, 1);
+        if((obval == NPY_DATETIME_NAT) && (meta != NULL)){
             if (legacy_print_mode > 125) {
                 ret = PyUnicode_FromFormat("np.datetime64('%s','%S')", iso, meta);
             } else {
@@ -959,7 +960,7 @@ datetimetype_repr(PyObject *self)
         Py_DECREF(meta);
     }
     else {
-        PyObject *meta = metastr_to_unicode(&scal->obmeta, 1);
+        PyObject *meta = metastr_to_unicode(obmeta, 1);
         if (meta == NULL) {
             return NULL;
         }
@@ -992,17 +993,19 @@ timedeltatype_repr(PyObject *self)
     }
 
     scal = (PyTimedeltaScalarObject *)self;
+    PyArray_DatetimeMetaData *obmeta = PyTimedeltaScalar_OBMETA(scal);
+    npy_datetime obval = PyArrayScalar_VAL(scal, Timedelta);
 
     /* The value */
-    if (scal->obval == NPY_DATETIME_NAT) {
+    if (obval == NPY_DATETIME_NAT) {
         val = PyUnicode_FromString("'NaT'");
     }
     else {
          /* Can't use "%lld" if HAVE_LONG_LONG is not defined */
 #if defined(HAVE_LONG_LONG)
-        val = PyUnicode_FromFormat("%lld", (long long)scal->obval);
+        val = PyUnicode_FromFormat("%lld", (long long)obval);
 #else
-        val = PyUnicode_FromFormat("%ld", (long)scal->obval);
+        val = PyUnicode_FromFormat("%ld", (long)obval);
 #endif
     }
     if (val == NULL) {
@@ -1010,7 +1013,7 @@ timedeltatype_repr(PyObject *self)
     }
 
     /* The metadata unit */
-    if (scal->obmeta.base == NPY_FR_GENERIC) {
+    if (obmeta->base == NPY_FR_GENERIC) {
         int legacy_print_mode = get_legacy_print_mode();
         if (legacy_print_mode == -1) {
             return NULL;
@@ -1023,7 +1026,7 @@ timedeltatype_repr(PyObject *self)
         }
     }
     else {
-        PyObject *meta = metastr_to_unicode(&scal->obmeta, 1);
+        PyObject *meta = metastr_to_unicode(obmeta, 1);
         if (meta == NULL) {
             Py_DECREF(val);
             return NULL;
@@ -1060,13 +1063,15 @@ datetimetype_str(PyObject *self)
     }
 
     scal = (PyDatetimeScalarObject *)self;
+    PyArray_DatetimeMetaData *obmeta = PyDatetimeScalar_OBMETA(scal);
+    npy_datetime obval = PyArrayScalar_VAL(scal, Datetime);
 
-    if (NpyDatetime_ConvertDatetime64ToDatetimeStruct(&scal->obmeta, scal->obval,
-                                                            &dts) < 0) {
+    if (NpyDatetime_ConvertDatetime64ToDatetimeStruct(
+                obmeta, obval, &dts) < 0) {
         return NULL;
     }
 
-    unit = scal->obmeta.base;
+    unit = obmeta->base;
     if (NpyDatetime_MakeISO8601Datetime(&dts, iso, sizeof(iso), 0, 0,
                             unit, -1, NPY_SAFE_CASTING) < 0) {
         return NULL;
@@ -1107,9 +1112,11 @@ timedeltatype_str(PyObject *self)
     }
 
     scal = (PyTimedeltaScalarObject *)self;
+    PyArray_DatetimeMetaData *obmeta = PyTimedeltaScalar_OBMETA(scal);
+    npy_datetime obval = PyArrayScalar_VAL(scal, Timedelta);
 
-    if (scal->obmeta.base >= 0 && scal->obmeta.base < NPY_DATETIME_NUMUNITS) {
-        basestr = _datetime_verbose_strings[scal->obmeta.base];
+    if (obmeta->base >= 0 && obmeta->base < NPY_DATETIME_NUMUNITS) {
+        basestr = _datetime_verbose_strings[obmeta->base];
     }
     else {
         PyErr_SetString(PyExc_RuntimeError,
@@ -1117,7 +1124,7 @@ timedeltatype_str(PyObject *self)
         return NULL;
     }
 
-    if (scal->obval == NPY_DATETIME_NAT) {
+    if (obval == NPY_DATETIME_NAT) {
         ret = PyUnicode_FromString("NaT");
     }
     else {
@@ -1126,10 +1133,10 @@ timedeltatype_str(PyObject *self)
          */
 #if defined(HAVE_LONG_LONG)
         ret = PyUnicode_FromFormat("%lld %s",
-            (long long)(scal->obval * scal->obmeta.num), basestr);
+            (long long)(obval * obmeta->num), basestr);
 #else
         ret = PyUnicode_FromFormat("%ld %s",
-            (long)(scal->obval * scal->obmeta.num), basestr);
+            (long)(obval * obmeta->num), basestr);
 #endif
     }
 
@@ -1664,15 +1671,15 @@ voidtype_flags_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
         return NULL;
     }
     ((PyArrayFlagsObject *)flagobj)->arr = NULL;
-    ((PyArrayFlagsObject *)flagobj)->flags = self->flags;
+    ((PyArrayFlagsObject *)flagobj)->flags = PyVoidScalar_FLAGS(self);
     return flagobj;
 }
 
 static PyObject *
 voidtype_dtypedescr_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
 {
-    Py_INCREF(self->descr);
-    return (PyObject *)self->descr;
+    Py_INCREF(PyVoidScalar_DESCR(self));
+    return (PyObject *)PyVoidScalar_DESCR(self);
 }
 
 
@@ -1876,12 +1883,13 @@ gentype_base_get(PyObject *NPY_UNUSED(self), void *NPY_UNUSED(ignored))
 static PyObject *
 voidtype_base_get(PyVoidScalarObject *self, void *NPY_UNUSED(ignored))
 {
-    if (self->base == NULL) {
+    PyObject *base = PyVoidScalar_BASE(self);
+    if (base == NULL) {
         Py_RETURN_NONE;
     }
     else {
-        Py_INCREF(self->base);
-        return self->base;
+        Py_INCREF(base);
+        return base;
     }
 }
 
@@ -2990,12 +2998,12 @@ static PyMethodDef @name@type_methods[] = {
 static Py_ssize_t
 voidtype_length(PyVoidScalarObject *self)
 {
-    if (!PyDataType_HASFIELDS(self->descr)) {
+    if (!PyDataType_HASFIELDS(PyVoidScalar_DESCR(self))) {
         return 0;
     }
     else {
         /* return the number of fields */
-        return (Py_ssize_t) PyTuple_GET_SIZE(self->descr->names);
+        return (Py_ssize_t) PyTuple_GET_SIZE(PyVoidScalar_DESCR(self)->names);
     }
 }
 
@@ -3008,12 +3016,12 @@ voidtype_item(PyVoidScalarObject *self, Py_ssize_t n)
     npy_intp m;
     PyObject *flist=NULL;
 
-    if (!(PyDataType_HASFIELDS(self->descr))) {
+    if (!(PyDataType_HASFIELDS(PyVoidScalar_DESCR(self)))) {
         PyErr_SetString(PyExc_IndexError,
                 "can't index void scalar without fields");
         return NULL;
     }
-    flist = self->descr->names;
+    flist = PyVoidScalar_DESCR(self)->names;
     m = PyTuple_GET_SIZE(flist);
     if (n < 0) {
         n += m;
@@ -3034,7 +3042,7 @@ voidtype_subscript(PyVoidScalarObject *self, PyObject *ind)
     PyObject *ret, *res;
 
     /* structured voids will accept an integer index */
-    if (PyDataType_HASFIELDS(self->descr)) {
+    if (PyDataType_HASFIELDS(PyVoidScalar_DESCR(self))) {
         n = PyArray_PyIntAsIntp(ind);
         if (!error_converting(n)) {
             return voidtype_item(self, (Py_ssize_t)n);
@@ -3067,13 +3075,13 @@ voidtype_ass_item(PyVoidScalarObject *self, Py_ssize_t n, PyObject *val)
     npy_intp m;
     PyObject *flist=NULL;
 
-    if (!(PyDataType_HASFIELDS(self->descr))) {
+    if (!(PyDataType_HASFIELDS(PyVoidScalar_DESCR(self)))) {
         PyErr_SetString(PyExc_IndexError,
                 "can't index void scalar without fields");
         return -1;
     }
 
-    flist = self->descr->names;
+    flist = PyVoidScalar_DESCR(self)->names;
     m = PyTuple_GET_SIZE(flist);
     if (n < 0) {
         n += m;
@@ -3093,7 +3101,7 @@ voidtype_ass_subscript(PyVoidScalarObject *self, PyObject *ind, PyObject *val)
     char *msg = "invalid index";
     PyObject *args;
 
-    if (!PyDataType_HASFIELDS(self->descr)) {
+    if (!PyDataType_HASFIELDS(PyVoidScalar_DESCR(self))) {
         PyErr_SetString(PyExc_IndexError,
                 "can't index void scalar without fields");
         return -1;
@@ -3254,15 +3262,15 @@ static int
     static char fmt[3] = "@fmt@";
 
     view->ndim = 0;
-    view->len = sizeof(scalar->obval);
-    view->itemsize = sizeof(scalar->obval);
+    view->len = sizeof(PyArrayScalar_VAL(scalar, @Name@));
+    view->itemsize = sizeof(PyArrayScalar_VAL(scalar, @Name@));
     view->shape = NULL;
     view->strides = NULL;
     view->suboffsets = NULL;
     view->readonly = 1;
     Py_INCREF(self);
     view->obj = self;
-    view->buf = &(scalar->obval);
+    view->buf = &PyArrayScalar_VAL(scalar, @Name@);
 
     if ((flags & PyBUF_FORMAT) != PyBUF_FORMAT) {
         /* It is unnecessary to find the correct format */
@@ -3302,7 +3310,7 @@ unicode_getbuffer(PyObject *self, Py_buffer *view, int flags)
     Py_INCREF(self);
     view->obj = self;
 
-    if (scalar->obval == NULL) {
+    if (PyArrayScalar_VAL(scalar, Unicode) == NULL) {
         /*
          * Unicode may not have the representation available, `scalar_value`
          * ensures materialization.
@@ -3310,13 +3318,13 @@ unicode_getbuffer(PyObject *self, Py_buffer *view, int flags)
         PyArray_Descr *descr = PyArray_DescrFromType(NPY_UNICODE);
         scalar_value(self, descr);
         Py_DECREF(descr);
-        if (scalar->obval == NULL) {
+        if (PyArrayScalar_VAL(scalar, Unicode) == NULL) {
             /* allocating memory failed */
             Py_SETREF(view->obj, NULL);
             return -1;
         }
     }
-    view->buf = scalar->obval;
+    view->buf = PyArrayScalar_VAL(scalar, Unicode);
 
     if ((flags & PyBUF_FORMAT) != PyBUF_FORMAT) {
         /* It is unnecessary to find the correct format */
@@ -3324,17 +3332,18 @@ unicode_getbuffer(PyObject *self, Py_buffer *view, int flags)
         return 0;
     }
 
-    if (scalar->buffer_fmt != NULL) {
-        view->format = scalar->buffer_fmt;
+    char *buffer_fmt = PyUnicodeScalar_BUFFER_FMT(scalar);
+    if (buffer_fmt != NULL) {
+        view->format = buffer_fmt;
     }
     else {
-        scalar->buffer_fmt = PyMem_Malloc(22);
-        if (scalar->buffer_fmt == NULL) {
+        buffer_fmt = PyMem_Malloc(22);
+        if (buffer_fmt == NULL) {
             Py_SETREF(view->obj, NULL);
             return -1;
         }
-        PyOS_snprintf(scalar->buffer_fmt, 22, "%" NPY_INTP_FMT "w", length);
-        view->format = scalar->buffer_fmt;
+        PyOS_snprintf(buffer_fmt, 22, "%" NPY_INTP_FMT "w", length);
+        view->format = buffer_fmt;
     }
 
     return 0;
@@ -3371,7 +3380,7 @@ static int
     Py_INCREF(self);
     view->obj = self;
 
-    view->buf = &(scalar->obval);
+    view->buf = &PyArrayScalar_VAL(scalar, @Name@);
 
     if ((flags & PyBUF_FORMAT) != PyBUF_FORMAT) {
         /* It is unnecessary to find the correct format */
@@ -3411,12 +3420,13 @@ NPY_NO_EXPORT PyTypeObject PyGenericArrType_Type = {
 static void
 void_dealloc(PyVoidScalarObject *v)
 {
-    if (v->flags & NPY_ARRAY_OWNDATA) {
-        npy_free_cache(v->obval, Py_SIZE(v));
+    PyVoidScalarObject_fields *f = PyVoidScalar_GET_ITEM_DATA(v);
+    if (f->flags & NPY_ARRAY_OWNDATA) {
+        npy_free_cache(f->obval, Py_SIZE(v));
     }
-    Py_XDECREF(v->descr);
-    Py_XDECREF(v->base);
-    if (_buffer_info_free(v->_buffer_info, (PyObject *)v) < 0) {
+    Py_XDECREF(f->descr);
+    Py_XDECREF(f->base);
+    if (_buffer_info_free(f->_buffer_info, (PyObject *)v) < 0) {
         PyErr_WriteUnraisable(NULL);
     }
     Py_TYPE(v)->tp_free(v);
@@ -3453,7 +3463,7 @@ unicode_arrtype_dealloc(PyObject *v)
 {
     /* note: may be null if it was never requested */
     PyMem_Free(PyArrayScalar_VAL(v, Unicode));
-    PyMem_Free(((PyUnicodeScalarObject *)v)->buffer_fmt);
+    PyMem_Free(PyUnicodeScalar_BUFFER_FMT((PyUnicodeScalarObject *)v));
     /* delegate to the base class */
     PyUnicode_Type.tp_dealloc(v);
 }
@@ -3641,7 +3651,7 @@ static PyObject *
 @name@_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *obj = NULL, *meta_obj = NULL;
-    Py@Name@ScalarObject *ret;
+    Py@Name@ScalarObject_fields *ret;
 
     static char *kwnames[] = {"", "", NULL};  /* positional-only */
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO", kwnames, &obj, &meta_obj)) {
@@ -3649,7 +3659,7 @@ static PyObject *
     }
 
     /* Allocate the return scalar */
-    ret = (Py@Name@ScalarObject *)Py@Name@ArrType_Type.tp_alloc(
+    ret = (Py@Name@ScalarObject_fields *)Py@Name@ArrType_Type.tp_alloc(
                                             &Py@Name@ArrType_Type, 0);
     if (ret == NULL) {
         return NULL;
@@ -3658,8 +3668,8 @@ static PyObject *
     /* Incorporate the metadata if its provided */
     if (meta_obj != NULL) {
         /* Parse the provided metadata input */
-        if (convert_pyobject_to_datetime_metadata(meta_obj, &ret->obmeta)
-                                                                    < 0) {
+        if (convert_pyobject_to_datetime_metadata(
+                    meta_obj, &ret->obmeta) < 0) {
             Py_DECREF(ret);
             return NULL;
         }
@@ -3844,18 +3854,18 @@ void_arrtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             npy_free_cache(destptr, memu);
             return PyErr_NoMemory();
         }
-        ((PyVoidScalarObject *)ret)->obval = destptr;
-        Py_SET_SIZE((PyVoidScalarObject *)ret, (int) memu);
-        ((PyVoidScalarObject *)ret)->flags = NPY_ARRAY_BEHAVED |
+        ((PyVoidScalarObject_fields *)ret)->obval = destptr;
+        Py_SET_SIZE((PyVarObject *)ret, (Py_ssize_t) memu);
+        ((PyVoidScalarObject_fields *)ret)->flags = NPY_ARRAY_BEHAVED |
                                              NPY_ARRAY_OWNDATA;
-        ((PyVoidScalarObject *)ret)->base = NULL;
-        ((PyVoidScalarObject *)ret)->descr =
+        ((PyVoidScalarObject_fields *)ret)->base = NULL;
+        ((PyVoidScalarObject_fields *)ret)->descr =
             (_PyArray_LegacyDescr *)PyArray_DescrNewFromType(NPY_VOID);
-        if (((PyVoidScalarObject *)ret)->descr == NULL) {
+        if (((PyVoidScalarObject_fields *)ret)->descr == NULL) {
             Py_DECREF(ret);
             return NULL;
         }
-        ((PyVoidScalarObject *)ret)->descr->elsize = (int) memu;
+        ((PyVoidScalarObject_fields *)ret)->descr->elsize = (int) memu;
         return ret;
     }
 
@@ -3969,7 +3979,7 @@ static npy_hash_t
         return PyBaseObject_Type.tp_hash(obj);
     }
 
-    meta = &((PyDatetimeScalarObject *)obj)->obmeta;
+    meta = Py@name@Scalar_OBMETA((Py@name@ScalarObject *)obj);
 
     npy_hash_t res = @lname@_hash(meta, val);
     return res;
@@ -4042,7 +4052,7 @@ void_arrtype_hash(PyObject *obj)
     x = 0x345678L;
     p = (PyVoidScalarObject *)obj;
     /* Cannot hash mutable void scalars */
-    if (p->flags & NPY_ARRAY_WRITEABLE) {
+    if (PyVoidScalar_FLAGS(p) & NPY_ARRAY_WRITEABLE) {
        PyErr_SetString(PyExc_TypeError, "unhashable type: 'writeable void-scalar'");
        return -1;
     }
@@ -4069,7 +4079,7 @@ object_arrtype_getattro(PyObjectScalarObject *obj, PyObject *attr) {
 
     /* first look in object and then hand off to generic type */
 
-    res = PyObject_GenericGetAttr(obj->obval, attr);
+    res = PyObject_GenericGetAttr(PyArrayScalar_VAL(obj, Object), attr);
     if (res) {
         return res;
     }
@@ -4082,7 +4092,7 @@ object_arrtype_setattro(PyObjectScalarObject *obj, PyObject *attr, PyObject *val
     int res;
     /* first look in object and then hand off to generic type */
 
-    res = PyObject_GenericSetAttr(obj->obval, attr, val);
+    res = PyObject_GenericSetAttr(PyArrayScalar_VAL(obj, Object), attr, val);
     if (res >= 0) {
         return res;
     }
@@ -4093,50 +4103,50 @@ object_arrtype_setattro(PyObjectScalarObject *obj, PyObject *attr, PyObject *val
 static PyObject *
 object_arrtype_concat(PyObjectScalarObject *self, PyObject *other)
 {
-    return PySequence_Concat(self->obval, other);
+    return PySequence_Concat(PyArrayScalar_VAL(self, Object), other);
 }
 
 static Py_ssize_t
 object_arrtype_length(PyObjectScalarObject *self)
 {
-    return PyObject_Length(self->obval);
+    return PyObject_Length(PyArrayScalar_VAL(self, Object));
 }
 
 static PyObject *
 object_arrtype_repeat(PyObjectScalarObject *self, Py_ssize_t count)
 {
-    return PySequence_Repeat(self->obval, count);
+    return PySequence_Repeat(PyArrayScalar_VAL(self, Object), count);
 }
 
 static PyObject *
 object_arrtype_subscript(PyObjectScalarObject *self, PyObject *key)
 {
-    return PyObject_GetItem(self->obval, key);
+    return PyObject_GetItem(PyArrayScalar_VAL(self, Object), key);
 }
 
 static int
 object_arrtype_ass_subscript(PyObjectScalarObject *self, PyObject *key,
                              PyObject *value)
 {
-    return PyObject_SetItem(self->obval, key, value);
+    return PyObject_SetItem(PyArrayScalar_VAL(self, Object), key, value);
 }
 
 static int
 object_arrtype_contains(PyObjectScalarObject *self, PyObject *ob)
 {
-    return PySequence_Contains(self->obval, ob);
+    return PySequence_Contains(PyArrayScalar_VAL(self, Object), ob);
 }
 
 static PyObject *
 object_arrtype_inplace_concat(PyObjectScalarObject *self, PyObject *o)
 {
-    return PySequence_InPlaceConcat(self->obval, o);
+    return PySequence_InPlaceConcat(PyArrayScalar_VAL(self, Object), o);
 }
 
 static PyObject *
 object_arrtype_inplace_repeat(PyObjectScalarObject *self, Py_ssize_t count)
 {
-    return PySequence_InPlaceRepeat(self->obval, count);
+    return PySequence_InPlaceRepeat(PyArrayScalar_VAL(self, Object), count);
 }
 
 static PySequenceMethods object_arrtype_as_sequence = {
@@ -4157,26 +4167,26 @@ static PyMappingMethods object_arrtype_as_mapping = {
 static int
 object_arrtype_getbuffer(PyObjectScalarObject *self, Py_buffer *view, int flags)
 {
-    PyBufferProcs *pb = Py_TYPE(self->obval)->tp_as_buffer;
+    PyBufferProcs *pb = Py_TYPE(PyArrayScalar_VAL(self, Object))->tp_as_buffer;
     if (pb == NULL || pb->bf_getbuffer == NULL) {
         PyErr_SetString(PyExc_TypeError,
                         "expected a readable buffer object");
         return -1;
     }
-    return (*pb->bf_getbuffer)(self->obval, view, flags);
+    return (*pb->bf_getbuffer)(PyArrayScalar_VAL(self, Object), view, flags);
 }
 
 static void
 object_arrtype_releasebuffer(PyObjectScalarObject *self, Py_buffer *view)
 {
-    PyBufferProcs *pb = Py_TYPE(self->obval)->tp_as_buffer;
+    PyBufferProcs *pb = Py_TYPE(PyArrayScalar_VAL(self, Object))->tp_as_buffer;
     if (pb == NULL) {
         PyErr_SetString(PyExc_TypeError,
                         "expected a readable buffer object");
         return;
     }
     if (pb->bf_releasebuffer != NULL) {
-        (*pb->bf_releasebuffer)(self->obval, view);
+        (*pb->bf_releasebuffer)(PyArrayScalar_VAL(self, Object), view);
     }
 }
 
@@ -4188,13 +4198,13 @@ static PyBufferProcs object_arrtype_as_buffer = {
 static PyObject *
 object_arrtype_call(PyObjectScalarObject *obj, PyObject *args, PyObject *kwds)
 {
-    return PyObject_Call(obj->obval, args, kwds);
+    return PyObject_Call(PyArrayScalar_VAL(obj, Object), args, kwds);
 }
 
 NPY_NO_EXPORT PyTypeObject PyObjectArrType_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "numpy." NPY_OBJECT_name,
-    .tp_basicsize = sizeof(PyObjectScalarObject),
+    .tp_basicsize = sizeof(PyObjectScalarObject_fields),
     .tp_dealloc = (destructor)object_arrtype_dealloc,
     .tp_as_sequence = &object_arrtype_as_sequence,
     .tp_as_mapping = &object_arrtype_as_mapping,
@@ -4235,25 +4245,30 @@ gen_arrtype_subscript(PyObject *self, PyObject *key)
  *         UByte, UShort, UInt, ULong, ULongLong,
  *         Half, Float, Double, LongDouble,
  *         CFloat, CDouble, CLongDouble,
- *         String, Unicode, Void,
+ *         Unicode, Void,
  *         Datetime, Timedelta#
  * #NAME = BOOL,
  *         BYTE, SHORT, INT, LONG, LONGLONG,
  *         UBYTE, USHORT, UINT, ULONG, ULONGLONG,
  *         HALF, FLOAT, DOUBLE, LONGDOUBLE,
  *         CFLOAT, CDOUBLE, CLONGDOUBLE,
- *         STRING, UNICODE, VOID,
+ *         UNICODE, VOID,
  *         DATETIME, TIMEDELTA#
  */
 
 NPY_NO_EXPORT PyTypeObject Py@Name@ArrType_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "numpy." NPY_@NAME@_name,
-    .tp_basicsize = sizeof(Py@Name@ScalarObject),
+    .tp_basicsize = sizeof(Py@Name@ScalarObject_fields),
 };
 
 /**end repeat**/
 
+NPY_NO_EXPORT PyTypeObject PyStringArrType_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "numpy." NPY_STRING_name,
+    .tp_basicsize = sizeof(PyBytesObject),
+};
 
 static PyMappingMethods gentype_as_mapping = {
     .mp_subscript = (binaryfunc)gen_arrtype_subscript,


### PR DESCRIPTION
Towards fixing https://github.com/numpy/numpy/issues/30704. Also see https://github.com/numpy/numpy/pull/30744.

This makes the structs backing the scalar objects opaque in the internal API. I also added a few accessors that were missing but for the most part we can use `PyArrayScalar_VAL` for this.

Because the bytes scalar extends `PyBytesObject`, I had to adjust some of the codegen to account for the fact that the NumPy headers don't define `PyBytesObject`.