### PR TITLE
CI: CI hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
       - "03 - Maintenance"
     ignore:
       - dependency-name: "bus1/cabuild"
-updates:
   - package-ecosystem: pip
     directory: /requirements
     schedule:

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -83,7 +83,7 @@ jobs:
     if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     container:
-        image: ghcr.io/nascheme/numpy-tsan:3.14t
+        image: ghcr.io/nascheme/numpy-tsan:3.14t@sha256:1ec427e2e480cc373d0fecbf21b8ac590fb94119fb81d18489945cd0afd04dd3
         options: --shm-size=2g # increase memory for large matrix ops
 
     steps:
@@ -114,7 +114,7 @@ jobs:
     if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     container:
-        image: ghcr.io/nascheme/cpython-asan:3.14
+        image: ghcr.io/nascheme/cpython-asan:3.14@sha256:b5bfbcdca07e86d22afaf66e3b57959e1c44756452dcabda1efde7711fd0bdde
         options: --shm-size=2g # increase memory for large matrix ops
 
     steps:

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -1,3 +1,7 @@
+# To update pinned container digests and pyenv version (not handled by Dependabot):
+# Containers: change tag and get new digest with
+#   docker pull <image>:<tag> && docker inspect --format='{{index .RepoDigests 0}}' <image>:<tag>
+# pyenv: see https://github.com/pyenv/pyenv/releases
 name: Test with compiler sanitizers
 
 on:

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -38,7 +38,7 @@ jobs:
         persist-credentials: false
     - name: Set up pyenv
       run: |
-        git clone https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
+        git clone --branch v2.6.25 --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
         PYENV_ROOT="$HOME/.pyenv"
         PYENV_BIN="$PYENV_ROOT/bin"
         PYENV_SHIMS="$PYENV_ROOT/shims"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,13 +7,34 @@ permissions: {}
 
 jobs:
   pr-labeler:
+    if: github.repository == 'numpy/numpy'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write  # to add labels
     steps:
     - name: Label the PR
-      uses: gerrymanoim/pr-prefix-labeler@c8062327f6de59a9ae1c19f7f07cacd0b976b6fa # v3
       continue-on-error: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: github.repository == 'numpy/numpy'
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+      with:
+        script: |
+          const yaml = require('js-yaml');
+          const {data} = await github.rest.repos.getContent({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            path: '.github/pr-prefix-labeler.yml',
+          });
+          const prefixToLabel = yaml.load(
+            Buffer.from(data.content, data.encoding).toString()
+          );
+          const title = context.payload.pull_request.title;
+          for (const [prefix, label] of Object.entries(prefixToLabel)) {
+            if (title.startsWith(prefix)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: [label],
+              });
+              break;
+            }
+          }

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Initialize binfmt_misc for qemu-user-static
       run: |
         # see https://hub.docker.com/r/tonistiigi/binfmt for available versions
-        docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52 --install all
+        docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52@sha256:1b804311fe87047a4c96d38b4b3ef6f62fca8cd125265917a9e3dc3c996c39e6 --install all
 
     - name: Install GCC cross-compilers
       run: |
