### PR TITLE
DOC: clarify ``BitGenerator.state`` getter copy/snapshot semantics

### DIFF
--- a/numpy/random/_mt19937.pyx
+++ b/numpy/random/_mt19937.pyx
@@ -264,6 +264,11 @@ cdef class MT19937(BitGenerator):
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        Getting ``state`` returns a new dictionary snapshot of the current
+        state. It is not a live view into the bit generator's internal state.
         """
         key = np.zeros(624, dtype=np.uint32)
         for i in range(624):

--- a/numpy/random/_pcg64.pyx
+++ b/numpy/random/_pcg64.pyx
@@ -199,6 +199,11 @@ cdef class PCG64(BitGenerator):
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        Getting ``state`` returns a new dictionary snapshot of the current
+        state. It is not a live view into the bit generator's internal state.
         """
         cdef np.ndarray state_vec
         cdef int has_uint32
@@ -433,6 +438,11 @@ cdef class PCG64DXSM(BitGenerator):
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        Getting ``state`` returns a new dictionary snapshot of the current
+        state. It is not a live view into the bit generator's internal state.
         """
         cdef np.ndarray state_vec
         cdef int has_uint32

--- a/numpy/random/_philox.pyx
+++ b/numpy/random/_philox.pyx
@@ -211,6 +211,11 @@ cdef class Philox(BitGenerator):
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        Getting ``state`` returns a new dictionary snapshot of the current
+        state. It is not a live view into the bit generator's internal state.
         """
         ctr = np.empty(4, dtype=np.uint64)
         key = np.empty(2, dtype=np.uint64)

--- a/numpy/random/_sfc64.pyx
+++ b/numpy/random/_sfc64.pyx
@@ -112,6 +112,11 @@ cdef class SFC64(BitGenerator):
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        Getting ``state`` returns a new dictionary snapshot of the current
+        state. It is not a live view into the bit generator's internal state.
         """
         cdef np.ndarray state_vec
         cdef int has_uint32

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -577,6 +577,11 @@ cdef class BitGenerator:
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        Getting ``state`` returns a new dictionary snapshot of the current
+        state. It is not a live view into the bit generator's internal state.
         """
         raise NotImplementedError('Not implemented in base BitGenerator')
 


### PR DESCRIPTION
## Summary
- clarify that `BitGenerator.state` getters return a fresh dictionary snapshot, not a live view into internal state
- apply the clarification consistently to `BitGenerator`, `PCG64`, `PCG64DXSM`, `MT19937`, `Philox`, and `SFC64` state property docs

## Why
Issue #22337 asks whether code such as:

```python
state0 = bitgen.state
# generate numbers
bitgen.state = state0
```
restores state or is a no-op. This PR documents the current behavior explicitly: the getter returns a new dictionary snapshot, so reassigning that dictionary restores the captured state.

## Validation
- `git diff --check`
- local pytest is unavailable in this environment (`No module named pytest`), so no test run here
