### PR TITLE
BUG: result_type treats builtin type objects as concrete instead of abstract (#31037)

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3653,6 +3653,44 @@ array_result_type(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t
             npy_mark_tmp_array_if_pyscalar(obj, arr[narr], NULL);
             ++narr;
         }
+        else if (obj == (PyObject *)&PyLong_Type ||
+                 obj == (PyObject *)&PyFloat_Type ||
+                 obj == (PyObject *)&PyComplex_Type ||
+                 obj == (PyObject *)&PyBool_Type) {
+            /*
+             * Python builtin types int/float/complex/bool are treated as
+             * abstract scalars, consistent with how Python scalar *instances*
+             * (e.g. 1, 1.0, 1j) behave under NEP 50 weak-type promotion.
+             * Previously these fell through to PyArray_DescrConverter which
+             * mapped them to the default NumPy dtype (e.g. int -> int64),
+             * causing np.result_type(np.int32, int) != np.result_type(np.int32, 1).
+             * See gh-31037.
+             */
+            PyObject *representative;
+            if (obj == (PyObject *)&PyBool_Type) {
+                representative = PyBool_FromLong(0);
+            }
+            else if (obj == (PyObject *)&PyLong_Type) {
+                representative = PyLong_FromLong(0);
+            }
+            else if (obj == (PyObject *)&PyFloat_Type) {
+                representative = PyFloat_FromDouble(0.0);
+            }
+            else {
+                representative = PyComplex_FromDoubles(0.0, 0.0);
+            }
+            if (representative == NULL) {
+                goto finish;
+            }
+            arr[narr] = (PyArrayObject *)PyArray_FROM_O(representative);
+            if (arr[narr] == NULL) {
+                Py_DECREF(representative);
+                goto finish;
+            }
+            npy_mark_tmp_array_if_pyscalar(representative, arr[narr], NULL);
+            Py_DECREF(representative);
+            ++narr;
+        }
         else {
             if (!PyArray_DescrConverter(obj, &dtypes[ndtypes])) {
                 goto finish;

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1194,6 +1194,27 @@ class TestTypes:
         self.check_promotion_cases(np.result_type)
         assert_(np.result_type(None) == np.dtype(None))
 
+    def test_result_type_builtin_types_as_abstract(self):
+        # gh-31037: Python builtin types (int, float, complex, bool) should be
+        # treated as abstract/weak scalars, consistent with scalar *instances*
+        # (e.g. 1, 1.0, 1j).  Before the fix these fell through to
+        # PyArray_DescrConverter which resolved them to the platform default
+        # dtype (e.g. int -> int64), so result_type(np.int32, int) returned
+        # int64 instead of int32.
+        assert_equal(np.result_type(np.int32(1), int(1)),
+                     np.result_type(np.int32, int))
+        assert_equal(np.result_type(np.float32(1), float(1)),
+                     np.result_type(np.float32, float))
+        assert_equal(np.result_type(np.complex64(1), complex(1)),
+                     np.result_type(np.complex64, complex))
+        # Concrete cases: narrower numpy type should win
+        assert_equal(np.result_type(np.int32, int), np.dtype(np.int32))
+        assert_equal(np.result_type(np.float32, float), np.dtype(np.float32))
+        assert_equal(np.result_type(np.complex64, complex), np.dtype(np.complex64))
+        # bool type: consistent with bool instance
+        assert_equal(np.result_type(np.bool_(True), bool(True)),
+                     np.result_type(np.bool_, bool))
+
     def test_promote_types_endian(self):
         # promote_types should always return native-endian types
         assert_equal(np.promote_types('<i8', '<i8'), np.dtype('i8'))


### PR DESCRIPTION
## Summary
- `np.result_type(np.int32, int)` returned `int64` instead of `int32`, inconsistent with `np.result_type(np.int32(1), 1)` which returns `int32` under NEP 50 weak-type promotion
- Root cause: Python builtin type objects (`int`, `float`, `complex`, `bool`) fell through to `PyArray_DescrConverter` which mapped them to concrete default dtypes, bypassing weak promotion
- Fix: intercept `PyLong_Type`, `PyFloat_Type`, `PyComplex_Type`, `PyBool_Type` and create representative 0-D arrays with Python-scalar flags, matching how instances are handled

## Test plan
- Added `test_result_type_builtin_types_as_abstract` verifying symmetry between type objects and instances
- All existing `test_result_type` tests pass

Closes #31037