### PR TITLE
ENH: add riscv64 to the wheel build matrix

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -51,9 +51,9 @@ jobs:
     steps:
       - name: Setup Python for riscv64
         if: matrix.buildplat[1] == 'manylinux_riscv64'
-        run: |
-          echo "/opt/python-3.12/bin" >> "$GITHUB_PATH"
-          /opt/python-3.12/bin/python3.12 -m pip install cibuildwheel==3.4.1
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
       - name: Checkout numpy
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -116,7 +116,7 @@ jobs:
 
       - name: Build wheels (riscv64)
         if: matrix.buildplat[1] == 'manylinux_riscv64'
-        run: python3 -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_TEST_COMMAND: "python -c \"import numpy; print(numpy.__version__); numpy.show_config()\""

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,12 +49,6 @@ jobs:
     env:
       IS_32_BIT: ${{ matrix.buildplat[1] == 'win32' }}  # used in cibw_test_command.sh
     steps:
-      - name: Setup Python for riscv64
-        if: matrix.buildplat[1] == 'manylinux_riscv64'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
       - name: Checkout numpy
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -109,17 +103,9 @@ jobs:
           fi
 
       - name: Build wheels
-        if: matrix.buildplat[1] != 'manylinux_riscv64'
         uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
-
-      - name: Build wheels (riscv64)
-        if: matrix.buildplat[1] == 'manylinux_riscv64'
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
-        env:
-          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
-          CIBW_TEST_COMMAND: "python -c \"import numpy; print(numpy.__version__); numpy.show_config()\""
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -39,6 +39,7 @@ jobs:
           - [ubuntu-22.04, musllinux_x86_64, ""]
           - [ubuntu-22.04-arm, manylinux_aarch64, ""]
           - [ubuntu-22.04-arm, musllinux_aarch64, ""]
+          - [ubuntu-24.04-riscv, manylinux_riscv64, ""]
           - [macos-15-intel, macosx_x86_64, openblas]
           - [macos-14, macosx_arm64, openblas]
           - [windows-2022, win_amd64, ""]
@@ -48,6 +49,12 @@ jobs:
     env:
       IS_32_BIT: ${{ matrix.buildplat[1] == 'win32' }}  # used in cibw_test_command.sh
     steps:
+      - name: Setup Python for riscv64
+        if: matrix.buildplat[1] == 'manylinux_riscv64'
+        run: |
+          echo "/opt/python-3.12/bin" >> "$GITHUB_PATH"
+          /opt/python-3.12/bin/python3.12 -m pip install cibuildwheel==3.4.1
+
       - name: Checkout numpy
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -102,9 +109,17 @@ jobs:
           fi
 
       - name: Build wheels
+        if: matrix.buildplat[1] != 'manylinux_riscv64'
         uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+
+      - name: Build wheels (riscv64)
+        if: matrix.buildplat[1] == 'manylinux_riscv64'
+        run: python3 -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          CIBW_TEST_COMMAND: "python -c \"import numpy; print(numpy.__version__); numpy.show_config()\""
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ build-dir = "build"
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
+manylinux-riscv64-image = "manylinux_2_39"
 musllinux-x86_64-image = "musllinux_1_2"
 musllinux-aarch64-image = "musllinux_1_2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ tracker = "https://github.com/numpy/numpy/issues"
 # build wheels for in CI are controlled in `.github/workflows/wheels.yml`.
 # universal2 wheels are not supported (see gh-21233), use `delocate-fuse` if you need them
 skip = ["*_i686", "*_ppc64le", "*_s390x", "*_universal2"]
+test-skip = "*-*linux_riscv64"  # xdist ordering bug (bytes_ vs str_); tracked in gh-XXXXX
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 before-test = "pip install -r {project}/requirements/test_requirements.txt"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,6 @@ tracker = "https://github.com/numpy/numpy/issues"
 # build wheels for in CI are controlled in `.github/workflows/wheels.yml`.
 # universal2 wheels are not supported (see gh-21233), use `delocate-fuse` if you need them
 skip = ["*_i686", "*_ppc64le", "*_s390x", "*_universal2"]
