### PR TITLE
ENH: Improve performance of npy_parse_arguments

### DIFF
--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -87,7 +87,6 @@ PyArray_PythonPyIntFromInt(PyObject *obj, int *value)
  *    total, required, and keyword arguments.
  * 3. Intern all keyword arguments strings to allow fast, identity based
  *    parsing and avoid string creation overhead on each call.
- * 4. Cache converter function pointers for the hot path.
  *
  * @param funcname Name of the function, mainly used for errors.
  * @param cache A cache object stored statically in the parsing function
@@ -192,9 +191,6 @@ initialize_keywords(const char *funcname,
 
     for (int i = 0; i < nspecs; i++) {
         const char *name = specs[i].name;
-
-        /* Cache converter function pointer */
-        cache->converters[i] = (npy_arg_converter)specs[i].converter;
 
         if (*name == '|' || *name == '$') {
             name++;  /* ignore | and $ */
@@ -374,7 +370,7 @@ _npy_parse_arguments(const char *funcname,
             continue;
         }
 
-        npy_arg_converter converter = cache->converters[i];
+        npy_arg_converter converter = (npy_arg_converter)specs[i].converter;
         void *data = specs[i].output;
 
         if (converter == NULL) {

--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -76,8 +76,6 @@ PyArray_PythonPyIntFromInt(PyObject *obj, int *value)
 }
 
 
-typedef int convert(PyObject *, void *);
-
 /**
  * Internal function to initialize keyword argument parsing.
  *
@@ -89,58 +87,45 @@ typedef int convert(PyObject *, void *);
  *    total, required, and keyword arguments.
  * 3. Intern all keyword arguments strings to allow fast, identity based
  *    parsing and avoid string creation overhead on each call.
+ * 4. Cache converter function pointers for the hot path.
  *
  * @param funcname Name of the function, mainly used for errors.
  * @param cache A cache object stored statically in the parsing function
- * @param va_orig Argument list to npy_parse_arguments
+ * @param specs Array of argument specifications
+ * @param nspecs Number of argument specifications
  * @return 0 on success, -1 on failure
  */
 static int
 initialize_keywords(const char *funcname,
-        _NpyArgParserCache *cache, va_list va_orig) {
-    va_list va;
-    int nargs = 0;
+        _NpyArgParserCache *cache, npy_arg_spec *specs, int nspecs) {
     int nkwargs = 0;
     int npositional_only = 0;
     int nrequired = 0;
     int npositional = 0;
     char state = '\0';
 
-    va_copy(va, va_orig);
-    while (1) {
-        /* Count length first: */
-        char *name = va_arg(va, char *);
-        convert *converter = va_arg(va, convert *);
-        void *data = va_arg(va, void *);
-
-        /* Check if this is the sentinel, only converter may be NULL */
-        if ((name == NULL) && (converter == NULL) && (data == NULL)) {
-            break;
-        }
+    for (int i = 0; i < nspecs; i++) {
+        const char *name = specs[i].name;
 
         if (name == NULL) {
             PyErr_Format(PyExc_SystemError,
                     "NumPy internal error: name is NULL in %s() at "
-                    "argument %d.", funcname, nargs);
-            va_end(va);
+                    "argument %d.", funcname, i);
             return -1;
         }
-        if (data == NULL) {
+        if (specs[i].output == NULL) {
             PyErr_Format(PyExc_SystemError,
                     "NumPy internal error: data is NULL in %s() at "
-                    "argument %d.", funcname, nargs);
-            va_end(va);
+                    "argument %d.", funcname, i);
             return -1;
         }
 
-        nargs += 1;
         if (*name == '|') {
             if (state == '$') {
                 PyErr_Format(PyExc_SystemError,
                         "NumPy internal error: positional argument `|` "
                         "after keyword only `$` one to %s() at argument %d.",
-                        funcname, nargs);
-                va_end(va);
+                        funcname, i + 1);
                 return -1;
             }
             state = '|';
@@ -156,8 +141,7 @@ initialize_keywords(const char *funcname,
                 PyErr_Format(PyExc_SystemError,
                         "NumPy internal error: non-required argument after "
                         "required | or $ one to %s() at argument %d.",
-                        funcname, nargs);
-                va_end(va);
+                        funcname, i + 1);
                 return -1;
             }
 
@@ -172,8 +156,7 @@ initialize_keywords(const char *funcname,
                 PyErr_Format(PyExc_SystemError,
                         "NumPy internal error: non-kwarg marked with $ "
                         "to %s() at argument %d or positional only following "
-                        "kwarg.", funcname, nargs);
-                va_end(va);
+                        "kwarg.", funcname, i + 1);
                 return -1;
             }
         }
@@ -181,18 +164,17 @@ initialize_keywords(const char *funcname,
             nkwargs += 1;
         }
     }
-    va_end(va);
 
     if (npositional == -1) {
-        npositional = nargs;
+        npositional = nspecs;
     }
 
-    if (nargs > _NPY_MAX_KWARGS) {
+    if (nspecs > _NPY_MAX_KWARGS) {
         PyErr_Format(PyExc_SystemError,
                 "NumPy internal error: function %s() has %d arguments, but "
                 "the maximum is currently limited to %d for easier parsing; "
                 "it can be increased by modifying `_NPY_MAX_KWARGS`.",
-                funcname, nargs, _NPY_MAX_KWARGS);
+                funcname, nspecs, _NPY_MAX_KWARGS);
         return -1;
     }
 
@@ -200,7 +182,7 @@ initialize_keywords(const char *funcname,
      * Do any necessary string allocation and interning,
      * creating a caching object.
      */
-    cache->nargs = nargs;
+    cache->nargs = nspecs;
     cache->npositional_only = npositional_only;
     cache->npositional = npositional;
     cache->nrequired = nrequired;
@@ -208,12 +190,11 @@ initialize_keywords(const char *funcname,
     /* NULL kw_strings for easier cleanup (and NULL termination) */
     memset(cache->kw_strings, 0, sizeof(PyObject *) * (nkwargs + 1));
 
-    va_copy(va, va_orig);
-    for (int i = 0; i < nargs; i++) {
-        /* Advance through non-kwargs, which do not require setup. */
-        char *name = va_arg(va, char *);
-        va_arg(va, convert *);
-        va_arg(va, void *);
+    for (int i = 0; i < nspecs; i++) {
+        const char *name = specs[i].name;
+
+        /* Cache converter function pointer */
+        cache->converters[i] = (npy_arg_converter)specs[i].converter;
 
         if (*name == '|' || *name == '$') {
             name++;  /* ignore | and $ */
@@ -222,13 +203,11 @@ initialize_keywords(const char *funcname,
             int i_kwarg = i - npositional_only;
             cache->kw_strings[i_kwarg] = PyUnicode_InternFromString(name);
             if (cache->kw_strings[i_kwarg] == NULL) {
-                va_end(va);
                 goto error;
             }
         }
     }
 
-    va_end(va);
     return 0;
 
 error:
@@ -288,25 +267,21 @@ raise_missing_argument(const char *funcname,
  * @param args Python passed args (METH_FASTCALL)
  * @param len_args Number of arguments (not flagged)
  * @param kwnames Tuple as passed by METH_FASTCALL or NULL.
- * @param ... List of arguments (see macro version).
+ * @param specs Array of argument specifications
+ * @param nspecs Number of argument specifications
  *
  * @return Returns 0 on success and -1 on failure.
  */
 NPY_NO_EXPORT int
 _npy_parse_arguments(const char *funcname,
-         /* cache_ptr is a NULL initialized persistent storage for data */
         _NpyArgParserCache *cache,
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames,
-        /* ... is NULL, NULL, NULL terminated: name, converter, value */
-        ...)
+        npy_arg_spec *specs, int nspecs)
 {
     if (!atomic_load_explicit((_Atomic(uint8_t) *)&cache->initialized, memory_order_acquire)) {
         LOCK_ARGPARSE_MUTEX;
         if (!atomic_load_explicit((_Atomic(uint8_t) *)&cache->initialized, memory_order_acquire)) {
-            va_list va;
-            va_start(va, kwnames);
-            int res = initialize_keywords(funcname, cache, va);
-            va_end(va);
+            int res = initialize_keywords(funcname, cache, specs, nspecs);
             if (res < 0) {
                 UNLOCK_ARGPARSE_MUTEX;
                 return -1;
@@ -394,38 +369,33 @@ _npy_parse_arguments(const char *funcname,
     assert(len_args + len_kwargs <= cache->nargs);
 
     /* At this time `all_arguments` holds either NULLs or the objects */
-    va_list va;
-    va_start(va, kwnames);
-
     for (int i = 0; i < max_nargs; i++) {
-        va_arg(va, char *);
-        convert *converter = va_arg(va, convert *);
-        void *data = va_arg(va, void *);
-
         if (all_arguments[i] == NULL) {
             continue;
         }
 
-        int res;
+        npy_arg_converter converter = cache->converters[i];
+        void *data = specs[i].output;
+
         if (converter == NULL) {
             *((PyObject **) data) = all_arguments[i];
             continue;
         }
-        res = converter(all_arguments[i], data);
+        int res = converter(all_arguments[i], data);
 
         if (NPY_UNLIKELY(res == NPY_SUCCEED)) {
             continue;
         }
         else if (NPY_UNLIKELY(res == NPY_FAIL)) {
             /* It is usually the users responsibility to clean up. */
-            goto converting_failed;
+            return -1;
         }
         else if (NPY_UNLIKELY(res == Py_CLEANUP_SUPPORTED)) {
             /* TODO: Implementing cleanup if/when needed should not be hard */
             PyErr_Format(PyExc_SystemError,
                     "converter cleanup of parameter %d to %s() not supported.",
                     i, funcname);
-            goto converting_failed;
+            return -1;
         }
         assert(0);
     }
@@ -435,21 +405,15 @@ _npy_parse_arguments(const char *funcname,
         /* (PyArg_* also does this after the actual parsing is finished) */
         if (NPY_UNLIKELY(max_nargs < cache->nrequired)) {
             raise_missing_argument(funcname, cache, max_nargs);
-            goto converting_failed;
+            return -1;
         }
         for (int i = 0; i < cache->nrequired; i++) {
             if (NPY_UNLIKELY(all_arguments[i] == NULL)) {
                 raise_missing_argument(funcname, cache, i);
-                goto converting_failed;
+                return -1;
             }
         }
     }
 
-    va_end(va);
     return 0;
-
-converting_failed:
-    va_end(va);
-    return -1;
-
 }

--- a/numpy/_core/src/common/npy_argparse.h
+++ b/numpy/_core/src/common/npy_argparse.h
@@ -22,6 +22,14 @@ PyArray_PythonPyIntFromInt(PyObject *obj, int *value);
 
 #define _NPY_MAX_KWARGS 15
 
+typedef int (*npy_arg_converter)(PyObject *, void *);
+
+typedef struct {
+    const char *name;
+    void *converter;
+    void *output;
+} npy_arg_spec;
+
 typedef struct {
     int npositional;
     int nargs;
@@ -30,6 +38,8 @@ typedef struct {
     npy_uint8 initialized;
     /* Null terminated list of keyword argument name strings */
     PyObject *kw_strings[_NPY_MAX_KWARGS+1];
+    /* Cached converter function pointers */
+    npy_arg_converter converters[_NPY_MAX_KWARGS];
 } _NpyArgParserCache;
 
 NPY_NO_EXPORT int init_argparse_mutex(void);
@@ -54,11 +64,10 @@ NPY_NO_EXPORT int init_argparse_mutex(void);
  *
  *     PyObject *argument1, *argument3;
  *     int argument2 = -1;
- *     if (npy_parse_arguments("method", args, len_args, kwnames),
- *                "argument1", NULL, &argument1,
- *                "|argument2", &PyArray_PythonPyIntFromInt, &argument2,
- *                "$argument3", NULL, &argument3,
- *                NULL, NULL, NULL) < 0) {
+ *     if (npy_parse_arguments("method", args, len_args, kwnames,
+ *                {"argument1", NULL, &argument1},
+ *                {"|argument2", &PyArray_PythonPyIntFromInt, &argument2},
+ *                {"$argument3", NULL, &argument3}) < 0) {
  *          return NULL;
  *      }
  * }
@@ -66,32 +75,32 @@ NPY_NO_EXPORT int init_argparse_mutex(void);
  *
  * The `NPY_PREPARE_ARGPARSER` macro sets up a static cache variable necessary
  * to hold data for speeding up the parsing. `npy_parse_arguments` must be
- * used in cunjunction with the macro defined in the same scope.
+ * used in conjunction with the macro defined in the same scope.
  * (No two `npy_parse_arguments` may share a single `NPY_PREPARE_ARGPARSER`.)
  *
  * @param funcname Function name
  * @param args Python passed args (METH_FASTCALL)
  * @param len_args Number of arguments (not flagged)
  * @param kwnames Tuple as passed by METH_FASTCALL or NULL.
- * @param ... List of arguments must be param1_name, param1_converter,
- *            *param1_outvalue, param2_name, ..., NULL, NULL, NULL.
- *            Where name is ``char *``, ``converter`` a python converter
- *            function or NULL and ``outvalue`` is the ``void *`` passed to
- *            the converter (holding the converted data or a borrowed
- *            reference if converter is NULL).
+ * @param ... List of argument specs as {name, converter, outvalue} structs.
+ *            Where name is ``const char *``, ``converter`` a python converter
+ *            function pointer or NULL and ``outvalue`` is the ``void *``
+ *            passed to the converter (holding the converted data or a
+ *            borrowed reference if converter is NULL).
  *
  * @return Returns 0 on success and -1 on failure.
  */
 NPY_NO_EXPORT int
 _npy_parse_arguments(const char *funcname,
-        /* cache_ptr is a NULL initialized persistent storage for data */
-        _NpyArgParserCache *cache_ptr,
+        _NpyArgParserCache *cache,
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames,
-        /* va_list is NULL, NULL, NULL terminated: name, converter, value */
-        ...) NPY_GCC_NONNULL(1);
+        npy_arg_spec *specs, int nspecs) NPY_GCC_NONNULL(1);
 
-#define npy_parse_arguments(funcname, args, len_args, kwnames, ...)      \
-        _npy_parse_arguments(funcname, &__argparse_cache,                \
-                args, len_args, kwnames, __VA_ARGS__)
+#define npy_parse_arguments(funcname, args, len_args, kwnames, ...)       \
+        _npy_parse_arguments(funcname, &__argparse_cache,                 \
+                args, len_args, kwnames,                                  \
+                (npy_arg_spec[]){__VA_ARGS__},                            \
+                (int)(sizeof((npy_arg_spec[]){__VA_ARGS__})               \
+                      / sizeof(npy_arg_spec)))
 
 #endif  /* NUMPY_CORE_SRC_COMMON_NPY_ARGPARSE_H */

--- a/numpy/_core/src/common/npy_argparse.h
+++ b/numpy/_core/src/common/npy_argparse.h
@@ -20,7 +20,7 @@
 NPY_NO_EXPORT int
 PyArray_PythonPyIntFromInt(PyObject *obj, int *value);
 
-#define _NPY_MAX_KWARGS 15
+#define _NPY_MAX_KWARGS 14
 
 typedef int (*npy_arg_converter)(PyObject *, void *);
 
@@ -38,8 +38,6 @@ typedef struct {
     npy_uint8 initialized;
     /* Null terminated list of keyword argument name strings */
     PyObject *kw_strings[_NPY_MAX_KWARGS+1];
-    /* Cached converter function pointers */
-    npy_arg_converter converters[_NPY_MAX_KWARGS];
 } _NpyArgParserCache;
 
 NPY_NO_EXPORT int init_argparse_mutex(void);

--- a/numpy/_core/src/common/npy_argparse.h
+++ b/numpy/_core/src/common/npy_argparse.h
@@ -94,11 +94,22 @@ _npy_parse_arguments(const char *funcname,
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames,
         npy_arg_spec *specs, int nspecs) NPY_GCC_NONNULL(1);
 
+#ifdef __cplusplus
+#define npy_parse_arguments(funcname, args, len_args, kwnames, ...)       \
+        [&]() -> int {                                                     \
+            npy_arg_spec _npy_specs_[] = {__VA_ARGS__};                   \
+            return _npy_parse_arguments(funcname, &__argparse_cache,       \
+                    args, len_args, kwnames,                               \
+                    _npy_specs_,                                           \
+                    (int)(sizeof(_npy_specs_) / sizeof(npy_arg_spec)));    \
+        }()
+#else
 #define npy_parse_arguments(funcname, args, len_args, kwnames, ...)       \
         _npy_parse_arguments(funcname, &__argparse_cache,                 \
                 args, len_args, kwnames,                                  \
                 (npy_arg_spec[]){__VA_ARGS__},                            \
                 (int)(sizeof((npy_arg_spec[]){__VA_ARGS__})               \
                       / sizeof(npy_arg_spec)))
+#endif
 
 #endif  /* NUMPY_CORE_SRC_COMMON_NPY_ARGPARSE_H */

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -33,11 +33,10 @@ argparse_example_function(PyObject *NPY_UNUSED(mod),
     int arg1;
     PyObject *arg2, *arg3, *arg4;
     if (npy_parse_arguments("func", args, len_args, kwnames,
-            "", &PyArray_PythonPyIntFromInt, &arg1,
-            "arg2", NULL, &arg2,
-            "|arg3", NULL, &arg3,
-            "$arg3", NULL, &arg4,
-            NULL, NULL, NULL) < 0) {
+            {"", &PyArray_PythonPyIntFromInt, &arg1},
+            {"arg2", NULL, &arg2},
+            {"|arg3", NULL, &arg3},
+            {"$arg3", NULL, &arg4}) < 0) {
         return NULL;
     }
     Py_RETURN_NONE;
@@ -57,9 +56,8 @@ threaded_argparse_example_function(PyObject *NPY_UNUSED(mod),
     int arg1;
     PyObject *arg2;
     if (npy_parse_arguments("thread_func", args, len_args, kwnames,
-            "$arg1", &PyArray_PythonPyIntFromInt, &arg1,
-            "$arg2", NULL, &arg2,
-            NULL, NULL, NULL) < 0) {
+            {"$arg1", &PyArray_PythonPyIntFromInt, &arg1},
+            {"$arg2", NULL, &arg2}) < 0) {
         return NULL;
     }
     Py_RETURN_NONE;

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -1420,9 +1420,8 @@ _discover_array_parameters(PyObject *NPY_UNUSED(self),
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments(
             "_discover_array_parameters", args, len_args, kwnames,
-            "", NULL, &obj,
-            "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
-            NULL, NULL, NULL) < 0) {
+            {"", NULL, &obj},
+            {"|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info}) < 0) {
         /* fixed is last to parse, so never necessary to clean up */
         return NULL;
     }

--- a/numpy/_core/src/multiarray/array_converter.c
+++ b/numpy/_core/src/multiarray/array_converter.c
@@ -221,11 +221,10 @@ array_converter_as_arrays(PyArrayArrayConverterObject *self,
     scalar_policy policy = CONVERT_IF_NO_ARRAY;
 
     NPY_PREPARE_ARGPARSER;
+    /* pyscalars: how to handle scalars (ignored if dtype is given). */
     if (npy_parse_arguments("as_arrays", args, len_args, kwnames,
-            "$subok", &PyArray_BoolConverter, &subok,
-            /* how to handle scalars (ignored if dtype is given). */
-            "$pyscalars", &pyscalar_mode_conv, &policy,
-            NULL, NULL, NULL) < 0) {
+            {"$subok", &PyArray_BoolConverter, &subok},
+            {"$pyscalars", &pyscalar_mode_conv, &policy}) < 0) {
         return NULL;
     }
     if (policy == CONVERT_IF_NO_ARRAY) {
@@ -286,11 +285,10 @@ array_converter_wrap(PyArrayArrayConverterObject *self,
     }
 
     NPY_PREPARE_ARGPARSER;
+    /* to_scalar is three-way "bool", if `None` inspect input to decide. */
     if (npy_parse_arguments("wrap", args, len_args, kwnames,
-            "", NULL, &obj,
-            /* Three-way "bool", if `None` inspect input to decide. */
-            "$to_scalar", NULL, &to_scalar,
-            NULL, NULL, NULL) < 0) {
+            {"", NULL, &obj},
+            {"$to_scalar", NULL, &to_scalar}) < 0) {
         return NULL;
     }
     if (to_scalar == Py_None) {
@@ -327,9 +325,8 @@ array_converter_result_type(PyArrayArrayConverterObject *self,
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("result_type", args, len_args, kwnames,
-            "|extra_dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
-            "|ensure_inexact", &PyArray_BoolConverter, &ensure_inexact,
-            NULL, NULL, NULL) < 0) {
+            {"|extra_dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info},
+            {"|ensure_inexact", &PyArray_BoolConverter, &ensure_inexact}) < 0) {
         goto finish;
     }
 

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -123,10 +123,9 @@ arr_bincount(PyObject *NPY_UNUSED(self), PyObject *const *args,
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("bincount", args, len_args, kwnames,
-                "list", NULL, &list,
-                "|weights", NULL, &weight,
-                "|minlength", NULL, &mlength,
-                NULL, NULL, NULL) < 0) {
+                {"list", NULL, &list},
+                {"|weights", NULL, &weight},
+                {"|minlength", NULL, &mlength}) < 0) {
         return NULL;
     }
 
@@ -553,12 +552,11 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t len_arg
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("interp", args, len_args, kwnames,
-                "x", NULL, &x,
-                "xp", NULL, &xp,
-                "fp", NULL, &fp,
-                "|left", NULL, &left,
-                "|right", NULL, &right,
-                NULL, NULL, NULL) < 0) {
+                {"x", NULL, &x},
+                {"xp", NULL, &xp},
+                {"fp", NULL, &fp},
+                {"|left", NULL, &left},
+                {"|right", NULL, &right}) < 0) {
         return NULL;
     }
 
@@ -725,12 +723,11 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("interp_complex", args, len_args, kwnames,
-                "x", NULL, &x,
-                "xp", NULL, &xp,
-                "fp", NULL, &fp,
-                "|left", NULL, &left,
-                "|right", NULL, &right,
-                NULL, NULL, NULL) < 0) {
+                {"x", NULL, &x},
+                {"xp", NULL, &xp},
+                {"fp", NULL, &fp},
+                {"|left", NULL, &left},
+                {"|right", NULL, &right}) < 0) {
         return NULL;
     }
 
@@ -1465,9 +1462,8 @@ arr_add_docstring(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("add_docstring", args, len_args, NULL,
-            "", NULL, &obj,
-            "", NULL, &str,
-            NULL, NULL, NULL) < 0) {
+            {"", NULL, &obj},
+            {"", NULL, &str}) < 0) {
         return NULL;
     }
     if (!PyUnicode_Check(str)) {

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -414,11 +414,10 @@ array_dlpack(PyArrayObject *self,
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("__dlpack__", args, len_args, kwnames,
-            "$stream", NULL, &stream,
-            "$max_version", NULL, &max_version,
-            "$dl_device", &device_converter, &result_device,
-            "$copy", &PyArray_CopyConverter, &copy_mode,
-            NULL, NULL, NULL)) {
+            {"$stream", NULL, &stream},
+            {"$max_version", NULL, &max_version},
+            {"$dl_device", &device_converter, &result_device},
+            {"$copy", &PyArray_CopyConverter, &copy_mode})) {
         return NULL;
     }
 
@@ -493,10 +492,9 @@ from_dlpack(PyObject *NPY_UNUSED(self),
     PyObject *obj, *copy = Py_None, *device = Py_None;
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("from_dlpack", args, len_args, kwnames,
-            "obj", NULL, &obj,
-            "$copy", NULL, &copy,
-            "$device", NULL, &device,
-            NULL, NULL, NULL) < 0) {
+            {"obj", NULL, &obj},
+            {"$copy", NULL, &copy},
+            {"$device", NULL, &device}) < 0) {
         return NULL;
     }
 

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -126,11 +126,10 @@ array_take(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("take", args, len_args, kwnames,
-            "indices", NULL, &indices,
-            "|axis", &PyArray_AxisConverter, &dimension,
-            "|out", &PyArray_OutputConverter, &out,
-            "|mode", &PyArray_ClipmodeConverter, &mode,
-            NULL, NULL, NULL) < 0) {
+            {"indices", NULL, &indices},
+            {"|axis", &PyArray_AxisConverter, &dimension},
+            {"|out", &PyArray_OutputConverter, &out},
+            {"|mode", &PyArray_ClipmodeConverter, &mode}) < 0) {
         return NULL;
     }
 
@@ -225,8 +224,7 @@ array_squeeze(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("squeeze", args, len_args, kwnames,
-            "|axis", NULL, &axis_in,
-            NULL, NULL, NULL) < 0) {
+            {"|axis", NULL, &axis_in}) < 0) {
         return NULL;
     }
 
@@ -253,9 +251,8 @@ array_view(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("view", args, len_args, kwnames,
-            "|dtype", NULL, &out_dtype,
-            "|type", NULL, &out_type,
-            NULL, NULL, NULL) < 0) {
+            {"|dtype", NULL, &out_dtype},
+            {"|type", NULL, &out_type}) < 0) {
         return NULL;
     }
 
