### PR TITLE
ENH: make PyDataMem_DefaultHandler and default extobj capsule immortal in free-threading

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -5170,7 +5170,11 @@ _multiarray_umath_exec(PyObject *m) {
     if (PyDataMem_DefaultHandler == NULL) {
         return -1;
     }
-
+#ifdef Py_GIL_DISABLED
+    int rc = PyUnstable_SetImmortal(PyDataMem_DefaultHandler);
+    assert(rc == 1);
+    (void)rc;
+#endif
     /*
      * Initialize the context-local current handler
      * with the default PyDataMem_Handler capsule.

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -5171,9 +5171,11 @@ _multiarray_umath_exec(PyObject *m) {
         return -1;
     }
 #ifdef Py_GIL_DISABLED
-    int rc = PyUnstable_SetImmortal(PyDataMem_DefaultHandler);
-    assert(rc == 1);
-    (void)rc;
+    if (PyUnstable_SetImmortal(PyDataMem_DefaultHandler) == 0) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Could not mark memory handler capsule as immortal");
+        return -1;
+    }
 #endif
     /*
      * Initialize the context-local current handler

--- a/numpy/_core/src/umath/extobj.c
+++ b/numpy/_core/src/umath/extobj.c
@@ -15,6 +15,7 @@
 #include "numpy/ufuncobject.h"
 
 #include "common.h"
+#include "npy_pycompat.h"
 
 
 #define UFUNC_ERR_IGNORE 0
@@ -145,6 +146,13 @@ init_extobj(void)
     if (npy_static_pydata.default_extobj_capsule == NULL) {
         return -1;
     }
+#ifdef Py_GIL_DISABLED
+    if (PyUnstable_SetImmortal(npy_static_pydata.default_extobj_capsule) == 0) {
+        PyErr_SetString(PyExc_RuntimeError, "Could not mark extobj capsule as immortal");
+        Py_CLEAR(npy_static_pydata.default_extobj_capsule);
+        return -1;
+    }
+#endif
     npy_static_pydata.npy_extobj_contextvar = PyContextVar_New(
             "numpy.ufunc.extobj", npy_static_pydata.default_extobj_capsule);
     if (npy_static_pydata.npy_extobj_contextvar == NULL) {


### PR DESCRIPTION
Towards fixing #30494 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

With this, multit-threading is almost ~30% faster than multi-processing on mac.
```console
❯ samply record python -X perf mtmp.py
Inner loops 10, multithreading  time: 2.76 sec, result sum: 717434683.1879176
Inner loops 10, multiprocessing time: 3.90 sec, result sum: 717434683.1879176
```
