### PR TITLE
BUG: fix fill_value propagation in mvoid.__getitem__

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3353,7 +3353,12 @@ class MaskedArray(ndarray):
                 # We should always re-cast to mvoid, otherwise users can
                 # change masks on rows that already have masked values, but not
                 # on rows that have no masked values, which is inconsistent.
-                return mvoid(dout, mask=mout, hardmask=self._hardmask)
+                return mvoid(
+                    dout,
+                    mask=mout,
+                    hardmask=self._hardmask,
+                    fill_value=self._fill_value
+                )
 
             # special case introduced in gh-5962
             elif (self.dtype.type is np.object_ and

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4071,6 +4071,19 @@ class TestMaskedArrayMethods:
         assert_equal(xd.mask, x.diagonal().mask)
         assert_equal(xd.data, x.diagonal().data)
 
+    def test_mvoid_fill_value_propagation(self):
+            data = [((1,),)]
+            dtype = [('a', 'i', (1,))]
+            fill_value = -1
+            
+            ma = np.ma.MaskedArray(data, dtype=dtype, fill_value=fill_value)
+            
+            subma_1 = ma[0]['a']
+            subma_2 = ma['a'][0]
+            
+            assert_equal(subma_1.fill_value, fill_value)
+            assert_equal(subma_1.fill_value, subma_2.fill_value)
+
 
 class TestMaskedArrayMathMethods:
     def _create_data(self):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4074,13 +4074,13 @@ class TestMaskedArrayMethods:
     def test_mvoid_fill_value_propagation(self):
         data = [((1,),)]
         dtype = [('a', 'i', (1,))]
-        fill_value = -1
-            
+        fill_value = 42
+
         ma = np.ma.MaskedArray(data, dtype=dtype, fill_value=fill_value)
-            
+
         subma_1 = ma[0]['a']
         subma_2 = ma['a'][0]
-            
+
         assert_equal(subma_1.fill_value, fill_value)
         assert_equal(subma_1.fill_value, subma_2.fill_value)
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4072,17 +4072,17 @@ class TestMaskedArrayMethods:
         assert_equal(xd.data, x.diagonal().data)
 
     def test_mvoid_fill_value_propagation(self):
-            data = [((1,),)]
-            dtype = [('a', 'i', (1,))]
-            fill_value = -1
+        data = [((1,),)]
+        dtype = [('a', 'i', (1,))]
+        fill_value = -1
             
-            ma = np.ma.MaskedArray(data, dtype=dtype, fill_value=fill_value)
+        ma = np.ma.MaskedArray(data, dtype=dtype, fill_value=fill_value)
             
-            subma_1 = ma[0]['a']
-            subma_2 = ma['a'][0]
+        subma_1 = ma[0]['a']
+        subma_2 = ma['a'][0]
             
-            assert_equal(subma_1.fill_value, fill_value)
-            assert_equal(subma_1.fill_value, subma_2.fill_value)
+        assert_equal(subma_1.fill_value, fill_value)
+        assert_equal(subma_1.fill_value, subma_2.fill_value)
 
 
 class TestMaskedArrayMathMethods:


### PR DESCRIPTION
Ensure that structured masked arrays correctly propagate the fill_value when accessing a field from an mvoid object (e.g., ma[0]['field']). Previously, accessing an array-valued field from an mvoid would lose the custom fill_value and revert to the default. Closes #28450

### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

--> The issue was located in mvoid.__getitem__. When a structured row was accessed, the mvoid constructor was called without passing the existing fill_value. This caused the resulting object to drop the custom fill_value and revert to the default. I updated the constructor call to explicitly propagate self._fill_value to the new mvoid instance.

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
--> I'm a Bsc Student in Computer Science and Engineering, currently finishing the third year. I was already familiar with numpy due to some of my previous projects, so when I was told that I needed to make a contribution to an open-source project, numpy seemed to fit what I was looking for.

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
--> No AI tools used
