### PR TITLE
ENH: make bound array method immortal to reduce reference counting contention

### DIFF
--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -129,9 +129,9 @@ is_contiguous(
  * param move_references UNUSED -- listed below but doxygen doesn't see as a parameter
  * @param strides Array of step sizes for each dimension of the arrays involved
  * @param out_loop Output pointer to the function that will perform the strided loop.
- * @param out_transferdata Output pointer to auxiliary data (if any) 
+ * @param out_transferdata Output pointer to auxiliary data (if any)
  *        needed by the out_loop function.
- * @param flags Output pointer to additional flags (if any) 
+ * @param flags Output pointer to additional flags (if any)
  *        needed by the out_loop function
  * @returns 0 on success -1 on failure.
  */
@@ -485,7 +485,9 @@ PyArrayMethod_FromSpec_int(PyArrayMethod_Spec *spec, int private)
         return NULL;
     }
     strcpy(res->method->name, spec->name);
-
+#ifdef Py_GIL_DISABLED
+    PyUnstable_SetImmortal((PyObject *)res->method);
+#endif
     return res;
 }
 

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -486,6 +486,9 @@ PyArrayMethod_FromSpec_int(PyArrayMethod_Spec *spec, int private)
     }
     strcpy(res->method->name, spec->name);
 #ifdef Py_GIL_DISABLED
+    // Mark immortal to reduce reference count contention in PyArray_GetCastingImpl
+    // If we ever allow replacing ArrayMethod objects or cleanup it DTypes or ufuncs, this may need to be reconsidered.
+    // An alternative that might help is to store cast methods in a PyArrayIdentityHash instead of a dict.
     PyUnstable_SetImmortal((PyObject *)res->method);
 #endif
     return res;


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

Running the script from https://github.com/numpy/numpy/issues/30494 under `perf c2c` found that there is a lot of reference counting contention in `PyArray_GetCastingImpl`. This PR makes the array methods immortal which removes the contention. 

See below for the `perf c2c` report (high RmtHitm indicates high cacheline contention):

```console

Cacheline 0x200025d4d00
  ----- HITM -----  ------- Store Refs ------  ------- CL --------                      ---------- cycles ----------    Total       cpu                                                                            Shared
  RmtHitm  LclHitm   L1 Hit  L1 Miss      N/A    Off  Node  PA cnt        Code address  rmt hitm  lcl hitm      load  records       cnt                       Symbol                                               Object         Source:Line  Node
+   6.54%    6.54%    0.00%    0.00%    0.00%   0x10     0       1      0x7069f8d74d85       397         0       656       19        10  [.] PyArray_GetCastingImpl   _multiarray_umath.cpython-315td-x86_64-linux-gnu.so  refcount.h:274       0
+   0.93%    0.93%    0.00%    0.00%    0.00%   0x10     0       1      0x7069f8d76757        51         0         0        4         3  [.] PyArray_CheckCastSafety  _multiarray_umath.cpython-315td-x86_64-linux-gnu.so  refcount.h:345       0
+  42.06%   42.06%    0.00%    0.00%    0.00%   0x1c     0       1      0x7069f8d5cd09       776         0       445      122        45  [.] NPY_cast_info_xfree      _multiarray_umath.cpython-315td-x86_64-linux-gnu.so  pyatomic_gcc.h:367   0
+  40.19%   40.19%    0.00%    0.00%    0.00%   0x1c     0       1      0x7069f8d74d94       204         0       112      138        48  [.] PyArray_GetCastingImpl   _multiarray_umath.cpython-315td-x86_64-linux-gnu.so  pyatomic_gcc.h:367   0
+   2.80%    2.80%    0.00%    0.00%    0.00%   0x1c     0       1      0x7069f8d76740       520         0       147       15        10  [.] PyArray_CheckCastSafety  _multiarray_umath.cpython-315td-x86_64-linux-gnu.so  pyatomic_gcc.h:367   0
+   1.87%    1.87%    0.00%    0.00%    0.00%   0x1c     0       1      0x7069f8d74d71       696         0      1573        5         3  [.] PyArray_GetCastingImpl   _multiarray_umath.cpython-315td-x86_64-linux-gnu.so  pyatomic_gcc.h:367   0
+   2.80%    2.80%    0.00%    0.00%    0.00%   0x20     0       1      0x7069f8d74d8e       479         0       443        9         6  [.] PyArray_GetCastingImpl   _multiarray_umath.cpython-315td-x86_64-linux-gnu.so  pyatomic_gcc.h:63    0
+   2.80%    2.80%    0.00%    0.00%    0.00%   0x20     0       1      0x7069f9dd8fe0       138         0         0        9         6  [.] _Py_DecRefSharedDebug    libpython3.15td.so.1.0                               pyatomic_gcc.h:130   0

```