### PR TITLE
ENH: Test ._is_numeric not .char in np.testing.assert_equal

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -744,7 +744,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
     ox, oy = x, y
 
     def isnumber(x):
-        return x.dtype.char in '?bhilqpBHILQPefdgFDG'
+        return x.dtype.kind in 'biufc'
 
     def istime(x):
         return x.dtype.char in "Mm"

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -744,7 +744,7 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
     ox, oy = x, y
 
     def isnumber(x):
-        return x.dtype.kind in 'biufc'
+        return type(x.dtype)._is_numeric
 
     def istime(x):
         return x.dtype.char in "Mm"


### PR DESCRIPTION
This PR makes assert_equal correctly handle NaN tests for user-defined float types.

This fixes an issue found when attempting to port ml_dtypes to use the NumPy 2 user dtype APIs (https://github.com/jax-ml/ml_dtypes/pull/360).

@seberg 
