### PR TITLE
BUG: Fix matrix_rank crash on empty matrices

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2130,6 +2130,10 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     if A.ndim < 2:
         return int(not all(A == 0))
 
+    # Handle empty matrices - rank is 0
+    if _is_empty_2d(A):
+        return zeros(A.shape[:-2], dtype=intp)
+
     S = svd(A, compute_uv=False, hermitian=hermitian)
 
     if tol is None:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1688,6 +1688,16 @@ class TestMatrixRank:
         assert_equal(4, matrix_rank(I, hermitian=True, tol=0.99e-8))
         assert_equal(3, matrix_rank(I, hermitian=True, tol=1.01e-8))
 
+    def test_empty_matrix(self):
+        # Empty matrices have rank 0
+        assert_equal(matrix_rank(np.empty((0, 3))), 0)
+        assert_equal(matrix_rank(np.empty((3, 0))), 0)
+        assert_equal(matrix_rank(np.empty((0, 0))), 0)
+        # Stacked empty matrices
+        assert_equal(matrix_rank(np.empty((2, 0, 3))), np.array([0, 0]))
+        # Empty matrix with custom tolerance (should still return 0)
+        assert_equal(matrix_rank(np.empty((0, 3)), tol=0.1), 0)
+
 
 def test_reduced_rank():
     # Test matrices with reduced rank


### PR DESCRIPTION
## Summary
Fixes #30915 

`numpy.linalg.matrix_rank` now correctly handles empty matrices (e.g., shape `(0, 3)`) by returning 0 instead of raising `ValueError`.

## Problem
Previously, calling `matrix_rank` on an empty matrix would crash with:
```
ValueError: zero-size array to reduction operation maximum which has no identity
```

This occurred because `S.max()` fails on empty arrays.

## Solution
Added the same `_is_empty_2d` guard that other linalg functions (`pinv`, `cond`) already use. The rank of an empty matrix is mathematically 0, so we return `zeros(A.shape[:-2], dtype=intp)`.

## Testing
Added comprehensive tests for:
- Empty matrices: (0, 3), (3, 0), (0, 0)
- Stacked empty matrices: (2, 0, 3)  
- Empty matrix with custom tolerance

All existing tests continue to pass.

## Backward Compatibility
✓ No breaking changes - only fixes a crash case
✓ All existing functionality preserved