### PR TITLE
BUG - Fix #30342: correct min_scalar_type boundary promotion

### DIFF
--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -38,6 +38,7 @@
 #include "arrayobject.h"
 #include "npy_static_data.h"
 #include "multiarraymodule.h"
+#include "numpy/halffloat.h"
 
 /*
  * Required length of string when converting from unsigned integer type.
@@ -1320,30 +1321,30 @@ static int min_scalar_type_num(char *valueptr, int type_num,
         }
         case NPY_FLOAT: {
             float value = *(float *)valueptr;
-            if ((value > -65000 && value < 65000) || !npy_isfinite(value)) {
+            if ((value > -NPY_MAX_HALF_NUM && value < NPY_MAX_HALF_NUM) || !npy_isfinite(value)) {
                 return NPY_HALF;
             }
             break;
         }
         case NPY_DOUBLE: {
             double value = *(double *)valueptr;
-            if ((value > -65000 && value < 65000) || !npy_isfinite(value)) {
+            if ((value > -NPY_MAX_HALF_NUM && value < NPY_MAX_HALF_NUM) || !npy_isfinite(value)) {
                 return NPY_HALF;
             }
-            else if (value > -3.4e38 && value < 3.4e38) {
+            else if (value > -__FLT_MAX__ && value < __FLT_MAX__) {
                 return NPY_FLOAT;
             }
             break;
         }
         case NPY_LONGDOUBLE: {
             npy_longdouble value = *(npy_longdouble *)valueptr;
-            if ((value > -65000 && value < 65000) || !npy_isfinite(value)) {
+            if ((value > -NPY_MAX_HALF_NUM && value < NPY_MAX_HALF_NUM) || !npy_isfinite(value)) {
                 return NPY_HALF;
             }
-            else if (value > -3.4e38 && value < 3.4e38) {
+            else if (value > -__FLT_MAX__ && value < __FLT_MAX__) {
                 return NPY_FLOAT;
             }
-            else if (value > -1.7e308 && value < 1.7e308) {
+            else if (value > -__DBL_MAX__ && value < __DBL_MAX__) {
                 return NPY_DOUBLE;
             }
             break;

--- a/numpy/_core/src/multiarray/convert_datatype.h
+++ b/numpy/_core/src/multiarray/convert_datatype.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+#define NPY_MAX_HALF_NUM 65504.0f
+
 extern NPY_NO_EXPORT npy_intp REQUIRED_STR_LEN[];
 
 NPY_NO_EXPORT PyObject *

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8327,6 +8327,19 @@ class TestMinScalarType:
         wanted = np.dtype('O')
         assert_equal(wanted, dt)
 
+    def test_float_max_boundaries(self):
+        f16_max = np.finfo(np.float16).max
+        f32_max = np.finfo(np.float32).max
+        f64_max = np.finfo(np.float64).max
+        assert_equal(np.min_scalar_type(f16_max), np.dtype('float16'))
+        assert_equal(np.min_scalar_type(-f16_max), np.dtype('float16'))
+        assert_equal(np.min_scalar_type(65504.2), np.dtype('float32')) 
+        assert_equal(np.min_scalar_type(f32_max), np.dtype('float32'))
+        assert_equal(np.min_scalar_type(-f32_max), np.dtype('float32'))
+        assert_equal(np.min_scalar_type(3.5e38), np.dtype('float64'))
+        assert_equal(np.min_scalar_type(f64_max), np.dtype('float64'))
+        assert_equal(np.min_scalar_type(-f64_max), np.dtype('float64'))
+
 
 from numpy._core._internal import _dtype_from_pep3118
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8336,6 +8336,7 @@ class TestMinScalarType:
         assert_equal(np.min_scalar_type(65504.2), np.dtype('float32')) 
         assert_equal(np.min_scalar_type(f32_max), np.dtype('float32'))
         assert_equal(np.min_scalar_type(-f32_max), np.dtype('float32'))
+        assert_equal(np.min_scalar_type(3.4028e38), np.dtype('float32'))
         assert_equal(np.min_scalar_type(3.5e38), np.dtype('float64'))
         assert_equal(np.min_scalar_type(f64_max), np.dtype('float64'))
         assert_equal(np.min_scalar_type(-f64_max), np.dtype('float64'))


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->The min_scalar_type function used approximate floating point literals for float64, float32 and float16 maximums. This caused values very close to the limits to be incorrectly promoted to higher precision types.

This patch replaces literals with exact C constants (FLT_MAX and DBL_MAX), and replaces the half float max with NPY_MAX_HALF, correcting the boundary logic to ensure proper type detection. I also added tests to make sure the previous problem didn't sustain, except for the cases where Python's rounding prevails.

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->My name is Manuel and, as most students, I have used numpy for a different set of reasons.
This contribution is part of a discipline at my college, being mandatory to fix a bug and add a feature to a open-source project, and as I have used numpy before, I thought it was the perfect choice.

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->No AI tools used
