### PR TITLE
BUG: fix datetime64/timedelta64 hashing across units

### DIFF
--- a/doc/release/upcoming_changes/00000.compatibility.rst
+++ b/doc/release/upcoming_changes/00000.compatibility.rst
@@ -1,0 +1,16 @@
+``datetime64`` and ``timedelta64`` hashing fixed across units
+-------------------------------------------------------------
+Hashing of `~numpy.datetime64` and `~numpy.timedelta64` scalars has been
+fixed so that equal values with different units produce matching hashes.
+For example, ``hash(np.datetime64(0, 's')) == hash(np.datetime64(0, 'us'))``
+now holds.
+
+For ``datetime64`` values in the ``datetime.datetime``-representable range
+(year 1--9999 with microsecond precision or coarser), the hash matches
+``hash(datetime.datetime(...))``, following the same approach as
+``pd.Timestamp.__hash__``. Similarly, ``timedelta64`` values that fit in a
+``datetime.timedelta`` hash to the same value as their Python equivalents.
+
+Values outside these ranges now hash based on a canonical nanosecond
+representation instead of the raw bytes of an internal struct, which could
+previously produce different hashes for equal values in different units.

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2857,20 +2857,65 @@ datetime_hash(PyArray_DatetimeMetaData *meta, npy_datetime dt)
 
     if (meta->base == NPY_FR_GENERIC) {
         obj = PyLong_FromLongLong(dt);
-    } else {
-        if (NpyDatetime_ConvertDatetime64ToDatetimeStruct(meta, dt, &dts) < 0) {
+        if (obj == NULL) {
             return -1;
         }
+        res = PyObject_Hash(obj);
+        Py_DECREF(obj);
+        return res;
+    }
 
-        if (dts.year < 1 || dts.year > 9999
-            || dts.ps != 0 || dts.as != 0) {
-            /* NpyDatetime_ConvertDatetime64ToDatetimeStruct does memset,
-             * so this is safe from loose struct packing. */
-            obj = PyBytes_FromStringAndSize((const char *)&dts, sizeof(dts));
-        } else {
-            obj = PyDateTime_FromDateAndTime(dts.year, dts.month, dts.day,
-                                             dts.hour, dts.min, dts.sec, dts.us);
+    if (NpyDatetime_ConvertDatetime64ToDatetimeStruct(meta, dt, &dts) < 0) {
+        return -1;
+    }
+
+    /*
+     * If the date is in the datetime.datetime range (year 1-9999) and
+     * has no sub-microsecond precision, hash as a Python datetime.
+     * This matches the pd.Timestamp.__hash__ approach and ensures
+     * hash(np.datetime64(x, 'us')) == hash(datetime(x)).
+     */
+    if (dts.year >= 1 && dts.year <= 9999
+            && dts.ps == 0 && dts.as == 0) {
+        obj = PyDateTime_FromDateAndTime(dts.year, dts.month, dts.day,
+                                         dts.hour, dts.min, dts.sec, dts.us);
+        if (obj == NULL) {
+            return -1;
         }
+        res = PyObject_Hash(obj);
+        Py_DECREF(obj);
+        return res;
+    }
+
+    /*
+     * Otherwise, compute a canonical nanosecond value from the
+     * datetimestruct and hash that. Since the struct is unit-independent,
+     * all datetime64 representations of the same time point produce the
+     * same struct and thus the same canonical_ns. This may overflow for
+     * dates outside ~1678-2262, but the overflow is consistent across
+     * units.
+     *
+     * For values with sub-nanosecond precision, include that component
+     * (in attoseconds) in the hash to distinguish them. dts.ps % 1000
+     * extracts only the sub-ns part of the picoseconds, since the
+     * nanosecond component (ps / 1000) is already in canonical_ns.
+     */
+    npy_datetime canonical_ns;
+    PyArray_DatetimeMetaData ns_meta = {NPY_FR_ns, 1};
+    if (NpyDatetime_ConvertDatetimeStructToDatetime64(
+                &ns_meta, &dts, &canonical_ns) < 0) {
+        return -1;
+    }
+
+    npy_int32 sub_ns_ps = dts.ps % 1000;
+    npy_int64 sub_ns_as = (npy_int64)sub_ns_ps * 1000000 + dts.as;
+
+    if (sub_ns_as == 0) {
+        obj = PyLong_FromLongLong(canonical_ns);
+    }
+    else {
+        obj = Py_BuildValue("(LL)",
+                (long long)canonical_ns, (long long)sub_ns_as);
     }
 
     if (obj == NULL) {
@@ -2878,9 +2923,7 @@ datetime_hash(PyArray_DatetimeMetaData *meta, npy_datetime dt)
     }
 
     res = PyObject_Hash(obj);
-
     Py_DECREF(obj);
-
     return res;
 }
 
@@ -3029,21 +3072,65 @@ timedelta_hash(PyArray_DatetimeMetaData *meta, npy_timedelta td)
 
     if (meta->base == NPY_FR_Y) {
         obj = PyLong_FromLongLong(td * 12);
-    } else if (meta->base == NPY_FR_M) {
-        obj = PyLong_FromLongLong(td);
-    } else {
-        if (convert_timedelta_to_timedeltastruct(meta, td, &tds) < 0) {
+        if (obj == NULL) {
             return -1;
         }
-
-        if (tds.day < -999999999 || tds.day > 999999999
-            || tds.ps != 0 || tds.as != 0) {
-            /* convert_timedelta_to_timedeltastruct does memset,
-             * so this is safe from loose struct packing. */
-            obj = PyBytes_FromStringAndSize((const char *)&tds, sizeof(tds));
-        } else {
-            obj = PyDelta_FromDSU(tds.day, tds.sec, tds.us);
+        res = PyObject_Hash(obj);
+        Py_DECREF(obj);
+        return res;
+    }
+    if (meta->base == NPY_FR_M) {
+        obj = PyLong_FromLongLong(td);
+        if (obj == NULL) {
+            return -1;
         }
+        res = PyObject_Hash(obj);
+        Py_DECREF(obj);
+        return res;
+    }
+
+    if (convert_timedelta_to_timedeltastruct(meta, td, &tds) < 0) {
+        return -1;
+    }
+
+    /*
+     * If it fits in a datetime.timedelta and has no sub-microsecond
+     * precision, hash as a Python timedelta. This ensures
+     * hash(np.timedelta64(d)) == hash(d) when d is a datetime.timedelta.
+     */
+    if (tds.day >= -999999999 && tds.day <= 999999999
+            && tds.ps == 0 && tds.as == 0) {
+        obj = PyDelta_FromDSU(tds.day, tds.sec, tds.us);
+        if (obj == NULL) {
+            return -1;
+        }
+        res = PyObject_Hash(obj);
+        Py_DECREF(obj);
+        return res;
+    }
+
+    /*
+     * Otherwise, compute a canonical nanosecond value from the struct
+     * and hash that. The timedeltastruct is unit-independent, so all
+     * timedelta64 representations of the same duration produce the
+     * same struct and thus the same canonical_ns. The conversion may
+     * overflow for large durations, but the overflow is consistent
+     * across units.
+     */
+    npy_int64 canonical_ns =
+            ((npy_int64)tds.day * 86400LL + tds.sec) * 1000000000LL
+            + (npy_int64)tds.us * 1000LL
+            + tds.ps / 1000;
+
+    npy_int32 sub_ns_ps = tds.ps % 1000;
+    npy_int64 sub_ns_as = (npy_int64)sub_ns_ps * 1000000 + tds.as;
+
+    if (sub_ns_as == 0) {
+        obj = PyLong_FromLongLong(canonical_ns);
+    }
+    else {
+        obj = Py_BuildValue("(LL)",
+                (long long)canonical_ns, (long long)sub_ns_as);
     }
 
     if (obj == NULL) {
@@ -3051,9 +3138,7 @@ timedelta_hash(PyArray_DatetimeMetaData *meta, npy_timedelta td)
     }
 
     res = PyObject_Hash(obj);
-
     Py_DECREF(obj);
-
     return res;
 }
 

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -2625,7 +2625,8 @@ class TestDateTime:
         assert nat1 != nat2
         assert hash(nat1) != hash(nat2)
 
-    @pytest.mark.parametrize('unit', ('Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us'))
+    @pytest.mark.parametrize('unit',
+                             ('Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'))
     def test_datetime_hash_weeks(self, unit):
         dt = np.datetime64(2348, 'W')  # 2015-01-01
         dt2 = np.datetime64(dt, unit)
@@ -2642,7 +2643,8 @@ class TestDateTime:
         assert isinstance(pydt, datetime.datetime)
         _assert_equal_hash(pydt, dt2)
 
-    @pytest.mark.parametrize('unit', ('Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us'))
+    @pytest.mark.parametrize('unit',
+                             ('Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'))
     def test_datetime_hash_big_negative(self, unit):
         dt = np.datetime64(-102894, 'W')  # -002-01-01
         dt2 = np.datetime64(dt, unit)
@@ -2665,11 +2667,36 @@ class TestDateTime:
         assert hash(dt) != hash(dt3)  # doesn't collide
 
     @pytest.mark.parametrize('wk', range(500000, 500010))  # 11552-09-04
-    @pytest.mark.parametrize('unit', ('W', 'D', 'h', 'm', 's', 'ms', 'us'))
+    @pytest.mark.parametrize('unit',
+                             ('W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'))
     def test_datetime_hash_big_positive(self, wk, unit):
         dt = np.datetime64(wk, 'W')
         dt2 = np.datetime64(dt, unit)
         _assert_equal_hash(dt, dt2)
+
+    @pytest.mark.parametrize('year', (1, 100, 1000, 1500, 2020, 5000, 9999))
+    @pytest.mark.parametrize('unit', ('s', 'ms', 'us'))
+    def test_datetime_hash_vs_pydatetime(self, year, unit):
+        # hash(np.datetime64(x, unit)) == hash(datetime(x)) for year 1-9999
+        dt = np.datetime64(f"{year:04d}-06-15", unit)
+        pydt = datetime.datetime(year, 6, 15)
+        _assert_equal_hash(pydt, dt)
+
+    @pytest.mark.parametrize('dt_str',
+                             ('0000-01-01', '10000-01-01'))
+    @pytest.mark.parametrize('unit', ('D', 's', 'ms', 'us'))
+    def test_datetime_hash_out_of_pydatetime_range(self, dt_str, unit):
+        # out-of-range dates should still hash consistently across units
+        dt = np.datetime64(dt_str, 'D')
+        dt2 = np.datetime64(dt_str, unit)
+        _assert_equal_hash(dt, dt2)
+
+    @pytest.mark.parametrize('unit', ('ns', 'ps', 'fs', 'as'))
+    def test_datetime_hash_sub_us_near_epoch(self, unit):
+        # sub-microsecond values near the epoch (no overflow for any unit)
+        dt_ns = np.datetime64(1, 'ns')
+        dt2 = np.datetime64(dt_ns, unit)
+        _assert_equal_hash(dt_ns, dt2)
 
     def test_timedelta_hash_generic(self):
         assert_raises(ValueError, hash, np.timedelta64(123))  # generic
@@ -2680,7 +2707,8 @@ class TestDateTime:
         td2 = np.timedelta64(td, unit)
         _assert_equal_hash(td, td2)
 
-    @pytest.mark.parametrize('unit', ('W', 'D', 'h', 'm', 's', 'ms', 'us'))
+    @pytest.mark.parametrize('unit',
+                             ('W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'))
     def test_timedelta_hash_weeks(self, unit):
         td = np.timedelta64(10, 'W')
         td2 = np.timedelta64(td, unit)
@@ -2707,11 +2735,35 @@ class TestDateTime:
         assert hash(td) != hash(td3)  # doesn't collide
 
     @pytest.mark.parametrize('wk', range(500000, 500010))
-    @pytest.mark.parametrize('unit', ('W', 'D', 'h', 'm', 's', 'ms', 'us'))
+    @pytest.mark.parametrize('unit',
+                             ('W', 'D', 'h', 'm', 's', 'ms', 'us'))
     def test_timedelta_hash_big_positive(self, wk, unit):
         td = np.timedelta64(wk, 'W')
         td2 = np.timedelta64(td, unit)
         _assert_equal_hash(td, td2)
+
+    @pytest.mark.parametrize('days', (0, 1, 100, 86400))
+    @pytest.mark.parametrize('unit', ('D', 's', 'ms', 'us'))
+    def test_timedelta_hash_vs_pytimedelta(self, days, unit):
+        # hash(np.timedelta64(d, unit)) == hash(timedelta(days=d))
+        nptd = np.timedelta64(days, 'D')
+        nptd2 = np.timedelta64(nptd, unit)
+        pytd = datetime.timedelta(days=days)
+        _assert_equal_hash(pytd, nptd2)
+
+    @pytest.mark.parametrize('unit', ('D', 's', 'ms'))
+    def test_timedelta_hash_big_days(self, unit):
+        # timedelta with day count > 999999999 (out of pytimedelta range)
+        td = np.timedelta64(1100000000, 'D')
+        td2 = np.timedelta64(td, unit)
+        _assert_equal_hash(td, td2)
+
+    @pytest.mark.parametrize('unit', ('ns', 'ps', 'fs', 'as'))
+    def test_timedelta_hash_sub_us(self, unit):
+        # sub-microsecond timedelta near zero (no overflow for any unit)
+        td_ns = np.timedelta64(1, 'ns')
+        td2 = np.timedelta64(td_ns, unit)
+        _assert_equal_hash(td_ns, td2)
 
     @pytest.mark.parametrize(
         "inputs, divisor, expected",


### PR DESCRIPTION
## Summary

- Fix `datetime64.__hash__` and `timedelta64.__hash__` so that equal-value objects with different units produce matching hashes.
- For `datetime64` in the `datetime.datetime` range (year 1–9999, microsecond precision or coarser), hashes now match `hash(datetime.datetime(...))`, following the `pd.Timestamp.__hash__` approach.
- Replace raw struct-bytes hashing with a canonical nanosecond representation for the fallback path (out-of-range or sub-microsecond values).

## Test plan

- [x] Extended existing cross-unit hash tests to include `'ns'` unit
- [x] Added `test_datetime_hash_vs_pydatetime` — verifies `datetime.datetime` hash compatibility for years 1–9999
- [x] Added `test_datetime_hash_out_of_pydatetime_range` — year 0 and 10000 consistent across units
- [x] Added `test_datetime_hash_sub_us_near_epoch` — sub-microsecond consistency across ns/ps/fs/as
- [x] Added `test_timedelta_hash_vs_pytimedelta` — verifies `datetime.timedelta` hash compatibility
- [x] Added `test_timedelta_hash_big_days` — out-of-pytimedelta-range consistency
- [x] Added `test_timedelta_hash_sub_us` — sub-microsecond timedelta consistency
- [x] All 538 tests in `test_datetime.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)