### PR TITLE
BUG: Fix f2py OpenMP support with Meson backend

### DIFF
--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -187,7 +187,7 @@ class MesonTemplate:
         
         # Determine the OpenMP library based on compiler/flags
         openmp_lib = 'gomp'  # Default for GCC
-        is_intel ('ifort' in str(arg) or 'ifx' in str(arg) or 'qopenmp' in str(arg).lower() 
+        is_intel = any('ifort' in str(arg) or 'ifx' in str(arg) or 'qopenmp' in str(arg).lower() 
                for arg in self.fortran_args)
         if is_intel:
             openmp_lib = 'iomp5'
@@ -203,7 +203,7 @@ class MesonTemplate:
 
         if compile_args:
             lines.append(f"    compile_args: [{', '.join(compile_args)}],")
-        
+
         # Add link args
         link_args = []
         if self.openmp_lib_dir:
@@ -212,11 +212,11 @@ class MesonTemplate:
 
         if is_intel and compile_args:
             link_args.extend(compile_args)
-        
+
         lines.append(f"    link_args: [{', '.join(link_args)}],")
         lines.append("  )")
         lines.append("endif")
-        
+
         return "\n".join(lines)
 
     def libraries_substitution(self) -> None:
@@ -257,14 +257,14 @@ class MesonTemplate:
     def rpath_substitution(self) -> None:
         """NEW: Generate rpath configuration for runtime library loading"""
         rpath_dirs = []
-        
+
         # Add all library directories
         rpath_dirs.extend([str(lib_dir) for lib_dir in self.library_dirs])
-        
+
         # Add OpenMP library directory if detected
         if self.openmp_lib_dir:
             rpath_dirs.append(str(self.openmp_lib_dir))
-        
+
         if rpath_dirs:
             # Remove duplicates while preserving order
             unique_rpath_dirs = list(dict.fromkeys(rpath_dirs))
@@ -272,7 +272,7 @@ class MesonTemplate:
             self.substitutions["rpath"] = f"{self.indent}install_rpath: [{rpath_list}],"
         else:
             self.substitutions["rpath"] = ""
-    
+
     def link_language_substitution(self) -> None:
         """Force Fortran as link language when OpenMP is used with Intel compilers"""
         # Intel compilers need Fortran linker for OpenMP, not C linker

--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -47,7 +47,7 @@ class MesonTemplate:
             f"'{x}'" if not (x.startswith("'") and x.endswith("'")) else x
             for x in fortran_args
         ]
-               self.has_openmp = self._detect_openmp(fortran_args)
+        self.has_openmp = self._detect_openmp(fortran_args)
         self.openmp_lib_dir = None
         if self.has_openmp:
             self.openmp_lib_dir = self._find_openmp_library()

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -9,6 +9,7 @@ project('${modulename}',
 fc = meson.get_compiler('fortran')
 
 py = import('python').find_installation('''${python}''', pure: false)
+${openmp_declaration}
 py_dep = py.dependency()
 
 incdir_numpy = run_command(py,
@@ -34,7 +35,6 @@ quadmath_dep = fc.find_library('quadmath', required: false)
 
 ${lib_declarations}
 ${lib_dir_declarations}
-
 py.extension_module('${modulename}',
                      [
 ${source_list},
@@ -55,4 +55,5 @@ ${lib_list}
 ${lib_dir_list}
                      ],
 ${fortran_args}
+${rpath}
                      install : true)


### PR DESCRIPTION
Fixes #30804
**Problem**
On Python 3.12+, f2py with OpenMP-enabled Fortran code fails in two ways:

1.Import error: ``ImportError: Library not loaded: @rpath/libgomp.1.dylib``
2.The Meson backend doesn't configure OpenMP dependencies or runtime library paths correctly.

**This PR**

1.Auto-detects OpenMP flags (``-fopenmp``, ``-qopenmp``) in compiler arguments
2.Adds OpenMP dependency with fallback when Meson can't find it automatically
3.Configures ``install_rpath`` to include OpenMP library directories
4.Supports both GCC (``libgomp``) and Intel (``libiomp5``) compilers

**Changea**
``numpy/f2py/_backends/_meson.py:`` Added OpenMP detection, dependency fallback, and rpath configuration.
``numpy/f2py/_backends/meson.build.template:``Added ``${openmp_declaration} and ${rpath}`` substitution variables.