@@ -302,10 +299,9 @@ array_argmax(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("argmax", args, len_args, kwnames,
-            "|axis", &PyArray_AxisConverter, &axis,
-            "|out", &PyArray_OutputConverter, &out,
-            "$keepdims", &PyArray_BoolConverter, &keepdims,
-            NULL, NULL, NULL) < 0) {
+            {"|axis", &PyArray_AxisConverter, &axis},
+            {"|out", &PyArray_OutputConverter, &out},
+            {"$keepdims", &PyArray_BoolConverter, &keepdims}) < 0) {
         return NULL;
     }
 
@@ -329,10 +325,9 @@ array_argmin(PyArrayObject *self,
     npy_bool keepdims = NPY_FALSE;
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("argmin", args, len_args, kwnames,
-            "|axis", &PyArray_AxisConverter, &axis,
-            "|out", &PyArray_OutputConverter, &out,
-            "$keepdims", &PyArray_BoolConverter, &keepdims,
-            NULL, NULL, NULL) < 0) {
+            {"|axis", &PyArray_AxisConverter, &axis},
+            {"|out", &PyArray_OutputConverter, &out},
+            {"$keepdims", &PyArray_BoolConverter, &keepdims}) < 0) {
         return NULL;
     }
 
@@ -773,12 +768,11 @@ array_astype(PyArrayObject *self,
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("astype", args, len_args, kwnames,
-            "dtype", &PyArray_DTypeOrDescrConverterRequired, &dt_info,
-            "|order", &PyArray_OrderConverter, &order,
-            "|casting", &PyArray_CastingConverterSameValue, &casting,
-            "|subok", &PyArray_PythonPyIntFromInt, &subok,
-            "|copy", &PyArray_AsTypeCopyConverter, &forcecopy,
-            NULL, NULL, NULL) < 0) {
+            {"dtype", &PyArray_DTypeOrDescrConverterRequired, &dt_info},
+            {"|order", &PyArray_OrderConverter, &order},
+            {"|casting", &PyArray_CastingConverterSameValue, &casting},
+            {"|subok", &PyArray_PythonPyIntFromInt, &subok},
+            {"|copy", &PyArray_AsTypeCopyConverter, &forcecopy}) < 0) {
         Py_XDECREF(dt_info.descr);
         Py_XDECREF(dt_info.dtype);
         return NULL;
@@ -1151,8 +1145,7 @@ array_copy(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("copy", args, len_args, kwnames,
-            "|order", PyArray_OrderConverter, &order,
-            NULL, NULL, NULL) < 0) {
+            {"|order", PyArray_OrderConverter, &order}) < 0) {
         return NULL;
     }
 
