### PR TITLE
BUG: Handle empty matrices in linalg.norm for ord=-2, -1, -inf

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2818,6 +2818,16 @@ def norm(x, ord=None, axis=None, keepdims=False):
         col_axis = normalize_axis_index(col_axis, nd)
         if row_axis == col_axis:
             raise ValueError('Duplicate axes given.')
+        if x.shape[row_axis] == 0 or x.shape[col_axis] == 0:
+            # Norm of an empty matrix is 0; use the Frobenius path
+            # which handles empty reductions correctly via add.reduce.
+            ret = sqrt(add.reduce((x.conj() * x).real, axis=axis))
+            if keepdims:
+                ret_shape = list(x.shape)
+                ret_shape[axis[0]] = 1
+                ret_shape[axis[1]] = 1
+                ret = ret.reshape(ret_shape)
+            return ret
         if ord == 2:
             ret = _multi_svd_norm(x, row_axis, col_axis, amax, 0)
         elif ord == -2:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -1476,6 +1476,13 @@ class _TestNorm2D(_TestNormBase):
     def test_matrix_empty(self):
         assert_equal(norm(self.array([[]], dtype=self.dt)), 0.0)
 
+    def test_matrix_empty_all_ords(self):
+        # gh-30916: norm with ord=-2 crashed on empty matrices
+        for shape in [(1, 0), (0, 1)]:
+            a = self.array(np.empty(shape, dtype=self.dt))
+            for order in [2, -2, 1, -1, np.inf, -np.inf, 'fro', 'nuc']:
+                assert_equal(norm(a, ord=order), 0.0)
+
     def test_matrix_return_type(self):
         a = self.array([[1, 0, 1], [0, 1, 1]])
 
@@ -2415,6 +2422,10 @@ def test_matrix_norm_empty():
             assert_equal(np.linalg.matrix_norm(x, ord=1), 0)
             assert_equal(np.linalg.matrix_norm(x, ord=2), 0)
             assert_equal(np.linalg.matrix_norm(x, ord=np.inf), 0)
+            # gh-30916
+            assert_equal(np.linalg.matrix_norm(x, ord=-1), 0)
+            assert_equal(np.linalg.matrix_norm(x, ord=-2), 0)
+            assert_equal(np.linalg.matrix_norm(x, ord=-np.inf), 0)
 
 def test_vector_norm():
     x = np.arange(9).reshape((3, 3))


### PR DESCRIPTION
`linalg.norm` (and `matrix_norm`) crashes with `ValueError` on empty matrices for `ord=-2`, `ord=-1`, and `ord=-inf`. PR #28343 fixed the positive orders by passing `initial=0` to `max`, but the same approach doesn't work for `min` since `min(initial=0)` would incorrectly clamp results for non-empty matrices.

This adds an early return for empty matrices that computes the result via the Frobenius path (`add.reduce`), which correctly handles empty reductions and returns 0. This approach is consistent with how other linalg functions handle empty matrices (e.g. `_is_empty_2d` guards in `pinv` and `cond`).

Closes #30916