### PR TITLE
DOC: document caveats of ndarray.resize on 3.14 and newer

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2254,12 +2254,19 @@ Shape Manipulation
     a different total number of elements then the old shape. If reallocation is
     necessary, then *self* must own its data, have *self* - ``>base==NULL``,
     have *self* - ``>weakrefs==NULL``, and (unless refcheck is 0) not be
-    referenced by any other array.  The fortran argument can be
-    :c:data:`NPY_ANYORDER`, :c:data:`NPY_CORDER`, or
-    :c:data:`NPY_FORTRANORDER`.  It currently has no effect. Eventually it
-    could be used to determine how the resize operation should view the data
-    when constructing a differently-dimensioned array.  Returns None on success
-    and NULL on error.
+    referenced by any other array.
+
+    On Python 3.13 and older, the check allows objects with exactly one
+    reference to be resized, because it is impossible to differentiate between
+    an array with one reference created via an extension and a uniquely
+    referenced array defined in a Python function. On Python 3.14 and newer,
+    the array must be uniquely referenced.
+
+    Resizing arrays in-place can often lead to memory fragmentation and should
+    be avoided if the goal is to reclaim memory. Create a new array and copy the
+    relevant subset of data over instead.
+
+    Returns None on success and NULL on error.
 
 .. c:function:: PyObject* PyArray_Transpose( \
         PyArrayObject* self, PyArray_Dims* permute)

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2254,11 +2254,12 @@ Shape Manipulation
     a different total number of elements then the old shape. If reallocation is
     necessary, then *self* must own its data, have *self* - ``>base==NULL``,
     have *self* - ``>weakrefs==NULL``, and (unless refcheck is 0) not be
-    referenced by any other array.
+    referenced by any other array. The *fortran* argument has no effect.
 
-    On Python 3.13 and older, the check allows objects with exactly one
-    reference to be reallocated in-place. On Python 3.14 and newer, the array
-    must be uniquely referenced. See the Python 3.14 `What's New entry
+    On Python 3.13 and older, the check allows uniquely referenced objects and
+    objects with exactly one reference to be reallocated in-place. On Python
+    3.14 and newer, the array must be uniquely referenced. See the Python 3.14
+    `What's New entry
     <https://docs.python.org/3/whatsnew/3.14.html#whatsnew314-refcount>`_ on
     this topic for more information on why there is a behavior difference.
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2257,13 +2257,18 @@ Shape Manipulation
     referenced by any other array.
 
     On Python 3.13 and older, the check allows objects with exactly one
-    reference to be resized, because it is impossible to differentiate between
-    an array with one reference created via an extension and a uniquely
-    referenced array defined in a Python function. On Python 3.14 and newer,
-    the array must be uniquely referenced.
+    reference to be reallocated in-place. On Python 3.14 and newer, the array
+    must be uniquely referenced. See the Python 3.14 `What's New entry
+    <https://docs.python.org/3/whatsnew/3.14.html#whatsnew314-refcount>`_ on
+    this topic for more information on why there is a behavior difference.
 
-    Resizing arrays in-place can often lead to memory fragmentation and should
-    be avoided. If the goal is to reclaim over-allocated memory, alternatives are to create a view or a copy of just the desired data, or using two passes to build the array: one to cheaply determine the shape and another to allocate and fill. Benchmark your use case to determine what is optimum. You may be surprised to find ``resize`` actually slows down or bloats your application.
+    Reallocating arrays in-place can often lead to memory fragmentation and
+    should be avoided. If the goal is to reclaim over-allocated memory,
+    alternatives are to create a view or a copy of just the desired data, or
+    using two passes to build the array: one to cheaply determine the shape and
+    another to allocate and fill. Benchmark your use case to determine what is
+    optimum. You may be surprised to find ``resize`` actually slows down or
+    bloats your application.
 
     Returns None on success and NULL on error.
 
