### PR TITLE
MAINT: typo 'seperators' to 'separators' as part of variable name

### DIFF
--- a/numpy/_utils/_pep440.py
+++ b/numpy/_utils/_pep440.py
@@ -419,7 +419,7 @@ def _parse_letter_version(letter, number):
         return letter, int(number)
 
 
-_local_version_seperators = re.compile(r"[\._-]")
+_local_version_separators = re.compile(r"[\._-]")
 
 
 def _parse_local_version(local):
@@ -429,7 +429,7 @@ def _parse_local_version(local):
     if local is not None:
         return tuple(
             part.lower() if not part.isdigit() else int(part)
-            for part in _local_version_seperators.split(local)
+            for part in _local_version_separators.split(local)
         )
 
 


### PR DESCRIPTION
Fix typo in variable name:  -> 