### PR TITLE
MAINT: Deprecate PyArray_BufferConverter and remove Python 2 buffer protocol remnants

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -595,14 +595,13 @@ From other objects
         PyObject* buf, PyArray_Descr* dtype, npy_intp count, npy_intp offset)
 
     Construct a one-dimensional ndarray of a single type from an
-    object, ``buf``, that exports the (single-segment) buffer protocol
-    (or has an attribute __buffer\__ that returns an object that
-    exports the buffer protocol). A writeable buffer will be tried
-    first followed by a read- only buffer. The :c:data:`NPY_ARRAY_WRITEABLE`
+    object, ``buf``, that exports the modern buffer protocol.
+    A writeable buffer will be tried
+    first followed by a read-only buffer. The :c:data:`NPY_ARRAY_WRITEABLE`
     flag of the returned array will reflect which one was
     successful. The data is assumed to start at ``offset`` bytes from
     the start of the memory location for the object. The type of the
-    data in the buffer will be interpreted depending on the data- type
+    data in the buffer will be interpreted depending on the data-type
     descriptor, ``dtype.`` If ``count`` is negative then it will be
     determined from the size of the buffer and the requested itemsize,
     otherwise, ``count`` represents how many elements should be
@@ -3858,6 +3857,9 @@ to.
     interpreted as array shapes.
 
 .. c:function:: int PyArray_BufferConverter(PyObject* obj, PyArray_Chunk* buf)
