### PR TITLE
DOC: clarify DLPack GPU tensor example with device='cpu' workaround

### DIFF
--- a/doc/source/user/basics.interoperability.rst
+++ b/doc/source/user/basics.interoperability.rst
@@ -487,16 +487,19 @@ will mean duplicating the memory. Do not do this for very large arrays:
 
 .. note::
 
-  Note that GPU tensors can't be converted to NumPy arrays since NumPy doesn't
-  support GPU devices:
+  GPU tensors cannot be directly zero-copy converted to NumPy arrays since
+  NumPy does not support GPU devices. However, since DLPack v1, cross-device
+  copy is supported via the ``device`` parameter:
 
    >>> x_torch = torch.arange(5, device='cuda')
-   >>> np.from_dlpack(x_torch)
+   >>> np.from_dlpack(x_torch)  # fails: implicit device=None means same device
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    RuntimeError: Unsupported device in DLTensor.
+   >>> np.from_dlpack(x_torch, device='cpu')  # works: explicit copy to CPU
+   array([0, 1, 2, 3, 4])
 
-  But, if both libraries support the device the data buffer is on, it is
+  If both libraries support the device the data buffer is on, it is
   possible to use the ``__dlpack__`` protocol (e.g. PyTorch_ and CuPy_):
 
    >>> x_torch = torch.arange(5, device='cuda')


### PR DESCRIPTION
### PR summary
- Update the DLPack example in the interoperability docs
- Show that `np.from_dlpack(x_torch, device='cpu')` works for GPU tensors since DLPack v1 supports cross-device copy
- Previous note was misleading: it implied GPU tensors cannot be converted to NumPy arrays at all

Closes #30936

### First time committer introduction
I use NumPy extensively for numerical computing. This is my first contribution to the NumPy project.

#### AI Disclosure
No AI tools used.