### PR TITLE
REL: Prepare for the NumPy 2.4.4 release

### DIFF
--- a/doc/changelog/2.4.4-changelog.rst
+++ b/doc/changelog/2.4.4-changelog.rst
@@ -1,15 +1,3 @@
-.. currentmodule:: numpy
-
-=========================
-NumPy 2.4.4 Release Notes
-=========================
-
-The NumPy 2.4.3 is a patch release that fixes bugs discovered after the 2.4.2
-release. It should finally close issue #30816, the OpenBLAS threading problem
-on ARM.
-
-This release supports Python versions 3.11-3.14
-
 
 Contributors
 ============
@@ -26,7 +14,6 @@ names contributed a patch for the first time.
 * Matti Picus
 * Nathan Goldbaum
 
-
 Pull requests merged
 ====================
 
@@ -39,3 +26,4 @@ A total of 7 pull requests were merged for this release.
 * `#31058 <https://github.com/numpy/numpy/pull/31058>`__: DOC: document caveats of ndarray.resize on 3.14 and newer
 * `#31079 <https://github.com/numpy/numpy/pull/31079>`__: TST: fix POWER VSX feature mapping (#30801)
 * `#31084 <https://github.com/numpy/numpy/pull/31084>`__: MAINT: numpy.i: Replace deprecated ``sprintf`` with ``snprintf``...
+


### PR DESCRIPTION
- Create 2.4.4-changelog.rst
- Update 2.4.4-notes.rst

[skip azp] [skip cirrus] [skip actions]

#### AI Disclosure

No AI was used.
