### PR TITLE
BUG: fix type issues in uses if PyDataType macros

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -4716,7 +4716,7 @@ set_typeinfo(PyObject *dict)
       * #name = STRING, UNICODE, VOID#
       */
 
-    PyDataType_MAKEUNSIZED(&@name@_Descr);
+    PyDataType_MAKEUNSIZED((PyArray_Descr *)&@name@_Descr);
 
     /**end repeat**/
 

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2089,7 +2089,7 @@ arraydescr_subdescr_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 NPY_NO_EXPORT PyObject *
 arraydescr_protocol_typestr_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 {
-    if (!PyDataType_ISLEGACY(NPY_DTYPE(self))) {
+    if (!PyDataType_ISLEGACY(self)) {
         return (PyObject *) Py_TYPE(self)->tp_str((PyObject *)self);
     }
 

--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -179,7 +179,7 @@ PyArray_RegisterDataType(PyArray_DescrProto *descr_proto)
         return -1;
     }
     descr_proto->type_num = -1;
-    if (PyDataType_ISUNSIZED(descr_proto)) {
+    if (descr_proto->elsize == 0) {
         PyErr_SetString(PyExc_ValueError, "cannot register a " \
                         "flexible data-type");
         return -1;


### PR DESCRIPTION
@kumaraditya303 and I ran into these working on support for the opaque PyObject build.

These `PyDataType` macros expect a `PyArray_Descr *` argument, but in all three cases happen to work because the macros use direct struct field accesses and all these structs share field names.