### PR TITLE
ENH: add dense integer fast path for np.unique counts/inverse

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -136,6 +136,64 @@ def _unpack_tuple(x):
         return x
 
 
+def _unique1d_dense_ints(
+    ar, return_inverse=False, return_counts=False, *, inverse_shape=None
+):
+    """
+    Fast path for dense integer/bool arrays when `return_index` is not needed.
+    """
+    if ar.size == 0 or ar.dtype.kind not in "uib":
+        return NotImplemented
+
+    ar_min = int(np.min(ar))
+    ar_max = int(np.max(ar))
+    ar_range = ar_max - ar_min
+
+    # `bincount` allocates one slot for every value in the covered range.
+    if ar_range < 0 or ar_range > np.iinfo(np.intp).max:
+        return NotImplemented
+    if ar_range > 6 * ar.size:
+        return NotImplemented
+
+    ar_min = ar.dtype.type(ar_min)
+
+    if ar_range == 0:
+        uniq = np.array([ar_min], dtype=ar.dtype)
+        ret = (uniq,)
+        if return_inverse:
+            ret += (np.zeros(ar.shape, dtype=np.intp).reshape(inverse_shape),)
+        if return_counts:
+            ret += (np.array([ar.size], dtype=np.intp),)
+        return ret
+
+    if ar.dtype.kind == "b":
+        shifted = ar.astype(np.intp, copy=False)
+    else:
+        # Subtract in the original dtype first so dense uint64 ranges near
+        # the intp limit do not overflow during promotion to intp.
+        shifted = np.subtract(ar, ar_min)
+        shifted = shifted.astype(np.intp, copy=False)
+    counts = np.bincount(shifted)
+    values = counts.nonzero()[0]
+
+    if ar.dtype.kind == "b":
+        uniq = values.astype(np.bool_, copy=False)
+    else:
+        uniq = values.astype(ar.dtype, copy=False)
+        uniq = np.add(uniq, ar_min)
+
+    ret = (uniq,)
+    if return_inverse:
+        lut = np.empty(counts.size, dtype=np.intp)
+        # Safe because shifted indices are a subset of the populated `values`.
+        lut[values] = np.arange(values.size, dtype=np.intp)
+        inv_idx = lut[shifted]
+        ret += (inv_idx.reshape(inverse_shape),)
+    if return_counts:
+        ret += (counts[values],)
+    return ret
+
+
 def _unique_dispatcher(ar, return_index=None, return_inverse=None,
                        return_counts=None, axis=None, *, equal_nan=None,
                        sorted=True):
