### PR TITLE
MAINT: bump ``ruff`` to ``0.15.2``

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -45,7 +45,7 @@ dependencies:
   - breathe>4.33.0
   # For linting
   - cython-lint
-  - ruff=0.14.7
+  - ruff=0.15.2
   - gitpython
   # Used in some tests
   - cffi

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -1046,9 +1046,11 @@ def isfortran(a: ndarray | generic) -> py_bool: ...
 def argwhere(a: ArrayLike) -> _Array2D[np.intp]: ...
 def flatnonzero(a: ArrayLike) -> _Array1D[np.intp]: ...
 
+# NOTE: we ignore UP047 because inlining `_AnyScalarT` would result in a lot of code duplication
+
 # keep in sync with `convolve` and `ma.core.correlate`
 @overload
-def correlate(
+def correlate(  # noqa: UP047
     a: _ArrayLike1D[_AnyNumericScalarT], v: _ArrayLike1D[_AnyNumericScalarT], mode: _CorrelateMode = "valid"
 ) -> _Array1D[_AnyNumericScalarT]: ...
 @overload
@@ -1068,7 +1070,7 @@ def correlate(
 
 # keep in sync with `correlate`
 @overload
-def convolve(
+def convolve(  # noqa: UP047
     a: _ArrayLike1D[_AnyNumericScalarT], v: _ArrayLike1D[_AnyNumericScalarT], mode: _CorrelateMode = "valid"
 ) -> _Array1D[_AnyNumericScalarT]: ...
 @overload
@@ -1089,7 +1091,7 @@ def convolve(
 # keep roughly in sync with `convolve` and `correlate`, but for 2-D output and an additional `out` overload,
 # and also keep in sync with `ma.core.outer` (minus `out`)
 @overload
-def outer(
+def outer(  # noqa: UP047
     a: _ArrayLike[_AnyNumericScalarT], b: _ArrayLike[_AnyNumericScalarT], out: None = None
 ) -> _Array2D[_AnyNumericScalarT]: ...
 @overload
@@ -1107,7 +1109,7 @@ def outer[ArrayT: np.ndarray](a: _ArrayLikeNumber_co | _ArrayLikeTD64_co, b: _Ar
 
 # keep in sync with numpy.linalg._linalg.tensordot (ignoring `/, *`)
 @overload
-def tensordot(
+def tensordot(  # noqa: UP047
     a: _ArrayLike[_AnyNumericScalarT], b: _ArrayLike[_AnyNumericScalarT], axes: int | tuple[_ShapeLike, _ShapeLike] = 2
 ) -> NDArray[_AnyNumericScalarT]: ...
 @overload
@@ -1127,7 +1129,7 @@ def tensordot(
 
 #
 @overload
-def cross(
+def cross(  # noqa: UP047
     a: _ArrayLike[_AnyNumericScalarT],
     b: _ArrayLike[_AnyNumericScalarT],
     axisa: int = -1,

--- a/numpy/lib/_arraysetops_impl.pyi
+++ b/numpy/lib/_arraysetops_impl.pyi
@@ -379,23 +379,25 @@ def unique_values[ScalarT: np.generic](x: _ArrayLike[ScalarT]) -> _Array1D[Scala
 @overload
 def unique_values(x: ArrayLike) -> _Array1D[Incomplete]: ...
 
+# NOTE: we ignore UP047 because inlining `_AnyScalarT` would result in a lot of code duplication
+
 #
 @overload  # known scalar-type, return_indices=False (default)
-def intersect1d(
+def intersect1d(  # noqa: UP047
     ar1: _ArrayLike[_AnyScalarT],
     ar2: _ArrayLike[_AnyScalarT],
     assume_unique: bool = False,
     return_indices: L[False] = False,
 ) -> _Array1D[_AnyScalarT]: ...
 @overload  # known scalar-type, return_indices=True (positional)
-def intersect1d(
+def intersect1d(  # noqa: UP047
     ar1: _ArrayLike[_AnyScalarT],
     ar2: _ArrayLike[_AnyScalarT],
     assume_unique: bool,
     return_indices: L[True],
 ) -> _IntersectResult[_AnyScalarT]: ...
 @overload  # known scalar-type, return_indices=True (keyword)
-def intersect1d(
+def intersect1d(  # noqa: UP047
     ar1: _ArrayLike[_AnyScalarT],
     ar2: _ArrayLike[_AnyScalarT],
     assume_unique: bool = False,
@@ -427,19 +429,23 @@ def intersect1d(
 
 #
 @overload
-def setxor1d(ar1: _ArrayLike[_AnyScalarT], ar2: _ArrayLike[_AnyScalarT], assume_unique: bool = False) -> _Array1D[_AnyScalarT]: ...
+def setxor1d(  # noqa: UP047
+    ar1: _ArrayLike[_AnyScalarT], ar2: _ArrayLike[_AnyScalarT], assume_unique: bool = False
+) -> _Array1D[_AnyScalarT]: ...
 @overload
 def setxor1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False) -> _Array1D[Incomplete]: ...
 
 #
 @overload
-def union1d(ar1: _ArrayLike[_AnyScalarT], ar2: _ArrayLike[_AnyScalarT]) -> _Array1D[_AnyScalarT]: ...
+def union1d(ar1: _ArrayLike[_AnyScalarT], ar2: _ArrayLike[_AnyScalarT]) -> _Array1D[_AnyScalarT]: ...  # noqa: UP047
 @overload
 def union1d(ar1: ArrayLike, ar2: ArrayLike) -> _Array1D[Incomplete]: ...
 
 #
 @overload
-def setdiff1d(ar1: _ArrayLike[_AnyScalarT], ar2: _ArrayLike[_AnyScalarT], assume_unique: bool = False) -> _Array1D[_AnyScalarT]: ...
+def setdiff1d(  # noqa: UP047
+    ar1: _ArrayLike[_AnyScalarT], ar2: _ArrayLike[_AnyScalarT], assume_unique: bool = False
+) -> _Array1D[_AnyScalarT]: ...
 @overload
 def setdiff1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False) -> _Array1D[Incomplete]: ...
 

--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -1036,9 +1036,11 @@ _AnyScalarT = TypeVar(
     np.float16, np.float32, np.longdouble, np.complex64, np.clongdouble,
 )  # fmt: skip
 
+# NOTE: we ignore UP047 because inlining `_AnyScalarT` would result in a lot of code duplication
+
 #
 @overload  # ~T, ~T  (we use constraints instead of a `: np.number` bound to prevent joins/unions)
-def cross(
+def cross(  # noqa: UP047
     x1: _ArrayLike1D2D[_AnyScalarT],
     x2: _ArrayLike1D2D[_AnyScalarT],
     /,
@@ -1123,11 +1125,11 @@ def cross[ScalarT: np.number](
 # -  9 overloads for the scalar cases (both args 1d)
 # - 18 overloads for the non-scalar cases (at least one arg >1d)
 @overload  # ?d ~T, 1d ~T
-def matmul(
+def matmul(  # noqa: UP047
     x1: _SupportsArray[_JustAnyShape, np.dtype[_AnyScalarT]], x2: _ArrayLike1D[_AnyScalarT], /
 ) -> NDArray[_AnyScalarT] | Any: ...
 @overload  # 1d ~T, ?d ~T
-def matmul(
+def matmul(  # noqa: UP047
     x1: _ArrayLike1D[_AnyScalarT], x2: _SupportsArray[_JustAnyShape, np.dtype[_AnyScalarT]], /
 ) -> NDArray[_AnyScalarT] | Any: ...
 @overload  # ?d bool, 1d bool
@@ -1167,7 +1169,7 @@ def matmul(
     x1: _AsArrayC128_1d, x2: _SupportsArray[_JustAnyShape, np.dtype[_to_complex128_co]], /
 ) -> NDArray[np.complex128] | Any: ...  # end workaround
 @overload  # 1d ~T, 1d ~T
-def matmul(x1: _ArrayLike1D[_AnyScalarT], x2: _ArrayLike1D[_AnyScalarT], /) -> _AnyScalarT: ...
+def matmul(x1: _ArrayLike1D[_AnyScalarT], x2: _ArrayLike1D[_AnyScalarT], /) -> _AnyScalarT: ...  # noqa: UP047
 @overload  # 1d +bool, 1d +bool
 def matmul(x1: _ToArrayBool_1d, x2: _ToArrayBool_1d, /) -> np.bool: ...
 @overload  # 1d ~int, 1d +int
@@ -1185,9 +1187,9 @@ def matmul(x1: _ToArrayComplex_1d, x2: _AsArrayC128_1d, /) -> np.complex128: ...
 @overload  # 1d fallback, 1d fallback
 def matmul(x1: _ToArrayComplex_1d, x2: _ToArrayComplex_1d, /) -> Any: ...  # end 1d x 1d
 @overload  # >=1d ~T, >=2d ~T
-def matmul(x1: _ArrayLike1ND[_AnyScalarT], x2: _ArrayLike2ND[_AnyScalarT], /) -> NDArray[_AnyScalarT]: ...
+def matmul(x1: _ArrayLike1ND[_AnyScalarT], x2: _ArrayLike2ND[_AnyScalarT], /) -> NDArray[_AnyScalarT]: ...  # noqa: UP047
 @overload  # >=2d ~T, >=1d ~T
-def matmul(x1: _ArrayLike2ND[_AnyScalarT], x2: _ArrayLike1ND[_AnyScalarT], /) -> NDArray[_AnyScalarT]: ...
+def matmul(x1: _ArrayLike2ND[_AnyScalarT], x2: _ArrayLike1ND[_AnyScalarT], /) -> NDArray[_AnyScalarT]: ...  # noqa: UP047
 @overload  # >=1d +bool, >=2d +bool
 def matmul(x1: _ToArrayBool_1nd, x2: _ToArrayBool_2nd, /) -> NDArray[np.bool]: ...
 @overload  # >=2d +bool, >=1d +bool

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -3806,9 +3806,11 @@ def inner(a: ArrayLike, b: ArrayLike) -> Incomplete: ...
 
 innerproduct = inner
 
+# NOTE: we ignore UP047 because inlining `_AnyScalarT` would result in a lot of code duplication
+
 # keep in sync with `_core.numeric.outer`
 @overload
-def outer(a: _ArrayLike[_AnyNumericScalarT], b: _ArrayLike[_AnyNumericScalarT]) -> _Masked2D[_AnyNumericScalarT]: ...
+def outer(a: _ArrayLike[_AnyNumericScalarT], b: _ArrayLike[_AnyNumericScalarT]) -> _Masked2D[_AnyNumericScalarT]: ...  # noqa: UP047
 @overload
 def outer(a: _ArrayLikeBool_co, b: _ArrayLikeBool_co) -> _Masked2D[np.bool]: ...
 @overload
@@ -3824,7 +3826,7 @@ outerproduct = outer
 
 # keep in sync with `convolve` and `_core.numeric.correlate`
 @overload
-def correlate(
+def correlate(  # noqa: UP047
     a: _ArrayLike[_AnyNumericScalarT],
     v: _ArrayLike[_AnyNumericScalarT],
     mode: _CorrelateMode = "valid",
@@ -3868,7 +3870,7 @@ def correlate(
 
 # keep in sync with `correlate` and `_core.numeric.convolve`
 @overload
-def convolve(
+def convolve(  # noqa: UP047
     a: _ArrayLike[_AnyNumericScalarT],
     v: _ArrayLike[_AnyNumericScalarT],
     mode: _CorrelateMode = "full",

--- a/numpy/ma/extras.pyi
+++ b/numpy/ma/extras.pyi
@@ -567,9 +567,11 @@ def unique(
     return_inverse: L[True],
 ) -> tuple[_MArray[Incomplete], _IntArray, _IntArray]: ...
 
+# NOTE: we ignore UP047 because inlining `_AnyScalarT` would result in a lot of code duplication
+
 # keep in sync with `lib._arraysetops_impl.intersect1d`
 @overload  # known scalar-type, return_indices=False (default)
-def intersect1d(
+def intersect1d(  # noqa: UP047
     ar1: _ArrayLike[_AnyScalarT], ar2: _ArrayLike[_AnyScalarT], assume_unique: bool = False
 ) -> _MArray1D[_AnyScalarT]: ...
 @overload  # unknown scalar-type, return_indices=False (default)
@@ -577,7 +579,7 @@ def intersect1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False) -> 
 
 # keep in sync with `lib._arraysetops_impl.setxor1d`
 @overload
-def setxor1d(
+def setxor1d(  # noqa: UP047
     ar1: _ArrayLike[_AnyScalarT], ar2: _ArrayLike[_AnyScalarT], assume_unique: bool = False
 ) -> _MArray1D[_AnyScalarT]: ...
 @overload
@@ -585,13 +587,13 @@ def setxor1d(ar1: ArrayLike, ar2: ArrayLike, assume_unique: bool = False) -> _MA
 
 # keep in sync with `lib._arraysetops_impl.union1d`
 @overload
-def union1d(ar1: _ArrayLike[_AnyScalarT], ar2: _ArrayLike[_AnyScalarT]) -> _MArray1D[_AnyScalarT]: ...
+def union1d(ar1: _ArrayLike[_AnyScalarT], ar2: _ArrayLike[_AnyScalarT]) -> _MArray1D[_AnyScalarT]: ...  # noqa: UP047
 @overload
 def union1d(ar1: ArrayLike, ar2: ArrayLike) -> _MArray1D[Incomplete]: ...
 
 # keep in sync with `lib._arraysetops_impl.setdiff1d`
 @overload
-def setdiff1d(
+def setdiff1d(  # noqa: UP047
     ar1: _ArrayLike[_AnyScalarT], ar2: _ArrayLike[_AnyScalarT], assume_unique: bool = False
 ) -> _MArray1D[_AnyScalarT]: ...
 @overload

--- a/numpy/testing/_private/utils.pyi
+++ b/numpy/testing/_private/utils.pyi
@@ -10,7 +10,6 @@ from pathlib import Path
 from re import Pattern
 from typing import (
     Any,
-    AnyStr,
     ClassVar,
     Final,
     Generic,
@@ -389,21 +388,21 @@ def tempdir(
     dir: None = None,
 ) -> _GeneratorContextManager[str]: ...
 @overload
-def tempdir(
+def tempdir[AnyStr: (bytes, str)](
     suffix: AnyStr | None = None,
     prefix: AnyStr | None = None,
     *,
     dir: GenericPath[AnyStr],
 ) -> _GeneratorContextManager[AnyStr]: ...
 @overload
-def tempdir(
+def tempdir[AnyStr: (bytes, str)](
     suffix: AnyStr | None = None,
     *,
     prefix: AnyStr,
     dir: GenericPath[AnyStr] | None = None,
 ) -> _GeneratorContextManager[AnyStr]: ...
 @overload
-def tempdir(
+def tempdir[AnyStr: (bytes, str)](
     suffix: AnyStr,
     prefix: AnyStr | None = None,
     dir: GenericPath[AnyStr] | None = None,
@@ -418,14 +417,14 @@ def temppath(
     text: bool = False,
 ) -> _GeneratorContextManager[str]: ...
 @overload
-def temppath(
+def temppath[AnyStr: (bytes, str)](
     suffix: AnyStr | None,
     prefix: AnyStr | None,
     dir: GenericPath[AnyStr],
     text: bool = False,
 ) -> _GeneratorContextManager[AnyStr]: ...
 @overload
-def temppath(
+def temppath[AnyStr: (bytes, str)](
     suffix: AnyStr | None = None,
     prefix: AnyStr | None = None,
     *,
@@ -433,14 +432,14 @@ def temppath(
     text: bool = False,
 ) -> _GeneratorContextManager[AnyStr]: ...
 @overload
-def temppath(
+def temppath[AnyStr: (bytes, str)](
     suffix: AnyStr | None,
     prefix: AnyStr,
     dir: GenericPath[AnyStr] | None = None,
     text: bool = False,
 ) -> _GeneratorContextManager[AnyStr]: ...
 @overload
-def temppath(
+def temppath[AnyStr: (bytes, str)](
     suffix: AnyStr | None = None,
     *,
     prefix: AnyStr,
@@ -448,7 +447,7 @@ def temppath(
     text: bool = False,
 ) -> _GeneratorContextManager[AnyStr]: ...
 @overload
-def temppath(
+def temppath[AnyStr: (bytes, str)](
     suffix: AnyStr,
     prefix: AnyStr | None = None,
     dir: GenericPath[AnyStr] | None = None,

--- a/requirements/linter_requirements.txt
+++ b/requirements/linter_requirements.txt
@@ -1,5 +1,5 @@
 # keep in sync with `environment.yml`
 cython-lint
-ruff==0.15.0
+ruff==0.15.2
 GitPython>=3.1.30
 spin

--- a/ruff.toml
+++ b/ruff.toml
@@ -19,7 +19,7 @@ line-ending = "lf"
 
 [lint]
 preview = true
-extend-select = [
+select = [
     "B",    # flake8-bugbear
     "C4",   # flake8-comprehensions
     "ISC",  # flake8-implicit-str-concat
@@ -34,6 +34,7 @@ extend-select = [
     "PERF", # perflint
     "E",    # pycodestyle/error
     "W",    # pycodestyle/warning
+    "F",    # pyflakes
     "PGH",  # pygrep-hooks
     "PLE",  # pylint/error
     "UP",   # pyupgrade


### PR DESCRIPTION
ref https://github.com/numpy/numpy/pull/30856#issuecomment-3936493429

The default ruleset changed in 0.15.2, so I had to tweak the config a bit to avoid 2510 ruff errors. 
It's probably a good idea that we (gradually) address some of these, but doing so here would be out of scope. For reference, here's the overview:

```
642     PLR2044 [*] empty-comment
376     RUF012  [ ] mutable-class-default
163     RUF059  [ ] unused-unpacked-variable
116     PLR0124 [ ] comparison-with-itself
108     RET504  [ ] unnecessary-assign
 94     FURB167 [*] regex-flag-alias
 89     RUF022  [-] unsorted-dunder-all
 88     BLE001  [ ] blind-except
 79     PYI047  [ ] unused-private-type-alias
 54     PYI015  [*] assignment-default-in-stub
 53     SIM102  [ ] collapsible-if
 47     SIM118  [-] in-dict-keys
 42     RUF010  [*] explicit-f-string-type-conversion
 42     SIM201  [ ] negate-equal-op
 39     PLR0402 [*] manual-from-import
 37     PYI042  [ ] snake-case-type-alias
 35     RUF100  [*] unused-noqa
 33     SIM117  [-] multiple-with-statements
 29     PLW0602 [ ] global-variable-not-assigned
 29     PYI010  [*] non-empty-stub-body
 25     PYI026  [*] type-alias-without-annotation
 21     DTZ001  [ ] call-datetime-without-tzinfo
 21     PYI046  [ ] unused-private-protocol
 20     PT031   [ ] pytest-warns-with-multiple-statements
 17     S110    [ ] try-except-pass
 16     SIM115  [ ] open-file-with-context-handler
 14     EXE001  [ ] shebang-not-executable
 14     TRY004  [ ] type-check-without-type-error
 13     PYI017  [ ] complex-assignment-in-stub
 13     PYI034  [ ] non-self-return-type
 13     TRY002  [ ] raise-vanilla-class
 12     PLW1510 [ ] subprocess-run-without-check
 11     PT014   [ ] pytest-duplicate-parametrize-test-cases
 11     PYI052  [ ] unannotated-assignment-in-stub
 10     PLC0206 [ ] dict-index-missing-items
  9     TRY300  [ ] try-consider-else
  5     D419    [ ] empty-docstring
  5     FURB105 [*] print-empty-string
  5     PLR1704 [ ] redefined-argument-from-local
  5     PLW0177 [ ] nan-comparison
  5     SIM114  [*] if-with-same-arms
  4     DTZ005  [ ] call-datetime-now-without-tzinfo
  4     PLR1730 [*] if-stmt-min-max
  4     S102    [ ] exec-builtin
  3     N999    [ ] invalid-module-name
  3     PLW0127 [ ] self-assigning-variable
  3     PYI064  [*] redundant-final-literal
  3     SIM103  [ ] needless-bool
  3     SIM208  [*] double-negation
  2     FURB122 [*] for-loop-writes
  2     PYI029  [*] str-or-repr-defined-in-stub
  2     PYI032  [*] any-eq-ne-annotation
  2     PYI063  [ ] pep484-style-positional-only-parameter
  2     PYI066  [ ] bad-version-info-order
  1     DTZ011  [ ] call-date-today
  1     PLR1711 [*] useless-return
  1     PLR1733 [*] unnecessary-dict-index-lookup
  1     PLW0406 [ ] import-self
  1     PYI002  [ ] complex-if-statement-in-stub
  1     PYI018  [ ] unused-private-type-var
  1     PYI045  [ ] iter-method-return-iterable
  1     PYI055  [*] unnecessary-type-union
  1     PYI059  [ ] generic-not-last-base-class
  1     RUF046  [*] unnecessary-cast-to-int
  1     SIM202  [ ] negate-not-equal-op
  1     TRY201  [ ] verbose-raise
  1     TRY203  [ ] useless-try-except
Found 2510 errors.
[*] 1103 fixable with the `--fix` option (406 hidden fixes can be enabled with the `--unsafe-fixes` option).
```

(The `PLR2044` is intentional and helps make the stubs a bit less unreadable, so we should ignore that one)