### PR TITLE
BUG: Fix ValueError in nanfunctions when MaskedArray is fully masked

### DIFF
--- a/doc/release/upcoming_changes/31069.improvement.rst
+++ b/doc/release/upcoming_changes/31069.improvement.rst
@@ -1,0 +1,3 @@
+``nanfunctions`` now support fully masked ``MaskedArray`` inputs
+----------------------------------------------------------------
+Functions like ``np.nanmean``, ``np.nanstd``, and ``np.nanpercentile`` no longer raise a ``ValueError`` when given a ``MaskedArray`` where all values are masked. For fully masked arrays, ``nanmean`` and ``nanstd`` now correctly return a masked array/constant instead of throwing an error, while ``nanpercentile`` returns ``NaN``.

--- a/doc/release/upcoming_changes/31069.improvement.rst
+++ b/doc/release/upcoming_changes/31069.improvement.rst
@@ -1,6 +1,12 @@
 ``nanfunctions`` now support fully masked ``MaskedArray`` inputs
 ----------------------------------------------------------------
-Functions like ``np.nanmean``, ``np.nanstd``, ``np.nanvar``, and ``np.nanpercentile`` no longer raise a ``ValueError`` when given a ``MaskedArray`` where all values are masked. For fully masked arrays, ``nanmean``, ``nanstd``, and ``nanvar`` now correctly return a masked array/constant instead of throwing an error, while ``nanpercentile`` returns ``NaN``.
+Functions like ``np.nanmean``, ``np.nanstd``, ``np.nanvar``, and
+``np.nanpercentile`` no longer raise a ``ValueError`` when given a
+``MaskedArray`` where all values are masked.
+
+For fully masked arrays, ``nanmean``, ``nanstd``, and ``nanvar`` now correctly
+return a masked array/constant instead of throwing an error, while
+``nanpercentile`` returns ``NaN``.
 
 This also changes behavior for *partially* masked arrays: masked values are now
 also treated as missing, the same as ``NaN``. For example,

--- a/doc/release/upcoming_changes/31069.improvement.rst
+++ b/doc/release/upcoming_changes/31069.improvement.rst
@@ -1,3 +1,9 @@
 ``nanfunctions`` now support fully masked ``MaskedArray`` inputs
 ----------------------------------------------------------------
-Functions like ``np.nanmean``, ``np.nanstd``, and ``np.nanpercentile`` no longer raise a ``ValueError`` when given a ``MaskedArray`` where all values are masked. For fully masked arrays, ``nanmean`` and ``nanstd`` now correctly return a masked array/constant instead of throwing an error, while ``nanpercentile`` returns ``NaN``.
+Functions like ``np.nanmean``, ``np.nanstd``, ``np.nanvar``, and ``np.nanpercentile`` no longer raise a ``ValueError`` when given a ``MaskedArray`` where all values are masked. For fully masked arrays, ``nanmean``, ``nanstd``, and ``nanvar`` now correctly return a masked array/constant instead of throwing an error, while ``nanpercentile`` returns ``NaN``.
+
+This also changes behavior for *partially* masked arrays: masked values are now
+also treated as missing, the same as ``NaN``. For example,
+``np.nanmedian(np.ma.MaskedArray([1, 2, 3, np.nan], mask=[False, True, False, False]))``
+now returns ``2.0`` (the median of ``[1, 3]``, with the masked ``2`` and the ``NaN``
+both excluded), where it previously returned a masked constant.

--- a/doc/release/upcoming_changes/31069.improvement.rst
+++ b/doc/release/upcoming_changes/31069.improvement.rst
@@ -1,15 +1,9 @@
-``nanfunctions`` now support fully masked ``MaskedArray`` inputs
-----------------------------------------------------------------
-Functions like ``np.nanmean``, ``np.nanstd``, ``np.nanvar``, and
-``np.nanpercentile`` no longer raise a ``ValueError`` when given a
-``MaskedArray`` where all values are masked.
-
-For fully masked arrays, ``nanmean``, ``nanstd``, and ``nanvar`` now correctly
-return a masked array/constant instead of throwing an error, while
-``nanpercentile`` returns ``NaN``.
-
-This also changes behavior for *partially* masked arrays: masked values are now
-also treated as missing, the same as ``NaN``. For example,
-``np.nanmedian(np.ma.MaskedArray([1, 2, 3, np.nan], mask=[False, True, False, False]))``
-now returns ``2.0`` (the median of ``[1, 3]``, with the masked ``2`` and the ``NaN``
-both excluded), where it previously returned a masked constant.
+``nanmean``, ``nanstd`` and ``nanvar`` no longer fail on read-only reductions
+-----------------------------------------------------------------------------
+These functions divide the running sum by the count in place, which assumed
+the sum was writeable. When it was not they raised
+``ValueError: output array is read-only`` instead of returning a result and they
+now allocate the output in that case, keeping the dtype the in-place divide
+would have produced. This is what made ``np.nanmean``, ``np.nanstd`` and
+``np.nanvar`` fail on a ``MaskedArray`` whose values are all masked, since
+``numpy.ma`` reduces that to the read-only ``np.ma.masked``.

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -172,6 +172,10 @@ def _remove_nan_1d(arr1d, second_arr1d=None, overwrite_input=False):
     else:
         c = np.isnan(arr1d)
 