@@ -376,6 +434,16 @@ def _unique1d(ar, return_index=False, return_inverse=False,
                 hash_unique.sort()
             # We wrap the result back in case it was a subclass of numpy.ndarray.
             return (conv.wrap(hash_unique),)
+
+    if (
+        not return_index and sorted and not np.ma.is_masked(ar)
+        and (dense_unique := _unique1d_dense_ints(
+            ar, return_inverse=return_inverse, return_counts=return_counts,
+            inverse_shape=inverse_shape,
+        )) is not NotImplemented
+    ):
+        conv = _array_converter(ar)
+        return (conv.wrap(dense_unique[0]),) + dense_unique[1:]
 
     # If we don't use the hash map, we use the slower sorting method.
     if optional_indices:

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy import ediff1d, intersect1d, isin, setdiff1d, setxor1d, union1d, unique
 from numpy.dtypes import StringDType
 from numpy.exceptions import AxisError
+from numpy.lib import _arraysetops_impl
 from numpy.testing import (
     assert_array_equal,
     assert_equal,
@@ -830,6 +831,60 @@ class TestUnique:
             i2 = np.array([], np.int64)
             c = np.array([], np.int64)
             self.check_all(a, b, i1, i2, c, dt)
+
+    @pytest.mark.parametrize("dtype", [np.int16, np.int64, np.uint32])
+    def test_unique_dense_integer_fast_path(self, dtype):
+        arr = np.array([12, 15, 12, 13, 15, 14, 12, 14], dtype=dtype)
+        values = np.array([12, 13, 14, 15], dtype=dtype)
+        inverse = np.array([0, 3, 0, 1, 3, 2, 0, 2], dtype=np.intp)
+        counts = np.array([3, 1, 2, 2], dtype=np.intp)
+
+        assert_array_equal(np.unique(arr), values)
+        assert_equal(np.unique(arr, return_inverse=True), (values, inverse))
+        assert_equal(np.unique(arr, return_counts=True), (values, counts))
+        assert_equal(
+            np.unique(arr, return_inverse=True, return_counts=True),
+            (values, inverse, counts),
+        )
+
+    def test_unique_dense_integer_negative_values(self):
+        arr = np.array([-3, -1, -3, -2, -1, -2, -3], dtype=np.int64)
+        values = np.array([-3, -2, -1], dtype=np.int64)
+        inverse = np.array([0, 2, 0, 1, 2, 1, 0], dtype=np.intp)
+        counts = np.array([3, 2, 2], dtype=np.intp)
+
+        assert_equal(np.unique(arr, return_inverse=True), (values, inverse))
+        assert_equal(np.unique(arr, return_counts=True), (values, counts))
+
+    def test_unique_dense_integer_bool(self):
+        arr = np.array([True, False, True, True, False], dtype=bool)
+        values = np.array([False, True], dtype=bool)
+        inverse = np.array([1, 0, 1, 1, 0], dtype=np.intp)
+        counts = np.array([2, 3], dtype=np.intp)
+
+        assert_array_equal(np.unique(arr), values)
+        assert_equal(np.unique(arr, return_inverse=True), (values, inverse))
+        assert_equal(np.unique(arr, return_counts=True), (values, counts))
+
+    def test_unique_dense_integer_large_uint_offset(self):
+        base = np.uint64(2**63 + 100)
+        arr = np.array([base + 2, base, base + 1, base + 2, base], dtype=np.uint64)
+        values = np.array([base, base + 1, base + 2], dtype=np.uint64)
+        inverse = np.array([2, 0, 1, 2, 0], dtype=np.intp)
+        counts = np.array([2, 1, 2], dtype=np.intp)
+
+        assert_equal(np.unique(arr, return_inverse=True), (values, inverse))
+        assert_equal(np.unique(arr, return_counts=True), (values, counts))
+
+    def test_unique_dense_integer_fast_path_skips_wide_range(self):
+        arr = np.array([0, 100], dtype=np.int64)
+        result = _arraysetops_impl._unique1d_dense_ints(arr, return_counts=True)
+        assert result is NotImplemented
+
+    def test_unique_dense_integer_fast_path_skips_range_above_intp(self):
+        arr = np.array([0, np.iinfo(np.intp).max + 1], dtype=np.uint64)
+        result = _arraysetops_impl._unique1d_dense_ints(arr, return_counts=True)
+        assert result is NotImplemented
 
     def test_unique_subclass(self):
         class Subclass(np.ndarray):


### PR DESCRIPTION
### PR summary
This PR adds a dense-range fast path to `np.unique` for 1-D integer/bool arrays with `return_counts=True` and/or `return_inverse=True` (when `return_index=False`).

Instead of always using the generic sort-based path (`O(n log n)`), it uses a bincount-based counting table (`O(n + k`), where `k` is the covered value range) when a heuristic determines that the range is small relative to the input size. This preserves existing semantics while significantly speeding up repeated-label workloads such as factorization, grouping, and frequency counting.

The optimization has `O(k)` temporary memory usage and is guarded to avoid excessive allocation. All unsupported or non-beneficial cases fall back to the existing implementation.

### Env
mac mini m4
Python 3.13

### Benchmarks (1e6 elements, dense integer labels)

| Operation | Old (s) | New (s) | Speedup |
|----------|--------:|--------:|--------:|
| groupby (runtime) | 0.032371 | 0.003108 | 10.4× |
| groupby (tree)    | 0.032300 | 0.003116 | 10.4× |
| counts (runtime)  | 0.006392 | 0.001388 | 4.6×  |
| counts (tree)     | 0.006341 | 0.001415 | 4.5×  |