### PR TITLE
ENH: Add TypeError for user-defined dtypes in dot, inner, vdot, and correlateError message for dot family

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -894,6 +894,12 @@ PyArray_InnerProduct(PyObject *op1, PyObject *op2)
     if (typenum == NPY_NOTYPE) {
         return NULL;
     }
+    if (typenum >= NPY_NTYPES_LEGACY) {
+    PyErr_SetString(PyExc_TypeError,
+        "dot() does not support user-defined dtypes. "
+        "Consider using '@' (matmul), np.vecdot, np.matvec, or np.vecmat instead.");
+    return NULL;
+    }
 
     typec = PyArray_DescrFromType(typenum);
     if (typec == NULL) {
@@ -989,6 +995,12 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     typenum = PyArray_ObjectType(op2, typenum);
     if (typenum == NPY_NOTYPE) {
         return NULL;
+    }
+    if (typenum >= NPY_NTYPES_LEGACY) {
+    PyErr_SetString(PyExc_TypeError,
+        "dot() does not support user-defined dtypes. "
+        "Consider using '@' (matmul), np.vecdot, np.matvec, or np.vecmat instead.");
+    return NULL;
     }
 
     typec = PyArray_DescrFromType(typenum);
@@ -1333,6 +1345,12 @@ PyArray_Correlate2(PyObject *op1, PyObject *op2, int mode)
     if (typenum == NPY_NOTYPE) {
         return NULL;
     }
+    if (typenum >= NPY_NTYPES_LEGACY) {
+    PyErr_SetString(PyExc_TypeError,
+        "correlate() does not support user-defined dtypes. "
+        "Consider using '@' (matmul), np.vecdot, np.matvec, or np.vecmat instead.");
+    return NULL;
+    }
 
     typec = PyArray_DescrFromType(typenum);
     Py_INCREF(typec);
@@ -1405,6 +1423,12 @@ PyArray_Correlate(PyObject *op1, PyObject *op2, int mode)
     typenum = PyArray_ObjectType(op2, typenum);
     if (typenum == NPY_NOTYPE) {
         return NULL;
+    }
+    if (typenum >= NPY_NTYPES_LEGACY) {
+    PyErr_SetString(PyExc_TypeError,
+        "correlate() does not support user-defined dtypes. "
+        "Consider using '@' (matmul), np.vecdot, np.matvec, or np.vecmat instead.");
+    return NULL;
     }
 
     typec = PyArray_DescrFromType(typenum);
@@ -2612,6 +2636,12 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
     typenum = PyArray_ObjectType(op2, typenum);
     if (typenum == NPY_NOTYPE) {
         return NULL;
+    }
+    if (typenum >= NPY_NTYPES_LEGACY) {
+    PyErr_SetString(PyExc_TypeError,
+        "vdot() does not support user-defined dtypes. "
+        "Consider using '@' (matmul), np.vecdot, np.matvec, or np.vecmat instead.");
+    return NULL;
     }
 
     type = PyArray_DescrFromType(typenum);

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -896,7 +896,7 @@ PyArray_InnerProduct(PyObject *op1, PyObject *op2)
     }
     if (typenum >= NPY_NTYPES_LEGACY) {
     PyErr_SetString(PyExc_TypeError,
-        "dot() does not support user-defined dtypes. "
+        "inner() does not support user-defined dtypes. "
         "Consider using '@' (matmul), np.vecdot, np.matvec, or np.vecmat instead.");
     return NULL;
     }

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -7347,20 +7347,19 @@ class TestDot:
             np.dot(3.0, BadObject())
     
     def test_user_defined_dtype_raises(self):
-    # regression test for gh-30793
-    # dot family should raise TypeError with helpful message for user dtypes
-    from numpy._core.tests.rational import rational
-    a = np.array([1, 2], dtype=rational)
-    b = np.array([3, 4], dtype=rational)
+        # regression test for gh-30793
+        from numpy._core.tests.rational import rational
+        a = np.array([1, 2], dtype=rational)
+        b = np.array([3, 4], dtype=rational)
 
-    with pytest.raises(TypeError, match="does not support user-defined dtypes"):
-        np.dot(a, b)
-    with pytest.raises(TypeError, match="does not support user-defined dtypes"):
-        np.inner(a, b)
-    with pytest.raises(TypeError, match="does not support user-defined dtypes"):
-        np.vdot(a, b)
-    with pytest.raises(TypeError, match="does not support user-defined dtypes"):
-        np.correlate(a, b)
+        with pytest.raises(TypeError, match="does not support user-defined dtypes"):
+            np.dot(a, b)
+        with pytest.raises(TypeError, match="does not support user-defined dtypes"):
+            np.inner(a, b)
+        with pytest.raises(TypeError, match="does not support user-defined dtypes"):
+            np.vdot(a, b)
+        with pytest.raises(TypeError, match="does not support user-defined dtypes"):
+            np.correlate(a, b)
 
 
 class MatmulCommon:

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -7348,9 +7348,9 @@ class TestDot:
     
     def test_user_defined_dtype_raises(self):
         # regression test for gh-30793
