### PR TITLE
Draft: ENH: Make dtypes immortal

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -4824,11 +4824,12 @@ set_typeinfo(PyObject *dict)
      * making them immortal avoids refcount overhead on every dtype lookup
      * (and avoids atomic refcount contention on free-threading builds).
      */
+#ifdef Py_GIL_DISABLED
     for (i = 0; i < NPY_NTYPES_LEGACY; i++) {
         PyUnstable_SetImmortal((PyObject *)_builtin_descrs[i]);
         PyUnstable_SetImmortal((PyObject *)Py_TYPE(_builtin_descrs[i]));
     }
-
+#endif
     return 0;
 
   error:

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -4817,6 +4817,18 @@ set_typeinfo(PyObject *dict)
     if (ret < 0) {
         return -1;
     }
+
+    /*
+     * Mark the builtin descriptors and their DTypeMeta types as immortal.
+     * These are singletons that live for the entire process lifetime, so
+     * making them immortal avoids refcount overhead on every dtype lookup
+     * (and avoids atomic refcount contention on free-threading builds).
+     */
+    for (i = 0; i < NPY_NTYPES_LEGACY; i++) {
+        PyUnstable_SetImmortal((PyObject *)_builtin_descrs[i]);
+        PyUnstable_SetImmortal((PyObject *)Py_TYPE(_builtin_descrs[i]));
+    }
+
     return 0;
 
   error:


### PR DESCRIPTION
### PR summary

Make the numpy standard dtypes immortal and the ufuncs use deferred ref counting to improve performance in the free-threading build.

**Update**: numbers below are for https://github.com/numpy/numpy/compare/main...eendebakpt:numpy:dtype_immortal_v2

This PR contains three improvements (all `Py_GIL_DISABLED`-only):

1. **Immortalize the builtin DType classes** at initialization (same precedent as the default extobj capsule and cached `ArrayMethod`s).
2. **Immortalize the builtin ufuncs** at umath init (module-lifetime singletons).
3. **Enable deferred refcounting for dynamically created ufuncs** (`frompyfunc` etc.), which must keep normal lifetime semantics and therefore cannot be immortalized.

Scaling results (CPython 3.14.3t, `np.sin` on a thread-local 4-element array; reproducer below):

| threads | main | PR |
|---|---|---|
| 1 | 3.14 Mcalls/s (1.00x) | 3.15 Mcalls/s (1.00x) |
| 2 | 3.94 Mcalls/s (1.26x) | 5.81 Mcalls/s (1.84x) |
| 4 | 4.25 Mcalls/s (1.35x) | 10.47 Mcalls/s (**3.33x**) |
| 8 | 4.19 Mcalls/s (1.33x) | 13.55 Mcalls/s (**4.31x**) |

A large-array control (100k elements) scales ~5x at 8 threads on both builds, confirming the ceiling is per-call overhead, not the inner loops.

Isolated contribution of each improvement (applied individually at runtime on the main build, same workload):

| configuration | 4 threads | 8 threads |
|---|---|---|
| main | 4.10 Mcalls/s (1.32x) | 3.99 Mcalls/s (1.29x) |
| + DType class immortal (1) | 5.24 Mcalls/s (1.71x) | 5.32 Mcalls/s (1.74x) |
| + ufunc immortal (2) | 5.06 Mcalls/s (1.58x) | 4.47 Mcalls/s (1.40x) |
| + ufunc deferred refcount (3) | 4.28 Mcalls/s (1.47x) | 4.00 Mcalls/s (1.37x) |
| + (1) and (2) together | 9.67 Mcalls/s (2.91x) | 9.75 Mcalls/s (2.94x) |

<details>
<summary>Benchmark script</summary>

```python
"""Multithreaded scaling of small-array ufunc calls on free-threaded CPython.

Each thread repeatedly calls np.sin on its own small array, so there is no
shared data between threads. Run with a free-threaded interpreter.
"""
import sys
import threading
import time

import numpy as np

N_SMALL = 100_000   # calls per thread, 4-element array
N_LARGE = 200       # calls per thread, 100_000-element array


def bench(nthreads, size, ncalls):
    barrier = threading.Barrier(nthreads + 1)

    def runner():
        arr = np.arange(size, dtype=np.float64)  # thread-local input
        barrier.wait()
        for _ in range(ncalls):
            np.sin(arr)
        barrier.wait()

    threads = [threading.Thread(target=runner) for _ in range(nthreads)]
    for t in threads:
        t.start()
    barrier.wait()
    t0 = time.perf_counter()
    barrier.wait()
    dt = time.perf_counter() - t0
    for t in threads:
        t.join()
    return nthreads * ncalls / dt


def sweep(title, size, ncalls):
    print(title)
    base = None
    for nthreads in (1, 2, 4, 8):
        rate = max(bench(nthreads, size, ncalls) for _ in range(3))
        if base is None:
            base = rate
        print(f"  {nthreads} thread(s): {rate:12,.0f} calls/s aggregate"
              f"  (scaling {rate / base:.2f}x)")


def main():
    gil = getattr(sys, "_is_gil_enabled", lambda: True)()
    print(f"python {sys.version.split()[0]}, GIL enabled: {gil}, "
          f"numpy {np.__version__}")
    sweep(f"np.sin, {4}-element array ({N_SMALL} calls/thread):",
          4, N_SMALL)
    sweep(f"np.sin, {100_000}-element array ({N_LARGE} calls/thread, control):",
          100_000, N_LARGE)


if __name__ == "__main__":
    main()
```

</details>

@ngoldbaum 

#### AI Disclosure

Claude was used for benchmarking and implementation.

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
