### PR TITLE
BUG: fix infinite recursion in np.ma.flatten_structured_array

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2590,7 +2590,7 @@ def flatten_structured_array(a):
 
         """
         for elm in iter(iterable):
-            if hasattr(elm, '__iter__'):
+            if not np.ndim(elm) == 0:
                 yield from flatten_sequence(elm)
             else:
                 yield elm

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2590,7 +2590,7 @@ def flatten_structured_array(a):
 
         """
         for elm in iter(iterable):
-            if not np.ndim(elm) == 0:
+            if hasattr(elm, "__iter__") and not isinstance(elm, (str, bytes)):
                 yield from flatten_sequence(elm)
             else:
                 yield elm

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -998,6 +998,13 @@ class TestMaskedArray:
         control = np.array([[[1., 1.], ], [[2., 2.], ]], dtype=float)
         assert_equal(test, control)
         assert_equal(test.dtype, control.dtype)
+        # for strings
+        ndtype = [('a', 'U5'), ('b', [('c', 'U5')])]
+        arr = np.array([('NumPy', ('array',)), ('array', ('numpy',))], dtype=ndtype)
+        test = flatten_structured_array(arr)
+        control = np.array([['NumPy', 'array'], ['array', 'numpy']], dtype='U5')
+        assert_equal(test, control)
+        assert_equal(test.dtype, control.dtype)
 
     def test_void0d(self):
         # Test creating a mvoid object


### PR DESCRIPTION
Towards resolving #29349 

Avoids recursion for both strings and objects.
