### PR TITLE
DOC: add missing one-character dtype codes to arrays.dtypes table (gh…

### DIFF
--- a/doc/source/reference/arrays.dtypes.rst
+++ b/doc/source/reference/arrays.dtypes.rst
@@ -270,16 +270,23 @@ Array-protocol type strings (see :ref:`arrays.interface`)
    ``'L'``             unsigned long integer
    ``'q'``             (signed) long long integer
    ``'Q'``             unsigned long long integer
+   ``'n'``             signed :class:`intp`
+   ``'N'``             unsigned :class:`uintp`
+   ``'p'``             signed integer large enough for pointers
+   ``'P'``             unsigned integer large enough for pointers
+   ``'e'``             half precision
    ``'f'``             single precision
    ``'F'``             complex single precision
    ``'d'``             double precision
    ``'D'``             complex double precision
    ``'g'``             long precision
    ``'G'``             complex long double precision
-   ``'O'``             (Python) objects
    ``'S'``             zero-terminated bytes (not recommended)
    ``'U'``             Unicode string
    ``'V'``             raw data (:class:`void`)
+   ``'O'``             (Python) objects
+   ``'M'``             :class:`datetime64`
+   ``'m'``             :class:`timedelta64`
    ==================  ========================
 
    .. admonition:: Example


### PR DESCRIPTION
…-15859)

### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?
Expanded dtype code table to include missing one-character codes (n, N, p, P, e, M, m)
-->

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->
Hello everyone! I am Vishal Kushwaha, and I am studying AI and ML at OVGU Magdeburg. I use NumPy in almost all of my personal and academic projects. I want to help our community and learn more from you all thus I decided to join you all here and try to contribute something.  
#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
No AI tools used for code or text generation, only for my understanding