### PR TITLE
DOC: remove a redundant build command

### DIFF
--- a/building_with_meson.md
+++ b/building_with_meson.md
@@ -14,9 +14,6 @@ have rough edges, please open an issue if you run into a problem._
   *Note: also make sure you have `pkg-config` and the usual system dependencies
   for NumPy*
 
-Then install spin:
-- `python -m pip install spin`
-
 **Compile and install:** `spin build`
 
 This builds in the `build/` directory, and installs into the `build-install` directory.


### PR DESCRIPTION
Both `environment.yml` and `build_requirements.txt` already include spin, so there is no need to install it again.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
