### PR TITLE
CI: add Linux x86_64 clang ASAN+LSAN job

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -108,3 +108,85 @@ jobs:
           python -m spin test \
           `find numpy -name "test*.py" | xargs grep -E -l "import threading|ThreadPoolExecutor" | tr '\n' ' '` \
            -- -v -s --timeout=600 --durations=10
+
+  clang_ASAN:
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        submodules: recursive
+        fetch-tags: true
+        persist-credentials: false
+
+    - name: Set up pyenv
+      run: |
+        git clone https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
+        PYENV_ROOT="$HOME/.pyenv"
+        PYENV_BIN="$PYENV_ROOT/bin"
+        PYENV_SHIMS="$PYENV_ROOT/shims"
+        echo "$PYENV_BIN" >> $GITHUB_PATH
+        echo "$PYENV_SHIMS" >> $GITHUB_PATH
+        echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
+
+    - name: Check pyenv is working
+      run: pyenv --version
+
+    - name: Install python & numpy build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -yq install \
+          libb2-dev \
+          libbz2-dev \
+          libffi-dev \
+          libgdbm-dev \
+          libgdbm-compat-dev \
+          liblzma-dev \
+          libncurses5-dev \
+          libopenblas-dev \
+          libreadline6-dev \
+          libsqlite3-dev \
+          libssl-dev \
+          libzstd-dev \
+          lzma-dev \
+          ninja-build \
+          tk-dev \
+          uuid-dev \
+          zlib1g-dev
+
+    - name: Install clang 21
+      run: |
+        curl -fsSLo /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+        chmod +x /tmp/llvm.sh
+        sudo /tmp/llvm.sh 21
+        CC=/usr/bin/clang-21
+        CXX=/usr/bin/clang++-21
+        echo "CC=$CC" >> $GITHUB_ENV
+        echo "CXX=$CXX" >> $GITHUB_ENV
+        sudo update-alternatives --install /usr/bin/cc cc $CC 100
+        sudo update-alternatives --install /usr/bin/c++ c++ $CXX 100
+
+    - name: Build Python with address sanitizer
+      run: |
+        CONFIGURE_OPTS="--with-address-sanitizer" pyenv install 3.14
+        pyenv global 3.14
+
+    - name: Install dependencies
+      run: |
+        pip install -r requirements/build_requirements.txt
+        pip install -r requirements/ci_requirements.txt
+        pip install -r requirements/test_requirements.txt
+        # xdist captures stdout/stderr, but we want the ASAN output
+        pip uninstall -y pytest-xdist
+
+    - name: Build
+      run: python -m spin build -j4 -- -Db_sanitize=address,leak
+
+    - name: Test
+      run: |
+        # pass -s to pytest to see ASAN errors and warnings, otherwise pytest captures them
+        export ASAN_OPTIONS="detect_leaks=1:symbolize=1:strict_init_order=true:allocator_may_return_null=1:use_sigaltstack=0"
+        export LSAN_OPTIONS="suppressions=$GITHUB_WORKSPACE/tools/ci/lsan_suppressions.txt"
+        python -m spin test -- -v -s --timeout=600 --durations=10

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -156,6 +156,8 @@ jobs:
           uuid-dev \
           zlib1g-dev
 
+    # TODO install as a regular ubuntu package in the previous step once
+    # ubuntu 26.04 is available in GHA
     - name: Install clang 21
       run: |
         curl -fsSLo /tmp/llvm.sh https://apt.llvm.org/llvm.sh

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2,6 +2,7 @@ import contextlib
 import ctypes
 import inspect
 import operator
+import os
 import pickle
 import sys
 import types
@@ -1518,6 +1519,7 @@ class TestFromDTypeAttribute:
         with pytest.raises(ValueError):
             np.dtype(dt_instance)
 
+    @pytest.mark.xfail("LSAN_OPTIONS" in os.environ, reason="known leak", run=False)
     def test_void_subtype(self):
         class dt(np.void):
             # This code path is fully untested before, so it is unclear
@@ -1897,6 +1899,7 @@ class TestUserDType:
     @pytest.mark.thread_unsafe(
         reason="crashes when GIL disabled, dtype setup is thread-unsafe",
     )
+    @pytest.mark.xfail("LSAN_OPTIONS" in os.environ, reason="known leak", run=False)
     def test_custom_structured_dtype(self):
         class mytype:
             pass
@@ -1920,6 +1923,7 @@ class TestUserDType:
     @pytest.mark.thread_unsafe(
         reason="crashes when GIL disabled, dtype setup is thread-unsafe",
     )
+    @pytest.mark.xfail("LSAN_OPTIONS" in os.environ, reason="known leak", run=False)
     def test_custom_structured_dtype_errors(self):
         class mytype:
             pass

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1,5 +1,6 @@
 import copy
 import gc
+import os
 import pickle
 import sys
 import tempfile
@@ -1908,6 +1909,7 @@ class TestRegression:
     @pytest.mark.filterwarnings(
         "ignore:.*align should be passed:numpy.exceptions.VisibleDeprecationWarning",
     )
+    @pytest.mark.xfail("LSAN_OPTIONS" in os.environ, reason="known leak", run=False)
     def test_pickle_py2_array_latin1_hack(self):
         # Check that unpickling hacks in Py3 that support
         # encoding='latin1' work correctly.

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import re
 import shlex
@@ -831,7 +832,8 @@ def test_freethreading_compatible(hello_world_f90, monkeypatch):
         rout = subprocess.run(cmd_run, capture_output=True, encoding='UTF-8')
         eout = ' Hello World\n'
         assert rout.stdout == eout