@@ -177,7 +177,7 @@ jobs:
           - [
               "loongarch64",
               "loongarch64-linux-gnu",
-              "cnclarechen/numpy-loong64-debian:v1",
+              "cnclarechen/numpy-loong64-debian:v1@sha256:1f35e614955fa9cba890172a73a068120f25f1cfcd59ad5521995e37cb7e2c3f",
               "-Dallow-noblas=true",
               "test_kind or test_multiarray or test_simd or test_umath or test_ufunc",
               "loong64"
@@ -199,7 +199,7 @@ jobs:
 
     - name: Initialize binfmt_misc for qemu-user-static
       run: |
-          docker run --rm --privileged tonistiigi/binfmt:qemu-v10.0.4-56 --install all
+          docker run --rm --privileged tonistiigi/binfmt:qemu-v10.0.4-56@sha256:30cc9a4d03765acac9be2ed0afc23af1ad018aed2c28ea4be8c2eb9afe03fbd1 --install all
 
     - name: Install GCC cross-compilers
       run: |

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -1,3 +1,8 @@
+# To update pinned container digests and uv version: not handled by Dependabot.
+# Containers: change tag and get new digest with
+#   docker pull <image>:<tag> && docker inspect --format='{{index .RepoDigests 0}}' <image>:<tag>
+# uv: change version in URL and update checksum (curl -sL <url> | sha256sum)
+#
 # Meson's Python module doesn't support crosscompiling,
 # and python dependencies may be another potential hurdle.
 # There might also be a need to run runtime tests during configure time.
@@ -88,7 +93,6 @@ jobs:
 
     - name: Initialize binfmt_misc for qemu-user-static
       run: |
-        # see https://hub.docker.com/r/tonistiigi/binfmt for available versions
         docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52@sha256:1b804311fe87047a4c96d38b4b3ef6f62fca8cd125265917a9e3dc3c996c39e6 --install all
 
     - name: Install GCC cross-compilers

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -110,7 +110,9 @@ jobs:
           -v /:/host -v $(pwd):/numpy ${DOCKER_CONTAINER} /bin/bash -c "
           apt update &&
           apt install -y cmake git curl ca-certificates &&
-          curl -LsSf https://astral.sh/uv/install.sh | sh &&
+          curl -LsSf https://astral.sh/uv/0.10.8/install.sh -o /tmp/uv-install.sh &&
+          echo 'eae5e1dae89cd0b74d357f549ccd6faa94b2ad6c1d89d78972a625655a4556ae  /tmp/uv-install.sh' | sha256sum -c - &&
+          sh /tmp/uv-install.sh &&
           export PATH="/root/.local/bin:$PATH" &&
           mkdir -p /lib64 && ln -s /host/lib64/ld-* /lib64/ &&
           ln -s /host/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu &&

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -1,5 +1,9 @@
 name: Linux SIMD tests
 
+# To update Intel SDE (not handled by Dependabot): download new version from
+# https://www.intel.com/content/www/us/en/developer/articles/tool/software-development-emulator.html
+# and update SDE_URL and SDE_SHA256 (curl -sL <url> | sha256sum)
+#
 # This file is meant for testing different SIMD-related build options and
 # optimization levels. See `meson_options.txt` for the available build options.
 #

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -197,7 +197,10 @@ jobs:
 
     - name: Install Intel SDE
       run: |
-        curl -o /tmp/sde.tar.xz https://downloadmirror.intel.com/859732/sde-external-9.58.0-2025-06-16-lin.tar.xz
+        SDE_URL="https://downloadmirror.intel.com/859732/sde-external-9.58.0-2025-06-16-lin.tar.xz"
+        SDE_SHA256="f849acecad4c9b108259c643b2688fd65c35723cd23368abe5dd64b917cc18c0"
+        curl -o /tmp/sde.tar.xz "$SDE_URL"
+        echo "$SDE_SHA256  /tmp/sde.tar.xz" | sha256sum -c -
         mkdir /tmp/sde && tar -xvf /tmp/sde.tar.xz -C /tmp/sde/
         sudo mv /tmp/sde/* /opt/sde && sudo ln -s /opt/sde/sde64 /usr/bin/sde
 
@@ -247,7 +250,10 @@ jobs:
 
     - name: Install Intel SDE
       run: |
-        curl -o /tmp/sde.tar.xz https://downloadmirror.intel.com/859732/sde-external-9.58.0-2025-06-16-lin.tar.xz
+        SDE_URL="https://downloadmirror.intel.com/859732/sde-external-9.58.0-2025-06-16-lin.tar.xz"
+        SDE_SHA256="f849acecad4c9b108259c643b2688fd65c35723cd23368abe5dd64b917cc18c0"
+        curl -o /tmp/sde.tar.xz "$SDE_URL"
+        echo "$SDE_SHA256  /tmp/sde.tar.xz" | sha256sum -c -
         mkdir /tmp/sde && tar -xvf /tmp/sde.tar.xz -C /tmp/sde/
         sudo mv /tmp/sde/* /opt/sde && sudo ln -s /opt/sde/sde64 /usr/bin/sde
 

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -36,7 +36,8 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: pip install git+https://github.com/hauntsaninja/mypy_primer.git@05f73ec3d85bb4f55676f3c57f2c3e5136228977 # HEAD of master on 2026-03-04, no tags/releases available
+        # To update: replace commit hash (no tags/releases available, use HEAD of master)
+        run: pip install git+https://github.com/hauntsaninja/mypy_primer.git@05f73ec3d85bb4f55676f3c57f2c3e5136228977  # HEAD of master on 2026-03-04
       - name: Run mypy_primer
         shell: bash
         run: |

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: pip install git+https://github.com/hauntsaninja/mypy_primer.git
+        run: pip install git+https://github.com/hauntsaninja/mypy_primer.git@05f73ec3d85bb4f55676f3c57f2c3e5136228977 # HEAD of master on 2026-03-04, no tags/releases available
       - name: Run mypy_primer
         shell: bash
         run: |


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Inspired by recent CI/CD attacks: https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation#summary-of-results

This adds some hardening to the CI pipeline:
* Checksums for direct intel downloads and versioned containers (rolling containers not checksummed)
* Pinned versions for some currently unpinned downloads
* Remove the [`gerrymanoim/pr-prefix-labeler`](https://github.com/gerrymanoim/pr-prefix-labeler) action and replace it with inlined logic that does the same thing. While this action was checksum verified and looks safe to me right now, `GITHUB_TOKEN` should not be passed externally and this is pretty minimal functionality to replicate. The label config is kept in the current `.github/pr-prefix-labeler.yml`.