### PR TITLE
BUG: Use BufferError for unsupported devices in DLPack and Array API

### DIFF
--- a/numpy/_array_api_info.py
+++ b/numpy/_array_api_info.py
@@ -172,7 +172,7 @@ class __array_namespace_info__:
 
         """
         if device not in ["cpu", None]:
-            raise ValueError(
+            raise BufferError(
                 'Device not understood. Only "cpu" is allowed, but received:'
                 f' {device}'
             )
@@ -239,7 +239,7 @@ class __array_namespace_info__:
 
         """
         if device not in ["cpu", None]:
-            raise ValueError(
+            raise BufferError(
                 'Device not understood. Only "cpu" is allowed, but received:'
                 f' {device}'
             )

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2669,7 +2669,7 @@ def astype(x, dtype, /, *, copy=True, device=None):
             f"It is a {type(x)} instead."
         )
     if device is not None and device != "cpu":
-        raise ValueError(
+        raise BufferError(
             'Device not understood. Only "cpu" is allowed, but received:'
             f' {device}'
         )

--- a/numpy/_core/src/multiarray/array_api_standard.c
+++ b/numpy/_core/src/multiarray/array_api_standard.c
@@ -31,7 +31,7 @@ array_to_device(PyObject *self, PyObject *args, PyObject *kwds)
     }
 
     if (strcmp(device, "cpu") != 0) {
-        PyErr_Format(PyExc_ValueError,
+        PyErr_Format(PyExc_BufferError,
                      "Unsupported device: %s. Only 'cpu' is accepted.", device);
         return NULL;
     }

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -1412,7 +1412,7 @@ PyArray_DeviceConverterOptional(PyObject *object, NPY_DEVICE *device)
         return NPY_SUCCEED;
     }
 
-    PyErr_Format(PyExc_ValueError,
+    PyErr_Format(PyExc_BufferError,
             "Device not understood. Only \"cpu\" is allowed, "
             "but received: %S", object);
     return NPY_FAIL;

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -579,7 +579,7 @@ from_dlpack(PyObject *NPY_UNUSED(self),
 
     const int ndim = dl_tensor.ndim;
     if (ndim > NPY_MAXDIMS) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_SetString(PyExc_BufferError,
                 "maxdims of DLPack tensor is higher than the supported "
                 "maxdims.");
         Py_DECREF(capsule);
@@ -591,14 +591,14 @@ from_dlpack(PyObject *NPY_UNUSED(self),
             device_type != kDLCUDAHost &&
             device_type != kDLROCMHost &&
             device_type != kDLCUDAManaged) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_SetString(PyExc_BufferError,
                 "Unsupported device in DLTensor.");
         Py_DECREF(capsule);
         return NULL;
     }
 
     if (dl_tensor.dtype.lanes != 1) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_SetString(PyExc_BufferError,
                 "Unsupported lanes in DLTensor dtype.");
         Py_DECREF(capsule);
         return NULL;
@@ -649,7 +649,7 @@ from_dlpack(PyObject *NPY_UNUSED(self),
     }
 
     if (typenum == -1) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_SetString(PyExc_BufferError,
                 "Unsupported dtype in DLTensor.");
         Py_DECREF(capsule);
         return NULL;

--- a/numpy/_core/tests/test_array_api_info.py
+++ b/numpy/_core/tests/test_array_api_info.py
@@ -30,7 +30,7 @@ def test_default_dtypes():
     assert dtypes["integral"] == np.intp == np.asarray(0).dtype
     assert dtypes["indexing"] == np.intp == np.argmax(np.zeros(10)).dtype
 
-    with pytest.raises(ValueError, match="Device not understood"):
+    with pytest.raises(BufferError, match="Device not understood"):
         info.default_dtypes(device="gpu")
 
 
@@ -105,7 +105,7 @@ def test_dtypes_invalid_kind():
 
 
 def test_dtypes_invalid_device():
-    with pytest.raises(ValueError, match="Device not understood"):
+    with pytest.raises(BufferError, match="Device not understood"):
         info.dtypes(device="gpu")
 
 

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -184,5 +184,5 @@ class TestDLPack:
 
         with pytest.raises(BufferError):
             x.__dlpack__(dl_device=(10, 0))
-        with pytest.raises(ValueError):
+        with pytest.raises(BufferError, match="Device not understood"):
             np.from_dlpack(x, device="gpu")

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10961,7 +10961,7 @@ class TestDevice:
         assert arr.device == "cpu"
 
         with assert_raises_regex(
-            ValueError,
+            BufferError,
             r"Device not understood. Only \"cpu\" is allowed, "
             r"but received: nonsense"
         ):
@@ -10978,6 +10978,12 @@ class TestDevice:
         arr = np.arange(5)
 
         assert arr.to_device("cpu") is arr
+        with assert_raises_regex(
+            BufferError,
+            r"Unsupported device: gpu. Only 'cpu' is accepted."
+        ):
+            arr.to_device("gpu")
+
         with assert_raises_regex(
             ValueError,
             r"The stream argument in to_device\(\) is not supported"


### PR DESCRIPTION
Fixes #30937
The Array API specification requires that functions encountering unsupported devices or incompatible DLPack features raise BufferError. Previously, several code paths in NumPy raised ValueError or RuntimeError instead. This PR standardizes the behavior across both C and Python implementations to ensure compliance with the specification and improve error consistency.
C-level updates
numpy/_core/src/multiarray/dlpack.c

Updated from_dlpack to raise BufferError instead of RuntimeError when encountering unsupported or incompatible DLPack inputs, including:
unsupported device types
unsupported dtype lanes
unsupported DLPack dtypes
tensors exceeding NPY_MAXDIMS
numpy/_core/src/multiarray/conversion_utils.c

Updated PyArray_DeviceConverterOptional to raise BufferError instead of ValueError when an unsupported device string (anything other than "cpu") is provided.
numpy/_core/src/multiarray/array_api_standard.c
Updated array_to_device to raise BufferError when an unsupported device is requested, aligning with the Array API specification for to_device.

Python-level updates
numpy/_core/numeric.py

Updated the Array API compatible astype implementation to raise BufferError instead of ValueError when an unsupported device string is provided.
numpy/_core/_array_api_info.py

Updated default_dtypes and dtypes inspection functions to raise BufferError when an unsupported device argument is passed.

Tests

Updated tests to reflect the new error behavior:
numpy/_core/tests/test_dlpack.py
Updated tests for np.from_dlpack(..., device="gpu") to expect BufferError.

numpy/_core/tests/test_array_api_info.py
Updated inspection function tests to expect BufferError when unsupported devices are provided.

numpy/_core/tests/test_multiarray.py
Updated TestDevice.test_device tests for creator functions (arange, zeros, empty, asarray, etc.) to expect BufferError for invalid device strings.

Added a new test verifying that to_device raises BufferError when an unsupported device is requested.

Motivation
This change ensures that device and buffer compatibility errors consistently raise BufferError, as required by the Array API specification. This improves consistency across NumPy’s DLPack and Array API code paths and aligns implementation behavior with documented expectations.