@@ -1271,12 +1264,12 @@ array_sort(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("sort", args, len_args, kwnames,
-            "|axis", &PyArray_PythonPyIntFromInt, &axis,
-            "|kind", &PyArray_SortkindConverter, &sortkind,
-            "|order", NULL, &order,
-            "$stable", &PyArray_OptionalBoolConverter, &stable,
-//            "$descending", &PyArray_OptionalBoolConverter, &descending,
-            NULL, NULL, NULL) < 0) {
+            {"|axis", &PyArray_PythonPyIntFromInt, &axis},
+            {"|kind", &PyArray_SortkindConverter, &sortkind},
+            {"|order", NULL, &order},
+            {"$stable", &PyArray_OptionalBoolConverter, &stable}
+            // {"$descending", &PyArray_OptionalBoolConverter, &descending}
+            ) < 0) {
         return NULL;
     }
 
@@ -1359,11 +1352,10 @@ array_partition(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("partition", args, len_args, kwnames,
-            "kth", NULL, &kthobj,
-            "|axis", &PyArray_PythonPyIntFromInt, &axis,
-            "|kind", &PyArray_SelectkindConverter, &sortkind,
-            "|order", NULL, &order,
-            NULL, NULL, NULL) < 0) {
+            {"kth", NULL, &kthobj},
+            {"|axis", &PyArray_PythonPyIntFromInt, &axis},
+            {"|kind", &PyArray_SelectkindConverter, &sortkind},
+            {"|order", NULL, &order}) < 0) {
         return NULL;
     }
 
