### PR TITLE
ENH: add C99 Annex G recoveries for complex multiplication and division following CPython

### DIFF
--- a/numpy/_core/src/npymath/npy_math_complex.c.src
+++ b/numpy/_core/src/npymath/npy_math_complex.c.src
@@ -89,34 +89,58 @@ cmul@c@(@ctype@ a, @ctype@ b)
     return npy_cpack@c@(ar*br - ai*bi, ar*bi + ai*br);
 }
 
-static inline
 @ctype@
 cdiv@c@(@ctype@ a, @ctype@ b)
 {
-    @type@ ar, ai, br, bi, abs_br, abs_bi;
+    @type@ ar, ai, br, bi, abs_br, abs_bi, rr, ri;
     ar = npy_creal@c@(a);
     ai = npy_cimag@c@(a);
     br = npy_creal@c@(b);
     bi = npy_cimag@c@(b);
     abs_br = npy_fabs@c@(br);
     abs_bi = npy_fabs@c@(bi);
-
     if (abs_br >= abs_bi) {
         if (abs_br == 0 && abs_bi == 0) {
             /* divide by zeros should yield a complex inf or nan */
-            return npy_cpack@c@(ar/abs_br, ai/abs_bi);
+            rr = ar/abs_br;
+            ri = ai/abs_bi;
         }
         else {
             @type@ rat = bi/br;
             @type@ scl = 1.0@C@/(br+bi*rat);
-            return npy_cpack@c@((ar + ai*rat)*scl, (ai - ar*rat)*scl);
+            rr = (ar + ai*rat)*scl;
+            ri = (ai - ar*rat)*scl;
         }
     }
     else {
         @type@ rat = br/bi;
         @type@ scl = 1.0@C@/(bi + br*rat);
-        return npy_cpack@c@((ar*rat + ai)*scl, (ai*rat - ar)*scl);
+        rr = (ar*rat + ai)*scl;
+        ri = (ai*rat - ar)*scl;
     }
+
+    /* Recover infinities and zeros that computed as nan+nanj.
+     * See e.g. the C11, Annex G.5.2, routine _Cdivd(). */
+    if (npy_isnan(rr) && npy_isnan(ri)) {
+        if ((npy_isinf(ar) || npy_isinf(ai))
+            && npy_isfinite(br) && npy_isfinite(bi))
+        {
+            @type@ x = npy_copysign@c@(npy_isinf(ar) ? 1.0 : 0.0, ar);
+            @type@ y = npy_copysign@c@(npy_isinf(ai) ? 1.0 : 0.0, ai);
+            rr = NPY_INFINITY@C@ * (x*br + y*bi);
+            ri = NPY_INFINITY@C@ * (y*br - x*bi);
+        }
+        else if ((npy_isinf(abs_br) || npy_isinf(abs_bi))
+                 && npy_isfinite(ar) && npy_isfinite(ai))
+        {
+            @type@ x = npy_copysign@c@(npy_isinf(br) ? 1.0 : 0.0, br);
+            @type@ y = npy_copysign@c@(npy_isinf(bi) ? 1.0 : 0.0, bi);
+            rr = 0.0 * (ar*x + ai*y);
+            ri = 0.0 * (ai*x - ar*y);
+        }
+    }
+
+    return npy_cpack@c@(rr, ri);
 }
 
 /*==========================================================

--- a/numpy/_core/src/npymath/npy_math_complex.c.src
+++ b/numpy/_core/src/npymath/npy_math_complex.c.src
@@ -122,7 +122,13 @@ cdiv@c@(@ctype@ a, @ctype@ b)
     /* Recover infinities and zeros that computed as nan+nanj.
      * See e.g. the C11, Annex G.5.2, routine _Cdivd(). */
     if (npy_isnan(rr) && npy_isnan(ri)) {
-        if ((npy_isinf(ar) || npy_isinf(ai))
+        if ((abs_br == 0 && abs_bi == 0)
+            && (!npy_isnan(ar) || !npy_isnan(ai)))
+        {
+            rr = npy_copysign@c@(NPY_INFINITY@C@, br) * ar;
+            ri = npy_copysign@c@(NPY_INFINITY@C@, bi) * ai;
+        }
+        else if ((npy_isinf(ar) || npy_isinf(ai))
             && npy_isfinite(br) && npy_isfinite(bi))
         {
             @type@ x = npy_copysign@c@(npy_isinf(ar) ? 1.0 : 0.0, ar);

--- a/numpy/_core/src/npymath/npy_math_complex.c.src
+++ b/numpy/_core/src/npymath/npy_math_complex.c.src
@@ -77,16 +77,51 @@ static const @ctype@ c_1@c@ = 1.0@C@;
  * These are necessary because we do not count on using a
  * C99 compiler.
  *=========================================================*/
-static inline
 @ctype@
 cmul@c@(@ctype@ a, @ctype@ b)
 {
-    @type@ ar, ai, br, bi;
+    @type@ ar, ai, br, bi, rr, ri;
     ar = npy_creal@c@(a);
     ai = npy_cimag@c@(a);
     br = npy_creal@c@(b);
     bi = npy_cimag@c@(b);
-    return npy_cpack@c@(ar*br - ai*bi, ar*bi + ai*br);
+    rr = ar*br - ai*bi;
+    ri = ar*bi + ai*br;
+
+    /* Recover infinities that computed as nan+nanj.
+     * See e.g. the C11, Annex G.5.1, routine _Cmultd(). */
+    if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
+        int recalc = 0;
+        if (npy_isinf(ar) || npy_isinf(ai)) {
+            ar = npy_copysign@c@(npy_isinf(ar) ? 1.0 : 0.0, ar);
+            ai = npy_copysign@c@(npy_isinf(ai) ? 1.0 : 0.0, ai);
+            if (npy_isnan(br)) br = npy_copysign@c@(0.0, br);
+            if (npy_isnan(bi)) bi = npy_copysign@c@(0.0, bi);
+            recalc = 1;
+        }
+        if (npy_isinf(br) || npy_isinf(bi)) {
+            br = npy_copysign@c@(npy_isinf(br) ? 1.0 : 0.0, br);
+            bi = npy_copysign@c@(npy_isinf(bi) ? 1.0 : 0.0, bi);
+            if (npy_isnan(ar)) ar = npy_copysign@c@(0.0, ar);
+            if (npy_isnan(ai)) ai = npy_copysign@c@(0.0, ai);
+            recalc = 1;
+        }
+        if (!recalc && (npy_isinf(ar*br) || npy_isinf(ai*bi)
+                     || npy_isinf(ar*bi) || npy_isinf(ai*br)))
+        {
+            if (npy_isnan(ar)) ar = npy_copysign@c@(0.0, ar);
+            if (npy_isnan(ai)) ai = npy_copysign@c@(0.0, ai);
+            if (npy_isnan(br)) br = npy_copysign@c@(0.0, br);
+            if (npy_isnan(bi)) bi = npy_copysign@c@(0.0, bi);
+            recalc = 1;
+        }
+        if (recalc) {
+            rr = NPY_INFINITY@C@ * (ar*br - ai*bi);
+            ri = NPY_INFINITY@C@ * (ar*bi + ai*br);
+        }
+    }
+
+    return npy_cpack@c@(rr, ri);
 }
 
 @ctype@
@@ -121,7 +156,7 @@ cdiv@c@(@ctype@ a, @ctype@ b)
 
     /* Recover infinities and zeros that computed as nan+nanj.
      * See e.g. the C11, Annex G.5.2, routine _Cdivd(). */
-    if (npy_isnan(rr) && npy_isnan(ri)) {
+    if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
         if ((abs_br == 0 && abs_bi == 0)
             && (!npy_isnan(ar) || !npy_isnan(ai)))
         {

--- a/numpy/_core/src/npymath/npy_math_complex.c.src
+++ b/numpy/_core/src/npymath/npy_math_complex.c.src
@@ -77,6 +77,7 @@ static const @ctype@ c_1@c@ = 1.0@C@;
  * These are necessary because we do not count on using a
  * C99 compiler.
  *=========================================================*/
+static inline
 @ctype@
 cmul@c@(@ctype@ a, @ctype@ b)
 {
@@ -124,6 +125,7 @@ cmul@c@(@ctype@ a, @ctype@ b)
     return npy_cpack@c@(rr, ri);
 }
 
+static inline
 @ctype@
 cdiv@c@(@ctype@ a, @ctype@ b)
 {

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -2392,17 +2392,41 @@ NPY_NO_EXPORT void
     UNARY_LOOP {
         const @ftype@ in1r = ((@ftype@ *)ip1)[0];
         const @ftype@ in1i = ((@ftype@ *)ip1)[1];
+        @ftype@ rr, ri;
         if (npy_fabs@c@(in1i) <= npy_fabs@c@(in1r)) {
             const @ftype@ r = in1i/in1r;
             const @ftype@ d = in1r + in1i*r;
-            ((@ftype@ *)op1)[0] = 1/d;
-            ((@ftype@ *)op1)[1] = -r/d;
+            rr = 1/d;
+            ri = -r/d;
         } else {
             const @ftype@ r = in1r/in1i;
             const @ftype@ d = in1r*r + in1i;
-            ((@ftype@ *)op1)[0] = r/d;
-            ((@ftype@ *)op1)[1] = -1/d;
+            rr = r/d;
+            ri = -1/d;
         }
+        /* Recover infinities and zeros that computed as nan+nanj.
+         * See e.g. the C11, Annex G.5.1, routine _Cdivd().
+         * Numerator is the constant 1+0j, so case 2 (numerator
+         * infinite) can never trigger. */
+        if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
+            const @ftype@ in1r_abs = npy_fabs@c@(in1r);
+            const @ftype@ in1i_abs = npy_fabs@c@(in1i);
+            if ((in1r_abs == 0 && in1i_abs == 0)
+                && (!npy_isnan(in1r) || !npy_isnan(in1i)))
+            {
+                npy_set_floatstatus_divbyzero();
+                rr = npy_copysign@c@(NPY_INFINITY@C@, in1r) * 1.0@c@;
+                ri = npy_copysign@c@(NPY_INFINITY@C@, in1r) * 0.0@c@;
+            }
+            else if (npy_isinf(in1r_abs) || npy_isinf(in1i_abs)) {
+                @ftype@ x = npy_copysign@c@(npy_isinf(in1r) ? 1.0 : 0.0, in1r);
+                @ftype@ y = npy_copysign@c@(npy_isinf(in1i) ? 1.0 : 0.0, in1i);
+                rr = 0.0@c@ * (1.0@c@*x + 0.0@c@*y);
+                ri = 0.0@c@ * (0.0@c@*x - 1.0@c@*y);
+            }
+        }
+        ((@ftype@ *)op1)[0] = rr;
+        ((@ftype@ *)op1)[1] = ri;
     }
 }
 

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -2265,7 +2265,7 @@ NPY_NO_EXPORT void
             ri = (in1i*rat - in1r)*scl;
         }
         /* Recover infinities and zeros that computed as nan+nanj.
-         * See e.g. the C11, Annex G.5.1, routine _Cdivd(). */
+         * See e.g. the C11, Annex G.5.2, routine _Cdivd(). */
         if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
             if ((in2r_abs == 0 && in2i_abs == 0)
                 && (!npy_isnan(in1r) && !npy_isnan(in1i)))
@@ -2430,7 +2430,7 @@ NPY_NO_EXPORT void
             ri = -1/d;
         }
         /* Recover infinities and zeros that computed as nan+nanj.
-         * See e.g. the C11, Annex G.5.1, routine _Cdivd().
+         * See e.g. the C11, Annex G.5.2, routine _Cdivd().
          * Numerator is the constant 1+0j, so case 2 (numerator
          * infinite) can never trigger. */
         if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -2196,7 +2196,13 @@ NPY_NO_EXPORT void
         /* Recover infinities and zeros that computed as nan+nanj.
          * See e.g. the C11, Annex G.5.1, routine _Cdivd(). */
         if (npy_isnan(rr) && npy_isnan(ri)) {
-            if ((npy_isinf(in1r) || npy_isinf(in1i))
+            if ((in2r_abs == 0 && in2i_abs == 0)
+                && (!npy_isnan(in1r) && !npy_isnan(in1i)))
+            {
+                rr = npy_copysign@c@(NPY_INFINITY@C@, in2r)*in1r;
+                ri = npy_copysign@c@(NPY_INFINITY@C@, in2r)*in1i;
+            }
+            else if ((npy_isinf(in1r) || npy_isinf(in1i))
                 && npy_isfinite(in2r) && npy_isfinite(in2i))
             {
                 @ftype@ x = npy_copysign@c@(npy_isinf(in1r) ? 1.0 : 0.0, in1r);

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -2436,9 +2436,9 @@ NPY_NO_EXPORT void
         if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
             const @ftype@ in1r_abs = npy_fabs@c@(in1r);
             const @ftype@ in1i_abs = npy_fabs@c@(in1i);
-            if ((in1r_abs == 0 && in1i_abs == 0)
-                && (!npy_isnan(in1r) || !npy_isnan(in1i)))
-            {
+            /* in1r_abs/in1i_abs == 0 implies in1r/in1i are +-0 (never nan),
+             * so unlike divide there is no numerator-nan clause to guard. */
+            if (in1r_abs == 0 && in1i_abs == 0) {
                 npy_set_floatstatus_divbyzero();
                 rr = npy_copysign@c@(NPY_INFINITY@C@, in1r) * 1.0@c@;
                 ri = npy_copysign@c@(NPY_INFINITY@C@, in1r) * 0.0@c@;

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -2125,12 +2125,49 @@ NPY_NO_EXPORT void
 @TYPE@_multiply(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
     BINARY_LOOP {
-        const @ftype@ in1r = ((@ftype@ *)ip1)[0];
-        const @ftype@ in1i = ((@ftype@ *)ip1)[1];
-        const @ftype@ in2r = ((@ftype@ *)ip2)[0];
-        const @ftype@ in2i = ((@ftype@ *)ip2)[1];
-        ((@ftype@ *)op1)[0] = in1r*in2r - in1i*in2i;
-        ((@ftype@ *)op1)[1] = in1r*in2i + in1i*in2r;
+        @ftype@ in1r = ((@ftype@ *)ip1)[0];
+        @ftype@ in1i = ((@ftype@ *)ip1)[1];
+        @ftype@ in2r = ((@ftype@ *)ip2)[0];
+        @ftype@ in2i = ((@ftype@ *)ip2)[1];
+        @ftype@ rr = in1r*in2r - in1i*in2i;
+        @ftype@ ri = in1r*in2i + in1i*in2r;
+        /* Recover infinities that computed as nan+nanj.
+         * See e.g. the C11, Annex G.5.1, routine _Cmultd(). */
+        if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
+            int recalc = 0;
+            if (npy_isinf(in1r) || npy_isinf(in1i)) {
+                /* "Box" the infinity and change NaNs in the other factor to 0 */
+                in1r = npy_copysign@c@(npy_isinf(in1r) ? 1.0 : 0.0, in1r);
+                in1i = npy_copysign@c@(npy_isinf(in1i) ? 1.0 : 0.0, in1i);
+                if (npy_isnan(in2r)) in2r = npy_copysign@c@(0.0, in2r);
+                if (npy_isnan(in2i)) in2i = npy_copysign@c@(0.0, in2i);
+                recalc = 1;
+            }
+            if (npy_isinf(in2r) || npy_isinf(in2i)) {
+                /* "Box" the infinity and change NaNs in the other factor to 0 */
+                in2r = npy_copysign@c@(npy_isinf(in2r) ? 1.0 : 0.0, in2r);
+                in2i = npy_copysign@c@(npy_isinf(in2i) ? 1.0 : 0.0, in2i);
+                if (npy_isnan(in1r)) in1r = npy_copysign@c@(0.0, in1r);
+                if (npy_isnan(in1i)) in1i = npy_copysign@c@(0.0, in1i);
+                recalc = 1;
+            }
+            if (!recalc && (npy_isinf(in1r*in2r) || npy_isinf(in1i*in2i)
+                         || npy_isinf(in1r*in2i) || npy_isinf(in1i*in2r)))
+            {
+                /* Recover infinities from overflow by changing NaNs to 0 */
+                if (npy_isnan(in1r)) in1r = npy_copysign@c@(0.0, in1r);
+                if (npy_isnan(in1i)) in1i = npy_copysign@c@(0.0, in1i);
+                if (npy_isnan(in2r)) in2r = npy_copysign@c@(0.0, in2r);
+                if (npy_isnan(in2i)) in2i = npy_copysign@c@(0.0, in2i);
+                recalc = 1;
+            }
+            if (recalc) {
+                rr = NPY_INFINITY@C@ * (in1r*in2r - in1i*in2i);
+                ri = NPY_INFINITY@C@ * (in1r*in2i + in1i*in2r);
+            }
+        }
+        ((@ftype@ *)op1)[0] = rr;
+        ((@ftype@ *)op1)[1] = ri;
     }
 }
 
@@ -2151,12 +2188,46 @@ NPY_NO_EXPORT int @TYPE@_multiply_indexed
             indx += shape;
         }
         indexed = (@ftype@ *)(ip1 + is1 * indx);
-        const @ftype@ a_r = indexed[0];
-        const @ftype@ a_i = indexed[1];
-        const @ftype@ b_r = ((@ftype@ *)value)[0];
-        const @ftype@ b_i = ((@ftype@ *)value)[1];
-        indexed[0] = a_r*b_r - a_i*b_i;
-        indexed[1] = a_r*b_i + a_i*b_r;
+        @ftype@ a_r = indexed[0];
+        @ftype@ a_i = indexed[1];
+        @ftype@ b_r = ((@ftype@ *)value)[0];
+        @ftype@ b_i = ((@ftype@ *)value)[1];
+        @ftype@ rr = a_r*b_r - a_i*b_i;
+        @ftype@ ri = a_r*b_i + a_i*b_r;
+        /* Recover infinities that computed as nan+nanj.
+         * See e.g. the C11, Annex G.5.1, routine _Cmultd(). */
+        if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
+            int recalc = 0;
+            if (npy_isinf(a_r) || npy_isinf(a_i)) {
+                a_r = npy_copysign@c@(npy_isinf(a_r) ? 1.0 : 0.0, a_r);
+                a_i = npy_copysign@c@(npy_isinf(a_i) ? 1.0 : 0.0, a_i);
+                if (npy_isnan(b_r)) b_r = npy_copysign@c@(0.0, b_r);
+                if (npy_isnan(b_i)) b_i = npy_copysign@c@(0.0, b_i);
+                recalc = 1;
+            }
+            if (npy_isinf(b_r) || npy_isinf(b_i)) {
+                b_r = npy_copysign@c@(npy_isinf(b_r) ? 1.0 : 0.0, b_r);
+                b_i = npy_copysign@c@(npy_isinf(b_i) ? 1.0 : 0.0, b_i);
+                if (npy_isnan(a_r)) a_r = npy_copysign@c@(0.0, a_r);
+                if (npy_isnan(a_i)) a_i = npy_copysign@c@(0.0, a_i);
+                recalc = 1;
+            }
+            if (!recalc && (npy_isinf(a_r*b_r) || npy_isinf(a_i*b_i)
+                         || npy_isinf(a_r*b_i) || npy_isinf(a_i*b_r)))
+            {
+                if (npy_isnan(a_r)) a_r = npy_copysign@c@(0.0, a_r);
+                if (npy_isnan(a_i)) a_i = npy_copysign@c@(0.0, a_i);
+                if (npy_isnan(b_r)) b_r = npy_copysign@c@(0.0, b_r);
+                if (npy_isnan(b_i)) b_i = npy_copysign@c@(0.0, b_i);
+                recalc = 1;
+            }
+            if (recalc) {
+                rr = NPY_INFINITY@C@ * (a_r*b_r - a_i*b_i);
+                ri = NPY_INFINITY@C@ * (a_r*b_i + a_i*b_r);
+            }
+        }
+        indexed[0] = rr;
+        indexed[1] = ri;
     }
     return 0;
 }
@@ -2195,7 +2266,7 @@ NPY_NO_EXPORT void
         }
         /* Recover infinities and zeros that computed as nan+nanj.
          * See e.g. the C11, Annex G.5.1, routine _Cdivd(). */