-        assert rout.stderr == ""
+        if "LSAN_OPTIONS" not in os.environ:
+            assert rout.stderr == ""
         assert rout.returncode == 0
 
 

--- a/tools/ci/lsan_suppressions.txt
+++ b/tools/ci/lsan_suppressions.txt
@@ -1,0 +1,33 @@
+# This file contains suppressions for the LSAN tool
+#
+# Reference: https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer#suppressions
+
+# 2 leaks when importing "numpy.exceptions" in initialize_static_globals
+# (check the duplicate frame number for the second leak)
+#0 0xffffb64476d0 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
+#1 0xffffb598e8d0 in PyFloat_FromDouble Objects/floatobject.c:128
+#2 0xffffb5dac0fc in fill_time Modules/posixmodule.c:2622
+#3 0xffffb5dc137c in _pystat_fromstructstat Modules/posixmodule.c:2740
+#3 0xffffb5dc13b4 in _pystat_fromstructstat Modules/posixmodule.c:2743
+#4 0xffffb5dc2d2c in posix_do_stat Modules/posixmodule.c:2868
+#5 0xffffb5dc331c in os_stat_impl Modules/posixmodule.c:3235
+#6 0xffffb5dc331c in os_stat Modules/clinic/posixmodule.c.h:105
+#7 0xffffb58484d8 in _PyEval_EvalFrameDefault Python/generated_cases.c.h:2383
+#8 0xffffb5c18174 in _PyEval_EvalFrame Include/internal/pycore_ceval.h:121
+#9 0xffffb5c18174 in _PyEval_Vector Python/ceval.c:2083
+#10 0xffffb593ccf4 in _PyObject_VectorcallTstate Include/internal/pycore_call.h:169
+#11 0xffffb593ccf4 in object_vacall Objects/call.c:819
+#12 0xffffb593d168 in PyObject_CallMethodObjArgs Objects/call.c:880
+#13 0xffffb5cbc6f0 in import_find_and_load Python/import.c:3737
+#14 0xffffb5cbc6f0 in PyImport_ImportModuleLevelObject Python/import.c:3819
+#15 0xffffb5bffca0 in builtin___import___impl Python/bltinmodule.c:285
+#16 0xffffb5bffca0 in builtin___import__ Python/clinic/bltinmodule.c.h:110
+#17 0xffffb593db9c in _PyObject_VectorcallTstate Include/internal/pycore_call.h:169
+#18 0xffffb593db9c in _PyObject_CallFunctionVa Objects/call.c:552
+#19 0xffffb593df38 in PyObject_CallFunction Objects/call.c:574
+#20 0xffffb5cbdb5c in PyImport_Import Python/import.c:4011
+#21 0xffffb5cbe17c in PyImport_ImportModule Python/import.c:3434
+#22 0xffffb1c61b44 in npy_import ../numpy/_core/src/common/npy_import.h:71
+#23 0xffffb1c61b44 in initialize_static_globals ../numpy/_core/src/multiarray/npy_static_data.c:124
+
+leak:initialize_static_globals


### PR DESCRIPTION
This PR adds a Linux x86_64 clang AddressSanitizer+LeakSanitizer job as discussed in https://github.com/numpy/numpy/pull/30761#issuecomment-3837059875 and #30583

I'll try to address the various comments found in #30583 regarding leak checks in this description.

For now, AddressSanitizer is only ran on macOS arm64 so it does make sense to add a job for Linux x86_64 which likely covers a much larger share of users and uses different optimisations not yet covered by existing AddressSanitizer tests. LeakSanitizer should not add much overhead to testing time compared to AddressSanitizer tests.

Limitations:
- CPython itself does not seem to be tested with `detect_leaks=1` and thus, leaks in CPython might be revealed here on CPython upgrades.
- The actual leak check is only done once the interpreter exits and the (native only) stack trace does not help tracking which tests leak. As mentioned by @seberg in https://github.com/numpy/numpy/pull/30583#issuecomment-3715109379, if this runs on every PR then you will know relatively well what might have caused the leak as it would be related to code changed in the PR itself.
- It's much easier to skip some tests rather than to try and update the suppression file (there are 4 tests skipped in this PR, at least one of those should be a leak mentioned in https://github.com/numpy/numpy/pull/30680#issue-3832871611) which mean those are not covered by AddressSanitizer, for this specific job.

Remarks:
- I didn't try to use `__lsan_do_leak_check`/`__lsan_do_recoverable_leak_check` to check if it could help narrow down which specific tests are actually leaking. This could be investigated as a future enhancement.
- I would expect more than 2 leaks for initialize_static_globals, furthermore, when running the full test suite, those do not appear (as opposed to running `python -c "import numpy"` or some subprocess tests in the test suite).
- Trying to use `ghcr.io/nascheme/numpy-asan:3.14t` shows many leaks and at this point, I did not check any of those and felt it was better to get something working reliably with the GIL-enabled interpreter rather than nothing.
- Running on Linux aarch64 (I do use this locally in a docker container on macOS at home where I do opensource contributions in my spare time) is really slow compared to x86_64 (which I'm more used to at work).
- Skipping tests is only done based on the presence of `LSAN_OPTIONS` in environment variables. I did not want to overcomplicate things to determine if leak sanitizer was actually enabled. This also means that if the suppression file evolves to be empty, it shall probably shall be kept, rather than removed, with no updates to the job or, this skip mechanism should be reworked.
- The leaks fixed by #30756 and #30761 were found while setting up this job in my fork.
