### PR TITLE
DOC: note that PR titles should use the commit message prefix convention

### DIFF
--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -269,6 +269,10 @@ function, add a release note to the ``doc/release/upcoming_changes/``
 directory, following the instructions and format in the
 ``doc/release/upcoming_changes/README.rst`` file.
 
+Use the same prefix convention for your pull request title as for commit
+messages (e.g., ``BUG:``, ``ENH:``, ``DOC:``). This enables automated labeling
+of your PR.
+
 
 .. _workflow_PR_timeline:
 


### PR DESCRIPTION
#### Reference Issues/PRs

None.

This came out of a live discussion with @rgommers.

#### What does this implement/fix?

NumPy's commit message documentation lists standard prefixes (BUG, ENH, DOC, etc.) but only in the context of commit messages. Contributors are not told that PR titles should also carry these prefixes, even though `.github/pr-prefix-labeler.yml` relies on them for automated label assignment.

This means new contributors can follow all the written guidelines and still end up with PRs that don't get labeled correctly, with no indication of what they did wrong.

This adds a one-sentence note to the "Asking for your changes to be merged" section pointing contributors to use the same prefix convention for PR titles, and explaining why (automated labeling).

No release note needed -- documentation-only change with no API or behavioral impact.

#### AI usage disclosure

These doc improvements are the result of a research-stage AI pipeline I and my team are building as part of helping OSS projects understand the state of their codebase and the quality of contributions. This addition was the highest confidence result from that pipeline and verified as high support during a training period and repeatedly validated by maintainer behavior in the test period.

I, as the human author, have read the outputs of the pipeline and guided this surgical addition to be helpful to future contributors to NumPy. 