@@ -1433,12 +1425,12 @@ array_argsort(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("argsort", args, len_args, kwnames,
-            "|axis", &PyArray_AxisConverter, &axis,
-            "|kind", &PyArray_SortkindConverter, &sortkind,
-            "|order", NULL, &order,
-            "$stable", &PyArray_OptionalBoolConverter, &stable,
-//            "$descending", &PyArray_OptionalBoolConverter, &descending,
-            NULL, NULL, NULL) < 0) {
+            {"|axis", &PyArray_AxisConverter, &axis},
+            {"|kind", &PyArray_SortkindConverter, &sortkind},
+            {"|order", NULL, &order},
+            {"$stable", &PyArray_OptionalBoolConverter, &stable}
+            // {"$descending", &PyArray_OptionalBoolConverter, &descending}
+            ) < 0) {
         return NULL;
     }
 
@@ -1515,11 +1507,10 @@ array_argpartition(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("argpartition", args, len_args, kwnames,
-            "kth", NULL, &kthobj,
-            "|axis", &PyArray_AxisConverter, &axis,
-            "|kind", &PyArray_SelectkindConverter, &sortkind,
-            "|order", NULL, &order,
-            NULL, NULL, NULL) < 0) {
+            {"kth", NULL, &kthobj},
+            {"|axis", &PyArray_AxisConverter, &axis},
+            {"|kind", &PyArray_SelectkindConverter, &sortkind},
+            {"|order", NULL, &order}) < 0) {
         return NULL;
     }
     if (order == Py_None) {
@@ -1580,10 +1571,9 @@ array_searchsorted(PyArrayObject *self,
 
     sorter = NULL;
     if (npy_parse_arguments("searchsorted", args, len_args, kwnames,
-            "v", NULL, &keys,
-            "|side", &PyArray_SearchsideConverter, &side,
-            "|sorter", NULL, &sorter,
-            NULL, NULL, NULL) < 0) {
+            {"v", NULL, &keys},
+            {"|side", &PyArray_SearchsideConverter, &side},
+            {"|sorter", NULL, &sorter}) < 0) {
         return NULL;
     }
     if (sorter == Py_None) {
@@ -2444,9 +2434,8 @@ array_dot(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("dot", args, len_args, kwnames,
-            "b", NULL, &b,
-            "|out", NULL, &o,
-            NULL, NULL, NULL) < 0) {
+            {"b", NULL, &b},
+            {"|out", NULL, &o}) < 0) {
         return NULL;
     }
 
@@ -2542,12 +2531,11 @@ array_trace(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("trace", args, len_args, kwnames,
-            "|offset", &PyArray_PythonPyIntFromInt, &offset,
-            "|axis1", &PyArray_PythonPyIntFromInt, &axis1,
-            "|axis2", &PyArray_PythonPyIntFromInt, &axis2,
-            "|dtype", &PyArray_DescrConverter2, &dtype,
-            "|out", &PyArray_OutputConverter, &out,
-            NULL, NULL, NULL) < 0) {
+            {"|offset", &PyArray_PythonPyIntFromInt, &offset},
+            {"|axis1", &PyArray_PythonPyIntFromInt, &axis1},
+            {"|axis2", &PyArray_PythonPyIntFromInt, &axis2},
+            {"|dtype", &PyArray_DescrConverter2, &dtype},
+            {"|out", &PyArray_OutputConverter, &out}) < 0) {
         Py_XDECREF(dtype);
         return NULL;
     }