-        if (npy_isnan(rr) && npy_isnan(ri)) {
+        if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
             if ((in2r_abs == 0 && in2i_abs == 0)
                 && (!npy_isnan(in1r) && !npy_isnan(in1i)))
             {

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -2172,25 +2172,49 @@ NPY_NO_EXPORT void
         const @ftype@ in2i = ((@ftype@ *)ip2)[1];
         const @ftype@ in2r_abs = npy_fabs@c@(in2r);
         const @ftype@ in2i_abs = npy_fabs@c@(in2i);
+
+        @ftype@ rr, ri;
         if (in2r_abs >= in2i_abs) {
             if (in2r_abs == 0 && in2i_abs == 0) {
                 /* divide by zero should yield a complex inf or nan */
-                ((@ftype@ *)op1)[0] = in1r/in2r_abs;
-                ((@ftype@ *)op1)[1] = in1i/in2i_abs;
+                rr = in1r/in2r_abs;
+                ri = in1i/in2i_abs;
             }
             else {
                 const @ftype@ rat = in2i/in2r;
                 const @ftype@ scl = 1.0@c@/(in2r + in2i*rat);
-                ((@ftype@ *)op1)[0] = (in1r + in1i*rat)*scl;
-                ((@ftype@ *)op1)[1] = (in1i - in1r*rat)*scl;
+                rr = (in1r + in1i*rat)*scl;
+                ri = (in1i - in1r*rat)*scl;
             }
         }
         else {
             const @ftype@ rat = in2r/in2i;
             const @ftype@ scl = 1.0@c@/(in2i + in2r*rat);
-            ((@ftype@ *)op1)[0] = (in1r*rat + in1i)*scl;
-            ((@ftype@ *)op1)[1] = (in1i*rat - in1r)*scl;
+            rr = (in1r*rat + in1i)*scl;
+            ri = (in1i*rat - in1r)*scl;
         }
+        /* Recover infinities and zeros that computed as nan+nanj.
+         * See e.g. the C11, Annex G.5.1, routine _Cdivd(). */
+        if (npy_isnan(rr) && npy_isnan(ri)) {
+            if ((npy_isinf(in1r) || npy_isinf(in1i))
+                && npy_isfinite(in2r) && npy_isfinite(in2i))
+            {
+                @ftype@ x = npy_copysign@c@(npy_isinf(in1r) ? 1.0 : 0.0, in1r);
+                @ftype@ y = npy_copysign@c@(npy_isinf(in1i) ? 1.0 : 0.0, in1i);
+                rr = NPY_INFINITY@C@ * (x*in2r + y*in2i);
+                ri = NPY_INFINITY@C@ * (y*in2r - x*in2i);
+            }
+            else if ((npy_isinf(in2r_abs) || npy_isinf(in2i_abs))
+                     && npy_isfinite(in1r) && npy_isfinite(in1i))
+            {
+                @ftype@ x = npy_copysign@c@(npy_isinf(in2r) ? 1.0 : 0.0, in2r);
+                @ftype@ y = npy_copysign@c@(npy_isinf(in2i) ? 1.0 : 0.0, in2i);
+                rr = 0.0 * (in1r*x + in1i*y);
+                ri = 0.0 * (in1i*x - in1r*y);
+            }
+        }
+        ((@ftype@ *)op1)[0] = rr;
+        ((@ftype@ *)op1)[1] = ri;
     }
 }
 

