### PR TITLE
DOC: clarify wording for ufunc ``order='A'`` semantics

### DIFF
--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -131,10 +131,10 @@ onwards, the default is 'same_kind'.
 .. rubric:: *order*
 
 Specifies the calculation iteration order/memory layout of the output array.
-Defaults to 'K'. 'C' means the output should be C-contiguous, 'F' means
-F-contiguous, 'A' means F-contiguous if the inputs are F-contiguous and
-not also not C-contiguous, C-contiguous otherwise, and 'K' means to match
-the element ordering of the inputs as closely as possible.
+Defaults to 'K'. 'C' means the output should be C-contiguous. 'F' means
+F-contiguous. 'A' means F-contiguous if the inputs are F-contiguous and
+not C-contiguous, and C-contiguous otherwise. 'K' means to match the
+element ordering of the inputs as closely as possible.
 
 .. rubric:: *dtype*
 


### PR DESCRIPTION
## Summary
- clarify the `order` keyword description in the ufunc API reference
- fix confusing phrasing (`not also not C-contiguous`)
- split the long sentence into clearer per-option statements for `'C'`, `'F'`, `'A'`, and `'K'`

Closes #26226.

## Validation
- docs-only wording change
