### PR TITLE
BUG: Show allocatable arrays in `dir()` for f2py modules

### DIFF
--- a/doc/release/upcoming_changes/30965.improvement.rst
+++ b/doc/release/upcoming_changes/30965.improvement.rst
@@ -1,0 +1,4 @@
+``f2py`` modules now show allocatable arrays in ``dir()``
+---------------------------------------------------------
+Allocatable module variables wrapped by ``f2py`` now appear in ``dir()``
+output, matching their accessibility by name.

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -576,6 +576,47 @@ fortran_repr(PyFortranObject *fp)
     return repr;
 }
 
+static PyObject *
+fortran_dir(PyFortranObject *fp, PyObject *Py_UNUSED(args))
+{
+    int i;
+    PyObject *dir_list = PyDict_Keys(fp->dict);
+    if (dir_list == NULL) {
+        return NULL;
+    }
+    for (i = 0; i < fp->len; i++) {
+        PyObject *name = PyUnicode_FromString(fp->defs[i].name);
+        if (name == NULL) {
+            Py_DECREF(dir_list);
+            return NULL;
+        }
+        int contains = PySequence_Contains(dir_list, name);
+        if (contains == -1) {
+            Py_DECREF(name);
+            Py_DECREF(dir_list);
+            return NULL;
+        }
+        if (!contains) {
+            if (PyList_Append(dir_list, name) < 0) {
+                Py_DECREF(name);
+                Py_DECREF(dir_list);
+                return NULL;
+            }
+        }
+        Py_DECREF(name);
+    }
+    if (PyList_Sort(dir_list) < 0) {
+        Py_DECREF(dir_list);
+        return NULL;
+    }
+    return dir_list;
+}
+
+static PyMethodDef fortran_methods[] = {
+        {"__dir__", (PyCFunction)fortran_dir, METH_NOARGS, NULL},
+        {NULL, NULL, 0, NULL}
+};
+
 PyTypeObject PyFortran_Type = {
         PyVarObject_HEAD_INIT(NULL, 0).tp_name = "fortran",
         .tp_basicsize = sizeof(PyFortranObject),
@@ -583,6 +624,7 @@ PyTypeObject PyFortran_Type = {
         .tp_getattr = (getattrfunc)fortran_getattr,
         .tp_setattr = (setattrfunc)fortran_setattr,
         .tp_repr = (reprfunc)fortran_repr,
+        .tp_methods = fortran_methods,
         .tp_call = (ternaryfunc)fortran_call,
 };
 

--- a/numpy/f2py/tests/test_modules.py
+++ b/numpy/f2py/tests/test_modules.py
@@ -58,11 +58,18 @@ class TestModuleAndSubroutine(util.F2PyTest):
     sources = [
         util.getpath("tests", "src", "modules", "gh25337", "data.f90"),
         util.getpath("tests", "src", "modules", "gh25337", "use_data.f90"),
+        util.getpath("tests", "src", "regression", "datonly.f90"),
     ]
 
     def test_gh25337(self):
         self.module.data.set_shift(3)
         assert "data" in dir(self.module)
+
+    def test_allocatable_in_dir(self):
+        # gh-27696: allocatable arrays should appear in dir()
+        names = dir(self.module.datonly)
+        assert "data_array" in names
+        assert "max_value" in names
 
 
 @pytest.mark.slow


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->

Add a `__dir__` method to `PyFortranObject` that includes all defs names (routines, variables, and allocatable arrays), not just the keys in the object dict. Previously, allocatable arrays were accessible via getattr but invisible to `dir()` because `PyFortranObject_New` only populated the dict with routines and non-allocatable variables.

Closes #27696


cc @2sn (sorry for the long delay)