### PR TITLE
BUG: avoid precision loss when printing user-defined floating dtypes

### DIFF
--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -540,10 +540,17 @@ def _get_format_function(data, **options):
         else:
             return formatdict['int']()
     elif issubclass(dtypeobj, _nt.floating):
-        if issubclass(dtypeobj, _nt.longdouble):
-            return formatdict['longfloat']()
+
+        # Defensive check: only use Dragon4 formatters for built-in floating types
+        # For custom floating types, fall back to numpystr (scalar string formatting)
+        
+        if dtypeobj in (_nt.float16, _nt.float32, _nt.float64, _nt.longdouble):
+            if issubclass(dtypeobj, _nt.longdouble):
+                return formatdict['longfloat']()
+            else:
+                return formatdict['float']()
         else:
-            return formatdict['float']()
+            return formatdict['numpystr']()
     elif issubclass(dtypeobj, _nt.complexfloating):
         if issubclass(dtypeobj, _nt.clongdouble):
             return formatdict['longcomplexfloat']()

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -531,39 +531,50 @@ def _get_format_function(data, **options):
     dtypeobj = dtype_.type
     formatdict = _get_formatdict(data, **options)
 
-    # Fallback for non-NumPy (user defined) dtypes
-    if dtypeobj is not None and not issubclass(dtypeobj, np.generic):
-        return formatdict["void"]()
+    #Early detection of user-defined dtypes
+    if dtypeobj is not None and getattr(dtypeobj, '__module__', 'numpy') != 'numpy':
+        return formatdict['void']()
+
     if dtypeobj is None:
         return formatdict["numpystr"]()
+
     elif issubclass(dtypeobj, _nt.bool):
         return formatdict['bool']()
+
     elif issubclass(dtypeobj, _nt.integer):
         if issubclass(dtypeobj, _nt.timedelta64):
             return formatdict['timedelta']()
         return formatdict['int']()
+
     elif issubclass(dtypeobj, _nt.floating):
         if issubclass(dtypeobj, _nt.longdouble):
             return formatdict['longfloat']()
         else:
             return formatdict['float']()
+
     elif issubclass(dtypeobj, _nt.complexfloating):
         if issubclass(dtypeobj, _nt.clongdouble):
             return formatdict['longcomplexfloat']()
         else:
             return formatdict['complexfloat']()
+
+    elif issubclass(dtypeobj, (_nt.str_, _nt.bytes_)):
+        return formatdict['numpystr']()
+
     elif issubclass(dtypeobj, _nt.datetime64):
         return formatdict['datetime']()
+
     elif issubclass(dtypeobj, _nt.object_):
         return formatdict['object']()
+
     elif issubclass(dtypeobj, _nt.void):
         if dtype_.names is not None:
             return StructuredVoidFormat.from_data(data, **options)
         else:
             return formatdict['void']()
+
     else:
         return formatdict['numpystr']()
