### PR TITLE
BUG: fix uint input for triu_indices and deprecate non-int

### DIFF
--- a/doc/release/upcoming_changes/30869.change.rst
+++ b/doc/release/upcoming_changes/30869.change.rst
@@ -1,0 +1,3 @@
+``numpy.triu_indices`` now accepts ``unsigned integers``
+--------------------------------------------------------
+``numpy.triu_indices`` previously used to error in some cases when ``unsigned integers`` were given as arguments. Now, it accepts them in all cases.

--- a/doc/release/upcoming_changes/30869.deprecation.rst
+++ b/doc/release/upcoming_changes/30869.deprecation.rst
@@ -1,0 +1,7 @@
+Inputs other than ``integers`` is deprecated
+--------------------------------------------
+Inputs other than integers is deprecated for ``numpy.triu_indices`` and ``numpy.tril_indices``.  
+
+The ``M``, ``k`` and ``N`` parameters of ``numpy.tri`` also deprecate non-integer arguments.
+
+The ``k`` parameter of both ``numpy.tril_indices_from`` and ``numpy.triu_indices_from`` deprecates non-integer arguments.

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -365,3 +365,31 @@ class TestRoundDeprecation(_DeprecationTestCase):
 
     def test_round_emits_deprecation_warning_scalar(self):
         self.assert_deprecated(lambda: np.ma.round_(3.14))
+
+class TestTriDeprecationWithNonInteger(_DeprecationTestCase):
+    # Deprecation in NumPy 2.5, 2026-02
+
+    def test_tri(self):
+        self.assert_deprecated(lambda: np.tri(M=2.3, k=3.14, N=np.object_(8)), num=2)
+
+    def test_triu_indices(self):
+        self.assert_deprecated(
+                               lambda: np.triu_indices(n=np.float64(7.14), k=3.2),
+                               num=2)
+
+    def test_tril_indices(self):
+        self.assert_deprecated(lambda: np.tril_indices(n=np.array(3.14)), num=1)
+
+    def test_triu_indices_from(self):
+        a = np.array([[ 0,  1,  2,  3],
+           [ 4,  5,  6,  7],
+           [ 8,  9, 10, 11],
+           [12, 13, 14, 15]])
+        self.assert_deprecated(lambda: np.triu_indices_from(a, k=np.object_(9.8)))
+
+    def test_tril_indices_from(self):
+        a = np.array([[ 0,  1,  2,  3],
+           [ 4,  5,  6,  7],
+           [ 8,  9, 10, 11],
+           [12, 13, 14, 15]])
+        self.assert_deprecated(lambda: np.tril_indices_from(a, k=9.8))

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -367,18 +367,17 @@ class TestRoundDeprecation(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.ma.round_(3.14))
 
 class TestTriDeprecationWithNonInteger(_DeprecationTestCase):
-    # Deprecation in NumPy 2.5, 2026-02
+    # Deprecation in NumPy 2.5, 2026-03
 
     def test_tri(self):
-        self.assert_deprecated(lambda: np.tri(M=2.3, k=3.14, N=np.object_(8)), num=2)
+        self.assert_deprecated(lambda: np.tri(M=2.3, k=3.14, N=np.object_(8)))
 
     def test_triu_indices(self):
-        self.assert_deprecated(
-                               lambda: np.triu_indices(n=np.float64(7.14), k=3.2),
-                               num=2)
+        self.assert_deprecated(lambda: np.triu_indices(n=np.float64(7.14), k=3.2))
+        self.assert_deprecated(lambda: np.triu_indices(n=4, k=np.bool(0)))
 
     def test_tril_indices(self):
