### PR TITLE
DOC: disambiguate numpy.dtype attribute links in generated docs

### DIFF
--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -611,7 +611,7 @@ The type of the data is described by the following :class:`dtype`  attributes:
 
    dtype.type
    dtype.kind
-   dtype.char
+   numpy.dtype.char
    dtype.num
    dtype.str
 

--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -611,7 +611,7 @@ The type of the data is described by the following :class:`dtype`  attributes:
 
    dtype.type
    dtype.kind
-   numpy.dtype.char
+   dtype.char
    dtype.num
    dtype.str
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5958,6 +5958,8 @@ add_newdoc('numpy._core.multiarray', 'dtype',
     dtype object. A dtype object can be constructed from different
     combinations of fundamental numeric types.
 
+    .. currentclass:: numpy.dtype
+
     Parameters
     ----------
     dtype

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5958,8 +5958,6 @@ add_newdoc('numpy._core.multiarray', 'dtype',
     dtype object. A dtype object can be constructed from different
     combinations of fundamental numeric types.
 
-    .. currentclass:: numpy.dtype
-
     Parameters
     ----------
     dtype

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5975,6 +5975,53 @@ add_newdoc('numpy._core.multiarray', 'dtype',
     metadata : dict, optional
         An optional dictionary with dtype metadata.
 
+    Attributes
+    ----------
+    dtype.alignment : int
+        The required alignment (bytes) of this dtype.
+    dtype.base : dtype
+        The base dtype of this dtype, if any.
+    dtype.byteorder : str
+        Byte order code for this dtype.
+    dtype.char : str
+        Single-character code identifying this dtype.
+    dtype.descr : list
+        `__array_interface__` description of this dtype.
+    dtype.fields : dict or None
+        Field-name dictionary for structured dtypes.
+    dtype.flags : int
+        Bit flags describing this dtype.
+    dtype.hasobject : bool
+        Whether this dtype contains Python objects.
+    dtype.isalignedstruct : bool
+        Whether this structured dtype has aligned fields.
+    dtype.isbuiltin : int
+        Whether this dtype maps to a built-in dtype.
+    dtype.isnative : bool
+        Whether this dtype uses native byte order.
+    dtype.itemsize : int
+        Element size of this dtype in bytes.
+    dtype.kind : str
+        Kind code of this dtype.
+    dtype.metadata : mappingproxy or None
+        Optional metadata associated with this dtype.
+    dtype.name : str
+        Name of this dtype.
+    dtype.names : tuple or None
+        Field names for structured dtypes.
+    dtype.ndim : int
+        Number of dimensions for sub-array dtypes, else 0.
+    dtype.num : int
+        Integer code identifying this dtype.
+    dtype.shape : tuple
+        Shape for sub-array dtypes, else ``()``.
+    dtype.str : str
+        Array-protocol type string of this dtype.
+    dtype.subdtype : tuple or None
+        Base dtype and shape if this is a sub-array dtype.
+    dtype.type : type
+        Scalar type associated with this dtype.
+
     See also
     --------
     result_type


### PR DESCRIPTION
## Problem
On the generated `numpy.dtype` page, attribute names like `char` can resolve to top-level objects (for example `numpy.char`) instead of dtype attributes (`numpy.dtype.char`) as reported in #28470.

## What this PR changes
- updates `numpy/_core/_add_newdocs.py`
- adds an explicit `Attributes` section to the `numpy.dtype` docsource using fully-qualified `dtype.*` entries

This keeps link resolution in the generated `reference/generated/numpy.dtype.html` page tied to dtype attributes.

## Validation
- `python3 -m compileall numpy/_core/_add_newdocs.py`
- fixed Circle doc-build warning by removing an invalid directive from an earlier attempt

Closes #28470.
