### PR TITLE
TYP/CI: separate ``typing_requirements.txt``

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -41,7 +41,7 @@ jobs:
         shell: bash
         run: |
           cd numpy_to_test
-          MYPY_VERSION=$(grep mypy== requirements/test_requirements.txt | sed -n 's/mypy==\([^;]*\).*/\1/p')
+          MYPY_VERSION=$(grep mypy== requirements/typing_requirements.txt | sed -n 's/mypy==\([^;]*\).*/\1/p')
 
           echo "new commit"
           git checkout $GITHUB_SHA

--- a/.github/workflows/stubtest.yml
+++ b/.github/workflows/stubtest.yml
@@ -14,7 +14,7 @@ on:
       - ".github/workflows/stubtest.yml"
       - "numpy/**"
       - "!numpy/**/tests/**"
-      - "requirements/test_requirements.txt"
+      - "requirements/typing_requirements.txt"
       - "tools/stubtest/**"
   workflow_dispatch:
 
@@ -49,13 +49,13 @@ jobs:
           activate-environment: true
           cache-dependency-glob: |
             requirements/build_requirements.txt
-            requirements/test_requirements.txt
+            requirements/typing_requirements.txt
 
       - name: uv pip install
         run: >-
           uv pip install
           -r requirements/build_requirements.txt
-          -r requirements/test_requirements.txt
+          -r requirements/typing_requirements.txt
 
       - name: spin build
         run: spin build -j2 -- -Dallow-noblas=true -Ddisable-optimization=true --vsenv

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -67,14 +67,14 @@ jobs:
         activate-environment: true
         cache-dependency-glob: |
           requirements/build_requirements.txt
-          requirements/test_requirements.txt
+          requirements/typing_requirements.txt
     - name: Install dependencies
       # orjson makes mypy faster but the default requirements.txt
       # can't install it because orjson doesn't support 32 bit Linux
       run: >-
         uv pip install
         -r requirements/build_requirements.txt
-        -r requirements/test_requirements.txt
+        -r requirements/typing_requirements.txt
         orjson
         basedpyright
     - name: Build
@@ -100,6 +100,6 @@ jobs:
     - name: Install dependencies
       run: >-
         uv pip install
-        -r requirements/test_requirements.txt
+        -r requirements/typing_requirements.txt
     - name: Run pyrefly
       run: pyrefly check

--- a/requirements/all_requirements.txt
+++ b/requirements/all_requirements.txt
@@ -3,4 +3,5 @@
 -r linter_requirements.txt
 -r release_requirements.txt
 -r test_requirements.txt
+-r typing_requirements.txt
 -r ci_requirements.txt

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -6,9 +6,6 @@ meson
 ninja; sys_platform != "emscripten"
 pytest-xdist
 pytest-timeout
-# For testing types
-mypy==1.19.1
-pyrefly==0.49.0
 # for optional f2py encoding detection
 charset-normalizer
 tzdata

--- a/requirements/typing_requirements.txt
+++ b/requirements/typing_requirements.txt
@@ -1,0 +1,4 @@
+-r test_requirements.txt
+
+mypy==1.19.1
+pyrefly==0.49.0

--- a/requirements/typing_requirements.txt
+++ b/requirements/typing_requirements.txt
@@ -1,3 +1,5 @@
+# static typing requirements that are not needed for runtime tests
+
 -r test_requirements.txt
 
 mypy==1.19.1


### PR DESCRIPTION
For (runtime) testing there is no need to install mypy and pyrefly, but because they were listed in `test_requirements.tst`, they are installed in more workflows that needed. 
By splitting off the the type-checker requirements into a new `typing_requirements.txt`, we can be more precise about this. The hope is that this will also resolve the armhf CI issues noted in https://github.com/numpy/numpy/pull/30863#issuecomment-3947960648