### PR TITLE
BUG: f2py: restore .r/.i field access on complex types via union typedef

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -89,9 +89,9 @@ typedefs['long_double'] = """
 typedef long double long_double;
 #endif
 """
-typedefs['complex_long_double'] = 'typedef npy_clongdouble complex_long_double;'
-typedefs['complex_float'] = 'typedef npy_cfloat complex_float;'
-typedefs['complex_double'] = 'typedef npy_cdouble complex_double;'
+typedefs['complex_long_double'] = 'typedef union { struct {long double r,i;}; npy_clongdouble _npy; } complex_long_double;'
+typedefs['complex_float'] = 'typedef union { struct {float r,i;}; npy_cfloat _npy; } complex_float;'
+typedefs['complex_double'] = 'typedef union { struct {double r,i;}; npy_cdouble _npy; } complex_double;'
 typedefs['string'] = """typedef char * string;"""
 typedefs['character'] = """typedef char character;"""
 
@@ -289,13 +289,13 @@ cppmacros['pyobj_from_float1'] = """
 #define pyobj_from_float1(v) (PyFloat_FromDouble(v))"""
 needs['pyobj_from_complex_long_double1'] = ['complex_long_double', 'npy_math.h']
 cppmacros['pyobj_from_complex_long_double1'] = """
-#define pyobj_from_complex_long_double1(v) (PyComplex_FromDoubles((double)npy_creall(v),(double)npy_cimagl(v)))"""
+#define pyobj_from_complex_long_double1(v) (PyComplex_FromDoubles((double)npy_creall(v._npy),(double)npy_cimagl(v._npy)))"""
 needs['pyobj_from_complex_double1'] = ['complex_double', 'npy_math.h']
 cppmacros['pyobj_from_complex_double1'] = """
-#define pyobj_from_complex_double1(v) (PyComplex_FromDoubles(npy_creal(v),npy_cimag(v)))"""
+#define pyobj_from_complex_double1(v) (PyComplex_FromDoubles(npy_creal(v._npy),npy_cimag(v._npy)))"""
 needs['pyobj_from_complex_float1'] = ['complex_float', 'npy_math.h']
 cppmacros['pyobj_from_complex_float1'] = """
-#define pyobj_from_complex_float1(v) (PyComplex_FromDoubles((double)npy_crealf(v),(double)npy_cimagf(v)))"""
+#define pyobj_from_complex_float1(v) (PyComplex_FromDoubles((double)npy_crealf(v._npy),(double)npy_cimagf(v._npy)))"""
 needs['pyobj_from_string1'] = ['string']
 cppmacros['pyobj_from_string1'] = """
 #define pyobj_from_string1(v) (PyUnicode_FromString((char *)v))"""
