### PR TITLE
BUG: Fix some leaks found via LeakSanitizer (#30756)

### DIFF
--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -182,6 +182,7 @@ PyUFunc_AddLoopFromSpec_int(PyObject *ufunc, PyArrayMethod_Spec *spec, int priv)
     PyObject *dtypes = PyArray_TupleFromItems(
             nargs, (PyObject **)bmeth->dtypes, 1);
     if (dtypes == NULL) {
+        Py_DECREF(bmeth);
         return -1;
     }
     PyObject *info = PyTuple_Pack(2, dtypes, bmeth->method);
@@ -190,7 +191,9 @@ PyUFunc_AddLoopFromSpec_int(PyObject *ufunc, PyArrayMethod_Spec *spec, int priv)
     if (info == NULL) {
         return -1;
     }
-    return PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
+    int res = PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
+    Py_DECREF(info);
+    return res;
 }
 
 
@@ -1357,8 +1360,9 @@ install_logical_ufunc_promoter(PyObject *ufunc)
     if (info == NULL) {
         return -1;
     }
-
-    return PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
+    int res = PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
+    Py_DECREF(info);
+    return res;
 }
 
 /*
@@ -1432,5 +1436,7 @@ PyUFunc_AddPromoter(
     if (info == NULL) {
         return -1;
     }
-    return PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
+    int res = PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
+    Py_DECREF(info);
+    return res;
 }


### PR DESCRIPTION
Backport of #30756.

The ref leak in `PyUFunc_AddLoopFromSpec_int` was the one reported when running `python -c 'import numpy'` with AddressSanitizer+LeakSanitizer enabled.
The other ones were found by searching for the same pattern.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
