### PR TITLE
Fix `os.path.commonprefix` deprecation

### DIFF
--- a/tools/c_coverage/c_coverage_report.py
+++ b/tools/c_coverage/c_coverage_report.py
@@ -84,7 +84,7 @@ class SourceFiles:
             if self.prefix is None:
                 self.prefix = path
             else:
-                self.prefix = os.path.commonprefix([self.prefix, path])
+                self.prefix = os.path.commonpath([self.prefix, path])
         return self.files[path]
 
     def clean_path(self, path):


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

`os.path.commonprefix` is deprecated in Python 3.15:

* https://docs.python.org/3.15/deprecations/
* https://docs.python.org/3/library/os.path.html#os.path.commonprefix
* https://sethmlarson.dev/deprecate-confusing-apis-like-os-path-commonprefix
* [python/cpython#74453](https://github.com/python/cpython/issues/74453) & [python/cpython#144436](https://github.com/python/cpython/pull/144436)
