### PR TITLE
BUG: avoid warning on ufunc with where=True and no output

### DIFF
--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4639,7 +4639,8 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
     }
 
     /* Warn if "where" is used without "out", issue 29561 */
-    if ((where_obj != NULL) && (full_args.out == NULL) && (out_obj == NULL)) {
+    if ((where_obj != NULL && where_obj != Py_True)
+        && (full_args.out == NULL) && (out_obj == NULL)) {
         if (PyErr_WarnEx(PyExc_UserWarning,
                 "'where' used without 'out', expect unitialized memory in output. "
                 "If this is intentional, use out=None.", 1) < 0) {

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -1751,6 +1751,10 @@ class TestUfunc:
         # Sanity check
         assert np.all(result1[::2] == [0, 4, 8, 12])
         assert np.all(result2[::2] == [0, 4, 8, 12])
+        # Also no warning for where=True
+        result3 = np.add(a, a, where=True)
+        # Sanity check
+        assert_array_equal(result3, a + a)
 
     @staticmethod
     def identityless_reduce_arrs():

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -3513,6 +3513,19 @@ class TestSpecialMethods:
                               'axis': 'axis0',
                               'initial': 'init0',
                               'where': 'where0'})
+        # reduce, kwargs, out=None is removed
+        res = np.multiply.reduce(a, axis='axis0', dtype='dtype0', out=None,
+                                 keepdims='keep0', initial='init0',
+                                 where='where0')
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], 'reduce')
+        assert_equal(res[3], (a,))
+        assert_equal(res[4], {'dtype': 'dtype0',
+                              'keepdims': 'keep0',
+                              'axis': 'axis0',
+                              'initial': 'init0',
+                              'where': 'where0'})
 
         # reduce, output equal to None removed, but not other explicit ones,
         # even if they are at their default value.


### PR DESCRIPTION
Backport of #31045.

Alternative fix for gh-31030. This does not change that `out=None` is removed from what is passed to the ufunc, but ensures that if from the ufunc one calls the original function with the original keyword arguments, there will only be a warning about a missing `out` argument if `where!=True`. Hence, the net effect is that the warning introduced in gh-29813 will no longer fire if there is no risk of uninitialized output.

(No AI was used.)