### PR TITLE
BUG: Fix `np.dot` to allow user dtypes

### DIFF
--- a/numpy/_core/src/common/cblasfuncs.c
+++ b/numpy/_core/src/common/cblasfuncs.c
@@ -364,7 +364,7 @@ cblas_matrixproduct(int typenum, PyArrayObject *ap1, PyArrayObject *ap2,
         }
     }
 
-    out_buf = new_array_for_sum(ap1, ap2, out, nd, dimensions, typenum, &result);
+    out_buf = new_array_for_sum(ap1, ap2, out, nd, dimensions, typenum, NULL, &result);
     if (out_buf == NULL) {
         goto fail;
     }

--- a/numpy/_core/src/common/cblasfuncs.c
+++ b/numpy/_core/src/common/cblasfuncs.c
@@ -225,10 +225,11 @@ _bad_strides(PyArrayObject *ap)
  * __array_ufunc__ nonsense is also assumed to have been taken care of.
  */
 NPY_NO_EXPORT PyObject *
-cblas_matrixproduct(int typenum, PyArrayObject *ap1, PyArrayObject *ap2,
+cblas_matrixproduct(PyArray_Descr *typec, PyArrayObject *ap1, PyArrayObject *ap2,
                     PyArrayObject *out)
 {
     PyArrayObject *result = NULL, *out_buf = NULL;
+    int typenum = typec->type_num;
     npy_intp j, lda, ldb;
     npy_intp l;
     int nd;
@@ -364,7 +365,7 @@ cblas_matrixproduct(int typenum, PyArrayObject *ap1, PyArrayObject *ap2,
         }
     }
 
-    out_buf = new_array_for_sum(ap1, ap2, out, nd, dimensions, typenum, NULL, &result);
+    out_buf = new_array_for_sum(ap1, ap2, out, nd, dimensions, typec, &result);
     if (out_buf == NULL) {
         goto fail;
     }

--- a/numpy/_core/src/common/cblasfuncs.h
+++ b/numpy/_core/src/common/cblasfuncs.h
@@ -2,6 +2,6 @@
 #define NUMPY_CORE_SRC_COMMON_CBLASFUNCS_H_
 
 NPY_NO_EXPORT PyObject *
-cblas_matrixproduct(int, PyArrayObject *, PyArrayObject *, PyArrayObject *);
+cblas_matrixproduct(PyArray_Descr *, PyArrayObject *, PyArrayObject *, PyArrayObject *);
 
 #endif  /* NUMPY_CORE_SRC_COMMON_CBLASFUNCS_H_ */

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -381,22 +381,16 @@ _may_have_objects(PyArray_Descr *dtype)
  */
 NPY_NO_EXPORT PyArrayObject *
 new_array_for_sum(PyArrayObject *ap1, PyArrayObject *ap2, PyArrayObject* out,
-                  int nd, npy_intp dimensions[], int typenum, PyArray_Descr *descr,
-                  PyArrayObject **result)
+                  int nd, npy_intp dimensions[], PyArray_Descr *descr, PyArrayObject **result)
 {
     PyArrayObject *out_buf;
 
     if (out) {
         int d;
-        int typenum_check = typenum;
-        if (typenum == NPY_NOTYPE) {
-            // user-defined dtype
-            typenum_check = descr->type_num;
-        }
 
         /* verify that out is usable */
         if (PyArray_NDIM(out) != nd ||
-            PyArray_TYPE(out) != typenum_check ||
+            PyArray_TYPE(out) != descr->type_num ||
             !PyArray_ISCARRAY(out)) {
             PyErr_SetString(PyExc_ValueError,
                 "output array is not acceptable (must have the right datatype, "
@@ -458,19 +452,11 @@ new_array_for_sum(PyArrayObject *ap1, PyArrayObject *ap2, PyArrayObject* out,
             subtype = Py_TYPE(ap1);
         }
 
-        // to accomodate user-defined dtypes, use descriptor when typenum is NPY_NOTYPE
-        if (typenum == NPY_NOTYPE) {
-            out_buf = (PyArrayObject *)PyArray_NewFromDescr(subtype, descr, nd, dimensions,
-                                                            NULL, NULL, 0,
-                                                            (PyObject *)
-                                                            (prior2 > prior1 ? ap2 : ap1));
-        }
-        else {
-            out_buf = (PyArrayObject *)PyArray_New(subtype, nd, dimensions,
-                                                   typenum, NULL, NULL, 0, 0,
-                                                   (PyObject *)
-                                                   (prior2 > prior1 ? ap2 : ap1));
-        }
+        Py_INCREF(descr);
+        out_buf = (PyArrayObject *)PyArray_NewFromDescr(subtype, descr, nd, dimensions,
+                                                        NULL, NULL, 0,
+                                                        (PyObject *)
+                                                        (prior2 > prior1 ? ap2 : ap1));
 
         if (out_buf != NULL && result) {
             Py_INCREF(out_buf);

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -460,7 +460,6 @@ new_array_for_sum(PyArrayObject *ap1, PyArrayObject *ap2, PyArrayObject* out,
 
         // to accomodate user-defined dtypes, use descriptor when typenum is NPY_NOTYPE
         if (typenum == NPY_NOTYPE) {
-            Py_INCREF(descr);
             out_buf = (PyArrayObject *)PyArray_NewFromDescr(subtype, descr, nd, dimensions,
                                                             NULL, NULL, 0,
                                                             (PyObject *)

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -381,16 +381,22 @@ _may_have_objects(PyArray_Descr *dtype)
  */
 NPY_NO_EXPORT PyArrayObject *
 new_array_for_sum(PyArrayObject *ap1, PyArrayObject *ap2, PyArrayObject* out,
-                  int nd, npy_intp dimensions[], int typenum, PyArrayObject **result)
+                  int nd, npy_intp dimensions[], int typenum, PyArray_Descr *descr,
+                  PyArrayObject **result)
 {
     PyArrayObject *out_buf;
 
     if (out) {
         int d;
+        int typenum_check = typenum;
+        if (typenum == NPY_NOTYPE) {
+            // user-defined dtype
+            typenum_check = descr->type_num;
+        }
 
         /* verify that out is usable */
         if (PyArray_NDIM(out) != nd ||
-            PyArray_TYPE(out) != typenum ||
+            PyArray_TYPE(out) != typenum_check ||
             !PyArray_ISCARRAY(out)) {
             PyErr_SetString(PyExc_ValueError,
                 "output array is not acceptable (must have the right datatype, "
@@ -452,10 +458,20 @@ new_array_for_sum(PyArrayObject *ap1, PyArrayObject *ap2, PyArrayObject* out,
             subtype = Py_TYPE(ap1);
         }
 
-        out_buf = (PyArrayObject *)PyArray_New(subtype, nd, dimensions,
-                                               typenum, NULL, NULL, 0, 0,
-                                               (PyObject *)
-                                               (prior2 > prior1 ? ap2 : ap1));
+        // to accomodate user-defined dtypes, use descriptor when typenum is NPY_NOTYPE
+        if (typenum == NPY_NOTYPE) {
+            Py_INCREF(descr);
+            out_buf = (PyArrayObject *)PyArray_NewFromDescr(subtype, descr, nd, dimensions,
+                                                            NULL, NULL, 0,
+                                                            (PyObject *)
+                                                            (prior2 > prior1 ? ap2 : ap1));
+        }
+        else {
+            out_buf = (PyArrayObject *)PyArray_New(subtype, nd, dimensions,
+                                                   typenum, NULL, NULL, 0, 0,
+                                                   (PyObject *)
+                                                   (prior2 > prior1 ? ap2 : ap1));
+        }
 
         if (out_buf != NULL && result) {
             Py_INCREF(out_buf);

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -390,7 +390,7 @@ new_array_for_sum(PyArrayObject *ap1, PyArrayObject *ap2, PyArrayObject* out,
 
         /* verify that out is usable */
         if (PyArray_NDIM(out) != nd ||
-            PyArray_TYPE(out) != descr->type_num ||
+            !PyArray_EquivTypes(PyArray_DESCR(out), descr) ||
             !PyArray_ISCARRAY(out)) {
             PyErr_SetString(PyExc_ValueError,
                 "output array is not acceptable (must have the right datatype, "

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -339,7 +339,8 @@ check_is_convertible_to_scalar(PyArrayObject *v);
  */
 NPY_NO_EXPORT PyArrayObject *
 new_array_for_sum(PyArrayObject *ap1, PyArrayObject *ap2, PyArrayObject* out,
-                  int nd, npy_intp dimensions[], int typenum, PyArrayObject **result);
+                  int nd, npy_intp dimensions[], int typenum, PyArray_Descr *descr,
+                  PyArrayObject **result);
 
 
 /*

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -339,8 +339,7 @@ check_is_convertible_to_scalar(PyArrayObject *v);
  */
 NPY_NO_EXPORT PyArrayObject *
 new_array_for_sum(PyArrayObject *ap1, PyArrayObject *ap2, PyArrayObject* out,
-                  int nd, npy_intp dimensions[], int typenum, PyArray_Descr *descr,
-                  PyArrayObject **result);
+                  int nd, npy_intp dimensions[], PyArray_Descr *descr, PyArrayObject **result);
 
 
 /*

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -899,7 +899,7 @@ PyArray_InnerProduct(PyObject *op1, PyObject *op2)
     if (typec == NULL) {
         typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
-    typec = NPY_DT_CALL_ensure_canonical(typec);
+    Py_SETREF(typec, NPY_DT_CALL_ensure_canonical(typec));
 
     Py_INCREF(typec);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, typec, 0, 0,
@@ -994,7 +994,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     if (typec == NULL) {
         typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
-    typec = NPY_DT_CALL_ensure_canonical(typec);
+    Py_SETREF(typec, NPY_DT_CALL_ensure_canonical(typec));
     typenum = typec->type_num;
 
     Py_INCREF(typec);
@@ -1336,7 +1336,7 @@ PyArray_Correlate2(PyObject *op1, PyObject *op2, int mode)
     if (typec == NULL) {
         typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
-    typec = NPY_DT_CALL_ensure_canonical(typec);
+    Py_SETREF(typec, NPY_DT_CALL_ensure_canonical(typec));
 
     Py_INCREF(typec);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, typec, 1, 1,
@@ -1416,7 +1416,7 @@ PyArray_Correlate(PyObject *op1, PyObject *op2, int mode)
     if (typec == NULL) {
         typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
-    typec = NPY_DT_CALL_ensure_canonical(typec);
+    Py_SETREF(typec, NPY_DT_CALL_ensure_canonical(typec));
 
     Py_INCREF(typec);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, typec, 1, 1,

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -989,6 +989,9 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     if (PyArray_DTypeFromObject(op1, NPY_MAXDIMS, &typec) < 0) {
         return NULL;
     }
+    if (PyArray_DTypeFromObject(op2, NPY_MAXDIMS, &typec) < 0) {
+        return NULL;
+    }
 
     if (typec != NULL) {
         if (NPY_DT_is_user_defined(typec)) {

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -983,18 +983,34 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     npy_intp dimensions[NPY_MAXDIMS];
     PyArray_DotFunc *dot;
     PyArray_Descr *typec = NULL;
+    int user_type = 0;
     NPY_BEGIN_THREADS_DEF;
 
-    typenum = PyArray_ObjectType(op1, NPY_NOTYPE);
-    if (typenum == NPY_NOTYPE) {
-        return NULL;
-    }
-    typenum = PyArray_ObjectType(op2, typenum);
-    if (typenum == NPY_NOTYPE) {
+    if (PyArray_DTypeFromObject(op1, NPY_MAXDIMS, &typec) < 0) {
         return NULL;
     }
 
-    typec = PyArray_DescrFromType(typenum);
+    if (typec != NULL) {
+        if (NPY_DT_is_user_defined(typec)) {
+            user_type = 1;
+        }
+    }
+
+    if (user_type) {
+        typenum = NULL;
+    }
+    else {
+        typenum = PyArray_ObjectType(op1, NPY_NOTYPE);
+        if (typenum == NPY_NOTYPE) {
+            return NULL;
+        }
+        typenum = PyArray_ObjectType(op2, typenum);
+        if (typenum == NPY_NOTYPE) {
+            return NULL;
+        }
+
+        typec = PyArray_DescrFromType(typenum);
+    }
     if (typec == NULL) {
         if (!PyErr_Occurred()) {
             PyErr_SetString(PyExc_TypeError,

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -899,13 +899,6 @@ PyArray_InnerProduct(PyObject *op1, PyObject *op2)
     if (typec == NULL) {
         typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
-    if (typec == NULL) {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError,
-                            "Cannot find a common data type.");
-        }
-        goto fail;
-    }
 
     Py_INCREF(typec);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, typec, 0, 0,
@@ -999,13 +992,6 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
 
     if (typec == NULL) {
         typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
-    }
-    if (typec == NULL) {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError,
-                            "Cannot find a common data type.");
-        }
-        return NULL;
     }
     typenum = typec->type_num;
 
@@ -2615,7 +2601,7 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
     npy_intp newdimptr[1] = {-1};
     PyArray_Dims newdims = {newdimptr, 1};
     PyArrayObject *ap1 = NULL, *ap2  = NULL, *ret = NULL;
-    PyArray_Descr *type;
+    PyArray_Descr *type = NULL;
     PyArray_DotFunc *vdot;
     NPY_BEGIN_THREADS_DEF;
 
@@ -2642,7 +2628,6 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
     if (type == NULL) {
         type = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
-    typenum = type->type_num;
 
     Py_INCREF(type);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, type, 0, 0, 0, NULL);
@@ -2690,7 +2675,7 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
     ip2 = PyArray_DATA(ap2);
     op = PyArray_DATA(ret);
 
-    switch (typenum) {
+    switch (type->type_num) {
         case NPY_CFLOAT:
             vdot = (PyArray_DotFunc *)CFLOAT_vdot;
             break;

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -996,6 +996,9 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     if (typec != NULL) {
         if (NPY_DT_is_user_defined(typec)) {
             user_type = 1;
+
+            // in new_array_for_sum we steal a reference
+            Py_INCREF(typec);
         }
     }
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -881,7 +881,6 @@ PyArray_InnerProduct(PyObject *op1, PyObject *op2)
 {
     PyArrayObject *ap1 = NULL;
     PyArrayObject *ap2 = NULL;
-    int typenum;
     PyArray_Descr *typec = NULL;
     PyObject* ap2t = NULL;
     npy_intp dims[NPY_MAXDIMS];
@@ -889,16 +888,17 @@ PyArray_InnerProduct(PyObject *op1, PyObject *op2)
     int i;
     PyObject* ret = NULL;
 
-    typenum = PyArray_ObjectType(op1, NPY_NOTYPE);
-    if (typenum == NPY_NOTYPE) {
+    if (PyArray_DTypeFromObject(op1, NPY_MAXDIMS, &typec) < 0) {
         return NULL;
     }
-    typenum = PyArray_ObjectType(op2, typenum);
-    if (typenum == NPY_NOTYPE) {
+    if (PyArray_DTypeFromObject(op2, NPY_MAXDIMS, &typec) < 0) {
+        Py_XDECREF(typec);
         return NULL;
     }
 
-    typec = PyArray_DescrFromType(typenum);
+    if (typec == NULL) {
+        typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
+    }
     if (typec == NULL) {
         if (!PyErr_Occurred()) {
             PyErr_SetString(PyExc_TypeError,
@@ -914,6 +914,8 @@ PyArray_InnerProduct(PyObject *op1, PyObject *op2)
         Py_DECREF(typec);
         goto fail;
     }
+
+    Py_INCREF(typec);
     ap2 = (PyArrayObject *)PyArray_FromAny(op2, typec, 0, 0,
                                            NPY_ARRAY_ALIGNED, NULL);
     if (ap2 == NULL) {
@@ -947,6 +949,7 @@ PyArray_InnerProduct(PyObject *op1, PyObject *op2)
     Py_DECREF(ap1);
     Py_DECREF(ap2);
     Py_DECREF(ap2t);
+    Py_DECREF(typec);
     return ret;
 
 fail:
@@ -954,6 +957,7 @@ fail:
     Py_XDECREF(ap2);
     Py_XDECREF(ap2t);
     Py_XDECREF(ret);
+    Py_XDECREF(typec);
     return NULL;
 }
 
@@ -993,28 +997,8 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
         return NULL;
     }
 
-    if (typec != NULL) {
-        if (NPY_DT_is_user_defined(typec)) {
-            // we steal a reference in new_array_for_sum
-            Py_INCREF(typec);
-            typenum = NPY_NOTYPE;
-        }
-        else {
-            Py_DECREF(typec);
-            typec = NULL;
-        }
-    }
     if (typec == NULL) {
-        typenum = PyArray_ObjectType(op1, NPY_NOTYPE);
-        if (typenum == NPY_NOTYPE) {
-            return NULL;
-        }
-        typenum = PyArray_ObjectType(op2, typenum);
-        if (typenum == NPY_NOTYPE) {
-            return NULL;
-        }
-
-        typec = PyArray_DescrFromType(typenum);
+        typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
     if (typec == NULL) {
         if (!PyErr_Occurred()) {
@@ -1023,6 +1007,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
         }
         return NULL;
     }
+    typenum = typec->type_num;
 
     Py_INCREF(typec);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, typec, 0, 0,
@@ -1031,6 +1016,8 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
         Py_DECREF(typec);
         return NULL;
     }
+
+    Py_INCREF(typec);
     ap2 = (PyArrayObject *)PyArray_FromAny(op2, typec, 0, 0,
                                         NPY_ARRAY_ALIGNED, NULL);
     if (ap2 == NULL) {
@@ -1042,7 +1029,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     if (PyArray_NDIM(ap1) <= 2 && PyArray_NDIM(ap2) <= 2 &&
             (NPY_DOUBLE == typenum || NPY_CDOUBLE == typenum ||
              NPY_FLOAT == typenum || NPY_CFLOAT == typenum)) {
-        return cblas_matrixproduct(typenum, ap1, ap2, out);
+        return cblas_matrixproduct(typec, ap1, ap2, out);
     }
 #endif
 
@@ -1083,7 +1070,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     is1 = PyArray_STRIDES(ap1)[PyArray_NDIM(ap1)-1];
     is2 = PyArray_STRIDES(ap2)[matchDim];
     /* Choose which subtype to return */
-    out_buf = new_array_for_sum(ap1, ap2, out, nd, dimensions, typenum, typec, &result);
+    out_buf = new_array_for_sum(ap1, ap2, out, nd, dimensions, typec, &result);
     if (out_buf == NULL) {
         goto fail;
     }
@@ -1145,6 +1132,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     /* Trigger possible copy-back into `result` */
     PyArray_ResolveWritebackIfCopy(out_buf);
     Py_DECREF(out_buf);
+    Py_DECREF(typec);
 
     return (PyObject *)result;
 
@@ -1153,6 +1141,7 @@ fail:
     Py_XDECREF(ap2);
     Py_XDECREF(out_buf);
     Py_XDECREF(result);
+    Py_XDECREF(typec);
     return NULL;
 }
 
@@ -1164,7 +1153,7 @@ fail:
  * inverted is set to 1 if computed correlate(ap2, ap1), 0 otherwise
  */
 static PyArrayObject*
-_pyarray_correlate(PyArrayObject *ap1, PyArrayObject *ap2, int typenum,
+_pyarray_correlate(PyArrayObject *ap1, PyArrayObject *ap2, PyArray_Descr *typec,
                    int mode, int *inverted)
 {
     PyArrayObject *ret;
@@ -1224,7 +1213,7 @@ _pyarray_correlate(PyArrayObject *ap1, PyArrayObject *ap2, int typenum,
      * Need to choose an output array that can hold a sum
      * -- use priority to determine which subtype.
      */
-    ret = new_array_for_sum(ap1, ap2, NULL, 1, &length, typenum, NULL, NULL);
+    ret = new_array_for_sum(ap1, ap2, NULL, 1, &length, typec, NULL);
     if (ret == NULL) {
         return NULL;
     }
@@ -1344,21 +1333,22 @@ NPY_NO_EXPORT PyObject *
 PyArray_Correlate2(PyObject *op1, PyObject *op2, int mode)
 {
     PyArrayObject *ap1, *ap2, *ret = NULL;
-    int typenum;
-    PyArray_Descr *typec;
+    PyArray_Descr *typec = NULL;
     int inverted;
     int st;
 
-    typenum = PyArray_ObjectType(op1, NPY_NOTYPE);
-    if (typenum == NPY_NOTYPE) {
+    if (PyArray_DTypeFromObject(op1, NPY_MAXDIMS, &typec) < 0) {
         return NULL;
     }
-    typenum = PyArray_ObjectType(op2, typenum);
-    if (typenum == NPY_NOTYPE) {
+    if (PyArray_DTypeFromObject(op2, NPY_MAXDIMS, &typec) < 0) {
+        Py_XDECREF(typec);
         return NULL;
     }
 
-    typec = PyArray_DescrFromType(typenum);
+    if (typec == NULL) {
+        typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
+    }
+
     Py_INCREF(typec);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, typec, 1, 1,
                                         NPY_ARRAY_DEFAULT, NULL);
@@ -1366,6 +1356,8 @@ PyArray_Correlate2(PyObject *op1, PyObject *op2, int mode)
         Py_DECREF(typec);
         return NULL;
     }
+
+    Py_INCREF(typec);
     ap2 = (PyArrayObject *)PyArray_FromAny(op2, typec, 1, 1,
                                         NPY_ARRAY_DEFAULT, NULL);
     if (ap2 == NULL) {
@@ -1382,7 +1374,7 @@ PyArray_Correlate2(PyObject *op1, PyObject *op2, int mode)
         ap2 = cap2;
     }
 
-    ret = _pyarray_correlate(ap1, ap2, typenum, mode, &inverted);
+    ret = _pyarray_correlate(ap1, ap2, typec, mode, &inverted);
     if (ret == NULL) {
         goto clean_ap2;
     }
@@ -1400,6 +1392,7 @@ PyArray_Correlate2(PyObject *op1, PyObject *op2, int mode)
 
     Py_DECREF(ap1);
     Py_DECREF(ap2);
+    Py_DECREF(typec);
     return (PyObject *)ret;
 
 clean_ret:
@@ -1408,6 +1401,8 @@ clean_ap2:
     Py_DECREF(ap2);
 clean_ap1:
     Py_DECREF(ap1);
+
+    Py_DECREF(typec);
     return NULL;
 }
 
@@ -1418,20 +1413,21 @@ NPY_NO_EXPORT PyObject *
 PyArray_Correlate(PyObject *op1, PyObject *op2, int mode)
 {
     PyArrayObject *ap1, *ap2, *ret = NULL;
-    int typenum;
     int unused;
-    PyArray_Descr *typec;
+    PyArray_Descr *typec = NULL;
 
-    typenum = PyArray_ObjectType(op1, NPY_NOTYPE);
-    if (typenum == NPY_NOTYPE) {
+    if (PyArray_DTypeFromObject(op1, NPY_MAXDIMS, &typec) < 0) {
         return NULL;
     }
-    typenum = PyArray_ObjectType(op2, typenum);
-    if (typenum == NPY_NOTYPE) {
+    if (PyArray_DTypeFromObject(op2, NPY_MAXDIMS, &typec) < 0) {
+        Py_XDECREF(typec);
         return NULL;
     }
 
-    typec = PyArray_DescrFromType(typenum);
+    if (typec == NULL) {
+        typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
+    }
+
     Py_INCREF(typec);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, typec, 1, 1,
                                             NPY_ARRAY_DEFAULT, NULL);
@@ -1439,24 +1435,28 @@ PyArray_Correlate(PyObject *op1, PyObject *op2, int mode)
         Py_DECREF(typec);
         return NULL;
     }
+
+    Py_INCREF(typec);
     ap2 = (PyArrayObject *)PyArray_FromAny(op2, typec, 1, 1,
                                            NPY_ARRAY_DEFAULT, NULL);
     if (ap2 == NULL) {
         goto fail;
     }
 
-    ret = _pyarray_correlate(ap1, ap2, typenum, mode, &unused);
+    ret = _pyarray_correlate(ap1, ap2, typec, mode, &unused);
     if (ret == NULL) {
         goto fail;
     }
     Py_DECREF(ap1);
     Py_DECREF(ap2);
+    Py_DECREF(typec);
     return (PyObject *)ret;
 
 fail:
     Py_XDECREF(ap1);
     Py_XDECREF(ap2);
     Py_XDECREF(ret);
+    Py_XDECREF(typec);
     return NULL;
 }
 
@@ -2631,16 +2631,19 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
      * Conjugating dot product using the BLAS for vectors.
      * Flattens both op1 and op2 before dotting.
      */
-    typenum = PyArray_ObjectType(op1, NPY_NOTYPE);
-    if (typenum == NPY_NOTYPE) {
+    if (PyArray_DTypeFromObject(op1, NPY_MAXDIMS, &type) < 0) {
         return NULL;
     }
-    typenum = PyArray_ObjectType(op2, typenum);
-    if (typenum == NPY_NOTYPE) {
+    if (PyArray_DTypeFromObject(op2, NPY_MAXDIMS, &type) < 0) {
+        Py_XDECREF(type);
         return NULL;
     }
 
-    type = PyArray_DescrFromType(typenum);
+    if (type == NULL) {
+        type = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
+    }
+    typenum = type->type_num;
+
     Py_INCREF(type);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, type, 0, 0, 0, NULL);
     if (ap1 == NULL) {
@@ -2656,6 +2659,7 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
     Py_DECREF(ap1);
     ap1 = (PyArrayObject *)op1;
 
+    Py_INCREF(type);
     ap2 = (PyArrayObject *)PyArray_FromAny(op2, type, 0, 0, 0, NULL);
     if (ap2 == NULL) {
         goto fail;
@@ -2674,7 +2678,7 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
     }
 
     /* array scalar output */
-    ret = new_array_for_sum(ap1, ap2, NULL, 0, (npy_intp *)NULL, typenum, NULL, NULL);
+    ret = new_array_for_sum(ap1, ap2, NULL, 0, (npy_intp *)NULL, type, NULL);
     if (ret == NULL) {
         goto fail;
     }
@@ -2719,11 +2723,13 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
 
     Py_XDECREF(ap1);
     Py_XDECREF(ap2);
+    Py_XDECREF(type);
     return PyArray_Return(ret);
 fail:
     Py_XDECREF(ap1);
     Py_XDECREF(ap2);
     Py_XDECREF(ret);
+    Py_XDECREF(type);
     return NULL;
 }
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -997,7 +997,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     }
 
     if (user_type) {
-        typenum = NULL;
+        typenum = NPY_NOTYPE;
     }
     else {
         typenum = PyArray_ObjectType(op1, NPY_NOTYPE);
@@ -1078,7 +1078,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     is1 = PyArray_STRIDES(ap1)[PyArray_NDIM(ap1)-1];
     is2 = PyArray_STRIDES(ap2)[matchDim];
     /* Choose which subtype to return */
-    out_buf = new_array_for_sum(ap1, ap2, out, nd, dimensions, typenum, &result);
+    out_buf = new_array_for_sum(ap1, ap2, out, nd, dimensions, typenum, typec, &result);
     if (out_buf == NULL) {
         goto fail;
     }
@@ -1219,7 +1219,7 @@ _pyarray_correlate(PyArrayObject *ap1, PyArrayObject *ap2, int typenum,
      * Need to choose an output array that can hold a sum
      * -- use priority to determine which subtype.
      */
-    ret = new_array_for_sum(ap1, ap2, NULL, 1, &length, typenum, NULL);
+    ret = new_array_for_sum(ap1, ap2, NULL, 1, &length, typenum, NULL, NULL);
     if (ret == NULL) {
         return NULL;
     }
@@ -2669,7 +2669,7 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
     }
 
     /* array scalar output */
-    ret = new_array_for_sum(ap1, ap2, NULL, 0, (npy_intp *)NULL, typenum, NULL);
+    ret = new_array_for_sum(ap1, ap2, NULL, 0, (npy_intp *)NULL, typenum, NULL, NULL);
     if (ret == NULL) {
         goto fail;
     }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -983,29 +983,28 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     npy_intp dimensions[NPY_MAXDIMS];
     PyArray_DotFunc *dot;
     PyArray_Descr *typec = NULL;
-    int user_type = 0;
     NPY_BEGIN_THREADS_DEF;
 
     if (PyArray_DTypeFromObject(op1, NPY_MAXDIMS, &typec) < 0) {
         return NULL;
     }
     if (PyArray_DTypeFromObject(op2, NPY_MAXDIMS, &typec) < 0) {
+        Py_XDECREF(typec);
         return NULL;
     }
 
     if (typec != NULL) {
         if (NPY_DT_is_user_defined(typec)) {
-            user_type = 1;
-
-            // in new_array_for_sum we steal a reference
+            // we steal a reference in new_array_for_sum
             Py_INCREF(typec);
+            typenum = NPY_NOTYPE;
+        }
+        else {
+            Py_DECREF(typec);
+            typec = NULL;
         }
     }
-
-    if (user_type) {
-        typenum = NPY_NOTYPE;
-    }
-    else {
+    if (typec == NULL) {
         typenum = PyArray_ObjectType(op1, NPY_NOTYPE);
         if (typenum == NPY_NOTYPE) {
             return NULL;

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -2631,7 +2631,7 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
     if (type == NULL) {
         type = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
-   Py_SETREF(typec, NPY_DT_CALL_ensure_canonical(typec));
+   Py_SETREF(type, NPY_DT_CALL_ensure_canonical(type));
 
     Py_INCREF(type);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, type, 0, 0, 0, NULL);

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -899,6 +899,7 @@ PyArray_InnerProduct(PyObject *op1, PyObject *op2)
     if (typec == NULL) {
         typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
+    typec = NPY_DT_CALL_ensure_canonical(typec);
 
     Py_INCREF(typec);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, typec, 0, 0,
@@ -993,6 +994,7 @@ PyArray_MatrixProduct2(PyObject *op1, PyObject *op2, PyArrayObject* out)
     if (typec == NULL) {
         typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
+    typec = NPY_DT_CALL_ensure_canonical(typec);
     typenum = typec->type_num;
 
     Py_INCREF(typec);
@@ -1334,6 +1336,7 @@ PyArray_Correlate2(PyObject *op1, PyObject *op2, int mode)
     if (typec == NULL) {
         typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
+    typec = NPY_DT_CALL_ensure_canonical(typec);
 
     Py_INCREF(typec);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, typec, 1, 1,
@@ -1413,6 +1416,7 @@ PyArray_Correlate(PyObject *op1, PyObject *op2, int mode)
     if (typec == NULL) {
         typec = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
+    typec = NPY_DT_CALL_ensure_canonical(typec);
 
     Py_INCREF(typec);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, typec, 1, 1,

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -2631,6 +2631,7 @@ array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_ar
     if (type == NULL) {
         type = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
+   Py_SETREF(typec, NPY_DT_CALL_ensure_canonical(typec));
 
     Py_INCREF(type);
     ap1 = (PyArrayObject *)PyArray_FromAny(op1, type, 0, 0, 0, NULL);

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -2594,7 +2594,6 @@ array_matrixproduct(PyObject *NPY_UNUSED(dummy),
 static PyObject *
 array_vdot(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t len_args)
 {
-    int typenum;
     char *ip1, *ip2, *op;
     npy_intp n, stride1, stride2;
     PyObject *op1, *op2;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -7259,6 +7259,13 @@ class TestDot:
         assert_equal(np.dot(b, a), res)
         assert_equal(np.dot(b, b), res)
 
+    def test_dot_has_native_byteorder(self):
+        # gh-30931
+        a = np.array([1, 2, 3], ">f8")
+        dot = a.dot([[], [], []])
+
+        assert_equal(dot.dtype, np.dtype("=f8"))
+
     def test_accelerate_framework_sgemv_fix(self):
 
         def aligned_array(shape, align, dtype, order='C'):


### PR DESCRIPTION
This is a start to fix `PyArray_MatrixProduct2` for user-defined dtypes, as a bug was reported in https://github.com/jax-ml/ml_dtypes/pull/360. This is a draft as I've not tested this outside of a dummy dtype. I will try to use the linked PR with this, but wanted to get this out if anyone has comments. ping @seberg - thanks!

There also seem to be other methods with the same issue, so we might need a helper function long run. Hopefully this stays minimal on more testing, though not sure if even this is small enough to backport.