### PR TITLE
DOC: Remove Python 2 array-protocol strings type note

### DIFF
--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -298,10 +298,10 @@ Array-protocol type strings (see :ref:`arrays.interface`)
 
    .. admonition:: Note on string types
 
-    For backward compatibility with existing code originally written to support
-    Python 2, ``S`` and ``a`` typestrings are zero-terminated bytes.
-    For unicode strings, use ``U``, `numpy.str_`.  For signed bytes that do not
-    need zero-termination ``b`` or ``i1`` can be used.
+    The ``S`` typestring for zero-terminated bytes is intended for backward 
+    compatibility and is not recommended to use.  For unicode strings, 
+    use ``U``, `numpy.str_`.  For signed bytes that do not need zero-termination, 
+    ``b`` or ``i1`` can be used.
 
 String with comma-separated fields
    A short-hand notation for specifying the format of a structured data type is

--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -294,15 +294,6 @@ Array-protocol type strings (see :ref:`arrays.interface`)
          >>> dt = np.dtype('S25')  # 25-length zero-terminated bytes
          >>> dt = np.dtype('U25')  # 25-character string
 
-   .. _string-dtype-note:
-
-   .. admonition:: Note on string types
-
-    The ``S`` typestring for zero-terminated bytes is intended for backward 
-    compatibility and is not recommended to use.  For unicode strings, 
-    use ``U``, `numpy.str_`.  For signed bytes that do not need zero-termination, 
-    ``b`` or ``i1`` can be used.
-
 String with comma-separated fields
    A short-hand notation for specifying the format of a structured data type is
    a comma-separated string of basic formats.

--- a/doc/source/reference/arrays.scalars.rst
+++ b/doc/source/reference/arrays.scalars.rst
@@ -327,8 +327,6 @@ elements the data type consists of.)
 
 .. warning::
 
-   See :ref:`Note on string types<string-dtype-note>`.
-
    Numeric Compatibility: If you used old typecode characters in your
    Numeric code (which was never recommended), you will need to change
    some of them to the new characters. In particular, the needed


### PR DESCRIPTION
Related to https://github.com/numpy/numpy/issues/22635 - removal of references to Python 2.  I edited the "Note on string types" in the doc on array-protocol type strings to remove Python 2.
Within the edited content, I also found and removed a reference to type "a" for zero-terminated bytes.  This type was removed from the list of supported types last month as part of merged PR: https://github.com/numpy/numpy/pull/30758#ref-issue-3882906912.