### PR TITLE
BUG: Fix busdaycalendar's handling of a bool array weekmask. (#30885)

### DIFF
--- a/numpy/_core/src/multiarray/datetime_busdaycal.c
+++ b/numpy/_core/src/multiarray/datetime_busdaycal.c
@@ -159,15 +159,15 @@ invalid_weekmask_string:
             int i;
 
             for (i = 0; i < 7; ++i) {
-                long val;
+                int val;
                 PyObject *f = PySequence_GetItem(obj, i);
                 if (f == NULL) {
                     Py_DECREF(obj);
                     return 0;
                 }
 
-                val = PyLong_AsLong(f);
-                if (error_converting(val)) {
+                val = PyObject_IsTrue(f);
+                if (val == -1) {
                     Py_DECREF(f);
                     Py_DECREF(obj);
                     return 0;

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -2212,6 +2212,11 @@ class TestDateTime:
         bdd = np.busdaycalendar(weekmask="0011001")
         assert_equal(bdd.weekmask, np.array([0, 0, 1, 1, 0, 0, 1], dtype='?'))
 
+        # Check length 7 bool array.
+        mask = np.array([False, True, True, True, True, False, False])
+        bdd = np.busdaycalendar(weekmask=mask)
+        assert_equal(bdd.weekmask, mask, strict=True)
+
         # Check length 7 string weekmask.
         bdd = np.busdaycalendar(weekmask="Mon Tue")
         assert_equal(bdd.weekmask, np.array([1, 1, 0, 0, 0, 0, 0], dtype='?'))


### PR DESCRIPTION
Backport of #30885.

Closes gh-30883.

This change is simple but it has implications beyond the problem observed in gh-30883.  With this change, when `weekmask` is a sequence, the boolean array is created by evaluating the "truthiness" of the elements in the sequence.  This might be more flexible than desired.

For example, with this PR, we have the following behavior:

```
In [1]: mask = ["x", "x", "x", "x", "", "", ""]

In [2]: cal = np.busdaycalendar(weekmask=mask)

In [3]: cal.weekmask
Out[3]: array([ True,  True,  True,  True, False, False, False])
```

Before this change, that sequence of strings would result in a `TypeError`:

```
In [13]: np.__version__
Out[13]: '2.4.2'

In [14]: mask = ["x", "x", "x", "x", "", "", ""]

In [15]: cal = np.busdaycalendar(weekmask=mask)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[15], line 1
----> 1 cal = np.busdaycalendar(weekmask=mask)

TypeError: 'str' object cannot be interpreted as an integer
```

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
