### PR TITLE
MAINT: Remove COLS_IN_ALPHA_INDEX from Doxyfile.

### DIFF
--- a/doc/source/doxyfile
+++ b/doc/source/doxyfile
@@ -148,7 +148,6 @@ VERBATIM_HEADERS       = YES
 # Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = YES
-COLS_IN_ALPHA_INDEX    = 5
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output
 #---------------------------------------------------------------------------


### PR DESCRIPTION
This removes a warning and should make no difference in the output, Doxygen has been ignoring the line since about version 1.9.x.

AI: Grok suggested removal of the line was the simplest solution.

[skip cirrus] [skip actions] [skip azp]

### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