-        from numpy._core.tests.rational import rational
-        a = np.array([1, 2], dtype=rational)
-        b = np.array([3, 4], dtype=rational)
+        ml_dtypes = pytest.importorskip("ml_dtypes")
+        a = np.array([1, 2], dtype=ml_dtypes.bfloat16)
+        b = np.array([3, 4], dtype=ml_dtypes.bfloat16)
 
         with pytest.raises(TypeError, match="does not support user-defined dtypes"):
             np.dot(a, b)
@@ -7360,8 +7360,6 @@ class TestDot:
             np.vdot(a, b)
         with pytest.raises(TypeError, match="does not support user-defined dtypes"):
             np.correlate(a, b)
-
-
 class MatmulCommon:
     """Common tests for '@' operator and numpy.matmul.
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -7345,7 +7345,7 @@ class TestDot:
 
         with pytest.raises(TypeError):
             np.dot(3.0, BadObject())
-    
+
     def test_user_defined_dtype_raises(self):
         # regression test for gh-30793
         ml_dtypes = pytest.importorskip("ml_dtypes")

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -7345,6 +7345,22 @@ class TestDot:
 
         with pytest.raises(TypeError):
             np.dot(3.0, BadObject())
+    
+    def test_user_defined_dtype_raises(self):
+    # regression test for gh-30793
+    # dot family should raise TypeError with helpful message for user dtypes
+    from numpy._core.tests.rational import rational
+    a = np.array([1, 2], dtype=rational)
+    b = np.array([3, 4], dtype=rational)
+
+    with pytest.raises(TypeError, match="does not support user-defined dtypes"):
+        np.dot(a, b)
+    with pytest.raises(TypeError, match="does not support user-defined dtypes"):
+        np.inner(a, b)
+    with pytest.raises(TypeError, match="does not support user-defined dtypes"):
+        np.vdot(a, b)
+    with pytest.raises(TypeError, match="does not support user-defined dtypes"):
+        np.correlate(a, b)
 
 
 class MatmulCommon:

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -9,7 +9,6 @@ project('${modulename}',
 fc = meson.get_compiler('fortran')
 
 py = import('python').find_installation('''${python}''', pure: false)
-${openmp_declaration}
 py_dep = py.dependency()
 
 incdir_numpy = run_command(py,
@@ -35,6 +34,7 @@ quadmath_dep = fc.find_library('quadmath', required: false)
 
 ${lib_declarations}
 ${lib_dir_declarations}
+
 py.extension_module('${modulename}',
                      [
 ${source_list},
@@ -55,5 +55,4 @@ ${lib_list}
 ${lib_dir_list}
                      ],
 ${fortran_args}
-${rpath}
                      install : true)

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -9,6 +9,7 @@ project('${modulename}',
 fc = meson.get_compiler('fortran')
 
 py = import('python').find_installation('''${python}''', pure: false)
+${openmp_declaration}
 py_dep = py.dependency()
 
 incdir_numpy = run_command(py,
@@ -34,7 +35,6 @@ quadmath_dep = fc.find_library('quadmath', required: false)
 
 ${lib_declarations}
 ${lib_dir_declarations}
-
 py.extension_module('${modulename}',
                      [
 ${source_list},
@@ -55,4 +55,5 @@ ${lib_list}
 ${lib_dir_list}
                      ],
 ${fortran_args}
+${rpath}
                      install : true)


### PR DESCRIPTION
as discussed in the issue, this is the first step better error messages 
for the dot family...

### Problem
`np.dot`, `np.inner`, `np.vdot`, and `np.correlate` hit a wall with 
user-defined dtypes because `PyArray_ObjectType` rejects non-legacy dtypes, 
that give the users a confusing error.

### Fix
added a `typenum >= NPY_NTYPES_LEGACY` check in the five affected C functions 
in `multiarraymodule.c`:
- `PyArray_InnerProduct`
- `PyArray_MatrixProduct2`
- `PyArray_Correlate`
- `PyArray_Correlate2`
- `array_vdot`

each one now raises a clear `TypeError` pointing to `@`, `np.vecdot`, 
`np.matvec`, or `np.vecmat` as alternatives.

### Test
tested locally with `ml_dtypes.bfloat16`:
```python
import numpy as np
import ml_dtypes
a = np.array([1.0, 2.0], dtype=ml_dtypes.bfloat16)
b = np.array([3.0, 4.0], dtype=ml_dtypes.bfloat16)
np.dot(a, b)
# TypeError: dot() does not support user-defined dtypes. 
# Consider using '@' (matmul), np.vecdot, np.matvec, or np.vecmat instead.