### PR TITLE
BUG: Raise BufferError instead of RuntimeError in from_dlpack

### DIFF
--- a/doc/release/upcoming_changes/30937.compatibility.rst
+++ b/doc/release/upcoming_changes/30937.compatibility.rst
@@ -1,0 +1,8 @@
+``from_dlpack`` raises ``BufferError`` instead of ``RuntimeError``
+------------------------------------------------------------------
+
+``np.from_dlpack`` now raises ``BufferError`` instead of ``RuntimeError``
+when the incoming DLPack tensor has an unsupported device, dtype, or
+exceeds the maximum number of dimensions. This aligns with the DLPack
+and Array API specifications, which recommend ``BufferError`` for data
+that cannot be imported.

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -577,7 +577,7 @@ from_dlpack(PyObject *NPY_UNUSED(self),
 
     const int ndim = dl_tensor.ndim;
     if (ndim > NPY_MAXDIMS) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_SetString(PyExc_BufferError,
                 "maxdims of DLPack tensor is higher than the supported "
                 "maxdims.");
         Py_DECREF(capsule);
@@ -589,14 +589,14 @@ from_dlpack(PyObject *NPY_UNUSED(self),
             device_type != kDLCUDAHost &&
             device_type != kDLROCMHost &&
             device_type != kDLCUDAManaged) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_SetString(PyExc_BufferError,
                 "Unsupported device in DLTensor.");
         Py_DECREF(capsule);
         return NULL;
     }
 
     if (dl_tensor.dtype.lanes != 1) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_SetString(PyExc_BufferError,
                 "Unsupported lanes in DLTensor dtype.");
         Py_DECREF(capsule);
         return NULL;
@@ -647,7 +647,7 @@ from_dlpack(PyObject *NPY_UNUSED(self),
     }
 
     if (typenum == -1) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_SetString(PyExc_BufferError,
                 "Unsupported dtype in DLTensor.");
         Py_DECREF(capsule);
         return NULL;


### PR DESCRIPTION
`from_dlpack` currently raises `RuntimeError` when it encounters an unsupported device, dtype, or dimension count in the incoming DLPack tensor. Both the DLPack spec and the Array API spec say this should be a `BufferError`.

This only changes the four `RuntimeError`s on the consumer side (`from_dlpack` in `dlpack.c`). The producer-side `RuntimeError` in `__dlpack__` for unsupported streams is left as-is, and `ValueError`s for invalid user arguments (like `device="gpu"`) are also untouched.

Closes #30937