-test-skip = "*-*linux_riscv64"  # xdist ordering bug (bytes_ vs str_); tracked in gh-31414
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 before-test = "pip install -r {project}/requirements/test_requirements.txt"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,7 @@ tracker = "https://github.com/numpy/numpy/issues"
 # build wheels for in CI are controlled in `.github/workflows/wheels.yml`.
 # universal2 wheels are not supported (see gh-21233), use `delocate-fuse` if you need them
 skip = ["*_i686", "*_ppc64le", "*_s390x", "*_universal2"]
-test-skip = "*-*linux_riscv64"  # xdist ordering bug (bytes_ vs str_); tracked in gh-XXXXX
+test-skip = "*-*linux_riscv64"  # xdist ordering bug (bytes_ vs str_); tracked in gh-31414
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 before-test = "pip install -r {project}/requirements/test_requirements.txt"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -27,5 +27,11 @@ fi
 
 # Run full tests with -n=auto. This makes pytest-xdist distribute tests across
 # the available N CPU cores. Also print the durations for the 10 slowest tests
-# to help with debugging slow or hanging tests
-python -c "import sys; import numpy; sys.exit(not numpy.test(label='full', extra_argv=['-n=auto', '--durations=10']))"
+# to help with debugging slow or hanging tests.
+# On riscv64 use 'fast' to stay within the CI time budget (the slowest 'full'
+# tests alone add ~15 min on native hardware).
+if [[ "$(uname -m)" == "riscv64" ]]; then
+    python -c "import sys; import numpy; sys.exit(not numpy.test(label='fast', extra_argv=['-n=auto', '--durations=10']))"
+else
+    python -c "import sys; import numpy; sys.exit(not numpy.test(label='full', extra_argv=['-n=auto', '--durations=10']))"
+fi


### PR DESCRIPTION
### PR summary

Add `manylinux_riscv64` to the wheel build matrix using native riscv64 runners provided by the [RISE RISC-V Software Ecosystem](https://riscv.org/rise/) project.

**Changes:**
- **`.github/workflows/wheels.yml`**: Add `[ubuntu-24.04-riscv, manylinux_riscv64, ""]` to the build matrix. Install cibuildwheel directly (actions/setup-python lacks riscv64 pre-built binaries). Use smoke test for riscv64 test phase.
- **`pyproject.toml`**: Add `manylinux-riscv64-image = "manylinux_2_39"` (manylinux_2_28 has no riscv64 support).

**Why native runners instead of QEMU:**

| Approach | Build time | Source |
|----------|-----------|--------|
| QEMU on x86_64 | ~38 minutes | Original PR approach |
| **RISE native runner** | **~3.5 minutes** | Tested on [riseproject-dev/numpy](https://github.com/riseproject-dev/numpy/pull/1) |

The [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners) are free for open source projects and provide native hardware (Scaleway EM-RV1). numpy is a priority project for RISE with no limitations on concurrent jobs.

Reference: [Ludovic Henry's comment on #30216](https://github.com/numpy/numpy/issues/30216#issuecomment-4080068394)

**Evidence:**
- Successful build: https://github.com/riseproject-dev/numpy/actions/runs/23261131704
- Wheel: `numpy-2.5.0.dev0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl`
- OpenBLAS: scipy-openblas64 (ILP64, riscv64_generic, from PyPI)
- Native build on BananaPi F3 (SpacemiT K1, rv64gc): SUCCESS

### First time committer introduction

I'm Bruno Verachten ([@gounthar](https://github.com/gounthar)), working on RISC-V software ecosystem enablement since 2022. I maintain a [community PEP 503 index](https://gounthar.github.io/riscv64-python-wheels/simple/) with 50+ riscv64 Python wheels built natively on BananaPi F3 boards. I use NumPy for data processing and benchmarking on RISC-V hardware, and I'm collaborating with the RISE project to bring native riscv64 CI to key Python packages.

#### AI Disclosure

No AI tools used.

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve Python ecosystem support on riscv64 platforms.