--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -2378,10 +2378,35 @@ NPY_NO_EXPORT void
 @TYPE@_square(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(data))
 {
     UNARY_LOOP {
-        const @ftype@ in1r = ((@ftype@ *)ip1)[0];
-        const @ftype@ in1i = ((@ftype@ *)ip1)[1];
-        ((@ftype@ *)op1)[0] = in1r*in1r - in1i*in1i;
-        ((@ftype@ *)op1)[1] = in1r*in1i + in1i*in1r;
+        @ftype@ in1r = ((@ftype@ *)ip1)[0];
+        @ftype@ in1i = ((@ftype@ *)ip1)[1];
+        @ftype@ rr = in1r*in1r - in1i*in1i;
+        @ftype@ ri = in1r*in1i + in1i*in1r;
+        /* Recover infinities that computed as nan+nanj.
+         * See e.g. the C11, Annex G.5.1, routine _Cmultd().
+         * Both operands are the same (z*z), so cases 1 and 2
+         * are identical; only check once. */
+        if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
+            int recalc = 0;
+            if (npy_isinf(in1r) || npy_isinf(in1i)) {
+                in1r = npy_copysign@c@(npy_isinf(in1r) ? 1.0 : 0.0, in1r);
+                in1i = npy_copysign@c@(npy_isinf(in1i) ? 1.0 : 0.0, in1i);
+                recalc = 1;
+            }
+            if (!recalc && (npy_isinf(in1r*in1r) || npy_isinf(in1i*in1i)
+                         || npy_isinf(in1r*in1i)))
+            {
+                if (npy_isnan(in1r)) in1r = npy_copysign@c@(0.0, in1r);
+                if (npy_isnan(in1i)) in1i = npy_copysign@c@(0.0, in1i);
+                recalc = 1;
+            }
+            if (recalc) {
+                rr = NPY_INFINITY@C@ * (in1r*in1r - in1i*in1i);
+                ri = NPY_INFINITY@C@ * (in1r*in1i + in1i*in1r);
+            }
+        }
+        ((@ftype@ *)op1)[0] = rr;
+        ((@ftype@ *)op1)[1] = ri;
     }
 }
 #endif

