### PR TITLE
BUG: Fix weak hash function in np.isin(). (#30840)

### DIFF
--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -63,7 +63,7 @@ empty_array_like(PyArrayObject *arr, npy_intp length)
 
 template <typename T>
 size_t hash_integer(const T *value, npy_bool equal_nan) {
-    return std::hash<T>{}(*value);
+    return npy_fnv1a(reinterpret_cast<const unsigned char*>(value), sizeof(T));
 }
 
 template <typename S, typename T, S (*real)(T), S (*imag)(T)>


### PR DESCRIPTION
Backport of #30840.

In a build of NumPy against libcxx, we found the following code regressed from almost instantaneous with NumPy 2.3 to over 40s with NumPy 2.4.

```
import numpy as np

full_list = np.array("2015-12-01T00:00:00.000000000", 'datetime64[ns]') + np.arange(162143) * np.timedelta64(4, 'h').astype('timedelta64[ns]')
sampled_dates = full_list[10:28]
np.isin(sampled_dates, full_list)
```

Our belief is the following:
* std::unordered_set in libcxx uses power of two hash buckets.
* std::hash is the identity function.
* in this particular example, we are hashing integers (datetime64 values) separated by multiples of a power of two.
* the net result is that all of the integers end up in the same hash bucket.

We can make the code more robust simply by using the same npy_fnv1a hash used elsewhere in the same file since it will do a better job of distributing hash bits.


<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
