### PR TITLE
BUG: fix dangling pointer in PyArray_FromInterface (gh-31036)

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -2176,6 +2176,7 @@ PyArray_FromInterface(PyObject *origin)
     PyObject *iface = NULL;
     PyObject *attr = NULL;
     PyObject *base = NULL;
+    PyObject *refs = NULL;  /* owned tuple to keep iface alive when base=origin */
     PyArrayObject *ret;
     PyArray_Descr *dtype = NULL;
     char *data = NULL;
@@ -2349,7 +2350,21 @@ PyArray_FromInterface(PyObject *origin)
         if (istrue) {
             dataflags &= ~NPY_ARRAY_WRITEABLE;
         }
-        base = origin;
+        /*
+         * The `iface` dict may carry a `__ref` entry that owns the memory
+         * pointed to by `data` (e.g. numpy scalars store a 0-d array there
+         * to keep the underlying buffer alive).  If we only hold `origin`
+         * as the array base the dict will be freed by Py_DECREF(iface)
+         * below, releasing `__ref` and leaving `data` as a dangling
+         * pointer.  Keep both `origin` and `iface` alive through the
+         * array's lifetime by using a (origin, iface) tuple as the base —
+         * the same pattern used in PyArray_FromStructInterface.
+         */
+        refs = PyTuple_Pack(2, origin, iface);
+        if (refs == NULL) {
+            goto fail;
+        }
+        base = refs;
     }
 
     /* Case for data access through buffer */
@@ -2404,9 +2419,11 @@ PyArray_FromInterface(PyObject *origin)
             dataflags, NULL, base);
     /*
      * Ref to dtype was stolen by PyArray_NewFromDescrAndBase
-     * Prevent DECREFing dtype in fail codepath by setting to NULL
+     * Prevent DECREFing dtype in fail codepath by setting to NULL.
+     * refs (if set) has been adopted by the array via base; release it.
      */
     dtype = NULL;
+    Py_CLEAR(refs);
     if (ret == NULL) {
         goto fail;
     }
@@ -2473,6 +2490,7 @@ PyArray_FromInterface(PyObject *origin)
  fail:
     Py_XDECREF(attr);
     Py_XDECREF(dtype);
+    Py_XDECREF(refs);
     Py_XDECREF(iface);
     return NULL;
 }

--- a/numpy/_core/tests/test_array_interface.py
+++ b/numpy/_core/tests/test_array_interface.py
@@ -220,3 +220,60 @@ def test_cstruct(get_module):
     stderr.write(' ---- free shared data ---- \n')
     arr = None
     stderr.write(' ---- OK!\n\n')
+
+
+def test_array_interface_without_array_struct():
+    """
+    Regression test for gh-31036.
+
+    An object that defines only ``__array_interface__`` (not
+    ``__array_struct__``) should produce a correct array.  Previously the
+    ``iface`` dict returned by ``__array_interface__`` was released
+    immediately after ``PyArray_NewFromDescrAndBase``, which freed the
+    ``__ref`` entry inside the dict (kept there by numpy scalars to pin
+    their buffer), leaving the new array with a dangling data pointer.
+    """
+    import gc
+
+    class InterfaceOnly:
+        """Wraps a numpy scalar, forwarding __array_interface__ but NOT
+        __array_struct__."""
+
+        def __init__(self, scalar):
+            self._scalar = scalar
+
+        @property
+        def __array_interface__(self):
+            return self._scalar.__array_interface__
+
+    for scalar in (np.int64(2), np.float64(3.14), np.int32(-7)):
+        obj = InterfaceOnly(scalar)
+
+        # Force GC so any freed temporary dicts are reclaimed
+        arr = np.asarray(obj)
+        gc.collect()
+
+        assert arr[()] == scalar, (
+            f"Expected {scalar!r}, got {arr[()]!r} — possible dangling "
+            f"pointer in __array_interface__ path"
+        )
+        assert arr.dtype == scalar.dtype
+
+    # Also verify arithmetic involving such an object gives the right result
+    # (the original issue from gh-31036).
+    class MyObj:
+        value = np.int64(2)
+
+        def __rsub__(self, other):
+            return self.value.__rsub__(other)
+
+        @property
+        def __array_interface__(self):
+            return self.value.__array_interface__
+
+    o = MyObj()
+    result = np.int64(1) - o
+    gc.collect()
+    assert result == np.int64(-1), (
+        f"Expected -1, got {result!r} — gh-31036 regression"
+    )

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8999,11 +8999,14 @@ class TestArrayCreationCopyArgument:
 
         arr = ArrayLike()
 
-        for copy, val in [(True, None), (np._CopyMode.ALWAYS, None),
-                          (False, arr), (np._CopyMode.IF_NEEDED, arr),
-                          (np._CopyMode.NEVER, arr)]:
+        for copy in (True, np._CopyMode.ALWAYS):
             res = np.array(arr, copy=copy)
-            assert res.base is val
+            assert res.base is None
+        for copy in (False, np._CopyMode.IF_NEEDED, np._CopyMode.NEVER):
+            res = np.array(arr, copy=copy)
+            # The base is a (origin, iface_dict) tuple that keeps both the
+            # source object and the interface dict alive (gh-31036 fix).
+            assert res.base[0] is arr
 
     def test___array__(self):
         base_arr = np.arange(10)


### PR DESCRIPTION
## Summary

Fixes #31036.

Objects that implement `__array_interface__` as a *property* (returning a fresh dict each call) but do **not** implement `__array_struct__` were silently producing corrupt array data.

### Root cause

`PyArray_FromInterface` reads the `data` pointer from the interface dict, calls `PyArray_NewFromDescrAndBase(... base=origin)`, then does `Py_DECREF(iface)`.

NumPy scalars embed a 0-d array under the `__ref` key of the interface dict to keep the scalar's buffer alive. When the dict was a temporary (returned by a property), its refcount hit zero at the `Py_DECREF`, freeing `__ref` and leaving the new array with a **dangling data pointer**.

### Fix

When the data comes from the pointer-tuple path (`iface['data'] = (ptr, readonly_flag)`), build a `(origin, iface)` tuple as the `base` instead of using `origin` alone. This keeps both the calling object *and* the interface dict alive for the entire lifetime of the array — the same pattern already used in `PyArray_FromStructInterface` with its `refs` tuple.

### Reproducer (from the issue)

```python
import numpy as np, gc

class MyObj:
    value = np.int64(2)
    def __rsub__(self, other):
        return self.value.__rsub__(other)
    @property
    def __array_interface__(self):
        return self.value.__array_interface__

o = MyObj()
result = np.int64(1) - o
gc.collect()
assert result == -1, f"got {result}"   # was failing with 0
```

### Tests

- `numpy/_core/tests/test_array_interface.py::test_array_interface_without_array_struct` — new pure-Python regression test
- Updated `TestArrayCreationCopyArgument::test_array_interfaces` in `test_multiarray.py` to reflect that `res.base` is now a `(origin, iface_dict)` tuple (both are kept alive); the array values and copy semantics are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)