--- a/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -240,7 +240,62 @@ simd_cmul_f32(npyv_f32 a, npyv_f32 b)
     npyv_f32 a_im = npyv_permi128_f32(a, 1, 1, 3, 3);
     // a_im * b_im, a_im * b_re
     npyv_f32 ab_iiir = npyv_mul_f32(a_im, b_rev);
-    return npyv_muladdsub_f32(a_re, b, ab_iiir);
+    npyv_f32 r = npyv_muladdsub_f32(a_re, b, ab_iiir);
+    /* Recover infinities that computed as nan+nanj.
+     * See e.g. the C11, Annex G.5.1, routine _Cmultd(). */
+    if (NPY_LIKELY(npyv_tobits_b32(npyv_notnan_f32(r))
+                   == (npy_uint64)((1ULL << npyv_nlanes_f32) - 1))) {
+        return r;
+    }
+    npy_float NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) r_buf[npyv_nlanes_f32];
+    npy_float NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) a_buf[npyv_nlanes_f32];
+    npy_float NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) b_buf[npyv_nlanes_f32];
+    npyv_store_f32(r_buf, r);
+    npyv_store_f32(a_buf, a);
+    npyv_store_f32(b_buf, b);
+    int recalc = 0;
+    for (int i = 0; i < npyv_nlanes_f32; i += 2) {
+        npy_float rr = r_buf[i], ri = r_buf[i+1];
+        if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
+            npy_float a_r = a_buf[i], a_i = a_buf[i+1];
+            npy_float b_r = b_buf[i], b_i = b_buf[i+1];
+            int recalc_elem = 0;
+            if (npy_isinf(a_r) || npy_isinf(a_i)) {
+                a_r = npy_copysignf(npy_isinf(a_r) ? 1.0f : 0.0f, a_r);
+                a_i = npy_copysignf(npy_isinf(a_i) ? 1.0f : 0.0f, a_i);
+                if (npy_isnan(b_r)) b_r = npy_copysignf(0.0f, b_r);
+                if (npy_isnan(b_i)) b_i = npy_copysignf(0.0f, b_i);
+                recalc_elem = 1;
+            }
+            if (npy_isinf(b_r) || npy_isinf(b_i)) {
+                b_r = npy_copysignf(npy_isinf(b_r) ? 1.0f : 0.0f, b_r);
+                b_i = npy_copysignf(npy_isinf(b_i) ? 1.0f : 0.0f, b_i);
+                if (npy_isnan(a_r)) a_r = npy_copysignf(0.0f, a_r);
+                if (npy_isnan(a_i)) a_i = npy_copysignf(0.0f, a_i);
+                recalc_elem = 1;
+            }
+            if (!recalc_elem && (npy_isinf(a_buf[i]*b_buf[i])
+                              || npy_isinf(a_buf[i+1]*b_buf[i+1])
+                              || npy_isinf(a_buf[i]*b_buf[i+1])
+                              || npy_isinf(a_buf[i+1]*b_buf[i])))
+            {
+                if (npy_isnan(a_r)) a_r = npy_copysignf(0.0f, a_r);
+                if (npy_isnan(a_i)) a_i = npy_copysignf(0.0f, a_i);
+                if (npy_isnan(b_r)) b_r = npy_copysignf(0.0f, b_r);
+                if (npy_isnan(b_i)) b_i = npy_copysignf(0.0f, b_i);
+                recalc_elem = 1;
+            }
+            if (recalc_elem) {
+                r_buf[i]   = NPY_INFINITYF * (a_r*b_r - a_i*b_i);
+                r_buf[i+1] = NPY_INFINITYF * (a_r*b_i + a_i*b_r);
+                recalc = 1;
+            }
+        }
+    }
+    if (NPY_UNLIKELY(recalc)) {
+        r = npyv_load_f32(r_buf);
+    }
+    return r;
 }
 
 NPY_FINLINE npyv_f32
@@ -281,7 +336,62 @@ simd_cmul_f64(npyv_f64 a, npyv_f64 b)
     npyv_f64 a_im = npyv_permi128_f64(a, 1, 1);
     // a_im * b_im, a_im * b_re
     npyv_f64 ab_iiir = npyv_mul_f64(a_im, b_rev);
-    return npyv_muladdsub_f64(a_re, b, ab_iiir);
+    npyv_f64 r = npyv_muladdsub_f64(a_re, b, ab_iiir);
+    /* Recover infinities that computed as nan+nanj.
+     * See e.g. the C11, Annex G.5.1, routine _Cmultd(). */
+    if (NPY_LIKELY(npyv_tobits_b64(npyv_notnan_f64(r))
+                   == (npy_uint64)((1ULL << npyv_nlanes_f64) - 1))) {
+        return r;
+    }
+    npy_double NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) r_buf[npyv_nlanes_f64];
+    npy_double NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) a_buf[npyv_nlanes_f64];
+    npy_double NPY_DECL_ALIGNED(NPY_SIMD_WIDTH) b_buf[npyv_nlanes_f64];
+    npyv_store_f64(r_buf, r);
+    npyv_store_f64(a_buf, a);
+    npyv_store_f64(b_buf, b);
+    int recalc = 0;
+    for (int i = 0; i < npyv_nlanes_f64; i += 2) {
+        npy_double rr = r_buf[i], ri = r_buf[i+1];
+        if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
+            npy_double a_r = a_buf[i], a_i = a_buf[i+1];
+            npy_double b_r = b_buf[i], b_i = b_buf[i+1];
+            int recalc_elem = 0;
+            if (npy_isinf(a_r) || npy_isinf(a_i)) {
+                a_r = npy_copysign(npy_isinf(a_r) ? 1.0 : 0.0, a_r);
+                a_i = npy_copysign(npy_isinf(a_i) ? 1.0 : 0.0, a_i);
+                if (npy_isnan(b_r)) b_r = npy_copysign(0.0, b_r);
+                if (npy_isnan(b_i)) b_i = npy_copysign(0.0, b_i);
+                recalc_elem = 1;
+            }
+            if (npy_isinf(b_r) || npy_isinf(b_i)) {
+                b_r = npy_copysign(npy_isinf(b_r) ? 1.0 : 0.0, b_r);
+                b_i = npy_copysign(npy_isinf(b_i) ? 1.0 : 0.0, b_i);
+                if (npy_isnan(a_r)) a_r = npy_copysign(0.0, a_r);
+                if (npy_isnan(a_i)) a_i = npy_copysign(0.0, a_i);
+                recalc_elem = 1;
+            }
+            if (!recalc_elem && (npy_isinf(a_buf[i]*b_buf[i])
+                              || npy_isinf(a_buf[i+1]*b_buf[i+1])
+                              || npy_isinf(a_buf[i]*b_buf[i+1])
+                              || npy_isinf(a_buf[i+1]*b_buf[i])))
+            {
+                if (npy_isnan(a_r)) a_r = npy_copysign(0.0, a_r);
+                if (npy_isnan(a_i)) a_i = npy_copysign(0.0, a_i);
+                if (npy_isnan(b_r)) b_r = npy_copysign(0.0, b_r);
+                if (npy_isnan(b_i)) b_i = npy_copysign(0.0, b_i);
+                recalc_elem = 1;
+            }
+            if (recalc_elem) {
+                r_buf[i]   = NPY_INFINITY * (a_r*b_r - a_i*b_i);
+                r_buf[i+1] = NPY_INFINITY * (a_r*b_i + a_i*b_r);
+                recalc = 1;
+            }
+        }
+    }
+    if (NPY_UNLIKELY(recalc)) {
+        r = npyv_load_f64(r_buf);
+    }
+    return r;
 }
 
 NPY_FINLINE npyv_f64

