### PR TITLE
ENH: Add internal real/imag ufuncs and use them for the attrs

### DIFF
--- a/doc/release/upcoming_changes/30984.capi.rst
+++ b/doc/release/upcoming_changes/30984.capi.rst
@@ -1,0 +1,4 @@
+* It is now possible to register ``".real"`` and ``".imag"``
+  ArrayMethods via ``PyUFunc_AddLoopsFromSpecs``.  These will
+  be used for ``.imag`` and ``.real`` and should (presumably)
+  set ``*view_offset`` in their ``resolve_descriptors`` function.

--- a/doc/release/upcoming_changes/30984.capi.rst
+++ b/doc/release/upcoming_changes/30984.capi.rst
@@ -1,4 +1,5 @@
-* It is now possible to register ``".real"`` and ``".imag"``
+* It is now possible to register ``"real"`` and ``"imag"``
   ArrayMethods via ``PyUFunc_AddLoopsFromSpecs``.  These will
-  be used for ``imag`` and ``real`` and should (presumably)
-  set ``*view_offset`` in their ``resolve_descriptors`` function.
+  be used for ``imag`` and ``real`` and should normally
+  set ``*view_offset`` in their ``resolve_descriptors`` function
+  to allow the array attributes to return views.

--- a/doc/release/upcoming_changes/30984.capi.rst
+++ b/doc/release/upcoming_changes/30984.capi.rst
@@ -1,4 +1,4 @@
 * It is now possible to register ``".real"`` and ``".imag"``
   ArrayMethods via ``PyUFunc_AddLoopsFromSpecs``.  These will
-  be used for ``.imag`` and ``.real`` and should (presumably)
+  be used for ``imag`` and ``real`` and should (presumably)
   set ``*view_offset`` in their ``resolve_descriptors`` function.

--- a/doc/release/upcoming_changes/30984.change.rst
+++ b/doc/release/upcoming_changes/30984.change.rst
@@ -1,0 +1,15 @@
+``object`` dtype in ``.real`` and ``.imag`` and related functions
+-----------------------------------------------------------------
+The array attributes ``.real`` and ``.imag`` now behave differently
+for object arrays and return ``getattr(element, "real", element)``
+or ``getattr(element, "imag", 0)`` elementwise.
+Additionally, the return for both is now read-only to avoid possible
+in-place changes having no effect.
+
+This change also affects ``np.isreal()`` which uses ``arr.imag``.
+
+Previously, ``.imag`` always returned ``0`` while ``.real`` returned
+the original array unmodified.
+The new behavior now returnes the correct values for complex Python
+objects but may also lead to surprises for example if ``element.real()``
+is a method and not a property.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1899,8 +1899,9 @@ with the rest of the ArrayMethod API.
             entry points, ``(module ':')? (object '.')* name``, with ``numpy``
             the default module. Examples: ``sin``, ``strings.str_len``,
             ``numpy.strings:str_len``.
-            ``"sort"``, ``"argsort"``, ``".real"``, ``".imag"`` and specific names
-            as they do not correspond directly to ufuncs.
+            Note that some names are supported but do not directly correspond
+            to ufuncs: ``"sort"``, ``"argsort"``, ``"real"``, ``"imag"``.
+            (These do use ufunc-likes or even ufuncs internally.)
 
         .. c:member:: PyArrayMethod_Spec *spec
 
@@ -1960,7 +1961,7 @@ with the rest of the ArrayMethod API.
         skipping a recursion protection step.
         This mainly allows the promoter to add new loop to the ufunc that must
         now match instead of the promoter itself.
-        (Normally, a promoter must modify)
+        (Normally, a promoter must modify the DTypes help find the right loop.)
 
 .. c:function:: int PyUFunc_GiveFloatingpointErrors( \
                         const char *name, int fpe_errors)

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1942,6 +1942,22 @@ with the rest of the ArrayMethod API.
    attempt a search for a new loop or promoter that can accomplish the operation
    by casting the inputs to the "promoted" DTypes.
 
+    A promoter should honor ``signature[]`` (if set). A promoter must return ``-1``
+    on failure. A Python error may be set but is not required (a general error is
+    set in either paths, although the original error is chained).
+    A promoter must return ``0`` or ``1`` on success.  NumPy normally checks that
+    ``new_op_dtypes`` are different from ``op_dtypes`` to prevent recursion.
+    This check is skipped if the promoter returns ``1``, which allows the promoter
+    to add a new loop (when adding a new loop, ``new_op_dtypes`` should be identical
+    to ``op_dtypes``).
+
+    .. versionchanged:: 2.5
+        After 2.5 a return of ``1`` indicates that the promoter was successful
+        skipping a recursion protection step.
+        This mainly allows the promoter to add new loop to the ufunc that must
+        now match instead of the promoter itself.
+        (Normally, a promoter must modify)
+
 .. c:function:: int PyUFunc_GiveFloatingpointErrors( \
                         const char *name, int fpe_errors)
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1899,6 +1899,8 @@ with the rest of the ArrayMethod API.
             entry points, ``(module ':')? (object '.')* name``, with ``numpy``
             the default module. Examples: ``sin``, ``strings.str_len``,
             ``numpy.strings:str_len``.
+            ``"sort"``, ``"argsort"``, ``".real"``, ``".imag"`` and specific names
+            as they do not correspond directly to ufuncs.
 
         .. c:member:: PyArrayMethod_Spec *spec
 
@@ -1912,6 +1914,8 @@ with the rest of the ArrayMethod API.
     Add multiple loops to ufuncs from ArrayMethod specs. This also
     handles the registration of methods for the ufunc-like functions
     ``sort`` and ``argsort``. See :ref:`array-methods-sorting` for details.
+    As well as for the array attributes ``.real`` and ``.imag`` needed
+    for user defined complex DTypes (with ``".real"`` and ``".imag"`` as names).
 
     The ``slots`` argument must be a  NULL-terminated array of
     `PyUFunc_LoopSlot` (see above), which give the name of the

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1914,9 +1914,9 @@ with the rest of the ArrayMethod API.
 
     Add multiple loops to ufuncs from ArrayMethod specs. This also
     handles the registration of methods for the ufunc-like functions
