### PR TITLE
MAINT: fix two minor issues noticed when touching the C API setup

### DIFF
--- a/numpy/_core/code_generators/verify_c_api_version.py
+++ b/numpy/_core/code_generators/verify_c_api_version.py
@@ -45,7 +45,7 @@ def check_api_version(apiversion):
                f"{apiversion}, with checksum {curapi_hash}, but recorded "
                f"checksum in _core/codegen_dir/cversions.txt is {api_hash}. "
                "If functions were added in the C API, you have to update "
-               f"C_API_VERSION in {__file__}."
+               f"C_API_VERSION in numpy/core/meson.build."
                )
         raise MismatchCAPIError(msg)
 

--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -180,7 +180,7 @@ PyArray_RegisterDataType(PyArray_DescrProto *descr_proto)
     }
     descr_proto->type_num = -1;
     if (PyDataType_ISUNSIZED(descr_proto)) {
-        PyErr_SetString(PyExc_ValueError, "cannot register a" \
+        PyErr_SetString(PyExc_ValueError, "cannot register a " \
                         "flexible data-type");
         return -1;
     }


### PR DESCRIPTION
Backport of #30913.

@kumaraditya303 and I are playing with the opaque PyObject API, which required updating the C API. I noticed the error message in `verify_c_api_version.py` is out of date. We also happened to trigger an unusual error in the user dtype setup and I noticed the error message is formatted incorrectly.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
