### PR TITLE
BUG: np.load(..., mmap_mode=...) raises ValueError for .npz

### DIFF
--- a/doc/release/upcoming_changes/31077.changes.rst
+++ b/doc/release/upcoming_changes/31077.changes.rst
@@ -1,0 +1,6 @@
+``np.load`` raises ``ValueError`` for ``mmap_mode`` with ``.npz`` files
+---------------------------------------------------------------------
+
+``np.load`` previously allowed using ``mmap_mode`` when loading ``.npz`` files.
+Since memory mapping is not supported for this format, it now raises a
+``ValueError`` when ``mmap_mode`` is specified.

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -466,6 +466,9 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
         fid.seek(-min(N, len(magic)), 1)  # back-up
         if magic.startswith((_ZIP_PREFIX, _ZIP_SUFFIX)):
             # zip-file (assume .npz)
+            if mmap_mode is not None:
+                raise ValueError("mmap_mode is not supported when loading .npz files.")
+            
             # Potentially transfer file ownership to NpzFile
             stack.pop_all()
             ret = NpzFile(fid, own_fid=own_fid, allow_pickle=allow_pickle,

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -228,6 +228,17 @@ class TestSavezLoad(RoundtripTest):
                 assert len(npz["test2"]) == 10
                 assert npz["metadata"] == b"Name: Test"
 
+    def test_mmap(self):
+        """"
+        Verify that np.load raises a ValueError when mmap_mode 
+        is used with .npz files, as mmap is not supported for .npz.
+        """
+        with temppath(prefix="numpy_test_npz_mmap_", suffix=".npz") as tmp:
+            np.savez(tmp, x=np.arange(10))
+
+            with pytest.raises(ValueError):
+                np.load(tmp, mmap_mode="r")
+
     @pytest.mark.skipif(not IS_64BIT, reason="Needs 64bit platform")
     @pytest.mark.slow
     @pytest.mark.thread_unsafe(reason="crashes with low memory")


### PR DESCRIPTION
### PR summary

Previously, `mmap_mode` could be passed to `np.load` on `.npz` (compressed) files, which is not supported and could silently fail or behave incorrectly.

This commit:

- Keeps the roundtrip tests for `.npz` intact.
- Adds a test to verify that `np.load(..., mmap_mode='r')` raises `ValueError` for `.npz` files.
- Skips `test_mmap` in `TestSavezLoad` subclass since mmap is not supported for `.npz` files.

Fixes numpy#28795  
See also numpy#5976

### First time committer introduction

Hi! I am a third-year Computer Engineering student. This is my first contribution to NumPy.  
I have been using NumPy for university projects and personal practice.  
I wanted to contribute by fixing the behavior of `np.load` with `mmap_mode` on `.npz` files, as I noticed it was a simple task to start contributing to NumPy.

#### AI Disclosure

I used AI (ChatGPT) only to navigate and understand which files were relevant to change.  
All code and test changes were written by me.