### PR TITLE
DOC: Clarifying that DataSource does not automatically decompress com…

### DIFF
--- a/numpy/lib/_datasource.py
+++ b/numpy/lib/_datasource.py
@@ -328,7 +328,7 @@ class DataSource:
         if not os.path.exists(os.path.dirname(upath)):
             os.makedirs(os.path.dirname(upath))
 
-        # TODO: Doesn't handle compressed files!
+        # Compressed files (.gz, .zip, .tar, etc.) are not automatically decompressed.
         if self._isurl(path):
             with urlopen(path) as openedurl:
                 with _open(upath, 'wb') as f:


### PR DESCRIPTION
This PR updates the docstring in DataSource._cache to clarify that compressed files
(.gz, .zip, .tar, etc.) are not automatically decompressed when retrieved.

- Removed TODO comment about compressed files.
- Added explanatory note.

This is a doc-only change and does not affect any behavior.
