### PR TITLE
ENH: Increase np.atleast_2d and np.atleast_3d performance

### DIFF
--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -125,7 +125,7 @@ def atleast_2d(*arys):
         if result.ndim == 0:
             result = result.reshape(1, 1)
         elif result.ndim == 1:
-            result = ary[_nx.newaxis, :]
+            result = result[_nx.newaxis, :]
         res.append(result)
     return tuple(res)
 
@@ -195,10 +195,10 @@ def atleast_3d(*arys):
         result = asanyarray(ary)
         if result.ndim == 0:
             result = result.reshape(1, 1, 1)
-        elif ary.ndim == 1:
-            result = ary[_nx.newaxis, :, _nx.newaxis]
-        elif ary.ndim == 2:
-            result = ary[:, :, _nx.newaxis]
+        elif result.ndim == 1:
+            result = result[_nx.newaxis, :, _nx.newaxis]
+        elif result.ndim == 2:
+            result = result[:, :, _nx.newaxis]
         res.append(result)
     return tuple(res)
 

--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -118,8 +118,8 @@ def atleast_2d(*arys):
         result = asanyarray(arys[0])
         if result.ndim == 0:
             result = result.reshape(1, 1)
-        elif ary.ndim == 1:
-            result = ary[_nx.newaxis, :]
+        elif result.ndim == 1:
+            result = result[_nx.newaxis, :]
         return result
     res = []
     for ary in arys:
@@ -191,10 +191,10 @@ def atleast_3d(*arys):
         result = asanyarray(arys[0])
         if result.ndim == 0:
             result = result.reshape(1, 1, 1)
-        elif ary.ndim == 1:
-            result = ary[_nx.newaxis, :, _nx.newaxis]
+        elif result.ndim == 1:
+            result = result[_nx.newaxis, :, _nx.newaxis]
         elif ary.ndim == 2:
-            result = ary[:, :, _nx.newaxis]
+            result = result[:, :, _nx.newaxis]
         return result
     res = []
     for ary in arys:

--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -114,20 +114,20 @@ def atleast_2d(*arys):
     (array([[1]]), array([[1, 2]]), array([[1, 2]]))
 
     """
+    if len(arys) == 1:
+        result = asanyarray(arys[0])
+        if result.ndim == 0:
+            result = result.reshape(1, 1)
+        return result
     res = []
     for ary in arys:
-        ary = asanyarray(ary)
-        if ary.ndim == 0:
-            result = ary.reshape(1, 1)
-        elif ary.ndim == 1:
+        result = asanyarray(ary)
+        if result.ndim == 0:
+            result = result.reshape(1, 1)
+        elif result.ndim == 1:
             result = ary[_nx.newaxis, :]
-        else:
-            result = ary
         res.append(result)
-    if len(res) == 1:
-        return res[0]
-    else:
-        return tuple(res)
+    return tuple(res)
 
 
 def _atleast_3d_dispatcher(*arys):
@@ -185,22 +185,22 @@ def atleast_3d(*arys):
     [[[1 2]]] (1, 1, 2)
 
     """
+    if len(arys) == 1:
+        result = asanyarray(arys[0])
+        if result.ndim == 0:
+            result = result.reshape(1, 1, 1)
+        return result
     res = []
     for ary in arys:
-        ary = asanyarray(ary)
-        if ary.ndim == 0:
-            result = ary.reshape(1, 1, 1)
+        result = asanyarray(ary)
+        if result.ndim == 0:
+            result = result.reshape(1, 1, 1)
         elif ary.ndim == 1:
             result = ary[_nx.newaxis, :, _nx.newaxis]
         elif ary.ndim == 2:
             result = ary[:, :, _nx.newaxis]
-        else:
-            result = ary
         res.append(result)
-    if len(res) == 1:
-        return res[0]
-    else:
-        return tuple(res)
+    return tuple(res)
 
 
 def _arrays_for_stack_dispatcher(arrays):

--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -118,6 +118,8 @@ def atleast_2d(*arys):
         result = asanyarray(arys[0])
         if result.ndim == 0:
             result = result.reshape(1, 1)
+        elif ary.ndim == 1:
+            result = ary[_nx.newaxis, :]
         return result
     res = []
     for ary in arys:
@@ -189,6 +191,10 @@ def atleast_3d(*arys):
         result = asanyarray(arys[0])
         if result.ndim == 0:
             result = result.reshape(1, 1, 1)
+        elif ary.ndim == 1:
+            result = ary[_nx.newaxis, :, _nx.newaxis]
+        elif ary.ndim == 2:
+            result = ary[:, :, _nx.newaxis]
         return result
     res = []
     for ary in arys:

--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -193,7 +193,7 @@ def atleast_3d(*arys):
             result = result.reshape(1, 1, 1)
         elif result.ndim == 1:
             result = result[_nx.newaxis, :, _nx.newaxis]
-        elif ary.ndim == 2:
+        elif result.ndim == 2:
             result = result[:, :, _nx.newaxis]
         return result
     res = []


### PR DESCRIPTION
This pull request is a features #26130 by @eendebakpt (credits to him for the great work 👍 ) and should improve the performance of `np.atleast_2d` and `np.atleast_3d`.

I've not tested the changes, but it seems quite obvious to me from looking at the code that these should be (at least in most cases) positive (and in general more positive than negative, but I'm not one hundred percent sure, so please correct me if I'm mistaken, thanks).

Credits to: @eendebakpt
Contributed by Benedikt Johannes