### PR TITLE
MAINT: Don't use vulture 2.15, it has false positives

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -354,7 +354,7 @@ jobs:
       run: |
         pip install -r requirements/build_requirements.txt
         pip install -r requirements/test_requirements.txt
-        pip install vulture
+        pip install "vulture!=2.15"
     - name: Build and install NumPy
       run: |
         # Install using the fastest way to build (no BLAS, no SIMD)


### PR DESCRIPTION
Backport of #30938.

CI is failing due to the update, I opened an issue there, this just blocks the broken version.

The CI failures look like:
```
numpy/_build_utils/tempita/_tempita.py:1031: unreachable code after 'while' (100% confidence)
numpy/f2py/_src_pyf.py:80: unreachable code after 'while' (100% confidence)
numpy/f2py/crackfortran.py:546: unreachable code after 'while' (100% confidence)
numpy/lib/_utils_impl.py:188: unreachable code after 'while' (100% confidence)
numpy/linalg/lapack_lite/make_lite.py:174: unreachable code after 'while' (100% confidence)
```
all of those are `while True` loops with perfectly fine `break` conditionals.

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
