### PR TITLE
MAINT: Use `npy_cfloat/npy_cdouble/npy_clongdouble` in `f2py`

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -89,10 +89,9 @@ typedefs['long_double'] = """
 typedef long double long_double;
 #endif
 """
-typedefs[
-    'complex_long_double'] = 'typedef struct {long double r,i;} complex_long_double;'
-typedefs['complex_float'] = 'typedef struct {float r,i;} complex_float;'
-typedefs['complex_double'] = 'typedef struct {double r,i;} complex_double;'
+typedefs['complex_long_double'] = 'typedef npy_clongdouble complex_long_double;'
+typedefs['complex_float'] = 'typedef npy_cfloat complex_float;'
+typedefs['complex_double'] = 'typedef npy_cdouble complex_double;'
 typedefs['string'] = """typedef char * string;"""
 typedefs['character'] = """typedef char character;"""
 
@@ -288,15 +287,15 @@ cppmacros['pyobj_from_double1'] = """
 #define pyobj_from_double1(v) (PyFloat_FromDouble(v))"""
 cppmacros['pyobj_from_float1'] = """
 #define pyobj_from_float1(v) (PyFloat_FromDouble(v))"""
-needs['pyobj_from_complex_long_double1'] = ['complex_long_double']
+needs['pyobj_from_complex_long_double1'] = ['complex_long_double', 'npy_math.h']
 cppmacros['pyobj_from_complex_long_double1'] = """
-#define pyobj_from_complex_long_double1(v) (PyComplex_FromDoubles(v.r,v.i))"""
-needs['pyobj_from_complex_double1'] = ['complex_double']
+#define pyobj_from_complex_long_double1(v) (PyComplex_FromDoubles((double)npy_creall(v),(double)npy_cimagl(v)))"""
+needs['pyobj_from_complex_double1'] = ['complex_double', 'npy_math.h']
 cppmacros['pyobj_from_complex_double1'] = """
-#define pyobj_from_complex_double1(v) (PyComplex_FromDoubles(v.r,v.i))"""
-needs['pyobj_from_complex_float1'] = ['complex_float']
+#define pyobj_from_complex_double1(v) (PyComplex_FromDoubles(npy_creal(v),npy_cimag(v)))"""
+needs['pyobj_from_complex_float1'] = ['complex_float', 'npy_math.h']
 cppmacros['pyobj_from_complex_float1'] = """
-#define pyobj_from_complex_float1(v) (PyComplex_FromDoubles(v.r,v.i))"""
+#define pyobj_from_complex_float1(v) (PyComplex_FromDoubles((double)npy_crealf(v),(double)npy_cimagf(v)))"""
 needs['pyobj_from_string1'] = ['string']
 cppmacros['pyobj_from_string1'] = """
 #define pyobj_from_string1(v) (PyUnicode_FromString((char *)v))"""
@@ -340,42 +339,56 @@ cppmacros['TRYPYARRAYTEMPLATE'] = """
         return 1
 """
 
