### PR TITLE
BUG: Raise informative error in common_type() when passed dtypes

### DIFF
--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -704,7 +704,13 @@ def common_type(*arrays):
     is_complex = False
     precision = 0
     for a in arrays:
-        t = a.dtype.type
+        try:
+            t = a.dtype.type
+        except AttributeError as e:
+            raise TypeError(
+                "common_type() requires arrays, not dtypes. "
+                "Pass arrays directly instead of their dtypes."
+            ) from e
         if iscomplexobj(a):
             is_complex = True
         if issubclass(t, _nx.integer):


### PR DESCRIPTION
## Summary
- Fixes #30890 by catching the `AttributeError` when `common_type()` is called with dtype arguments instead of arrays
- Raises a clear `TypeError` with an informative message: "common_type() requires arrays, not dtypes. Pass arrays directly instead of their dtypes."

## Background
Previously, calling `np.common_type(np.dtype('f4'), np.dtype('f4'))` would raise:
```
AttributeError: 'numpy.dtypes.Float32DType' object has no attribute 'dtype'. Did you mean: 'type'?
```

This error message is confusing because it exposes internal implementation details rather than clearly explaining the user's mistake.

## Changes
Wrapped the `a.dtype.type` access in a try/except block to catch `AttributeError` and raise a more informative `TypeError` instead, as suggested by @ngoldbaum in the issue.

## Test plan
- [x] Verified the fix works with the reproduction case from the issue
- [x] All existing tests in `numpy/lib/tests/test_type_check.py` pass (51 tests)
- [x] Normal use cases continue to work correctly
