### PR TITLE
ENH: convert PyArrayDTypeMeta_Type to a heap type

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1876,9 +1876,8 @@ typedef struct {
 } PyArray_StringDTypeObject;
 
 /*
- * PyArray_DTypeMeta related definitions.
- *
- * As of now, this API is preliminary and will be extended as necessary.
+ * PyArray_DTypeMeta related definitions. Only for internal use, should be moved
+ * away from public headers eventually
  */
 #if defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD
     /*
@@ -1887,18 +1886,20 @@ typedef struct {
      * Part of this (at least the size) is expected to be public API without
      * further modifications.
      */
-    /* TODO: Make this definition public in the API, as soon as its settled */
-    NPY_NO_EXPORT extern PyTypeObject PyArrayDTypeMeta_Type;
+    /*
+     * This is made public in _public_dtype_api_table.h via the PyArray_API table,
+     * but there it is a dereferenced pointer
+     */
+    NPY_NO_EXPORT extern PyTypeObject *PyArrayDTypeMeta_Type;
 
     /*
      * While NumPy DTypes would not need to be heap types the plan is to
      * make DTypes available in Python at which point they will be heap types.
+     *
      * Since we also wish to add fields to the DType class, this looks like
      * a typical instance definition, but with PyHeapTypeObject instead of
      * only the PyObject_HEAD.
-     * This must only be exposed very extremely careful consideration, since
-     * it is a fairly complex construct which may be better to allow
-     * refactoring of.
+     * This is exposed in dtype_api.h
      */
     typedef struct {
         PyHeapTypeObject super;

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -85,12 +85,15 @@ discover_descriptor_from_pycomplex(
 NPY_NO_EXPORT int
 initialize_and_map_pytypes_to_dtypes()
 {
+    Py_SET_TYPE((PyTypeObject *)&PyArray_IntAbstractDType, PyArrayDTypeMeta_Type);
     if (PyType_Ready((PyTypeObject *)&PyArray_IntAbstractDType) < 0) {
         return -1;
     }
+    Py_SET_TYPE((PyTypeObject *)&PyArray_FloatAbstractDType, PyArrayDTypeMeta_Type);
     if (PyType_Ready((PyTypeObject *)&PyArray_FloatAbstractDType) < 0) {
         return -1;
     }
+    Py_SET_TYPE((PyTypeObject *)&PyArray_ComplexAbstractDType, PyArrayDTypeMeta_Type);
     if (PyType_Ready((PyTypeObject *)&PyArray_ComplexAbstractDType) < 0) {
         return -1;
     }
@@ -101,18 +104,21 @@ initialize_and_map_pytypes_to_dtypes()
     ((PyTypeObject *)&PyArray_PyLongDType)->tp_base =
         (PyTypeObject *)&PyArray_IntAbstractDType;
     PyArray_PyLongDType.scalar_type = &PyLong_Type;
+    Py_SET_TYPE((PyTypeObject *)&PyArray_PyLongDType, PyArrayDTypeMeta_Type);
     if (PyType_Ready((PyTypeObject *)&PyArray_PyLongDType) < 0) {
         return -1;
     }
     ((PyTypeObject *)&PyArray_PyFloatDType)->tp_base =
         (PyTypeObject *)&PyArray_FloatAbstractDType;
     PyArray_PyFloatDType.scalar_type = &PyFloat_Type;
+    Py_SET_TYPE((PyTypeObject *)&PyArray_PyFloatDType, PyArrayDTypeMeta_Type);
     if (PyType_Ready((PyTypeObject *)&PyArray_PyFloatDType) < 0) {
         return -1;
     }
     ((PyTypeObject *)&PyArray_PyComplexDType)->tp_base =
         (PyTypeObject *)&PyArray_ComplexAbstractDType;
     PyArray_PyComplexDType.scalar_type = &PyComplex_Type;
+    Py_SET_TYPE((PyTypeObject *)&PyArray_PyComplexDType, PyArrayDTypeMeta_Type);
     if (PyType_Ready((PyTypeObject *)&PyArray_PyComplexDType) < 0) {
         return -1;
     }
@@ -292,7 +298,7 @@ complex_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
  * Here, also define types corresponding to the python scalars.
  */
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_IntAbstractDType = {{{
-        PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
+        PyVarObject_HEAD_INIT(NULL, 0)
         .tp_name = "numpy.dtypes._IntegerAbstractDType",
         .tp_base = &PyArrayDescr_Type,
         .tp_basicsize = sizeof(PyArray_Descr),
@@ -309,7 +315,7 @@ NPY_DType_Slots pylongdtype_slots = {
 };
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyLongDType = {{{
-        PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
+        PyVarObject_HEAD_INIT(NULL, 0)
         .tp_name = "numpy.dtypes._PyLongDType",
         .tp_base = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
         .tp_basicsize = sizeof(PyArray_Descr),
@@ -321,7 +327,7 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyLongDType = {{{
 };
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_FloatAbstractDType = {{{
-        PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
+        PyVarObject_HEAD_INIT(NULL, 0)
         .tp_name = "numpy.dtypes._FloatAbstractDType",
         .tp_base = &PyArrayDescr_Type,
         .tp_basicsize = sizeof(PyArray_Descr),
@@ -338,7 +344,7 @@ NPY_DType_Slots pyfloatdtype_slots = {
 };
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatDType = {{{
-        PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
+        PyVarObject_HEAD_INIT(NULL, 0)
         .tp_name = "numpy.dtypes._PyFloatDType",
         .tp_base = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
         .tp_basicsize = sizeof(PyArray_Descr),
@@ -350,7 +356,7 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatDType = {{{
 };
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_ComplexAbstractDType = {{{
-        PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
+        PyVarObject_HEAD_INIT(NULL, 0)
         .tp_name = "numpy.dtypes._ComplexAbstractDType",
         .tp_base = &PyArrayDescr_Type,
         .tp_basicsize = sizeof(PyArray_Descr),
@@ -367,7 +373,7 @@ NPY_DType_Slots pycomplexdtype_slots = {
 };
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexDType = {{{
-        PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
+        PyVarObject_HEAD_INIT(NULL, 0)
         .tp_name = "numpy.dtypes._PyComplexDType",
         .tp_base = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
         .tp_basicsize = sizeof(PyArray_Descr),

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -242,7 +242,7 @@ npy_discover_dtype_from_pytype(PyTypeObject *pytype)
             return NULL;
         }
     }
-    assert(DType == Py_None || PyObject_TypeCheck(DType, (PyTypeObject *)&PyArrayDTypeMeta_Type));
+    assert(DType == Py_None || PyObject_TypeCheck(DType, PyArrayDTypeMeta_Type));
     return (PyArray_DTypeMeta *)DType;
 }
 
@@ -1274,7 +1274,7 @@ PyArray_DiscoverDTypeAndShape(
     /* Validate input of requested descriptor and DType */
     if (fixed_DType != NULL) {
         assert(PyObject_TypeCheck(
-                (PyObject *)fixed_DType, (PyTypeObject *)&PyArrayDTypeMeta_Type));
+                (PyObject *)fixed_DType, PyArrayDTypeMeta_Type));
     }
 
     if (requested_descr != NULL) {

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -222,7 +222,7 @@ validate_spec(PyArrayMethod_Spec *spec)
                     "(method: %s)", spec->name);
             return -1;
         }
-        if (!PyObject_TypeCheck(spec->dtypes[i], &PyArrayDTypeMeta_Type)) {
+        if (!PyObject_TypeCheck(spec->dtypes[i], PyArrayDTypeMeta_Type)) {
             PyErr_Format(PyExc_TypeError,
                     "ArrayMethod provided object %R is not a DType."
                     "(method: %s)", spec->dtypes[i], spec->name);
@@ -407,7 +407,7 @@ NPY_NO_EXPORT PyObject *
 PyArrayMethod_FromSpec(PyArrayMethod_Spec *spec)
 {
     for (int i = 0; i < spec->nin + spec->nout; i++) {
-        if (!PyObject_TypeCheck(spec->dtypes[i], &PyArrayDTypeMeta_Type)) {
+        if (!PyObject_TypeCheck(spec->dtypes[i], PyArrayDTypeMeta_Type)) {
             PyErr_SetString(PyExc_RuntimeError,
                     "ArrayMethod spec contained a non DType.");
             return NULL;

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -248,7 +248,7 @@ _get_castingimpl(PyObject *NPY_UNUSED(module), PyObject *args)
 {
     PyArray_DTypeMeta *from, *to;
     if (!PyArg_ParseTuple(args, "O!O!:_get_castingimpl",
-            &PyArrayDTypeMeta_Type, &from, &PyArrayDTypeMeta_Type, &to)) {
+            PyArrayDTypeMeta_Type, &from, PyArrayDTypeMeta_Type, &to)) {
         return NULL;
     }
     return PyArray_GetBoundCastingImpl(from, to);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1472,7 +1472,7 @@ PyArray_DTypeOrDescrConverterRequired(PyObject *obj, npy_dtype_info *dt_info)
     dt_info->dtype = NULL;
     dt_info->descr = NULL;
 
-    if (PyObject_TypeCheck(obj, &PyArrayDTypeMeta_Type)) {
+    if (PyObject_TypeCheck(obj, PyArrayDTypeMeta_Type)) {
         if (obj == (PyObject *)&PyArrayDescr_Type) {
             PyErr_SetString(PyExc_TypeError,
                             "Cannot convert np.dtype into a dtype.");
@@ -2493,7 +2493,7 @@ arraydescr_new(PyTypeObject *subtype,
                 PyObject *args, PyObject *kwds)
 {
     if (subtype != &PyArrayDescr_Type) {
-        if (Py_TYPE(subtype) == &PyArrayDTypeMeta_Type &&
+        if (Py_TYPE(subtype) == PyArrayDTypeMeta_Type &&
                 (NPY_DT_SLOTS((PyArray_DTypeMeta *)subtype)) != NULL &&
                 !NPY_DT_is_legacy((PyArray_DTypeMeta *)subtype) &&
                 subtype->tp_new != PyArrayDescr_Type.tp_new) {

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -1148,7 +1148,7 @@ dtypemeta_wrap_legacy_descriptor(
      */
     static PyArray_DTypeMeta prototype = {
         {{
-            PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
+            PyVarObject_HEAD_INIT(NULL, 0)
             .tp_name = NULL,  /* set below */
             .tp_basicsize = sizeof(_PyArray_LegacyDescr),
             .tp_flags = Py_TPFLAGS_DEFAULT,
@@ -1160,6 +1160,7 @@ dtypemeta_wrap_legacy_descriptor(
         /* Further fields are not common between DTypes */
     };
     memcpy(dtype_class, &prototype, sizeof(PyArray_DTypeMeta));
+    Py_SET_TYPE((PyTypeObject *)dtype_class, PyArrayDTypeMeta_Type);
     /* Fix name and superclass of the Type*/
     ((PyTypeObject *)dtype_class)->tp_name = name;
     ((PyTypeObject *)dtype_class)->tp_base = dtype_super_class,
@@ -1310,6 +1311,28 @@ dtypemeta_get_is_numeric(PyArray_DTypeMeta *self, void *NPY_UNUSED(ignored)) {
     return PyBool_FromLong(NPY_DT_is_numeric(self));
 }
 
+static PyObject *
+dtypemeta_getattro(PyObject *self, PyObject *name)
+{
+    /*
+     * Legacy (non-heap) DType types store their module in tp_name as
+     * "module.classname" (e.g. "numpy.dtypes.TimeDelta64DType"), but their
+     * MRO does not include PyType_Type so type.__module__'s data descriptor
+     * is never found during attribute lookup, causing __module__ to fall back
+     * to the string stored in _DTypeMeta's tp_dict by PyType_FromSpecWithBases.
+     * Intercept here and compute the correct module from tp_name.
+     * TODO: remove this after converting all legacy DTypes to heap types.
+     */
+    if (PyUnicode_CompareWithASCIIString(name, "__module__") == 0
+            && !(((PyTypeObject *)self)->tp_flags & Py_TPFLAGS_HEAPTYPE)) {
+        const char *tp_name = ((PyTypeObject *)self)->tp_name;
+        const char *dot = strrchr(tp_name, '.');
+        assert(dot != NULL);
+        return PyUnicode_FromStringAndSize(tp_name, dot - tp_name);
+    }
+    return PyType_Type.tp_getattro(self, name);
+}
+
 /*
  * Simple exposed information, defined for each DType (class).
  */
@@ -1368,23 +1391,41 @@ initialize_legacy_dtypemeta_aliases(_PyArray_LegacyDescr **_builtin_descrs) {
     _Void_dtype = NPY_DTYPE(_builtin_descrs[NPY_VOID]);
 }
 
-NPY_NO_EXPORT PyTypeObject PyArrayDTypeMeta_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "numpy._DTypeMeta",
-    .tp_basicsize = sizeof(PyArray_DTypeMeta),
-    .tp_dealloc = (destructor)dtypemeta_dealloc,
+static PyType_Slot dtypemeta_slots[] = {
+    {Py_tp_dealloc, (void *)dtypemeta_dealloc},
     /* Types are garbage collected (see dtypemeta_is_gc documentation) */
-    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
-    .tp_doc = "Preliminary NumPy API: The Type of NumPy DTypes (metaclass)",
-    .tp_traverse = (traverseproc)dtypemeta_traverse,
-    .tp_members = dtypemeta_members,
-    .tp_getset = dtypemeta_getset,
-    .tp_base = NULL,  /* set to PyType_Type at import time */
-    .tp_init = (initproc)dtypemeta_init,
-    .tp_alloc = dtypemeta_alloc,
-    .tp_new = dtypemeta_new,
-    .tp_is_gc = dtypemeta_is_gc,
+    {Py_tp_traverse, (void *)dtypemeta_traverse},
+    {Py_tp_members, (void *)dtypemeta_members},
+    {Py_tp_getset, (void *)dtypemeta_getset},
+    {Py_tp_getattro, (void *)dtypemeta_getattro},
+    {Py_tp_init, (void *)dtypemeta_init},
+    {Py_tp_alloc, (void *)dtypemeta_alloc},
+    {Py_tp_new, (void *)dtypemeta_new},
+    {Py_tp_is_gc, (void *)dtypemeta_is_gc},
+    {Py_tp_doc, (void *)"Preliminary NumPy API: The Type of NumPy DTypes (metaclass)"},
+    {0, NULL},
 };
+
+static PyType_Spec dtypemeta_spec = {
+    .name = "numpy._DTypeMeta",
+    .basicsize = sizeof(PyArray_DTypeMeta),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .slots = dtypemeta_slots,
+};
+
+NPY_NO_EXPORT PyTypeObject *PyArrayDTypeMeta_Type = NULL;
+
+NPY_NO_EXPORT int
+PyArrayDTypeMeta_Type_init(void) {
+    PyObject *bases = PyTuple_Pack(1, &PyType_Type);
+    if (bases == NULL) {
+        return -1;
+    }
+    PyArrayDTypeMeta_Type = (PyTypeObject *)PyType_FromSpecWithBases(
+            &dtypemeta_spec, bases);
+    Py_DECREF(bases);
+    return (PyArrayDTypeMeta_Type != NULL) ? 0 : -1;
+}
 
 PyArray_DTypeMeta *_Bool_dtype = NULL;
 PyArray_DTypeMeta *_Byte_dtype = NULL;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -1409,7 +1409,7 @@ static PyType_Slot dtypemeta_slots[] = {
 static PyType_Spec dtypemeta_spec = {
     .name = "numpy._DTypeMeta",
     .basicsize = sizeof(PyArray_DTypeMeta),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_IMMUTABLETYPE,
     .slots = dtypemeta_slots,
 };
 

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -174,6 +174,9 @@ dtypemeta_wrap_legacy_descriptor(
 NPY_NO_EXPORT void
 initialize_legacy_dtypemeta_aliases(_PyArray_LegacyDescr **_builtin_descrs);
 
+NPY_NO_EXPORT int
+PyArrayDTypeMeta_Type_init(void);
+
 /*
  * NumPy's builtin DTypes:
  */

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -4991,13 +4991,12 @@ _multiarray_umath_exec(PyObject *m) {
         return -1;
     }
 
-    PyArrayDTypeMeta_Type.tp_base = &PyType_Type;
-    if (PyType_Ready(&PyArrayDTypeMeta_Type) < 0) {
+    if (PyArrayDTypeMeta_Type_init() < 0) {
         return -1;
     }
 
     PyArrayDescr_Type.tp_hash = PyArray_DescrHash;
-    Py_SET_TYPE(&PyArrayDescr_Type, &PyArrayDTypeMeta_Type);
+    Py_SET_TYPE(&PyArrayDescr_Type, PyArrayDTypeMeta_Type);
     if (PyType_Ready(&PyArrayDescr_Type) < 0) {
         return -1;
     }

--- a/numpy/_core/src/multiarray/public_dtype_api.c
+++ b/numpy/_core/src/multiarray/public_dtype_api.c
@@ -29,7 +29,7 @@ int
 PyArrayInitDTypeMeta_FromSpec(
         PyArray_DTypeMeta *DType, PyArrayDTypeMeta_Spec *spec)
 {
-    if (!PyObject_TypeCheck(DType, &PyArrayDTypeMeta_Type)) {
+    if (!PyObject_TypeCheck(DType, PyArrayDTypeMeta_Type)) {
         PyErr_SetString(PyExc_RuntimeError,
                 "Passed in DType must be a valid (initialized) DTypeMeta "
                 "instance!");
@@ -127,7 +127,7 @@ _fill_dtype_api(void *full_api_table[])
     void **api_table = full_api_table + 320;
 
     /* The type of the DType metaclass */
-    api_table[0] = &PyArrayDTypeMeta_Type;
+    api_table[0] = PyArrayDTypeMeta_Type;
     /* Boolean */
     api_table[1] = &PyArray_BoolDType;
     /* Integers */

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -1011,7 +1011,7 @@ init_string_dtype(void)
     };
 
     /* Loaded dynamically, so needs to be set here: */
-    ((PyObject *)&PyArray_StringDType)->ob_type = &PyArrayDTypeMeta_Type;
+    ((PyObject *)&PyArray_StringDType)->ob_type = PyArrayDTypeMeta_Type;
     ((PyTypeObject *)&PyArray_StringDType)->tp_base = &PyArrayDescr_Type;
     if (PyType_Ready((PyTypeObject *)&PyArray_StringDType) < 0) {
         return -1;

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -100,7 +100,7 @@ PyUFunc_AddLoop(PyUFuncObject *ufunc, PyObject *info, int ignore_duplicate)
     for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(DType_tuple); i++) {
         PyObject *item = PyTuple_GET_ITEM(DType_tuple, i);
         if (item != Py_None
-                && !PyObject_TypeCheck(item, &PyArrayDTypeMeta_Type)) {
+                && !PyObject_TypeCheck(item, PyArrayDTypeMeta_Type)) {
             PyErr_SetString(PyExc_TypeError,
                     "DType tuple may only contain None and DType classes");
             return -1;

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3828,7 +3828,7 @@ _check_and_copy_sig_to_signature(
  */
 static PyArray_DTypeMeta *
 _get_dtype(PyObject *dtype_obj) {
-    if (PyObject_TypeCheck(dtype_obj, &PyArrayDTypeMeta_Type)) {
+    if (PyObject_TypeCheck(dtype_obj, PyArrayDTypeMeta_Type)) {
         Py_INCREF(dtype_obj);
         return (PyArray_DTypeMeta *)dtype_obj;
     }


### PR DESCRIPTION

### PR summary

Towards #31026. Convert PyArray_DTypeMeta to a heap type ~that uses multiphase initialization~. I am still worried about performance. I ran `spin bench -c` and the results were all over the place: some slower, some faster, by up to 50%. I tried reversing the commits and running again, the results seemed to be consistent, but still all over the place. Here is an example for just `bench_itemselection`:

| Change   | Before [7baf0e7c] <main>   | After [d2bbb722] <dtype-meta>   |   Ratio | Benchmark (Parameter)                                                    |
|----------|----------------------------|---------------------------------|---------|--------------------------------------------------------------------------|
| +        | 3.73±0.01μs                | 4.06±0.2μs                      |    1.09 | bench_itemselection.Take.time_contiguous((1000, 3), 'wrap', 'complex64') |
| -        | 9.93±0.08μs                | 9.41±0.02μs                     |    0.95 | bench_itemselection.Take.time_contiguous((2, 1000, 1), 'wrap', 'O')      |
| -        | 23.0±0.2μs                 | 17.7±0.2μs                      |    0.77 | bench_itemselection.Take.time_contiguous((1000, 1), 'clip', 'i,O')       |
| -        | 32.5±0.1μs                 | 24.5±0.06μs                     |    0.75 | bench_itemselection.Take.time_contiguous((1000, 3), 'clip', 'i,O')       |
| -        | 45.5±0.5μs                 | 33.8±0.3μs                      |    0.74 | bench_itemselection.Take.time_contiguous((2, 1000, 1), 'clip', 'i,O')    |


 Change   | Before [d2bbb722] <dtype-meta>   | After [7baf0e7c] <main>   |   Ratio | Benchmark (Parameter)                                                        |
|----------|----------------------------------|---------------------------|---------|------------------------------------------------------------------------------|
| +        | 17.5±0.3μs                       | 23.2±0.3μs                |    1.33 | bench_itemselection.Take.time_contiguous((1000, 1), 'clip', 'i,O')           |
| +        | 33.9±0.4μs                       | 45.0±0.8μs                |    1.33 | bench_itemselection.Take.time_contiguous((2, 1000, 1), 'clip', 'i,O')        |
| +        | 25.3±0.7μs                       | 32.6±0.4μs                |    1.29 | bench_itemselection.Take.time_contiguous((1000, 3), 'clip', 'i,O')           |
| -        | 808±10ns                         | 764±20ns                  |    0.95 | bench_itemselection.PutMask.time_sparse(True, 'int64')                       |
| -        | 1.27±0.01μs                      | 1.20±0.01μs               |    0.95 | bench_itemselection.Take.time_contiguous((1000, 1), 'wrap', 'complex128')    |
| -        | 1.16±0.01μs                      | 1.10±0μs                  |    0.95 | bench_itemselection.Take.time_contiguous((1000, 1), 'wrap', 'float64')       |
| -        | 2.28±0.05μs                      | 2.16±0.01μs               |    0.95 | bench_itemselection.Take.time_contiguous((2, 1000, 1), 'clip', 'complex128') |
| -        | 943±7ns                          | 891±6ns                   |    0.94 | bench_itemselection.PutMask.time_dense(True, 'float32')                      |
| -        | 948±6ns                          | 891±30ns                  |    0.94 | bench_itemselection.PutMask.time_sparse(False, 'float16')                    |
| -        | 837±9ns                          | 786±10ns                  |    0.94 | bench_itemselection.PutMask.time_sparse(True, 'float16')                     |
| -        | 842±6ns                          | 794±7ns                   |    0.94 | bench_itemselection.PutMask.time_sparse(True, 'int16')                       |
| -        | 969±10ns                         | 901±20ns                  |    0.93 | bench_itemselection.PutMask.time_dense(True, 'int16')                        |
| -        | 4.51±0.4μs                       | 3.88±0μs                  |    0.86 | bench_itemselection.Take.time_contiguous((1000, 3), 'clip', 'int16')         |
| -        | 4.62±0.02μs                      | 3.87±0.01μs               |    0.84 | bench_itemselection.Take.time_contiguous((1000, 3), 'clip', 'float16')       |
| -        | 3.89±0.4μs                       | 3.28±0.05μs               |    0.84 | bench_itemselection.Take.time_contiguous((1000, 3), 'raise', 'float64')      |

#### AI Disclosure
I used claude code to help me. I went over every change to make sure it was required.
