### PR TITLE
ENH, PERF: allocate memory as part of the array object for scalars

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -173,7 +173,7 @@ enum NPY_TYPECHAR {
  * should be downstream compatible, but the actual algorithms used may be
  * different than before. The new approach should be more flexible and easier
  * to update.
- * 
+ *
  * Names with a leading underscore are private, and should only be used
  * internally by NumPy.
  *
@@ -187,7 +187,7 @@ typedef enum {
         NPY_HEAPSORT = 1,
         NPY_MERGESORT = 2,
         NPY_STABLESORT = 2,
-        // new style names 
+        // new style names
         _NPY_SORT_HEAPSORT = 1,
         NPY_SORT_DEFAULT = 0,
         NPY_SORT_STABLE = 2,
@@ -914,12 +914,20 @@ typedef int (PyArray_FinalizeFunc)(PyArrayObject *, PyObject *);
  */
 
 /*
- * If set, the array owns the data: it will be free'd when the array
- * is deleted.
+ * If set, the array owns the data: if the data is not stored on the
+ * instance, it will be free'd when the array is deleted.
  *
  * This flag may be tested for in PyArray_FLAGS(arr).
  */
 #define NPY_ARRAY_OWNDATA         0x0004
+
+/*
+ * If set, the data is stored on the array instance.
+ *
+ * This flag may be tested for in PyArray_FLAGS(arr).
+ * (MAYBE: allow it to be requested as well?)
+ */
+#define NPY_ARRAY_DATAONINSTANCE  0x0008
 
 /*
  * An array never has the next four set; they're only used as parameter
@@ -1957,7 +1965,7 @@ typedef struct {
  * #endif
  * #ifndef NUMPY_CORE_INCLUDE_NUMPY_NPY_1_7_DEPRECATED_API_H_
  * #define NUMPY_CORE_INCLUDE_NUMPY_NPY_1_7_DEPRECATED_API_H_
- * 
+ *
  * #ifndef NPY_NO_DEPRECATED_API
  * #if defined(_WIN32)
  * #define _WARN___STR2__(x) #x

--- a/numpy/_core/src/multiarray/alloc.h
+++ b/numpy/_core/src/multiarray/alloc.h
@@ -44,7 +44,12 @@ npy_free_cache_dim_obj(PyArray_Dims dims)
 static inline void
 npy_free_cache_dim_array(PyArrayObject * arr)
 {
-    npy_free_cache_dim(PyArray_DIMS(arr), PyArray_NDIM(arr));
+    /* deallocate if not part of the array instance */
+    if ((PyArray_DIMS(arr) != NULL)
+        && (PyArray_DIMS(arr) !=
+            (npy_intp *)((char*)arr + Py_TYPE(arr)->tp_basicsize))) {
+        npy_free_cache_dim(PyArray_DIMS(arr), PyArray_NDIM(arr));
+    }
 }
 
 extern PyDataMem_Handler default_handler;

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -429,8 +429,24 @@ _clear_array_attributes(PyArrayObject *self, npy_bool unraisable)
                 }
             }
         }
-        /* mem_handler can be absent if NPY_ARRAY_OWNDATA arbitrarily set */
-        if (fa->mem_handler == NULL) {
+        if (fa->mem_handler != NULL) {
+            size_t nbytes = PyArray_NBYTES(self);
+            if (nbytes == 0) {
+                nbytes = 1;
+            }
+            PyDataMem_UserFREE(fa->data, nbytes, fa->mem_handler);
+            Py_CLEAR(fa->mem_handler);
+        }
+        else if (!PyArray_CHKFLAGS(self, NPY_ARRAY_DATAONINSTANCE)) {
+            /*
+             * Without a handler, data should be on the instance; if not,
+             * someone did something arbitrary, so warn and try free.
+             *
+             * TODO: strengthen this so we can refuse the temptation to guess?
+             * mem_handler = NULL should just signal no deallocation needed.
+             * If we do this, also remove the error paths in array_setstate
+             * and PyArray_Resize.
+             */
             if (npy_global_state.warn_if_no_mem_policy) {
                 char const *msg = "Trying to dealloc data, but a memory policy "
                     "is not set. If you take ownership of the data, you must "
@@ -442,14 +458,6 @@ _clear_array_attributes(PyArrayObject *self, npy_bool unraisable)
             }
             // Guess at malloc/free ???
             free(fa->data);
-        }
-        else {
-            size_t nbytes = PyArray_NBYTES(self);
-            if (nbytes == 0) {
-                nbytes = 1;
-            }
-            PyDataMem_UserFREE(fa->data, nbytes, fa->mem_handler);
-            Py_CLEAR(fa->mem_handler);
         }
         fa->data = NULL;
     }

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -455,7 +455,7 @@ _clear_array_attributes(PyArrayObject *self, npy_bool unraisable)
     }
 
     /* must match allocation in PyArray_NewFromDescr */
