### PR TITLE
BUG: np.ones/ones_like raise ValueError for datetime64 with generic unit

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -230,7 +230,11 @@ def ones(shape, dtype=None, order='C', *, device=None, like=None):
         )
 
     a = empty(shape, dtype, order, device=device)
-    multiarray.copyto(a, 1, casting='unsafe')
+    try:
+        fill_value = array(1, dtype=a.dtype)
+    except TypeError:
+        fill_value = 1
+    multiarray.copyto(a, fill_value, casting='unsafe')
     return a
 
 
@@ -310,7 +314,11 @@ def ones_like(
     res = empty_like(
         a, dtype=dtype, order=order, subok=subok, shape=shape, device=device
     )
-    multiarray.copyto(res, 1, casting='unsafe')
+    try:
+        fill_value = array(1, dtype=res.dtype)
+    except TypeError:
+        fill_value = 1
+    multiarray.copyto(res, fill_value, casting='unsafe')
     return res
 
 


### PR DESCRIPTION
Fixes a bug where np.ones(1, "M8") and np.ones_like(np.empty(1, "M8")) silently create an invalid datetime64 array with generic unit instead of raising an error immediately.
#30903

# **Root cause**: 
_ones()_ and _ones_like()_ fill the allocated array using multiarray.copyto(a, 1, casting='unsafe'). The raw Python integer 1 is copied directly into memory, bypassing NumPy's datetime type-checking pipeline entirely. The error is only triggered later — e.g. when printing — because that's when the C-level conversion (NpyDatetime_ConvertDatetime64ToDatetimeStruct) finally inspects the value.

By contrast, np.array(1, dtype="M8") correctly raises ValueError immediately because it goes through the standard type-checking path.

# **Fix**: 
Wrap the fill value in _array(1, dtype=a.dtype)_ before calling _copyto_. This forces the same validation path and raises ValueError at the point of creation. A TypeError catch is added for dtypes like _void_ that legitimately cannot convert integer 1 to bytes, preserving their existing behavior. The same fix is applied to _ones_like()_.

Built locally using spin build and ran the existing test suite:
```
spin test -t numpy/_core/tests/test_numeric.py::TestCreationFuncs
# 9 passed
```
And manually verified the fix.

## **First time committer introduction**
Hi! I'm Riccardo, a Python developer learning to contribute to open-source projects. I've recently started learning NumPy for my university course. This is one of my first contributions, and I found this issue quite interesting and that's why I tried to solve it

AI Disclosure
I used Antigravity (Google DeepMind) as an AI assistant to help me understand the issue, trace through the relevant source files (including the C-level _datetime.c_), and reason about the correct fix. 

**The final code changes were written and applied by me**. All interactions with the NumPy repository (commits, push, PR submission) are performed by me directly.