-        self.assert_deprecated(lambda: np.tril_indices(n=np.array(3.14)), num=1)
+        self.assert_deprecated(lambda: np.tril_indices(n=np.array(3.14)))
 
     def test_triu_indices_from(self):
         a = np.array([[ 0,  1,  2,  3],

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -25,6 +25,7 @@ from numpy._core.numeric import (
     nonzero,
     ones,
     promote_types,
+    unsignedinteger,
     where,
     zeros,
 )
@@ -388,20 +389,19 @@ def diagflat(v, k=0):
     return conv.wrap(res)
 
 def _to_int(n):
-    a = int(n)
-    dtype_not_int = True
 
-    if hasattr(n, "dtype") and n.dtype.kind in "iu":
-        dtype_not_int = False
-
-    if dtype_not_int and not isinstance(n, int):
+    try:
+        n = operator.index(n)
+    except TypeError:
+        # Deprecated NumPy 2.5, 2026-02
         warnings.warn(
             (f"Cannot convert {type(n).__name__} safely to an integer."
-             "This will raise an error in future versions(Deprecated NumPy 2.4)"),
+             "This will raise an error in future versions (Deprecated NumPy 2.5)"),
             DeprecationWarning,
             skip_file_prefixes=(os.path.dirname(__file__),),
         )
-    return a
+
+    return n
 
 @finalize_array_function_like
 @set_module('numpy')
@@ -1159,8 +1159,8 @@ def triu_indices(n, k=0, m=None):
 
     """
 
-    if hasattr(k, "dtype") and k.dtype.kind == "u":
-        k = int(k)
+    if isinstance(k, unsignedinteger):
+        k = operator.index(k)
 
     tri_ = ~tri(n, m, k=k - 1, dtype=bool)
 

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -20,7 +20,6 @@ from numpy._core.numeric import (
     int16,
     int32,
     int64,
-    integer,
     intp,
     multiply,
     nonzero,
@@ -432,11 +431,11 @@ def tri(N, M=None, k=0, dtype=float, *, like=None):
 
     """
 
-    w = []
+    warning_for_type = None
     try:
         N = operator.index(N)
     except TypeError:
-        w.append(N)
+        warning_for_type = warning_for_type or type(N)
 
     if like is not None:
         return _tri_with_like(like, N, M=M, k=k, dtype=dtype)
@@ -447,12 +446,12 @@ def tri(N, M=None, k=0, dtype=float, *, like=None):
         try:
             M = operator.index(M)
         except TypeError:
-            w.append(M)
+            warning_for_type = warning_for_type or type(M)
 
     try:
         k = operator.index(k)
     except TypeError:
-        w.append(k)
+        warning_for_type = warning_for_type or type(k)
 
     m = greater_equal.outer(arange(N, dtype=_min_int(0, N)),
                             arange(-k, M - k, dtype=_min_int(-k, M - k)))
@@ -460,10 +459,10 @@ def tri(N, M=None, k=0, dtype=float, *, like=None):
     # Avoid making a copy if the requested type is already bool
     m = m.astype(dtype, copy=False)
 
-    # warn for all deprecated
-    for i in w:
+    # Deprecation in NumPy 2.5, 2026-03
+    if warning_for_type:
         warnings.warn(
-            (f"Cannot convert {type(i).__name__} safely to an integer."
+            (f"Cannot convert {(warning_for_type).__name__} safely to an integer."
              "This will raise an error in future versions (Deprecated NumPy 2.5)"),
             DeprecationWarning,
             skip_file_prefixes=(os.path.dirname(__file__),),
@@ -1161,9 +1160,18 @@ def triu_indices(n, k=0, m=None):
 
     """
 
-    # To make sure unsigned integers, etc. get converted to int
-    if isinstance(k, integer):
+    try:
         k = operator.index(k)
+    except TypeError:
+        # If same instance,then warning will be given in tri
+        if not isinstance(k, type(k - 1)):
+            # Deprecated in NumPy 2.5, 2026-03
+            warnings.warn(
+                (f"Cannot convert {type(k).__name__} safely to an integer."
+                 "This will raise an error in future versions (Deprecated NumPy 2.5)"),
+                DeprecationWarning,
+                skip_file_prefixes=(os.path.dirname(__file__),),
+            )
 
     tri_ = ~tri(n, m, k=k - 1, dtype=bool)
 

--- a/numpy/lib/tests/test_twodim_base.py
+++ b/numpy/lib/tests/test_twodim_base.py
@@ -467,6 +467,7 @@ class TestTriuIndices:
         iu2 = triu_indices(4, k=2)
         iu3 = triu_indices(4, m=5)
         iu4 = triu_indices(4, k=2, m=5)
+        iu5 = triu_indices(np.uint64(4), m=np.uint8(4))
 
         a = np.array([[1, 2, 3, 4],
                       [5, 6, 7, 8],
@@ -510,6 +511,10 @@ class TestTriuIndices:
                                   [11, 12, -1, -1, -10],
                                   [16, 17, 18, -1, -1]]))
 
+        # For unsigned integer
+        assert_array_equal(iu5,
+                           (array([0, 0, 0, 0, 1, 1, 1, 2, 2, 3]),
+                            array([0, 1, 2, 3, 1, 2, 3, 2, 3, 3])))
 
 class TestTrilIndicesFrom:
     def test_exceptions(self):

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -47,11 +47,11 @@ class FindFuncs(ast.NodeVisitor):
                 # This file
                 return
 
-            # See if stacklevel exists:
+            # See if stacklevel or skip_file_prefixes exists:
             if len(node.args) == 3:
                 return
             args = {kw.arg for kw in node.keywords}
-            if "stacklevel" in args:
+            if "stacklevel" or "skip_file_prefixes" in args:
                 return
             raise AssertionError(
                 "warnings should have an appropriate stacklevel; "

--- a/numpy/tests/test_warnings.py
+++ b/numpy/tests/test_warnings.py
@@ -51,10 +51,12 @@ class FindFuncs(ast.NodeVisitor):
             if len(node.args) == 3:
                 return
             args = {kw.arg for kw in node.keywords}
-            if "stacklevel" or "skip_file_prefixes" in args:
+            if "stacklevel" in args:
+                return
+            if "skip_file_prefixes" in args:
                 return
             raise AssertionError(
-                "warnings should have an appropriate stacklevel; "
+                "warnings should have an appropriate stacklevel or skip_file_prefixes; "
                 f"found in {self.__filename} on line {node.lineno}")
 
 


### PR DESCRIPTION
resolves #29488 
Does not raise an error when any or all of of `n`, `m` and `k` are unsigned integers. 