-    npy_free_cache_dim(fa->dimensions, 2 * fa->nd);
+    npy_free_cache_dim_array(self); // frees it if not on instance.
     fa->dimensions = NULL;
     Py_CLEAR(fa->descr);
     return 0;

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -744,10 +744,46 @@ PyArray_NewFromDescr_int(
         }
     }
     /*
+     * Check dimensions and find total array size `nbytes`.
+     */
+    int is_zero = 0;
+    for (int i = 0; i < nd; i++) {
+        if (dims[i] == 0) {
+            /*
+             * Continue calculating the max size "as if" this were 1
+             * to get the proper overflow error
+             */
+            is_zero = 1;
+            continue;
+        }
+        if (dims[i] < 0) {
+            PyErr_SetString(PyExc_ValueError,
+                            "negative dimensions are not allowed");
+            Py_DECREF(descr);
+            return NULL;
+        }
+        /*
+         * Care needs to be taken to avoid integer overflow when multiplying
+         * the dimensions together to get the total size of the array.
+         */
+        if (npy_mul_sizes_with_overflow(&nbytes, nbytes, dims[i])) {
+            PyErr_SetString(PyExc_ValueError,
+                            "array is too big; `arr.size * arr.dtype.itemsize` "
+                            "is larger than the maximum possible size.");
+            Py_DECREF(descr);
+            return NULL;
+        }
+    }
+    if (is_zero) {
+        nbytes = 0;
+    }
+    /*
      * Create the array instance.
      *
      * For standard arrays, we allocate extra memory for the dimensions and
-     * strides, to avoid the overhead of another allocation.
+     * strides, as well as the data themselves if small enough (and the
+     * default memory handler is used), to avoid the overhead of allocating
+     * tracked memory with PyDataMem_UserNew.
      *
      * We do this bypassing the standard tp_alloc, basically copying the
      * relevant code from PyType_GenericAlloc in Objects/typeobject.c.
@@ -755,19 +791,38 @@ PyArray_NewFromDescr_int(
      * instances, as this would change the array object structure order.
      *
      * TODO: possible extensions:
-     * - Also store small bits of data.
      * - Maybe extend to subtype as long as tp_itemsize == 0
      *   && tp_alloc == PyObject_GenericAlloc?
      */
