### PR TITLE
CI: Use spin test for linux.full job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -130,7 +130,7 @@ jobs:
     - uses: ./.github/meson_actions
 
   full:
-    # Install as editable, then run the full test suite with code coverage
+    # Install as editable, then run the full test suite
     needs: [smoke_test]
     runs-on: ubuntu-22.04
     steps:
@@ -162,8 +162,7 @@ jobs:
         pip install -e . --no-build-isolation
     - name: Run full test suite
       run: |
-        pytest numpy --durations=10 --timeout=600 --cov-report=html:build/coverage
-        # TODO: gcov
+        spin test -- --durations=10 --timeout=600
       env:
         PYTHONOPTIMIZE: 2
 


### PR DESCRIPTION
## Use spin test for linux.full job

- Part of https://github.com/numpy/numpy/issues/30886

## Notes
- Have added one item to #30886 for doing code coverage that will cover both C and Python