### PR TITLE
BUG: fix infinite recursion in np.ma.flatten_structured_array (#30855)

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2579,7 +2579,7 @@ def flatten_structured_array(a):
 
         """
         for elm in iter(iterable):
-            if hasattr(elm, '__iter__'):
+            if hasattr(elm, "__iter__") and not isinstance(elm, (str, bytes)):
                 yield from flatten_sequence(elm)
             else:
                 yield elm

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -997,6 +997,13 @@ class TestMaskedArray:
         control = np.array([[[1., 1.], ], [[2., 2.], ]], dtype=float)
         assert_equal(test, control)
         assert_equal(test.dtype, control.dtype)
+        # for strings
+        ndtype = [('a', 'U5'), ('b', [('c', 'U5')])]
+        arr = np.array([('NumPy', ('array',)), ('array', ('numpy',))], dtype=ndtype)
+        test = flatten_structured_array(arr)
+        control = np.array([['NumPy', 'array'], ['array', 'numpy']], dtype='U5')
+        assert_equal(test, control)
+        assert_equal(test.dtype, control.dtype)
 
     def test_void0d(self):
         # Test creating a mvoid object


### PR DESCRIPTION
Backport of #30855.

Towards resolving https://github.com/numpy/numpy/issues/29349

Avoids recursion for both strings and objects.
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
