### PR TITLE
CI/BUG: add native jobs for s390x, fix bug in `pack_inner`

### DIFF
--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -75,9 +75,9 @@ jobs:
     - name: Install clang
       if: matrix.config.compiler == 'clang'
       run: |
-        sudo apt install -y clang
-        echo CC=clang >> $GITHUB_ENV
-        echo CXX=clang++ >> $GITHUB_ENV
+        sudo apt install -y clang-20
+        echo CC=clang-20 >> $GITHUB_ENV
+        echo CXX=clang++-20 >> $GITHUB_ENV
 
     - name: Meson Build
       run: |

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -1,4 +1,4 @@
-name: Native ppc64le Linux Test
+name: Native ppc64le and s390x Linux Tests
 
 on:
   pull_request:
@@ -20,21 +20,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  native_ppc64le:
-    # This job runs only in the main NumPy repository.
-    # It requires a native ppc64le GHA runner, which is not available on forks.
+  native_ppc64le_and_s390x:
+    # These jobs runs only in the main NumPy repository.
+    # It requires a native ppc64le and s390x GHA runners, which are not available on forks.
     # For more details, see: https://github.com/numpy/numpy/issues/29125
     if: github.repository == 'numpy/numpy'
-    runs-on: ubuntu-24.04-ppc64le-p10
+    runs-on: ${{ matrix.config.runner }}
 
     strategy:
       fail-fast: false
       matrix:
         config:
-          - name: "GCC"
+          - name: "GCC (ppc64le)"
             args: "-Dallow-noblas=false"
-          - name: "clang"
+            runner: ubuntu-24.04-ppc64le-p10
+            compiler: "gcc"
+          - name: "clang (ppc64le)"
             args: "-Dallow-noblas=false"
+            runner: ubuntu-24.04-ppc64le-p10
+            compiler: "clang"
+          - name: "GCC (s390x)"
+            args: "-Dallow-noblas=false"
+            runner: ubuntu-24.04-s390x
+            compiler: "gcc"
+          - name: "clang (s390x)"
+            args: "-Dallow-noblas=false"
+            runner: ubuntu-24.04-s390x
+            compiler: "clang"
+          - name: "GCC with zvector (s390x)"
+            args: "-Dallow-noblas=false -Dcpu-baseline=vx"
+            runner: ubuntu-24.04-s390x
+            compiler: "gcc"
+          - name: "clang with zvector (s390x)"
+            args: "-Dallow-noblas=false -Dcpu-baseline=vx"
+            runner: ubuntu-24.04-s390x
+            compiler: "clang"
 
     name: "${{ matrix.config.name }}"
     steps:
@@ -53,7 +73,7 @@ jobs:
         echo "/home/runner/.local/bin" >> $GITHUB_PATH
 
     - name: Install clang
-      if: matrix.config.name == 'clang'
+      if: matrix.config.compiler == 'clang'
       run: |
         sudo apt install -y clang
         export CC=clang

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -76,8 +76,8 @@ jobs:
       if: matrix.config.compiler == 'clang'
       run: |
         sudo apt install -y clang
-        export CC=clang
-        export CXX=clang++
+        echo CC=clang >> $GITHUB_ENV
+        echo CXX=clang++ >> $GITHUB_ENV
 
     - name: Meson Build
       run: |

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -38,7 +38,7 @@ jobs:
             args: "-Dallow-noblas=false"
             runner: ubuntu-24.04-s390x
           - name: "GCC with zvector (s390x)"
-            args: "-Dallow-noblas=false -Dcpu-baseline=vx"
+            args: "-Dallow-noblas=false -Dcpu-baseline=vxe2"
             runner: ubuntu-24.04-s390x
 
     name: "${{ matrix.config.name }}"
@@ -84,7 +84,7 @@ jobs:
             args: "-Dallow-noblas=false"
             runner: ubuntu-24.04-s390x
           - name: "clang with zvector (s390x)"
-            args: "-Dallow-noblas=false -Dcpu-baseline=vx"
+            args: "-Dallow-noblas=false -Dcpu-baseline=vxe2"
             runner: ubuntu-24.04-s390x
 
     name: "${{ matrix.config.name }}"

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -1,4 +1,4 @@
-name: Native ppc64le and s390x Linux Tests
+name: Linux ppc64le and s390x native tests
 
 on:
   pull_request:

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -43,18 +43,10 @@ jobs:
             args: "-Dallow-noblas=false"
             runner: ubuntu-24.04-s390x
             compiler: "gcc"
