### PR TITLE
MAINT,BUG: refactor ``PyArray_DescrFromScalar`` for parametric support

### DIFF
--- a/doc/release/upcoming_changes/31067.c_api.rst
+++ b/doc/release/upcoming_changes/31067.c_api.rst
@@ -1,0 +1,8 @@
+``PyArray_DescrFromScalar`` now preserves parametric dtype information
+----------------------------------------------------------------------
+``PyArray_DescrFromScalar`` now correctly returns the full dtype descriptor for
+scalars of user-defined parametric data types, including any dtype parameters.
+Previously, parameters were silently discarded, which could cause incorrect
+results in operations like ``astype`` on scalar objects. Internally, the
+function now delegates to ``discover_descr_from_pyobject``, which handles
+parametric dtypes correctly.

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -573,15 +573,10 @@ discover_datetime_and_timedelta_from_pyobject(
         PyArray_DTypeMeta *cls, PyObject *obj) {
     if (PyArray_IsScalar(obj, Datetime) ||
             PyArray_IsScalar(obj, Timedelta)) {
-        PyArray_DatetimeMetaData *meta;
-        PyArray_Descr *descr = PyArray_DescrFromScalar(obj);
-        meta = get_datetime_metadata_from_dtype(descr);
-        if (meta == NULL) {
-            return NULL;
-        }
-        PyArray_Descr *new_descr = create_datetime_dtype(cls->type_num, meta);
-        Py_DECREF(descr);
-        return new_descr;
+        /* Extract metadata directly from the scalar object. */
+        PyArray_DatetimeMetaData *meta =
+                &((PyDatetimeScalarObject *)obj)->obmeta;
+        return create_datetime_dtype(cls->type_num, meta);
     }
     else {
         return find_object_datetime_type(obj, cls->type_num);

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -402,67 +402,37 @@ PyArray_DescrFromTypeObject(PyObject *type)
 NPY_NO_EXPORT PyArray_Descr *
 PyArray_DescrFromScalar(PyObject *sc)
 {
-    int type_num;
-    PyArray_Descr *descr;
-
-    if (PyArray_IsScalar(sc, Void)) {
-        descr = (PyArray_Descr *)((PyVoidScalarObject *)sc)->descr;
-        Py_INCREF(descr);
-        return descr;
+    /*
+     * Look up the DType directly from the scalar's type.  This avoids calling
+     * the NPY_DT_default_descr slot (via PyArray_GetDefaultDescr), which for
+     * parametric dtypes may raise an error or return an incorrect stub.
+     * Once we have the DType class, discover_descr_from_pyobject extracts the
+     * correct instance-specific descriptor (handling void, datetime, string,
+     * and new-style user-defined parametric dtypes correctly).
+     */
+    PyArray_DTypeMeta *DType =
+            (PyArray_DTypeMeta *)PyArray_DiscoverDTypeFromScalarType(Py_TYPE(sc));
+    if (DType != NULL) {
+        PyArray_Descr *result = NPY_DT_CALL_discover_descr_from_pyobject(DType, sc);
+        Py_DECREF(DType);
+        return result;
     }
 
-    if (PyArray_IsScalar(sc, Datetime) || PyArray_IsScalar(sc, Timedelta)) {
-        PyArray_DatetimeMetaData *dt_data;
-
-        if (PyArray_IsScalar(sc, Datetime)) {
-            descr = PyArray_DescrNewFromType(NPY_DATETIME);
-        }
-        else {
-            /* Timedelta */
-            descr = PyArray_DescrNewFromType(NPY_TIMEDELTA);
-        }
-        if (descr == NULL) {
-            return NULL;
-        }
-        dt_data = &(((PyArray_DatetimeDTypeMetaData *)((_PyArray_LegacyDescr *)descr)->c_metadata)->meta);
-        memcpy(dt_data, &((PyDatetimeScalarObject *)sc)->obmeta,
-               sizeof(PyArray_DatetimeMetaData));
-
-        return descr;
-    }
-
-    descr = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(sc));
+    /*
+     * Fallback for scalar subclasses that are not directly in the scalar-type
+     * registry (e.g. a Python subclass of np.float64).  These are always
+     * legacy non-parametric dtypes, so PyArray_DescrFromTypeObject is safe:
+     * it walks the MRO to find the registered base type and calls
+     * PyArray_GetDefaultDescr, which works correctly for non-parametric dtypes.
+     */
+    PyArray_Descr *descr = PyArray_DescrFromTypeObject((PyObject *)Py_TYPE(sc));
     if (descr == NULL) {
         return NULL;
     }
-    if (PyDataType_ISLEGACY(descr) && PyDataType_ISUNSIZED(descr)) {
-        PyArray_DESCR_REPLACE(descr);
-        if (descr == NULL) {
-            return NULL;
-        }
-        type_num = descr->type_num;
-        if (type_num == NPY_STRING) {
-            descr->elsize = PyBytes_GET_SIZE(sc);
-        }
-        else if (type_num == NPY_UNICODE) {
-            descr->elsize = PyUnicode_GET_LENGTH(sc) * 4;
-        }
-        else {
-            _PyArray_LegacyDescr *ldescr = (_PyArray_LegacyDescr *)descr;
-            PyArray_Descr *dtype;
-            dtype = (PyArray_Descr *)PyObject_GetAttrString(sc, "dtype");
-            if (dtype != NULL) {
-                descr->elsize = dtype->elsize;
-                ldescr->fields = PyDataType_FIELDS(dtype);
-                Py_XINCREF(ldescr->fields);
-                ldescr->names = PyDataType_NAMES(dtype);
-                Py_XINCREF(ldescr->names);
-                Py_DECREF(dtype);
-            }
-            PyErr_Clear();
-        }
-    }
-    return descr;
+    DType = NPY_DTYPE(descr);
+    PyArray_Descr *result = NPY_DT_CALL_discover_descr_from_pyobject(DType, sc);
+    Py_DECREF(descr);
+    return result;
 }
 
 /*NUMPY_API


### PR DESCRIPTION
### PR summary

When PyArray_DescrFromScalar is called on a scalar corresponding to a user-defined parametric dtype, it silently discards the parameters of this dtype and replaces them with the defaults.

This shows up for example when the `astype` member function of the scalar type is called, which internally tries to construct a 0-D array as an intermediate step. This array ends up having the wrong dtype (parameters are lost) and as a result the conversion can unexpectedly break.

The problem was discovered during the development of a user-defined fixed-point dtype, where it ended up discarding the 'number of fractional bits' parameter, completely breaking the conversion. We currently work around this by overriding the `astype` member function of the scalar type.

It currently also shows up in a more subtle way in [numpy_quaddtype](https://github.com/numpy/numpy-quaddtype) where it silently discards the backend parameter, resulting in a temporary conversion to the default SLEEF backend. This is relatively harmless but still unexpected.

I did not see an obvious way to trigger this issue with the SFloat user-defined dtype that is used in the numpy test suite, because it doesn't have a corresponding scalar type. Instead, the added tests are simply there in an attempt to catch potential regressions caused by this change, and are entirely optional.

#### AI Disclosure

Claude Sonnet 4.6 was used to identify and fix the bug. I have reviewed the rationale and proposed fix, and they seem reasonable to me. However I have limited knowledge of numpy internals and can't judge whether this is the most appropriate solution.

The full AI-generated description of the bug and proposed solution can be found here:
https://gist.github.com/MaartenBaert/3cf4a926f139b0ec551d23bc5920ecc7