### PR TITLE
ENH, PERF: allocate dims and strides on array object by default.

### DIFF
--- a/numpy/_core/src/multiarray/alloc.h
+++ b/numpy/_core/src/multiarray/alloc.h
@@ -44,7 +44,12 @@ npy_free_cache_dim_obj(PyArray_Dims dims)
 static inline void
 npy_free_cache_dim_array(PyArrayObject * arr)
 {
-    npy_free_cache_dim(PyArray_DIMS(arr), PyArray_NDIM(arr));
+    /* deallocate if not part of the array instance */
+    if ((PyArray_DIMS(arr) != NULL)
+        && (PyArray_DIMS(arr) !=
+            (npy_intp *)((char*)arr + Py_TYPE(arr)->tp_basicsize))) {
+        npy_free_cache_dim(PyArray_DIMS(arr), PyArray_NDIM(arr));
+    }
 }
 
 extern PyDataMem_Handler default_handler;

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -455,7 +455,7 @@ _clear_array_attributes(PyArrayObject *self, npy_bool unraisable)
     }
 
     /* must match allocation in PyArray_NewFromDescr */
-    npy_free_cache_dim(fa->dimensions, 2 * fa->nd);
+    npy_free_cache_dim_array(self); // frees it if not on instance.
     fa->dimensions = NULL;
     Py_CLEAR(fa->descr);
     return 0;

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -743,15 +743,65 @@ PyArray_NewFromDescr_int(
             }
         }
     }
-
-    fa = (PyArrayObject_fields *) subtype->tp_alloc(subtype, 0);
-    if (fa == NULL) {
-        Py_DECREF(descr);
-        return NULL;
+    /*
+     * Create the array instance.
+     *
+     * For standard arrays, we allocate extra memory for the dimensions and
+     * strides, to avoid the overhead of another allocation.
+     *
+     * We do this bypassing the standard tp_alloc, basically copying the
+     * relevant code from PyType_GenericAlloc in Objects/typeobject.c.
+     * Note that we cannot use the standard machinery for variable size
+     * instances, as this would change the array object structure order.
+     *
+     * TODO: possible extensions:
+     * - Also store small bits of data.
+     * - Maybe extend to subtype as long as tp_itemsize == 0
+     *   && tp_alloc == PyObject_GenericAlloc?
+     */
+    if (subtype == &PyArray_Type) {
+        size_t size = subtype->tp_basicsize;
+        /* Alignment to intp should be guaranteed (last item is a pointer). */
+        assert(size % NPY_ALIGNOF(npy_intp) == 0);
+        /* Add space for dimensions and strides. */
+        size += sizeof(npy_intp) * nd * 2;
+        /* Allocate the object and extra space */
+        char *alloc = PyObject_Malloc(size);
+        if (alloc == NULL) {
+            Py_DECREF(descr);
+            return PyErr_NoMemory();
+        }
+        /* PyType_GenericAlloc zeroes the extra bytes, but we don't need to. */
+        fa = (PyArrayObject_fields *)PyObject_Init((PyObject *)alloc, subtype);
+        fa->dimensions = (npy_intp*)((char*)fa + subtype->tp_basicsize);
+    }
+    else {
+        /* For subtypes, do not presume tp_alloc is the same. */
+        fa = (PyArrayObject_fields *) subtype->tp_alloc(subtype, 0);
+        if (fa == NULL) {
+            Py_DECREF(descr);
+            return NULL;
+        }
+        if (nd > 0) {
+            /* Allocate space for the dimensions and strides. */
+            fa->dimensions = npy_alloc_cache_dim(2 * nd);
+            if (fa->dimensions == NULL) {
+                PyErr_NoMemory();
+                goto fail;
+            }
+            /* Ensure this doesn't look like on-instance. */
+            assert(fa->dimensions != (npy_intp*)((char*)fa + subtype->tp_basicsize));
+        }
+    }
+    if (nd > 0) {
+        fa->strides = fa->dimensions + nd;
+    }
+    else {
+        fa->dimensions = NULL;
+        fa->strides = NULL;
     }
     fa->_buffer_info = NULL;
     fa->nd = nd;
-    fa->dimensions = NULL;
     fa->data = NULL;
     fa->mem_handler = NULL;
 
@@ -778,13 +828,6 @@ PyArray_NewFromDescr_int(
     NPY_traverse_info_init(&fill_zero_info);
 
     if (nd > 0) {
-        fa->dimensions = npy_alloc_cache_dim(2 * nd);
-        if (fa->dimensions == NULL) {
-            PyErr_NoMemory();
-            goto fail;
-        }
-        fa->strides = fa->dimensions + nd;
-
         /*
          * Copy dimensions, check them, and find total array size `nbytes`
          */
@@ -839,8 +882,6 @@ PyArray_NewFromDescr_int(
         }
     }
     else {
-        fa->dimensions = NULL;
-        fa->strides = NULL;
         fa->flags |= NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_F_CONTIGUOUS;
     }
 

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -142,10 +142,11 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
 
     if (new_nd > 0) {
         if (PyArray_NDIM(self) != new_nd) {
-            /* Different number of dimensions. */
+            /* Different number of dimensions: need new dims & strides. */
+            npy_free_cache_dim_array(self);
             ((PyArrayObject_fields *)self)->nd = new_nd;
             /* Need new dimensions and strides arrays */
-            dimptr = PyDimMem_RENEW(PyArray_DIMS(self), 3*new_nd);
+            dimptr = npy_alloc_cache_dim(2 * new_nd);
             if (dimptr == NULL) {
                 PyErr_SetString(PyExc_MemoryError,
                                 "cannot allocate memory for array");


### PR DESCRIPTION
This is a subset of #31092, only allocating space for the dimensions and strides. The effect is much less big than when one also includes data, but still a nice benefit. Mostly split out since I need to understand where a memory leak comes from... But perhaps also good to just make the PRs smaller.

### Details
Allocate memory for the dimensions and strides as part of the object, to avoid the overhead of an extra allocation.  This will only become useless memory if the array shape is set (now deprecated) or the array is resized in-place (frowned upon).

Note that the above is done only for standard arrays, though I think in principle it could be extended to subttypes with a suitable check.

Also, allocating space for data is done only for the standard allocator.

### Timings
```
%timeit np.empty(())
133->127 ns

a = 1.6
%timeit np.array(a)
151->137 ns

%timeit np.add(a, a)
581->557 ns

b = np.array(a)
%timeit np.add(b, b)
293->279 ns
```

No AI was used.