-          - name: "clang (s390x)"
-            args: "-Dallow-noblas=false"
-            runner: ubuntu-24.04-s390x
-            compiler: "clang"
           - name: "GCC with zvector (s390x)"
             args: "-Dallow-noblas=false -Dcpu-baseline=vx"
             runner: ubuntu-24.04-s390x
             compiler: "gcc"
-          - name: "clang with zvector (s390x)"
-            args: "-Dallow-noblas=false -Dcpu-baseline=vx"
-            runner: ubuntu-24.04-s390x
-            compiler: "clang"
 
     name: "${{ matrix.config.name }}"
     steps:

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -34,19 +34,12 @@ jobs:
           - name: "GCC (ppc64le)"
             args: "-Dallow-noblas=false"
             runner: ubuntu-24.04-ppc64le-p10
-            compiler: "gcc"
-          - name: "clang (ppc64le)"
-            args: "-Dallow-noblas=false"
-            runner: ubuntu-24.04-ppc64le-p10
-            compiler: "clang"
           - name: "GCC (s390x)"
             args: "-Dallow-noblas=false"
             runner: ubuntu-24.04-s390x
-            compiler: "gcc"
           - name: "GCC with zvector (s390x)"
             args: "-Dallow-noblas=false -Dcpu-baseline=vx"
             runner: ubuntu-24.04-s390x
-            compiler: "gcc"
 
     name: "${{ matrix.config.name }}"
     steps:
@@ -64,13 +57,6 @@ jobs:
         pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         echo "/home/runner/.local/bin" >> $GITHUB_PATH
 
-    - name: Install clang
-      if: matrix.config.compiler == 'clang'
-      run: |
-        sudo apt install -y clang-20
-        echo CC=clang-20 >> $GITHUB_ENV
-        echo CXX=clang++-20 >> $GITHUB_ENV
-
     - name: Meson Build
       run: |
         spin build -- ${{ matrix.config.args }}
@@ -82,3 +68,72 @@ jobs:
     - name: Run Tests
       run: |
         spin test -- --timeout=60 --durations=10
