### PR TITLE
CI: use nascheme/cpython_sanity for clang ASAN

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -113,82 +113,31 @@ jobs:
     # To enable this workflow on a fork, comment out:
     if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
+    container:
+        image: ghcr.io/nascheme/cpython-asan:3.14
+        options: --shm-size=2g # increase memory for large matrix ops
 
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      with:
-        submodules: recursive
-        fetch-tags: true
-        persist-credentials: false
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Trust working directory and initialize submodules
+        run: |
+          git config --global --add safe.directory /__w/numpy/numpy
+          git submodule update --init --recursive
 
-    - name: Set up pyenv
-      run: |
-        git clone https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
-        PYENV_ROOT="$HOME/.pyenv"
-        PYENV_BIN="$PYENV_ROOT/bin"
-        PYENV_SHIMS="$PYENV_ROOT/shims"
-        echo "$PYENV_BIN" >> $GITHUB_PATH
-        echo "$PYENV_SHIMS" >> $GITHUB_PATH
-        echo "PYENV_ROOT=$PYENV_ROOT" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: |
+          pip install -r requirements/build_requirements.txt
+          pip install -r requirements/ci_requirements.txt
+          pip install -r requirements/test_requirements.txt
+          # xdist captures stdout/stderr, but we want the ASAN output
+          pip uninstall -y pytest-xdist
 
-    - name: Check pyenv is working
-      run: pyenv --version
+      - name: Build NumPy with AddressSanitizer & LeakSanitizer
+        run: python -m spin build -j4 -- -Db_sanitize=address,leak
 
-    - name: Install python & numpy build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get -yq install \
-          libb2-dev \
-          libbz2-dev \
-          libffi-dev \
-          libgdbm-dev \
-          libgdbm-compat-dev \
-          liblzma-dev \
-          libncurses5-dev \
-          libopenblas-dev \
-          libreadline6-dev \
-          libsqlite3-dev \
-          libssl-dev \
-          libzstd-dev \
-          lzma-dev \
-          ninja-build \
-          tk-dev \
-          uuid-dev \
-          zlib1g-dev
-
-    # TODO install as a regular ubuntu package in the previous step once
-    # ubuntu 26.04 is available in GHA
-    - name: Install clang 21
-      run: |
-        curl -fsSLo /tmp/llvm.sh https://apt.llvm.org/llvm.sh
-        chmod +x /tmp/llvm.sh
-        sudo /tmp/llvm.sh 21
-        CC=/usr/bin/clang-21
-        CXX=/usr/bin/clang++-21
-        echo "CC=$CC" >> $GITHUB_ENV
-        echo "CXX=$CXX" >> $GITHUB_ENV
-        sudo update-alternatives --install /usr/bin/cc cc $CC 100
-        sudo update-alternatives --install /usr/bin/c++ c++ $CXX 100
-
-    - name: Build Python with address sanitizer
-      run: |
-        CONFIGURE_OPTS="--with-address-sanitizer" pyenv install 3.14
-        pyenv global 3.14
-
-    - name: Install dependencies
-      run: |
-        pip install -r requirements/build_requirements.txt
-        pip install -r requirements/ci_requirements.txt
-        pip install -r requirements/test_requirements.txt
-        # xdist captures stdout/stderr, but we want the ASAN output
-        pip uninstall -y pytest-xdist
-
-    - name: Build
-      run: python -m spin build -j4 -- -Db_sanitize=address,leak
-
-    - name: Test
-      run: |
-        # pass -s to pytest to see ASAN errors and warnings, otherwise pytest captures them
-        export ASAN_OPTIONS="detect_leaks=1:symbolize=1:strict_init_order=true:allocator_may_return_null=1:use_sigaltstack=0"
-        export LSAN_OPTIONS="suppressions=$GITHUB_WORKSPACE/tools/ci/lsan_suppressions.txt"
-        python -m spin test -- -v -s --timeout=600 --durations=10
+      - name: Test
+        run: |
+          # pass -s to pytest to see ASAN errors and warnings, otherwise pytest captures them
+          export ASAN_OPTIONS="detect_leaks=1:symbolize=1:strict_init_order=true:allocator_may_return_null=1:use_sigaltstack=0"
+          export LSAN_OPTIONS="suppressions=$GITHUB_WORKSPACE/tools/ci/lsan_suppressions.txt"
+          python -m spin test -- -v -s --timeout=600 --durations=10


### PR DESCRIPTION
[nascheme/cpython_sanity](https://github.com/nascheme/cpython_sanity) now provides an ASAN GIL-enabled python image.
This image can be used similarly as is done for the clang_TSAN job and thus speed-up the clang_ASAN job as building python is no longer necessary.

Follow-up on #30800 where the request to use [nascheme/cpython_sanity](https://github.com/nascheme/cpython_sanity) has been made but a GIL-enabled image was not yet available.
