### PR TITLE
TST: fix POWER VSX feature mapping (#30801)

### DIFF
--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -378,10 +378,42 @@ is_power = re.match(r"^(powerpc|ppc)64", machine, re.IGNORECASE)
 @pytest.mark.skipif(not is_linux or not is_power, reason="Only for Linux and Power")
 class Test_POWER_Features(AbstractTest):
     features = ["VSX", "VSX2", "VSX3", "VSX4"]
-    features_map = {"VSX2": "ARCH_2_07", "VSX3": "ARCH_3_00", "VSX4": "ARCH_3_1"}
+    features_map = {
+        "VSX":  "ARCH_2_06",
+        "VSX2": "ARCH_2_07",
+        "VSX3": "ARCH_3_00",
+        "VSX4": "ARCH_3_1B"
+    }
 
     def load_flags(self):
         self.load_flags_auxv()
+        platform = self._get_platform()
+
+        if platform:
+            power_match = re.search(r'power(\d+)', platform, re.IGNORECASE)
+            if power_match:
+                power_gen = int(power_match.group(1))
+                if power_gen >= 7:
+                    self.features_flags.add("ARCH_2_06")
+                if power_gen >= 8:
+                    self.features_flags.add("ARCH_2_07")
+                if power_gen >= 9:
+                    self.features_flags.add("ARCH_3_00")
+                if power_gen >= 10:
+                    self.features_flags.add("ARCH_3_1B")
+
+    def _get_platform(self):
+        """Get the AT_PLATFORM value from AUXV"""
+        try:
+            auxv = subprocess.check_output(['/bin/true'], env={"LD_SHOW_AUXV": "1"})
+            for line in auxv.split(b'\n'):
+                if line.startswith(b'AT_PLATFORM'):
+                    parts = line.split(b':', 1)
+                    if len(parts) == 2:
+                        return parts[1].strip().decode().lower()
+        except Exception:
+            pass
+        return None
 
 
 is_zarch = re.match(r"^(s390x)", machine, re.IGNORECASE)


### PR DESCRIPTION
Backport of #30801.

** Problem**
On POWER systems, the CPU feature tests check for a literal "VSX" flag in AT_HWCAP. However, Linux never reports a "VSX" auxv flag. VSX is a baseline capability implied by POWER ISA ≥ 2.06, so the test-side detection incorrectly reports VSX as unavailable, causing false failures on POWER (e.g. Power10,power9).

turns out theres another issue too - on some POWER systems AT_HWCAP shows up in hex format like 0xdc0065c2 instead of the string format with actual flag names. the existing load_flags_auxv() only works with string format so it just fails when its hex.

**This PR**

1. Maps VSX to ARCH_2_06, VSX2 to ARCH_2_07, VSX3 to ARCH_3_00, and VSX4 to ARCH_3_1B (fixed typo from ARCH_3_1)
2. Parses AT_PLATFORM to figure out the POWER generation (power7, power8, power9, power10 etc)
3. Uses the platform info to add the right ARCH flags based on which POWER version it is
4. Works on both hex and string AUXV formats now

**Changes**
 1.fixed the features_map with correct ISA levels
2.rewrote load_flags() to check AT_PLATFORM and infer ISA levels from that
3.added _get_platform() helper to get the platform string

**Note**
test-only change, no runtime behavior modified. should work on both POWER9 and POWER10 now.

Fixes gh-30529