@@ -4267,9 +4272,9 @@ Memory management
 .. c:function:: int PyArray_ResolveWritebackIfCopy(PyArrayObject* obj)
 
     If ``obj->flags`` has :c:data:`NPY_ARRAY_WRITEBACKIFCOPY`, this function
-    clears the flags, `DECREF` s
-    `obj->base` and makes it writeable, and sets ``obj->base`` to NULL. It then
-    copies ``obj->data`` to `obj->base->data`, and returns the error state of
+    clears the flags, ``DECREF`` s
+    ``obj->base`` and makes it writeable, and sets ``obj->base`` to NULL. It then
+    copies ``obj->data`` to ``obj->base->data``, and returns the error state of
     the copy operation. This is the opposite of
     :c:func:`PyArray_SetWritebackIfCopyBase`. Usually this is called once
     you are finished with ``obj``, just before ``Py_DECREF(obj)``. It may be called
@@ -4505,9 +4510,9 @@ Miscellaneous Macros
 
     If ``obj->flags`` has :c:data:`NPY_ARRAY_WRITEBACKIFCOPY`, this function
     clears the flags, `DECREF` s
-    `obj->base` and makes it writeable, and sets ``obj->base`` to NULL. In
+    ``obj->base`` and makes it writeable, and sets ``obj->base`` to NULL. In
     contrast to :c:func:`PyArray_ResolveWritebackIfCopy` it makes no attempt
-    to copy the data from `obj->base`. This undoes
+    to copy the data from ``obj->base``. This undoes
     :c:func:`PyArray_SetWritebackIfCopyBase`. Usually this is called after an
     error when you are finished with ``obj``, just before ``Py_DECREF(obj)``.
     It may be called multiple times, or with ``NULL`` input.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2263,8 +2263,7 @@ Shape Manipulation
     the array must be uniquely referenced.
 
     Resizing arrays in-place can often lead to memory fragmentation and should
