### PR TITLE
BUG: Allow explicit `out=None`  for `ufunc` overrides.

### DIFF
--- a/doc/release/upcoming_changes/31032.improvement.rst
+++ b/doc/release/upcoming_changes/31032.improvement.rst
@@ -1,0 +1,8 @@
+Allow explicit `out=None` for `ufunc` overrides if the `where` keyword is present
+---------------------------------------------------------------------------------
+Numpy now emits the warning:
+``UserWarning: 'where' used without 'out', expect unitialized memory in output.
+If this is intentional, use out=None.``
+
+This change allows `out=None` to be propagated through ``__array_ufunc__()``
+if the `where` keyword is also present.

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -120,16 +120,6 @@ initialize_normal_kwds(PyObject *out_args,
             return -1;
         }
     }
-    else {
-        /* Ensure that `out` is not present. */
-        int res = PyDict_Contains(normal_kwds, npy_interned_str.out);
-        if (res < 0) {
-            return -1;
-        }
-        if (res) {
-            return PyDict_DelItem(normal_kwds, npy_interned_str.out);
-        }
-    }
     return 0;
 }
 

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -113,9 +113,9 @@ initialize_normal_kwds(PyObject *out_args,
         }
     }
 
-    int contains_where = PyDict_Contains(normal_kwds, npy_interned_str.where)
+    int contains_where = PyDict_Contains(normal_kwds, npy_interned_str.where);
     if (contains_where < 0) {
-        return -1
+        return -1;
     }
 
     if (out_args != NULL) {

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -125,7 +125,7 @@ initialize_normal_kwds(PyObject *out_args,
             return -1;
         }
     }
-    else if contains_where {
+    else if (contains_where == 0) {
         /* Ensure that `out` is not present unless `where` is present. */
         int res = PyDict_Contains(normal_kwds, npy_interned_str.out);
         if (res < 0) {

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -100,7 +100,7 @@ fail:
  * normalized version (and always pass it even if it was passed by position).
  */
 static int
-initialize_normal_kwds(PyObject *out_args,
+initialize_normal_kwds(PyObject *out_args, PyObject *wheremask_obj,
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames,
         PyObject *normal_kwds)
 {
@@ -113,11 +113,6 @@ initialize_normal_kwds(PyObject *out_args,
         }
     }
 
-    int contains_where = PyDict_Contains(normal_kwds, npy_interned_str.where);
-    if (contains_where < 0) {
-        return -1;
-    }
-
     if (out_args != NULL) {
         /* Replace `out` argument with the normalized version */
         int res = PyDict_SetItem(normal_kwds, npy_interned_str.out, out_args);
@@ -125,7 +120,7 @@ initialize_normal_kwds(PyObject *out_args,
             return -1;
         }
     }
-    else if (contains_where == 0) {
+    else if (wheremask_obj == NULL) {
         /* Ensure that `out` is not present unless `where` is present. */
         int res = PyDict_Contains(normal_kwds, npy_interned_str.out);
         if (res < 0) {
@@ -246,7 +241,7 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
     if (normal_kwds == NULL) {
         goto fail;
     }
-    if (initialize_normal_kwds(out_args,
+    if (initialize_normal_kwds(out_args, wheremask_obj,
             args, len_args, kwnames, normal_kwds) < 0) {
         goto fail;
     }

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -113,11 +113,26 @@ initialize_normal_kwds(PyObject *out_args,
         }
     }
 
+    int contains_where = PyDict_Contains(normal_kwds, npy_interned_str.where)
+    if (contains_where < 0) {
+        return -1
+    }
+
     if (out_args != NULL) {
         /* Replace `out` argument with the normalized version */
         int res = PyDict_SetItem(normal_kwds, npy_interned_str.out, out_args);
         if (res < 0) {
             return -1;
+        }
+    }
+    else if (contains_where == 0) {
+        /* Ensure that `out` is not present unless `where` is present. */
+        int res = PyDict_Contains(normal_kwds, npy_interned_str.out);
+        if (res < 0) {
+            return -1;
+        }
+        if (res) {
+            return PyDict_DelItem(normal_kwds, npy_interned_str.out);
         }
     }
     return 0;

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -125,7 +125,7 @@ initialize_normal_kwds(PyObject *out_args,
             return -1;
         }
     }
-    else if (contains_where == 0) {
+    else if contains_where {
         /* Ensure that `out` is not present unless `where` is present. */
         int res = PyDict_Contains(normal_kwds, npy_interned_str.out);
         if (res < 0) {

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -3663,17 +3663,17 @@ class TestSpecialMethods:
         res = np.multiply.reduce(a, None, out=(None,), dtype=None)
         assert_equal(res[4], {'axis': None, 'dtype': None})
         res = np.multiply.reduce(a, 0, None, None, False, 2, True)
-        assert_equal(res[4], {'axis': 0, 'dtype': None, 'keepdims': False,
-                              'initial': 2, 'where': True})
+        assert_equal(res[4], {'axis': 0, 'dtype': None, 'out': None,
+                              'keepdims': False, 'initial': 2, 'where': True})
         # np._NoValue ignored for initial
         res = np.multiply.reduce(a, 0, None, None, False,
                                  np._NoValue, True)
-        assert_equal(res[4], {'axis': 0, 'dtype': None, 'keepdims': False,
-                              'where': True})
+        assert_equal(res[4], {'axis': 0, 'dtype': None, 'out': None,
+                              'keepdims': False, 'where': True})
         # None kept for initial, True for where.
         res = np.multiply.reduce(a, 0, None, None, False, None, True)
-        assert_equal(res[4], {'axis': 0, 'dtype': None, 'keepdims': False,
-                              'initial': None, 'where': True})
+        assert_equal(res[4], {'axis': 0, 'dtype': None, 'out': None,
+                              'keepdims': False, 'initial': None, 'where': True})
 
         # reduce, wrong args
         assert_raises(ValueError, np.multiply.reduce, a, out=())


### PR DESCRIPTION
### PR summary

This PR fixes #31030 by not deleting `out` at the end of `initialize_normal_kwds()`.
