### PR TITLE
MAINT: f2py: replace deprecated `sprintf` with `snprintf`

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -855,7 +855,7 @@ character_from_pyobj(character* v, PyObject *obj, const char *errmess) {
         size_t len = strlen(mess);
         snprintf(mess + len, F2PY_MESSAGE_BUFFER_SIZE - len,
                 " -- expected str|bytes|sequence-of-str-or-bytes, got ");
-        f2py_describe(obj, mess + len);
+        f2py_describe(obj, mess + strlen(mess));
         PyErr_SetString(err, mess);
         Py_DECREF(err);
     }

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -853,9 +853,9 @@ character_from_pyobj(character* v, PyObject *obj, const char *errmess) {
             PyErr_Clear();
         }
         size_t len = strlen(mess);
-        snprintf(mess + len, F2PY_MESSAGE_BUFFER_SIZE - len),
+        snprintf(mess + len, F2PY_MESSAGE_BUFFER_SIZE - len,
                 " -- expected str|bytes|sequence-of-str-or-bytes, got ");
-        f2py_describe(obj, mess + strlen(mess));
+        f2py_describe(obj, mess + len);
         PyErr_SetString(err, mess);
         Py_DECREF(err);
     }

--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -535,7 +535,7 @@ cppmacros['CHECKSTRING'] = """
 #define CHECKSTRING(check,tcheck,name,show,var)\\
     if (!(check)) {\\
         char errstring[256];\\
-        sprintf(errstring, \"%s: \"show, \"(\"tcheck\") failed for \"name, slen(var), var);\\
+        snprintf(errstring, sizeof(errstring), \"%s: \"show, \"(\"tcheck\") failed for \"name, slen(var), var);\\
         PyErr_SetString(#modulename#_error, errstring);\\
         /*goto capi_fail;*/\\
     } else """
@@ -543,7 +543,7 @@ cppmacros['CHECKSCALAR'] = """
 #define CHECKSCALAR(check,tcheck,name,show,var)\\
     if (!(check)) {\\
         char errstring[256];\\
-        sprintf(errstring, \"%s: \"show, \"(\"tcheck\") failed for \"name, var);\\
+        snprintf(errstring, sizeof(errstring), \"%s: \"show, \"(\"tcheck\") failed for \"name, var);\\
         PyErr_SetString(#modulename#_error,errstring);\\
         /*goto capi_fail;*/\\
     } else """
@@ -852,7 +852,8 @@ character_from_pyobj(character* v, PyObject *obj, const char *errmess) {
             Py_INCREF(err);
             PyErr_Clear();
         }
-        sprintf(mess + strlen(mess),
+        size_t len = strlen(mess);
+        snprintf(mess + len, F2PY_MESSAGE_BUFFER_SIZE - len),
                 " -- expected str|bytes|sequence-of-str-or-bytes, got ");
         f2py_describe(obj, mess + strlen(mess));
         PyErr_SetString(err, mess);


### PR DESCRIPTION
### PR summary
See gh-30997

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
I wasn't sure what the size should be for the `mess + strlen(mess)` case so ChatGPT suggested that patch.

cc @mattip 