### PR TITLE
DOC: add versionadded directive for numpy.concat 

### DIFF
--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -210,6 +210,10 @@ def concatenate(arrays, axis=0, out=None, *, dtype=None, casting="same_kind"):
 
     Join a sequence of arrays along an existing axis.
 
+    .. versionadded:: 2.0
+    ``numpy.concat`` added as a shorthand for ``numpy.concatenate``.
+
+
     Parameters
     ----------
     a1, a2, ... : sequence of array_like

--- a/numpy/_core/multiarray.py
+++ b/numpy/_core/multiarray.py
@@ -211,8 +211,7 @@ def concatenate(arrays, axis=0, out=None, *, dtype=None, casting="same_kind"):
     Join a sequence of arrays along an existing axis.
 
     .. versionadded:: 2.0
-    ``numpy.concat`` added as a shorthand for ``numpy.concatenate``.
-
+        ``numpy.concat`` added as a shorthand for ``numpy.concatenate``.
 
     Parameters
     ----------


### PR DESCRIPTION
Resolves: [#28369](https://github.com/numpy/numpy/issues/28369)

Adds a `.. versionadded:: 2.0` directive to the `numpy.concatenate` docstring to document the introduction of `numpy.concat` in NumPy 2.0.

Previously, the documentation did not explicitly indicate that numpy.concat was added in version 2.0 as a shorthand for `numpy.concatenate`. This change ensures the addition is properly recorded using the standard Sphinx versionadded directive, consistent with existing documentation patterns in the codebase.