### PR TITLE
API: Make PyArray_Chunk opaque on internal builds

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -855,7 +855,13 @@ typedef struct {
         void *ptr;
         npy_intp len;
         int flags;
-} PyArray_Chunk;
+} PyArray_Chunk_fields;
+
+#if defined(NPY_INTERNAL_BUILD) && (NPY_INTERNAL_BUILD)
+typedef struct PyArray_Chunk PyArray_Chunk;
+#else
+typedef PyArray_Chunk_fields PyArray_Chunk;
+#endif
 
 typedef struct {
     NPY_DATETIMEUNIT base;

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -1113,7 +1113,7 @@ array_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
     int itemsize;
     PyArray_Dims dims = {NULL, 0};
     PyArray_Dims strides = {NULL, -1};
-    PyArray_Chunk buffer;
+    PyArray_Chunk_fields buffer;
     npy_longlong offset = 0;
     NPY_ORDER order = NPY_CORDER;
     int is_f_order = 0;

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -297,9 +297,11 @@ PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
 {
     Py_buffer view;
 
-    buf->ptr = NULL;
-    buf->flags = NPY_ARRAY_BEHAVED;
-    buf->base = NULL;
+    PyArray_Chunk_fields *_buf = (PyArray_Chunk_fields *)buf;
+
+    _buf->ptr = NULL;
+    _buf->flags = NPY_ARRAY_BEHAVED;
+    _buf->base = NULL;
     if (obj == Py_None) {
         return NPY_SUCCEED;
     }
@@ -307,15 +309,15 @@ PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
     if (PyObject_GetBuffer(obj, &view,
                 PyBUF_ANY_CONTIGUOUS|PyBUF_WRITABLE|PyBUF_SIMPLE) != 0) {
         PyErr_Clear();
-        buf->flags &= ~NPY_ARRAY_WRITEABLE;
+        _buf->flags &= ~NPY_ARRAY_WRITEABLE;
         if (PyObject_GetBuffer(obj, &view,
                 PyBUF_ANY_CONTIGUOUS|PyBUF_SIMPLE) != 0) {
             return NPY_FAIL;
         }
     }
 
-    buf->ptr = view.buf;
-    buf->len = (npy_intp) view.len;
+    _buf->ptr = view.buf;
+    _buf->len = (npy_intp) view.len;
 
     /*
      * Both of the deprecated functions PyObject_AsWriteBuffer and
@@ -327,10 +329,10 @@ PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
 
     /* Point to the base of the buffer object if present */
     if (PyMemoryView_Check(obj)) {
-        buf->base = PyMemoryView_GET_BASE(obj);
+        _buf->base = PyMemoryView_GET_BASE(obj);
     }
-    if (buf->base == NULL) {
-        buf->base = obj;
+    if (_buf->base == NULL) {
+        _buf->base = obj;
     }
     return NPY_SUCCEED;
 }


### PR DESCRIPTION
I didn't expose any accessors because I'm not sure this struct should be or needs to be public at all. c.f. #30813.