### PR TITLE
BUG: fix FNV-1a 64-bit selection by using NPY_SIZEOF_UINTP (#31035)

### DIFF
--- a/numpy/_core/src/multiarray/fnv.c
+++ b/numpy/_core/src/multiarray/fnv.c
@@ -72,14 +72,15 @@ npy_fnv1a_64(const void *buf, size_t len, npy_uint64 hval)
 
 /*
  * Compute a size_t FNV-1a hash of the given data
- * This will use 32-bit or 64-bit hash depending on the size of size_t
+ * This will use 32-bit or 64-bit hash depending on the size of npy_uintp.
+ * npy_uintp has the same size as size_t.
  */
 size_t 
 npy_fnv1a(const void *buf, size_t len)
 {
-#if NPY_SIZEOF_SIZE_T == 8
+#if NPY_SIZEOF_UINTP == 8
     return (size_t)npy_fnv1a_64(buf, len, FNV1A_64_INIT);
-#else /* NPY_SIZEOF_SIZE_T == 4 */
+#else /* NPY_SIZEOF_UINTP == 4 */
     return (size_t)npy_fnv1a_32(buf, len, FNV1A_32_INIT);
 #endif
 }


### PR DESCRIPTION
Backport of #31035.

close #31034

<details><summary>benchmark result</summary>

| Change   | Before [621413ba] <main>   | After [b9ccff1e] <fix_size_t>   |   Ratio | Benchmark (Parameter)                                                                |
|----------|----------------------------|---------------------------------|---------|--------------------------------------------------------------------------------------|
| -        | 807±30μs                   | 746±10μs                        |    0.92 | bench_lib.Unique.time_unique_values(200000, 90.0, 0.2, <class 'numpy.float64'>)      |
| -        | 1.64±0.02ms                | 1.52±0.01ms                     |    0.92 | bench_lib.UniqueIntegers.time_unique_values(100000, 5000, <class 'numpy.int64'>)     |
| -        | 1.26±0.01ms                | 1.16±0.02ms                     |    0.92 | bench_lib.UniqueIntegers.time_unique_values(100000, 5000, <class 'numpy.uint32'>)    |
| -        | 14.8±0.1ms                 | 13.6±0.1ms                      |    0.92 | bench_lib.UniqueIntegers.time_unique_values(1000000, 5000, <class 'numpy.int64'>)    |
| -        | 3.38±0.05μs                | 3.10±0.03μs                     |    0.92 | bench_lib.UniqueIntegers.time_unique_values(200, 25, <class 'numpy.int64'>)          |
| -        | 1.04±0.01ms                | 936±9μs                         |    0.9  | bench_lib.UniqueIntegers.time_unique_values(100000, 5000, <class 'numpy.int16'>)     |
| -        | 9.87±0.07ms                | 8.75±0.07ms                     |    0.89 | bench_lib.UniqueIntegers.time_unique_values(1000000, 5000, <class 'numpy.int16'>)    |
| -        | 11.8±0.1ms                 | 10.5±0.09ms                     |    0.89 | bench_lib.UniqueIntegers.time_unique_values(1000000, 5000, <class 'numpy.uint32'>)   |
| -        | 37.1±0.1ms                 | 29.4±0.1ms                      |    0.79 | bench_lib.UniqueIntegers.time_unique_values(1000000, 250000, <class 'numpy.int64'>)  |
| -        | 29.5±0.2ms                 | 22.6±0.2ms                      |    0.77 | bench_lib.UniqueIntegers.time_unique_values(1000000, 250000, <class 'numpy.uint32'>) |

</details>