-needs['TRYCOMPLEXPYARRAYTEMPLATE'] = ['PRINTPYOBJERR']
+needs['TRYCOMPLEXPYARRAYTEMPLATE'] = ['PRINTPYOBJERR', 'npy_math.h']
 cppmacros['TRYCOMPLEXPYARRAYTEMPLATE'] = """
 #define TRYCOMPLEXPYARRAYTEMPLATEOBJECT case NPY_OBJECT: PyArray_SETITEM(arr, PyArray_DATA(arr), pyobj_from_complex_ ## ctype ## 1((*v))); break;
+/* Helper to extract real/imag from complex value via cast to npy_cdouble */
+static inline double _f2py_creal_as_double(const void *p, int typenum) {
+    if (typenum == NPY_CFLOAT) return (double)npy_crealf(*(const npy_cfloat *)p);
+    if (typenum == NPY_CLONGDOUBLE) return (double)npy_creall(*(const npy_clongdouble *)p);
+    return npy_creal(*(const npy_cdouble *)p);
+}
+static inline double _f2py_cimag_as_double(const void *p, int typenum) {
+    if (typenum == NPY_CFLOAT) return (double)npy_cimagf(*(const npy_cfloat *)p);
+    if (typenum == NPY_CLONGDOUBLE) return (double)npy_cimagl(*(const npy_clongdouble *)p);
+    return npy_cimag(*(const npy_cdouble *)p);
+}
 #define TRYCOMPLEXPYARRAYTEMPLATE(ctype,typecode)\\
         PyArrayObject *arr = NULL;\\
+        double _re, _im;\\
         if (!obj) return -2;\\
         if (!PyArray_Check(obj)) return -1;\\
         if (!(arr=(PyArrayObject *)obj)) {fprintf(stderr,\"TRYCOMPLEXPYARRAYTEMPLATE:\");PRINTPYOBJERR(obj);return 0;}\\
+        _re = _f2py_creal_as_double(v, typecode == 'F' ? NPY_CFLOAT : (typecode == 'D' ? NPY_CDOUBLE : NPY_CLONGDOUBLE));\\
+        _im = _f2py_cimag_as_double(v, typecode == 'F' ? NPY_CFLOAT : (typecode == 'D' ? NPY_CDOUBLE : NPY_CLONGDOUBLE));\\
         if (PyArray_DESCR(arr)->type==typecode) {\\
-            *(ctype *)(PyArray_DATA(arr))=(*v).r;\\
-            *(ctype *)(PyArray_DATA(arr)+sizeof(ctype))=(*v).i;\\
+            *(ctype *)(PyArray_DATA(arr))=(ctype)_re;\\
+            *(ctype *)(PyArray_DATA(arr)+sizeof(ctype))=(ctype)_im;\\
             return 1;\\
         }\\
         switch (PyArray_TYPE(arr)) {\\
-                case NPY_CDOUBLE: *(npy_double *)(PyArray_DATA(arr))=(*v).r;\\
-                                  *(npy_double *)(PyArray_DATA(arr)+sizeof(npy_double))=(*v).i;\\
+                case NPY_CDOUBLE: npy_csetreal((npy_cdouble *)PyArray_DATA(arr), _re);\\
+                                  npy_csetimag((npy_cdouble *)PyArray_DATA(arr), _im);\\
                                   break;\\
-                case NPY_CFLOAT: *(npy_float *)(PyArray_DATA(arr))=(*v).r;\\
-                                 *(npy_float *)(PyArray_DATA(arr)+sizeof(npy_float))=(*v).i;\\
+                case NPY_CFLOAT: npy_csetrealf((npy_cfloat *)PyArray_DATA(arr), (float)_re);\\
+                                 npy_csetimagf((npy_cfloat *)PyArray_DATA(arr), (float)_im);\\
                                  break;\\
-                case NPY_DOUBLE: *(npy_double *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_LONG: *(npy_long *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_FLOAT: *(npy_float *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_INT: *(npy_int *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_SHORT: *(npy_short *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_UBYTE: *(npy_ubyte *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_BYTE: *(npy_byte *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_BOOL: *(npy_bool *)(PyArray_DATA(arr))=((*v).r!=0 && (*v).i!=0); break;\\
-                case NPY_USHORT: *(npy_ushort *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_UINT: *(npy_uint *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_ULONG: *(npy_ulong *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_LONGLONG: *(npy_longlong *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_ULONGLONG: *(npy_ulonglong *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_LONGDOUBLE: *(npy_longdouble *)(PyArray_DATA(arr))=(*v).r; break;\\
-                case NPY_CLONGDOUBLE: *(npy_longdouble *)(PyArray_DATA(arr))=(*v).r;\\
-                                      *(npy_longdouble *)(PyArray_DATA(arr)+sizeof(npy_longdouble))=(*v).i;\\
+                case NPY_DOUBLE: *(npy_double *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_LONG: *(npy_long *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_FLOAT: *(npy_float *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_INT: *(npy_int *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_SHORT: *(npy_short *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_UBYTE: *(npy_ubyte *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_BYTE: *(npy_byte *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_BOOL: *(npy_bool *)(PyArray_DATA(arr))=(_re!=0 && _im!=0); break;\\
+                case NPY_USHORT: *(npy_ushort *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_UINT: *(npy_uint *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_ULONG: *(npy_ulong *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_LONGLONG: *(npy_longlong *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_ULONGLONG: *(npy_ulonglong *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_LONGDOUBLE: *(npy_longdouble *)(PyArray_DATA(arr))=_re; break;\\
+                case NPY_CLONGDOUBLE: npy_csetreall((npy_clongdouble *)PyArray_DATA(arr), (npy_longdouble)_re);\\
+                                      npy_csetimagl((npy_clongdouble *)PyArray_DATA(arr), (npy_longdouble)_im);\\
                                       break;\\
                 case NPY_OBJECT: PyArray_SETITEM(arr, PyArray_DATA(arr), pyobj_from_complex_ ## ctype ## 1((*v))); break;\\
                 default: return -2;\\
@@ -1133,7 +1146,7 @@ cfuncs['complex_long_double_from_pyobj'] = """
 static int
 complex_long_double_from_pyobj(complex_long_double* v, PyObject *obj, const char *errmess)
 {
-    complex_double cd = {0.0,0.0};
+    complex_double cd = npy_cpack(0.0, 0.0);
     if (PyArray_CheckScalar(obj)){
         if PyArray_IsScalar(obj, CLongDouble) {
             PyArray_ScalarAsCtype(obj, v);
@@ -1142,15 +1155,16 @@ complex_long_double_from_pyobj(complex_long_double* v, PyObject *obj, const char
         else if (PyArray_Check(obj)) {
             PyArrayObject *arr = (PyArrayObject *)obj;
             if (PyArray_TYPE(arr)==NPY_CLONGDOUBLE) {
-                (*v).r = npy_creall(*(((npy_clongdouble *)PyArray_DATA(arr))));
-                (*v).i = npy_cimagl(*(((npy_clongdouble *)PyArray_DATA(arr))));
+                npy_clongdouble tmp = *(npy_clongdouble *)PyArray_DATA(arr);
+                npy_csetreall(v, npy_creall(tmp));
+                npy_csetimagl(v, npy_cimagl(tmp));
                 return 1;
             }
         }
     }
     if (complex_double_from_pyobj(&cd,obj,errmess)) {
-        (*v).r = (long_double)cd.r;
-        (*v).i = (long_double)cd.i;
+        npy_csetreall(v, (long_double)npy_creal(cd));
+        npy_csetimagl(v, (long_double)npy_cimag(cd));
         return 1;
     }
     return 0;
@@ -1165,22 +1179,22 @@ complex_double_from_pyobj(complex_double* v, PyObject *obj, const char *errmess)
     Py_complex c;
     if (PyComplex_Check(obj)) {
         c = PyComplex_AsCComplex(obj);
-        (*v).r = c.real;
-        (*v).i = c.imag;
+        npy_csetreal(v, c.real);
+        npy_csetimag(v, c.imag);
         return 1;
     }
     if (PyArray_IsScalar(obj, ComplexFloating)) {
         if (PyArray_IsScalar(obj, CFloat)) {
-            npy_cfloat new;
-            PyArray_ScalarAsCtype(obj, &new);
-            (*v).r = (double)npy_crealf(new);
-            (*v).i = (double)npy_cimagf(new);
+            npy_cfloat tmp;
+            PyArray_ScalarAsCtype(obj, &tmp);
+            npy_csetreal(v, (double)npy_crealf(tmp));
+            npy_csetimag(v, (double)npy_cimagf(tmp));
         }
         else if (PyArray_IsScalar(obj, CLongDouble)) {
-            npy_clongdouble new;
-            PyArray_ScalarAsCtype(obj, &new);
-            (*v).r = (double)npy_creall(new);
-            (*v).i = (double)npy_cimagl(new);
+            npy_clongdouble tmp;
+            PyArray_ScalarAsCtype(obj, &tmp);
+            npy_csetreal(v, (double)npy_creall(tmp));
+            npy_csetimag(v, (double)npy_cimagl(tmp));
         }
         else { /* if (PyArray_IsScalar(obj, CDouble)) */
             PyArray_ScalarAsCtype(obj, v);
@@ -1198,20 +1212,21 @@ complex_double_from_pyobj(complex_double* v, PyObject *obj, const char *errmess)
         if (arr == NULL) {
             return 0;
         }
-        (*v).r = npy_creal(*(((npy_cdouble *)PyArray_DATA(arr))));
-        (*v).i = npy_cimag(*(((npy_cdouble *)PyArray_DATA(arr))));
+        npy_cdouble tmp = *(npy_cdouble *)PyArray_DATA(arr);
+        npy_csetreal(v, npy_creal(tmp));
+        npy_csetimag(v, npy_cimag(tmp));
         Py_DECREF(arr);
         return 1;
     }
     /* Python does not provide PyNumber_Complex function :-( */
-    (*v).i = 0.0;
+    npy_csetimag(v, 0.0);
     if (PyFloat_Check(obj)) {
-        (*v).r = PyFloat_AsDouble(obj);
-        return !((*v).r == -1.0 && PyErr_Occurred());
+        npy_csetreal(v, PyFloat_AsDouble(obj));
+        return !(npy_creal(*v) == -1.0 && PyErr_Occurred());
     }
     if (PyLong_Check(obj)) {
-        (*v).r = PyLong_AsDouble(obj);
-        return !((*v).r == -1.0 && PyErr_Occurred());
+        npy_csetreal(v, PyLong_AsDouble(obj));
+        return !(npy_creal(*v) == -1.0 && PyErr_Occurred());
     }
     if (PySequence_Check(obj) && !(PyBytes_Check(obj) || PyUnicode_Check(obj))) {
         PyObject *tmp = PySequence_GetItem(obj,0);
@@ -1240,10 +1255,10 @@ cfuncs['complex_float_from_pyobj'] = """
 static int
 complex_float_from_pyobj(complex_float* v,PyObject *obj,const char *errmess)
 {
-    complex_double cd={0.0,0.0};
+    complex_double cd = npy_cpack(0.0, 0.0);
     if (complex_double_from_pyobj(&cd,obj,errmess)) {
-        (*v).r = (float)cd.r;
-        (*v).i = (float)cd.i;
+        npy_csetrealf(v, (float)npy_creal(cd));
+        npy_csetimagf(v, (float)npy_cimag(cd));
         return 1;
     }
     return 0;

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -353,15 +353,15 @@ static inline double _f2py_cimag_as_double(const void *p, int typenum) {
     if (typenum == NPY_CLONGDOUBLE) return (double)npy_cimagl(*(const npy_clongdouble *)p);
     return npy_cimag(*(const npy_cdouble *)p);
 }
-#define TRYCOMPLEXPYARRAYTEMPLATE(ctype,typecode)\\
+#define TRYCOMPLEXPYARRAYTEMPLATE(ctype,typenum)\\
         PyArrayObject *arr = NULL;\\
         double _re, _im;\\
         if (!obj) return -2;\\
         if (!PyArray_Check(obj)) return -1;\\
         if (!(arr=(PyArrayObject *)obj)) {fprintf(stderr,\"TRYCOMPLEXPYARRAYTEMPLATE:\");PRINTPYOBJERR(obj);return 0;}\\
-        _re = _f2py_creal_as_double(v, typecode == 'F' ? NPY_CFLOAT : (typecode == 'D' ? NPY_CDOUBLE : NPY_CLONGDOUBLE));\\
-        _im = _f2py_cimag_as_double(v, typecode == 'F' ? NPY_CFLOAT : (typecode == 'D' ? NPY_CDOUBLE : NPY_CLONGDOUBLE));\\
-        if (PyArray_DESCR(arr)->type==typecode) {\\
+        _re = _f2py_creal_as_double(v, typenum);\\
+        _im = _f2py_cimag_as_double(v, typenum);\\
+        if (PyArray_TYPE(arr)==typenum) {\\
             *(ctype *)(PyArray_DATA(arr))=(ctype)_re;\\
             *(ctype *)(PyArray_DATA(arr)+sizeof(ctype))=(ctype)_im;\\
             return 1;\\
@@ -1322,11 +1322,11 @@ cfuncs[
 needs['try_pyarr_from_complex_float'] = [
     'pyobj_from_complex_float1', 'TRYCOMPLEXPYARRAYTEMPLATE', 'complex_float']
 cfuncs[
-    'try_pyarr_from_complex_float'] = 'static int try_pyarr_from_complex_float(PyObject* obj,complex_float* v) {\n    TRYCOMPLEXPYARRAYTEMPLATE(float,\'F\');\n}\n'
+    'try_pyarr_from_complex_float'] = 'static int try_pyarr_from_complex_float(PyObject* obj,complex_float* v) {\n    TRYCOMPLEXPYARRAYTEMPLATE(float,NPY_CFLOAT);\n}\n'
 needs['try_pyarr_from_complex_double'] = [
     'pyobj_from_complex_double1', 'TRYCOMPLEXPYARRAYTEMPLATE', 'complex_double']
 cfuncs[
-    'try_pyarr_from_complex_double'] = 'static int try_pyarr_from_complex_double(PyObject* obj,complex_double* v) {\n    TRYCOMPLEXPYARRAYTEMPLATE(double,\'D\');\n}\n'
+    'try_pyarr_from_complex_double'] = 'static int try_pyarr_from_complex_double(PyObject* obj,complex_double* v) {\n    TRYCOMPLEXPYARRAYTEMPLATE(double,NPY_CDOUBLE);\n}\n'
 
 
 needs['create_cb_arglist'] = ['CFUNCSMESS', 'PRINTPYOBJERR', 'MINMAX']


### PR DESCRIPTION
<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Replaces custom complex struct definitions (struct {T r,i;}) with the `npy_cfloat`, `npy_cdouble`, `npy_clongdouble` types. Updates accessor patterns from .r/.i to `npy_creal/npy_cimag/npy_csetreal/npy_csetimag`. Replaces `{0.0,0.0}` initializers with `npy_cpack()`.

The `TRYCOMPLEXPYARRAYTEMPLATE` macro now uses helper functions to extract real/imag parts as doubles, since the `npy` accessor functions are type-specific while the macro is type-generic.

Closes #19996