--- a/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -511,13 +511,47 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
 loop_scalar:
 #endif
     for (; len > 0; --len, b_src0 += b_ssrc0, b_src1 += b_ssrc1, b_dst += b_sdst) {
-        const @ftype@ a_r = ((@ftype@ *)b_src0)[0];
-        const @ftype@ a_i = ((@ftype@ *)b_src0)[1];
-        const @ftype@ b_r = ((@ftype@ *)b_src1)[0];
-        const @ftype@ b_i = ((@ftype@ *)b_src1)[1];
+        @ftype@ a_r = ((@ftype@ *)b_src0)[0];
+        @ftype@ a_i = ((@ftype@ *)b_src0)[1];
+        @ftype@ b_r = ((@ftype@ *)b_src1)[0];
+        @ftype@ b_i = ((@ftype@ *)b_src1)[1];
     #if @is_mul@
-        ((@ftype@ *)b_dst)[0] = a_r*b_r - a_i*b_i;
-        ((@ftype@ *)b_dst)[1] = a_r*b_i + a_i*b_r;
+        @ftype@ rr = a_r*b_r - a_i*b_i;
+        @ftype@ ri = a_r*b_i + a_i*b_r;
+        /* Recover infinities that computed as nan+nanj.
+         * See e.g. the C11, Annex G.5.1, routine _Cmultd(). */
+        if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
+            int recalc = 0;
+            if (npy_isinf(a_r) || npy_isinf(a_i)) {
+                a_r = npy_copysign@c@(npy_isinf(a_r) ? 1.0 : 0.0, a_r);
+                a_i = npy_copysign@c@(npy_isinf(a_i) ? 1.0 : 0.0, a_i);
+                if (npy_isnan(b_r)) b_r = npy_copysign@c@(0.0, b_r);
+                if (npy_isnan(b_i)) b_i = npy_copysign@c@(0.0, b_i);
+                recalc = 1;
+            }
+            if (npy_isinf(b_r) || npy_isinf(b_i)) {
+                b_r = npy_copysign@c@(npy_isinf(b_r) ? 1.0 : 0.0, b_r);
+                b_i = npy_copysign@c@(npy_isinf(b_i) ? 1.0 : 0.0, b_i);
+                if (npy_isnan(a_r)) a_r = npy_copysign@c@(0.0, a_r);
+                if (npy_isnan(a_i)) a_i = npy_copysign@c@(0.0, a_i);
+                recalc = 1;
+            }
+            if (!recalc && (npy_isinf(a_r*b_r) || npy_isinf(a_i*b_i)
+                         || npy_isinf(a_r*b_i) || npy_isinf(a_i*b_r)))
+            {
+                if (npy_isnan(a_r)) a_r = npy_copysign@c@(0.0, a_r);
+                if (npy_isnan(a_i)) a_i = npy_copysign@c@(0.0, a_i);
+                if (npy_isnan(b_r)) b_r = npy_copysign@c@(0.0, b_r);
+                if (npy_isnan(b_i)) b_i = npy_copysign@c@(0.0, b_i);
+                recalc = 1;
+            }
+            if (recalc) {
+                rr = NPY_INFINITY@C@ * (a_r*b_r - a_i*b_i);
+                ri = NPY_INFINITY@C@ * (a_r*b_i + a_i*b_r);
+            }
+        }
+        ((@ftype@ *)b_dst)[0] = rr;
+        ((@ftype@ *)b_dst)[1] = ri;
     #else
         ((@ftype@ *)b_dst)[0] = a_r @OP@ b_r;
         ((@ftype@ *)b_dst)[1] = a_i @OP@ b_i;

--- a/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -818,8 +818,37 @@ loop_scalar:
         const @ftype@ rl = ((@ftype@ *)b_src)[0];
         const @ftype@ im = ((@ftype@ *)b_src)[1];
     #if @is_square@
-        ((@ftype@ *)b_dst)[0] = rl*rl - im*im;
-        ((@ftype@ *)b_dst)[1] = rl*im + im*rl;
+        @ftype@ rr = rl*rl - im*im;
+        @ftype@ ri = rl*im + im*rl;
+        /* Recover infinities that computed as nan+nanj.
+         * See e.g. the C11, Annex G.5.1, routine _Cmultd().
+         * Both operands are the same (z*z), so cases 1 and 2
+         * are identical; only check once. */
+        if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
+            @ftype@ a_r = rl;
+            @ftype@ a_i = im;
+            int recalc = 0;
+            /* Case 1&2: z is infinite */
+            if (npy_isinf(a_r) || npy_isinf(a_i)) {
+                a_r = npy_copysign@c@(npy_isinf(a_r) ? 1.0 : 0.0, a_r);
+                a_i = npy_copysign@c@(npy_isinf(a_i) ? 1.0 : 0.0, a_i);
+                recalc = 1;
+            }
+            /* Case 3: intermediate overflow */
+            if (!recalc && (npy_isinf(rl*rl) || npy_isinf(im*im)
+                         || npy_isinf(rl*im)))
+            {
+                if (npy_isnan(a_r)) a_r = npy_copysign@c@(0.0, a_r);
+                if (npy_isnan(a_i)) a_i = npy_copysign@c@(0.0, a_i);
+                recalc = 1;
+            }
+            if (recalc) {
+                rr = NPY_INFINITY@C@ * (a_r*a_r - a_i*a_i);
+                ri = NPY_INFINITY@C@ * (a_r*a_i + a_i*a_r);
+            }
+        }
+        ((@ftype@ *)b_dst)[0] = rr;
+        ((@ftype@ *)b_dst)[1] = ri;
     #else
         ((@ftype@ *)b_dst)[0] = rl;
         ((@ftype@ *)b_dst)[1] = -im;

--- a/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -686,13 +686,47 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
             indx += shape;
         }
         indexed = (@ftype@ *)(ip1 + is1 * indx);
-        const @ftype@ b_r = ((@ftype@ *)value)[0];
-        const @ftype@ b_i = ((@ftype@ *)value)[1];
+        @ftype@ b_r = ((@ftype@ *)value)[0];
+        @ftype@ b_i = ((@ftype@ *)value)[1];
     #if @is_mul@
-        const @ftype@ a_r = indexed[0];
-        const @ftype@ a_i = indexed[1];
-        indexed[0] = a_r*b_r - a_i*b_i;
-        indexed[1] = a_r*b_i + a_i*b_r;
+        @ftype@ a_r = indexed[0];
+        @ftype@ a_i = indexed[1];
+        @ftype@ rr = a_r*b_r - a_i*b_i;
+        @ftype@ ri = a_r*b_i + a_i*b_r;
+        /* Recover infinities that computed as nan+nanj.
+         * See e.g. the C11, Annex G.5.1, routine _Cmultd(). */
+        if (NPY_UNLIKELY(npy_isnan(rr) && npy_isnan(ri))) {
+            int recalc = 0;
+            if (npy_isinf(a_r) || npy_isinf(a_i)) {
+                a_r = npy_copysign@c@(npy_isinf(a_r) ? 1.0 : 0.0, a_r);
+                a_i = npy_copysign@c@(npy_isinf(a_i) ? 1.0 : 0.0, a_i);
+                if (npy_isnan(b_r)) b_r = npy_copysign@c@(0.0, b_r);
+                if (npy_isnan(b_i)) b_i = npy_copysign@c@(0.0, b_i);
+                recalc = 1;
+            }
+            if (npy_isinf(b_r) || npy_isinf(b_i)) {
+                b_r = npy_copysign@c@(npy_isinf(b_r) ? 1.0 : 0.0, b_r);
+                b_i = npy_copysign@c@(npy_isinf(b_i) ? 1.0 : 0.0, b_i);
+                if (npy_isnan(a_r)) a_r = npy_copysign@c@(0.0, a_r);
+                if (npy_isnan(a_i)) a_i = npy_copysign@c@(0.0, a_i);
+                recalc = 1;
+            }
+            if (!recalc && (npy_isinf(a_r*b_r) || npy_isinf(a_i*b_i)
+                         || npy_isinf(a_r*b_i) || npy_isinf(a_i*b_r)))
+            {
+                if (npy_isnan(a_r)) a_r = npy_copysign@c@(0.0, a_r);
+                if (npy_isnan(a_i)) a_i = npy_copysign@c@(0.0, a_i);
+                if (npy_isnan(b_r)) b_r = npy_copysign@c@(0.0, b_r);
+                if (npy_isnan(b_i)) b_i = npy_copysign@c@(0.0, b_i);
+                recalc = 1;
+            }
+            if (recalc) {
+                rr = NPY_INFINITY@C@ * (a_r*b_r - a_i*b_i);
+                ri = NPY_INFINITY@C@ * (a_r*b_i + a_i*b_r);
+            }
+        }
+        indexed[0] = rr;
+        indexed[1] = ri;
     #else
         indexed[0] @OP@= b_r;
         indexed[1] @OP@= b_i;