-
 def _recursive_guard(fillvalue='...'):
     """
     Like the python 3.2 reprlib.recursive_repr, but forwards *args and **kwargs

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -533,9 +533,9 @@ def _get_format_function(data, **options):
     formatdict = _get_formatdict(data, **options)
 
     # Fallback for non-NumPy (user defined) dtypes
+    # Fallback for non-NumPy (user defined) dtypes
     if dtypeobj is not None and dtypeobj.__module__ != "numpy":
-        return formatdict["numpystr"]()
-
+       return formatdict["void"]()
     if dtypeobj is None:
         return formatdict["numpystr"]()
     elif issubclass(dtypeobj, _nt.bool):

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -531,9 +531,6 @@ def _get_format_function(data, **options):
     dtypeobj = dtype_.type
     formatdict = _get_formatdict(data, **options)
 
-    # Handle NumPy string types FIRST (must keep quotes)
-    if dtypeobj is not None and issubclass(dtypeobj, (_nt.str_, _nt.bytes_)):
-        return formatdict['numpystr']()
     # Fallback for non-NumPy (user defined) dtypes
     if dtypeobj is not None and not issubclass(dtypeobj, np.generic):
         return formatdict["void"]()

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -494,8 +494,9 @@ def _get_formatdict(data, *, precision, floatmode, suppress, sign, legacy,
         'timedelta': lambda: TimedeltaFormat(data),
         'object': lambda: _object_format,
         'void': lambda: str_format,
-        'numpystr': lambda: repr_format}
-
+        # Use str() for formatting; repr() often duplicates dtype information.
+        'numpystr': lambda: str_format,
+        }
     # we need to wrap values in `formatter` in a lambda, so that the interface
     # is the same as the above values.
     def indirect(x):
@@ -542,8 +543,7 @@ def _get_format_function(data, **options):
     elif issubclass(dtypeobj, _nt.integer):
         if issubclass(dtypeobj, _nt.timedelta64):
             return formatdict['timedelta']()
-        else:
-            return formatdict['int']()
+        return formatdict['int']()
     elif issubclass(dtypeobj, _nt.floating):
         if issubclass(dtypeobj, _nt.longdouble):
             return formatdict['longfloat']()

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -544,7 +544,10 @@ def _get_format_function(data, **options):
         # Defensive check: only use Dragon4 formatters for built-in floating types
         # For custom floating types, fall back to numpystr (scalar string formatting)
 
-        if dtypeobj.builtin:
+        if (
+            issubclass(dtypeobj, _nt.floating)
+            and dtypeobj.__module__ == "numpy"
+        ):
             if issubclass(dtypeobj, _nt.longdouble):
                 return formatdict['longfloat']()
             else:

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -531,10 +531,11 @@ def _get_format_function(data, **options):
     dtypeobj = dtype_.type
     formatdict = _get_formatdict(data, **options)
 
-    #Early detection of user-defined dtypes
-    if dtypeobj is not None and getattr(dtypeobj, '__module__', 'numpy') != 'numpy':
-        return formatdict['void']()
-
+    # NOTE: removed an overly-broad module-based early guard that routed
+    # non-`numpy`-module dtype classes (e.g. `StringDType`) to the `void`
+    # formatter. Such types can still be core NumPy dtypes and must use the
+    # appropriate formatter (e.g. `numpystr` for string dtypes). See PR
+    # discussion for a targeted strategy for user-defined floating dtypes.
     if dtypeobj is None:
         return formatdict["numpystr"]()
 

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -494,9 +494,9 @@ def _get_formatdict(data, *, precision, floatmode, suppress, sign, legacy,
         'timedelta': lambda: TimedeltaFormat(data),
         'object': lambda: _object_format,
         'void': lambda: str_format,
-        # Use str() for formatting; repr() often duplicates dtype information.
-        'numpystr': lambda: str_format,
-        }
+        # Strings should keep quotes, so use repr()
+        'numpystr': lambda: repr_format,
+    }
     # we need to wrap values in `formatter` in a lambda, so that the interface
     # is the same as the above values.
     def indirect(x):

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -495,6 +495,7 @@ def _get_formatdict(data, *, precision, floatmode, suppress, sign, legacy,
         'object': lambda: _object_format,
         'void': lambda: str_format,
         'numpystr': lambda: repr_format}
+
     # we need to wrap values in `formatter` in a lambda, so that the interface
     # is the same as the above values.
     def indirect(x):
@@ -521,6 +522,7 @@ def _get_formatdict(data, *, precision, floatmode, suppress, sign, legacy,
                 formatdict[key] = indirect(formatter[key])
 
     return formatdict
+
 def _get_format_function(data, **options):
     """
     find the right formatting function for the dtype_
@@ -565,7 +567,6 @@ def _get_format_function(data, **options):
             return StructuredVoidFormat.from_data(data, **options)
         else:
             return formatdict['void']()
-
     else:
         return formatdict['numpystr']()
 

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -533,7 +533,7 @@ def _get_format_function(data, **options):
 
     if dtypeobj is None:
         return formatdict["numpystr"]()
-    elif (getattr(dtypeobj, "__module__") != "numpy"
+    elif (getattr(dtypeobj, "__module__", None) != "numpy"
             and not issubclass(dtypeobj, str)):
         # Use `str()` as a default format for non-NumPy dtypes. This should be
         # improved.  We use `str` assuming that `repr` is likely to duplicate

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -494,9 +494,7 @@ def _get_formatdict(data, *, precision, floatmode, suppress, sign, legacy,
         'timedelta': lambda: TimedeltaFormat(data),
         'object': lambda: _object_format,
         'void': lambda: str_format,
-        # Strings should keep quotes, so use repr()
-        'numpystr': lambda: repr_format,
-    }
+        'numpystr': lambda: repr_format}
     # we need to wrap values in `formatter` in a lambda, so that the interface
     # is the same as the above values.
     def indirect(x):
@@ -531,43 +529,37 @@ def _get_format_function(data, **options):
     dtypeobj = dtype_.type
     formatdict = _get_formatdict(data, **options)
 
-    # NOTE: removed an overly-broad module-based early guard that routed
-    # non-`numpy`-module dtype classes (e.g. `StringDType`) to the `void`
-    # formatter. Such types can still be core NumPy dtypes and must use the
-    # appropriate formatter (e.g. `numpystr` for string dtypes). See PR
-    # discussion for a targeted strategy for user-defined floating dtypes.
     if dtypeobj is None:
         return formatdict["numpystr"]()