+    # For masked arrays, also treat masked values as if they are NaN (gh-29117).
+    if isinstance(arr1d, np.ma.MaskedArray):
+        c = np.asarray(c) | np.ma.getmaskarray(arr1d)
+
     s = np.nonzero(c)[0]
     if s.size == arr1d.size:
         warnings.warn("All-NaN slice encountered", RuntimeWarning,
@@ -229,6 +233,9 @@ def _divide_by_count(a, b, out=None):
     with np.errstate(invalid='ignore', divide='ignore'):
         if isinstance(a, np.ndarray):
             if out is None:
+                # Skip in-place divide for read-only arrays (gh-29117).
+                if not a.flags.writeable:
+                    return np.divide(a, b, casting='unsafe')
                 return np.divide(a, b, out=a, casting='unsafe')
             else:
                 return np.divide(a, b, out=out, casting='unsafe')
@@ -1995,7 +2002,11 @@ def nanstd(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue,
                  keepdims=keepdims, where=where, mean=mean,
                  correction=correction)
     if isinstance(var, np.ndarray):
-        std = np.sqrt(var, out=var)
+        # Skip in-place sqrt for read-only arrays (gh-29117).
+        if not var.flags.writeable:
+            std = np.sqrt(var)
+        else:
+            std = np.sqrt(var, out=var)
     elif hasattr(var, 'dtype'):
         std = var.dtype.type(np.sqrt(var))
     else:

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -172,10 +172,6 @@ def _remove_nan_1d(arr1d, second_arr1d=None, overwrite_input=False):
     else:
         c = np.isnan(arr1d)
 
-    # For masked arrays, also treat masked values as if they are NaN (gh-29117).
-    if isinstance(arr1d, np.ma.MaskedArray):
-        c = np.asarray(c) | np.ma.getmaskarray(arr1d)
-
     s = np.nonzero(c)[0]
     if s.size == arr1d.size:
         warnings.warn("All-NaN slice encountered", RuntimeWarning,
@@ -233,9 +229,11 @@ def _divide_by_count(a, b, out=None):
     with np.errstate(invalid='ignore', divide='ignore'):
         if isinstance(a, np.ndarray):
             if out is None:
-                # Skip in-place divide for read-only arrays (gh-29117).
+                # `a` is normally a temporary we can divide into, but
+                # some reductions return a read-only result (gh-29117).
+                # Allocate then, keeping the dtype the in-place divide gives.
                 if not a.flags.writeable:
-                    return np.divide(a, b, casting='unsafe')
+                    return np.divide(a, b, dtype=a.dtype, casting='unsafe')
                 return np.divide(a, b, out=a, casting='unsafe')
             else:
                 return np.divide(a, b, out=out, casting='unsafe')
@@ -2002,11 +2000,9 @@ def nanstd(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue,
                  keepdims=keepdims, where=where, mean=mean,
                  correction=correction)
     if isinstance(var, np.ndarray):
-        # Skip in-place sqrt for read-only arrays (gh-29117).
-        if not var.flags.writeable:
-            std = np.sqrt(var)
-        else:
-            std = np.sqrt(var, out=var)
+        # Take the square root in place, unless `var` came back read-only
+        # (gh-29117), in which case we have to allocate.
+        std = np.sqrt(var, out=var if var.flags.writeable else None)
     elif hasattr(var, 'dtype'):
         std = var.dtype.type(np.sqrt(var))
     else:

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1449,6 +1449,7 @@ def test_memmap_takes_fast_route(tmpdir):
             np.nanmin(mm, out=np.zeros(2))
 
 
+@pytest.mark.filterwarnings("ignore:All-NaN slice:RuntimeWarning")
 def test_masked_array_all_masked():
     """
     Test that `nan*` functions do not raise a `ValueError` when passed a
@@ -1456,12 +1457,9 @@ def test_masked_array_all_masked():
     """
     vals_ma = np.ma.MaskedArray([np.nan, 3], mask=[True, True])
 
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', RuntimeWarning)
+    for f in [np.nanmean, np.nanstd]:
+        res = f(vals_ma)
+        assert_(np.ma.is_masked(res))
 
-        for f in [np.nanmean, np.nanstd]:
-            res = f(vals_ma)
-            assert_(np.ma.is_masked(res), msg=f"{f.__name__} failed to return masked")
-
-        res = np.nanpercentile(vals_ma, 90)
-        assert_(np.isnan(res), msg="nanpercentile failed to return NaN")
+    res = np.nanpercentile(vals_ma, 90)
+    assert_(np.isnan(res))

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1447,3 +1447,21 @@ def test_memmap_takes_fast_route(tmpdir):
         # For completeness, same for nanmin.
         with pytest.raises(ValueError, match="reduction operation fmin"):
             np.nanmin(mm, out=np.zeros(2))
+
+
+def test_masked_array_all_masked():
+    """
+    Test that `nan*` functions do not raise a `ValueError` when passed a
+    `MaskedArray` where all values are masked (gh-29117).
+    """
+    vals_ma = np.ma.MaskedArray([np.nan, 3], mask=[True, True])
+    
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        
+        for f in [np.nanmean, np.nanstd]:
+            res = f(vals_ma)
+            assert_(np.ma.is_masked(res), msg=f"{f.__name__} failed to return masked")
+            
+        res = np.nanpercentile(vals_ma, 90)
+        assert_(np.isnan(res), msg="nanpercentile failed to return NaN")

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1455,13 +1455,13 @@ def test_masked_array_all_masked():
     `MaskedArray` where all values are masked (gh-29117).
     """
     vals_ma = np.ma.MaskedArray([np.nan, 3], mask=[True, True])
-    
+
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', RuntimeWarning)
-        
+
         for f in [np.nanmean, np.nanstd]:
             res = f(vals_ma)
             assert_(np.ma.is_masked(res), msg=f"{f.__name__} failed to return masked")
-            
+
         res = np.nanpercentile(vals_ma, 90)
         assert_(np.isnan(res), msg="nanpercentile failed to return NaN")

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1449,17 +1449,30 @@ def test_memmap_takes_fast_route(tmpdir):
             np.nanmin(mm, out=np.zeros(2))
 
 
-@pytest.mark.filterwarnings("ignore:All-NaN slice:RuntimeWarning")
-def test_masked_array_all_masked():
-    """
-    Test that `nan*` functions do not raise a `ValueError` when passed a
-    `MaskedArray` where all values are masked (gh-29117).
-    """
+@pytest.mark.parametrize("f", [np.nanmean, np.nanstd, np.nanvar])
+def test_masked_array_all_masked(f):
+    # gh-29117: these used to raise `ValueError: output array is read-only`;
+    # a fully masked array should return a masked constant instead
+    vals_ma = np.ma.MaskedArray([np.nan, 3], mask=[True, True])
+    res = f(vals_ma)
+    assert_(np.ma.is_masked(res))
+
+
+def test_masked_array_all_masked_nanmedian():
+    # nanmedian returns a masked constant for a fully masked array, like
+    # nanmean/nanstd/nanvar, but it also emits a RuntimeWarning (gh-29117)
     vals_ma = np.ma.MaskedArray([np.nan, 3], mask=[True, True])
 
-    for f in [np.nanmean, np.nanstd]:
-        res = f(vals_ma)
-        assert_(np.ma.is_masked(res))
+    with pytest.warns(RuntimeWarning, match="All-NaN slice encountered"):
+        res = np.nanmedian(vals_ma)
+    assert_(np.ma.is_masked(res))
 
-    res = np.nanpercentile(vals_ma, 90)
+
+def test_masked_array_all_masked_nanpercentile():
+    # nanpercentile returns NaN rather than a masked constant for a fully
+    # masked array (gh-29117)
+    vals_ma = np.ma.MaskedArray([np.nan, 3], mask=[True, True])
+
+    with pytest.warns(RuntimeWarning, match="All-NaN slice encountered"):
+        res = np.nanpercentile(vals_ma, 90)
     assert_(np.isnan(res))

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1458,11 +1458,3 @@ def test_divide_by_count_read_only():
     assert_equal(res, np.array([3.0], dtype=np.float32))
     # the fallback must not promote the result to float64
     assert_equal(res.dtype, np.float32)
-
-
-@pytest.mark.parametrize("f", [np.nanmean, np.nanstd, np.nanvar])
-def test_all_masked_maskedarray(f):
-    # gh-29117: an all-masked MaskedArray reduces to the read-only
-    # `np.ma.masked`, which these used to try to divide into
-    vals_ma = np.ma.MaskedArray([np.nan, 3], mask=[True, True])
-    assert_(np.ma.is_masked(f(vals_ma)))

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -7,7 +7,7 @@ import pytest
 import numpy as np
 from numpy._core.numeric import normalize_axis_tuple
 from numpy.exceptions import AxisError, ComplexWarning
-from numpy.lib._nanfunctions_impl import _nan_mask, _replace_nan
+from numpy.lib._nanfunctions_impl import _divide_by_count, _nan_mask, _replace_nan
 from numpy.testing import (
     assert_,
     assert_almost_equal,
@@ -1449,30 +1449,20 @@ def test_memmap_takes_fast_route(tmpdir):
             np.nanmin(mm, out=np.zeros(2))
 
 
+def test_divide_by_count_read_only():
+    # gh-29117: `a` is normally divided into in place, but some reductions
+    # return a read-only array, so that is not always possible.
+    a = np.array([6.0], dtype=np.float32)
+    a.flags.writeable = False
+    res = _divide_by_count(a, np.array([2], dtype=np.intp))
+    assert_equal(res, np.array([3.0], dtype=np.float32))
+    # the fallback must not promote the result to float64
+    assert_equal(res.dtype, np.float32)
+
+
 @pytest.mark.parametrize("f", [np.nanmean, np.nanstd, np.nanvar])
-def test_masked_array_all_masked(f):
-    # gh-29117: these used to raise `ValueError: output array is read-only`;
-    # a fully masked array should return a masked constant instead
+def test_all_masked_maskedarray(f):
+    # gh-29117: an all-masked MaskedArray reduces to the read-only
+    # `np.ma.masked`, which these used to try to divide into
     vals_ma = np.ma.MaskedArray([np.nan, 3], mask=[True, True])
-    res = f(vals_ma)
-    assert_(np.ma.is_masked(res))
-
-
-def test_masked_array_all_masked_nanmedian():
-    # nanmedian returns a masked constant for a fully masked array, like
-    # nanmean/nanstd/nanvar, but it also emits a RuntimeWarning (gh-29117)
-    vals_ma = np.ma.MaskedArray([np.nan, 3], mask=[True, True])
-
-    with pytest.warns(RuntimeWarning, match="All-NaN slice encountered"):
-        res = np.nanmedian(vals_ma)
-    assert_(np.ma.is_masked(res))
-
-
-def test_masked_array_all_masked_nanpercentile():
-    # nanpercentile returns NaN rather than a masked constant for a fully
-    # masked array (gh-29117)
-    vals_ma = np.ma.MaskedArray([np.nan, 3], mask=[True, True])
-
-    with pytest.warns(RuntimeWarning, match="All-NaN slice encountered"):
-        res = np.nanpercentile(vals_ma, 90)
-    assert_(np.isnan(res))
+    assert_(np.ma.is_masked(f(vals_ma)))

--- a/numpy/ma/tests/test_regression.py
+++ b/numpy/ma/tests/test_regression.py
@@ -81,3 +81,10 @@ class TestRegression:
         np.ma.array((1, (b"", b"")),
                     dtype=[("x", np.int_),
                           ("y", [("i", np.void), ("j", np.void)])])
+
+    def test_nanfunctions_all_masked(self):
+        # see gh-29117. An all-masked array reduces to the read-only
+        # `np.ma.masked`, which these used to try to divide into.
+        a = np.ma.MaskedArray([np.nan, 3], mask=[True, True])
+        for f in (np.nanmean, np.nanstd, np.nanvar):
+            assert_(np.ma.is_masked(f(a)), f.__name__)


### PR DESCRIPTION
### PR summary
I ran into this problem and there is a equivalent issue #29117 related to this.



- `nanmean`, `nanstd` throw `ValueError: output array is read-only`, as it was trying to write to the buffer which has no permisson to write to (when everything is nan). Fix (for `nanmean`): removing `out=a` from `np.divide(a, b, out=a, casting='unsafe')` so that division is not done inplace. Subsequently same done for `nanstd`.


 - `nanpercentile`  [np.isnan(arr1d)](https://github.com/numpy/numpy/blob/7baf0e7c71dfc2de9fa5022cf51cb4873efd4285/numpy/lib/_nanfunctions_impl.py#L173) on a MaskedArray returns a MaskedArray. The masked positions in that result have fill_value=False,  and `np.asarray(c)` strips the outer mask and gives boolean data. This data is `or`ed with mask to get the "real" mask so `np.nonzero(c)` would skip them. 

 ```
vals, mask = np.array([np.nan, 3]), [True, True]
vals_ma = np.ma.MaskedArray(vals, mask=mask)
``` 



<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
No AI tools used
Edit: Later used it to write release note and comments. 