### PR TITLE
Bump the Array API version to 2025.12

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -308,7 +308,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: data-apis/array-api-tests
-        ref: '3c273cd34d51c64ed893737306d36adab23a94a1'  # v2025.05.23
+        ref: '41379d15d26d67a1e66c840e775d41a8a7fb1516'  # v2026.02.26
         submodules: 'true'
         path: 'array-api-tests'
         persist-credentials: false

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -667,7 +667,7 @@ else:
     # import with `from numpy import *`.
     __future_scalars__ = {"str", "bytes", "object"}
 
-    __array_api_version__ = "2024.12"
+    __array_api_version__ = "2025.12"
 
     from ._array_api_info import __array_namespace_info__
 

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -870,7 +870,7 @@ type _DTypeNum = L[
 ]
 type _DTypeBuiltinKind = L[0, 1, 2]
 
-type _ArrayAPIVersion = L["2021.12", "2022.12", "2023.12", "2024.12"]
+type _ArrayAPIVersion = L["2021.12", "2022.12", "2023.12", "2024.12", "2025.12"]
 
 type _CastingKind = L["no", "equiv", "safe", "same_kind", "same_value", "unsafe"]
 
@@ -1067,7 +1067,7 @@ __NUMPY_SETUP__: Final[L[False]] = False
 __numpy_submodules__: Final[set[LiteralString]] = ...
 __former_attrs__: Final[_FormerAttrsDict] = ...
 __future_scalars__: Final[set[L["bytes", "str", "object"]]] = ...
-__array_api_version__: Final[L["2024.12"]] = "2024.12"
+__array_api_version__: Final[L["2025.12"]] = "2025.12"
 test: Final[PytestTester] = ...
 
 @type_check_only

--- a/numpy/_array_api_info.py
+++ b/numpy/_array_api_info.py
@@ -322,7 +322,7 @@ class __array_namespace_info__:
         """
         The devices supported by NumPy.
 
-        For NumPy, this always returns ``['cpu']``.
+        For NumPy, this always returns ``('cpu',)``.
 
         Returns
         -------
@@ -340,7 +340,7 @@ class __array_namespace_info__:
         --------
         >>> info = np.__array_namespace_info__()
         >>> info.devices()
-        ['cpu']
+        ('cpu',)
 
         """
-        return ["cpu"]
+        return ("cpu",)

--- a/numpy/_core/tests/test_array_api_info.py
+++ b/numpy/_core/tests/test_array_api_info.py
@@ -110,4 +110,4 @@ def test_dtypes_invalid_device():
 
 
 def test_devices():
-    assert info.devices() == ["cpu"]
+    assert info.devices() == ("cpu",)

--- a/tools/ci/array-api-xfails.txt
+++ b/tools/ci/array-api-xfails.txt
@@ -41,6 +41,9 @@ array_api_tests/test_operators_and_elementwise_functions.py::test_clip
 array_api_tests/test_signatures.py::test_extension_func_signature[fft.fftfreq]
 array_api_tests/test_signatures.py::test_extension_func_signature[fft.rfftfreq]
 
+array_api_tests/test_fft.py::test_fftfreq
+array_api_tests/test_fft.py::test_rfftfreq
+
 # fails on np.repeat(np.array([]), np.array([])) test case
 array_api_tests/test_manipulation_functions.py::test_repeat
 
@@ -63,3 +66,13 @@ array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity 
 array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(x1_i is -infinity and isfinite(x2_i) and x2_i < 0) -> +infinity]
 array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i > 0 and x2_i is -infinity) -> -0]
 array_api_tests/test_special_cases.py::test_iop[__ifloordiv__(isfinite(x1_i) and x1_i < 0 and x2_i is +infinity) -> -0]
+
+# complex plane special cases
+array_api_tests/test_special_cases.py::test_unary[expm1((real(x_i) is +0 or real(x_i) == -0) and imag(x_i) is +0) -> 0 + 0j]
+array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is +infinity and imag(x_i) is +0) -> +infinity + 0j]
+array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is -infinity and imag(x_i) is +infinity) -> -1 + 0j]
+array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is +infinity and imag(x_i) is +infinity) -> infinity + NaN j]
+array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is -infinity and imag(x_i) is NaN) -> -1 + 0j]
+array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is +infinity and imag(x_i) is NaN) -> infinity + NaN j]
+array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is NaN and imag(x_i) is +0) -> NaN + 0j]
+array_api_tests/test_special_cases.py::test_unary[tanh(real(x_i) is +infinity and isfinite(imag(x_i)) and imag(x_i) > 0) -> 1 + 0j]


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

Bump the Array API version to 2025.12; on CI, bump the test suite version to match. 

The new xfails are in fact not new; the updated test suite catches these edge cases which it missed before:

```
FAILED array_api_tests/test_special_cases.py::test_unary[expm1((real(x_i) is +0 or real(x_i) == -0) and imag(x_i) is +0) -> 0 + 0j] - AssertionError: out=(-0+0j), but should be 0 + 0j [expm1()]
FAILED array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is +infinity and imag(x_i) is +0) -> +infinity + 0j] - AssertionError: out=(inf+nanj), but should be +infinity + 0j [expm1()] 
FAILED array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is -infinity and imag(x_i) is +infinity) -> -1 + 0j] - AssertionError: out=(nan+nanj), but should be -1 + 0j [expm1()]
FAILED array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is +infinity and imag(x_i) is +infinity) -> infinity + NaN j] - AssertionError: out=(nan+nanj), but should be infinity + NaN j [expm1()]
FAILED array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is -infinity and imag(x_i) is NaN) -> -1 + 0j] - AssertionError: out=(nan+nanj), but should be -1 + 0j [expm1()]
FAILED array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is +infinity and imag(x_i) is NaN) -> infinity + NaN j] - AssertionError: out=(nan+nanj), but should be infinity + NaN j [expm1()]
FAILED array_api_tests/test_special_cases.py::test_unary[expm1(real(x_i) is NaN and imag(x_i) is +0) -> NaN + 0j] - AssertionError: out=(nan+nanj), but should be NaN + 0j [expm1()]
FAILED array_api_tests/test_special_cases.py::test_unary[tanh(real(x_i) is +infinity and isfinite(imag(x_i)) and imag(x_i) > 0) -> 1 + 0j] - AssertionError: out=(1-0j), but should be 1 + 0j [tanh()]
```

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

No AI.