### PR TITLE
ENH: ``numpy.where``: don't silently truncate Python scalars

### DIFF
--- a/doc/release/upcoming_changes/30803.compatibility.rst
+++ b/doc/release/upcoming_changes/30803.compatibility.rst
@@ -1,0 +1,8 @@
+``numpy.where`` no longer truncates Python integers
+---------------------------------------------------
+
+Previously, if the ``x`` or ``y`` argument of ``numpy.where`` was a Python integer
+that was out of range of the output type, it would be silently truncated.
+Now, an `OverflowError` will be raised instead.
+
+This change also applies to the underlying C API function ``PyArray_Where``.

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3275,6 +3275,21 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
     if (common_dt == NULL) {
         goto fail;
     }
+
+    if (PyArray_FLAGS(ax) & NPY_ARRAY_WAS_PYTHON_LITERAL) {
+        if (npy_update_operand_for_scalar(&ax, x, common_dt, NPY_SAFE_CASTING) < 0) {
+            goto fail;
+        }
+        op_in[2] = ax;
+    }
+
+    if (PyArray_FLAGS(ay) & NPY_ARRAY_WAS_PYTHON_LITERAL) {
+        if (npy_update_operand_for_scalar(&ay, y, common_dt, NPY_SAFE_CASTING) < 0) {
+            goto fail;
+        }
+        op_in[3] = ay;
+    }
+
     npy_intp itemsize = common_dt->elsize;
 
     // If x and y don't have references, we ask the iterator to create buffers

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -9618,6 +9618,13 @@ class TestWhere:
         assert_raises(ValueError, np.where, c, a, a)
         assert_raises(ValueError, np.where, c[0], a, b)
 
+    def test_scalar_overflow(self):
+        c = [True]
+        a = np.array([1], dtype=np.uint8)
+        b = 1000
+        assert_raises(OverflowError, np.where, c, a, b)
+        assert_raises(OverflowError, np.where, c, b, a)
+
     def test_string(self):
         # gh-4778 check strings are properly filled with nulls
         a = np.array("abc")


### PR DESCRIPTION
Since NumPy 2.0, code like the following will cause a scalar value to be truncated:

    >>> np.where([False], np.array([1], dtype=np.uint8), 1000)
    array([232], dtype=uint8)

(in NumPy 1.x, it would instead output a uint16 array)

This is dangerous, and inconsistent with other NumPy functions, e.g.:

    >>> np.multiply(np.array([1], dtype=np.uint8), 1000)
    Traceback (most recent call last):
      File "<python-input-3>", line 1, in <module>
        np.multiply(np.array([1], dtype=np.uint8), 1000)
        ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    OverflowError: Python integer 1000 out of bounds for uint8

Use `npy_update_operand_for_scalar` to bring the behavior of `where` in line with other functions.

Closes #27006.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
