### PR TITLE
DOC: AI policy exception for Dependabot

### DIFF
--- a/doc/source/dev/ai_policy.rst
+++ b/doc/source/dev/ai_policy.rst
@@ -63,6 +63,10 @@ AI Agents
 The use of an AI agent that writes code and then submits a pull request autonomously is
 not permitted. A human must check any generated code and submit a pull request according
 to the 'Responsibility' section above.
+The only exception to this rule is `Dependabot`_, which is used for automated dependency 
+updates.
+
+.. _Dependabot: https://github.com/dependabot
 
 Other Resources
 ---------------


### PR DESCRIPTION
After merging https://github.com/numpy/numpy/pull/30933 I realized that Dependabot might also be considered to be an "AI Agent", seeing as it's not unlikely that it uses AI for *something*, or otherwise will do so in the near future.