### PR TITLE
BUG: propagate out=None to __array_ufunc__ dispatch kwargs

### DIFF
--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -121,13 +121,30 @@ initialize_normal_kwds(PyObject *out_args,
         }
     }
     else {
-        /* Ensure that `out` is not present. */
-        int res = PyDict_Contains(normal_kwds, npy_interned_str.out);
+        /*
+         * No normalized outputs (out_args is NULL), which means either no
+         * `out` was passed or `out=None` was passed explicitly.  If the user
+         * passed `out=None` it will already be in normal_kwds (copied from
+         * kwnames above); preserve it so that __array_ufunc__ implementations
+         * can forward it to the ufunc and suppress the "where without out"
+         * warning.  Only delete `out` from the dict when its value is not
+         * None (which would indicate a stale entry that should not be
+         * forwarded).
+         */
+        PyObject *out_val = NULL;
+        int res = PyDict_GetItemRef(normal_kwds, npy_interned_str.out, &out_val);
         if (res < 0) {
             return -1;
         }
-        if (res) {
-            return PyDict_DelItem(normal_kwds, npy_interned_str.out);
+        if (res == 1) {
+            /* `out` is present in the dict */
+            int is_none = (out_val == Py_None);
+            Py_DECREF(out_val);
+            if (!is_none) {
+                /* Non-None value without a real out_args — remove it. */
+                return PyDict_DelItem(normal_kwds, npy_interned_str.out);
+            }
+            /* out=None: leave it in the dict so __array_ufunc__ receives it */
         }
     }
     return 0;

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -1761,6 +1761,41 @@ class TestUfunc:
         # Sanity check
         assert_array_equal(result3, a + a)
 
+    def test_where_out_none_propagated_to_array_ufunc(self):
+        # Regression test for gh-31030: out=None must be forwarded to
+        # __array_ufunc__ so subclasses can pass it on and suppress the
+        # "where without out" warning.
+        import dataclasses
+        import warnings
+
+        @dataclasses.dataclass
+        class DuckArray:
+            ndarray: np.ndarray
+            received_kwargs: dict = dataclasses.field(default_factory=dict)
+
+            def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+                self.received_kwargs = dict(kwargs)
+                return ufunc(
+                    *[x.ndarray if isinstance(x, DuckArray) else x
+                      for x in inputs],
+                    **kwargs,
+                )
+
+        a = DuckArray(np.array([1.0]))
+        mask = np.array([True])
+
+        # out=None must arrive in __array_ufunc__ kwargs so the inner call
+        # does not trigger the "where without out" warning (gh-31030).
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = np.log(a, where=mask, out=None)
+
+        # Verify that out=None was forwarded into __array_ufunc__
+        assert "out" in a.received_kwargs, (
+            "out=None was not propagated to __array_ufunc__"
+        )
+        assert a.received_kwargs["out"] is None
+
     @staticmethod
     def identityless_reduce_arrs():
         yield np.empty((2, 3, 4), order='C')


### PR DESCRIPTION
## Summary

Fixes #31030.

When a user passes `out=None` explicitly to a ufunc that has a subclass
override (e.g. `np.log(duck_array, where=mask, out=None)`), the
`out=None` was silently dropped before `__array_ufunc__` was called.
This caused subclass implementations that forward `**kwargs` back to the
underlying ufunc to lose the `out=None` signal, triggering a spurious
`UserWarning: 'where' used without 'out'` on the re-entrant call.

### Root cause

`initialize_normal_kwds` in `numpy/_core/src/umath/override.c` builds
the keyword dict that is passed to `__array_ufunc__`.  When no real
output arrays are present (`out_args == NULL`), the function
**unconditionally deleted** any `out` key that had been copied from the
original `kwnames`.  This erased an explicit `out=None` before dispatch.

### Fix

In the `out_args == NULL` branch, preserve an `out` entry whose value
is `None` (the user's explicit intent).  A non-`None` value is still
removed to maintain the previous behaviour for unexpected cases.

## Changes

- `numpy/_core/src/umath/override.c` — fix `initialize_normal_kwds` to
  keep `out=None` in the normalized keyword dict.
- `numpy/_core/tests/test_ufunc.py` — add regression test
  `test_where_out_none_propagated_to_array_ufunc` that uses a
  `DuckArray` subclass to verify `out=None` reaches `__array_ufunc__`
  and that no `UserWarning` is raised.

## Test plan

- [ ] New regression test `TestUfunc::test_where_out_none_propagated_to_array_ufunc` passes
- [ ] Existing `test_where_warns` continues to pass (no regression on the warning itself)
- [ ] `python -m pytest numpy/_core/tests/test_ufunc.py -k "where" -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)