### PR TITLE
CI: pin pixi asan build to 3.15.0a6 and re-introduce SetImmortal bindings

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -5170,7 +5170,13 @@ _multiarray_umath_exec(PyObject *m) {
     if (PyDataMem_DefaultHandler == NULL) {
         return -1;
     }
-
+#ifdef Py_GIL_DISABLED
+    if (PyUnstable_SetImmortal(PyDataMem_DefaultHandler) == 0) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Could not mark memory handler capsule as immortal");
+        return -1;
+    }
+#endif
     /*
      * Initialize the context-local current handler
      * with the default PyDataMem_Handler capsule.

--- a/numpy/_core/src/umath/extobj.c
+++ b/numpy/_core/src/umath/extobj.c
@@ -15,6 +15,7 @@
 #include "numpy/ufuncobject.h"
 
 #include "common.h"
+#include "npy_pycompat.h"
 
 
 #define UFUNC_ERR_IGNORE 0
@@ -145,6 +146,13 @@ init_extobj(void)
     if (npy_static_pydata.default_extobj_capsule == NULL) {
         return -1;
     }
+#ifdef Py_GIL_DISABLED
+    if (PyUnstable_SetImmortal(npy_static_pydata.default_extobj_capsule) == 0) {
+        PyErr_SetString(PyExc_RuntimeError, "Could not mark extobj capsule as immortal");
+        Py_CLEAR(npy_static_pydata.default_extobj_capsule);
+        return -1;
+    }
+#endif
     npy_static_pydata.npy_extobj_contextvar = PyContextVar_New(
             "numpy.ufunc.extobj", npy_static_pydata.default_extobj_capsule);
     if (npy_static_pydata.npy_extobj_contextvar == NULL) {

--- a/pixi-packages/asan/pixi.toml
+++ b/pixi-packages/asan/pixi.toml
@@ -19,7 +19,8 @@ extra-args = ["-Csetup-args=-Db_sanitize=address", "-Csetup-args=-Dbuildtype=deb
 [package.host-dependencies]
 python.git = "https://github.com/python/cpython"
 python.subdirectory = "Tools/pixi-packages/asan"
-python.rev = "8bb5b6e8ce61da41b5affd5eb12d9cc46b5af448"
+# v3.15.0a6
+python.rev = "15b216f30d0445469ec31bc7509fcc55a216ef7c"
 
 meson-python = "*"
 cython = "*"

--- a/pixi-packages/asan/pixi.toml
+++ b/pixi-packages/asan/pixi.toml
@@ -19,6 +19,7 @@ extra-args = ["-Csetup-args=-Db_sanitize=address", "-Csetup-args=-Dbuildtype=deb
 [package.host-dependencies]
 python.git = "https://github.com/python/cpython"
 python.subdirectory = "Tools/pixi-packages/asan"
+python.rev = "8bb5b6e8ce61da41b5affd5eb12d9cc46b5af448"
 
 meson-python = "*"
 cython = "*"


### PR DESCRIPTION
Alternate fix for #30888 (see #30889).