+    PyObject *mem_handler = NULL;
+    if (data == NULL) {
+        mem_handler = PyDataMem_GetHandler();
+        if (mem_handler == NULL) {
+            Py_DECREF(descr);
+            return NULL;
+        }
+    }
+
     if (subtype == &PyArray_Type) {
         size_t size = subtype->tp_basicsize;
         /* Alignment to intp should be guaranteed (last item is a pointer). */
         assert(size % NPY_ALIGNOF(npy_intp) == 0);
         /* Add space for dimensions and strides. */
         size += sizeof(npy_intp) * nd * 2;
+        /* Possibly, add space for data. */
+        size_t data_offset = 0;
+        if (data == NULL && nbytes < size
+                && mem_handler == PyDataMem_DefaultHandler) {
+            /* Round up if needed to ensure data will be aligned */
+            size_t align = NPY_ALIGNOF(npy_clongdouble);
+            data_offset = ((size + align - 1) / align) * align;
+            /* Always allocate at least one byte for the data. */
+            size = data_offset + (nbytes == 0 ? 1 : nbytes);
+        }
         /* Allocate the object and extra space */
         char *alloc = PyObject_Malloc(size);
         if (alloc == NULL) {
+            Py_XDECREF(mem_handler);
             Py_DECREF(descr);
             return PyErr_NoMemory();
         }
@@ -775,23 +830,34 @@ PyArray_NewFromDescr_int(
         fa = (PyArrayObject_fields *)PyObject_Init((PyObject *)alloc, subtype);
         fa->dimensions = nd == 0 ? NULL :
             (npy_intp*)((char*)fa + subtype->tp_basicsize);
+        if (data_offset) {
+            fa->flags = NPY_ARRAY_DATAONINSTANCE;
+            fa->data = (char*)fa + data_offset;
+            Py_CLEAR(mem_handler);
+        }
+        else {
+            fa->flags = 0;
+            fa->data = NULL;
+        }
     }
     else {
         /* For subtypes, do not presume tp_alloc is the same. */
         fa = (PyArrayObject_fields *) subtype->tp_alloc(subtype, 0);
         if (fa == NULL) {
+            Py_XDECREF(mem_handler);
             Py_DECREF(descr);
             return NULL;
         }
         fa->dimensions = NULL;
+        fa->flags = 0;
+        fa->data = NULL;
     }
     fa->_buffer_info = NULL;
     fa->nd = nd;
-    fa->data = NULL;
-    fa->mem_handler = NULL;
+    fa->mem_handler = mem_handler;  /* NULL if it will not be needed */
 
     if (data == NULL) {
-        fa->flags = NPY_ARRAY_DEFAULT;
+        fa->flags |= NPY_ARRAY_DEFAULT;
         if (flags) {
             fa->flags |= NPY_ARRAY_F_CONTIGUOUS;
             if (nd > 1) {
@@ -824,49 +890,25 @@ PyArray_NewFromDescr_int(
             assert(fa->dimensions != (npy_intp*)((char*)fa + subtype->tp_basicsize));
         }
         fa->strides = fa->dimensions + nd;
-
-        /*
-         * Copy dimensions, check them, and find total array size `nbytes`
-         */
-        int is_zero = 0;
+        /* Fill dimensions. */
         for (int i = 0; i < nd; i++) {
             fa->dimensions[i] = dims[i];
-
-            if (fa->dimensions[i] == 0) {
-                /*
-                 * Continue calculating the max size "as if" this were 1
-                 * to get the proper overflow error
-                 */
-                is_zero = 1;
-                continue;
-            }
-
-            if (fa->dimensions[i] < 0) {
-                PyErr_SetString(PyExc_ValueError,
-                        "negative dimensions are not allowed");
-                goto fail;
-            }
-
-            /*
-             * Care needs to be taken to avoid integer overflow when multiplying
-             * the dimensions together to get the total size of the array.
-             */
-            if (npy_mul_sizes_with_overflow(&nbytes, nbytes, fa->dimensions[i])) {
-                PyErr_SetString(PyExc_ValueError,
-                        "array is too big; `arr.size * arr.dtype.itemsize` "
-                        "is larger than the maximum possible size.");
-                goto fail;
-            }
-        }
-        if (is_zero) {
-            nbytes = 0;
         }
 
         /* Fill the strides (or copy them if they were passed in) */
         if (strides == NULL) {
-            /* fill the strides and set the contiguity flags */
-            _array_fill_strides(fa->strides, dims, nd, descr->elsize,
-                                flags, &(fa->flags));
+            if (nbytes > 0) {
+                /* fill the strides and set the contiguity flags */
+                _array_fill_strides(fa->strides, dims, nd, descr->elsize,
+                                    flags, &(fa->flags));
+            }
+            else {
+                /* All strides are 0 */
+                for (int i = 0; i < nd; i++) {
+                    fa->strides[i] = 0;
+                }
+                fa->flags |= NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_F_CONTIGUOUS;
+            }
         }
         else {
             /* User to provided strides (user is responsible for correctness) */
@@ -883,7 +925,6 @@ PyArray_NewFromDescr_int(
         fa->strides = NULL;
         fa->flags |= NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_F_CONTIGUOUS;
     }
-
 
     if (data == NULL) {
         /* This closely follows PyArray_ZeroContiguousBuffer. We can't use
@@ -918,33 +959,33 @@ PyArray_NewFromDescr_int(
                 PyDataType_FLAGCHK(descr, NPY_NEEDS_INIT) ||
                 ((cflags & _NPY_ARRAY_ZEROED) && (fill_zero_info.func == NULL)));
 
-        /* Store the handler in case the default is modified */
-        fa->mem_handler = PyDataMem_GetHandler();
-        if (fa->mem_handler == NULL) {
-            goto fail;
-        }
-        /*
-         * Allocate something even for zero-space arrays
-         * e.g. shape=(0,) -- otherwise buffer exposure
-         * (a.data) doesn't work as it should.
-         */
-        if (nbytes == 0) {
-            nbytes = 1;
-            /* Make sure all the strides are 0 */
-            for (int i = 0; i < nd; i++) {
-                fa->strides[i] = 0;
+        if (fa->data != NULL) {
+            /* data on instance; zero if needed. */
+            data = fa->data;
+            if (use_calloc) {
+                memset(data, 0, nbytes);
             }
         }
-
-        if (use_calloc) {
-            data = PyDataMem_UserNEW_ZEROED(nbytes, 1, fa->mem_handler);
-        }
         else {
-            data = PyDataMem_UserNEW(nbytes, fa->mem_handler);
-        }
-        if (data == NULL) {
-            raise_memory_error(fa->nd, fa->dimensions, descr);
-            goto fail;
+            /*
+             * Allocate something even for zero-space arrays
+             * e.g. shape=(0,) -- otherwise buffer exposure
+             * (a.data) doesn't work as it should.
+             */
+            if (nbytes == 0) {
+                nbytes = 1;
+            }
+
+            if (use_calloc) {
+                data = PyDataMem_UserNEW_ZEROED(nbytes, 1, fa->mem_handler);
+            }
+            else {
+                data = PyDataMem_UserNEW(nbytes, fa->mem_handler);
+            }
+            if (data == NULL) {
+                raise_memory_error(fa->nd, fa->dimensions, descr);
+                goto fail;
+            }
         }
 
         /*
@@ -1038,7 +1079,6 @@ PyArray_NewFromDescr_int(
 
  fail:
     NPY_traverse_info_xfree(&fill_zero_info);
-    Py_XDECREF(fa->mem_handler);
     Py_DECREF(fa);
     return NULL;
 }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -743,15 +743,50 @@ PyArray_NewFromDescr_int(
             }
         }
     }
-
-    fa = (PyArrayObject_fields *) subtype->tp_alloc(subtype, 0);
-    if (fa == NULL) {
-        Py_DECREF(descr);
-        return NULL;
+    /*
+     * Create the array instance.
+     *
+     * For standard arrays, we allocate extra memory for the dimensions and
+     * strides, to avoid the overhead of another allocation.
+     *
+     * We do this bypassing the standard tp_alloc, basically copying the
+     * relevant code from PyType_GenericAlloc in Objects/typeobject.c.
+     * Note that we cannot use the standard machinery for variable size
+     * instances, as this would change the array object structure order.
+     *
+     * TODO: possible extensions:
+     * - Also store small bits of data.
+     * - Maybe extend to subtype as long as tp_itemsize == 0
+     *   && tp_alloc == PyObject_GenericAlloc?
+     */
+    if (subtype == &PyArray_Type) {
+        size_t size = subtype->tp_basicsize;
+        /* Alignment to intp should be guaranteed (last item is a pointer). */
+        assert(size % NPY_ALIGNOF(npy_intp) == 0);
+        /* Add space for dimensions and strides. */
+        size += sizeof(npy_intp) * nd * 2;
+        /* Allocate the object and extra space */
+        char *alloc = PyObject_Malloc(size);
+        if (alloc == NULL) {
+            Py_DECREF(descr);
+            return PyErr_NoMemory();
+        }
+        /* PyType_GenericAlloc zeroes the extra bytes, but we don't need to. */
+        fa = (PyArrayObject_fields *)PyObject_Init((PyObject *)alloc, subtype);
+        fa->dimensions = nd == 0 ? NULL :
+            (npy_intp*)((char*)fa + subtype->tp_basicsize);
+    }
+    else {
+        /* For subtypes, do not presume tp_alloc is the same. */
+        fa = (PyArrayObject_fields *) subtype->tp_alloc(subtype, 0);
+        if (fa == NULL) {
+            Py_DECREF(descr);
+            return NULL;
+        }
+        fa->dimensions = NULL;
     }
     fa->_buffer_info = NULL;
     fa->nd = nd;
-    fa->dimensions = NULL;
     fa->data = NULL;
     fa->mem_handler = NULL;
 
@@ -778,10 +813,15 @@ PyArray_NewFromDescr_int(
     NPY_traverse_info_init(&fill_zero_info);
 
     if (nd > 0) {
-        fa->dimensions = npy_alloc_cache_dim(2 * nd);
         if (fa->dimensions == NULL) {
-            PyErr_NoMemory();
-            goto fail;
+            /* Not on instance, so allocate space here. */
+            fa->dimensions = npy_alloc_cache_dim(2 * nd);
+            if (fa->dimensions == NULL) {
+                PyErr_NoMemory();
+                goto fail;
+            }
+            /* Ensure this doesn't look like on-instance. */
+            assert(fa->dimensions != (npy_intp*)((char*)fa + subtype->tp_basicsize));
         }
         fa->strides = fa->dimensions + nd;
 

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -142,10 +142,11 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
 
     if (new_nd > 0) {
         if (PyArray_NDIM(self) != new_nd) {
-            /* Different number of dimensions. */
+            /* Different number of dimensions: need new dims & strides. */
+            npy_free_cache_dim_array(self);
             ((PyArrayObject_fields *)self)->nd = new_nd;
             /* Need new dimensions and strides arrays */
-            dimptr = PyDimMem_RENEW(PyArray_DIMS(self), 3*new_nd);
+            dimptr = npy_alloc_cache_dim(2 * new_nd);
             if (dimptr == NULL) {
                 PyErr_SetString(PyExc_MemoryError,
                                 "cannot allocate memory for array");

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -100,14 +100,7 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
                 return -1;
             }
         }
-        /* Reallocate space if needed - allocating 0 is forbidden */
-        PyObject *handler = PyArray_HANDLER(self);
-        if (handler == NULL) {
-            /* This can happen if someone arbitrarily sets NPY_ARRAY_OWNDATA */
-            PyErr_SetString(PyExc_RuntimeError,
-                            "no memory handler found but OWNDATA flag set");
-            return -1;
-        }
+
         if (newnbytes < oldnbytes) {
             /* Clear now removed data (if dtype has references) */
             if (PyArray_ClearBuffer(
@@ -116,10 +109,52 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
                 return -1;
             }
         }
-
-        new_data = PyDataMem_UserRENEW(PyArray_DATA(self),
-                                       newnbytes == 0 ? 1 : newnbytes,
-                                       handler);
+        /* Reallocate space if needed - allocating 0 is forbidden */
+        PyObject *handler = PyArray_HANDLER(self);
+        if (handler != NULL) {
+            new_data = PyDataMem_UserRENEW(PyArray_DATA(self),
+                                           newnbytes == 0 ? 1 : newnbytes,
+                                           handler);
+        }
+        else if (PyArray_CHKFLAGS(self, NPY_ARRAY_DATAONINSTANCE)) {
+            /*
+             * The data was stored on instance, so has no reference.
+             * If the data still fits, just keep it, otherwise allocate.
+             * TODO: make this a plain else; see comment in array_dealloc.
+             */
+            if (newnbytes <= oldnbytes) {
+                new_data = PyArray_DATA(self);
+            }
+            else {
+                handler = PyDataMem_GetHandler();
+                if (handler == NULL) {
+                    return -1;
+                }
+                new_data = PyDataMem_UserNEW(newnbytes == 0 ? 1 : newnbytes,
+                                             handler);
+                if (new_data != NULL) {
+                    PyArray_CLEARFLAGS(self, NPY_ARRAY_DATAONINSTANCE);
+                    /* Copy existing data. */
+                    memmove(new_data, PyArray_DATA(self),
+                            oldnbytes < newnbytes ? oldnbytes : newnbytes);
+                    /* Set mem_handler, new_data set below. */
+                    ((PyArrayObject_fields *)self)->mem_handler = handler;
+                }
+                else {
+                    Py_DECREF(handler);
+                    /* Error raised below. */
+                }
+            }
+        }
+        else {
+            /*
+             * Without a handler, data should be on the instance; if not,
+             * someone arbitrarily set NPY_ARRAY_OWNDATA, so raise.
+             */
+            PyErr_SetString(PyExc_RuntimeError,
+                            "no memory handler found but OWNDATA flag set");
+            return -1;
+        }
         if (new_data == NULL) {
             PyErr_SetString(PyExc_MemoryError,
                     "cannot allocate memory for array");
@@ -145,7 +180,6 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
             /* Different number of dimensions: need new dims & strides. */
             npy_free_cache_dim_array(self);
             ((PyArrayObject_fields *)self)->nd = new_nd;
-            /* Need new dimensions and strides arrays */
             dimptr = npy_alloc_cache_dim(2 * new_nd);
             if (dimptr == NULL) {
                 PyErr_SetString(PyExc_MemoryError,

--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -237,7 +237,8 @@ def test_set_policy(get_module):
     get_handler_version = np._core.multiarray.get_handler_version
     orig_policy_name = get_handler_name()
 
-    a = np.arange(10).reshape((2, 5))  # a doesn't own its own data
+    # Large array so we are sure not to store on the instance.
+    a = np.empty(1000).reshape((-1, 5))  # a doesn't own its own data
     assert get_handler_name(a) is None
     assert get_handler_version(a) is None
     assert get_handler_name(a.base) == orig_policy_name
@@ -292,7 +293,8 @@ def test_policy_propagation(get_module):
 
     get_handler_name = np._core.multiarray.get_handler_name
     orig_policy_name = get_handler_name()
-    a = np.arange(10).view(MyArr).reshape((2, 5))
+    # Large array so we for sure do not store on the instance.
+    a = np.empty(1000).view(MyArr).reshape((-1, 5))
     assert get_handler_name(a) is None
     assert a.flags.owndata is False
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6372,6 +6372,13 @@ class TestResize:
                 np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]).flat)
         assert_array_equal(x[9:].flat, 0)
 
+    def test_scalar(self):
+        x = np.array(1.5)
+        x.resize((5, 5))
+        expected = np.zeros((5, 5))
+        expected[0, 0] = 1.5
+        assert_array_equal(x, expected)
+
     def test_check_reference(self):
         x = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
         y = x


### PR DESCRIPTION
@seberg, @eendebakpt: this is an updated (and greatly improved) version of #29878, making use of the fact that in previous PRs I removed the explicit dependence on how data were allocated.

### Details

Allocate memory for the dimensions and strides, as well as small amounts of data, as part of the object, to avoid the overhead of multiple allocations (with the allocation of tracked memory for data especially large).

Note that the above is done only for standard arrays, though I think in principle it could be extended to subttypes with a suitable check.

Also, allocating space for data is done only for the standard allocator.

### Timings
```
%timeit np.empty(())
133->68.2 ns
a = 1.6

%timeit np.array(a)
151->83 ns

%timeit np.add(a, a)
581->423 ns

b = np.array(a)
%timeit np.add(b, b)
293->225 ns
```

No AI was used.