-
+    elif getattr(dtypeobj, "__module__") != "numpy":
+        # Use `str()` as a default format for non-NumPy dtypes. This should be
+        # improved.  We use `str` assuming that `repr` is likely to duplicate
+        # information that is contained in the dtype.
+        # (Do this early, because e.g. quaddtype subclasses floating.)
+        return formatdict['void']()
     elif issubclass(dtypeobj, _nt.bool):
         return formatdict['bool']()
-
     elif issubclass(dtypeobj, _nt.integer):
         if issubclass(dtypeobj, _nt.timedelta64):
             return formatdict['timedelta']()
-        return formatdict['int']()
-
+        else:
+            return formatdict['int']()
     elif issubclass(dtypeobj, _nt.floating):
         if issubclass(dtypeobj, _nt.longdouble):
             return formatdict['longfloat']()
         else:
             return formatdict['float']()
-
     elif issubclass(dtypeobj, _nt.complexfloating):
         if issubclass(dtypeobj, _nt.clongdouble):
             return formatdict['longcomplexfloat']()
         else:
             return formatdict['complexfloat']()
-
     elif issubclass(dtypeobj, (_nt.str_, _nt.bytes_)):
         return formatdict['numpystr']()
-
     elif issubclass(dtypeobj, _nt.datetime64):
         return formatdict['datetime']()
-
     elif issubclass(dtypeobj, _nt.object_):
         return formatdict['object']()
-
     elif issubclass(dtypeobj, _nt.void):
         if dtype_.names is not None:
             return StructuredVoidFormat.from_data(data, **options)
@@ -576,6 +568,8 @@ def _get_format_function(data, **options):
 
     else:
         return formatdict['numpystr']()
+
+
 def _recursive_guard(fillvalue='...'):
     """
     Like the python 3.2 reprlib.recursive_repr, but forwards *args and **kwargs

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -533,7 +533,8 @@ def _get_format_function(data, **options):
 
     if dtypeobj is None:
         return formatdict["numpystr"]()
-    elif getattr(dtypeobj, "__module__") != "numpy":
+    elif (getattr(dtypeobj, "__module__") != "numpy"
+            and not issubclass(dtypeobj, str)):
         # Use `str()` as a default format for non-NumPy dtypes. This should be
         # improved.  We use `str` assuming that `repr` is likely to duplicate
         # information that is contained in the dtype.

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -1343,5 +1343,6 @@ def test_user_defined_floating_dtype_printing_does_not_corrupt_precision():
     np.set_printoptions(precision=34, floatmode="fixed")
     s = repr(arr)
 
-    assert s.strip() == "[3.14159265358979323846264338327950288]"
+    # Use startswith for platform stability; exact representation may vary
+    assert s.strip().startswith("[3.14159265358979323846264338")
 

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -1321,3 +1321,33 @@ def test_multithreaded_array_printing():
     # reasons this test makes sure it is set up in a thread-safe manner
 
     run_threaded(TestPrintOptions().test_floatmode, 500)
+
+
+
+
+
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_user_defined_floating_dtype_printing_does_not_corrupt_precision():
+    """
+    Ensure that array printing does not use NumPy Dragon4 formatting
+    for user-defined floating dtypes, which would silently truncate
+    precision to float64.
+    """
+    try:
+        from numpy_quaddtype import QuadPrecDType
+    except ImportError:
+        pytest.skip("numpy-quaddtype not installed")
+
+    pi_str = "3.14159265358979323846264338327950288"
+    arr = np.array([pi_str], dtype=QuadPrecDType())
+
+    np.set_printoptions(precision=34, floatmode="fixed")
+    s = repr(arr)
+
+    # Float64 artifact digits should not appear
+    assert "931159979" not in s

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -1322,14 +1322,8 @@ def test_multithreaded_array_printing():
 
     run_threaded(TestPrintOptions().test_floatmode, 500)
 
-
-
-
-
-
 import numpy as np
 import pytest
-
 
 @pytest.mark.filterwarnings("ignore")
 def test_user_defined_floating_dtype_printing_does_not_corrupt_precision():
@@ -1349,5 +1343,5 @@ def test_user_defined_floating_dtype_printing_does_not_corrupt_precision():
     np.set_printoptions(precision=34, floatmode="fixed")
     s = repr(arr)
 
-    # Float64 artifact digits should not appear
-    assert "931159979" not in s
+    assert s.strip() == "[3.14159265358979323846264338327950288]"
+

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -1344,5 +1344,6 @@ def test_user_defined_floating_dtype_printing_does_not_corrupt_precision():
     s = repr(arr)
 
     # Use startswith for platform stability; exact representation may vary
-    assert s.strip().startswith("[3.14159265358979323846264338")
+    assert s.strip().startswith("[3.1415926535897932")
+
 

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -1322,9 +1322,6 @@ def test_multithreaded_array_printing():
 
     run_threaded(TestPrintOptions().test_floatmode, 500)
 
-import numpy as np
-import pytest
-
 @pytest.mark.filterwarnings("ignore")
 def test_user_defined_floating_dtype_printing_does_not_corrupt_precision():
     """