--- a/numpy/_core/src/umath/scalarmath.c.src
+++ b/numpy/_core/src/umath/scalarmath.c.src
@@ -429,11 +429,14 @@ static inline int
  * TODO: Mark as  to work around FPEs not being issues on clang 12.
  *       This should be removed when possible.
  */
+/* Use the ufunc loop directly to avoid duplicating the complicated logic */
 static inline int
-@name@_ctype_multiply( @type@ a, @type@ b, @type@ *out)
+@name@_ctype_multiply(@type@ a, @type@ b, @type@ *out)
 {
-    npy_csetreal@c@(out, npy_creal@c@(a) * npy_creal@c@(b) - npy_cimag@c@(a) * npy_cimag@c@(b));
-    npy_csetimag@c@(out, npy_creal@c@(a) * npy_cimag@c@(b) + npy_cimag@c@(a) * npy_creal@c@(b));
+    char *args[3] = {(char *)&a, (char *)&b, (char *)out};
+    npy_intp steps[3] = {0, 0, 0};
+    npy_intp size = 1;
+    @TYPE@_multiply(args, &size, steps, NULL);
     return 0;
 }
 

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -478,6 +478,81 @@ class TestComplexDivision:
                     assert_equal(result.real, ex[0])
                     assert_equal(result.imag, ex[1])
 
+    def test_annex_g(self):
+        # C99 Annex G.5.1 recovery cases for complex division.
+        # Test cases from CPython 3.14 cmath tests.
+        INF = np.inf
+        NAN = np.nan
+
+        def assert_strict_equal(x, y):
+            assert_equal(x, y)
+            assert_equal(np.copysign(1., x), np.copysign(1., y))
+
+        with np.errstate(all="ignore"):
+            data = (
+                (complex(INF, 1), complex(0, 1), complex(NAN, -INF)),
+                (complex(INF, -INF), complex(1, 0), complex(INF, -INF)),
+                (complex(INF, INF), complex(0, 1), complex(INF, -INF)),
+                (complex(NAN, INF), complex(2**1000, 2**-1000), complex(INF, INF)),
+                (complex(INF, NAN), complex(2**1000, 2**-1000), complex(INF, -INF)),
+                (complex(1, 1), complex(INF, INF), complex(0.0, 0.0)),
+                (complex(1, 1), complex(INF, -INF), complex(0.0, 0.0)),
+                (complex(1, 1), complex(-INF, INF), complex(0.0, -0.0)),
+                (complex(1, 1), complex(-INF, -INF), complex(-0.0, 0.0)),
+                (complex(INF, 1), complex(INF, INF), complex(NAN, NAN)),
+                (complex(1, INF), complex(INF, INF), complex(NAN, NAN)),
+                (complex(INF, 1), complex(1, INF), complex(NAN, NAN)),
+            )
+            for n, d, expected in data:
+                result = np.complex128(n) / np.complex128(d)
+                if np.isnan(expected.real):
+                    assert_(np.isnan(result.real))
+                else:
+                    assert_strict_equal(result.real, expected.real)
+                if np.isnan(expected.imag):
+                    assert_(np.isnan(result.imag))
+                else:
+                    assert_strict_equal(result.imag, expected.imag)
+
+
+class TestComplexMultiplication:
+    def test_annex_g(self):
+        # C99 Annex G.5.1 recovery cases for complex multiplication.
+        # Test cases from CPython 3.14 cmath tests.
+        INF = np.inf
+        NAN = np.nan
+
+        def assert_strict_equal(x, y):
+            assert_equal(x, y)
+            assert_equal(np.copysign(1., x), np.copysign(1., y))
+
+        with np.errstate(all="ignore"):
+            data = (
+                (complex(1e300, 1), complex(INF, INF), complex(NAN, INF)),
+                (complex(1e300, 1), complex(NAN, INF), complex(-INF, INF)),
+                (complex(1e300, 1), complex(INF, NAN), complex(INF, INF)),
+                (complex(INF, 1), complex(NAN, INF), complex(NAN, INF)),
+                (complex(INF, 1), complex(INF, NAN), complex(INF, NAN)),
+                (complex(NAN, 1), complex(1, INF), complex(-INF, NAN)),
+                (complex(1, NAN), complex(1, INF), complex(NAN, INF)),
+                (complex(1e200, NAN), complex(1e200, NAN), complex(INF, NAN)),
+                (complex(1e200, NAN), complex(NAN, 1e200), complex(NAN, INF)),
+                (complex(NAN, 1e200), complex(1e200, NAN), complex(NAN, INF)),
+                (complex(NAN, 1e200), complex(NAN, 1e200), complex(-INF, NAN)),
+                (complex(NAN, NAN), complex(NAN, NAN), complex(NAN, NAN)),
+            )
+            for z, w, expected in data:
+                for result in (np.complex128(z) * np.complex128(w),
+                               np.complex128(w) * np.complex128(z)):
+                    if np.isnan(expected.real):
+                        assert_(np.isnan(result.real))
+                    else:
+                        assert_strict_equal(result.real, expected.real)
+                    if np.isnan(expected.imag):
+                        assert_(np.isnan(result.imag))
+                    else:
+                        assert_strict_equal(result.imag, expected.imag)
+
 
 class TestConversion:
     def test_int_from_long(self):

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -595,6 +595,53 @@ class TestComplexReciprocal:
                     assert_strict_equal(div_result.imag, result.imag)
 
 
+class TestComplexSquare:
+    def test_annex_g(self):
+        # C99 Annex G.5.1 recovery cases for complex square (z*z).
+        # Since both operands are the same, cases 1 and 2 of multiply
+        # recovery are identical — only one check is needed.
+        INF = np.inf
+        NAN = np.nan
+
+        def assert_strict_equal(x, y):
+            assert_equal(x, y)
+            assert_equal(np.copysign(1., x), np.copysign(1., y))
+
+        with np.errstate(all="ignore"):
+            data = (
+                # Cases where recovery triggers (both rr and ri are NaN):
+                # Case 1&2: z has infinite component
+                (complex(INF, NAN), complex(INF, NAN)),
+                (complex(NAN, INF), complex(-INF, NAN)),
+                # Case 3: intermediate overflow
+                (complex(1e200, NAN), complex(INF, NAN)),
+                (complex(NAN, 1e200), complex(-INF, NAN)),
+                # No recovery possible (NaN stays)
+                (complex(NAN, 1), complex(NAN, NAN)),
+                (complex(1, NAN), complex(NAN, NAN)),
+                (complex(NAN, NAN), complex(NAN, NAN)),
+                # No recovery needed (not both NaN)
+                (complex(INF, 1), complex(INF, INF)),
+                (complex(-INF, 1), complex(INF, -INF)),
+                (complex(INF, INF), complex(NAN, INF)),
+                (complex(INF, -INF), complex(NAN, -INF)),
+            )
+            for z, expected in data:
+                z128 = np.complex128(z)
+                # np.square, scalar ** 2, np.power all reduce to z*z
+                for result in (np.square(z128), z128 ** 2,
+                               np.power(z128, 2),
+                               np.float_power(z128, 2)):
+                    if np.isnan(expected.real):
+                        assert_(np.isnan(result.real))
+                    else:
+                        assert_strict_equal(result.real, expected.real)
+                    if np.isnan(expected.imag):
+                        assert_(np.isnan(result.imag))
+                    else:
+                        assert_strict_equal(result.imag, expected.imag)
+
+
 class TestConversion:
     def test_int_from_long(self):
         l = [1e6, 1e12, 1e18, -1e6, -1e12, -1e18]

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -554,6 +554,47 @@ class TestComplexMultiplication:
                         assert_strict_equal(result.imag, expected.imag)
 
 
+class TestComplexReciprocal:
+    def test_annex_g(self):
+        # C99 Annex G.5.1 recovery cases for complex reciprocal (1/z).
+        # reciprocal is division with numerator 1+0j, so only
+        # cases 1 (denom zero) and 3 (denom infinite) apply.
+        INF = np.inf
+        NAN = np.nan
+
+        def assert_strict_equal(x, y):
+            assert_equal(x, y)
+            assert_equal(np.copysign(1., x), np.copysign(1., y))
+
+        with np.errstate(all="ignore"):
+            data = (
+                (complex(INF, INF), complex(0.0, -0.0)),
+                (complex(INF, -INF), complex(0.0, 0.0)),
+                (complex(-INF, INF), complex(-0.0, -0.0)),
+                (complex(-INF, -INF), complex(-0.0, 0.0)),
+                (complex(0.0, 0.0), complex(INF, NAN)),
+            )
+            for z, expected in data:
+                result = np.reciprocal(np.complex128(z))
+                if np.isnan(expected.real):
+                    assert_(np.isnan(result.real))
+                else:
+                    assert_strict_equal(result.real, expected.real)
+                if np.isnan(expected.imag):
+                    assert_(np.isnan(result.imag))
+                else:
+                    assert_strict_equal(result.imag, expected.imag)
+                div_result = np.complex128(1.0) / np.complex128(z)
+                if np.isnan(expected.real):
+                    assert_(np.isnan(div_result.real))
+                else:
+                    assert_strict_equal(div_result.real, result.real)
+                if np.isnan(expected.imag):
+                    assert_(np.isnan(div_result.imag))
+                else:
+                    assert_strict_equal(div_result.imag, result.imag)
+
+
 class TestConversion:
     def test_int_from_long(self):
         l = [1e6, 1e12, 1e18, -1e6, -1e12, -1e18]

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -479,7 +479,7 @@ class TestComplexDivision:
                     assert_equal(result.imag, ex[1])
 
     def test_annex_g(self):