@@ -2616,8 +2604,7 @@ array_flatten(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("flatten", args, len_args, kwnames,
-            "|order", PyArray_OrderConverter, &order,
-            NULL, NULL, NULL) < 0) {
+            {"|order", PyArray_OrderConverter, &order}) < 0) {
         return NULL;
     }
     return PyArray_Flatten(self, order);
@@ -2632,8 +2619,7 @@ array_ravel(PyArrayObject *self,
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("ravel", args, len_args, kwnames,
-            "|order", PyArray_OrderConverter, &order,
-            NULL, NULL, NULL) < 0) {
+            {"|order", PyArray_OrderConverter, &order}) < 0) {
         return NULL;
     }
     return PyArray_Ravel(self, order);

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1429,6 +1429,7 @@ array_argsort(PyArrayObject *self,
             {"|kind", &PyArray_SortkindConverter, &sortkind},
             {"|order", NULL, &order},
             {"$stable", &PyArray_OptionalBoolConverter, &stable}
+            // TODO: add descending sorts, gh-14728
             // {"$descending", &PyArray_OptionalBoolConverter, &descending}
             ) < 0) {
         return NULL;

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1448,10 +1448,9 @@ array_putmask(PyObject *NPY_UNUSED(module), PyObject *const *args,
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("putmask", args, len_args, kwnames,
-            "", NULL, &array,
-            "mask", NULL, &mask,
-            "values", NULL, &values,
-            NULL, NULL, NULL) < 0) {
+            {"", NULL, &array},
+            {"mask", NULL, &mask},
+            {"values", NULL, &values}) < 0) {
         return NULL;
     }
     if (!PyArray_Check(array)) {
@@ -1723,15 +1722,14 @@ array_array(PyObject *NPY_UNUSED(ignored),
 
     if (len_args != 1 || (kwnames != NULL)) {
         if (npy_parse_arguments("array", args, len_args, kwnames,
-                "object", NULL, &op,
-                "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
-                "$copy", &PyArray_CopyConverter, &copy,
-                "$order", &PyArray_OrderConverter, &order,
-                "$subok", &PyArray_BoolConverter, &subok,
-                "$ndmin", &PyArray_PythonPyIntFromInt, &ndmin,
-                "$ndmax", &PyArray_PythonPyIntFromInt, &ndmax,
-                "$like", NULL, &like,
-                NULL, NULL, NULL) < 0) {
+                {"object", NULL, &op},
+                {"|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info},
+                {"$copy", &PyArray_CopyConverter, &copy},
+                {"$order", &PyArray_OrderConverter, &order},
+                {"$subok", &PyArray_BoolConverter, &subok},
+                {"$ndmin", &PyArray_PythonPyIntFromInt, &ndmin},
+                {"$ndmax", &PyArray_PythonPyIntFromInt, &ndmax},
+                {"$like", NULL, &like}) < 0) {
             Py_XDECREF(dt_info.descr);
             Py_XDECREF(dt_info.dtype);
             return NULL;
@@ -1779,13 +1777,12 @@ array_asarray(PyObject *NPY_UNUSED(ignored),
 
     if (len_args != 1 || (kwnames != NULL)) {
         if (npy_parse_arguments("asarray", args, len_args, kwnames,
-                "a", NULL, &op,
-                "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
-                "|order", &PyArray_OrderConverter, &order,
-                "$device", &PyArray_DeviceConverterOptional, &device,
-                "$copy", &PyArray_CopyConverter, &copy,
-                "$like", NULL, &like,
-                NULL, NULL, NULL) < 0) {
+                {"a", NULL, &op},
+                {"|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info},
+                {"|order", &PyArray_OrderConverter, &order},
+                {"$device", &PyArray_DeviceConverterOptional, &device},
+                {"$copy", &PyArray_CopyConverter, &copy},
+                {"$like", NULL, &like}) < 0) {
             Py_XDECREF(dt_info.descr);
             Py_XDECREF(dt_info.dtype);
             return NULL;
@@ -1825,13 +1822,12 @@ array_asanyarray(PyObject *NPY_UNUSED(ignored),
 
     if (len_args != 1 || (kwnames != NULL)) {
         if (npy_parse_arguments("asanyarray", args, len_args, kwnames,
-                "a", NULL, &op,
-                "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
-                "|order", &PyArray_OrderConverter, &order,
-                "$device", &PyArray_DeviceConverterOptional, &device,
-                "$copy", &PyArray_CopyConverter, &copy,
-                "$like", NULL, &like,
-                NULL, NULL, NULL) < 0) {
+                {"a", NULL, &op},
+                {"|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info},
+                {"|order", &PyArray_OrderConverter, &order},
+                {"$device", &PyArray_DeviceConverterOptional, &device},
+                {"$copy", &PyArray_CopyConverter, &copy},
+                {"$like", NULL, &like}) < 0) {
             Py_XDECREF(dt_info.descr);
             Py_XDECREF(dt_info.dtype);
             return NULL;
@@ -1869,10 +1865,9 @@ array_ascontiguousarray(PyObject *NPY_UNUSED(ignored),
 
     if (len_args != 1 || (kwnames != NULL)) {
         if (npy_parse_arguments("ascontiguousarray", args, len_args, kwnames,
-                "a", NULL, &op,
-                "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
-                "$like", NULL, &like,
-                NULL, NULL, NULL) < 0) {
+                {"a", NULL, &op},
+                {"|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info},
+                {"$like", NULL, &like}) < 0) {
             Py_XDECREF(dt_info.descr);
             Py_XDECREF(dt_info.dtype);
             return NULL;
@@ -1911,10 +1906,9 @@ array_asfortranarray(PyObject *NPY_UNUSED(ignored),
 
     if (len_args != 1 || (kwnames != NULL)) {
         if (npy_parse_arguments("asfortranarray", args, len_args, kwnames,
-                "a", NULL, &op,
-                "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
-                "$like", NULL, &like,
-                NULL, NULL, NULL) < 0) {
+                {"a", NULL, &op},
+                {"|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info},
+                {"$like", NULL, &like}) < 0) {
             Py_XDECREF(dt_info.descr);
             Py_XDECREF(dt_info.dtype);
             return NULL;
@@ -1952,11 +1946,10 @@ array_copyto(PyObject *NPY_UNUSED(ignored),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("copyto", args, len_args, kwnames,
-            "dst", NULL, &dst_obj,
-            "src", NULL, &src_obj,
-            "|casting", &PyArray_CastingConverter, &casting,
-            "|where", NULL, &wheremask_in,
-            NULL, NULL, NULL) < 0) {
+            {"dst", NULL, &dst_obj},
+            {"src", NULL, &src_obj},
+            {"|casting", &PyArray_CastingConverter, &casting},
+            {"|where", NULL, &wheremask_in}) < 0) {
         goto fail;
     }
 
@@ -2035,12 +2028,11 @@ array_empty(PyObject *NPY_UNUSED(ignored),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("empty", args, len_args, kwnames,
-            "shape", &PyArray_IntpConverter, &shape,
-            "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
-            "|order", &PyArray_OrderConverter, &order,
-            "$device", &PyArray_DeviceConverterOptional, &device,
-            "$like", NULL, &like,
-            NULL, NULL, NULL) < 0) {
+            {"shape", &PyArray_IntpConverter, &shape},
+            {"|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info},
+            {"|order", &PyArray_OrderConverter, &order},
+            {"$device", &PyArray_DeviceConverterOptional, &device},
+            {"$like", NULL, &like}) < 0) {
         goto fail;
     }
 
@@ -2094,13 +2086,12 @@ array_empty_like(PyObject *NPY_UNUSED(ignored),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("empty_like", args, len_args, kwnames,
-            "prototype", &PyArray_Converter, &prototype,
-            "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
-            "|order", &PyArray_OrderConverter, &order,
-            "|subok", &PyArray_PythonPyIntFromInt, &subok,
-            "|shape", &PyArray_OptionalIntpConverter, &shape,
-            "$device", &PyArray_DeviceConverterOptional, &device,
-            NULL, NULL, NULL) < 0) {
+            {"prototype", &PyArray_Converter, &prototype},
+            {"|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info},
+            {"|order", &PyArray_OrderConverter, &order},
+            {"|subok", &PyArray_PythonPyIntFromInt, &subok},
+            {"|shape", &PyArray_OptionalIntpConverter, &shape},
+            {"$device", &PyArray_DeviceConverterOptional, &device}) < 0) {
         goto fail;
     }
     /* steals the reference to dt_info.descr if it's not NULL */
@@ -2240,12 +2231,11 @@ array_zeros(PyObject *NPY_UNUSED(ignored),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("zeros", args, len_args, kwnames,
-            "shape", &PyArray_IntpConverter, &shape,
-            "|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info,
-            "|order", &PyArray_OrderConverter, &order,
-            "$device", &PyArray_DeviceConverterOptional, &device,
-            "$like", NULL, &like,
-            NULL, NULL, NULL) < 0) {
+            {"shape", &PyArray_IntpConverter, &shape},
+            {"|dtype", &PyArray_DTypeOrDescrConverterOptional, &dt_info},
+            {"|order", &PyArray_OrderConverter, &order},
+            {"$device", &PyArray_DeviceConverterOptional, &device},
+            {"$like", NULL, &like}) < 0) {
         goto finish;
     }
 
@@ -2292,8 +2282,7 @@ array_count_nonzero(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("count_nonzero", args, len_args, NULL,
-            "", PyArray_Converter, &array,
-            NULL, NULL, NULL) < 0) {
+            {"", PyArray_Converter, &array}) < 0) {
         return NULL;
     }
 
@@ -2515,12 +2504,11 @@ array_concatenate(PyObject *NPY_UNUSED(dummy),
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("concatenate", args, len_args, kwnames,
-            "seq", NULL, &a0,
-            "|axis", &PyArray_AxisConverter, &axis,
-            "|out", NULL, &out,
-            "$dtype", &PyArray_DescrConverter2, &dtype,
-            "$casting", &PyArray_CastingConverter, &casting,
-            NULL, NULL, NULL) < 0) {
+            {"seq", NULL, &a0},
+            {"|axis", &PyArray_AxisConverter, &axis},
+            {"|out", NULL, &out},
+            {"$dtype", &PyArray_DescrConverter2, &dtype},
+            {"$casting", &PyArray_CastingConverter, &casting}) < 0) {
         return NULL;
     }
     if (out != NULL) {
@@ -2546,9 +2534,8 @@ array_innerproduct(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("innerproduct", args, len_args, NULL,
-            "", NULL, &a0,
-            "", NULL, &b0,
-            NULL, NULL, NULL) < 0) {
+            {"", NULL, &a0},
+            {"", NULL, &b0}) < 0) {
     return NULL;
     }
 
@@ -2564,10 +2551,9 @@ array_matrixproduct(PyObject *NPY_UNUSED(dummy),
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("dot", args, len_args, kwnames,
-            "a", NULL, &a,
-            "b", NULL, &v,
-            "|out", NULL, &o,
-            NULL, NULL, NULL) < 0) {
+            {"a", NULL, &a},
+            {"b", NULL, &v},
+            {"|out", NULL, &o}) < 0) {
         return NULL;
     }
     if (o != NULL) {
@@ -2600,9 +2586,8 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("vdot", args, len_args, NULL,
-            "", NULL, &op1,
-            "", NULL, &op2,
-            NULL, NULL, NULL) < 0) {
+            {"", NULL, &op1},
+            {"", NULL, &op2}) < 0) {
         return NULL;
     }
 
@@ -2986,11 +2971,10 @@ array_einsum(PyObject *NPY_UNUSED(dummy),
     /* Get the keyword arguments */
     if (kwnames != NULL) {
         if (npy_parse_arguments("einsum", args+nargs, 0, kwnames,
-                "$out", NULL, &out_obj,
-                "$order", &PyArray_OrderConverter, &order,
-                "$casting", &PyArray_CastingConverter, &casting,
-                "$dtype", &PyArray_DescrConverter2, &dtype,
-                NULL, NULL, NULL) < 0) {
+                {"$out", NULL, &out_obj},
+                {"$order", &PyArray_OrderConverter, &order},
+                {"$casting", &PyArray_CastingConverter, &casting},
+                {"$dtype", &PyArray_DescrConverter2, &dtype}) < 0) {
             goto finish;
         }
         if (out_obj != NULL && !PyArray_Check(out_obj)) {
@@ -3032,10 +3016,9 @@ array_correlate(PyObject *NPY_UNUSED(dummy),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("correlate", args, len_args, kwnames,
-            "a", NULL, &a0,
-            "v", NULL, &shape,
-            "|mode", &PyArray_CorrelatemodeConverter, &mode,
-            NULL, NULL, NULL) < 0) {
+            {"a", NULL, &a0},
+            {"v", NULL, &shape},
+            {"|mode", &PyArray_CorrelatemodeConverter, &mode}) < 0) {
         return NULL;
     }
     return PyArray_Correlate(a0, shape, mode);
@@ -3050,10 +3033,9 @@ array_correlate2(PyObject *NPY_UNUSED(dummy),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("correlate2", args, len_args, kwnames,
-            "a", NULL, &a0,
-            "v", NULL, &shape,
-            "|mode", &PyArray_CorrelatemodeConverter, &mode,
-            NULL, NULL, NULL) < 0) {
+            {"a", NULL, &a0},
+            {"v", NULL, &shape},
+            {"|mode", &PyArray_CorrelatemodeConverter, &mode}) < 0) {
         return NULL;
     }
     return PyArray_Correlate2(a0, shape, mode);
@@ -3070,13 +3052,12 @@ array_arange(PyObject *NPY_UNUSED(ignored),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("arange", args, len_args, kwnames,
-            "|start", NULL, &o_start,
-            "|stop", NULL, &o_stop,
-            "|step", NULL, &o_step,
-            "|dtype", &PyArray_DescrConverter2, &typecode,
-            "$device", &PyArray_DeviceConverterOptional, &device,
-            "$like", NULL, &like,
-            NULL, NULL, NULL) < 0) {
+            {"|start", NULL, &o_start},
+            {"|stop", NULL, &o_stop},
+            {"|step", NULL, &o_step},
+            {"|dtype", &PyArray_DescrConverter2, &typecode},
+            {"$device", &PyArray_DeviceConverterOptional, &device},
+            {"$like", NULL, &like}) < 0) {
         Py_XDECREF(typecode);
         return NULL;
     }
@@ -3451,10 +3432,9 @@ array_where(PyObject *NPY_UNUSED(ignored), PyObject *const *args, Py_ssize_t len
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("where", args, len_args, NULL,
-            "", NULL, &obj,
-            "|x", NULL, &x,
-            "|y", NULL, &y,
-            NULL, NULL, NULL) < 0) {
+            {"", NULL, &obj},
+            {"|x", NULL, &x},
+            {"|y", NULL, &y}) < 0) {
         return NULL;
     }
 
@@ -3470,9 +3450,8 @@ array_lexsort(PyObject *NPY_UNUSED(ignored), PyObject *const *args, Py_ssize_t l
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("lexsort", args, len_args, kwnames,
-            "keys", NULL, &obj,
-            "|axis", PyArray_PythonPyIntFromInt, &axis,
-            NULL, NULL, NULL) < 0) {
+            {"keys", NULL, &obj},
+            {"|axis", PyArray_PythonPyIntFromInt, &axis}) < 0) {
         return NULL;
     }
     return PyArray_Return((PyArrayObject *)PyArray_LexSort(obj, axis));
@@ -3491,10 +3470,9 @@ array_can_cast_safely(PyObject *NPY_UNUSED(self),
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("can_cast", args, len_args, kwnames,
-            "from_", NULL, &from_obj,
-            "to", &PyArray_DescrConverter2, &d2,
-            "|casting", &PyArray_CastingConverter, &casting,
-            NULL, NULL, NULL) < 0) {
+            {"from_", NULL, &from_obj},
+            {"to", &PyArray_DescrConverter2, &d2},
+            {"|casting", &PyArray_CastingConverter, &casting}) < 0) {
         goto finish;
     }
     if (d2 == NULL) {
@@ -3561,9 +3539,8 @@ array_promote_types(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("promote_types", args, len_args, NULL,
-            "", PyArray_DescrConverter2, &d1,
-            "", PyArray_DescrConverter2, &d2,
-            NULL, NULL, NULL) < 0) {
+            {"", PyArray_DescrConverter2, &d1},
+            {"", PyArray_DescrConverter2, &d2}) < 0) {
         goto finish;
     }
 
@@ -3743,15 +3720,14 @@ dragon4_scientific(PyObject *NPY_UNUSED(dummy),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("dragon4_scientific", args, len_args, kwnames,
-            "x", NULL , &obj,
-            "|precision", &PyArray_PythonPyIntFromInt, &precision,
-            "|unique", &PyArray_PythonPyIntFromInt, &unique,
-            "|sign", &PyArray_PythonPyIntFromInt, &sign,
-            "|trim", &trimmode_converter, &trim,
-            "|pad_left", &PyArray_PythonPyIntFromInt, &pad_left,
-            "|exp_digits", &PyArray_PythonPyIntFromInt, &exp_digits,
-            "|min_digits", &PyArray_PythonPyIntFromInt, &min_digits,
-            NULL, NULL, NULL) < 0) {
+            {"x", NULL, &obj},
+            {"|precision", &PyArray_PythonPyIntFromInt, &precision},
+            {"|unique", &PyArray_PythonPyIntFromInt, &unique},
+            {"|sign", &PyArray_PythonPyIntFromInt, &sign},
+            {"|trim", &trimmode_converter, &trim},
+            {"|pad_left", &PyArray_PythonPyIntFromInt, &pad_left},
+            {"|exp_digits", &PyArray_PythonPyIntFromInt, &exp_digits},
+            {"|min_digits", &PyArray_PythonPyIntFromInt, &min_digits}) < 0) {
         return NULL;
     }
 
@@ -3786,16 +3762,15 @@ dragon4_positional(PyObject *NPY_UNUSED(dummy),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("dragon4_positional", args, len_args, kwnames,
-            "x", NULL , &obj,
-            "|precision", &PyArray_PythonPyIntFromInt, &precision,
-            "|unique", &PyArray_PythonPyIntFromInt, &unique,
-            "|fractional", &PyArray_PythonPyIntFromInt, &fractional,
-            "|sign", &PyArray_PythonPyIntFromInt, &sign,
-            "|trim", &trimmode_converter, &trim,
-            "|pad_left", &PyArray_PythonPyIntFromInt, &pad_left,
-            "|pad_right", &PyArray_PythonPyIntFromInt, &pad_right,
-            "|min_digits", &PyArray_PythonPyIntFromInt, &min_digits,
-            NULL, NULL, NULL) < 0) {
+            {"x", NULL, &obj},
+            {"|precision", &PyArray_PythonPyIntFromInt, &precision},
+            {"|unique", &PyArray_PythonPyIntFromInt, &unique},
+            {"|fractional", &PyArray_PythonPyIntFromInt, &fractional},
+            {"|sign", &PyArray_PythonPyIntFromInt, &sign},
+            {"|trim", &trimmode_converter, &trim},
+            {"|pad_left", &PyArray_PythonPyIntFromInt, &pad_left},
+            {"|pad_right", &PyArray_PythonPyIntFromInt, &pad_right},
+            {"|min_digits", &PyArray_PythonPyIntFromInt, &min_digits}) < 0) {
         return NULL;
     }
 
@@ -4323,10 +4298,9 @@ normalize_axis_index(PyObject *NPY_UNUSED(self),
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("normalize_axis_index", args, len_args, kwnames,
-            "axis", &PyArray_PythonPyIntFromInt, &axis,
-            "ndim", &PyArray_PythonPyIntFromInt, &ndim,
-            "|msg_prefix", NULL, &msg_prefix,
-            NULL, NULL, NULL) < 0) {
+            {"axis", &PyArray_PythonPyIntFromInt, &axis},
+            {"ndim", &PyArray_PythonPyIntFromInt, &ndim},
+            {"|msg_prefix", NULL, &msg_prefix}) < 0) {
         return NULL;
     }
     if (check_and_adjust_axis_msg(&axis, ndim, msg_prefix) < 0) {

--- a/numpy/_core/src/multiarray/textreading/readtext.c
+++ b/numpy/_core/src/multiarray/textreading/readtext.c
@@ -208,21 +208,20 @@ _load_from_filelike(PyObject *NPY_UNUSED(mod),
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("_load_from_filelike", args, len_args, kwnames,
-            "file", NULL, &file,
-            "|delimiter", &parse_control_character, &pc.delimiter,
-            "|comment", &parse_control_character, &pc.comment,
-            "|quote", &parse_control_character, &pc.quote,
-            "|imaginary_unit", &parse_control_character, &pc.imaginary_unit,
-            "|usecols", NULL, &usecols_obj,
-            "|skiplines", &PyArray_IntpFromPyIntConverter, &skiplines,
-            "|max_rows", &PyArray_IntpFromPyIntConverter, &max_rows,
-            "|converters", NULL, &converters,
-            "|dtype", NULL, &dtype,
-            "|encoding", NULL, &encoding_obj,
-            "|filelike", &PyArray_BoolConverter, &filelike,
-            "|byte_converters", &PyArray_BoolConverter, &pc.python_byte_converters,
-            "|c_byte_converters", PyArray_BoolConverter, &pc.c_byte_converters,
-            NULL, NULL, NULL) < 0) {
+            {"file", NULL, &file},
+            {"|delimiter", &parse_control_character, &pc.delimiter},
+            {"|comment", &parse_control_character, &pc.comment},
+            {"|quote", &parse_control_character, &pc.quote},
+            {"|imaginary_unit", &parse_control_character, &pc.imaginary_unit},
+            {"|usecols", NULL, &usecols_obj},
+            {"|skiplines", &PyArray_IntpFromPyIntConverter, &skiplines},
+            {"|max_rows", &PyArray_IntpFromPyIntConverter, &max_rows},
+            {"|converters", NULL, &converters},
+            {"|dtype", NULL, &dtype},
+            {"|encoding", NULL, &encoding_obj},
+            {"|filelike", &PyArray_BoolConverter, &filelike},
+            {"|byte_converters", &PyArray_BoolConverter, &pc.python_byte_converters},
+            {"|c_byte_converters", PyArray_BoolConverter, &pc.c_byte_converters}) < 0) {
         return NULL;
     }
 

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -493,11 +493,13 @@ array__unique_hash(PyObject *NPY_UNUSED(module),
     npy_bool equal_nan = NPY_TRUE;  // default to True
 
     NPY_PREPARE_ARGPARSER;
-    if (npy_parse_arguments("_unique_hash", args, len_args, kwnames,
-                            "arr", &PyArray_Converter, &arr,
-                            "|equal_nan",  &PyArray_BoolConverter, &equal_nan,
-                            NULL, NULL, NULL
-                            ) < 0
+    npy_arg_spec parse_specs[] = {
+        {"arr", (void *)&PyArray_Converter, &arr},
+        {"|equal_nan", (void *)&PyArray_BoolConverter, &equal_nan},
+    };
+    if (_npy_parse_arguments("_unique_hash", &__argparse_cache,
+                            args, len_args, kwnames,
+                            parse_specs, 2) < 0
     ) {
         Py_XDECREF(arr);
         return NULL;

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -493,14 +493,9 @@ array__unique_hash(PyObject *NPY_UNUSED(module),
     npy_bool equal_nan = NPY_TRUE;  // default to True
 
     NPY_PREPARE_ARGPARSER;
-    npy_arg_spec parse_specs[] = {
-        {"arr", (void *)&PyArray_Converter, &arr},
-        {"|equal_nan", (void *)&PyArray_BoolConverter, &equal_nan},
-    };
-    if (_npy_parse_arguments("_unique_hash", &__argparse_cache,
-                            args, len_args, kwnames,
-                            parse_specs, 2) < 0
-    ) {
+    if (npy_parse_arguments("_unique_hash", args, len_args, kwnames,
+            {"arr", (void *)&PyArray_Converter, &arr},
+            {"|equal_nan", (void *)&PyArray_BoolConverter, &equal_nan}) < 0) {
         Py_XDECREF(arr);
         return NULL;
     }

--- a/numpy/_core/src/umath/extobj.c
+++ b/numpy/_core/src/umath/extobj.c
@@ -213,14 +213,13 @@ extobj_make_extobj(PyObject *NPY_UNUSED(mod),
 
     NPY_PREPARE_ARGPARSER;
     if (npy_parse_arguments("_seterrobj", args, len_args, kwnames,
-            "$all", &errmodeconverter, &all_mode,
-            "$divide", &errmodeconverter, &divide_mode,
-            "$over", &errmodeconverter, &over_mode,
-            "$under", &errmodeconverter, &under_mode,
-            "$invalid", &errmodeconverter, &invalid_mode,
-            "$bufsize", &PyArray_IntpFromPyIntConverter, &bufsize,
-            "$call", NULL, &pyfunc,
-            NULL, NULL, NULL) < 0) {
+            {"$all", &errmodeconverter, &all_mode},
+            {"$divide", &errmodeconverter, &divide_mode},
+            {"$over", &errmodeconverter, &over_mode},
+            {"$under", &errmodeconverter, &under_mode},
+            {"$invalid", &errmodeconverter, &invalid_mode},
+            {"$bufsize", &PyArray_IntpFromPyIntConverter, &bufsize},
+            {"$call", NULL, &pyfunc}) < 0) {
         return NULL;
     }
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3493,12 +3493,11 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         NPY_PREPARE_ARGPARSER;
 
         if (npy_parse_arguments("reduceat", args, len_args, kwnames,
-                "array", NULL, &op,
-                "indices", NULL, &indices_obj,
-                "|axis", NULL, &axes_obj,
-                "|dtype", NULL, &otype_obj,
-                "|out", NULL, &out_obj,
-                NULL, NULL, NULL) < 0) {
+                {"array", NULL, &op},
+                {"indices", NULL, &indices_obj},
+                {"|axis", NULL, &axes_obj},
+                {"|dtype", NULL, &otype_obj},
+                {"|out", NULL, &out_obj}) < 0) {
             goto fail;
         }
         /* Prepare inputs for PyUfunc_CheckOverride */
@@ -3512,11 +3511,10 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         NPY_PREPARE_ARGPARSER;
 
         if (npy_parse_arguments("accumulate", args, len_args, kwnames,
-                "array", NULL, &op,
-                "|axis", NULL, &axes_obj,
-                "|dtype", NULL, &otype_obj,
-                "|out", NULL, &out_obj,
-                NULL, NULL, NULL) < 0) {
+                {"array", NULL, &op},
+                {"|axis", NULL, &axes_obj},
+                {"|dtype", NULL, &otype_obj},
+                {"|out", NULL, &out_obj}) < 0) {
             goto fail;
         }
         /* Prepare input for PyUfunc_CheckOverride */
@@ -3530,14 +3528,13 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         NPY_PREPARE_ARGPARSER;
 
         if (npy_parse_arguments("reduce", args, len_args, kwnames,
-                "array", NULL, &op,
-                "|axis", NULL, &axes_obj,
-                "|dtype", NULL, &otype_obj,
-                "|out", NULL, &out_obj,
-                "|keepdims", NULL, &keepdims_obj,
-                "|initial", &_not_NoValue, &initial,
-                "|where", NULL, &wheremask_obj,
-                NULL, NULL, NULL) < 0) {
+                {"array", NULL, &op},
+                {"|axis", NULL, &axes_obj},
+                {"|dtype", NULL, &otype_obj},
+                {"|out", NULL, &out_obj},
+                {"|keepdims", NULL, &keepdims_obj},
+                {"|initial", &_not_NoValue, &initial},
+                {"|where", NULL, &wheremask_obj}) < 0) {
             goto fail;
         }
         /* Prepare input for PyUfunc_CheckOverride */
@@ -4546,15 +4543,14 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
             NPY_PREPARE_ARGPARSER;
 
             if (npy_parse_arguments(ufunc->name, args + len_args, 0, kwnames,
-                    "$out", NULL, &out_obj,
-                    "$where", NULL, &where_obj,
-                    "$casting", NULL, &casting_obj,
-                    "$order", NULL, &order_obj,
-                    "$subok", NULL, &subok_obj,
-                    "$dtype", NULL, &dtype_obj,
-                    "$signature", NULL, &signature_obj,
-                    "$sig", NULL, &sig_obj,
-                    NULL, NULL, NULL) < 0) {
+                    {"$out", NULL, &out_obj},
+                    {"$where", NULL, &where_obj},
+                    {"$casting", NULL, &casting_obj},
+                    {"$order", NULL, &order_obj},
+                    {"$subok", NULL, &subok_obj},
+                    {"$dtype", NULL, &dtype_obj},
+                    {"$signature", NULL, &signature_obj},
+                    {"$sig", NULL, &sig_obj}) < 0) {
                 goto fail;
             }
         }
@@ -4562,17 +4558,16 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
             NPY_PREPARE_ARGPARSER;
 
             if (npy_parse_arguments(ufunc->name, args + len_args, 0, kwnames,
-                    "$out", NULL, &out_obj,
-                    "$axes", NULL, &axes_obj,
-                    "$axis", NULL, &axis_obj,
-                    "$keepdims", NULL, &keepdims_obj,
-                    "$casting", NULL, &casting_obj,
-                    "$order", NULL, &order_obj,
-                    "$subok", NULL, &subok_obj,
-                    "$dtype", NULL, &dtype_obj,
-                    "$signature", NULL, &signature_obj,
-                    "$sig", NULL, &sig_obj,
-                    NULL, NULL, NULL) < 0) {
+                    {"$out", NULL, &out_obj},
+                    {"$axes", NULL, &axes_obj},
+                    {"$axis", NULL, &axis_obj},
+                    {"$keepdims", NULL, &keepdims_obj},
+                    {"$casting", NULL, &casting_obj},
+                    {"$order", NULL, &order_obj},
+                    {"$subok", NULL, &subok_obj},
+                    {"$dtype", NULL, &dtype_obj},
+                    {"$signature", NULL, &signature_obj},
+                    {"$sig", NULL, &sig_obj}) < 0) {
                 goto fail;
             }
             if (NPY_UNLIKELY((axes_obj != NULL) && (axis_obj != NULL))) {
@@ -6211,11 +6206,10 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
     npy_bool reduction = NPY_FALSE;
 
     if (npy_parse_arguments("resolve_dtypes", args, len_args, kwnames,
-            "", NULL, &descrs_tuple,
-            "$signature", NULL, &signature_obj,
-            "$casting", &PyArray_CastingConverter, &casting,
-            "$reduction", &PyArray_BoolConverter, &reduction,
-            NULL, NULL, NULL) < 0) {
+            {"", NULL, &descrs_tuple},
+            {"$signature", NULL, &signature_obj},
+            {"$casting", &PyArray_CastingConverter, &casting},
+            {"$reduction", &PyArray_BoolConverter, &reduction}) < 0) {
         return NULL;
     }
 
@@ -6466,9 +6460,8 @@ py_get_strided_loop(PyUFuncObject *ufunc,
     npy_intp fixed_strides[NPY_MAXARGS];
 
     if (npy_parse_arguments("_get_strided_loop", args, len_args, kwnames,
-            "", NULL, &call_info_obj,
-            "$fixed_strides", NULL, &fixed_strides_obj,
-            NULL, NULL, NULL) < 0) {
+            {"", NULL, &call_info_obj},
+            {"$fixed_strides", NULL, &fixed_strides_obj}) < 0) {
         return NULL;
     }
 


### PR DESCRIPTION
We eliminate the variadic argument parsing in `npy_parse_arguments` to improve performance. In the PR the variadic arguments are handled at compile time.

Benchmark using
```
import time
import sys
import numpy as np
x = np.array([1., 2.])
y = np.array([0., 0.])

outer = 10
inner = 3
iterations = 200_000

for _ in range(outer):
    t00=0
    for _ in range(inner):
        t0 = time.perf_counter()
        for _ in range(iterations):
            np.add.reduce(x, axis=0)
        dt = time.perf_counter() - t0
        t00 += dt
   
    print(f'{1e9*t00/(inner*iterations):.2f} [ns] / operation')
print(sys.executable)
print(np)
```
shows an improvement of 787 to 762 ns / operation.

PR created with help from Claude

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