-    be avoided if the goal is to reclaim memory. Create a new array and copy the
-    relevant subset of data over instead.
+    be avoided. If the goal is to reclaim over-allocated memory, alternatives are to create a view or a copy of just the desired data, or using two passes to build the array: one to cheaply determine the shape and another to allocate and fill. Benchmark your use case to determine what is optimum. You may be surprised to find ``resize`` actually slows down or bloats your application.
 
     Returns None on success and NULL on error.
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -4164,6 +4164,7 @@ _array_method_doc('resize', "*new_shape, refcheck=True",
         Shape of resized array.
     refcheck : bool, optional
         If False, reference count will not be checked. Default is True.
+        See Notes below for more explanation.
 
     Returns
     -------
@@ -4185,25 +4186,29 @@ _array_method_doc('resize', "*new_shape, refcheck=True",
     Only contiguous arrays (data elements consecutive in memory) can be
     resized.
 
-    Resizing arrays in-place can increase memory fragmentation. For that reason,
-    it is often preferable to allocate new memory for the result by calling
-    ``np.resize`` instead. This can reduce overall memory usage, even in
-    situations where one might expect to avoid wasting memory by resizing
-    in-place.
+    Reallocating arrays in-place can often lead to memory fragmentation and
+    should be avoided. If the goal is to reclaim over-allocated memory,
+    alternatives are to create a view or a copy of just the desired data, or
+    using two passes to build the array: one to cheaply determine the shape and
+    another to allocate and fill. Benchmark your use case to determine what is
+    optimum. You may be surprised to find ``resize`` actually slows down or
+    bloats your application.
 
     The purpose of the reference count check is to make sure you
     do not use this array as a buffer for another Python object and then
     reallocate the memory.
 
-    Note that CPython 3.14 changed reference counting for function locals, so
-    that NumPy cannot tell the difference between situations where an array is
-    referenced by exactly one object or an array is referenced by the
-    interpreter or by a C, C++, or Cython function. In these cases, NumPy may
-    raise a ValueError in a situation where an array has no references and it is
-    safe to resize in-place.
+    On Python 3.13 and older, the check allows objects with exactly one
+    reference to be reallocated in-place. On Python 3.14 and newer, the array
+    must be uniquely referenced. See [1]_ for more details.
 
     If you are sure that you have not shared the memory for this array with
     another Python object, then you may safely set `refcheck` to False.
+
+
+    References
+    ----------
+    .. [1] Python 3.14 What's New, https://docs.python.org/3/whatsnew/3.14.html#whatsnew314-refcount
 
     Examples
     --------

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -4172,12 +4172,7 @@ _array_method_doc('resize', "*new_shape, refcheck=True",
     Raises
     ------
     ValueError
-        If `a` does not own its own data or references or views to it exist,
-        and the data memory must be changed.
-
-    SystemError
-        If the `order` keyword argument is specified. This behaviour is a
-        bug in NumPy.
+        If `a` does not own its own data or references or views to may exist.
 
     See Also
     --------
@@ -4190,12 +4185,25 @@ _array_method_doc('resize', "*new_shape, refcheck=True",
     Only contiguous arrays (data elements consecutive in memory) can be
     resized.
 
+    Resizing arrays in-place can increase memory fragmentation. For that reason,
+    it is often preferable to allocate new memory for the result by calling
+    ``np.resize`` instead. This can reduce overall memory usage, even in
+    situations where one might expect to avoid wasting memory by resizing
+    in-place.
+
     The purpose of the reference count check is to make sure you
     do not use this array as a buffer for another Python object and then
-    reallocate the memory. However, reference counts can increase in
-    other ways so if you are sure that you have not shared the memory
-    for this array with another Python object, then you may safely set
-    `refcheck` to False.
+    reallocate the memory.
+
+    Note that CPython 3.14 changed reference counting for function locals, so
+    that NumPy cannot tell the difference between situations where an array is
+    referenced by exactly one object or an array is referenced by the
+    interpreter or by a C, C++, or Cython function. In these cases, NumPy may
+    raise a ValueError in a situation where an array has no references and it is
+    safe to resize in-place.
+
+    If you are sure that you have not shared the memory for this array with
+    another Python object, then you may safely set `refcheck` to False.
 
     Examples
     --------

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -190,6 +190,11 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
  * weak-references and no base object.
  *
  * On Python 3.13 and older, the check allows objects with exactly one
+ * reference to be reallocated in-place. On Python 3.14 and newer, the array
+ * must be uniquely referenced. In some cases this can lead to spurious
+ * ValueErrors on Python 3.14.
+ *
+ * On Python 3.13 and older, the check allows objects with exactly one
  * reference to be resized, because it is impossible to differentiate between
  * an array with one reference created via an extension and a uniquely
  * referenced array defined in a Python function.

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -100,11 +100,10 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
                     PyErr_SetString(
                             PyExc_ValueError,
                             "cannot resize an array that may be referenced "
-                            "by another object in this way.\n"
-                            "It is possible that the array is not referenced by "
-                            "another object and this is a false positive.\n"
+                            "by another object.\n"
+                            "It is possible that this is a false positive.\n"
                             "If you are sure that the array is uniquely referenced, "
-                            "set refcheck=False to disable this check, otherwise use np.resize.");
+                            "set refcheck=False.");
                     return -1;
                 }
 #else

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -192,7 +192,7 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
  * On Python 3.13 and older, the check allows objects with exactly one
  * reference to be reallocated in-place. On Python 3.14 and newer, the array
  * must be uniquely referenced. In some cases this can lead to spurious
- * ValueErrors on Python 3.14.
+ * ValueErrors.
  *
  */
 NPY_NO_EXPORT PyObject *

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -77,26 +77,40 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
             return -1;
         }
 
+        static const char *msg =
+                "cannot resize an array that references or is referenced\n"
+                "by another object in this way.\n"
+                "Use the np.resize function to get a new resized copy or\n "
+                "set refcheck=False to disable this check";
         if (PyArray_BASE(self) != NULL
               || (((PyArrayObject_fields *)self)->weakreflist != NULL)) {
-            PyErr_SetString(PyExc_ValueError,
-                    "cannot resize an array that "
-                    "references or is referenced\n"
-                    "by another array in this way. Use the np.resize function.");
+            PyErr_SetString(PyExc_ValueError, msg);
             return -1;
         }
         if (refcheck) {
 #if PY_VERSION_HEX >= 0x030E00B0
+            // Python 3.14 changed reference counting semantics for function-
+            // local variables. There is no way to tell if the calling function
+            // has been optimized (because it might be implemented in C or Cython)
+            //
+            // Instead, warn if the refcount is exactly 2 that this might be a
+            // false positive
             if (!PyUnstable_Object_IsUniquelyReferenced((PyObject *)self)) {
+                if (Py_REFCNT(self) == 2) {
+                    PyErr_SetString(
+                            PyExc_ValueError,
+                            "cannot resize an array that may be referenced "
+                            "by another object in this way.\n"
+                            "It is possible that the array is not referenced by "
+                            "another object and this is a false positive.\n"
+                            "If you are sure that the array is uniquely referenced, "
+                            "set refcheck=False to disable this check, otherwise use np.resize.");
+                    return -1;
+                }
 #else
             if (Py_REFCNT(self) > 2) {
 #endif
-                PyErr_SetString(
-                        PyExc_ValueError,
-                        "cannot resize an array that "
-                        "references or is referenced\n"
-                        "by another array in this way.\n"
-                        "Use the np.resize function or refcheck=False");
+                PyErr_SetString(PyExc_ValueError, msg);
                 return -1;
             }
         }
@@ -175,6 +189,12 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
  * array and it is contiguous.  If refcheck is 0, then the reference count is
  * not checked and assumed to be 1.  You still must own this data and have no
  * weak-references and no base object.
+ *
+ * On Python 3.13 and older, the check allows objects with exactly one
+ * reference to be resized, because it is impossible to differentiate between
+ * an array with one reference created via an extension and a uniquely
+ * referenced array defined in a Python function.
+ *
  */
 NPY_NO_EXPORT PyObject *
 PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -194,11 +194,6 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
  * must be uniquely referenced. In some cases this can lead to spurious
  * ValueErrors on Python 3.14.
  *
- * On Python 3.13 and older, the check allows objects with exactly one
- * reference to be resized, because it is impossible to differentiate between
- * an array with one reference created via an extension and a uniquely
- * referenced array defined in a Python function.
- *
  */
 NPY_NO_EXPORT PyObject *
 PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,

--- a/numpy/_core/tests/examples/cython/checks.pyx
+++ b/numpy/_core/tests/examples/cython/checks.pyx
@@ -4,6 +4,7 @@
 Functions in this module give python-space wrappers for cython functions
 exposed in numpy/__init__.pxd, so they can be tested in test_cython.py
 """
+import numpy as np
 cimport numpy as cnp
 cnp.import_array()
 
@@ -372,3 +373,9 @@ def check_npy_uintp_type_enum():
     # Regression test for gh-27890: cnp.NPY_UINTP was not defined.
     # Cython would fail to compile this before gh-27890 was fixed.
     return cnp.NPY_UINTP > 0
+
+
+def resize_refcheck_test():
+    # should run without error, see gh-30991
+    a = np.array([[0, 1], [2, 3]], order='C')
+    a.resize((2, 1))

--- a/numpy/_core/tests/examples/cython/checks.pyx
+++ b/numpy/_core/tests/examples/cython/checks.pyx
@@ -376,6 +376,6 @@ def check_npy_uintp_type_enum():
 
 
 def resize_refcheck_test():
-    # should run without error, see gh-30991
+    # see gh-30991
     a = np.array([[0, 1], [2, 3]], order='C')
     a.resize((2, 1))

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -350,3 +350,12 @@ def test_npystring_allocators_other_dtype(install_temp):
 def test_npy_uintp_type_enum(install_temp):
     import checks
     assert checks.check_npy_uintp_type_enum()
+
+
+@pytest.mark.skipif(sysconfig.get_platform() == 'win-arm64',
+                    reason='no checks module on win-arm64')
+def test_resize_refcheck(install_temp):
+    import checks
+    if sys.version_info >= (3, 14):
+        with pytest.raises(ValueError):
+            checks.resize_refcheck_test()

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -352,10 +352,16 @@ def test_npy_uintp_type_enum(install_temp):
     assert checks.check_npy_uintp_type_enum()
 
 
-@pytest.mark.skipif(sysconfig.get_platform() == 'win-arm64',
-                    reason='no checks module on win-arm64')
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Tests behavior that happens on Python 3.14 and newer"
+)
+@pytest.mark.skipif(
+    sysconfig.get_platform() == 'win-arm64',
+    reason='no checks module on win-arm64'
+)
 def test_resize_refcheck(install_temp):
     import checks
-    if sys.version_info >= (3, 14):
-        with pytest.raises(ValueError):
-            checks.resize_refcheck_test()
+    msg = "It is possible that this is a false positive."
+    with pytest.raises(ValueError, match=msg):
+        checks.resize_refcheck_test()

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -13,8 +13,10 @@ import os
 import pathlib
 import pickle
 import re
+import subprocess
 import sys
 import tempfile
+import textwrap
 import tracemalloc
 import warnings
 import weakref
@@ -6376,6 +6378,22 @@ class TestResize:
         x = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
         y = x
         assert_raises(ValueError, x.resize, (5, 1))
+
+    def test_check_reference_module_scope(self):
+        code = textwrap.dedent("""
+            import numpy as np
+
+            # See gh-30991
+            a = np.array([[0, 1], [2, 3]], order='C')
+            a.resize((2, 1))
+        """)
+        try:
+            subprocess.check_output([sys.executable, "-c", code],
+                                    stderr=subprocess.STDOUT, text=True)
+        except subprocess.CalledProcessError as e:
+            assert sys.version_info >= (3, 14)
+            assert "ValueError" in e.stdout
+            assert "It is possible that the array is not referenced" in e.stdout
 
     def test_check_reference_2(self):
         # see gh-30265

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6395,6 +6395,9 @@ class TestResize:
             assert sys.version_info >= (3, 14)
             assert "ValueError" in e.stdout
             assert "It is possible that this is a false positive." in e.stdout
+        else:
+            if sys.version_info >= (3, 14):
+                raise AsseritonError("Unexpected success of resize refcheck")
 
     def test_check_reference_2(self):
         # see gh-30265

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6379,6 +6379,7 @@ class TestResize:
         y = x
         assert_raises(ValueError, x.resize, (5, 1))
 
+    @pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
     def test_check_reference_module_scope(self):
         code = textwrap.dedent("""
             import numpy as np

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6394,7 +6394,7 @@ class TestResize:
         except subprocess.CalledProcessError as e:
             assert sys.version_info >= (3, 14)
             assert "ValueError" in e.stdout
-            assert "It is possible that the array is not referenced" in e.stdout
+            assert "It is possible that this is a false positive." in e.stdout
 
     def test_check_reference_2(self):
         # see gh-30265


### PR DESCRIPTION
Closes #30991.

This doesn't "fix" the regression, because I don't think there's a way to do that without introducing new bugs or depending on interpreter internals and/or trying to argue for yet another `PyUnstable` C API function we can use.

I'm also a little concerned that the old check is actually incorrect for arrays created by C extensions: the check on 3.13 and older allows resizing an array created directly via e.g. `PyArray_FromAny` with exactly one reference.

IMO it's better to keep the logic of the check the same and simply improve the documentation and error messages.

Now when the reference count is exactly 2, the error message on 3.14 and newer explains that this might be a false positive.

I added tests which trigger the behaviors we expect to happen on different Python versions. I also deleted some out-of-date docs about an unused `order` argument and added some notes that resizing in-place can lead to memory fragmentation and worse overall memory usage.

Also looking for any ideas for ways to make the error messages and docstrings less wordy.