@@ -1146,7 +1146,7 @@ cfuncs['complex_long_double_from_pyobj'] = """
 static int
 complex_long_double_from_pyobj(complex_long_double* v, PyObject *obj, const char *errmess)
 {
-    complex_double cd = npy_cpack(0.0, 0.0);
+    complex_double cd = {.r=0, .i=0};
     if (PyArray_CheckScalar(obj)){
         if PyArray_IsScalar(obj, CLongDouble) {
             PyArray_ScalarAsCtype(obj, v);
@@ -1156,15 +1156,15 @@ complex_long_double_from_pyobj(complex_long_double* v, PyObject *obj, const char
             PyArrayObject *arr = (PyArrayObject *)obj;
             if (PyArray_TYPE(arr)==NPY_CLONGDOUBLE) {
                 npy_clongdouble tmp = *(npy_clongdouble *)PyArray_DATA(arr);
-                npy_csetreall(v, npy_creall(tmp));
-                npy_csetimagl(v, npy_cimagl(tmp));
+                npy_csetreall(&v->_npy, npy_creall(tmp));
+                npy_csetimagl(&v->_npy, npy_cimagl(tmp));
                 return 1;
             }
         }
     }
     if (complex_double_from_pyobj(&cd,obj,errmess)) {
-        npy_csetreall(v, (long_double)npy_creal(cd));
-        npy_csetimagl(v, (long_double)npy_cimag(cd));
+        npy_csetreall(&v->_npy, (long_double)npy_creal(cd._npy));
+        npy_csetimagl(&v->_npy, (long_double)npy_cimag(cd._npy));
         return 1;
     }
     return 0;
@@ -1179,22 +1179,22 @@ complex_double_from_pyobj(complex_double* v, PyObject *obj, const char *errmess)
     Py_complex c;
     if (PyComplex_Check(obj)) {
         c = PyComplex_AsCComplex(obj);
-        npy_csetreal(v, c.real);
-        npy_csetimag(v, c.imag);
+        npy_csetreal(&v->_npy, c.real);
+        npy_csetimag(&v->_npy, c.imag);
         return 1;
     }
     if (PyArray_IsScalar(obj, ComplexFloating)) {
         if (PyArray_IsScalar(obj, CFloat)) {
             npy_cfloat tmp;
             PyArray_ScalarAsCtype(obj, &tmp);
-            npy_csetreal(v, (double)npy_crealf(tmp));
-            npy_csetimag(v, (double)npy_cimagf(tmp));
+            npy_csetreal(&v->_npy, (double)npy_crealf(tmp));
+            npy_csetimag(&v->_npy, (double)npy_cimagf(tmp));
         }
         else if (PyArray_IsScalar(obj, CLongDouble)) {
             npy_clongdouble tmp;
             PyArray_ScalarAsCtype(obj, &tmp);
-            npy_csetreal(v, (double)npy_creall(tmp));
-            npy_csetimag(v, (double)npy_cimagl(tmp));
+            npy_csetreal(&v->_npy, (double)npy_creall(tmp));
+            npy_csetimag(&v->_npy, (double)npy_cimagl(tmp));
         }
         else { /* if (PyArray_IsScalar(obj, CDouble)) */
             PyArray_ScalarAsCtype(obj, v);
@@ -1213,20 +1213,20 @@ complex_double_from_pyobj(complex_double* v, PyObject *obj, const char *errmess)
             return 0;
         }
         npy_cdouble tmp = *(npy_cdouble *)PyArray_DATA(arr);
-        npy_csetreal(v, npy_creal(tmp));
-        npy_csetimag(v, npy_cimag(tmp));
+        npy_csetreal(&v->_npy, npy_creal(tmp));
+        npy_csetimag(&v->_npy, npy_cimag(tmp));
         Py_DECREF(arr);
         return 1;
     }
     /* Python does not provide PyNumber_Complex function :-( */
-    npy_csetimag(v, 0.0);
+    npy_csetimag(&v->_npy, 0.0);
     if (PyFloat_Check(obj)) {
-        npy_csetreal(v, PyFloat_AsDouble(obj));
-        return !(npy_creal(*v) == -1.0 && PyErr_Occurred());
+        npy_csetreal(&v->_npy, PyFloat_AsDouble(obj));
+        return !(npy_creal(v->_npy) == -1.0 && PyErr_Occurred());
     }
     if (PyLong_Check(obj)) {
-        npy_csetreal(v, PyLong_AsDouble(obj));
-        return !(npy_creal(*v) == -1.0 && PyErr_Occurred());
+        npy_csetreal(&v->_npy, PyLong_AsDouble(obj));
+        return !(npy_creal(v->_npy) == -1.0 && PyErr_Occurred());
     }
     if (PySequence_Check(obj) && !(PyBytes_Check(obj) || PyUnicode_Check(obj))) {
         PyObject *tmp = PySequence_GetItem(obj,0);
@@ -1255,10 +1255,10 @@ cfuncs['complex_float_from_pyobj'] = """
 static int
 complex_float_from_pyobj(complex_float* v,PyObject *obj,const char *errmess)
 {
-    complex_double cd = npy_cpack(0.0, 0.0);
+    complex_double cd = {.r=0, .i=0};
     if (complex_double_from_pyobj(&cd,obj,errmess)) {
-        npy_csetrealf(v, (float)npy_creal(cd));
-        npy_csetimagf(v, (float)npy_cimag(cd));
+        npy_csetrealf(&v->_npy, (float)npy_creal(cd._npy));
+        npy_csetimagf(&v->_npy, (float)npy_cimag(cd._npy));
         return 1;
     }
     return 0;

--- a/numpy/f2py/tests/src/regression/complex_struct_compat.f90
+++ b/numpy/f2py/tests/src/regression/complex_struct_compat.f90
@@ -1,0 +1,8 @@
+      subroutine zero_imag(c, n)
+        complex*16, intent(inout) :: c(n)
+        integer, intent(in) :: n
+        integer :: k
+        do k = 1, n
+          c(k) = cmplx(dble(c(k)), 0.0d0, kind=8)
+        end do
+      end subroutine

--- a/numpy/f2py/tests/src/regression/complex_struct_compat.pyf
+++ b/numpy/f2py/tests/src/regression/complex_struct_compat.pyf
@@ -1,0 +1,12 @@
+python module _complex_struct_compat_test
+    interface
+    subroutine zero_imag(c, n)
+        callstatement { int k; for(k=0;k<n;k++) (c+k)->i = 0.0; }
+        callprotoargument complex_double*, int*
+
+        complex*16 intent(inout), dimension(n) :: c
+        integer intent(hide), depend(c) :: n = shape(c,0)
+
+    end subroutine zero_imag
+    end interface
+end python module _complex_struct_compat_test

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -176,6 +176,23 @@ def test_gh25784():
 
 
 @pytest.mark.slow
+class TestComplexStructCompat(util.F2PyTest):
+    # Check that .r/.i field access works on complex_double pointers in
+    # callstatements (scipy compatibility, gh-30966 follow-up)
+    sources = [
+        util.getpath("tests", "src", "regression", "complex_struct_compat.pyf"),
+        util.getpath("tests", "src", "regression", "complex_struct_compat.f90"),
+    ]
+    module_name = "_complex_struct_compat_test"
+
+    def test_complex_struct_field_access(self):
+        c = np.array([1 + 2j, 3 + 4j, 5 + 6j], dtype=np.complex128)
+        self.module.zero_imag(c)
+        npt.assert_array_equal(c.imag, [0.0, 0.0, 0.0])
+        npt.assert_array_equal(c.real, [1.0, 3.0, 5.0])
+
+
+@pytest.mark.slow
 class TestAssignmentOnlyModules(util.F2PyTest):
     # Ensure that variables are exposed without functions or subroutines in a module
     sources = [util.getpath("tests", "src", "regression", "assignOnlyModule.f90")]


### PR DESCRIPTION
#30966 changed `f2py`'s complex_double/complex_float/complex_long_double typedefs from `struct {T r,i;}` to direct `npy_cdouble`/`npy_cfloat`/ `npy_clongdouble` aliases.


and forgot to check downstream. In this case it broke scipy https://github.com/scipy/scipy/issues/24775 because .pyf callstatements use `(a+k)->r` and `(a+k)->i` on complex_double* pointers, and npy_cdouble (double _Complex) has no .r/.i fields as reported by @lucascolley (thanks!)

Fix by using a union containing an anonymous struct (for .r/.i backward compat) and the native npy_* type (for layout guarantee):

    typedef union { struct {double r,i;}; npy_cdouble _npy; } complex_double;

Internal `_from_pyobj` functions and `pyobj_from` macros now access the `_npy` member for npy_cset*/npy_creal*/npy_cimag* calls, while `rules.py` and `callstatement .r/.i` patterns work unchanged through the anonymous struct.

Closes scipy/scipy#24775. Tested on SciPy this time 😅 

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
