### PR TITLE
ENH: improve UFuncOutputCastingError message to explain resolved dtype

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -359,7 +359,7 @@ existing array rather than create a new one.
     >>> a += b  # b is not automatically converted to integer type
     Traceback (most recent call last):
         ...
-    numpy._core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'add' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
+    numpy._core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'add' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'. This means the resolved dtype for the ufunc result is dtype('float64'), which cannot be safely stored in an output array of dtype dtype('int64').
 
 When operating with arrays of different types, the type of the resulting
 array corresponds to the more general or precise one (a behavior known

--- a/numpy/_core/_exceptions.py
+++ b/numpy/_core/_exceptions.py
@@ -101,7 +101,10 @@ class _UFuncOutputCastingError(_UFuncCastingError):
         i_str = f"{self.out_i} " if self.ufunc.nout != 1 else ""
         return (
             f"Cannot cast ufunc {self.ufunc.__name__!r} output {i_str}from "
-            f"{self.from_!r} to {self.to!r} with casting rule {self.casting!r}"
+            f"{self.from_!r} to {self.to!r} with casting rule {self.casting!r}. "
+            f"This means the resolved dtype for the ufunc result is "
+            f"{self.from_!r}, which cannot be safely stored in an output "
+            f"array of dtype {self.to!r}."
         )
 
 


### PR DESCRIPTION
## Summary
- Improves the `_UFuncOutputCastingError` message to explain that the unexpected dtype (e.g. `float64`) is the resolved result type of the ufunc loop, not an input type
- Updates the quickstart doc example to match

Before:
```
Cannot cast ufunc 'add' output from dtype('float64') to dtype('uint64') with casting rule 'same_kind'
```

After:
```
Cannot cast ufunc 'add' output from dtype('float64') to dtype('uint64') with casting rule 'same_kind'. This means the resolved dtype for the ufunc result is dtype('float64'), which cannot be safely stored in an output array of dtype dtype('uint64').
```

Closes #14828