### PR TITLE
MAINT: Add explicit ZeroDivisionError messages in polynomial division

### DIFF
--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -793,7 +793,7 @@ def chebdiv(c1, c2):
     # c1, c2 are trimmed copies
     [c1, c2] = pu.as_series([c1, c2])
     if c2[-1] == 0:
-        raise ZeroDivisionError  # FIXME: add message with details to exception
+        raise ZeroDivisionError("The divisor cannot be the zero polynomial.")
 
     # note: this is more efficient than `pu._div(chebmul, c1, c2)`
     lc1 = len(c1)

--- a/numpy/polynomial/polynomial.py
+++ b/numpy/polynomial/polynomial.py
@@ -401,7 +401,7 @@ def polydiv(c1, c2):
     # c1, c2 are trimmed copies
     [c1, c2] = pu.as_series([c1, c2])
     if c2[-1] == 0:
-        raise ZeroDivisionError  # FIXME: add message with details to exception
+        raise ZeroDivisionError("The divisor cannot be the zero polynomial.")
 
     # note: this is more efficient than `pu._div(polymul, c1, c2)`
     lc1 = len(c1)

--- a/numpy/polynomial/polyutils.py
+++ b/numpy/polynomial/polyutils.py
@@ -533,7 +533,7 @@ def _div(mul_f, c1, c2):
     # c1, c2 are trimmed copies
     [c1, c2] = as_series([c1, c2])
     if c2[-1] == 0:
-        raise ZeroDivisionError  # FIXME: add message with details to exception
+        raise ZeroDivisionError("The divisor cannot be the zero polynomial.")
 
     lc1 = len(c1)
     lc2 = len(c2)

--- a/numpy/polynomial/tests/test_chebyshev.py
+++ b/numpy/polynomial/tests/test_chebyshev.py
@@ -6,7 +6,7 @@ from functools import reduce
 import numpy as np
 import numpy.polynomial.chebyshev as cheb
 from numpy.polynomial.polynomial import polyval
-from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises
+from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises, assert_raises_regex
 
 
 def trim(x):
@@ -100,6 +100,8 @@ class TestArithmetic:
                 assert_equal(trim(res), trim(tgt), err_msg=msg)
 
     def test_chebdiv(self):
+        assert_raises_regex(ZeroDivisionError, "zero polynomial",
+                            cheb.chebdiv, [1], [0])
         for i in range(5):
             for j in range(5):
                 msg = f"At i={i}, j={j}"

--- a/numpy/polynomial/tests/test_polynomial.py
+++ b/numpy/polynomial/tests/test_polynomial.py
@@ -103,7 +103,7 @@ class TestArithmetic:
 
     def test_polydiv(self):
         # check zero division
-        assert_raises(ZeroDivisionError, poly.polydiv, [1], [0])
+        assert_raises_regex(ZeroDivisionError, "zero polynomial", poly.polydiv, [1], [0])
 
         # check scalar division
         quo, rem = poly.polydiv([2], [2])

--- a/numpy/polynomial/tests/test_polyutils.py
+++ b/numpy/polynomial/tests/test_polyutils.py
@@ -3,7 +3,7 @@
 """
 import numpy as np
 import numpy.polynomial.polyutils as pu
-from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises
+from numpy.testing import assert_, assert_almost_equal, assert_equal, assert_raises, assert_raises_regex
 
 
 class TestMisc:
@@ -52,7 +52,7 @@ class TestMisc:
 
     def test_div_zerodiv(self):
         # c2[-1] == 0
-        assert_raises(ZeroDivisionError, pu._div, pu._div, (1, 2, 3), [0])
+        assert_raises_regex(ZeroDivisionError, "zero polynomial", pu._div, pu._div, (1, 2, 3), [0])
 
     def test_pow_too_large(self):
         # power > maxpower


### PR DESCRIPTION
This PR has a narrow scope: it only adds explicit ZeroDivisionError messages and targeted regression tests.

## Summary
Replace bare `ZeroDivisionError` raises with explicit messages when dividing by a zero polynomial, addressing an existing in-code FIXME.

## Changes
- `numpy/polynomial/polyutils.py`: `_div` now raises:
  - `ZeroDivisionError("The divisor cannot be the zero polynomial.")`
- `numpy/polynomial/polynomial.py`: `polydiv` updated with the same message.
- `numpy/polynomial/chebyshev.py`: `chebdiv` updated with the same message.
- Added/updated tests to assert the error message using `assert_raises_regex(..., "zero polynomial", ...)` in:
  - `numpy/polynomial/tests/test_polyutils.py`
  - `numpy/polynomial/tests/test_polynomial.py`
  - `numpy/polynomial/tests/test_chebyshev.py`

## Validation
- `spin test -t numpy/polynomial/tests/test_polyutils.py`
- `spin test -t numpy/polynomial/tests/test_polynomial.py`
- `spin test -t numpy/polynomial/tests/test_chebyshev.py`
