### PR TITLE
MAINT: change ruff version to 0.15.4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -45,7 +45,7 @@ dependencies:
   - breathe>4.33.0
   # For linting
   - cython-lint
-  - ruff=0.15.2
+  - ruff=0.15.4
   - gitpython
   # Used in some tests
   - cffi


### PR DESCRIPTION
`ruff` errored in my conda environment.
`linter_requirements.txt` already uses `0.15.4`, so may be `environment.yml` should also use it.                                                                                                            