### PR TITLE
DOC: clarify ``nan_to_num(copy=...)`` behavior in NumPy 2.x

### DIFF
--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -394,11 +394,16 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     ----------
     x : scalar or array_like
         Input data.
-    copy : bool, optional
-        Whether to create a copy of `x` (True) or to replace values
-        in-place (False). The in-place operation only occurs if
-        casting to an array does not require a copy.
-        Default is True.
+    copy : {bool, None}, optional
+        Controls what kind of copy is made when coercing `x` to an array.
+
+        - ``True`` (default): always create a copy.
+        - ``None``: only create a copy if needed.
+        - ``False``: never create a copy. If a copy is required, a
+          ``ValueError`` is raised.
+
+        In-place replacement only occurs when casting to an array does not
+        require a copy.
     nan : int, float, or bool or array_like of int, float, or bool, optional
         Values to be used to fill NaN values. If no values are passed
         then NaN values will be replaced with 0.0.


### PR DESCRIPTION
## Summary
- clarify `nan_to_num(copy=...)` docs to match NumPy 2.x `copy` semantics
- document all accepted modes: `True` (always copy), `None` (copy if needed), and `False` (never copy)
- explicitly note that `copy=False` raises `ValueError` when a copy is required

## Why
Issue #29045 notes that the current wording reads like NumPy 1.x behavior and can mislead users when `copy=False` is used with non-array inputs in NumPy 2.x.

Closes #29045
