### PR TITLE
MAINT: numpy.i: Replace deprecated `sprintf` with `snprintf`

### DIFF
--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -457,10 +457,10 @@ void free_cap(PyObject * cap)
     {
       for (i = 0; i < n-1; i++)
       {
-        sprintf(s, "%d, ", exact_dimensions[i]);
+        snprintf(s, sizeof(s), "%d, ", exact_dimensions[i]);
         strcat(dims_str,s);
       }
-      sprintf(s, " or %d", exact_dimensions[n-1]);
+      snprintf(s, sizeof(s), " or %d", exact_dimensions[n-1]);
       strcat(dims_str,s);
       PyErr_Format(PyExc_TypeError,
                    "Array must have %s dimensions.  Given array has %d dimensions",
@@ -497,11 +497,11 @@ void free_cap(PyObject * cap)
       {
         if (size[i] == -1)
         {
-          sprintf(s, "*,");
+          snprintf(s, sizeof(s), "*,");
         }
         else
         {
-          sprintf(s, "%ld,", (long int)size[i]);
+          snprintf(s, sizeof(s), "%ld,", (long int)size[i]);
         }
         strcat(desired_dims,s);
       }
@@ -509,7 +509,7 @@ void free_cap(PyObject * cap)
       desired_dims[len-1] = ']';
       for (i = 0; i < n; i++)
       {
-        sprintf(s, "%ld,", (long int)array_size(ary,i));
+        snprintf(s, sizeof(s), "%ld,", (long int)array_size(ary,i));
         strcat(actual_dims,s);
       }
       len = strlen(actual_dims);

--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -40,6 +40,7 @@
 #define NO_IMPORT_ARRAY
 #endif
 #include "stdio.h"
+#include <string.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 %}
@@ -444,8 +445,8 @@ void free_cap(PyObject * cap)
   {
     int success = 0;
     int i;
-    const size_t dims_str_size = 255;
-    char dims_str[dims_str_size] = "";
+    char dims_str[255] = "";
+    char s[255];
     for (i = 0; i < n && !success; i++)
     {
       if (array_numdims(ary) == exact_dimensions[i])
@@ -455,22 +456,13 @@ void free_cap(PyObject * cap)
     }
     if (!success)
     {
-      int used_buffer_space = 0;
-      int written;
-      for (i = 0; i < n-1; i++) {
-        written = snprintf(dims_str + used_buffer_space, 
-                           dims_str_size - used_buffer_space, 
-                           "%d, ", 
-                           exact_dimensions[i]);
-        if (written < 0)
-          written = 0;
-        if (written >= (int)(dims_str_size - used_buffer_space))
-          written = (int)(dims_str_size - used_buffer_space) - 1;
-        used_buffer_space += written;
+      for (i = 0; i < n-1; i++)
+      {
+        snprintf(s, sizeof(s), "%d, ", exact_dimensions[i]);
+        strncat(dims_str, s, sizeof(dims_str) - strlen(dims_str) - 1);
       }
-
-      snprintf(dims_str + used_buffer_space, dims_str_size - used_buffer_space,
-               "or %d", exact_dimensions[n-1]);
+      snprintf(s, sizeof(s), " or %d", exact_dimensions[n-1]);
+      strncat(dims_str, s, sizeof(dims_str) - strlen(dims_str) - 1);
       PyErr_Format(PyExc_TypeError,
                    "Array must have %s dimensions.  Given array has %d dimensions",
                    dims_str,
@@ -490,9 +482,9 @@ void free_cap(PyObject * cap)
     int i;
     int success = 1;
     size_t len;
-    const size_t dims_str_size = 255;
-    char desired_dims[dims_str_size] = "[";
-    char actual_dims[dims_str_size] = "[";
+    char desired_dims[255] = "[";
+    char s[255];
+    char actual_dims[255] = "[";
     for(i=0; i < n;i++)
     {
       if (size[i] != -1 &&  size[i] != array_size(ary,i))
@@ -502,40 +494,24 @@ void free_cap(PyObject * cap)
     }
     if (!success)
     {
-      int used_buffer_space = strlen(desired_dims);
-      int written;
-        
-      for (i = 0; i < n; i++) {
+      for (i = 0; i < n; i++)
+      {
         if (size[i] == -1)
-          written = snprintf(desired_dims + used_buffer_space, 
-                             dims_str_size - used_buffer_space, 
-                             "*,");
+        {
+          snprintf(s, sizeof(s), "*,");
+        }
         else
-          written = snprintf(desired_dims + used_buffer_space, 
-                             dims_str_size - used_buffer_space, 
-                             "%ld,", 
-                             (long int)size[i]);
-        if (written < 0)
-          written = 0;
-        if (written >= (int)(dims_str_size - used_buffer_space))
-          written = (int)(dims_str_size - used_buffer_space) - 1;
-        used_buffer_space += written;
+        {
+          snprintf(s, sizeof(s), "%ld,", (long int)size[i]);
+        }
+        strncat(desired_dims, s, sizeof(desired_dims) - strlen(desired_dims) - 1);
       }
       len = strlen(desired_dims);
       desired_dims[len-1] = ']';
-
-      used_buffer_space = strlen(actual_dims);
       for (i = 0; i < n; i++)
       {
-        written = snprintf(actual_dims + used_buffer_space, 
-                           dims_str_size - used_buffer_space, 
-                           "%ld,", 
-                           (long int)array_size(ary,i));
-        if (written < 0)
-          written = 0;
-        if (written >= (int)(dims_str_size - used_buffer_space))
-          written = (int)(dims_str_size - used_buffer_space) - 1;
-        used_buffer_space += written;
+        snprintf(s, sizeof(s), "%ld,", (long int)array_size(ary,i));
+        strncat(actual_dims, s, sizeof(actual_dims) - strlen(actual_dims) - 1);
       }
       len = strlen(actual_dims);
       actual_dims[len-1] = ']';

--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -444,8 +444,8 @@ void free_cap(PyObject * cap)
   {
     int success = 0;
     int i;
-    char dims_str[255] = "";
-    char s[255];
+    const size_t dims_str_size = 255;
+    char dims_str[dims_str_size] = "";
     for (i = 0; i < n && !success; i++)
     {
       if (array_numdims(ary) == exact_dimensions[i])
@@ -455,13 +455,19 @@ void free_cap(PyObject * cap)
     }
     if (!success)
     {
+      int used_buffer_space = 0;
+      int written;
       for (i = 0; i < n-1; i++)
       {
-        snprintf(s, sizeof(s), "%d, ", exact_dimensions[i]);
-        strcat(dims_str,s);
+        written = snprintf(dims_str + used_buffer_space, dims_str_size - used_buffer_space, "%d, ", exact_dimensions[i]);
+        if (written < 0)
+          written = 0;
+        if (written >= (int)(dims_str_size - used_buffer_space))
+          written = (int)(dims_str_size - used_buffer_space) - 1;
+        used_buffer_space += written;
       }
-      snprintf(s, sizeof(s), " or %d", exact_dimensions[n-1]);
-      strcat(dims_str,s);
+
+      snprintf(dims_str + used_buffer_space, dims_str_size - used_buffer_space, "or %d", exact_dimensions[n-1]);
       PyErr_Format(PyExc_TypeError,
                    "Array must have %s dimensions.  Given array has %d dimensions",
                    dims_str,
@@ -481,9 +487,9 @@ void free_cap(PyObject * cap)
     int i;
     int success = 1;
     size_t len;
-    char desired_dims[255] = "[";
-    char s[255];
-    char actual_dims[255] = "[";
+    const size_t dims_str_size = 255;
+    char desired_dims[dims_str_size] = "[";
+    char actual_dims[dims_str_size] = "[";
     for(i=0; i < n;i++)
     {
       if (size[i] != -1 &&  size[i] != array_size(ary,i))
@@ -493,24 +499,37 @@ void free_cap(PyObject * cap)
     }
     if (!success)
     {
+      int used_buffer_space = strlen(desired_dims);
+      int written;
+        
       for (i = 0; i < n; i++)
       {
         if (size[i] == -1)
         {
-          snprintf(s, sizeof(s), "*,");
+          written = snprintf(desired_dims + used_buffer_space, dims_str_size - used_buffer_space, "*,");
         }
         else
         {
-          snprintf(s, sizeof(s), "%ld,", (long int)size[i]);
+          written = snprintf(desired_dims + used_buffer_space, dims_str_size - used_buffer_space, "%ld,", (long int)size[i]);
         }
-        strcat(desired_dims,s);
+        if (written < 0)
+          written = 0;
+        if (written >= (int)(dims_str_size - used_buffer_space))
+          written = (int)(dims_str_size - used_buffer_space) - 1;
+        used_buffer_space += written;
       }
       len = strlen(desired_dims);
       desired_dims[len-1] = ']';
+
+      used_buffer_space = strlen(actual_dims);
       for (i = 0; i < n; i++)
       {
-        snprintf(s, sizeof(s), "%ld,", (long int)array_size(ary,i));
-        strcat(actual_dims,s);
+        written = snprintf(actual_dims + used_buffer_space, dims_str_size - used_buffer_space, "%ld,", (long int)array_size(ary,i));
+        if (written < 0)
+          written = 0;
+        if (written >= (int)(dims_str_size - used_buffer_space))
+          written = (int)(dims_str_size - used_buffer_space) - 1;
+        used_buffer_space += written;
       }
       len = strlen(actual_dims);
       actual_dims[len-1] = ']';

--- a/tools/swig/numpy.i
+++ b/tools/swig/numpy.i
@@ -457,9 +457,11 @@ void free_cap(PyObject * cap)
     {
       int used_buffer_space = 0;
       int written;
-      for (i = 0; i < n-1; i++)
-      {
-        written = snprintf(dims_str + used_buffer_space, dims_str_size - used_buffer_space, "%d, ", exact_dimensions[i]);
+      for (i = 0; i < n-1; i++) {
+        written = snprintf(dims_str + used_buffer_space, 
+                           dims_str_size - used_buffer_space, 
+                           "%d, ", 
+                           exact_dimensions[i]);
         if (written < 0)
           written = 0;
         if (written >= (int)(dims_str_size - used_buffer_space))
@@ -467,7 +469,8 @@ void free_cap(PyObject * cap)
         used_buffer_space += written;
       }
 
-      snprintf(dims_str + used_buffer_space, dims_str_size - used_buffer_space, "or %d", exact_dimensions[n-1]);
+      snprintf(dims_str + used_buffer_space, dims_str_size - used_buffer_space,
+               "or %d", exact_dimensions[n-1]);
       PyErr_Format(PyExc_TypeError,
                    "Array must have %s dimensions.  Given array has %d dimensions",
                    dims_str,
@@ -502,16 +505,16 @@ void free_cap(PyObject * cap)
       int used_buffer_space = strlen(desired_dims);
       int written;
         
-      for (i = 0; i < n; i++)
-      {
+      for (i = 0; i < n; i++) {
         if (size[i] == -1)
-        {
-          written = snprintf(desired_dims + used_buffer_space, dims_str_size - used_buffer_space, "*,");
-        }
+          written = snprintf(desired_dims + used_buffer_space, 
+                             dims_str_size - used_buffer_space, 
+                             "*,");
         else
-        {
-          written = snprintf(desired_dims + used_buffer_space, dims_str_size - used_buffer_space, "%ld,", (long int)size[i]);
-        }
+          written = snprintf(desired_dims + used_buffer_space, 
+                             dims_str_size - used_buffer_space, 
+                             "%ld,", 
+                             (long int)size[i]);
         if (written < 0)
           written = 0;
         if (written >= (int)(dims_str_size - used_buffer_space))
@@ -524,7 +527,10 @@ void free_cap(PyObject * cap)
       used_buffer_space = strlen(actual_dims);
       for (i = 0; i < n; i++)
       {
-        written = snprintf(actual_dims + used_buffer_space, dims_str_size - used_buffer_space, "%ld,", (long int)array_size(ary,i));
+        written = snprintf(actual_dims + used_buffer_space, 
+                           dims_str_size - used_buffer_space, 
+                           "%ld,", 
+                           (long int)array_size(ary,i));
         if (written < 0)
           written = 0;
         if (written >= (int)(dims_str_size - used_buffer_space))


### PR DESCRIPTION
### PR summary
This PR is for #31055.
The suggested changes in `tools/swig/numpy.i` replace deprecated `sprintf` with `snprintf`. 

Similar issue was raised in #30997 and resolved in #30998.

### First time committer introduction
Hi, I'm Denis Prokopenko, Researcher at King's College London. My main use of `numpy` is development of medical imaging methods. This particular PR was inspired by similar changes introduced in [STIR](https://github.com/UCL/STIR) https://github.com/UCL/STIR/pull/1699.

#### AI Disclosure
No AI tools used