-    ``sort`` and ``argsort``. See :ref:`array-methods-sorting` for details.
-    As well as for the array attributes ``.real`` and ``.imag`` needed
-    for user defined complex DTypes (with ``".real"`` and ``".imag"`` as names).
+    ``sort`` and ``argsort`` (see :ref:`array-methods-sorting` for details),
+    as well as for the array attributes ``.real`` and ``.imag`` needed
+    for user defined complex DTypes (with ``"real"`` and ``"imag"`` as names).
 
     The ``slots`` argument must be a  NULL-terminated array of
     `PyUFunc_LoopSlot` (see above), which give the name of the

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2666,7 +2666,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('imag',
     The imaginary part of the array.
 
     Returns a view into the original array for complex arrays.
-    For non-compelx ones, returns a zero array of the same dtype.
+    For non-complex arrays, returns a zero array of the same dtype.
     For ``object`` arrays returns elementwise ``.imag`` or ``0``
     if ``.imag`` is undefined.
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -2665,6 +2665,11 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('imag',
     """
     The imaginary part of the array.
 
+    Returns a view into the original array for complex arrays.
+    For non-compelx ones, returns a zero array of the same dtype.
+    For ``object`` arrays returns elementwise ``.imag`` or ``0``
+    if ``.imag`` is undefined.
+
     Examples
     --------
     >>> import numpy as np
@@ -2855,6 +2860,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('ndim',
 add_newdoc('numpy._core.multiarray', 'ndarray', ('real',
     """
     The real part of the array.
+
+    Usually returns a view into the original array, but returns
+    elementwise ``.real`` for arrays of objects.
 
     Examples
     --------

--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -1172,6 +1172,18 @@ defdict = {
           TD(O),
           signature='(n),(n,m)->(m)',
           ),
+# Real and imag ufunc helpers (loops added later):
+'real':
+    Ufunc(1, 1, None,
+          docstrings.get('numpy._core.umath.real'),
+          None,
+          ),
+'imag':
+    Ufunc(1, 1, None,
+          docstrings.get('numpy._core.umath.imag'),
+          None,
+          ),
+# String ufuncs (loops added later):
 'str_len':
     Ufunc(1, 1, Zero,
           docstrings.get('numpy._core.umath.str_len'),

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -4544,8 +4544,8 @@ add_newdoc('numpy._core.umath', 'real',
 
     Notes
     -----
-    This ufunc is used internally in the implement of the `ndarray.real`
-    attribute and `np.real` function which should be used instead.
+    This ufunc is used internally to implement the `ndarray.real`
+    attribute and the `np.real` function. It should not be used directly.
 
     """)
 
@@ -4573,8 +4573,8 @@ add_newdoc('numpy._core.umath', 'imag',
 
     Notes
     -----
-    This ufunc is used internally in the implement of the `ndarray.imag`
-    attribute and `np.imag` function which should be used instead.
+    This ufunc is used internally to implement the `ndarray.imag`
+    attribute and the `np.imag` function. It should not be used directly.
 
     """)
 

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -4524,10 +4524,7 @@ add_newdoc('numpy._core.umath', 'bitwise_count',
 
 add_newdoc('numpy._core.umath', 'real',
     """
-    Returns the real part of the elements in the array. Unlike most ufuncs,
-    the return may be a view into the original array.
-
-    Unlike typical ufuncs, the return is typically a view into the original array.
+    Returns the real part of the elements in the array.
 
     Parameters
     ----------
@@ -4547,8 +4544,8 @@ add_newdoc('numpy._core.umath', 'real',
 
     Notes
     -----
-    This ufunc is used to implement the `ndarray.real` attribute which is usually
-    preferred.
+    This ufunc is used internally in the implement of the `ndarray.real`
+    attribute and `np.real` function which should be used instead.
 
     """)
 
@@ -4576,11 +4573,8 @@ add_newdoc('numpy._core.umath', 'imag',
 
     Notes
     -----
-    This ufunc is used to implement the `ndarray.imag` attribute which is usually
-    preferred. Unlike the attribute, this ufunc raises an error for non-complex
-    inputs.
-    The attribute itself additionally returns a broadcast, read-only array of zeros
-    for known real dtypes.
+    This ufunc is used internally in the implement of the `ndarray.imag`
+    attribute and `np.imag` function which should be used instead.
 
     """)
 

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -4522,6 +4522,68 @@ add_newdoc('numpy._core.umath', 'bitwise_count',
 
     """)
 
+add_newdoc('numpy._core.umath', 'real',
+    """
+    Returns the real part of the elements in the array. Unlike most ufuncs,
+    the return may be a view into the original array.
+
+    Unlike typical ufuncs, the return is typically a view into the original array.
+
+    Parameters
+    ----------
+    x : array_like
+    $PARAMS
+
+    Returns
+    -------
+    y : ndarray
+        Real part of input array.
+        $OUT_SCALAR_1
+
+    See Also
+    --------
+    ndarray.real
+    ndarray.imag
+
+    Notes
+    -----
+    This ufunc is used to implement the `ndarray.real` attribute which is usually
+    preferred.
+
+    """)
+
+add_newdoc('numpy._core.umath', 'imag',
+    """
+    Returns the imaginary part of the elements in the array.
+
+    Unlike typical ufuncs, the return is typically a view into the original array.
+
+    Parameters
+    ----------
+    x : array_like
+    $PARAMS
+
+    Returns
+    -------
+    y : ndarray
+        Complex part of input array or zeros.
+        $OUT_SCALAR_1
+
+    See Also
+    --------
+    ndarray.imag
+    ndarray.real
+
+    Notes
+    -----
+    This ufunc is used to implement the `ndarray.imag` attribute which is usually
+    preferred. Unlike the attribute, this ufunc raises an error for non-complex
+    inputs.
+    The attribute itself additionally returns a broadcast, read-only array of zeros
+    for known real dtypes.
+
+    """)
+
 add_newdoc('numpy._core.umath', 'str_len',
     """
     Returns the length of each element. For byte strings,

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -80,6 +80,7 @@ typedef enum {
      * assume that if set, it also applies to normal operations though!
      */
     NPY_METH_IS_REORDERABLE = 1 << 3,
+    _NPY_METH_IS_CAST = 1 << 4,  /* automatically set for casts */
     /*
      * Private flag for now for *logic* functions.  The logical functions
      * `logical_or` and `logical_and` can always cast the inputs to booleans
@@ -114,18 +115,18 @@ typedef struct PyArrayMethod_Context_tag {
     PyArray_Descr *const *descriptors;
  #if NPY_FEATURE_VERSION > NPY_2_3_API_VERSION
     void * _reserved;
-    /* 
+    /*
      * Optional flag to pass information into the inner loop
      * NPY_ARRAYMETHOD_CONTEXT_FLAGS
      */
     uint64_t flags;
-    
+
     /*
      * Optional run-time parameters to pass to the loop (currently used in sorting).
      * Fixed parameters are expected to be passed via auxdata.
      */
     void *parameters;
-    
+
     /* Structure may grow (this is harmless for DType authors) */
  #endif
 } PyArrayMethod_Context;

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -80,7 +80,6 @@ typedef enum {
      * assume that if set, it also applies to normal operations though!
      */
     NPY_METH_IS_REORDERABLE = 1 << 3,
-    _NPY_METH_IS_CAST = 1 << 4,  /* automatically set for casts */
     /*
      * Private flag for now for *logic* functions.  The logical functions
      * `logical_or` and `logical_and` can always cast the inputs to booleans
@@ -115,18 +114,18 @@ typedef struct PyArrayMethod_Context_tag {
     PyArray_Descr *const *descriptors;
  #if NPY_FEATURE_VERSION > NPY_2_3_API_VERSION
     void * _reserved;
-    /*
+    /* 
      * Optional flag to pass information into the inner loop
      * NPY_ARRAYMETHOD_CONTEXT_FLAGS
      */
     uint64_t flags;
-
+    
     /*
      * Optional run-time parameters to pass to the loop (currently used in sorting).
      * Fixed parameters are expected to be passed via auxdata.
      */
     void *parameters;
-
+    
     /* Structure may grow (this is harmless for DType authors) */
  #endif
 } PyArrayMethod_Context;

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1207,6 +1207,7 @@ src_umath = umath_gen_headers + [
   src_file.process('src/umath/scalarmath.c.src'),
   'src/umath/ufunc_object.c',
   'src/umath/umathmodule.c',
+  'src/umath/real_imag_ufuncs.cpp',
   'src/umath/special_integer_comparisons.cpp',
   'src/umath/string_ufuncs.cpp',
   'src/umath/stringdtype_ufuncs.cpp',

--- a/numpy/_core/src/common/lowlevel_strided_loops.h
+++ b/numpy/_core/src/common/lowlevel_strided_loops.h
@@ -10,10 +10,14 @@
 /* For PyArray_ macros used below */
 #include "numpy/ndarrayobject.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * NOTE: This API should remain private for the time being, to allow
  *       for further refinement.  I think the 'aligned' mechanism
- *       needs changing, for example. 
+ *       needs changing, for example.
  *
  *       Note: Updated in 2018 to distinguish "true" from "uint" alignment.
  */
@@ -786,5 +790,10 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
                     stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1); \
                     stride2 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size2, arr2); \
                 }
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* NUMPY_CORE_SRC_COMMON_LOWLEVEL_STRIDED_LOOPS_H_ */

--- a/numpy/_core/src/common/lowlevel_strided_loops.h
+++ b/numpy/_core/src/common/lowlevel_strided_loops.h
@@ -10,14 +10,10 @@
 /* For PyArray_ macros used below */
 #include "numpy/ndarrayobject.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /*
  * NOTE: This API should remain private for the time being, to allow
  *       for further refinement.  I think the 'aligned' mechanism
- *       needs changing, for example.
+ *       needs changing, for example. 
  *
  *       Note: Updated in 2018 to distinguish "true" from "uint" alignment.
  */
@@ -790,10 +786,5 @@ PyArray_EQUIVALENTLY_ITERABLE_OVERLAP_OK(PyArrayObject *arr1, PyArrayObject *arr
                     stride1 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size1, arr1); \
                     stride2 = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(size2, arr2); \
                 }
-
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif  /* NUMPY_CORE_SRC_COMMON_LOWLEVEL_STRIDED_LOOPS_H_ */

--- a/numpy/_core/src/common/npy_import.h
+++ b/numpy/_core/src/common/npy_import.h
@@ -49,8 +49,6 @@ typedef struct npy_runtime_imports_struct {
     PyObject *_var;
     PyObject *_view_is_safe;
     PyObject *_void_scalar_to_string;
-    PyObject *sort;
-    PyObject *argsort;
 } npy_runtime_imports_struct;
 
 NPY_VISIBILITY_HIDDEN extern npy_runtime_imports_struct npy_runtime_imports;

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -86,7 +86,7 @@ default_resolve_descriptors(
      * abstract ones or unspecified outputs).  We can use the common-dtype
      * operation to provide a default here.
      */
-    if (method->casting == NPY_NO_CASTING && (method->flags & _NPY_METH_IS_CAST)) {
+    if (method->casting == NPY_NO_CASTING) {
         /*
          * By (current) definition no-casting should imply viewable.  This
          * is currently indicated for example for object to object cast.
@@ -129,9 +129,9 @@ is_contiguous(
  * param move_references UNUSED -- listed below but doxygen doesn't see as a parameter
  * @param strides Array of step sizes for each dimension of the arrays involved
  * @param out_loop Output pointer to the function that will perform the strided loop.
- * @param out_transferdata Output pointer to auxiliary data (if any)
+ * @param out_transferdata Output pointer to auxiliary data (if any) 
  *        needed by the out_loop function.
- * @param flags Output pointer to additional flags (if any)
+ * @param flags Output pointer to additional flags (if any) 
  *        needed by the out_loop function
  * @returns 0 on success -1 on failure.
  */

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -86,7 +86,7 @@ default_resolve_descriptors(
      * abstract ones or unspecified outputs).  We can use the common-dtype
      * operation to provide a default here.
      */
-    if (method->casting == NPY_NO_CASTING) {
+    if (method->casting == NPY_NO_CASTING && (method->flags & _NPY_METH_IS_CAST)) {
         /*
          * By (current) definition no-casting should imply viewable.  This
          * is currently indicated for example for object to object cast.
@@ -129,9 +129,9 @@ is_contiguous(
  * param move_references UNUSED -- listed below but doxygen doesn't see as a parameter
  * @param strides Array of step sizes for each dimension of the arrays involved
  * @param out_loop Output pointer to the function that will perform the strided loop.
- * @param out_transferdata Output pointer to auxiliary data (if any) 
+ * @param out_transferdata Output pointer to auxiliary data (if any)
  *        needed by the out_loop function.
- * @param flags Output pointer to additional flags (if any) 
+ * @param flags Output pointer to additional flags (if any)
  *        needed by the out_loop function
  * @returns 0 on success -1 on failure.
  */

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -930,7 +930,7 @@ PyArray_CastDescrToDType(PyArray_Descr *descr, PyArray_DTypeMeta *given_DType)
         Py_INCREF(descr);
         return descr;
     }
-    if (!NPY_DT_is_parametric(given_DType)) {
+    if (!NPY_DT_is_parametric(given_DType) && !NPY_DT_is_abstract(given_DType)) {
         /*
          * Don't actually do anything, the default is always the result
          * of any cast.
@@ -2087,6 +2087,7 @@ PyArray_AddCastingImplementation_FromSpec(PyArrayMethod_Spec *spec, int private)
 {
     /* Create a bound method, unbind and store it */
     PyBoundArrayMethodObject *meth = PyArrayMethod_FromSpec_int(spec, private);
+    meth->method->flags |= _NPY_METH_IS_CAST;
     if (meth == NULL) {
         return -1;
     }

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2087,10 +2087,10 @@ PyArray_AddCastingImplementation_FromSpec(PyArrayMethod_Spec *spec, int private)
 {
     /* Create a bound method, unbind and store it */
     PyBoundArrayMethodObject *meth = PyArrayMethod_FromSpec_int(spec, private);
-    meth->method->flags |= _NPY_METH_IS_CAST;
     if (meth == NULL) {
         return -1;
     }
+    meth->method->flags |= _NPY_METH_IS_CAST;
     int res = PyArray_AddCastingImplementation(meth);
     Py_DECREF(meth);
     if (res < 0) {

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2087,7 +2087,6 @@ PyArray_AddCastingImplementation_FromSpec(PyArrayMethod_Spec *spec, int private)
 {
     /* Create a bound method, unbind and store it */
     PyBoundArrayMethodObject *meth = PyArrayMethod_FromSpec_int(spec, private);
-    meth->method->flags |= _NPY_METH_IS_CAST;
     if (meth == NULL) {
         return -1;
     }

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2087,6 +2087,7 @@ PyArray_AddCastingImplementation_FromSpec(PyArrayMethod_Spec *spec, int private)
 {
     /* Create a bound method, unbind and store it */
     PyBoundArrayMethodObject *meth = PyArrayMethod_FromSpec_int(spec, private);
+    meth->method->flags |= _NPY_METH_IS_CAST;
     if (meth == NULL) {
         return -1;
     }

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -96,7 +96,7 @@ typedef struct {
      */
     PyArrayMethodObject *sort_meth;
     PyArrayMethodObject *argsort_meth;
-    /* Definition for real and imagine parts, and the (internal) ufuncs */
+    /* Definition for real and imaginary parts, and the (internal) ufuncs */
     PyBoundArrayMethodObject *real_meth;
     PyBoundArrayMethodObject *imag_meth;
 } NPY_DType_Slots;

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -96,6 +96,9 @@ typedef struct {
      */
     PyArrayMethodObject *sort_meth;
     PyArrayMethodObject *argsort_meth;
+    /* Definition for real and imagine parts, and the (internal) ufuncs */
+    PyBoundArrayMethodObject *real_meth;
+    PyBoundArrayMethodObject *imag_meth;
 } NPY_DType_Slots;
 
 // This must be updated if new slots before within_dtype_castingimpl

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -575,6 +575,12 @@ array_base_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 }
 
 
+/*
+ * Fetches the real or imaginary part of an array. If `need_view` is set the return
+ * cannot be a copy (must be a view).
+ * If `need_view` is zero it will return the `ufunc`s result (a new array) and set it
+ * to read-only.
+ */
 static PyObject *
 _get_part(PyArrayObject *self, PyObject *ufunc, PyBoundArrayMethodObject *meth, int need_view)
 {

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -22,6 +22,7 @@
 #include "getset.h"
 #include "arrayobject.h"
 #include "mem_overlap.h"
+#include "number.h"
 #include "alloc.h"
 #include "npy_buffer.h"
 #include "shape.h"
@@ -573,145 +574,105 @@ array_base_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
     }
 }
 
-/*
- * Create a view of a complex array with an equivalent data-type
- * except it is real instead of complex.
- */
-static PyArrayObject *
-_get_part(PyArrayObject *self, int imag)
-{
-    int float_type_num;
-    PyArray_Descr *type;
-    PyArrayObject *ret;
-    int offset;
-
-    switch (PyArray_DESCR(self)->type_num) {
-        case NPY_CFLOAT:
-            float_type_num = NPY_FLOAT;
-            break;
-        case NPY_CDOUBLE:
-            float_type_num = NPY_DOUBLE;
-            break;
-        case NPY_CLONGDOUBLE:
-            float_type_num = NPY_LONGDOUBLE;
-            break;
-        default:
-            PyErr_Format(PyExc_ValueError,
-                     "Cannot convert complex type number %d to float",
-                     PyArray_DESCR(self)->type_num);
-            return NULL;
-
-    }
-    type = PyArray_DescrFromType(float_type_num);
-    if (type == NULL) {
-        return NULL;
-    }
-
-    offset = (imag ? type->elsize : 0);
-
-    if (!PyArray_ISNBO(PyArray_DESCR(self)->byteorder)) {
-        Py_SETREF(type, PyArray_DescrNew(type));
-        if (type == NULL) {
-            return NULL;
-        }
-        type->byteorder = PyArray_DESCR(self)->byteorder;
-    }
-    ret = (PyArrayObject *)PyArray_NewFromDescrAndBase(
-            Py_TYPE(self),
-            type,
-            PyArray_NDIM(self),
-            PyArray_DIMS(self),
-            PyArray_STRIDES(self),
-            PyArray_BYTES(self) + offset,
-            PyArray_FLAGS(self), (PyObject *)self, (PyObject *)self);
-    if (ret == NULL) {
-        return NULL;
-    }
-    return ret;
-}
-
-/* For Object arrays, we need to get and set the
-   real part of each element.
- */
 
 static PyObject *
 array_real_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
-    PyArrayObject *ret;
+    PyObject *ret;
 
-    if (PyArray_ISCOMPLEX(self)) {
-        ret = _get_part(self, 0);
-        return (PyObject *)ret;
+    // NOTE(seberg): Would be nice to refine this via abstract dtype
+    // presumably replacing the error catching below.
+    // That can also transition/change so `string_arr.real` can raise.
+    int known_real = (PyArray_TYPE(self) < NPY_NTYPES_LEGACY
+        && !PyArray_ISCOMPLEX(self) && !PyArray_ISOBJECT(self));
+
+    if (!known_real) {
+        ret = PyArray_GenericUnaryFunction(self, n_ops.real);
+        if (ret == NULL) {
+            if (!PyErr_ExceptionMatches(npy_static_pydata._UFuncNoLoopError)) {
+                return NULL;
+            }
+            PyErr_Clear();
+        }
+        else {
+            return ret;
+        }
     }
-    else {
-        Py_INCREF(self);
-        return (PyObject *)self;
-    }
+
+    // We assume this is a real type, so return a view into self.
+    return PyArray_View(self, NULL, NULL);
 }
-
 
 static int
 array_real_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
 {
-    PyArrayObject *ret;
-    PyArrayObject *new;
-    int retcode;
-
     if (val == NULL) {
         PyErr_SetString(PyExc_AttributeError,
-                "Cannot delete array real part");
+                "Cannot delete array imaginary part");
         return -1;
     }
-    if (PyArray_ISCOMPLEX(self)) {
-        ret = _get_part(self, 0);
-        if (ret == NULL) {
-            return -1;
-        }
+    PyArrayObject *real_part = (PyArrayObject *)array_real_get(self, NULL);
+
+    PyArrayObject *rbase = real_part;
+    while (PyArray_BASE(rbase) != NULL && PyArray_Check(PyArray_BASE(rbase))) {
+        rbase = (PyArrayObject *)PyArray_BASE(rbase);
     }
-    else {
-        Py_INCREF(self);
-        ret = self;
+    PyArrayObject *sbase = self;
+    while (PyArray_BASE(sbase) != NULL && PyArray_Check(PyArray_BASE(sbase))) {
+        sbase = (PyArrayObject *)PyArray_BASE(sbase);
     }
-    new = (PyArrayObject *)PyArray_FROM_O(val);
-    if (new == NULL) {
-        Py_DECREF(ret);
+    // After collapsing bases, they should be identical (one base of real must be
+    // either self or self.base).
+    if (rbase != sbase) {
+        PyErr_SetString(PyExc_TypeError,
+            "Cannot set real part when `arr.real` is not a view.");
         return -1;
     }
-    retcode = PyArray_CopyInto(ret, new);
-    Py_DECREF(ret);
-    Py_DECREF(new);
-    return retcode;
+
+    return PyArray_CopyObject(real_part, val);
 }
 
-/* For Object arrays we need to get
-   and set the imaginary part of
-   each element
-*/
 
 static PyObject *
 array_imag_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
-    PyArrayObject *ret;
+    PyObject *ret;
 
-    if (PyArray_ISCOMPLEX(self)) {
-        ret = _get_part(self, 1);
-    }
-    else {
-        Py_INCREF(PyArray_DESCR(self));
-        ret = (PyArrayObject *)PyArray_NewFromDescr_int(
-                Py_TYPE(self),
-                PyArray_DESCR(self),
-                PyArray_NDIM(self),
-                PyArray_DIMS(self),
-                NULL, NULL,
-                PyArray_ISFORTRAN(self),
-                (PyObject *)self, NULL, _NPY_ARRAY_ZEROED);
+    // NOTE(seberg): Would be nice to refine this via abstract dtype
+    // presumably replacing the error catching below.
+    // That can also transition/change so `string_arr.imag` can raise.
+    int known_real = (PyArray_TYPE(self) < NPY_NTYPES_LEGACY
+        && !PyArray_ISCOMPLEX(self) && !PyArray_ISOBJECT(self));
+
+    if (!known_real) {
+        ret = PyArray_GenericUnaryFunction(self, n_ops.imag);
         if (ret == NULL) {
-            return NULL;
+            if (!PyErr_ExceptionMatches(npy_static_pydata._UFuncNoLoopError)) {
+                return NULL;
+            }
+            PyErr_Clear();
         }
-        PyArray_CLEARFLAGS(ret, NPY_ARRAY_WRITEABLE);
+        else {
+            return ret;
+        }
     }
-    return (PyObject *) ret;
+
+    // We assume this is a real type, so return a zeroed+broadcast array.
+    Py_INCREF(PyArray_DESCR(self));
+    ret = PyArray_NewFromDescr_int(
+            Py_TYPE(self),
+            PyArray_DESCR(self),
+            PyArray_NDIM(self),
+            PyArray_DIMS(self),
+            NULL, NULL,
+            PyArray_ISFORTRAN(self),
+            (PyObject *)self, NULL, _NPY_ARRAY_ZEROED);
+    if (ret == NULL) {
+        return NULL;
+    }
+    PyArray_CLEARFLAGS((PyArrayObject *)ret, NPY_ARRAY_WRITEABLE);
+
+    return (PyObject *)ret;
 }
 
 static int
@@ -722,30 +683,31 @@ array_imag_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
                 "Cannot delete array imaginary part");
         return -1;
     }
-    if (PyArray_ISCOMPLEX(self)) {
-        PyArrayObject *ret;
-        PyArrayObject *new;
-        int retcode;
+    PyArrayObject *imag_part = (PyArrayObject *)array_imag_get(self, NULL);
 
-        ret = _get_part(self, 1);
-        if (ret == NULL) {
-            return -1;
-        }
-        new = (PyArrayObject *)PyArray_FROM_O(val);
-        if (new == NULL) {
-            Py_DECREF(ret);
-            return -1;
-        }
-        retcode = PyArray_CopyInto(ret, new);
-        Py_DECREF(ret);
-        Py_DECREF(new);
-        return retcode;
+    PyArrayObject *ibase = imag_part;
+    while (PyArray_BASE(ibase) != NULL && PyArray_Check(PyArray_BASE(ibase))) {
+        ibase = (PyArrayObject *)PyArray_BASE(ibase);
     }
-    else {
-        PyErr_SetString(PyExc_TypeError,
+    PyArrayObject *sbase = self;
+    while (PyArray_BASE(sbase) != NULL && PyArray_Check(PyArray_BASE(sbase))) {
+        sbase = (PyArrayObject *)PyArray_BASE(sbase);
+    }
+    // After collapsing bases, they should be identical (one base of imag must be
+    // either self or self.base).
+    if (ibase != sbase) {
+        if (PyArray_DTYPE(self) == PyArray_DTYPE(imag_part)) {
+            PyErr_SetString(PyExc_TypeError,
                 "array does not have imaginary part to set");
+        }
+        else {
+            PyErr_SetString(PyExc_TypeError,
+                "Cannot set imagine part when `arr.imag` is not a view.");
+        }
         return -1;
     }
+
+    return PyArray_CopyObject(imag_part, val);
 }
 
 static PyObject *

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -593,7 +593,7 @@ _get_part(PyArrayObject *self, PyObject *ufunc, PyBoundArrayMethodObject *meth, 
             Py_TYPE(self), loop_descrs[1],
             PyArray_NDIM(self), PyArray_DIMS(self),
             PyArray_STRIDES(self), PyArray_BYTES(self) + view_offset,
-            PyArray_FLAGS(self), NULL, (PyObject *)self,
+            PyArray_FLAGS(self), (PyObject *)self, (PyObject *)self,
             _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
     }
     else if (!need_view) {

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -622,7 +622,6 @@ array_real_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
     return _get_part(self, n_ops.real, meth, /* need_view */ 0);
 }
 
-
 static int
 array_real_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
 {
@@ -652,7 +651,9 @@ array_real_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
         }
     }
 
-    return PyArray_CopyObject(part, val);
+    int ret = PyArray_CopyObject(part, val);
+    Py_DECREF(part);
+    return ret;
 }
 
 
@@ -682,7 +683,6 @@ array_imag_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
     return _get_part(self, n_ops.imag, meth, /* need_view */ 0);
 }
 
-
 static int
 array_imag_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
 {
@@ -710,7 +710,9 @@ array_imag_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
         return -1;
     }
 
-    return PyArray_CopyObject(part, val);
+    int ret = PyArray_CopyObject(part, val);
+    Py_DECREF(part);
+    return ret;
 }
 
 static PyObject *

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -576,104 +576,112 @@ array_base_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 
 
 static PyObject *
-array_real_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
+_get_part(PyArrayObject *self, PyObject *ufunc, PyBoundArrayMethodObject *meth, int need_view)
 {
-    PyObject *ret;
-
-    // NOTE(seberg): Would be nice to refine this via abstract dtype
-    // presumably replacing the error catching below.
-    // That can also transition/change so `string_arr.real` can raise.
-    int known_real = (PyArray_TYPE(self) < NPY_NTYPES_LEGACY
-        && !PyArray_ISCOMPLEX(self) && !PyArray_ISOBJECT(self));
-
-    if (!known_real) {
-        ret = PyArray_GenericUnaryFunction(self, n_ops.real);
-        if (ret == NULL) {
-            if (!PyErr_ExceptionMatches(npy_static_pydata._UFuncNoLoopError)) {
-                return NULL;
-            }
-            PyErr_Clear();
-        }
-        else {
-            return ret;
-        }
+    PyObject *ret = NULL;
+    PyArray_Descr *descrs[2] = {PyArray_DESCR(self), NULL};
+    PyArray_Descr *loop_descrs[2] = {NULL, NULL};
+    npy_intp view_offset = NPY_MIN_INTP;
+    int res = meth->method->resolve_descriptors(
+        meth->method, meth->dtypes, descrs, loop_descrs, &view_offset);
+    if (res < 0) {
+        return NULL;
+    }
+    if (view_offset != NPY_MIN_INTP) {
+        Py_INCREF(loop_descrs[1]);
+        ret = PyArray_NewFromDescr_int(
+            Py_TYPE(self), loop_descrs[1],
+            PyArray_NDIM(self), PyArray_DIMS(self),
+            PyArray_STRIDES(self), PyArray_BYTES(self) + view_offset,
+            PyArray_FLAGS(self), NULL, (PyObject *)self,
+            _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
+    }
+    else if (!need_view) {
+        // resolve_descriptors was successful, but view_offset is not set so we call
+        // the ufunc to let it deal with the (potential) complexity.
+        ret = PyArray_GenericUnaryFunction(self, ufunc);
     }
 
-    // We assume this is a real type, so return a view into self.
-    return PyArray_View(self, NULL, NULL);
+    Py_DECREF(loop_descrs[0]);
+    Py_DECREF(loop_descrs[1]);
+    return ret;
 }
+
+
+static PyObject *
+array_real_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
+{
+    PyBoundArrayMethodObject *meth = NPY_DT_SLOTS(NPY_DTYPE(PyArray_DTYPE(self)))->real_meth;
+
+    if (meth == NULL) {
+        // If the method is not set, we just assume this can be seen as "real"
+        // it really may be nice to change that one day.
+        return Py_NewRef((PyObject *)self);
+    }
+
+    return _get_part(self, n_ops.real, meth, /* need_view */ 0);
+}
+
 
 static int
 array_real_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
 {
     if (val == NULL) {
         PyErr_SetString(PyExc_AttributeError,
-                "Cannot delete array imaginary part");
-        return -1;
-    }
-    PyArrayObject *real_part = (PyArrayObject *)array_real_get(self, NULL);
-
-    PyArrayObject *rbase = real_part;
-    while (PyArray_BASE(rbase) != NULL && PyArray_Check(PyArray_BASE(rbase))) {
-        rbase = (PyArrayObject *)PyArray_BASE(rbase);
-    }
-    PyArrayObject *sbase = self;
-    while (PyArray_BASE(sbase) != NULL && PyArray_Check(PyArray_BASE(sbase))) {
-        sbase = (PyArrayObject *)PyArray_BASE(sbase);
-    }
-    // After collapsing bases, they should be identical (one base of real must be
-    // either self or self.base).
-    if (rbase != sbase) {
-        PyErr_SetString(PyExc_TypeError,
-            "Cannot set real part when `arr.real` is not a view.");
+                "Cannot delete array real part");
         return -1;
     }
 
-    return PyArray_CopyObject(real_part, val);
+    PyArrayObject *part;
+    PyBoundArrayMethodObject *meth = NPY_DT_SLOTS(NPY_DTYPE(PyArray_DTYPE(self)))->real_meth;
+
+    if (meth == NULL) {
+        // See above, we may want to not guess this always...
+        Py_INCREF(self);
+        part = self;
+    }
+    else {
+        part = (PyArrayObject *)_get_part(
+            self, n_ops.real, meth, /* need_view */ 1);
+        if (part == NULL) {
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(PyExc_TypeError,
+                        "Cannot set real part when `.real` isn't a view.");
+            }
+            return -1;
+        }
+    }
+
+    return PyArray_CopyObject(part, val);
 }
 
 
 static PyObject *
 array_imag_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
-    PyObject *ret;
+    PyBoundArrayMethodObject *meth = NPY_DT_SLOTS(NPY_DTYPE(PyArray_DTYPE(self)))->imag_meth;
 
-    // NOTE(seberg): Would be nice to refine this via abstract dtype
-    // presumably replacing the error catching below.
-    // That can also transition/change so `string_arr.imag` can raise.
-    int known_real = (PyArray_TYPE(self) < NPY_NTYPES_LEGACY
-        && !PyArray_ISCOMPLEX(self) && !PyArray_ISOBJECT(self));
-
-    if (!known_real) {
-        ret = PyArray_GenericUnaryFunction(self, n_ops.imag);
+    if (meth == NULL) {
+        // We assume this is a real type, so return a zeroed+broadcast array.
+        Py_INCREF(PyArray_DESCR(self));
+        PyObject *ret = PyArray_NewFromDescr_int(
+                Py_TYPE(self),
+                PyArray_DESCR(self),
+                PyArray_NDIM(self),
+                PyArray_DIMS(self),
+                NULL, NULL,
+                PyArray_ISFORTRAN(self),
+                (PyObject *)self, NULL, _NPY_ARRAY_ZEROED);
         if (ret == NULL) {
-            if (!PyErr_ExceptionMatches(npy_static_pydata._UFuncNoLoopError)) {
-                return NULL;
-            }
-            PyErr_Clear();
+            return NULL;
         }
-        else {
-            return ret;
-        }
+        PyArray_CLEARFLAGS((PyArrayObject *)ret, NPY_ARRAY_WRITEABLE);
+        return ret;
     }
 
-    // We assume this is a real type, so return a zeroed+broadcast array.
-    Py_INCREF(PyArray_DESCR(self));
-    ret = PyArray_NewFromDescr_int(
-            Py_TYPE(self),
-            PyArray_DESCR(self),
-            PyArray_NDIM(self),
-            PyArray_DIMS(self),
-            NULL, NULL,
-            PyArray_ISFORTRAN(self),
-            (PyObject *)self, NULL, _NPY_ARRAY_ZEROED);
-    if (ret == NULL) {
-        return NULL;
-    }
-    PyArray_CLEARFLAGS((PyArrayObject *)ret, NPY_ARRAY_WRITEABLE);
-
-    return (PyObject *)ret;
+    return _get_part(self, n_ops.imag, meth, /* need_view */ 0);
 }
+
 
 static int
 array_imag_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
@@ -683,31 +691,26 @@ array_imag_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
                 "Cannot delete array imaginary part");
         return -1;
     }
-    PyArrayObject *imag_part = (PyArrayObject *)array_imag_get(self, NULL);
+    PyArrayObject *part;
+    PyBoundArrayMethodObject *meth = NPY_DT_SLOTS(NPY_DTYPE(PyArray_DTYPE(self)))->imag_meth;
 
-    PyArrayObject *ibase = imag_part;
-    while (PyArray_BASE(ibase) != NULL && PyArray_Check(PyArray_BASE(ibase))) {
-        ibase = (PyArrayObject *)PyArray_BASE(ibase);
+    if (meth == NULL) {
+        PyErr_SetString(PyExc_TypeError,
+            "Cannot set imaginary part of non-complex array.");
+        return -1;
     }
-    PyArrayObject *sbase = self;
-    while (PyArray_BASE(sbase) != NULL && PyArray_Check(PyArray_BASE(sbase))) {
-        sbase = (PyArrayObject *)PyArray_BASE(sbase);
-    }
-    // After collapsing bases, they should be identical (one base of imag must be
-    // either self or self.base).
-    if (ibase != sbase) {
-        if (PyArray_DTYPE(self) == PyArray_DTYPE(imag_part)) {
+
+    part = (PyArrayObject *)_get_part(
+        self, n_ops.imag, meth, /* need_view */ 1);
+    if (part == NULL) {
+        if (!PyErr_Occurred()) {
             PyErr_SetString(PyExc_TypeError,
-                "array does not have imaginary part to set");
-        }
-        else {
-            PyErr_SetString(PyExc_TypeError,
-                "Cannot set imagine part when `arr.imag` is not a view.");
+                    "Cannot set imaginary part when `.imag` isn't a view.");
         }
         return -1;
     }
 
-    return PyArray_CopyObject(imag_part, val);
+    return PyArray_CopyObject(part, val);
 }
 
 static PyObject *

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -600,6 +600,11 @@ _get_part(PyArrayObject *self, PyObject *ufunc, PyBoundArrayMethodObject *meth, 
         // resolve_descriptors was successful, but view_offset is not set so we call
         // the ufunc to let it deal with the (potential) complexity.
         ret = PyArray_GenericUnaryFunction(self, ufunc);
+        if (ret != NULL && PyArray_Check(ret)) {
+            // Make result read-only, since otherwise `arr.imag[...] = val`
+            // would for example work.
+            PyArray_CLEARFLAGS((PyArrayObject *)ret, NPY_ARRAY_WRITEABLE);
+        }
     }
 
     Py_DECREF(loop_descrs[0]);
@@ -663,7 +668,7 @@ array_imag_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
     PyBoundArrayMethodObject *meth = NPY_DT_SLOTS(NPY_DTYPE(PyArray_DTYPE(self)))->imag_meth;
 
     if (meth == NULL) {
-        // We assume this is a real type, so return a zeroed+broadcast array.
+        // We assume this is a real type, so return a zeroed array.
         Py_INCREF(PyArray_DESCR(self));
         PyObject *ret = PyArray_NewFromDescr_int(
                 Py_TYPE(self),

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -70,6 +70,8 @@ intern_strings(void)
     INTERN_STRING(dl_device, "dl_device");
     INTERN_STRING(max_version, "max_version");
     INTERN_STRING(array_dealloc, "array_dealloc");
+    INTERN_STRING(real, "real");
+    INTERN_STRING(imag, "imag");
     return 0;
 }
 

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -72,6 +72,8 @@ intern_strings(void)
     INTERN_STRING(array_dealloc, "array_dealloc");
     INTERN_STRING(real, "real");
     INTERN_STRING(imag, "imag");
+    INTERN_STRING(sort, "sort");
+    INTERN_STRING(argsort, "argsort");
     return 0;
 }
 

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -49,6 +49,8 @@ typedef struct npy_interned_str_struct {
     PyObject *dl_device;
     PyObject *max_version;
     PyObject *array_dealloc;
+    PyObject *real;
+    PyObject *imag;
 } npy_interned_str_struct;
 
 /*

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -51,6 +51,8 @@ typedef struct npy_interned_str_struct {
     PyObject *array_dealloc;
     PyObject *real;
     PyObject *imag;
+    PyObject *sort;
+    PyObject *argsort;
 } npy_interned_str_struct;
 
 /*

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -122,6 +122,8 @@ _PyArray_SetNumericOps(PyObject *dict)
     SET(conjugate);
     SET(matmul);
     SET(clip);
+    SET(real);
+    SET(imag);
 
     // initialize static globals needed for matmul
     npy_static_pydata.axes_1d_obj_kwargs = Py_BuildValue(

--- a/numpy/_core/src/multiarray/number.h
+++ b/numpy/_core/src/multiarray/number.h
@@ -41,6 +41,8 @@ typedef struct {
     PyObject *conjugate;
     PyObject *matmul;
     PyObject *clip;
+    PyObject *real;
+    PyObject *imag;
 } NumericOps;
 
 extern NPY_NO_EXPORT NumericOps n_ops;

--- a/numpy/_core/src/umath/_scaled_float_dtype.c
+++ b/numpy/_core/src/umath/_scaled_float_dtype.c
@@ -1026,8 +1026,9 @@ sfloat_init_ufuncs(void) {
     PyUFunc_LoopSlot loops[] = {
         {"multiply", &multiply_spec},
         {"_core._multiarray_umath.add", &add_spec},
+        // These names must match exactly right now (not ufuncs)
         {"numpy:sort", &sort_spec},
-        {"numpy._core.fromnumeric:argsort", &argsort_spec},
+        {"numpy:argsort", &argsort_spec},
         {NULL, NULL}
     };
     if (PyUFunc_AddLoopsFromSpecs(loops) < 0) {

--- a/numpy/_core/src/umath/_scaled_float_dtype.c
+++ b/numpy/_core/src/umath/_scaled_float_dtype.c
@@ -1027,8 +1027,8 @@ sfloat_init_ufuncs(void) {
         {"multiply", &multiply_spec},
         {"_core._multiarray_umath.add", &add_spec},
         // These names must match exactly right now (not ufuncs)
-        {"numpy:sort", &sort_spec},
-        {"numpy:argsort", &argsort_spec},
+        {"sort", &sort_spec},
+        {"argsort", &argsort_spec},
         {NULL, NULL}
     };
     if (PyUFunc_AddLoopsFromSpecs(loops) < 0) {

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -194,6 +194,33 @@ PyUFunc_AddLoopFromSpec_int(PyObject *ufunc, PyArrayMethod_Spec *spec, int priv)
 }
 
 
+
+/*
+ * There are a few ArrayMethods we store on the DType since they are not
+ * (only) used via ufuncs.  Some don't need to be bound (DTypes attached)
+ * and are currently not.
+ */
+template <auto slot, bool bound>
+static int
+set_static_method(PyArrayMethod_Spec *spec) {
+    PyArray_DTypeMeta *dtype = spec->dtypes[0];
+    PyBoundArrayMethodObject *meth = PyArrayMethod_FromSpec_int(spec, 0);
+    if (meth == NULL) {
+        return -1;
+    }
+
+    if constexpr (!bound) {
+        Py_INCREF(meth->method);
+        NPY_DT_SLOTS(dtype)->*slot = meth->method;
+        Py_DECREF(meth);
+    }
+    else {
+        NPY_DT_SLOTS(dtype)->*slot = meth;
+    }
+    return 0;
+}
+
+
 /*UFUNC_API
  * Add multiple loops to ufuncs from ArrayMethod specs. This also
  * handles the registration of sort and argsort methods for dtypes
@@ -202,64 +229,67 @@ PyUFunc_AddLoopFromSpec_int(PyObject *ufunc, PyArrayMethod_Spec *spec, int priv)
 NPY_NO_EXPORT int
 PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots)
 {
-    if (npy_cache_import_runtime(
-            "numpy", "sort", &npy_runtime_imports.sort) < 0) {
-        return -1;
-    }
-    if (npy_cache_import_runtime(
-            "numpy", "argsort", &npy_runtime_imports.argsort) < 0) {
-        return -1;
-    }
+    int ret = -1;
+    PyObject *ufunc = NULL;
 
     PyUFunc_LoopSlot *slot;
     for (slot = slots; slot->name != NULL; slot++) {
-        PyObject *ufunc = npy_import_entry_point(slot->name);
-        if (ufunc == NULL) {
-            return -1;
+        // Hardcode slot names for attributes and non-ufuncs stored on the DType
+        // (Also avoids circular imports a bit.)
+        if (strcmp(slot->name, ".real") == 0) {
+            Py_XSETREF(ufunc, npy_interned_str.real);
+        }
+        else if (strcmp(slot->name, ".imag") == 0) {
+            Py_XSETREF(ufunc, npy_interned_str.imag);
+        }
+        else if (strcmp(slot->name, "numpy:sort") == 0) {
+            Py_XSETREF(ufunc, npy_interned_str.sort);
+        }
+        else if (strcmp(slot->name, "numpy:argsort") == 0) {
+            Py_XSETREF(ufunc, npy_interned_str.argsort);
+        }
+        else {
+            Py_XSETREF(ufunc, npy_import_entry_point(slot->name));
+            if (ufunc == NULL) {
+                goto finish;
+            }
         }
 
-        if (ufunc == npy_runtime_imports.sort) {
-            Py_DECREF(ufunc);
-
-            PyArray_DTypeMeta *dtype = slot->spec->dtypes[0];
-            PyBoundArrayMethodObject *sort_meth = PyArrayMethod_FromSpec_int(slot->spec, 0);
-            if (sort_meth == NULL) {
-                return -1;
+        if (ufunc == npy_interned_str.real) {
+            if (set_static_method<&NPY_DType_Slots::real_meth, true>(slot->spec) < 0) {
+                goto finish;
             }
-
-            NPY_DT_SLOTS(dtype)->sort_meth = sort_meth->method;
-            Py_INCREF(sort_meth->method);
-            Py_DECREF(sort_meth);
         }
-        else if (ufunc == npy_runtime_imports.argsort) {
-            Py_DECREF(ufunc);
-
-            PyArray_DTypeMeta *dtype = slot->spec->dtypes[0];
-            PyBoundArrayMethodObject *argsort_meth = PyArrayMethod_FromSpec_int(slot->spec, 0);
-            if (argsort_meth == NULL) {
-                return -1;
+        else if (ufunc == npy_interned_str.imag) {
+            if (set_static_method<&NPY_DType_Slots::imag_meth, true>(slot->spec) < 0) {
+                goto finish;
             }
-
-            NPY_DT_SLOTS(dtype)->argsort_meth = argsort_meth->method;
-            Py_INCREF(argsort_meth->method);
-            Py_DECREF(argsort_meth);
+        }
+        else if (ufunc == npy_interned_str.sort) {
+            if (set_static_method<&NPY_DType_Slots::sort_meth, false>(slot->spec) < 0) {
+                goto finish;
+            }
+        }
+        else if (ufunc == npy_interned_str.argsort) {
+            if (set_static_method<&NPY_DType_Slots::argsort_meth, false>(slot->spec) < 0) {
+                goto finish;
+            }
         }
         else {
             if (!PyObject_TypeCheck(ufunc, &PyUFunc_Type)) {
                 PyErr_Format(PyExc_TypeError, "%s was not a ufunc!", slot->name);
-                Py_DECREF(ufunc);
-                return -1;
+                goto finish;
             }
-
-            int ret = PyUFunc_AddLoopFromSpec_int(ufunc, slot->spec, 0);
-            Py_DECREF(ufunc);
-            if (ret < 0) {
-                return -1;
+            if (PyUFunc_AddLoopFromSpec_int(ufunc, slot->spec, 0) < 0) {
+                goto finish;
             }
         }
     }
 
-    return 0;
+    ret = 0;
+  finish:
+    Py_XDECREF(ufunc);
+    return ret;
 }
 
 
@@ -595,22 +625,24 @@ call_promoter_and_recurse(PyUFuncObject *ufunc, PyObject *info,
             return NULL;
         }
         /*
-        * If none of the dtypes changes, we would recurse infinitely, abort.
-        * (Of course it is nevertheless possible to recurse infinitely.)
-        *
-        * TODO: We could allow users to signal this directly and also move
-        *       the call to be (almost immediate).  That would call it
-        *       unnecessarily sometimes, but may allow additional flexibility.
-        */
-        int dtypes_changed = 0;
-        for (int i = 0; i < nargs; i++) {
-            if (new_op_dtypes[i] != op_dtypes[i]) {
-                dtypes_changed = 1;
-                break;
+         * If none of the dtypes changes, we would recurse infinitely, abort.
+         * (Of course it is nevertheless possible to recurse infinitely.)
+         *
+         * TODO: We could allow users to signal this directly and also move
+         *       the call to be (almost immediate).  That would call it
+         *       unnecessarily sometimes, but may allow additional flexibility.
+         */
+        if (promoter_result != 1) {
+            int dtypes_changed = 0;
+            for (int i = 0; i < nargs; i++) {
+                if (new_op_dtypes[i] != op_dtypes[i]) {
+                    dtypes_changed = 1;
+                    break;
+                }
             }
-        }
-        if (!dtypes_changed) {
-            goto finish;
+            if (!dtypes_changed) {
+                goto finish;
+            }
         }
     }
     else {

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -236,10 +236,10 @@ PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots)
     for (slot = slots; slot->name != NULL; slot++) {
         // Hardcode slot names for attributes and non-ufuncs stored on the DType
         // (Also avoids circular imports a bit.)
-        if (strcmp(slot->name, ".real") == 0) {
+        if (strcmp(slot->name, "real") == 0) {
             Py_XSETREF(ufunc, npy_interned_str.real);
         }
-        else if (strcmp(slot->name, ".imag") == 0) {
+        else if (strcmp(slot->name, "imag") == 0) {
             Py_XSETREF(ufunc, npy_interned_str.imag);
         }
         else if (strcmp(slot->name, "sort") == 0) {
@@ -627,10 +627,7 @@ call_promoter_and_recurse(PyUFuncObject *ufunc, PyObject *info,
         /*
          * If none of the dtypes changes, we would recurse infinitely, abort.
          * (Of course it is nevertheless possible to recurse infinitely.)
-         *
-         * TODO: We could allow users to signal this directly and also move
-         *       the call to be (almost immediate).  That would call it
-         *       unnecessarily sometimes, but may allow additional flexibility.
+         * If the user indicates a `1` result, we trust the user.
          */
         if (promoter_result != 1) {
             int dtypes_changed = 0;

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -242,10 +242,10 @@ PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots)
         else if (strcmp(slot->name, ".imag") == 0) {
             Py_XSETREF(ufunc, npy_interned_str.imag);
         }
-        else if (strcmp(slot->name, "numpy:sort") == 0) {
+        else if (strcmp(slot->name, "sort") == 0) {
             Py_XSETREF(ufunc, npy_interned_str.sort);
         }
-        else if (strcmp(slot->name, "numpy:argsort") == 0) {
+        else if (strcmp(slot->name, "argsort") == 0) {
             Py_XSETREF(ufunc, npy_interned_str.argsort);
         }
         else {

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -237,16 +237,16 @@ PyUFunc_AddLoopsFromSpecs(PyUFunc_LoopSlot *slots)
         // Hardcode slot names for attributes and non-ufuncs stored on the DType
         // (Also avoids circular imports a bit.)
         if (strcmp(slot->name, "real") == 0) {
-            Py_XSETREF(ufunc, npy_interned_str.real);
+            Py_XSETREF(ufunc, Py_NewRef(npy_interned_str.real));
         }
         else if (strcmp(slot->name, "imag") == 0) {
-            Py_XSETREF(ufunc, npy_interned_str.imag);
+            Py_XSETREF(ufunc, Py_NewRef(npy_interned_str.imag));
         }
         else if (strcmp(slot->name, "sort") == 0) {
-            Py_XSETREF(ufunc, npy_interned_str.sort);
+            Py_XSETREF(ufunc, Py_NewRef(npy_interned_str.sort));
         }
         else if (strcmp(slot->name, "argsort") == 0) {
-            Py_XSETREF(ufunc, npy_interned_str.argsort);
+            Py_XSETREF(ufunc, Py_NewRef(npy_interned_str.argsort));
         }
         else {
             Py_XSETREF(ufunc, npy_import_entry_point(slot->name));

--- a/numpy/_core/src/umath/real_imag_ufuncs.cpp
+++ b/numpy/_core/src/umath/real_imag_ufuncs.cpp
@@ -217,7 +217,7 @@ real_imag_promoter(PyObject *ufunc,
     if (info == NULL) {
         return -1;
     }
-    int res = PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
+    int res = PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 1);
     Py_DECREF(info);
     if (res < 0) {
         return -1;

--- a/numpy/_core/src/umath/real_imag_ufuncs.cpp
+++ b/numpy/_core/src/umath/real_imag_ufuncs.cpp
@@ -9,8 +9,10 @@
 #define _UMATHMODULE
 
 #include <Python.h>
+#include "npy_pycompat.h"  // PyObject_GetOptionalAttr
 #include "numpy/ndarraytypes.h"
 #include "numpy/ufuncobject.h"
+#include "dispatching.h"
 
 #include "numpyos.h"
 #include "dtypemeta.h"
@@ -81,46 +83,6 @@ static int extract_complex_part_loop(
 }
 
 
-
-template <int complex_num, typename real_type, int real_num, bool real_part>
-static int
-register_real_for_type(PyObject *ufunc)
-{
-    PyArray_DTypeMeta *dtypes[2] = {
-        PyArray_DTypeFromTypeNum(complex_num),
-        PyArray_DTypeFromTypeNum(real_num),
-    };
-    PyType_Slot meth_slots[] = {
-        {NPY_METH_resolve_descriptors, (void *)&complex_to_real_resolve_descriptors<real_num, real_part>},
-        {NPY_METH_strided_loop, (void *)&extract_complex_part_loop<real_type, real_part>},
-        {0, NULL}
-    };
-    PyArrayMethod_Spec meth_spec = {
-        .nin = 1,
-        .nout = 1,
-        .dtypes = dtypes,
-        .slots = meth_slots,
-    };
-    int res = PyUFunc_AddLoopFromSpec(ufunc, &meth_spec);
-    Py_DECREF(dtypes[0]);
-    Py_DECREF(dtypes[1]);
-    return res;
-}
-
-
-template <int complex_num, typename real_type, int real_num>
-static int
-register_both_for_type(PyObject *real_ufunc, PyObject *imag_ufunc) {
-    if (register_real_for_type<complex_num, real_type, real_num, true>(real_ufunc) < 0) {
-        return -1;
-    }
-    if (register_real_for_type<complex_num, real_type, real_num, false>(imag_ufunc) < 0) {
-        return -1;
-    }
-    return 0;
-}
-
-
 template <auto component>
 static int
 object_get_comp_strided_loop(
@@ -161,12 +123,56 @@ object_get_comp_strided_loop(
 }
 
 
+template <int complex_num, typename real_type, int real_num, bool real_part>
 static int
-register_object_loops(PyObject *real_ufunc, PyObject *imag_ufunc)
+register_one_for_type(const char *name)
+{
+    PyArray_DTypeMeta *dtypes[2] = {
+        PyArray_DTypeFromTypeNum(complex_num),
+        PyArray_DTypeFromTypeNum(real_num),
+    };
+    PyType_Slot meth_slots[] = {
+        {NPY_METH_resolve_descriptors, (void *)&complex_to_real_resolve_descriptors<real_num, real_part>},
+        {NPY_METH_strided_loop, (void *)&extract_complex_part_loop<real_type, real_part>},
+        {0, NULL}
+    };
+    PyArrayMethod_Spec meth_spec = {
+        .nin = 1,
+        .nout = 1,
+        .dtypes = dtypes,
+        .slots = meth_slots,
+    };
+    PyUFunc_LoopSlot slots[] = {
+        {.name = name, .spec = &meth_spec},
+        {0, nullptr}
+    };
+    int res = PyUFunc_AddLoopsFromSpecs(slots);
+    Py_DECREF(dtypes[0]);
+    Py_DECREF(dtypes[1]);
+    return res;
+}
+
+
+template <int complex_num, typename real_type, int real_num>
+static int
+register_both_for_type() {
+    if (register_one_for_type<complex_num, real_type, real_num, true>(".real") < 0) {
+        return -1;
+    }
+    if (register_one_for_type<complex_num, real_type, real_num, false>(".imag") < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+
+template <auto component>
+static int
+register_one_object_loop(const char *name)
 {
     PyArray_DTypeMeta *dtypes[2] = {&PyArray_ObjectDType, &PyArray_ObjectDType};
     PyType_Slot meth_slots[] = {
-        {NPY_METH_strided_loop, nullptr},
+        {NPY_METH_strided_loop, (void *)&object_get_comp_strided_loop<component>},
         {0, nullptr}
     };
     PyArrayMethod_Spec meth_spec = {
@@ -175,13 +181,71 @@ register_object_loops(PyObject *real_ufunc, PyObject *imag_ufunc)
         .dtypes = dtypes,
         .slots = meth_slots,
     };
-    meth_slots[0].pfunc = (void *)&object_get_comp_strided_loop<&npy_interned_str_struct::real>;
-    int res = PyUFunc_AddLoopFromSpec(real_ufunc, &meth_spec);
+    PyUFunc_LoopSlot slots[] = {
+        {.name = name, .spec = &meth_spec},
+        {0, nullptr}
+    };
+    return PyUFunc_AddLoopsFromSpecs(slots);
+}
+
+
+template <auto slot>
+static int
+real_imag_promoter(PyObject *ufunc,
+        PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
+        PyArray_DTypeMeta *new_op_dtypes[])
+{
+    PyBoundArrayMethodObject *meth = NPY_DT_SLOTS(op_dtypes[0])->*slot;
+    if (meth == NULL) {
+        return -1;  // nothing to do.
+    }
+    if (signature[1] != NULL && signature[1] != meth->dtypes[1]) {
+        // out signature requested, but not compatible (may be unreachable).
+        return -1;
+    }
+
+    /*
+     * Dynamically add the loop to the ufunc, since it seem it was missing.
+     */
+    PyObject *DType_tuple = PyTuple_FromArray((PyObject **)meth->dtypes, 2);
+    if (DType_tuple == NULL) {
+        return -1;
+    }
+    PyObject *info = PyTuple_Pack(2, DType_tuple, meth->method);
+    Py_DECREF(DType_tuple);
+    if (info == NULL) {
+        return -1;
+    }
+    int res = PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
+    Py_DECREF(info);
     if (res < 0) {
         return -1;
     }
-    meth_slots[0].pfunc = (void *)&object_get_comp_strided_loop<&npy_interned_str_struct::imag>;
-    res = PyUFunc_AddLoopFromSpec(imag_ufunc, &meth_spec);
+    new_op_dtypes[0] = NPY_DT_NewRef(meth->dtypes[0]);
+    new_op_dtypes[1] = NPY_DT_NewRef(meth->dtypes[1]);
+    return 1;
+}
+
+
+
+template <auto slot>
+static int
+add_promoter_for_slot(PyObject *ufunc)
+{
+    PyObject *promoter = PyCapsule_New(
+        (void *)real_imag_promoter<slot>, "numpy._ufunc_promoter", NULL);
+    if (promoter == NULL) {
+        return -1;
+    }
+    PyObject *dtypes[2] = {(PyObject *)&PyArrayDescr_Type, (PyObject *)&PyArrayDescr_Type};
+    PyObject *info = PyTuple_FromArray(dtypes, 2);
+    if (info == NULL) {
+        Py_DECREF(promoter);
+        return -1;
+    }
+    int res = PyUFunc_AddPromoter(ufunc, info, promoter);
+    Py_DECREF(info);
+    Py_DECREF(promoter);
     return res;
 }
 
@@ -196,19 +260,32 @@ init_real_imag_ufuncs(PyObject *umath)
         goto finish;
     }
 
-    if (register_both_for_type<NPY_CFLOAT, npy_float32, NPY_FLOAT>(real_ufunc, imag_ufunc) < 0) {
+    if (register_both_for_type<NPY_CFLOAT, npy_float32, NPY_FLOAT>() < 0) {
         goto finish;
     }
-    if (register_both_for_type<NPY_CDOUBLE, npy_float64, NPY_DOUBLE>(real_ufunc, imag_ufunc) < 0) {
+    if (register_both_for_type<NPY_CDOUBLE, npy_float64, NPY_DOUBLE>() < 0) {
         goto finish;
     }
-    if (register_both_for_type<NPY_CLONGDOUBLE, npy_longdouble, NPY_LONGDOUBLE>(real_ufunc, imag_ufunc) < 0) {
+    if (register_both_for_type<NPY_CLONGDOUBLE, npy_longdouble, NPY_LONGDOUBLE>() < 0) {
         goto finish;
     }
-    if (register_object_loops(real_ufunc, imag_ufunc) < 0) {
+    if (register_one_object_loop<&npy_interned_str_struct::real>(".real") < 0) {
+        goto finish;
+    }
+    if (register_one_object_loop<&npy_interned_str_struct::imag>(".imag") < 0) {
         goto finish;
     }
 
+    /*
+     * The above actually only adds the method to the DType itself. We deal with
+     * the ufunc by adding a general fall-back method that
+     */
+    if (add_promoter_for_slot<&NPY_DType_Slots::real_meth>(real_ufunc) < 0) {
+        goto finish;
+    }
+    if (add_promoter_for_slot<&NPY_DType_Slots::imag_meth>(imag_ufunc) < 0) {
+        goto finish;
+    }
     res = 0;
   finish:
     Py_XDECREF(real_ufunc);

--- a/numpy/_core/src/umath/real_imag_ufuncs.cpp
+++ b/numpy/_core/src/umath/real_imag_ufuncs.cpp
@@ -1,7 +1,7 @@
 /*
  * This file implements the real and imag ufuncs which are in turn used
- * for the `.imag` and `.real` attributes of arrays.
- * The ArrayMethods are primarily stored on the DType for `.real` and `.imag`
+ * for the `imag` and `real` attributes of arrays.
+ * The ArrayMethods are primarily stored on the DType for `real` and `imag`
  * while the ufunc uses a promoter to access these dynamically.
  */
 
@@ -154,10 +154,10 @@ register_one_for_type(
 template <typename real_type>
 static int
 register_both_for_type(PyArray_DTypeMeta *complex_dtype, PyArray_DTypeMeta *real_dtype) {
-    if (register_one_for_type<real_type, true>(".real", complex_dtype, real_dtype) < 0) {
+    if (register_one_for_type<real_type, true>("real", complex_dtype, real_dtype) < 0) {
         return -1;
     }
-    if (register_one_for_type<real_type, false>(".imag", complex_dtype, real_dtype) < 0) {
+    if (register_one_for_type<real_type, false>("imag", complex_dtype, real_dtype) < 0) {
         return -1;
     }
     return 0;
@@ -270,16 +270,17 @@ init_real_imag_ufuncs(PyObject *umath)
     if (register_both_for_type<npy_longdouble>(&PyArray_CLongDoubleDType, &PyArray_LongDoubleDType) < 0) {
         goto finish;
     }
-    if (register_one_object_loop<&npy_interned_str_struct::real>(".real") < 0) {
+    if (register_one_object_loop<&npy_interned_str_struct::real>("real") < 0) {
         goto finish;
     }
-    if (register_one_object_loop<&npy_interned_str_struct::imag>(".imag") < 0) {
+    if (register_one_object_loop<&npy_interned_str_struct::imag>("imag") < 0) {
         goto finish;
     }
 
     /*
      * The above actually only adds the method to the DType itself. We deal with
-     * the ufunc by adding a general fall-back method that
+     * the ufunc by adding a general fall-back method that dynamically registers
+     * loops based on the above DType method slots.
      */
     if (add_promoter_for_slot<&NPY_DType_Slots::real_meth>(real_ufunc) < 0) {
         goto finish;

--- a/numpy/_core/src/umath/real_imag_ufuncs.cpp
+++ b/numpy/_core/src/umath/real_imag_ufuncs.cpp
@@ -67,14 +67,12 @@ static int extract_complex_part_loop(
     npy_intp istride = strides[0];
     npy_intp ostride = strides[1];
 
+    if constexpr (!real_part) {
+        in += sizeof(real_type);
+    }
+
     while (N--) {
-        real_type value;
-        if constexpr (real_part) {
-            value = *reinterpret_cast<real_type *>(in);
-        }
-        else {
-            value = *reinterpret_cast<real_type *>(in + sizeof(real_type));
-        }
+        real_type value = *reinterpret_cast<real_type *>(in);
         *reinterpret_cast<real_type *>(out) = value;
         in += istride;
         out += ostride;

--- a/numpy/_core/src/umath/real_imag_ufuncs.cpp
+++ b/numpy/_core/src/umath/real_imag_ufuncs.cpp
@@ -1,0 +1,218 @@
+/*
+ * real/imag ufuncs: 1 input (complex), 1 output (float).
+ * No dedicated loops: either a view is returned (view_offset path in ufunc
+ * fast path) or the get_loop returns a copy loop for the real/imag part.
+ */
+
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define _MULTIARRAYMODULE
+#define _UMATHMODULE
+
+#include <Python.h>
+#include "numpy/ndarraytypes.h"
+#include "numpy/ufuncobject.h"
+
+#include "numpyos.h"
+#include "dtypemeta.h"
+#include "dtype_transfer.h"
+#include "lowlevel_strided_loops.h"
+#include "array_method.h"
+
+#include "real_imag_ufuncs.h"
+
+
+template <int real_num, bool real_part>
+static NPY_CASTING
+complex_to_real_resolve_descriptors(
+        PyArrayMethodObject *NPY_UNUSED(self),
+        PyArray_DTypeMeta *const dtypes[2],
+        PyArray_Descr *const given_descrs[2],
+        PyArray_Descr *loop_descrs[2],
+        npy_intp *view_offset)
+{
+    Py_INCREF(given_descrs[0]);
+    loop_descrs[0] = given_descrs[0];
+    loop_descrs[1] = PyArray_DescrFromType(real_num);
+
+    if (PyDataType_ISBYTESWAPPED(loop_descrs[0])) {
+        Py_SETREF(
+            loop_descrs[1], PyArray_DescrNewByteorder(loop_descrs[1], NPY_SWAP));
+        if (loop_descrs[1] == NULL) {
+            Py_DECREF(loop_descrs[0]);
+            return _NPY_ERROR_OCCURRED_IN_CAST;
+        }
+    }
+    if constexpr (real_part) {
+        *view_offset = 0;
+    }
+    else {
+        *view_offset = loop_descrs[1]->elsize;
+    }
+    return NPY_NO_CASTING;
+}
+
+
+/* We shouldn't normally use it, but define a simple loop anyway. */
+template <typename real_type, bool real_part>
+static int extract_complex_part_loop(
+        PyArrayMethod_Context *context, char *const data[],
+        npy_intp const dimensions[], npy_intp const strides[],
+        NpyAuxData *NPY_UNUSED(auxdata))
+{
+    npy_intp N = dimensions[0];
+    char *in = data[0];
+    char *out = data[1];
+    npy_intp istride = strides[0];
+    npy_intp ostride = strides[1];
+
+    while (N--) {
+        real_type value;
+        if constexpr (real_part) {
+            value = *reinterpret_cast<real_type *>(in);
+        }
+        else {
+            value = *reinterpret_cast<real_type *>(in + sizeof(real_type));
+        }
+        *reinterpret_cast<real_type *>(out) = value;
+        in += istride;
+        out += ostride;
+    }
+    return 0;
+}
+
+
+
+template <int complex_num, typename real_type, int real_num, bool real_part>
+static int
+register_real_for_type(PyObject *ufunc)
+{
+    PyArray_DTypeMeta *dtypes[2] = {
+        PyArray_DTypeFromTypeNum(complex_num),
+        PyArray_DTypeFromTypeNum(real_num),
+    };
+    PyType_Slot meth_slots[] = {
+        {NPY_METH_resolve_descriptors, (void *)&complex_to_real_resolve_descriptors<real_num, real_part>},
+        {NPY_METH_strided_loop, (void *)&extract_complex_part_loop<real_type, real_part>},
+        {0, NULL}
+    };
+    PyArrayMethod_Spec meth_spec = {
+        .nin = 1,
+        .nout = 1,
+        .dtypes = dtypes,
+        .slots = meth_slots,
+    };
+    int res = PyUFunc_AddLoopFromSpec(ufunc, &meth_spec);
+    Py_DECREF(dtypes[0]);
+    Py_DECREF(dtypes[1]);
+    return res;
+}
+
+
+template <int complex_num, typename real_type, int real_num>
+static int
+register_both_for_type(PyObject *real_ufunc, PyObject *imag_ufunc) {
+    if (register_real_for_type<complex_num, real_type, real_num, true>(real_ufunc) < 0) {
+        return -1;
+    }
+    if (register_real_for_type<complex_num, real_type, real_num, false>(imag_ufunc) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+
+template <auto component>
+static int
+object_get_comp_strided_loop(
+        PyArrayMethod_Context *context, char *const data[],
+        npy_intp const dimensions[], npy_intp const strides[],
+        NpyAuxData *auxdata)
+{
+    npy_intp N = dimensions[0];
+    char *in = data[0];
+    char *out = data[1];
+    npy_intp istride = strides[0];
+    npy_intp ostride = strides[1];
+
+    while (N--) {
+        PyObject *obj = *reinterpret_cast<PyObject **>(in);
+        PyObject *attr;
+        if (PyObject_GetOptionalAttr(obj, npy_interned_str.*component, &attr) < 0) {
+            return -1;
+        }
+        if (attr == NULL) {
+            if constexpr (component == &npy_interned_str_struct::real) {
+                attr = Py_NewRef(obj);  // just use the old object...
+            }
+            else {
+                // Use long zero as a best bet (also historical value)
+                attr = PyLong_FromLong(0);
+                if (attr == NULL) {
+                    return -1;
+                }
+            }
+        }
+
+        Py_XSETREF((*reinterpret_cast<PyObject **>(out)), attr);
+        in += istride;
+        out += ostride;
+    }
+    return 0;
+}
+
+
+static int
+register_object_loops(PyObject *real_ufunc, PyObject *imag_ufunc)
+{
+    PyArray_DTypeMeta *dtypes[2] = {&PyArray_ObjectDType, &PyArray_ObjectDType};
+    PyType_Slot meth_slots[] = {
+        {NPY_METH_strided_loop, nullptr},
+        {0, nullptr}
+    };
+    PyArrayMethod_Spec meth_spec = {
+        .nin = 1,
+        .nout = 1,
+        .dtypes = dtypes,
+        .slots = meth_slots,
+    };
+    meth_slots[0].pfunc = (void *)&object_get_comp_strided_loop<&npy_interned_str_struct::real>;
+    int res = PyUFunc_AddLoopFromSpec(real_ufunc, &meth_spec);
+    if (res < 0) {
+        return -1;
+    }
+    meth_slots[0].pfunc = (void *)&object_get_comp_strided_loop<&npy_interned_str_struct::imag>;
+    res = PyUFunc_AddLoopFromSpec(imag_ufunc, &meth_spec);
+    return res;
+}
+
+
+NPY_NO_EXPORT int
+init_real_imag_ufuncs(PyObject *umath)
+{
+    int res = -1;
+    PyObject *real_ufunc = PyObject_GetAttr(umath, npy_interned_str.real);
+    PyObject *imag_ufunc = PyObject_GetAttr(umath, npy_interned_str.imag);
+    if (real_ufunc == NULL || imag_ufunc == NULL) {
+        goto finish;
+    }
+
+    if (register_both_for_type<NPY_CFLOAT, npy_float32, NPY_FLOAT>(real_ufunc, imag_ufunc) < 0) {
+        goto finish;
+    }
+    if (register_both_for_type<NPY_CDOUBLE, npy_float64, NPY_DOUBLE>(real_ufunc, imag_ufunc) < 0) {
+        goto finish;
+    }
+    if (register_both_for_type<NPY_CLONGDOUBLE, npy_longdouble, NPY_LONGDOUBLE>(real_ufunc, imag_ufunc) < 0) {
+        goto finish;
+    }
+    if (register_object_loops(real_ufunc, imag_ufunc) < 0) {
+        goto finish;
+    }
+
+    res = 0;
+  finish:
+    Py_XDECREF(real_ufunc);
+    Py_XDECREF(imag_ufunc);
+
+    return res;
+}

--- a/numpy/_core/src/umath/real_imag_ufuncs.cpp
+++ b/numpy/_core/src/umath/real_imag_ufuncs.cpp
@@ -1,7 +1,8 @@
 /*
- * real/imag ufuncs: 1 input (complex), 1 output (float).
- * No dedicated loops: either a view is returned (view_offset path in ufunc
- * fast path) or the get_loop returns a copy loop for the real/imag part.
+ * This file implements the real and imag ufuncs which are in turn used
+ * for the `.imag` and `.real` attributes of arrays.
+ * The ArrayMethods are primarily stored on the DType for `.real` and `.imag`
+ * while the ufunc uses a promoter to access these dynamically.
  */
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
@@ -134,14 +135,17 @@ register_one_for_type(const char *name)
         {NPY_METH_strided_loop, (void *)&extract_complex_part_loop<real_type, real_part>},
         {0, NULL}
     };
-    PyArrayMethod_Spec meth_spec = {
-        .nin = 1,
-        .nout = 1,
-        .dtypes = dtypes,
-        .slots = meth_slots,
-    };
+    PyArrayMethod_Spec meth_spec;
+    meth_spec.name = "generic_real_imag_loop";
+    meth_spec.flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
+    meth_spec.nin = 1;
+    meth_spec.nout = 1;
+    meth_spec.dtypes = dtypes;
+    meth_spec.slots = meth_slots;
+    meth_spec.casting = NPY_NO_CASTING;
+
     PyUFunc_LoopSlot slots[] = {
-        {.name = name, .spec = &meth_spec},
+        {name, &meth_spec},
         {0, nullptr}
     };
     int res = PyUFunc_AddLoopsFromSpecs(slots);
@@ -173,14 +177,17 @@ register_one_object_loop(const char *name)
         {NPY_METH_strided_loop, (void *)&object_get_comp_strided_loop<component>},
         {0, nullptr}
     };
-    PyArrayMethod_Spec meth_spec = {
-        .nin = 1,
-        .nout = 1,
-        .dtypes = dtypes,
-        .slots = meth_slots,
-    };
+    PyArrayMethod_Spec meth_spec;
+    meth_spec.name = "object_real_imag_loop";
+    meth_spec.flags = (NPY_ARRAYMETHOD_FLAGS)(
+        NPY_METH_NO_FLOATINGPOINT_ERRORS|NPY_METH_REQUIRES_PYAPI);
+    meth_spec.nin = 1;
+    meth_spec.nout = 1;
+    meth_spec.dtypes = dtypes;
+    meth_spec.slots = meth_slots;
+    meth_spec.casting = NPY_NO_CASTING;
     PyUFunc_LoopSlot slots[] = {
-        {.name = name, .spec = &meth_spec},
+        {name, &meth_spec},
         {0, nullptr}
     };
     return PyUFunc_AddLoopsFromSpecs(slots);

--- a/numpy/_core/src/umath/real_imag_ufuncs.cpp
+++ b/numpy/_core/src/umath/real_imag_ufuncs.cpp
@@ -24,7 +24,7 @@
 #include "real_imag_ufuncs.h"
 
 
-template <int real_num, bool real_part>
+template <bool real_part>
 static NPY_CASTING
 complex_to_real_resolve_descriptors(
         PyArrayMethodObject *NPY_UNUSED(self),
@@ -35,7 +35,8 @@ complex_to_real_resolve_descriptors(
 {
     Py_INCREF(given_descrs[0]);
     loop_descrs[0] = given_descrs[0];
-    loop_descrs[1] = PyArray_DescrFromType(real_num);
+    Py_INCREF(dtypes[1]->singleton);
+    loop_descrs[1] = dtypes[1]->singleton;
 
     if (PyDataType_ISBYTESWAPPED(loop_descrs[0])) {
         Py_SETREF(
@@ -122,16 +123,14 @@ object_get_comp_strided_loop(
 }
 
 
-template <int complex_num, typename real_type, int real_num, bool real_part>
+template <typename real_type, bool real_part>
 static int
-register_one_for_type(const char *name)
+register_one_for_type(
+    const char *name, PyArray_DTypeMeta *complex_dtype, PyArray_DTypeMeta *real_dtype)
 {
-    PyArray_DTypeMeta *dtypes[2] = {
-        PyArray_DTypeFromTypeNum(complex_num),
-        PyArray_DTypeFromTypeNum(real_num),
-    };
+    PyArray_DTypeMeta *dtypes[2] = {complex_dtype, real_dtype};
     PyType_Slot meth_slots[] = {
-        {NPY_METH_resolve_descriptors, (void *)&complex_to_real_resolve_descriptors<real_num, real_part>},
+        {NPY_METH_resolve_descriptors, (void *)&complex_to_real_resolve_descriptors<real_part>},
         {NPY_METH_strided_loop, (void *)&extract_complex_part_loop<real_type, real_part>},
         {0, NULL}
     };
@@ -148,20 +147,17 @@ register_one_for_type(const char *name)
         {name, &meth_spec},
         {0, nullptr}
     };
-    int res = PyUFunc_AddLoopsFromSpecs(slots);
-    Py_DECREF(dtypes[0]);
-    Py_DECREF(dtypes[1]);
-    return res;
+    return PyUFunc_AddLoopsFromSpecs(slots);
 }
 
 
-template <int complex_num, typename real_type, int real_num>
+template <typename real_type>
 static int
-register_both_for_type() {
-    if (register_one_for_type<complex_num, real_type, real_num, true>(".real") < 0) {
+register_both_for_type(PyArray_DTypeMeta *complex_dtype, PyArray_DTypeMeta *real_dtype) {
+    if (register_one_for_type<real_type, true>(".real", complex_dtype, real_dtype) < 0) {
         return -1;
     }
-    if (register_one_for_type<complex_num, real_type, real_num, false>(".imag") < 0) {
+    if (register_one_for_type<real_type, false>(".imag", complex_dtype, real_dtype) < 0) {
         return -1;
     }
     return 0;
@@ -265,13 +261,13 @@ init_real_imag_ufuncs(PyObject *umath)
         goto finish;
     }
 
-    if (register_both_for_type<NPY_CFLOAT, npy_float32, NPY_FLOAT>() < 0) {
+    if (register_both_for_type<npy_float32>(&PyArray_CFloatDType, &PyArray_FloatDType) < 0) {
         goto finish;
     }
-    if (register_both_for_type<NPY_CDOUBLE, npy_float64, NPY_DOUBLE>() < 0) {
+    if (register_both_for_type<npy_float64>(&PyArray_CDoubleDType, &PyArray_DoubleDType) < 0) {
         goto finish;
     }
-    if (register_both_for_type<NPY_CLONGDOUBLE, npy_longdouble, NPY_LONGDOUBLE>() < 0) {
+    if (register_both_for_type<npy_longdouble>(&PyArray_CLongDoubleDType, &PyArray_LongDoubleDType) < 0) {
         goto finish;
     }
     if (register_one_object_loop<&npy_interned_str_struct::real>(".real") < 0) {

--- a/numpy/_core/src/umath/real_imag_ufuncs.h
+++ b/numpy/_core/src/umath/real_imag_ufuncs.h
@@ -1,0 +1,15 @@
+#ifndef _NPY_CORE_SRC_UMATH_REAL_IMAG_UFUNCS_H_
+#define _NPY_CORE_SRC_UMATH_REAL_IMAG_UFUNCS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NPY_NO_EXPORT int
+init_real_imag_ufuncs(PyObject *umath);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* _NPY_CORE_SRC_UMATH_REAL_IMAG_UFUNCS_H_ */

--- a/numpy/_core/src/umath/special_integer_comparisons.cpp
+++ b/numpy/_core/src/umath/special_integer_comparisons.cpp
@@ -106,7 +106,7 @@ get_min_max(int typenum, long long *min, unsigned long long *max)
 
 /*
  * Determine if a Python long is within the typenums range, smaller, or larger.
- * 
+ *
  * Function returns -1 for errors.
  */
 static inline int
@@ -344,7 +344,7 @@ add_dtype_loops(PyObject *umath, PyArrayMethod_Spec *spec, PyObject *info)
         goto fail;
     }
 
-    /* 
+    /*
      * NOTE: Iterates all type numbers, it would be nice to reduce this.
      *       (that would be easier if we consolidate int DTypes in general.)
      */

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -101,7 +101,7 @@ resolve_descriptors(int nop,
         PyUFuncObject *ufunc, PyArrayMethodObject *ufuncimpl,
         PyArrayObject *operands[], PyArray_Descr *dtypes[],
         PyArray_DTypeMeta *signature[], PyArray_DTypeMeta *original_DTypes[],
-        PyObject *inputs_tup, NPY_CASTING casting, npy_intp *view_offset);
+        PyObject *inputs_tup, NPY_CASTING casting);
 
 
 /*UFUNC_API*/
@@ -615,7 +615,6 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
         PyArray_DTypeMeta *out_op_DTypes[],
         npy_bool *force_legacy_promotion,
         npy_bool *promoting_pyscalars,
-        npy_bool *all_input_scalars,
         PyObject *order_obj, NPY_ORDER *out_order,
         PyObject *casting_obj, NPY_CASTING *out_casting,
         PyObject *subok_obj, npy_bool *out_subok,
@@ -629,12 +628,10 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
 
     /* Convert and fill in input arguments */
     npy_bool all_scalar = NPY_TRUE;
-    npy_bool any_scalar = NPY_FALSE;  /* any 0-D object, legacy scalar */
-    *all_input_scalars = NPY_TRUE;
+    npy_bool any_scalar = NPY_FALSE;
     *force_legacy_promotion = NPY_FALSE;
     *promoting_pyscalars = NPY_FALSE;
     for (int i = 0; i < nin; i++) {
-        int was_pyscalar = 0;
         obj = PyTuple_GET_ITEM(full_args.in, i);
 
         if (PyArray_Check(obj)) {
@@ -643,18 +640,13 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
         }
         else {
             /* Convert the input to an array and check for special cases */
-            out_op[i] = (PyArrayObject *)PyArray_FromAny_int(
-                    obj, NULL, NULL, 0, NPY_MAXDIMS, 0, NULL, &was_pyscalar);
+            out_op[i] = (PyArrayObject *)PyArray_FromAny(obj, NULL, 0, 0, 0, NULL);
             if (out_op[i] == NULL) {
                 goto fail;
             }
         }
         out_op_DTypes[i] = NPY_DTYPE(PyArray_DESCR(out_op[i]));
         Py_INCREF(out_op_DTypes[i]);
-
-        if (!was_pyscalar) {
-            *all_input_scalars = NPY_FALSE;
-        }
 
         if (nin == 1) {
             /*
@@ -687,8 +679,7 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
          * `np.can_cast(operand, dtype)`.  The flag is local to this use, but
          * necessary to propagate the information to the legacy type resolution.
          */
-        if (was_pyscalar &&
-                npy_mark_tmp_array_if_pyscalar(obj, out_op[i], &out_op_DTypes[i])) {
+        if (npy_mark_tmp_array_if_pyscalar(obj, out_op[i], &out_op_DTypes[i])) {
             if (PyArray_FLAGS(out_op[i]) & NPY_ARRAY_WAS_PYTHON_INT
                     && PyArray_TYPE(out_op[i]) != NPY_LONG) {
                 /*
@@ -2363,10 +2354,8 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
      * casting safety could in principle be set to the default same-kind.
      * (although this should possibly happen through a deprecation)
      */
-    npy_intp view_offset = NPY_MIN_INTP;  // ignored, not sensible for reductions
     int res = resolve_descriptors(3, ufunc, ufuncimpl,
-            ops, out_descrs, signature, operation_DTypes, NULL,
-            casting, &view_offset);
+            ops, out_descrs, signature, operation_DTypes, NULL, casting);
 
     Py_XDECREF(operation_DTypes[0]);
     Py_XDECREF(operation_DTypes[1]);
@@ -4046,7 +4035,7 @@ resolve_descriptors(int nop,
         PyUFuncObject *ufunc, PyArrayMethodObject *ufuncimpl,
         PyArrayObject *operands[], PyArray_Descr *dtypes[],
         PyArray_DTypeMeta *signature[], PyArray_DTypeMeta *original_DTypes[],
-        PyObject *inputs_tup, NPY_CASTING casting, npy_intp *view_offset)
+        PyObject *inputs_tup, NPY_CASTING casting)
 {
     int retval = -1;
     NPY_CASTING safety;
@@ -4089,9 +4078,10 @@ resolve_descriptors(int nop,
         }
         n_cleanup = nop;
 
+        npy_intp view_offset = NPY_MIN_INTP;  /* currently ignored */
         safety = ufuncimpl->resolve_descriptors_with_scalars(
             ufuncimpl, signature, original_descrs, input_scalars,
-            dtypes, view_offset
+            dtypes, &view_offset
         );
 
         /* For scalars, replace the operand if needed (scalars can't be out) */
@@ -4158,8 +4148,10 @@ resolve_descriptors(int nop,
 
     if (ufuncimpl->resolve_descriptors != &wrapped_legacy_resolve_descriptors) {
         /* The default: use the `ufuncimpl` as nature intended it */
+        npy_intp view_offset = NPY_MIN_INTP;  /* currently ignored */
+
         safety = ufuncimpl->resolve_descriptors(ufuncimpl,
-                signature, original_descrs, dtypes, view_offset);
+                signature, original_descrs, dtypes, &view_offset);
         goto check_safety;
     }
     else {
@@ -4677,14 +4669,12 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
     int keepdims = -1;  /* We need to know if it was passed */
     npy_bool force_legacy_promotion;
     npy_bool promoting_pyscalars;
-    npy_bool all_input_scalars;
     if (convert_ufunc_arguments(ufunc,
             /* extract operand related information: */
             full_args, operands,
             operand_DTypes,
             &force_legacy_promotion,
             &promoting_pyscalars,
-            &all_input_scalars,
             /* extract general information: */
             order_obj, &order,
             casting_obj, &casting,
@@ -4711,37 +4701,16 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
     }
 
     /* Find the correct descriptors for the operation */
-    npy_intp view_offset = NPY_MIN_INTP;
     if (resolve_descriptors(nop, ufunc, ufuncimpl,
             operands, operation_descrs, signature, operand_DTypes,
-            full_args.in, casting, &view_offset) < 0) {
+            full_args.in, casting) < 0) {
         goto fail;
     }
 
     /*
-     * If it is just a view, do that (mainly/only `arr.real` and `arr.image`).
+     * Do the final preparations and call the inner-loop.
      */
-    if (view_offset != NPY_MIN_INTP
-            && !ufunc->core_enabled
-            && ufunc->nin == 1 && ufunc->nout == 1
-            && operands[1] == NULL && where_obj == NULL) {
-        return_scalar = all_input_scalars;  // disable the typical 0-D->scalar
-
-        Py_INCREF(operation_descrs[1]);
-        operands[1] = (PyArrayObject *)PyArray_NewFromDescr_int(
-                &PyArray_Type, operation_descrs[1],
-                PyArray_NDIM(operands[0]), PyArray_DIMS(operands[0]),
-                PyArray_STRIDES(operands[0]), PyArray_BYTES(operands[0]) + view_offset,
-                PyArray_FLAGS(operands[0]), NULL, (PyObject *)operands[0],
-                _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
-        if (operands[1] == NULL) {
-            goto fail;
-        }
-    }
-    /*
-     * Otherwise do the final preparations and call the inner-loop.
-     */
-    else if (!ufunc->core_enabled) {
+    if (!ufunc->core_enabled) {
         errval = PyUFunc_GenericFunctionInternal(ufunc, ufuncimpl,
                 operation_descrs, operands, casting, order,
                 wheremask);
@@ -6055,10 +6024,8 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
         }
 
         /* Find the correct operation_descrs for the operation */
-        npy_intp view_offset = NPY_MIN_INTP;  // ignored, not sensible for ufunc.at
         int resolve_result = resolve_descriptors(nop, ufunc, ufuncimpl,
-                tmp_operands, operation_descrs, signature, operand_DTypes, NULL,
-                NPY_UNSAFE_CASTING, &view_offset);
+                tmp_operands, operation_descrs, signature, operand_DTypes, NULL, NPY_UNSAFE_CASTING);
         for (int i = 0; i < 3; i++) {
             Py_XDECREF(signature[i]);
             Py_XDECREF(operand_DTypes[i]);
@@ -6379,10 +6346,9 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
         }
 
         /* Find the correct descriptors for the operation */
-        npy_intp view_offset = NPY_MIN_INTP;  // ignored, not sensible for reductions
         if (resolve_descriptors(ufunc->nargs, ufunc, ufuncimpl,
                 dummy_arrays, operation_descrs, signature, DTypes,
-                NULL, casting, &view_offset) < 0) {
+                NULL, casting) < 0) {
             goto finish;
         }
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -101,7 +101,7 @@ resolve_descriptors(int nop,
         PyUFuncObject *ufunc, PyArrayMethodObject *ufuncimpl,
         PyArrayObject *operands[], PyArray_Descr *dtypes[],
         PyArray_DTypeMeta *signature[], PyArray_DTypeMeta *original_DTypes[],
-        PyObject *inputs_tup, NPY_CASTING casting);
+        PyObject *inputs_tup, NPY_CASTING casting, npy_intp *view_offset);
 
 
 /*UFUNC_API*/
@@ -615,6 +615,7 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
         PyArray_DTypeMeta *out_op_DTypes[],
         npy_bool *force_legacy_promotion,
         npy_bool *promoting_pyscalars,
+        npy_bool *all_input_scalars,
         PyObject *order_obj, NPY_ORDER *out_order,
         PyObject *casting_obj, NPY_CASTING *out_casting,
         PyObject *subok_obj, npy_bool *out_subok,
@@ -628,10 +629,12 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
 
     /* Convert and fill in input arguments */
     npy_bool all_scalar = NPY_TRUE;
-    npy_bool any_scalar = NPY_FALSE;
+    npy_bool any_scalar = NPY_FALSE;  /* any 0-D object, legacy scalar */
+    *all_input_scalars = NPY_TRUE;
     *force_legacy_promotion = NPY_FALSE;
     *promoting_pyscalars = NPY_FALSE;
     for (int i = 0; i < nin; i++) {
+        int was_pyscalar = 0;
         obj = PyTuple_GET_ITEM(full_args.in, i);
 
         if (PyArray_Check(obj)) {
@@ -640,13 +643,18 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
         }
         else {
             /* Convert the input to an array and check for special cases */
-            out_op[i] = (PyArrayObject *)PyArray_FromAny(obj, NULL, 0, 0, 0, NULL);
+            out_op[i] = (PyArrayObject *)PyArray_FromAny_int(
+                    obj, NULL, NULL, 0, NPY_MAXDIMS, 0, NULL, &was_pyscalar);
             if (out_op[i] == NULL) {
                 goto fail;
             }
         }
         out_op_DTypes[i] = NPY_DTYPE(PyArray_DESCR(out_op[i]));
         Py_INCREF(out_op_DTypes[i]);
+
+        if (!was_pyscalar) {
+            *all_input_scalars = NPY_FALSE;
+        }
 
         if (nin == 1) {
             /*
@@ -679,7 +687,8 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
          * `np.can_cast(operand, dtype)`.  The flag is local to this use, but
          * necessary to propagate the information to the legacy type resolution.
          */
-        if (npy_mark_tmp_array_if_pyscalar(obj, out_op[i], &out_op_DTypes[i])) {
+        if (was_pyscalar &&
+                npy_mark_tmp_array_if_pyscalar(obj, out_op[i], &out_op_DTypes[i])) {
             if (PyArray_FLAGS(out_op[i]) & NPY_ARRAY_WAS_PYTHON_INT
                     && PyArray_TYPE(out_op[i]) != NPY_LONG) {
                 /*
@@ -2354,8 +2363,10 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
      * casting safety could in principle be set to the default same-kind.
      * (although this should possibly happen through a deprecation)
      */
+    npy_intp view_offset = NPY_MIN_INTP;  // ignored, not sensible for reductions
     int res = resolve_descriptors(3, ufunc, ufuncimpl,
-            ops, out_descrs, signature, operation_DTypes, NULL, casting);
+            ops, out_descrs, signature, operation_DTypes, NULL,
+            casting, &view_offset);
 
     Py_XDECREF(operation_DTypes[0]);
     Py_XDECREF(operation_DTypes[1]);
@@ -4035,7 +4046,7 @@ resolve_descriptors(int nop,
         PyUFuncObject *ufunc, PyArrayMethodObject *ufuncimpl,
         PyArrayObject *operands[], PyArray_Descr *dtypes[],
         PyArray_DTypeMeta *signature[], PyArray_DTypeMeta *original_DTypes[],
-        PyObject *inputs_tup, NPY_CASTING casting)
+        PyObject *inputs_tup, NPY_CASTING casting, npy_intp *view_offset)
 {
     int retval = -1;
     NPY_CASTING safety;
@@ -4078,10 +4089,9 @@ resolve_descriptors(int nop,
         }
         n_cleanup = nop;
 
-        npy_intp view_offset = NPY_MIN_INTP;  /* currently ignored */
         safety = ufuncimpl->resolve_descriptors_with_scalars(
             ufuncimpl, signature, original_descrs, input_scalars,
-            dtypes, &view_offset
+            dtypes, view_offset
         );
 
         /* For scalars, replace the operand if needed (scalars can't be out) */
@@ -4148,10 +4158,8 @@ resolve_descriptors(int nop,
 
     if (ufuncimpl->resolve_descriptors != &wrapped_legacy_resolve_descriptors) {
         /* The default: use the `ufuncimpl` as nature intended it */
-        npy_intp view_offset = NPY_MIN_INTP;  /* currently ignored */
-
         safety = ufuncimpl->resolve_descriptors(ufuncimpl,
-                signature, original_descrs, dtypes, &view_offset);
+                signature, original_descrs, dtypes, view_offset);
         goto check_safety;
     }
     else {
@@ -4669,12 +4677,14 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
     int keepdims = -1;  /* We need to know if it was passed */
     npy_bool force_legacy_promotion;
     npy_bool promoting_pyscalars;
+    npy_bool all_input_scalars;
     if (convert_ufunc_arguments(ufunc,
             /* extract operand related information: */
             full_args, operands,
             operand_DTypes,
             &force_legacy_promotion,
             &promoting_pyscalars,
+            &all_input_scalars,
             /* extract general information: */
             order_obj, &order,
             casting_obj, &casting,
@@ -4701,16 +4711,37 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
     }
 
     /* Find the correct descriptors for the operation */
+    npy_intp view_offset = NPY_MIN_INTP;
     if (resolve_descriptors(nop, ufunc, ufuncimpl,
             operands, operation_descrs, signature, operand_DTypes,
-            full_args.in, casting) < 0) {
+            full_args.in, casting, &view_offset) < 0) {
         goto fail;
     }
 
     /*
-     * Do the final preparations and call the inner-loop.
+     * If it is just a view, do that (mainly/only `arr.real` and `arr.image`).
      */
-    if (!ufunc->core_enabled) {
+    if (view_offset != NPY_MIN_INTP
+            && !ufunc->core_enabled
+            && ufunc->nin == 1 && ufunc->nout == 1
+            && operands[1] == NULL && where_obj == NULL) {
+        return_scalar = all_input_scalars;  // disable the typical 0-D->scalar
+
+        Py_INCREF(operation_descrs[1]);
+        operands[1] = (PyArrayObject *)PyArray_NewFromDescr_int(
+                &PyArray_Type, operation_descrs[1],
+                PyArray_NDIM(operands[0]), PyArray_DIMS(operands[0]),
+                PyArray_STRIDES(operands[0]), PyArray_BYTES(operands[0]) + view_offset,
+                PyArray_FLAGS(operands[0]), NULL, (PyObject *)operands[0],
+                _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
+        if (operands[1] == NULL) {
+            goto fail;
+        }
+    }
+    /*
+     * Otherwise do the final preparations and call the inner-loop.
+     */
+    else if (!ufunc->core_enabled) {
         errval = PyUFunc_GenericFunctionInternal(ufunc, ufuncimpl,
                 operation_descrs, operands, casting, order,
                 wheremask);
@@ -6024,8 +6055,10 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
         }
 
         /* Find the correct operation_descrs for the operation */
+        npy_intp view_offset = NPY_MIN_INTP;  // ignored, not sensible for ufunc.at
         int resolve_result = resolve_descriptors(nop, ufunc, ufuncimpl,
-                tmp_operands, operation_descrs, signature, operand_DTypes, NULL, NPY_UNSAFE_CASTING);
+                tmp_operands, operation_descrs, signature, operand_DTypes, NULL,
+                NPY_UNSAFE_CASTING, &view_offset);
         for (int i = 0; i < 3; i++) {
             Py_XDECREF(signature[i]);
             Py_XDECREF(operand_DTypes[i]);
@@ -6346,9 +6379,10 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
         }
 
         /* Find the correct descriptors for the operation */
+        npy_intp view_offset = NPY_MIN_INTP;  // ignored, not sensible for reductions
         if (resolve_descriptors(ufunc->nargs, ufunc, ufuncimpl,
                 dummy_arrays, operation_descrs, signature, DTypes,
-                NULL, casting) < 0) {
+                NULL, casting, &view_offset) < 0) {
             goto finish;
         }
 

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -31,6 +31,7 @@
 #include "string_ufuncs.h"
 #include "stringdtype_ufuncs.h"
 #include "special_integer_comparisons.h"
+#include "real_imag_ufuncs.h"
 #include "extobj.h"  /* for _extobject_contextvar exposure */
 #include "ufunc_type_resolution.h"
 
@@ -271,6 +272,10 @@ int initumath(PyObject *m)
     Py_DECREF(s);
 
     if (init_string_ufuncs(d) < 0) {
+        return -1;
+    }
+
+    if (init_real_imag_ufuncs(m) < 0) {
         return -1;
     }
 

--- a/numpy/_core/tests/test_arrayobject.py
+++ b/numpy/_core/tests/test_arrayobject.py
@@ -4,6 +4,7 @@ import pytest
 
 import numpy as np
 from numpy.testing import HAS_REFCOUNT, assert_array_equal
+from numpy._core._rational_tests import rational
 
 
 def test_matrix_transpose_raises_error_for_1d():
@@ -93,3 +94,105 @@ def test_cleanup_with_refs_non_contig():
     actual_ref_obj = sys.getrefcount(obj)
     assert actual_ref_dtype == expected_ref_dtype
     assert actual_ref_obj == actual_ref_dtype
+
+
+@pytest.mark.parametrize("dtype",
+    list("?bhilqnpBHILQNPefdgSUV") + ["M8[ns]", "m8[ns]", rational])
+def test_real_imag_attributes_non_complex(dtype):
+    dtype = np.dtype(dtype)
+
+    a = np.array([[1, 2, 3], [4, 5, 6]]).astype(dtype)
+    assert a.real is a
+    # One could imagine broadcasting, but doesn't right now:
+    imag = a.imag
+    assert imag.strides == a.strides
+    assert imag.dtype == a.dtype
+    # This part is rather unclear:
+    assert (imag == np.zeros((), dtype=a.dtype)).all()
+    assert imag.flags.writeable is False
+
+    class myarr(np.ndarray):
+        def __array_finalize__(self, obj):
+            self.finalized_with = obj
+
+    ma = a.view(myarr)
+    assert ma.real is ma
+    assert type(ma.imag) is myarr
+    assert ma.imag.finalized_with is ma
+
+
+@pytest.mark.parametrize("dtype,real_dt",
+    [(">c8", ">f4"), ("c16", "f8"), ("clongdouble", "longdouble")])
+@pytest.mark.parametrize("variation", ["transpose", "set_writeable"])
+def test_real_imag_attributes_complex(dtype, real_dt, variation):
+    a = np.array([[1, 2j, 3], [4, 5j, 6]]).astype(dtype)
+    real = np.array([[1, 0, 3], [4, 0, 6]], dtype=real_dt)
+    imag = np.array([[0, 2, 0], [0, 5, 0]], dtype=real_dt)
+
+    if variation == "transpose":
+        a = a.T
+        real = real.T
+        imag = imag.T
+    elif variation == "set_writeable":
+        a.flags.writeable = False
+
+
+    assert_array_equal(a.real, real)
+    assert_array_equal(a.imag, imag)
+    assert a.real.dtype == real_dt
+    assert a.imag.dtype == real_dt
+    assert np.may_share_memory(a.real, a)
+    assert np.may_share_memory(a.imag, a)
+    assert a.real.flags.writeable == a.flags.writeable
+    assert a.imag.flags.writeable == a.flags.writeable
+
+    class myarr(np.ndarray):
+        def __array_finalize__(self, obj):
+            self.finalized_with = obj
+
+    ma = a.view(myarr)
+    assert ma.real.finalized_with is ma
+    assert ma.imag.finalized_with is ma
+
+
+def test_real_imag_attributes_object():
+    a = np.array([[1, 0.5+2j, 3, int], [4, 5j, "string", {}]], dtype=object)
+
+    # NOTE(seberg): doing something for non-numbers is guesswork...
+    real = np.array([[1, 0.5, 3, int.real], [4, 0, "string", {}]], dtype=object)
+    imag = np.array([[0, 2, 0, int.imag], [0, 5, 0, 0]], dtype=object)
+
+    assert_array_equal(a.real, real)
+    assert_array_equal(a.imag, imag)
+    assert a.real.dtype == object
+    assert a.imag.dtype == object
+    assert not np.may_share_memory(a.real, a)
+    assert not np.may_share_memory(a.imag, a)
+    assert not a.real.flags.writeable
+    assert not a.imag.flags.writeable
+
+    # Object returns new arrays via ufuncs, so call wrap
+    class myarr(np.ndarray):
+        def __array_wrap__(self, *args, **kwargs):
+            ret = super().__array_wrap__(*args, **kwargs)
+            ret.wrap_called = True
+            return ret
+
+    ma = a.view(myarr)
+    assert ma.real.wrap_called
+    assert ma.imag.wrap_called
+
+
+@pytest.mark.parametrize("ufunc,attr", [
+    (np._core.umath.real, "real"), (np._core.umath.imag, "imag")])
+def test_real_imag_ufunc_minimal(ufunc, attr):
+    with pytest.raises(TypeError):
+        ufunc(np.array([1, 2, 3]))  # non-complex or object raises
+
+    arr = np.array([1+2j, 3+4j])
+    res = ufunc(arr)
+    assert_array_equal(res, getattr(arr, attr), strict=True)
+
+    arr = np.array([1+2j, 3+4j], dtype=object)
+    res = ufunc(arr)
+    assert_array_equal(res, getattr(arr, attr), strict=True)

--- a/numpy/_core/tests/test_arrayobject.py
+++ b/numpy/_core/tests/test_arrayobject.py
@@ -3,8 +3,8 @@ import sys
 import pytest
 
 import numpy as np
-from numpy.testing import HAS_REFCOUNT, assert_array_equal
 from numpy._core._rational_tests import rational
+from numpy.testing import HAS_REFCOUNT, assert_array_equal
 
 
 def test_matrix_transpose_raises_error_for_1d():
@@ -136,7 +136,6 @@ def test_real_imag_attributes_complex(dtype, real_dt, variation):
     elif variation == "set_writeable":
         a.flags.writeable = False
 
-
     assert_array_equal(a.real, real)
     assert_array_equal(a.imag, imag)
     assert a.real.dtype == real_dt
@@ -156,7 +155,7 @@ def test_real_imag_attributes_complex(dtype, real_dt, variation):
 
 
 def test_real_imag_attributes_object():
-    a = np.array([[1, 0.5+2j, 3, int], [4, 5j, "string", {}]], dtype=object)
+    a = np.array([[1, 0.5 + 2j, 3, int], [4, 5j, "string", {}]], dtype=object)
 
     # NOTE(seberg): doing something for non-numbers is guesswork...
     real = np.array([[1, 0.5, 3, int.real], [4, 0, "string", {}]], dtype=object)
@@ -189,10 +188,10 @@ def test_real_imag_ufunc_minimal(ufunc, attr):
     with pytest.raises(TypeError):
         ufunc(np.array([1, 2, 3]))  # non-complex or object raises
 
-    arr = np.array([1+2j, 3+4j])
+    arr = np.array([1 + 2j, 3 + 4j])
     res = ufunc(arr)
     assert_array_equal(res, getattr(arr, attr), strict=True)
 
-    arr = np.array([1+2j, 3+4j], dtype=object)
+    arr = np.array([1 + 2j, 3 + 4j], dtype=object)
     res = ufunc(arr)
     assert_array_equal(res, getattr(arr, attr), strict=True)

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -248,21 +248,15 @@ def isreal(x):
     The function does not work on string arrays.
 
     >>> a = np.array([2j, "a"], dtype=np.str_)
-    >>> np.isreal(a)  # Warns about non-elementwise comparison
-    False
+    >>> np.isreal(a)  # Compares as strings currently
+    array([False, False])
 
-    Returns True for all elements in input array of ``dtype=np.object_`` even if
-    any of the elements is complex.
+    Returns True for all elements that either have no ``.imag`` attribute
+    or for which that attribute is zero:
 
     >>> a = np.array([1, "2", 3+4j], dtype=np.object_)
     >>> np.isreal(a)
-    array([ True,  True,  True])
-
-    isreal should not be used with object arrays
-
-    >>> a = np.array([1+2j, 2+1j], dtype=np.object_)
-    >>> np.isreal(a)
-    array([ True,  True])
+    array([ True,  True,  False])
 
     """
     return imag(x) == 0

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -248,7 +248,7 @@ def isreal(x):
     The function does not work on string arrays.
 
     >>> a = np.array([2j, "a"], dtype=np.str_)
-    >>> np.isreal(a)  # Compares as strings currently
+    >>> np.isreal(a)  # returns the result of `"" == 0` currently.
     array([False, False])
 
     Returns True for all elements that either have no ``.imag`` attribute


### PR DESCRIPTION
**This is a work in progress, although already functional**

I am trying to figure out how to restructure `.imag` and `.real` to:
* Allow complex dtypes not defined inside NumPy
* Ideally, not hard-code that they must be views
  - *Fix `object` dtype behavior* (a bit?) by not returning views.
  - It was also brought up by Warren.
* Define one part of a future `finfo` (the ability to fetch the corresponding real type)
* (while not breaking current strange behavior)

The approach here is to define _internal_ `imag` and `real` ufuncs, plus we need a few small tweaks to allow those ufuncs to return actual `view`s.

One wrinkle is that `arr.imag = 0` works and right now is a bit hacked, because I wasn't sure I like a `set_imag` ufunc (but maybe that is the better solution?).
There is also a wrinkle that if `arr.real`/`arr.imag` still need weird special handling for backcompat since a ufunc really can't return a broadcasted array of zeros.

(The code looks wrong, but it is mainly boilerplate ufunc code+docs.)

Generally, I think this is a reasonable approach to make it a ufuncs, although there may be some details to hash out. Ping @ngoldbaum and @mhvk in case you have some thoughts already. 

EDIT: Closes gh-1740

*EDIT: Should have mentioned that I tried to use an agent to write some of the ufunc code, but it didn't do a job I liked, so there is practically nothing left of it.*