+
+  docker_ppc64le_and_s390x:
+    # These jobs runs only in the main NumPy repository.
+    # It requires a native ppc64le and s390x GHA runners, which are not available on forks.
+    # For more details, see: https://github.com/numpy/numpy/issues/29125
+    if: github.repository == 'numpy/numpy'
+    runs-on: ${{ matrix.config.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "clang (ppc64le)"
+            args: "-Dallow-noblas=false"
+            runner: ubuntu-24.04-ppc64le-p10
+          - name: "clang (s390x)"
+            args: "-Dallow-noblas=false"
+            runner: ubuntu-24.04-s390x
+          - name: "clang with zvector (s390x)"
+            args: "-Dallow-noblas=false -Dcpu-baseline=vx"
+            runner: ubuntu-24.04-s390x
+
+    name: "${{ matrix.config.name }}"
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        submodules: recursive
+        fetch-tags: true
+
+    - name: Install dependencies
+      run: |
+        docker run --name the_container --interactive \
+          -v $(pwd):/numpy -w /numpy \
+          fedora:43 \
+          /bin/bash -c "
+          dnf update -y &&
+          dnf install -y gcc gcc-c++ gfortran ninja-build python3-pip python3-devel \
+                         openblas-devel lapack-devel pkg-config \
+                         clang &&
+          pip3 install --upgrade pip &&
+          pip3 install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
+        "
+        docker commit the_container the_container
+        echo CC=clang >> $GITHUB_ENV
+        echo CXX=clang++ >> $GITHUB_ENV
+
+    - name: Meson Build
+      run: |
+        BUILD_ARGS="${{ matrix.config.args }}"
+        docker run --rm -e "TERM=xterm-256color" -e "CC=$CC" -e "CXX=$CXX" \
+          -v $(pwd):/numpy -w /numpy \
+          the_container \
+          /bin/bash -c "
+            spin build -- ${BUILD_ARGS}
+          "
+
+    - name: Meson Log
+      if: always()
+      run: cat build/meson-logs/meson-log.txt
+
+    - name: Run Tests
+      run: |
+        docker run --rm -e "TERM=xterm-256color" -e "CC=$CC" -e "CXX=$CXX" \
+          -v $(pwd):/numpy \
+          -w /numpy \
+          the_container \
+          /bin/bash -c "
+            spin test -- --timeout=60 --durations=10
+          "

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -1,4 +1,4 @@
-name: Linux ppc64le and s390x native tests
+name: Linux IBM tests
 
 on:
   pull_request:
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  native_ppc64le_and_s390x:
+  native_ibm:
     # These jobs runs only in the main NumPy repository.
     # It requires a native ppc64le and s390x GHA runners, which are not available on forks.
     # For more details, see: https://github.com/numpy/numpy/issues/29125
@@ -31,13 +31,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: "GCC (ppc64le)"
+          - name: "ppc64le/gcc - baseline(default)"
             args: "-Dallow-noblas=false"
             runner: ubuntu-24.04-ppc64le-p10
-          - name: "GCC (s390x)"
+          - name: "s390x/gcc - baseline(default)"
             args: "-Dallow-noblas=false"
             runner: ubuntu-24.04-s390x
-          - name: "GCC with zvector (s390x)"
+          - name: "s390x/gcc - baseline(Z15/VXE2)"
             args: "-Dallow-noblas=false -Dcpu-baseline=vxe2"
             runner: ubuntu-24.04-s390x
 
@@ -69,7 +69,7 @@ jobs:
       run: |
         spin test -- --timeout=60 --durations=10
 
-  docker_ppc64le_and_s390x:
+  docker_ibm:
     # These jobs runs only in the main NumPy repository.
     # It requires a native ppc64le and s390x GHA runners, which are not available on forks.
     # For more details, see: https://github.com/numpy/numpy/issues/29125
@@ -80,10 +80,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: "clang (s390x)"
+          - name: "s390x/clang - baseline(default)"
             args: "-Dallow-noblas=false"
             runner: ubuntu-24.04-s390x
-          - name: "clang with zvector (s390x)"
+          - name: "s390x/clang - baseline(Z15/VXE2)"
             args: "-Dallow-noblas=false -Dcpu-baseline=vxe2"
             runner: ubuntu-24.04-s390x
 

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -80,9 +80,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: "clang (ppc64le)"
-            args: "-Dallow-noblas=false"
-            runner: ubuntu-24.04-ppc64le-p10
           - name: "clang (s390x)"
             args: "-Dallow-noblas=false"
             runner: ubuntu-24.04-s390x

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -34,12 +34,27 @@ jobs:
           - name: "ppc64le/gcc - baseline(default)"
             args: "-Dallow-noblas=false"
             runner: ubuntu-24.04-ppc64le-p10
+            compiler: "gcc"
+          - name: "ppc64le/clang - baseline(default)"
+            args: "-Dallow-noblas=false"
+            runner: ubuntu-24.04-ppc64le-p10
+            compiler: "clang"
           - name: "s390x/gcc - baseline(default)"
             args: "-Dallow-noblas=false"
             runner: ubuntu-24.04-s390x
+            compiler: "gcc"
+          - name: "s390x/clang - baseline(default)"
+            args: "-Dallow-noblas=false"
+            runner: ubuntu-24.04-s390x
+            compiler: "clang"
           - name: "s390x/gcc - baseline(Z15/VXE2)"
             args: "-Dallow-noblas=false -Dcpu-baseline=vxe2"
             runner: ubuntu-24.04-s390x
+            compiler: "gcc"
+          - name: "s390x/clang - baseline(Z15/VXE2)"
+            args: "-Dallow-noblas=false -Dcpu-baseline=vxe2"
+            runner: ubuntu-24.04-s390x
+            compiler: "clang"
 
     name: "${{ matrix.config.name }}"
     steps:
@@ -57,6 +72,15 @@ jobs:
         pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         echo "/home/runner/.local/bin" >> $GITHUB_PATH
 
+    - name: Install clang
+      if: matrix.config.compiler == 'clang'
+      run: |
+        sudo apt install -y clang-20
+        echo CC=clang-20 >> $GITHUB_ENV
+        echo CXX=clang++-20 >> $GITHUB_ENV
+        echo "CFLAGS=-fno-strict-aliasing" >> $GITHUB_ENV
+        echo "CXXFLAGS=-fno-strict-aliasing" >> $GITHUB_ENV
+
     - name: Meson Build
       run: |
         spin build -- ${{ matrix.config.args }}
@@ -68,69 +92,3 @@ jobs:
     - name: Run Tests
       run: |
         spin test -- --timeout=60 --durations=10
-
-  docker_ibm:
-    # These jobs runs only in the main NumPy repository.
-    # It requires a native ppc64le and s390x GHA runners, which are not available on forks.
-    # For more details, see: https://github.com/numpy/numpy/issues/29125
-    if: github.repository == 'numpy/numpy'
-    runs-on: ${{ matrix.config.runner }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - name: "s390x/clang - baseline(default)"
-            args: "-Dallow-noblas=false"
-            runner: ubuntu-24.04-s390x
-          - name: "s390x/clang - baseline(Z15/VXE2)"
-            args: "-Dallow-noblas=false -Dcpu-baseline=vxe2"
-            runner: ubuntu-24.04-s390x
-
-    name: "${{ matrix.config.name }}"
-    steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      with:
-        submodules: recursive
-        fetch-tags: true
-
-    - name: Install dependencies
-      run: |
-        docker run --name the_container --interactive \
-          -v $(pwd):/numpy -w /numpy \
-          fedora:43 \
-          /bin/bash -c "
-          dnf update -y &&
-          dnf install -y gcc gcc-c++ gfortran ninja-build python3-pip python3-devel \
-                         openblas-devel lapack-devel pkg-config \
-                         clang &&
-          pip3 install --upgrade pip &&
-          pip3 install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
-        "
-        docker commit the_container the_container
-        echo CC=clang >> $GITHUB_ENV
-        echo CXX=clang++ >> $GITHUB_ENV
-
-    - name: Meson Build
-      run: |
-        BUILD_ARGS="${{ matrix.config.args }}"
-        docker run --rm -e "TERM=xterm-256color" -e "CC=$CC" -e "CXX=$CXX" \
-          -v $(pwd):/numpy -w /numpy \
-          the_container \
-          /bin/bash -c "
-            spin build -- ${BUILD_ARGS}
-          "
-
-    - name: Meson Log
-      if: always()
-      run: cat build/meson-logs/meson-log.txt
-
-    - name: Run Tests
-      run: |
-        docker run --rm -e "TERM=xterm-256color" -e "CC=$CC" -e "CXX=$CXX" \
-          -v $(pwd):/numpy \
-          -w /numpy \
-          the_container \
-          /bin/bash -c "
-            spin test -- --timeout=60 --durations=10
-          "

--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -78,8 +78,6 @@ jobs:
         sudo apt install -y clang-20
         echo CC=clang-20 >> $GITHUB_ENV
         echo CXX=clang++-20 >> $GITHUB_ENV
-        echo "CFLAGS=-fno-strict-aliasing" >> $GITHUB_ENV
-        echo "CXXFLAGS=-fno-strict-aliasing" >> $GITHUB_ENV
 
     - name: Meson Build
       run: |

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -44,25 +44,6 @@ jobs:
       matrix:
         BUILD_PROP:
           - [
-              "s390x",
-              "s390x-linux-gnu",
-              "s390x/ubuntu:22.04",
-              "-Dallow-noblas=true",
-              # Skipping TestRationalFunctions.test_gcd_overflow test
-              # because of a possible qemu bug that appears to be related to int64 overflow in absolute operation.
-              # TODO(@seiko2plus): Confirm the bug and provide a minimal reproducer, then report it to upstream.
-              "(test_kind or test_multiarray or test_simd or test_umath or test_ufunc) and not test_gcd_overflow",
-              "s390x"
-            ]
-          - [
-              "s390x - baseline(Z13)",
-              "s390x-linux-gnu",
-              "s390x/ubuntu:22.04",
-              "-Dallow-noblas=true -Dcpu-baseline=vx",
-              "(test_kind or test_multiarray or test_simd or test_umath or test_ufunc) and not test_gcd_overflow",
-              "s390x"
-            ]
-          - [
               "riscv64",
               "riscv64-linux-gnu",
               "riscv64/ubuntu:22.04",

--- a/numpy/_core/src/common/simd/vec/arithmetic.h
+++ b/numpy/_core/src/common/simd/vec/arithmetic.h
@@ -286,7 +286,7 @@ NPY_FINLINE npyv_u64 npyv_divc_u64(npyv_u64 a, const npyv_u64x3 divisor)
 // divide each signed 64-bit element by a precomputed divisor (round towards zero)
 NPY_FINLINE npyv_s64 npyv_divc_s64(npyv_s64 a, const npyv_s64x3 divisor)
 {
-    npyv_b64 overflow = npyv_and_b64(vec_cmpeq(a, npyv_setall_s64(-1LL << 63)), (npyv_b64)divisor.val[1]);
+    npyv_b64 overflow = npyv_and_b64(vec_cmpeq(a, npyv_setall_s64(0x8000000000000000LL)), (npyv_b64)divisor.val[1]);
     npyv_s64 d = vec_sel(divisor.val[0], npyv_setall_s64(1), overflow);
     return vec_div(a, d);
 }

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -1615,9 +1615,29 @@ pack_inner(const char *inptr,
             #else
                 npy_uint64 arr[4] = {bb[0], bb[1], bb[2], bb[3]};
             #endif
+
+            #if NPY_BYTE_ORDER == NPY_BIG_ENDIAN
+                #if NPY_SIMD_WIDTH == 16
+                arr[0] = npy_bswap8(arr[0]);
+                #elif NPY_SIMD_WIDTH == 32
+                arr[0] = npy_bswap8(arr[0]);
+                arr[1] = npy_bswap8(arr[1]);
+                #else
+                arr[0] = npy_bswap8(arr[0]);
+                arr[1] = npy_bswap8(arr[1]);
+                arr[2] = npy_bswap8(arr[2]);
+                arr[3] = npy_bswap8(arr[3]);
+                #endif
+            #endif
                 memcpy(outptr, arr, sizeof(arr));
                 outptr += vstepx4;
             } else {
+                #if NPY_BYTE_ORDER == NPY_BIG_ENDIAN
+                bb[0] = npy_bswap8(bb[0]);
+                bb[1] = npy_bswap8(bb[1]);
+                bb[2] = npy_bswap8(bb[2]);
+                bb[3] = npy_bswap8(bb[3]);
+                #endif
                 for(int i = 0; i < 4; i++) {
                     for (int j = 0; j < vstep; j++) {
                         memcpy(outptr, (char*)&bb[i] + j, 1);
@@ -1632,6 +1652,11 @@ pack_inner(const char *inptr,
                 va = npyv_rev64_u8(va);
             }
             npy_uint64 bb = npyv_tobits_b8(npyv_cmpneq_u8(va, v_zero));
+
+            #if NPY_BYTE_ORDER == NPY_BIG_ENDIAN
+            bb = npy_bswap8(bb);
+            #endif
+
             for (int i = 0; i < vstep; ++i) {
                 memcpy(outptr, (char*)&bb + i, 1);
                 outptr += out_stride;

--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -400,7 +400,7 @@ class Test_ZARCH_Features(AbstractTest):
     features = ["VX", "VXE", "VXE2"]
 
     def load_flags(self):
-        self.load_flags_auxv()
+        self.load_flags_cpuinfo("features")
 
 
 is_arm = re.match(r"^(arm|aarch64)", machine, re.IGNORECASE)

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -7,6 +7,11 @@ project('${modulename}',
                             'buildtype=${buildtype}'
                           ])
 fc = meson.get_compiler('fortran')
+cc = meson.get_compiler('c')
+
+add_project_arguments(
+  cc.get_supported_arguments( '-fno-strict-aliasing'), language : 'c'
+)
 
 py = import('python').find_installation('''${python}''', pure: false)
 py_dep = py.dependency()


### PR DESCRIPTION
Rename workflow linux-ppc64le.yml into linux-actionspz.yml.
Copy and update ppc64le workflow for s390x.
Disable qemu-based workflows for s390x.

Fix big endian issue in `pack_inner`.

Closes: https://github.com/numpy/numpy/issues/30817

@mkumatag @rgommers