### PR TITLE
DOC: clarify float-scalar handling in array_split

### DIFF
--- a/numpy/lib/_shape_base_impl.py
+++ b/numpy/lib/_shape_base_impl.py
@@ -728,6 +728,9 @@ def array_split(ary, indices_or_sections, axis=0):
     into n sections, it returns l % n sub-arrays of size l//n + 1
     and the rest of size l//n.
 
+    If `indices_or_sections` is a floating-point scalar, it is truncated
+    toward zero through ``int(indices_or_sections)`` before splitting.
+
     See Also
     --------
     split : Split array into multiple sub-arrays of equal size.


### PR DESCRIPTION
## Summary
- clarify `numpy.array_split` docs for scalar `indices_or_sections`
- document that floating-point scalars are truncated toward zero via `int(indices_or_sections)` before splitting

Closes #29494.

## Validation
- `python3 -m compileall numpy/lib/_shape_base_impl.py`