-        # C99 Annex G.5.1 recovery cases for complex division.
+        # C99 Annex G.5.2 recovery cases for complex division.
         # Test cases from CPython 3.14 cmath tests.
         INF = np.inf
         NAN = np.nan
@@ -556,7 +556,7 @@ class TestComplexMultiplication:
 
 class TestComplexReciprocal:
     def test_annex_g(self):
-        # C99 Annex G.5.1 recovery cases for complex reciprocal (1/z).
+        # C99 Annex G.5.2 recovery cases for complex reciprocal (1/z).
         # reciprocal is division with numerator 1+0j, so only
         # cases 1 (denom zero) and 3 (denom infinite) apply.
         INF = np.inf

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -24,6 +24,7 @@ from numpy.testing import (
     assert_almost_equal,
     assert_array_almost_equal,
     assert_array_almost_equal_nulp,
+    assert_array_compare,
     assert_array_equal,
     assert_array_max_ulp,
     assert_equal,
@@ -654,6 +655,87 @@ class TestDivision:
             assert_(np.isinf(y)[0])
             y = 0.0 / x
             assert_(np.isnan(y)[0])
+
+    def test_division_annex_g_complex(self):
+        # C99 Annex G.5.1 recovery cases for complex division.
+        # Test cases from CPython 3.14 cmath tests.
+        INF = np.inf
+        NAN = np.nan
+
+        def assert_array_strict_equal(x, y):
+            def comparison(a, b):
+                return np.logical_and(
+                    a == b,
+                    (np.copysign(1., a) == np.copysign(1., b))
+                )
+            assert_array_compare(comparison, x.real, y.real, strict=True)
+            assert_array_compare(comparison, x.imag, y.imag, strict=True)
+
+        with np.errstate(all="ignore"):
+            x = np.array([
+                complex(INF, 1), complex(INF, -INF), complex(INF, INF),
+                complex(NAN, INF), complex(INF, NAN),
+                complex(1, 1), complex(1, 1), complex(1, 1), complex(1, 1),
+                complex(INF, 1), complex(1, INF), complex(INF, 1),
+            ], dtype=np.complex128)
+            y = np.array([
+                complex(0, 1), complex(1, 0), complex(0, 1),
+                complex(2**1000, 2**-1000), complex(2**1000, 2**-1000),
+                complex(INF, INF), complex(INF, -INF),
+                complex(-INF, INF), complex(-INF, -INF),
+                complex(INF, INF), complex(INF, INF), complex(1, INF),
+            ], dtype=np.complex128)
+            expected = np.array([
+                complex(NAN, -INF), complex(INF, -INF), complex(INF, -INF),
+                complex(INF, INF), complex(INF, -INF),
+                complex(0.0, 0.0), complex(0.0, 0.0),
+                complex(0.0, -0.0), complex(-0.0, 0.0),
+                complex(NAN, NAN), complex(NAN, NAN), complex(NAN, NAN),
+            ], dtype=np.complex128)
+            assert_array_strict_equal(x / y, expected)
+
+    def test_multiplication_annex_g_complex(self):
+        # C99 Annex G.5.1 recovery cases for complex multiplication.
+        # Test cases from CPython 3.14 cmath tests.
+        INF = np.inf
+        NAN = np.nan
+
+        def assert_array_strict_equal(x, y):
+            def comparison(a, b):
+                return np.logical_and(
+                    a == b,
+                    (np.copysign(1., a) == np.copysign(1., b))
+                )
+            assert_array_compare(comparison, x.real, y.real, strict=True)
+            assert_array_compare(comparison, x.imag, y.imag, strict=True)
+
+        with np.errstate(all="ignore"):
+            x = np.array([
+                complex(1e300, 1), complex(1e300, 1), complex(1e300, 1),
+                complex(INF, 1), complex(INF, 1),
+                complex(NAN, 1), complex(1, NAN),
+                complex(1e200, NAN), complex(1e200, NAN),
+                complex(NAN, 1e200), complex(NAN, 1e200),
+                complex(NAN, NAN),
+            ], dtype=np.complex128)
+            y = np.array([
+                complex(INF, INF), complex(NAN, INF), complex(INF, NAN),
+                complex(NAN, INF), complex(INF, NAN),
+                complex(1, INF), complex(1, INF),
+                complex(1e200, NAN), complex(NAN, 1e200),
+                complex(1e200, NAN), complex(NAN, 1e200),
+                complex(NAN, NAN),
+            ], dtype=np.complex128)
+            expected = np.array([
+                complex(NAN, INF), complex(-INF, INF), complex(INF, INF),
+                complex(NAN, INF), complex(INF, NAN),
+                complex(-INF, NAN), complex(NAN, INF),
+                complex(INF, NAN), complex(NAN, INF),
+                complex(NAN, INF), complex(-INF, NAN),
+                complex(NAN, NAN),
+            ], dtype=np.complex128)
+            assert_array_strict_equal(x * y, expected)
+            assert_array_strict_equal(y * x, expected)
 
     def test_floor_division_complex(self):
         # check that floor division, divmod and remainder raises type errors

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -694,49 +694,6 @@ class TestDivision:
             ], dtype=np.complex128)
             assert_array_strict_equal(x / y, expected)
 
-    def test_multiplication_annex_g_complex(self):
-        # C99 Annex G.5.1 recovery cases for complex multiplication.
-        # Test cases from CPython 3.14 cmath tests.
-        INF = np.inf
-        NAN = np.nan
-
-        def assert_array_strict_equal(x, y):
-            def comparison(a, b):
-                return np.logical_and(
-                    a == b,
-                    (np.copysign(1., a) == np.copysign(1., b))
-                )
-            assert_array_compare(comparison, x.real, y.real, strict=True)
-            assert_array_compare(comparison, x.imag, y.imag, strict=True)
-
-        with np.errstate(all="ignore"):
-            x = np.array([
-                complex(1e300, 1), complex(1e300, 1), complex(1e300, 1),
-                complex(INF, 1), complex(INF, 1),
-                complex(NAN, 1), complex(1, NAN),
-                complex(1e200, NAN), complex(1e200, NAN),
-                complex(NAN, 1e200), complex(NAN, 1e200),
-                complex(NAN, NAN),
-            ], dtype=np.complex128)
-            y = np.array([
-                complex(INF, INF), complex(NAN, INF), complex(INF, NAN),
-                complex(NAN, INF), complex(INF, NAN),
-                complex(1, INF), complex(1, INF),
-                complex(1e200, NAN), complex(NAN, 1e200),
-                complex(1e200, NAN), complex(NAN, 1e200),
-                complex(NAN, NAN),
-            ], dtype=np.complex128)
-            expected = np.array([
-                complex(NAN, INF), complex(-INF, INF), complex(INF, INF),
-                complex(NAN, INF), complex(INF, NAN),
-                complex(-INF, NAN), complex(NAN, INF),
-                complex(INF, NAN), complex(NAN, INF),
-                complex(NAN, INF), complex(-INF, NAN),
-                complex(NAN, NAN),
-            ], dtype=np.complex128)
-            assert_array_strict_equal(x * y, expected)
-            assert_array_strict_equal(y * x, expected)
-
     def test_reciprocal_annex_g_complex(self):
         # C99 Annex G.5.1 recovery cases for complex reciprocal (1/z).
         # reciprocal is division with numerator 1+0j, so only
@@ -847,6 +804,122 @@ def _signs(dt):
         return (+1,)
     else:
         return (+1, -1)
