### PR TITLE
DOC: Update Contributor Guide with copyright and license reminders

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -183,8 +183,8 @@ Guidelines
 * No changes are ever committed without review and approval by a core
   team member. Please ask politely on the PR or on the `mailing list`_ if you
   get no response to your pull request within a week.
-* Do not include copyright notices in source code. Any code you contribute to 
-  the project is in agreement with the project `license <https://numpy.org/devdocs/license.html>`_.
+* Do not include copyright notices in source code without explicitly discussing the need first. 
+  In general, any code you contribute to the project is under the project `license <https://numpy.org/devdocs/license.html>`_.
 
 .. _stylistic-guidelines:
 

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -183,6 +183,8 @@ Guidelines
 * No changes are ever committed without review and approval by a core
   team member. Please ask politely on the PR or on the `mailing list`_ if you
   get no response to your pull request within a week.
+* Do not include copyright notices in source code. Any code you contribute to 
+  the project is in agreement with the project `license <https://numpy.org/devdocs/license.html>`_.
 
 .. _stylistic-guidelines:
 


### PR DESCRIPTION
Relates to https://github.com/numpy/numpy/issues/23315. Adds two sentences to the Contributor Guide "guidelines" section which discourage copyright notices in the source code and remind contributors that they agree to the license.