### PR TITLE
DOC: align __array__ signature with keyword-only copy

### DIFF
--- a/doc/source/user/basics.interoperability.rst
+++ b/doc/source/user/basics.interoperability.rst
@@ -139,7 +139,9 @@ new ndarray object. This is not optimal, as coercing arrays into ndarrays may
 cause performance problems or create the need for copies and loss of metadata,
 as the original object and any attributes/behavior it may have had, is lost.
 
-The signature of the method should be ``__array__(self, dtype=None, copy=None)``.
+The signature of the method should be
+``__array__(self, dtype=None, *, copy=None)``.
+The ``copy`` argument is keyword-only, matching ``ndarray.__array__``.
 If a passed ``dtype`` isn't ``None`` and different than the object's data type,
 a casting should happen to a specified type. If ``copy`` is ``None``, a copy
 should be made only if ``dtype`` argument enforces it. For ``copy=True``, a copy


### PR DESCRIPTION
## Summary
- update `doc/source/user/basics.interoperability.rst` to document `__array__` as
  `__array__(self, dtype=None, *, copy=None)`
- add a short clarifying sentence that `copy` is keyword-only, matching `ndarray.__array__`

This aligns the interoperability guide with the current `ndarray.__array__` signature and avoids confusion around positional `copy` arguments.

Closes #30907