+
+
+class TestMultiplySquarePower:
+    def test_multiplication_annex_g_complex(self):
+        # C99 Annex G.5.1 recovery cases for complex multiplication.
+        # Test cases from CPython 3.14 cmath tests.
+        INF = np.inf
+        NAN = np.nan
+
+        def assert_array_strict_equal(x, y):
+            def comparison(a, b):
+                return np.logical_and(
+                    a == b,
+                    (np.copysign(1., a) == np.copysign(1., b))
+                )
+            assert_array_compare(comparison, x.real, y.real, strict=True)
+            assert_array_compare(comparison, x.imag, y.imag, strict=True)
+
+        with np.errstate(all="ignore"):
+            x = np.array([
+                complex(1e300, 1), complex(1e300, 1), complex(1e300, 1),
+                complex(INF, 1), complex(INF, 1),
+                complex(NAN, 1), complex(1, NAN),
+                complex(1e200, NAN), complex(1e200, NAN),
+                complex(NAN, 1e200), complex(NAN, 1e200),
+                complex(NAN, NAN),
+            ], dtype=np.complex128)
+            y = np.array([
+                complex(INF, INF), complex(NAN, INF), complex(INF, NAN),
+                complex(NAN, INF), complex(INF, NAN),
+                complex(1, INF), complex(1, INF),
+                complex(1e200, NAN), complex(NAN, 1e200),
+                complex(1e200, NAN), complex(NAN, 1e200),
+                complex(NAN, NAN),
+            ], dtype=np.complex128)
+            expected = np.array([
+                complex(NAN, INF), complex(-INF, INF), complex(INF, INF),
+                complex(NAN, INF), complex(INF, NAN),
+                complex(-INF, NAN), complex(NAN, INF),
+                complex(INF, NAN), complex(NAN, INF),
+                complex(NAN, INF), complex(-INF, NAN),
+                complex(NAN, NAN),
+            ], dtype=np.complex128)
+            assert_array_strict_equal(x * y, expected)
+            assert_array_strict_equal(y * x, expected)
+
+    def test_square_annex_g_complex(self):
+        # C99 Annex G.5.1 recovery cases for complex square (z*z).
+        # Since both operands are the same, cases 1 and 2 of multiply
+        # recovery are identical — only one check is needed.
+        INF = np.inf
+        NAN = np.nan
+
+        def assert_array_strict_equal(x, y):
+            def comparison(a, b):
+                return np.logical_and(
+                    a == b,
+                    (np.copysign(1., a) == np.copysign(1., b))
+                )
+            assert_array_compare(comparison, x.real, y.real, strict=True)
+            assert_array_compare(comparison, x.imag, y.imag, strict=True)
+
+        with np.errstate(all="ignore"):
+            x = np.array([
+                # Cases where recovery triggers (both rr and ri are NaN):
+                # Case 1&2: z has infinite component
+                complex(INF, NAN), complex(NAN, INF),
+                # Case 3: intermediate overflow
+                complex(1e200, NAN), complex(NAN, 1e200),
+                # No recovery possible (NaN stays)
+                complex(NAN, 1), complex(1, NAN), complex(NAN, NAN),
+                # No recovery needed (not both NaN)
+                complex(INF, 1), complex(-INF, 1),
+                complex(INF, INF), complex(INF, -INF),
+            ], dtype=np.complex128)
+            expected = np.array([
+                complex(INF, NAN), complex(-INF, NAN),
+                complex(INF, NAN), complex(-INF, NAN),
+                complex(NAN, NAN), complex(NAN, NAN), complex(NAN, NAN),
+                complex(INF, INF), complex(INF, -INF),
+                complex(NAN, INF), complex(NAN, -INF),
+            ], dtype=np.complex128)
+            assert_array_strict_equal(np.square(x), expected)
+
+    def test_power_annex_g_complex(self):
+        # np.power(z, 2) for complex types delegates to npy_cpow which
+        # unrolls integer exponent 2 as cmul(z, z), getting Annex G
+        # recovery from cmul.
+        INF = np.inf
+        NAN = np.nan
+
+        def assert_array_strict_equal(x, y):
+            def comparison(a, b):
+                return np.logical_and(
+                    a == b,
+                    (np.copysign(1., a) == np.copysign(1., b))
+                )
+            assert_array_compare(comparison, x.real, y.real, strict=True)
+            assert_array_compare(comparison, x.imag, y.imag, strict=True)
+
+        with np.errstate(all="ignore"):
+            x = np.array([
+                complex(INF, NAN), complex(NAN, INF),
+                complex(1e200, NAN), complex(NAN, 1e200),
+                complex(NAN, 1), complex(1, NAN), complex(NAN, NAN),
+                complex(INF, 1), complex(-INF, 1),
+            ], dtype=np.complex128)
+            expected = np.array([
+                complex(INF, NAN), complex(-INF, NAN),
+                complex(INF, NAN), complex(-INF, NAN),
+                complex(NAN, NAN), complex(NAN, NAN), complex(NAN, NAN),
+                complex(INF, INF), complex(INF, -INF),
+            ], dtype=np.complex128)
+            assert_array_strict_equal(np.power(x, 2), expected)
+            assert_array_strict_equal(x ** 2, expected)
+            assert_array_strict_equal(np.float_power(x, 2), expected)
 
 
 class TestRemainder:

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -737,6 +737,39 @@ class TestDivision:
             assert_array_strict_equal(x * y, expected)
             assert_array_strict_equal(y * x, expected)
 
+    def test_reciprocal_annex_g_complex(self):
+        # C99 Annex G.5.1 recovery cases for complex reciprocal (1/z).
+        # reciprocal is division with numerator 1+0j, so only
+        # cases 1 (denom zero) and 3 (denom infinite) apply.
+        INF = np.inf
+        NAN = np.nan
+
+        def assert_array_strict_equal(x, y):
+            def comparison(a, b):
+                return np.logical_and(
+                    a == b,
+                    (np.copysign(1., a) == np.copysign(1., b))
+                )
+            assert_array_compare(comparison, x.real, y.real, strict=True)
+            assert_array_compare(comparison, x.imag, y.imag, strict=True)
+
+        with np.errstate(all="ignore"):
+            x = np.array([
+                complex(INF, INF), complex(INF, -INF),
+                complex(-INF, INF), complex(-INF, -INF),
+            ], dtype=np.complex128)
+            expected = np.array([
+                complex(0.0, -0.0), complex(0.0, 0.0),
+                complex(-0.0, -0.0), complex(-0.0, 0.0),
+            ], dtype=np.complex128)
+            assert_array_strict_equal(np.reciprocal(x), expected)
+            assert_array_strict_equal(np.reciprocal(x), 1.0 / x)
+
+            x = np.array([complex(0.0, 0.0)], dtype=np.complex128)
+            expected = np.array([complex(INF, NAN)], dtype=np.complex128)
+            assert_array_strict_equal(np.reciprocal(x), expected)
+            assert_array_strict_equal(np.reciprocal(x), 1.0 / x)
+
     def test_floor_division_complex(self):
         # check that floor division, divmod and remainder raises type errors
         x = np.array(

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -657,7 +657,7 @@ class TestDivision:
             assert_(np.isnan(y)[0])
 
     def test_division_annex_g_complex(self):
-        # C99 Annex G.5.1 recovery cases for complex division.
+        # C99 Annex G.5.2 recovery cases for complex division.
         # Test cases from CPython 3.14 cmath tests.
         INF = np.inf
         NAN = np.nan
@@ -695,7 +695,7 @@ class TestDivision:
             assert_array_strict_equal(x / y, expected)
 
     def test_reciprocal_annex_g_complex(self):
-        # C99 Annex G.5.1 recovery cases for complex reciprocal (1/z).
+        # C99 Annex G.5.2 recovery cases for complex reciprocal (1/z).
         # reciprocal is division with numerator 1+0j, so only
         # cases 1 (denom zero) and 3 (denom infinite) apply.
         INF = np.inf


### PR DESCRIPTION
Adds C99 Annex G recoveries to complex multiplication and division that would otherwise result in nan + nanj
Closes https://github.com/numpy/numpy/issues/30805
Closes https://github.com/numpy/numpy/issues/26560
Closes https://github.com/numpy/numpy/issues/17425
Closes https://github.com/numpy/numpy/issues/30470

See relevant CPython PRs that did these updates for CPython:
https://github.com/python/cpython/pull/120287 and https://github.com/python/cpython/pull/119457

Because multiplication also has a SIMD implementation, we have to adapt that too because otherwise you'd get different answers depending on whether you have SIMD compiled numpy or not or whether you are working with complex64 and complex128 vs complex256 because I only see SIMD implementations for fp32 and fp64 only.