### PR TITLE
Remove reference to Python 2 from count_nonzero() docstring

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -484,16 +484,11 @@ def _count_nonzero_dispatcher(a, axis=None, *, keepdims=None):
 def count_nonzero(a, axis=None, *, keepdims=False):
     """
     Counts the number of non-zero values in the array ``a``.
-
-    The word "non-zero" is in reference to the Python 2.x
-    built-in method ``__nonzero__()`` (renamed ``__bool__()``
-    in Python 3.x) of Python objects that tests an object's
-    "truthfulness". For example, any number is considered
-    truthful if it is nonzero, whereas any string is considered
-    truthful if it is not the empty string. Thus, this function
-    (recursively) counts how many elements in ``a`` (and in
-    sub-arrays thereof) have their ``__nonzero__()`` or ``__bool__()``
-    method evaluated to ``True``.
+    
+    A non-zero value is one that evaluates to truthful in a boolean
+    context, including any non-zero number and any string that 
+    is not empty. This function recursively counts how many elements 
+    in ``a`` (and its sub-arrays) are non-zero values.
 
     Parameters
     ----------

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -484,10 +484,10 @@ def _count_nonzero_dispatcher(a, axis=None, *, keepdims=None):
 def count_nonzero(a, axis=None, *, keepdims=False):
     """
     Counts the number of non-zero values in the array ``a``.
-    
+
     A non-zero value is one that evaluates to truthful in a boolean
-    context, including any non-zero number and any string that 
-    is not empty. This function recursively counts how many elements 
+    context, including any non-zero number and any string that
+    is not empty. This function recursively counts how many elements
     in ``a`` (and its sub-arrays) are non-zero values.
 
     Parameters


### PR DESCRIPTION
Related to https://github.com/numpy/numpy/issues/22635 - removal of references to Python 2.  I edited the count_nonzero() docstring to remove reference to Python 2.   The function name itself is still based on Python 2's legacy method __nonzero__ , but that's more of an implicit reference.