### PR TITLE
PERF: speed up array_equal for equal_nan=True

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2549,7 +2549,7 @@ def array_equal(a1, a2, equal_nan=False):
     if cannot_have_nan:
         return builtins.bool(asarray(a1 == a2).all())
 
-    # fast path for a1 and a2 being all NaN arrays
+    # Fast path for a1 and a2 being all NaN arrays
     a1nan = isnan(a1)
     if a1nan.all():
         return builtins.bool(isnan(a2).all())

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2471,6 +2471,7 @@ _no_nan_types = {
 def _dtype_cannot_hold_nan(dtype):
     return type(dtype) in _no_nan_types
 
+
 @array_function_dispatch(_array_equal_dispatcher)
 def array_equal(a1, a2, equal_nan=False):
     """
@@ -2548,10 +2549,14 @@ def array_equal(a1, a2, equal_nan=False):
     if cannot_have_nan:
         return builtins.bool(asarray(a1 == a2).all())
 
-    # Optimized NaN handling: single vectorized predicate + reduction
-    # replaces the original boolean-mask + fancy-index approach
-    equal_or_both_nan = (a1 == a2) | (isnan(a1) & isnan(a2))
+    # fast path for a1 and a2 being all NaN arrays
+    a1nan = isnan(a1)
+    if a1nan.all():
+        return builtins.bool(isnan(a2).all())
+
+    equal_or_both_nan = (a1 == a2) | (a1nan & isnan(a2))
     return builtins.bool(equal_or_both_nan.all())
+
 
 def _array_equiv_dispatcher(a1, a2):
     return (a1, a2)


### PR DESCRIPTION
## What does this PR do?

Speed up `np.array_equal` for `equal_nan=True` by avoiding boolean masking
and indexing, using a single vectorized predicate and reduction.

Local tests: `pytest "numpy/_core/tests"` all passed
Full test suite covered by CI.

## Performance

Local ASV benchmarks show significant speedups for `equal_nan=True`

### ASV results (continuous, main vs HEAD)

| Benchmark | Before | After | Ratio |
|---|---:|---:|---:|
| float + NaN | 15.0±1ms | 2.97±0.08ms | 0.22 (~4.5× faster) |
| datetime64 + NaT | 26.3±0.2μs | 12.2±0.4μs | 0.46 (~2.2× faster) |

No measurable changes observed for the corresponding `equal_nan=False` cases.

The benchmark below is included for transparency and to document the measurement
methodology; it is not proposed to be added in-tree unless maintainers think it would be useful.


<details>
<summary>Click to expand: ASV benchmark code used</summary>

To reproduce my numbers, create `numpy/benchmarks/benchmarks/bench_array_equal.py`:

```python
# numpy/benchmarks/benchmarks/bench_array_equal.py

import numpy as np


class ArrayEqual:
    """
    ASV benchmarks for np.array_equal.

    Goals:
    - Cover equal_nan=True (optimization target) and equal_nan=False (regression guard).
    - Add an explicit "high NaN density" stress test to address concerns where the
      equal_nan=True path may do extra work when NaNs are very frequent.
    """

    # High-NaN stress test parameters: directly targets the review concern.
    params = ([0.0, 0.1, 0.5, 0.9, 1.0],)
    param_names = ["nan_ratio"]

    def setup(self, nan_ratio):
        rng = np.random.default_rng(42)

        # ------------------------------
        # Case 1: large float array with NaNs (main optimization target)
        # Fixed-pattern NaNs (historical / existing coverage)
        # ------------------------------
        shape = (2000, 2000)
        a = rng.integers(1, 100, size=shape, dtype=np.int64)
        b = a.astype(np.float64)
        b[b == 50] = np.nan
        self.f_nan = b
        self.f_nan_copy = b.copy()

        # ------------------------------
        # Case 1b: high NaN density float array (review concern coverage)
        # NaN ratio is parameterized to exercise extreme densities.
        # ------------------------------
        hi_shape = (2000, 2000)
        x = rng.standard_normal(size=hi_shape).astype(np.float64)
        if nan_ratio != 0.0:
            mask = rng.random(size=hi_shape) < nan_ratio
            x[mask] = np.nan
        self.f_hi_nan = x
        self.f_hi_nan_copy = x.copy()

        # ------------------------------
        # Case 2: Fortran-order integer array (memory layout edge)
        # ------------------------------
        f_shape = (3000, 1000)
        c_int = rng.integers(-1000, 1000, size=f_shape, dtype=np.int64)
        self.int_f = np.asfortranarray(c_int)
        self.int_f_copy = np.asfortranarray(c_int)

        # ------------------------------
        # Case 3: datetime64 with NaT (semantic edge)
        # ------------------------------
        n = 10000
        base = np.datetime64("2000-01-01", "D")
        days = rng.integers(0, 365 * 50, size=n)
        dt = base + days.astype("timedelta64[D]")
        dt2 = dt.copy()
        mask = rng.random(n) < 0.001
        dt2[mask] = np.datetime64("NaT")
        self.dt = dt2
        self.dt_copy = dt2.copy()

    # ---- float + NaN (fixed-pattern) ----
    def time_float_nan_copy_eqnan_true(self, nan_ratio):
        np.array_equal(self.f_nan, self.f_nan_copy, equal_nan=True)

    def time_float_nan_copy_eqnan_false(self, nan_ratio):
        np.array_equal(self.f_nan, self.f_nan_copy, equal_nan=False)

    # ---- float + high NaN density (parameterized) ----
    def time_float_high_nan_copy_eqnan_true(self, nan_ratio):
        np.array_equal(self.f_hi_nan, self.f_hi_nan_copy, equal_nan=True)

    def time_float_high_nan_copy_eqnan_false(self, nan_ratio):
        np.array_equal(self.f_hi_nan, self.f_hi_nan_copy, equal_nan=False)

    # ---- Fortran-order int ----
    def time_fortran_int_copy_eqnan_true(self, nan_ratio):
        np.array_equal(self.int_f, self.int_f_copy, equal_nan=True)

    def time_fortran_int_copy_eqnan_false(self, nan_ratio):
        np.array_equal(self.int_f, self.int_f_copy, equal_nan=False)

    # ---- datetime64 NaT ----
    def time_datetime_nat_copy_eqnan_true(self, nan_ratio):
        np.array_equal(self.dt, self.dt_copy, equal_nan=True)

    def time_datetime_nat_copy_eqnan_false(self, nan_ratio):
        np.array_equal(self.dt, self.dt_copy, equal_nan=False)
```

apply the new `array_equal` function, commit and run:

```bash
cd numpy/benchmarks
asv continuous main HEAD -b "bench_array_equal.ArrayEqual"
```


</details>