@@ -1332,18 +1329,14 @@ def test_user_defined_floating_dtype_printing_does_not_corrupt_precision():
     for user-defined floating dtypes, which would silently truncate
     precision to float64.
     """
-    try:
-        from numpy_quaddtype import QuadPrecDType
-    except ImportError:
-        pytest.skip("numpy-quaddtype not installed")
+    QuadPrecDType = pytest.importorskip("numpy_quaddtype").QuadPrecDType
 
     pi_str = "3.14159265358979323846264338327950288"
     arr = np.array([pi_str], dtype=QuadPrecDType())
 
-    np.set_printoptions(precision=34, floatmode="fixed")
-    s = repr(arr)
+    with np.printoptions(precision=34, floatmode="fixed"):
+        s = str(arr)
 
-    # Use startswith for platform stability; exact representation may vary
+    # float64 would truncate the last digit here due to precision loss
     assert s.strip().startswith("[3.1415926535897932")
-
 

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -13,6 +13,7 @@ from numpy.testing import (
     IS_WASM,
     assert_,
     assert_equal,
+    assert_array_equal,
     assert_raises,
     assert_raises_regex,
 )
@@ -1322,7 +1323,7 @@ def test_multithreaded_array_printing():
 
     run_threaded(TestPrintOptions().test_floatmode, 500)
 
-@pytest.mark.filterwarnings("ignore")
+
 def test_user_defined_floating_dtype_printing_does_not_corrupt_precision():
     """
     Ensure that array printing does not use NumPy Dragon4 formatting
@@ -1333,10 +1334,6 @@ def test_user_defined_floating_dtype_printing_does_not_corrupt_precision():
 
     pi_str = "3.14159265358979323846264338327950288"
     arr = np.array([pi_str], dtype=QuadPrecDType())
-
-    with np.printoptions(precision=34, floatmode="fixed"):
-        s = str(arr)
-
-    # float64 would truncate the last digit here due to precision loss
-    assert s.strip().startswith("[3.1415926535897932")
-
+    res = np.array(str(arr).strip("[] "), dtype=QuadPrecDType())
+    # Check that the string representation round-trips correctly.
+    assert_array_equal(res, arr)

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -8,12 +8,13 @@ from hypothesis.extra import numpy as hynp
 
 import numpy as np
 from numpy._core.arrayprint import _typelessdata
+from numpy._utils import _pep440
 from numpy.testing import (
     HAS_REFCOUNT,
     IS_WASM,
     assert_,
-    assert_equal,
     assert_array_equal,
+    assert_equal,
     assert_raises,
     assert_raises_regex,
 )
@@ -1330,7 +1331,20 @@ def test_user_defined_floating_dtype_printing_does_not_corrupt_precision():
     for user-defined floating dtypes, which would silently truncate
     precision to float64.
     """
-    QuadPrecDType = pytest.importorskip("numpy_quaddtype").QuadPrecDType
+    # Quaddtype (<=1.0.0) may have a bug that leads to test failures elsewhere
+    # (this may also be an interplay of numpy/quaddtype but let's hope new
+    # quaddtype versions will fix it.)
+    from importlib.metadata import version
+
+    try:
+        quaddtype_version = version("numpy_quaddtype")
+    except Exception:
+        pytest.skip("numpy_quaddtype not installed")
+    else:
+        if _pep440.Version(quaddtype_version) <= _pep440.Version("1.0.0"):
+            pytest.skip("critical bug in quaddtype during import")
+
+    numpy_quaddtype = pytest.importorskip("numpy_quaddtype")
 
     pi_str = "3.14159265358979323846264338327950288"
     arr = np.array([pi_str], dtype=QuadPrecDType())

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -9,3 +9,5 @@ pytest-timeout
 # for optional f2py encoding detection
 charset-normalizer
 tzdata
+# Ensure we install quaddtype in CI for some wheel setups (mac):
+numpy_quaddtype ; python_version<"3.15" and sys_platform=="darwin"


### PR DESCRIPTION
### Problem
NumPy array printing applies Dragon4 formatting to all floating dtypes.
For user-defined floating dtypes with higher precision, Dragon4 internally
casts to float64, silently corrupting printed digits.

### This PR
- Restricts Dragon4 formatting to built-in NumPy floating types
  (float16, float32, float64, longdouble)
- Falls back to existing scalar string formatting for other floating dtypes
- Prevents silent precision corruption during array printing

### Notes
This is a defensive, correctness-preserving change.
It does not redesign the DType API.

Fixes #30796
