### PR TITLE
ENH: Replace PyTyple_Pack with PyTuple_FromArray

### DIFF
--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -1384,7 +1384,7 @@ _parse_axes_arg(PyUFuncObject *ufunc, int op_core_num_dims[], PyObject *axes,
             Py_INCREF(op_axes_tuple);
         }
         else if (op_ncore == 1) {
-            op_axes_tuple = PyTuple_Pack(1, op_axes_tuple);
+            op_axes_tuple = PyTuple_FromArray(&op_axes_tuple, 1);
             if (op_axes_tuple == NULL) {
                 return -1;
             }
@@ -3412,7 +3412,7 @@ _set_full_args_out(int nout, PyObject *out_obj, ufunc_full_args *full_args)
             return 0;
         }
         /* Can be an array if it only has one output */
-        full_args->out = PyTuple_Pack(1, out_obj);
+        full_args->out = PyTuple_FromArray(&out_obj, 1);
         if (full_args->out == NULL) {
             return -1;
         }
@@ -3502,7 +3502,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             goto fail;
         }
         /* Prepare inputs for PyUfunc_CheckOverride */
-        full_args.in = PyTuple_Pack(2, op, indices_obj);
+        PyObject *reduce_in[] = {op, indices_obj};
+        full_args.in = PyTuple_FromArray(reduce_in, 2);
         if (full_args.in == NULL) {
             goto fail;
         }
@@ -3520,7 +3521,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             goto fail;
         }
         /* Prepare input for PyUfunc_CheckOverride */
-        full_args.in = PyTuple_Pack(1, op);
+        full_args.in = PyTuple_FromArray(&op, 1);
         if (full_args.in == NULL) {
             goto fail;
         }
@@ -3541,7 +3542,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             goto fail;
         }
         /* Prepare input for PyUfunc_CheckOverride */
-        full_args.in = PyTuple_Pack(1, op);
+        full_args.in = PyTuple_FromArray(&op, 1);
         if (full_args.in == NULL) {
             goto fail;
         }
@@ -3557,7 +3558,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             goto fail;
         }
         if (out_obj != Py_None) {
-            full_args.out = PyTuple_Pack(1, out_obj);
+            full_args.out = PyTuple_FromArray(&out_obj, 1);
             if (full_args.out == NULL) {
                 goto fail;
             }
@@ -6422,7 +6423,8 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
         ((PyArray_Descr **)context->descriptors)[i] = operation_descrs[i];
     }
 
-    result = PyTuple_Pack(2, result_dtype_tuple, capsule);
+    PyObject *result_items[] = {result_dtype_tuple, capsule};
+    result = PyTuple_FromArray(result_items, 2);
     /* cleanup and return */
     Py_DECREF(capsule);
 


### PR DESCRIPTION
Replace `PyTyple_Pack` (which uses variadic arguments) with the more performant `PyTuple_FromArray`.

Benchmark using
```
import time
import sys
# about 100 ms for python start and numpy import
import numpy as np
x = np.array([1., 2.])
y = np.array([0., 0.])


outer = 10
inner = 3
iterations = 200_000

for _ in range(outer):
    t00=0
    for _ in range(inner):
        t0 = time.perf_counter()
        for _ in range(iterations):
            np.add.reduce(x)
        dt = time.perf_counter() - t0
        t00 += dt
   
    print(f'{1e9*t00/(inner*iterations):.2f} [ns] / operation')
print(sys.executable)
print(np)
```
shows an improvement of 764 to 731 ns / operation.

PR created with help from Claude

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