+
+.. deprecated:: 2.5
+    PyArray_BufferConverter is deprecated. Use the standard buffer protocol instead.
 
     Convert any Python object, *obj*, with a (single-segment) buffer
     interface to a variable with members that detail the object's use

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -850,8 +850,6 @@ typedef struct tagPyArrayObject {
 /* Legacy structure for buffer protocol support */
 
 #if defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD
-typedef struct _PyArray_Chunk PyArray_Chunk;
-#else
 typedef struct {
         PyObject_HEAD
         PyObject *base;
@@ -859,6 +857,8 @@ typedef struct {
         npy_intp len;
         int flags;
 } PyArray_Chunk;
+#else
+typedef struct _PyArray_Chunk PyArray_Chunk;
 #endif
 
 typedef struct {

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -847,8 +847,11 @@ typedef struct tagPyArrayObject {
  * compatible with multiple NumPy versions.
  */
 
-/* Mirrors buffer object to ptr */
+/* Legacy structure for buffer protocol support */
 
+#if defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD
+typedef struct _PyArray_Chunk PyArray_Chunk;
+#else
 typedef struct {
         PyObject_HEAD
         PyObject *base;
@@ -856,6 +859,7 @@ typedef struct {
         npy_intp len;
         int flags;
 } PyArray_Chunk;
+#endif
 
 typedef struct {
     NPY_DATETIMEUNIT base;

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -1133,7 +1133,7 @@ array_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
                                      &dims,
                                      PyArray_DescrConverter,
                                      &descr,
-                                     PyArray_BufferConverter,
+                                     PyArray_BufferConverter_Impl,
                                      &buffer,
                                      &offset,
                                      &PyArray_OptionalIntpConverter,

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -19,6 +19,19 @@
 extern "C" {
 #endif
 
+/*
+ * The following is the internal definition of PyArray_Chunk. It is made
+ * opaque in the public headers (ndarraytypes.h) to prevent use by
+ * downstream projects and to eventually remove it from NumPy internals.
+ */
+struct _PyArray_Chunk {
+        PyObject_HEAD
+        PyObject *base;
+        void *ptr;
+        npy_intp len;
+        int flags;
+};
+
 #define error_converting(x)  (((x) == -1) && PyErr_Occurred())
 
 

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -293,14 +293,9 @@ PyArray_AsTypeCopyConverter(PyObject *obj, NPY_ASTYPECOPYMODE *copymode)
  * memory...
  */
 NPY_NO_EXPORT int
-PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
+PyArray_BufferConverter_Impl(PyObject *obj, PyArray_Chunk *buf)
 {
     Py_buffer view;
-
-    if (DEPRECATE("PyArray_BufferConverter is deprecated in NumPy 2.5. "
-                  "Use the standard buffer protocol instead.") < 0) {
-        return NPY_FAIL;
-    }
 
     buf->ptr = NULL;
     buf->flags = NPY_ARRAY_BEHAVED;
@@ -338,6 +333,20 @@ PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
         buf->base = obj;
     }
     return NPY_SUCCEED;
+}
+
+
+/*NUMPY_API
+ * This function will warn. Internally we prefer the _Impl version.
+ */
+NPY_NO_EXPORT int
+PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
+{
+    if (DEPRECATE("PyArray_BufferConverter is deprecated in NumPy 2.5. "
+                  "Use the standard buffer protocol instead.") < 0) {
+        return NPY_FAIL;
+    }
+    return PyArray_BufferConverter_Impl(obj, buf);
 }
 
 /*NUMPY_API

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -297,6 +297,11 @@ PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
 {
     Py_buffer view;
 
+    if (DEPRECATE("PyArray_BufferConverter is deprecated in NumPy 2.5. "
+                  "Use the standard buffer protocol instead.") < 0) {
+        return NPY_FAIL;
+    }
+
     buf->ptr = NULL;
     buf->flags = NPY_ARRAY_BEHAVED;
     buf->base = NULL;

--- a/numpy/_core/src/multiarray/conversion_utils.h
+++ b/numpy/_core/src/multiarray/conversion_utils.h
@@ -33,6 +33,9 @@ NPY_NO_EXPORT int
 PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf);
 
 NPY_NO_EXPORT int
+PyArray_BufferConverter_Impl(PyObject *obj, PyArray_Chunk *buf);
+
+NPY_NO_EXPORT int
 PyArray_BoolConverter(PyObject *object, npy_bool *val);
 
 NPY_NO_EXPORT int


### PR DESCRIPTION
…l remnants

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
Description
Fixes #30813
This PR removes remaining remnants of the legacy Python 2 buffer protocol from NumPy internals and moves related structures toward the modern Python buffer protocol. The changes isolate legacy structures from the public API, introduce internal definitions where still required for compatibility, and formally deprecate legacy conversion helpers.

These updates reduce technical debt while preserving source and binary compatibility for downstream projects.
Changes
Public header modernization
numpy/_core/include/numpy/ndarraytypes.h
Make PyArray_Chunk opaque when building NumPy internally (NPY_INTERNAL_BUILD).
Prevent internal code from relying on the legacy public definition while maintaining compatibility for external extensions.
Internal compatibility layer
numpy/_core/src/multiarray/common.h
Added a binary-compatible internal definition of:

struct _PyArray_Chunk
Ensures internal code paths such as the ndarray constructor (array_new) continue to work during the transition.
Deprecation of legacy converters
numpy/_core/src/multiarray/conversion_utils.c

Added a deprecation warning to:

PyArray_BufferConverter

Marked as deprecated starting in NumPy 2.5.

Users are encouraged to use the standard Python buffer protocol instead.

Documentation updates

doc/source/reference/c-api/array.rst

Updated documentation for PyArray_FromBuffer.

Removed references to the legacy __buffer__ attribute and the single-segment buffer protocol.

Added:

.. deprecated:: 2.5

for PyArray_BufferConverter.

Verification

Confirmed np.ndarray(..., buffer=...) triggers the expected deprecation warning.

Verified np.frombuffer continues to work normally without warnings.

Ensured existing internal usage of PyArray_Chunk remains functional.

Motivation
These changes remove remaining dependencies on legacy Python 2 buffer protocol mechanisms while preserving compatibility with existing internal code paths. This reduces technical debt and moves NumPy further toward exclusive use of the modern Python buffer protocol.