### PR TITLE
MAINT: use pointers to dtype dtypes instead of direct object access

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3533,13 +3533,15 @@ Also see :ref:`dtypemeta` for documentation on ``PyArray_DTypeMeta`` and
 .. c:function:: int PyArrayInitDTypeMeta_FromSpec( \
                 PyArray_DTypeMeta *Dtype, PyArrayDTypeMeta_Spec *spec)
 
- Initialize a new DType.  It must currently be a static Python C type that is
- declared as :c:type:`PyArray_DTypeMeta` and not :c:type:`PyTypeObject`.
+ Initialize a new DType.  It must currently be a Python C type that is
+ declared as :c:type:`PyArray_DTypeMetaPtr` and not :c:type:`PyTypeObject`.
  Further, it must subclass `np.dtype` and set its type to
- :c:type:`PyArrayDTypeMeta_Type` (before calling :c:func:`PyType_Ready()`),
+ :c:type:`PyArrayDTypeMeta_TypePtr` (before calling :c:func:`PyType_Ready()`),
  which has additional fields compared to a normal :c:type:`PyTypeObject`. See
  the examples in the ``numpy-user-dtypes`` repository for usage with both
  parametric and non-parametric data types.
+
+ The type can be either a static type or a heap type.
 
 .. _dtype-flags:
 

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -807,9 +807,9 @@ PyArrayMethod_Context and PyArrayMethod_Spec
 PyArray_DTypeMeta and PyArrayDTypeMeta_Spec
 -------------------------------------------
 
-.. c:var:: PyTypeObject PyArrayDTypeMeta_Type
+.. c:var:: PyTypeObject PyArrayDTypeMeta_TypePtr
 
-   The python type object corresponding to :c:type:`PyArray_DTypeMeta`.
+   A pointer to the python type object corresponding to :c:type:`PyArray_DTypeMeta`.
 
 .. c:type:: PyArray_DTypeMeta
 
@@ -919,10 +919,10 @@ Exposed DTypes classes (``PyArray_DTypeMeta`` objects)
 ------------------------------------------------------
 
 For use with promoters, NumPy exposes a number of Dtypes following the
-pattern ``PyArray_<Name>DType`` corresponding to those found in `np.dtypes`.
+pattern ``PyArray_<Name>DTypePtr`` corresponding to those found in `np.dtypes`.
 
-Additionally, the three DTypes, ``PyArray_PyLongDType``,
-``PyArray_PyFloatDType``, ``PyArray_PyComplexDType`` correspond to the
+Additionally, the three DTypes, ``PyArray_PyLongDTypePtr``,
+``PyArray_PyFloatDTypePtr``, ``PyArray_PyComplexDTypePtr`` correspond to the
 Python scalar values.  These cannot be used in all places, but do allow
 for example the common dtype operation and implementing promotion with them
 may be necessary.
@@ -930,14 +930,16 @@ may be necessary.
 Further, the following abstract DTypes are defined which cover both the
 builtin NumPy ones and the python ones, and users can in principle subclass
 from them (this does not inherit any DType specific functionality):
-* ``PyArray_IntAbstractDType``
-* ``PyArray_FloatAbstractDType``
-* ``PyArray_ComplexAbstractDType``
+* ``PyArray_IntAbstractDTypePtr``
+* ``PyArray_FloatAbstractDTypePtr``
+* ``PyArray_ComplexAbstractDTypePtr``
 
 .. warning::
     As of NumPy 2.0, the *only* valid use for these DTypes is registering a
     promoter conveniently to e.g. match "any integers" (and subclass checks).
-    Because of this, they are not exposed to Python.
+    Because of this, they are not exposed to Python. From NumPy 2.0 to 2.5 they
+    were exposed without the `Ptr` suffix, at some point the non-pointer version
+    will be removed.
 
 
 PyUFunc_Type and PyUFuncObject

--- a/numpy/_core/include/numpy/_public_dtype_api_table.h
+++ b/numpy/_core/include/numpy/_public_dtype_api_table.h
@@ -17,7 +17,8 @@
 #if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
 
 /*
- * The type of the DType metaclass
+ * The type of the DType metaclass. At some point deprecate these
+ * non-pointer definitions
  */
 #define PyArrayDTypeMeta_Type (*(PyTypeObject *)(PyArray_API + 320)[0])
 /*
@@ -81,6 +82,74 @@
 #define PyArray_ComplexAbstractDType (*(PyArray_DTypeMeta *)PyArray_API[368])
 
 #endif /* NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION */
+
+#if NPY_FEATURE_VERSION >= NPY_2_5_API_VERSION
+
+/*
+ * Pointer to the type of the DType metaclass
+ */
+#define PyArrayDTypeMeta_TypePtr (PyTypeObject *)(PyArray_API + 320)[0]
+/*
+ * NumPy's builtin DTypes:
+ */
+#define PyArray_BoolDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[1]
+/* Integers */
+#define PyArray_ByteDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[2]
+#define PyArray_UByteDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[3]
+#define PyArray_ShortDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[4]
+#define PyArray_UShortDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[5]
+#define PyArray_IntDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[6]
+#define PyArray_UIntDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[7]
+#define PyArray_LongDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[8]
+#define PyArray_ULongDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[9]
+#define PyArray_LongLongDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[10]
+#define PyArray_ULongLongDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[11]
+/* Integer aliases */
+#define PyArray_Int8DTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[12]
+#define PyArray_UInt8DTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[13]
+#define PyArray_Int16DTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[14]
+#define PyArray_UInt16DTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[15]
+#define PyArray_Int32DTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[16]
+#define PyArray_UInt32DTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[17]
+#define PyArray_Int64DTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[18]
+#define PyArray_UInt64DTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[19]
+#define PyArray_IntpDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[20]
+#define PyArray_UIntpDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[21]
+/* Floats */
+#define PyArray_HalfDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[22]
+#define PyArray_FloatDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[23]
+#define PyArray_DoubleDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[24]
+#define PyArray_LongDoubleDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[25]
+/* Complex */
+#define PyArray_CFloatDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[26]
+#define PyArray_CDoubleDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[27]
+#define PyArray_CLongDoubleDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[28]
+/* String/Bytes */
+#define PyArray_BytesDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[29]
+#define PyArray_UnicodeDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[30]
+/* Datetime/Timedelta */
+#define PyArray_DatetimeDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[31]
+#define PyArray_TimedeltaDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[32]
+/* Object/Void */
+#define PyArray_ObjectDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[33]
+#define PyArray_VoidDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[34]
+/* Python types (used as markers for scalars) */
+#define PyArray_PyLongDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[35]
+#define PyArray_PyFloatDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[36]
+#define PyArray_PyComplexDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[37]
+/* Default integer type */
+#define PyArray_DefaultIntDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[38]
+/* New non-legacy DTypes follow in the order they were added */
+#define PyArray_StringDTypePtr (PyArray_DTypeMeta *)(PyArray_API + 320)[39]
+
+/* NOTE: offset 40 is free */
+
+/* Need to start with a larger offset again for the abstract classes: */
+#define PyArray_IntAbstractDTypePtr (PyArray_DTypeMeta *)PyArray_API[366]
+#define PyArray_FloatAbstractDTypePtr (PyArray_DTypeMeta *)PyArray_API[367]
+#define PyArray_ComplexAbstractDTypePtr (PyArray_DTypeMeta *)PyArray_API[368]
+
+#endif /* NPY_FEATURE_VERSION >= NPY_2_5_API_VERSION */
 
 #endif  /* NPY_INTERNAL_BUILD */
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY__PUBLIC_DTYPE_API_TABLE_H_ */

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1887,7 +1887,11 @@ typedef struct {
      * Part of this (at least the size) is expected to be public API without
      * further modifications.
      */
-    /* TODO: Make this definition public in the API, as soon as its settled */
+    NPY_NO_EXPORT extern PyTypeObject *PyArrayDTypeMeta_TypePtr;
+    /*
+     * This is made public in _public_dtype_api_table.h via the PyArray_API table,
+     * where it is a dereferenced pointer. Maybe deprecate at some point.
+     */
     NPY_NO_EXPORT extern PyTypeObject PyArrayDTypeMeta_Type;
 
     /*

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -85,49 +85,49 @@ discover_descriptor_from_pycomplex(
 NPY_NO_EXPORT int
 initialize_and_map_pytypes_to_dtypes()
 {
-    if (PyType_Ready((PyTypeObject *)&PyArray_IntAbstractDType) < 0) {
+    if (PyType_Ready((PyTypeObject *)PyArray_IntAbstractDTypePtr) < 0) {
         return -1;
     }
-    if (PyType_Ready((PyTypeObject *)&PyArray_FloatAbstractDType) < 0) {
+    if (PyType_Ready((PyTypeObject *)PyArray_FloatAbstractDTypePtr) < 0) {
         return -1;
     }
-    if (PyType_Ready((PyTypeObject *)&PyArray_ComplexAbstractDType) < 0) {
+    if (PyType_Ready((PyTypeObject *)PyArray_ComplexAbstractDTypePtr) < 0) {
         return -1;
     }
     /*
      * Delayed assignments to avoid "error C2099: initializer is not a constant"
      * in windows compilers.  Can hopefully be done in structs in the future.
      */
-    ((PyTypeObject *)&PyArray_PyLongDType)->tp_base =
-        (PyTypeObject *)&PyArray_IntAbstractDType;
-    PyArray_PyLongDType.scalar_type = &PyLong_Type;
-    if (PyType_Ready((PyTypeObject *)&PyArray_PyLongDType) < 0) {
+    ((PyTypeObject *)PyArray_PyLongDTypePtr)->tp_base =
+        (PyTypeObject *)PyArray_IntAbstractDTypePtr;
+    PyArray_PyLongDTypePtr->scalar_type = &PyLong_Type;
+    if (PyType_Ready((PyTypeObject *)PyArray_PyLongDTypePtr) < 0) {
         return -1;
     }
-    ((PyTypeObject *)&PyArray_PyFloatDType)->tp_base =
-        (PyTypeObject *)&PyArray_FloatAbstractDType;
-    PyArray_PyFloatDType.scalar_type = &PyFloat_Type;
-    if (PyType_Ready((PyTypeObject *)&PyArray_PyFloatDType) < 0) {
+    ((PyTypeObject *)PyArray_PyFloatDTypePtr)->tp_base =
+        (PyTypeObject *)PyArray_FloatAbstractDTypePtr;
+    PyArray_PyFloatDTypePtr->scalar_type = &PyFloat_Type;
+    if (PyType_Ready((PyTypeObject *)PyArray_PyFloatDTypePtr) < 0) {
         return -1;
     }
-    ((PyTypeObject *)&PyArray_PyComplexDType)->tp_base =
-        (PyTypeObject *)&PyArray_ComplexAbstractDType;
-    PyArray_PyComplexDType.scalar_type = &PyComplex_Type;
-    if (PyType_Ready((PyTypeObject *)&PyArray_PyComplexDType) < 0) {
+    ((PyTypeObject *)PyArray_PyComplexDTypePtr)->tp_base =
+        (PyTypeObject *)PyArray_ComplexAbstractDTypePtr;
+    PyArray_PyComplexDTypePtr->scalar_type = &PyComplex_Type;
+    if (PyType_Ready((PyTypeObject *)PyArray_PyComplexDTypePtr) < 0) {
         return -1;
     }
 
     /* Register the new DTypes for discovery */
     if (_PyArray_MapPyTypeToDType(
-            &PyArray_PyLongDType, &PyLong_Type, NPY_FALSE) < 0) {
+            PyArray_PyLongDTypePtr, &PyLong_Type, NPY_FALSE) < 0) {
         return -1;
     }
     if (_PyArray_MapPyTypeToDType(
-            &PyArray_PyFloatDType, &PyFloat_Type, NPY_FALSE) < 0) {
+            PyArray_PyFloatDTypePtr, &PyFloat_Type, NPY_FALSE) < 0) {
         return -1;
     }
     if (_PyArray_MapPyTypeToDType(
-            &PyArray_PyComplexDType, &PyComplex_Type, NPY_FALSE) < 0) {
+            PyArray_PyComplexDTypePtr, &PyComplex_Type, NPY_FALSE) < 0) {
         return -1;
     }
 
@@ -170,12 +170,12 @@ int_common_dtype(PyArray_DTypeMeta *NPY_UNUSED(cls), PyArray_DTypeMeta *other)
     if (NPY_DT_is_legacy(other) && other->type_num < NPY_NTYPES_LEGACY) {
         if (other->type_num == NPY_BOOL) {
             /* Use the default integer for bools: */
-            return NPY_DT_NewRef(&PyArray_IntpDType);
+            return NPY_DT_NewRef(PyArray_IntpDTypePtr);
         }
     }
     else if (NPY_DT_is_legacy(other)) {
         /* This is a back-compat fallback to usually do the right thing... */
-        PyArray_DTypeMeta *uint8_dt = &PyArray_UInt8DType;
+        PyArray_DTypeMeta *uint8_dt = PyArray_UInt8DTypePtr;
         PyArray_DTypeMeta *res = NPY_DT_CALL_common_dtype(other, uint8_dt);
         if (res == NULL) {
             PyErr_Clear();
@@ -187,7 +187,7 @@ int_common_dtype(PyArray_DTypeMeta *NPY_UNUSED(cls), PyArray_DTypeMeta *other)
             return res;
         }
         /* Try again with `int8`, an error may have been set, though */
-        PyArray_DTypeMeta *int8_dt = &PyArray_Int8DType;
+        PyArray_DTypeMeta *int8_dt = PyArray_Int8DTypePtr;
         res = NPY_DT_CALL_common_dtype(other, int8_dt);
         if (res == NULL) {
             PyErr_Clear();
@@ -199,7 +199,7 @@ int_common_dtype(PyArray_DTypeMeta *NPY_UNUSED(cls), PyArray_DTypeMeta *other)
             return res;
         }
         /* And finally, we will try the default integer, just for sports... */
-        PyArray_DTypeMeta *default_int = &PyArray_IntpDType;
+        PyArray_DTypeMeta *default_int = PyArray_IntpDTypePtr;
         res = NPY_DT_CALL_common_dtype(other, default_int);
         if (res == NULL) {
             PyErr_Clear();
@@ -217,16 +217,16 @@ float_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
     if (NPY_DT_is_legacy(other) && other->type_num < NPY_NTYPES_LEGACY) {
         if (other->type_num == NPY_BOOL || PyTypeNum_ISINTEGER(other->type_num)) {
             /* Use the default integer for bools and ints: */
-            return NPY_DT_NewRef(&PyArray_DoubleDType);
+            return NPY_DT_NewRef(PyArray_DoubleDTypePtr);
         }
     }
-    else if (other == &PyArray_PyLongDType) {
+    else if (other == PyArray_PyLongDTypePtr) {
         Py_INCREF(cls);
         return cls;
     }
     else if (NPY_DT_is_legacy(other)) {
         /* This is a back-compat fallback to usually do the right thing... */
-        PyArray_DTypeMeta *half_dt = &PyArray_HalfDType;
+        PyArray_DTypeMeta *half_dt = PyArray_HalfDTypePtr;
         PyArray_DTypeMeta *res = NPY_DT_CALL_common_dtype(other, half_dt);
         if (res == NULL) {
             PyErr_Clear();
@@ -238,7 +238,7 @@ float_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
             return res;
         }
         /* Retry with double (the default float) */
-        PyArray_DTypeMeta *double_dt = &PyArray_DoubleDType;
+        PyArray_DTypeMeta *double_dt = PyArray_DoubleDTypePtr;
         res = NPY_DT_CALL_common_dtype(other, double_dt);
         return res;
     }
@@ -254,12 +254,12 @@ complex_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
         if (other->type_num == NPY_BOOL ||
                 PyTypeNum_ISINTEGER(other->type_num)) {
             /* Use the default integer for bools and ints: */
-            return NPY_DT_NewRef(&PyArray_CDoubleDType);
+            return NPY_DT_NewRef(PyArray_CDoubleDTypePtr);
         }
     }
     else if (NPY_DT_is_legacy(other)) {
         /* This is a back-compat fallback to usually do the right thing... */
-        PyArray_DTypeMeta *cfloat_dt = &PyArray_CFloatDType;
+        PyArray_DTypeMeta *cfloat_dt = PyArray_CFloatDTypePtr;
         PyArray_DTypeMeta *res = NPY_DT_CALL_common_dtype(other, cfloat_dt);
         if (res == NULL) {
             PyErr_Clear();
@@ -271,13 +271,13 @@ complex_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
             return res;
         }
         /* Retry with cdouble (the default complex) */
-        PyArray_DTypeMeta *cdouble_dt = &PyArray_CDoubleDType;
+        PyArray_DTypeMeta *cdouble_dt = PyArray_CDoubleDTypePtr;
         res = NPY_DT_CALL_common_dtype(other, cdouble_dt);
         return res;
 
     }
-    else if (other == &PyArray_PyLongDType ||
-             other == &PyArray_PyFloatDType) {
+    else if (other == PyArray_PyLongDTypePtr ||
+             other == PyArray_PyFloatDTypePtr) {
         Py_INCREF(cls);
         return cls;
     }
@@ -301,6 +301,7 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_IntAbstractDType = {{{
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
 };
+NPY_NO_EXPORT PyArray_DTypeMeta *PyArray_IntAbstractDTypePtr = &PyArray_IntAbstractDType;
 
 NPY_DType_Slots pylongdtype_slots = {
     .discover_descr_from_pyobject = discover_descriptor_from_pylong,
@@ -319,6 +320,7 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyLongDType = {{{
     .dt_slots = &pylongdtype_slots,
     .scalar_type = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
 };
+NPY_NO_EXPORT PyArray_DTypeMeta *PyArray_PyLongDTypePtr = &PyArray_PyLongDType;
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_FloatAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
@@ -330,6 +332,7 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_FloatAbstractDType = {{{
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
 };
+NPY_NO_EXPORT PyArray_DTypeMeta *PyArray_FloatAbstractDTypePtr = &PyArray_FloatAbstractDType;
 
 NPY_DType_Slots pyfloatdtype_slots = {
     .discover_descr_from_pyobject = discover_descriptor_from_pyfloat,
@@ -348,6 +351,7 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyFloatDType = {{{
     .dt_slots = &pyfloatdtype_slots,
     .scalar_type = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
 };
+NPY_NO_EXPORT PyArray_DTypeMeta *PyArray_PyFloatDTypePtr = &PyArray_PyFloatDType;
 
 NPY_NO_EXPORT PyArray_DTypeMeta PyArray_ComplexAbstractDType = {{{
         PyVarObject_HEAD_INIT(&PyArrayDTypeMeta_Type, 0)
@@ -359,6 +363,7 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_ComplexAbstractDType = {{{
     .type_num = -1,
     .flags = NPY_DT_ABSTRACT,
 };
+NPY_NO_EXPORT PyArray_DTypeMeta *PyArray_ComplexAbstractDTypePtr = &PyArray_ComplexAbstractDType;
 
 NPY_DType_Slots pycomplexdtype_slots = {
     .discover_descr_from_pyobject = discover_descriptor_from_pycomplex,
@@ -377,6 +382,7 @@ NPY_NO_EXPORT PyArray_DTypeMeta PyArray_PyComplexDType = {{{
     .dt_slots = &pycomplexdtype_slots,
     .scalar_type = NULL,  /* set in initialize_and_map_pytypes_to_dtypes */
 };
+NPY_NO_EXPORT PyArray_DTypeMeta *PyArray_PyComplexDTypePtr = &PyArray_PyComplexDType;
 
 
 /*

--- a/numpy/_core/src/multiarray/abstractdtypes.h
+++ b/numpy/_core/src/multiarray/abstractdtypes.h
@@ -15,12 +15,20 @@ extern "C" {
  * may be necessary to make them (partially) public, to allow user-defined
  * dtypes to perform value based casting.
  */
+/* Once we convert the dtype types to heap types, we can remove the non-ptr ones */
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_IntAbstractDType;
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_FloatAbstractDType;
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_ComplexAbstractDType;
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyLongDType;
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyFloatDType;
 NPY_NO_EXPORT extern PyArray_DTypeMeta PyArray_PyComplexDType;
+
+NPY_NO_EXPORT extern PyArray_DTypeMeta *PyArray_IntAbstractDTypePtr;
+NPY_NO_EXPORT extern PyArray_DTypeMeta *PyArray_FloatAbstractDTypePtr;
+NPY_NO_EXPORT extern PyArray_DTypeMeta *PyArray_ComplexAbstractDTypePtr;
+NPY_NO_EXPORT extern PyArray_DTypeMeta *PyArray_PyLongDTypePtr;
+NPY_NO_EXPORT extern PyArray_DTypeMeta *PyArray_PyFloatDTypePtr;
+NPY_NO_EXPORT extern PyArray_DTypeMeta *PyArray_PyComplexDTypePtr;
 
 NPY_NO_EXPORT int
 initialize_and_map_pytypes_to_dtypes(void);
@@ -45,24 +53,24 @@ npy_mark_tmp_array_if_pyscalar(
     if (PyLong_CheckExact(obj)) {
         ((PyArrayObject_fields *)arr)->flags |= NPY_ARRAY_WAS_PYTHON_INT;
         if (dtype != NULL) {
-            Py_INCREF(&PyArray_PyLongDType);
-            Py_SETREF(*dtype, &PyArray_PyLongDType);
+            Py_INCREF(PyArray_PyLongDTypePtr);
+            Py_SETREF(*dtype, PyArray_PyLongDTypePtr);
         }
         return 1;
     }
     else if (PyFloat_CheckExact(obj)) {
         ((PyArrayObject_fields *)arr)->flags |= NPY_ARRAY_WAS_PYTHON_FLOAT;
         if (dtype != NULL) {
-            Py_INCREF(&PyArray_PyFloatDType);
-            Py_SETREF(*dtype, &PyArray_PyFloatDType);
+            Py_INCREF(PyArray_PyFloatDTypePtr);
+            Py_SETREF(*dtype, PyArray_PyFloatDTypePtr);
         }
         return 1;
     }
     else if (PyComplex_CheckExact(obj)) {
         ((PyArrayObject_fields *)arr)->flags |= NPY_ARRAY_WAS_PYTHON_COMPLEX;
         if (dtype != NULL) {
-            Py_INCREF(&PyArray_PyComplexDType);
-            Py_SETREF(*dtype, &PyArray_PyComplexDType);
+            Py_INCREF(PyArray_PyComplexDTypePtr);
+            Py_SETREF(*dtype, PyArray_PyComplexDTypePtr);
         }
         return 1;
     }

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -196,7 +196,7 @@ _PyArray_MapPyTypeToDType(
     if (res < 0) {
         return -1;
     }
-    else if (DType == &PyArray_StringDType) {
+    else if (DType == PyArray_StringDTypePtr) {
         // PyArray_StringDType's scalar is str which we allow because it doesn't
         // participate in DType inference, so don't add it to the
         // pytype to type mapping
@@ -228,10 +228,10 @@ npy_discover_dtype_from_pytype(PyTypeObject *pytype)
         DType = Py_NewRef(Py_None);
     }
     else if (pytype == &PyFloat_Type) {
-        DType = Py_NewRef((PyObject *)&PyArray_PyFloatDType);
+        DType = Py_NewRef(PyArray_PyFloatDTypePtr);
     }
     else if (pytype == &PyLong_Type) {
-        DType = Py_NewRef((PyObject *)&PyArray_PyLongDType);
+        DType = Py_NewRef(PyArray_PyLongDTypePtr);
     }
     else {
         int res = PyDict_GetItemRef(_global_pytype_to_type_dict,
@@ -242,7 +242,7 @@ npy_discover_dtype_from_pytype(PyTypeObject *pytype)
             return NULL;
         }
     }
-    assert(DType == Py_None || PyObject_TypeCheck(DType, (PyTypeObject *)&PyArrayDTypeMeta_Type));
+    assert(DType == Py_None || PyObject_TypeCheck(DType, PyArrayDTypeMeta_TypePtr));
     return (PyArray_DTypeMeta *)DType;
 }
 
@@ -1274,7 +1274,7 @@ PyArray_DiscoverDTypeAndShape(
     /* Validate input of requested descriptor and DType */
     if (fixed_DType != NULL) {
         assert(PyObject_TypeCheck(
-                (PyObject *)fixed_DType, (PyTypeObject *)&PyArrayDTypeMeta_Type));
+                (PyObject *)fixed_DType, PyArrayDTypeMeta_TypePtr));
     }
 
     if (requested_descr != NULL) {

--- a/numpy/_core/src/multiarray/array_converter.c
+++ b/numpy/_core/src/multiarray/array_converter.c
@@ -348,8 +348,8 @@ array_converter_result_type(PyArrayArrayConverterObject *self,
                     "extra_dtype and ensure_inexact are mutually exclusive.");
             goto finish;
         }
-        Py_INCREF(&PyArray_PyFloatDType);
-        dt_info.dtype = &PyArray_PyFloatDType;
+        Py_INCREF(PyArray_PyFloatDTypePtr);
+        dt_info.dtype = PyArray_PyFloatDTypePtr;
     }
 
     if (dt_info.dtype != NULL) {

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -222,7 +222,7 @@ validate_spec(PyArrayMethod_Spec *spec)
                     "(method: %s)", spec->name);
             return -1;
         }
-        if (!PyObject_TypeCheck(spec->dtypes[i], &PyArrayDTypeMeta_Type)) {
+        if (!PyObject_TypeCheck(spec->dtypes[i], PyArrayDTypeMeta_TypePtr)) {
             PyErr_Format(PyExc_TypeError,
                     "ArrayMethod provided object %R is not a DType."
                     "(method: %s)", spec->dtypes[i], spec->name);
@@ -407,7 +407,7 @@ NPY_NO_EXPORT PyObject *
 PyArrayMethod_FromSpec(PyArrayMethod_Spec *spec)
 {
     for (int i = 0; i < spec->nin + spec->nout; i++) {
-        if (!PyObject_TypeCheck(spec->dtypes[i], &PyArrayDTypeMeta_Type)) {
+        if (!PyObject_TypeCheck(spec->dtypes[i], PyArrayDTypeMeta_TypePtr)) {
             PyErr_SetString(PyExc_RuntimeError,
                     "ArrayMethod spec contained a non DType.");
             return NULL;

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -4573,16 +4573,16 @@ set_typeinfo(PyObject *dict)
      *         CFloat, CDouble, CLongDouble,
      *         Object, String, Unicode, Void,
      *         Datetime, Timedelta#
-     * #scls = PyArrayDescr_Type,
-     *         PyArray_IntAbstractDType*10,
-     *         PyArray_FloatAbstractDType*4,
-     *         PyArray_ComplexAbstractDType*3,
-     *         PyArrayDescr_Type*6 #
+     * #scls = &PyArrayDescr_Type,
+     *         PyArray_IntAbstractDTypePtr*10,
+     *         PyArray_FloatAbstractDTypePtr*4,
+     *         PyArray_ComplexAbstractDTypePtr*3,
+     *         &PyArrayDescr_Type*6 #
      */
     dtypemeta = dtypemeta_wrap_legacy_descriptor(
             _builtin_descrs[NPY_@NAME@],
             &_Py@Name@_ArrFuncs,
-            (PyTypeObject *)&@scls@,
+            (PyTypeObject *)@scls@,
             "numpy.dtypes." NPY_@NAME@_Name "DType",
 #ifdef NPY_@NAME@_alias
             "numpy.dtypes." NPY_@NAME@_Alias "DType"

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -39,7 +39,7 @@ _array_find_python_scalar_type(PyObject *op)
     }
     else if (PyLong_Check(op)) {
         return NPY_DT_CALL_discover_descr_from_pyobject(
-                &PyArray_PyLongDType, op);
+                PyArray_PyLongDTypePtr, op);
     }
     return NULL;
 }

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -248,7 +248,7 @@ _get_castingimpl(PyObject *NPY_UNUSED(module), PyObject *args)
 {
     PyArray_DTypeMeta *from, *to;
     if (!PyArg_ParseTuple(args, "O!O!:_get_castingimpl",
-            &PyArrayDTypeMeta_Type, &from, &PyArrayDTypeMeta_Type, &to)) {
+            PyArrayDTypeMeta_TypePtr, &from, PyArrayDTypeMeta_TypePtr, &to)) {
         return NULL;
     }
     return PyArray_GetBoundCastingImpl(from, to);
@@ -772,15 +772,15 @@ can_cast_pyscalar_scalar_to(
     PyArray_Descr *default_dtype;
     if (flags & NPY_ARRAY_WAS_PYTHON_INT) {
         default_dtype = PyArray_DescrNewFromType(NPY_INTP);
-        from_DType = &PyArray_PyLongDType;
+        from_DType = PyArray_PyLongDTypePtr;
     }
     else if (flags & NPY_ARRAY_WAS_PYTHON_FLOAT) {
         default_dtype = PyArray_DescrNewFromType(NPY_FLOAT64);
-        from_DType =  &PyArray_PyFloatDType;
+        from_DType =  PyArray_PyFloatDTypePtr;
     }
     else {
         default_dtype = PyArray_DescrNewFromType(NPY_COMPLEX128);
-        from_DType = &PyArray_PyComplexDType;
+        from_DType = PyArray_PyComplexDTypePtr;
     }
 
     PyArray_Descr *from = npy_find_descr_for_scalar(
@@ -1631,13 +1631,13 @@ PyArray_ResultType(
         all_descriptors[i_all] = NULL;  /* no descriptor for py-scalars */
         if (PyArray_FLAGS(arrs[i]) & NPY_ARRAY_WAS_PYTHON_INT) {
             /* This could even be an object dtype here for large ints */
-            all_DTypes[i_all] = &PyArray_PyLongDType;
+            all_DTypes[i_all] = PyArray_PyLongDTypePtr;
         }
         else if (PyArray_FLAGS(arrs[i]) & NPY_ARRAY_WAS_PYTHON_FLOAT) {
-            all_DTypes[i_all] = &PyArray_PyFloatDType;
+            all_DTypes[i_all] = PyArray_PyFloatDTypePtr;
         }
         else if (PyArray_FLAGS(arrs[i]) & NPY_ARRAY_WAS_PYTHON_COMPLEX) {
-            all_DTypes[i_all] = &PyArray_PyComplexDType;
+            all_DTypes[i_all] = PyArray_PyComplexDTypePtr;
         }
         else {
             all_descriptors[i_all] = PyArray_DTYPE(arrs[i]);
@@ -2633,8 +2633,8 @@ static int
 PyArray_InitializeStringCasts(void)
 {
     int result = -1;
-    PyArray_DTypeMeta *string = &PyArray_BytesDType;
-    PyArray_DTypeMeta *unicode = &PyArray_UnicodeDType;
+    PyArray_DTypeMeta *string = PyArray_BytesDTypePtr;
+    PyArray_DTypeMeta *unicode = PyArray_UnicodeDTypePtr;
     PyArray_DTypeMeta *other_dt = NULL;
 
     /* Add most casts as legacy ones */
@@ -3318,7 +3318,7 @@ void_to_void_get_loop(
 static int
 PyArray_InitializeVoidToVoidCast(void)
 {
-    PyArray_DTypeMeta *Void = &PyArray_VoidDType;
+    PyArray_DTypeMeta *Void = PyArray_VoidDTypePtr;
     PyArray_DTypeMeta *dtypes[2] = {Void, Void};
     PyType_Slot slots[] = {
             {NPY_METH_get_loop, &void_to_void_get_loop},
@@ -3363,7 +3363,7 @@ object_to_any_resolve_descriptors(
          * StringDType is excluded since using the parameters of that dtype
          * requires creating an instance explicitly
          */
-        if (NPY_DT_is_parametric(dtypes[1]) && dtypes[1] != &PyArray_StringDType) {
+        if (NPY_DT_is_parametric(dtypes[1]) && dtypes[1] != PyArray_StringDTypePtr) {
             PyErr_Format(PyExc_TypeError,
                     "casting from object to the parametric DType %S requires "
                     "the specified output dtype instance. "
@@ -3464,7 +3464,7 @@ object_to_object_get_loop(
 static int
 PyArray_InitializeObjectToObjectCast(void)
 {
-    PyArray_DTypeMeta *Object = &PyArray_ObjectDType;
+    PyArray_DTypeMeta *Object = PyArray_ObjectDTypePtr;
     PyArray_DTypeMeta *dtypes[2] = {Object, Object};
     PyType_Slot slots[] = {
             {NPY_METH_get_loop, &object_to_object_get_loop},

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -4218,10 +4218,10 @@ PyArray_InitializeDatetimeCasts()
     slots[2].slot = 0;
     slots[2].pfunc = NULL;
 
-    PyArray_DTypeMeta *datetime = &PyArray_DatetimeDType;
-    PyArray_DTypeMeta *timedelta = &PyArray_TimedeltaDType;
-    PyArray_DTypeMeta *string = &PyArray_BytesDType;
-    PyArray_DTypeMeta *unicode = &PyArray_UnicodeDType;
+    PyArray_DTypeMeta *datetime = PyArray_DatetimeDTypePtr;
+    PyArray_DTypeMeta *timedelta = PyArray_TimedeltaDTypePtr;
+    PyArray_DTypeMeta *string = PyArray_BytesDTypePtr;
+    PyArray_DTypeMeta *unicode = PyArray_UnicodeDTypePtr;
     PyArray_DTypeMeta *tmp = NULL;
 
     dtypes[0] = datetime;

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -494,7 +494,7 @@ _convert_from_array_descr(PyObject *obj, int align)
                     "Field elements must be tuples with at most 3 elements, got '%R'", item);
             goto fail;
         }
-        if (PyObject_IsInstance((PyObject *)conv, (PyObject *)&PyArray_StringDType)) {
+        if (PyObject_IsInstance((PyObject *)conv, (PyObject *)PyArray_StringDTypePtr)) {
             PyErr_Format(PyExc_TypeError,
                          "StringDType is not currently supported for structured dtype fields.");
             goto fail;
@@ -1472,7 +1472,7 @@ PyArray_DTypeOrDescrConverterRequired(PyObject *obj, npy_dtype_info *dt_info)
     dt_info->dtype = NULL;
     dt_info->descr = NULL;
 
-    if (PyObject_TypeCheck(obj, &PyArrayDTypeMeta_Type)) {
+    if (PyObject_TypeCheck(obj, PyArrayDTypeMeta_TypePtr)) {
         if (obj == (PyObject *)&PyArrayDescr_Type) {
             PyErr_SetString(PyExc_TypeError,
                             "Cannot convert np.dtype into a dtype.");
@@ -2493,7 +2493,7 @@ arraydescr_new(PyTypeObject *subtype,
                 PyObject *args, PyObject *kwds)
 {
     if (subtype != &PyArrayDescr_Type) {
-        if (Py_TYPE(subtype) == &PyArrayDTypeMeta_Type &&
+        if (Py_TYPE(subtype) == PyArrayDTypeMeta_TypePtr &&
                 (NPY_DT_SLOTS((PyArray_DTypeMeta *)subtype)) != NULL &&
                 !NPY_DT_is_legacy((PyArray_DTypeMeta *)subtype) &&
                 subtype->tp_new != PyArrayDescr_Type.tp_new) {

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -941,29 +941,29 @@ default_builtin_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
          * If our own DType is not numerical or has lower priority (e.g.
          * integer but abstract one is float), signal not implemented.
          */
-        if (other == &PyArray_PyComplexDType) {
+        if (other == PyArray_PyComplexDTypePtr) {
             if (PyTypeNum_ISCOMPLEX(cls->type_num)) {
                 Py_INCREF(cls);
                 return cls;
             }
             else if (cls->type_num == NPY_HALF || cls->type_num == NPY_FLOAT) {
-                return NPY_DT_NewRef(&PyArray_CFloatDType);
+                return NPY_DT_NewRef(PyArray_CFloatDTypePtr);
             }
             else if (cls->type_num == NPY_DOUBLE) {
-                return NPY_DT_NewRef(&PyArray_CDoubleDType);
+                return NPY_DT_NewRef(PyArray_CDoubleDTypePtr);
             }
             else if (cls->type_num == NPY_LONGDOUBLE) {
-                return NPY_DT_NewRef(&PyArray_CLongDoubleDType);
+                return NPY_DT_NewRef(PyArray_CLongDoubleDTypePtr);
             }
         }
-        else if (other == &PyArray_PyFloatDType) {
+        else if (other == PyArray_PyFloatDTypePtr) {
             if (PyTypeNum_ISCOMPLEX(cls->type_num)
                     || PyTypeNum_ISFLOAT(cls->type_num)) {
                 Py_INCREF(cls);
                 return cls;
             }
         }
-        else if (other == &PyArray_PyLongDType) {
+        else if (other == PyArray_PyLongDTypePtr) {
             if (PyTypeNum_ISCOMPLEX(cls->type_num)
                     || PyTypeNum_ISFLOAT(cls->type_num)
                     || PyTypeNum_ISINTEGER(cls->type_num)
@@ -1380,6 +1380,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayDTypeMeta_Type = {
     .tp_new = dtypemeta_new,
     .tp_is_gc = dtypemeta_is_gc,
 };
+NPY_NO_EXPORT PyTypeObject *PyArrayDTypeMeta_TypePtr = &PyArrayDTypeMeta_Type;
 
 PyArray_DTypeMeta *_Bool_dtype = NULL;
 PyArray_DTypeMeta *_Byte_dtype = NULL;

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -223,52 +223,53 @@ extern PyArray_DTypeMeta *_Timedelta_dtype;
 extern PyArray_DTypeMeta *_Object_dtype;
 extern PyArray_DTypeMeta *_Void_dtype;
 
-#define PyArray_BoolDType (*(_Bool_dtype))
+/* Define aliases for the types that are public API */
+#define PyArray_BoolDTypePtr _Bool_dtype
 /* Integers */
-#define PyArray_ByteDType (*(_Byte_dtype))
-#define PyArray_UByteDType (*(_UByte_dtype))
-#define PyArray_ShortDType (*(_Short_dtype))
-#define PyArray_UShortDType (*(_UShort_dtype))
-#define PyArray_IntDType (*(_Int_dtype))
-#define PyArray_UIntDType (*(_UInt_dtype))
-#define PyArray_LongDType (*(_Long_dtype))
-#define PyArray_ULongDType (*(_ULong_dtype))
-#define PyArray_LongLongDType (*(_LongLong_dtype))
-#define PyArray_ULongLongDType (*(_ULongLong_dtype))
+#define PyArray_ByteDTypePtr _Byte_dtype
+#define PyArray_UByteDTypePtr _UByte_dtype
+#define PyArray_ShortDTypePtr _Short_dtype
+#define PyArray_UShortDTypePtr _UShort_dtype
+#define PyArray_IntDTypePtr _Int_dtype
+#define PyArray_UIntDTypePtr _UInt_dtype
+#define PyArray_LongDTypePtr _Long_dtype
+#define PyArray_ULongDTypePtr _ULong_dtype
+#define PyArray_LongLongDTypePtr _LongLong_dtype
+#define PyArray_ULongLongDTypePtr _ULongLong_dtype
 /* Integer aliases */
-#define PyArray_Int8DType (*(_Int8_dtype))
-#define PyArray_UInt8DType (*(_UInt8_dtype))
-#define PyArray_Int16DType (*(_Int16_dtype))
-#define PyArray_UInt16DType (*(_UInt16_dtype))
-#define PyArray_Int32DType (*(_Int32_dtype))
-#define PyArray_UInt32DType (*(_UInt32_dtype))
-#define PyArray_Int64DType (*(_Int64_dtype))
-#define PyArray_UInt64DType (*(_UInt64_dtype))
-#define PyArray_IntpDType (*(_Intp_dtype))
-#define PyArray_UIntpDType (*(_UIntp_dtype))
-#define PyArray_DefaultIntDType (*(_DefaultInt_dtype))
+#define PyArray_Int8DTypePtr _Int8_dtype
+#define PyArray_UInt8DTypePtr _UInt8_dtype
+#define PyArray_Int16DTypePtr _Int16_dtype
+#define PyArray_UInt16DTypePtr _UInt16_dtype
+#define PyArray_Int32DTypePtr _Int32_dtype
+#define PyArray_UInt32DTypePtr _UInt32_dtype
+#define PyArray_Int64DTypePtr _Int64_dtype
+#define PyArray_UInt64DTypePtr _UInt64_dtype
+#define PyArray_IntpDTypePtr _Intp_dtype
+#define PyArray_UIntpDTypePtr _UIntp_dtype
+#define PyArray_DefaultIntDTypePtr _DefaultInt_dtype
 /* Floats */
-#define PyArray_HalfDType (*(_Half_dtype))
-#define PyArray_FloatDType (*(_Float_dtype))
-#define PyArray_DoubleDType (*(_Double_dtype))
-#define PyArray_LongDoubleDType (*(_LongDouble_dtype))
+#define PyArray_HalfDTypePtr _Half_dtype
+#define PyArray_FloatDTypePtr _Float_dtype
+#define PyArray_DoubleDTypePtr _Double_dtype
+#define PyArray_LongDoubleDTypePtr _LongDouble_dtype
 /* Complex */
-#define PyArray_CFloatDType (*(_CFloat_dtype))
-#define PyArray_CDoubleDType (*(_CDouble_dtype))
-#define PyArray_CLongDoubleDType (*(_CLongDouble_dtype))
+#define PyArray_CFloatDTypePtr _CFloat_dtype
+#define PyArray_CDoubleDTypePtr _CDouble_dtype
+#define PyArray_CLongDoubleDTypePtr _CLongDouble_dtype
 /* String/Bytes */
-#define PyArray_BytesDType (*(_Bytes_dtype))
-#define PyArray_UnicodeDType (*(_Unicode_dtype))
+#define PyArray_BytesDTypePtr _Bytes_dtype
+#define PyArray_UnicodeDTypePtr _Unicode_dtype
+/* Datetime/Timedelta */
+#define PyArray_DatetimeDTypePtr _Datetime_dtype
+#define PyArray_TimedeltaDTypePtr _Timedelta_dtype
 // StringDType is not a legacy DType and has a static dtypemeta implementation
 // we can refer to, so no need for the indirection we use for the built-in
 // dtypes.
-extern PyArray_DTypeMeta PyArray_StringDType;
-/* Datetime/Timedelta */
-#define PyArray_DatetimeDType (*(_Datetime_dtype))
-#define PyArray_TimedeltaDType (*(_Timedelta_dtype))
+extern PyArray_DTypeMeta *PyArray_StringDTypePtr;
 /* Object/Void */
-#define PyArray_ObjectDType (*(_Object_dtype))
-#define PyArray_VoidDType (*(_Void_dtype))
+#define PyArray_ObjectDTypePtr _Object_dtype
+#define PyArray_VoidDTypePtr _Void_dtype
 
 #ifdef __cplusplus
 }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -4149,7 +4149,7 @@ _vec_string(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *NPY_UNUSED(kw
         method = PyObject_GetAttr((PyObject *)&PyBytes_Type, method_name);
     }
     else if (PyArray_TYPE(char_array) == NPY_UNICODE ||
-             NPY_DTYPE(PyArray_DTYPE(char_array)) == &PyArray_StringDType) {
+             NPY_DTYPE(PyArray_DTYPE(char_array)) == PyArray_StringDTypePtr) {
         method = PyObject_GetAttr((PyObject *)&PyUnicode_Type, method_name);
     }
     else {
@@ -4999,12 +4999,12 @@ _multiarray_umath_exec(PyObject *m) {
     }
 
     PyArrayDTypeMeta_Type.tp_base = &PyType_Type;
-    if (PyType_Ready(&PyArrayDTypeMeta_Type) < 0) {
+    if (PyType_Ready(PyArrayDTypeMeta_TypePtr) < 0) {
         return -1;
     }
 
     PyArrayDescr_Type.tp_hash = PyArray_DescrHash;
-    Py_SET_TYPE(&PyArrayDescr_Type, &PyArrayDTypeMeta_Type);
+    Py_SET_TYPE(&PyArrayDescr_Type, PyArrayDTypeMeta_TypePtr);
     if (PyType_Ready(&PyArrayDescr_Type) < 0) {
         return -1;
     }
@@ -5248,10 +5248,10 @@ _multiarray_umath_exec(PyObject *m) {
 
     if (PyObject_CallFunction(
             npy_runtime_imports._add_dtype_helper,
-            "Os", (PyObject *)&PyArray_StringDType, NULL) == NULL) {
+            "Os", PyArray_StringDTypePtr, NULL) == NULL) {
         return -1;
     }
-    PyDict_SetItemString(d, "StringDType", (PyObject *)&PyArray_StringDType);
+    PyDict_SetItemString(d, "StringDType", (PyObject *)PyArray_StringDTypePtr);
 
     // initialize static reference to a zero-like array
     npy_static_pydata.zero_pyint_like_arr = PyArray_ZEROS(

--- a/numpy/_core/src/multiarray/public_dtype_api.c
+++ b/numpy/_core/src/multiarray/public_dtype_api.c
@@ -29,7 +29,7 @@ int
 PyArrayInitDTypeMeta_FromSpec(
         PyArray_DTypeMeta *DType, PyArrayDTypeMeta_Spec *spec)
 {
-    if (!PyObject_TypeCheck(DType, &PyArrayDTypeMeta_Type)) {
+    if (!PyObject_TypeCheck(DType, PyArrayDTypeMeta_TypePtr)) {
         PyErr_SetString(PyExc_RuntimeError,
                 "Passed in DType must be a valid (initialized) DTypeMeta "
                 "instance!");
@@ -127,59 +127,59 @@ _fill_dtype_api(void *full_api_table[])
     void **api_table = full_api_table + 320;
 
     /* The type of the DType metaclass */
-    api_table[0] = &PyArrayDTypeMeta_Type;
+    api_table[0] = PyArrayDTypeMeta_TypePtr;
     /* Boolean */
-    api_table[1] = &PyArray_BoolDType;
+    api_table[1] = PyArray_BoolDTypePtr;
     /* Integers */
-    api_table[2] = &PyArray_ByteDType;
-    api_table[3] = &PyArray_UByteDType;
-    api_table[4] = &PyArray_ShortDType;
-    api_table[5] = &PyArray_UShortDType;
-    api_table[6] = &PyArray_IntDType;
-    api_table[7] = &PyArray_UIntDType;
-    api_table[8] = &PyArray_LongDType;
-    api_table[9] = &PyArray_ULongDType;
-    api_table[10] = &PyArray_LongLongDType;
-    api_table[11] = &PyArray_ULongLongDType;
+    api_table[2] = PyArray_ByteDTypePtr;
+    api_table[3] = PyArray_UByteDTypePtr;
+    api_table[4] = PyArray_ShortDTypePtr;
+    api_table[5] = PyArray_UShortDTypePtr;
+    api_table[6] = PyArray_IntDTypePtr;
+    api_table[7] = PyArray_UIntDTypePtr;
+    api_table[8] = PyArray_LongDTypePtr;
+    api_table[9] = PyArray_ULongDTypePtr;
+    api_table[10] = PyArray_LongLongDTypePtr;
+    api_table[11] = PyArray_ULongLongDTypePtr;
     /* Integer aliases */
-    api_table[12] = &PyArray_Int8DType;
-    api_table[13] = &PyArray_UInt8DType;
-    api_table[14] = &PyArray_Int16DType;
-    api_table[15] = &PyArray_UInt16DType;
-    api_table[16] = &PyArray_Int32DType;
-    api_table[17] = &PyArray_UInt32DType;
-    api_table[18] = &PyArray_Int64DType;
-    api_table[19] = &PyArray_UInt64DType;
-    api_table[20] = &PyArray_IntpDType;
-    api_table[21] = &PyArray_UIntpDType;
+    api_table[12] = PyArray_Int8DTypePtr;
+    api_table[13] = PyArray_UInt8DTypePtr;
+    api_table[14] = PyArray_Int16DTypePtr;
+    api_table[15] = PyArray_UInt16DTypePtr;
+    api_table[16] = PyArray_Int32DTypePtr;
+    api_table[17] = PyArray_UInt32DTypePtr;
+    api_table[18] = PyArray_Int64DTypePtr;
+    api_table[19] = PyArray_UInt64DTypePtr;
+    api_table[20] = PyArray_IntpDTypePtr;
+    api_table[21] = PyArray_UIntpDTypePtr;
     /* Floats */
-    api_table[22] = &PyArray_HalfDType;
-    api_table[23] = &PyArray_FloatDType;
-    api_table[24] = &PyArray_DoubleDType;
-    api_table[25] = &PyArray_LongDoubleDType;
+    api_table[22] = PyArray_HalfDTypePtr;
+    api_table[23] = PyArray_FloatDTypePtr;
+    api_table[24] = PyArray_DoubleDTypePtr;
+    api_table[25] = PyArray_LongDoubleDTypePtr;
     /* Complex */
-    api_table[26] = &PyArray_CFloatDType;
-    api_table[27] = &PyArray_CDoubleDType;
-    api_table[28] = &PyArray_CLongDoubleDType;
+    api_table[26] = PyArray_CFloatDTypePtr;
+    api_table[27] = PyArray_CDoubleDTypePtr;
+    api_table[28] = PyArray_CLongDoubleDTypePtr;
     /* String/Bytes */
-    api_table[29] = &PyArray_BytesDType;
-    api_table[30] = &PyArray_UnicodeDType;
+    api_table[29] = PyArray_BytesDTypePtr;
+    api_table[30] = PyArray_UnicodeDTypePtr;
     /* Datetime/Timedelta */
-    api_table[31] = &PyArray_DatetimeDType;
-    api_table[32] = &PyArray_TimedeltaDType;
+    api_table[31] = PyArray_DatetimeDTypePtr;
+    api_table[32] = PyArray_TimedeltaDTypePtr;
     /* Object and Structured */
-    api_table[33] = &PyArray_ObjectDType;
-    api_table[34] = &PyArray_VoidDType;
+    api_table[33] = PyArray_ObjectDTypePtr;
+    api_table[34] = PyArray_VoidDTypePtr;
     /* Abstract */
-    api_table[35] = &PyArray_PyLongDType;
-    api_table[36] = &PyArray_PyFloatDType;
-    api_table[37] = &PyArray_PyComplexDType;
-    api_table[38] = &PyArray_DefaultIntDType;
+    api_table[35] = PyArray_PyLongDTypePtr;
+    api_table[36] = PyArray_PyFloatDTypePtr;
+    api_table[37] = PyArray_PyComplexDTypePtr;
+    api_table[38] = PyArray_DefaultIntDTypePtr;
     /* Non-legacy DTypes that are built in to NumPy */
-    api_table[39] = &PyArray_StringDType;
+    api_table[39] = PyArray_StringDTypePtr;
 
     /* Abstract ones added directly: */
-    full_api_table[366] = &PyArray_IntAbstractDType;
-    full_api_table[367] = &PyArray_FloatAbstractDType;
-    full_api_table[368] = &PyArray_ComplexAbstractDType;
+    full_api_table[366] = PyArray_IntAbstractDTypePtr;
+    full_api_table[367] = PyArray_FloatAbstractDTypePtr;
+    full_api_table[368] = PyArray_ComplexAbstractDTypePtr;
 }

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -931,7 +931,7 @@ static PyType_Slot int2s_slots[] = {
 
 static PyArray_DTypeMeta **
 get_s2type_dtypes(NPY_TYPES typenum) {
-    return get_dtypes(&PyArray_StringDType, typenum_to_dtypemeta(typenum));
+    return get_dtypes(PyArray_StringDTypePtr, typenum_to_dtypemeta(typenum));
 }
 
 template<typename NpyType, typename NpyLongType, NPY_TYPES typenum>
@@ -949,7 +949,7 @@ getStringToIntCastSpec() {
 
 static PyArray_DTypeMeta **
 get_type2s_dtypes(NPY_TYPES typenum) {
-    return get_dtypes(typenum_to_dtypemeta(typenum), &PyArray_StringDType);
+    return get_dtypes(typenum_to_dtypemeta(typenum), PyArray_StringDTypePtr);
 }
 
 template<typename NpyType, typename TClongType, NPY_TYPES typenum>
@@ -2103,8 +2103,8 @@ to_float(double x) {
 NPY_NO_EXPORT PyArrayMethod_Spec **
 get_casts() {
     PyArray_DTypeMeta **t2t_dtypes = get_dtypes(
-        &PyArray_StringDType,
-        &PyArray_StringDType
+        PyArray_StringDTypePtr,
+        PyArray_StringDTypePtr
     );
 
     PyArrayMethod_Spec *ThisToThisCastSpec = get_cast_spec(
@@ -2131,7 +2131,7 @@ get_casts() {
 #endif
 
     PyArray_DTypeMeta **u2s_dtypes = get_dtypes(
-            &PyArray_UnicodeDType, &PyArray_StringDType);
+            PyArray_UnicodeDTypePtr, PyArray_StringDTypePtr);
 
     PyArrayMethod_Spec *UnicodeToStringCastSpec = get_cast_spec(
         make_type2s_name(NPY_UNICODE),
@@ -2142,7 +2142,7 @@ get_casts() {
     );
 
     PyArray_DTypeMeta **s2u_dtypes = get_dtypes(
-            &PyArray_StringDType, &PyArray_UnicodeDType);
+            PyArray_StringDTypePtr, PyArray_UnicodeDTypePtr);
 
     PyArrayMethod_Spec *StringToUnicodeCastSpec = get_cast_spec(
         make_s2type_name(NPY_UNICODE),
@@ -2153,7 +2153,7 @@ get_casts() {
     );
 
     PyArray_DTypeMeta **s2b_dtypes =
-            get_dtypes(&PyArray_StringDType, &PyArray_BoolDType);
+            get_dtypes(PyArray_StringDTypePtr, PyArray_BoolDTypePtr);
 
     PyArrayMethod_Spec *StringToBoolCastSpec = get_cast_spec(
         make_s2type_name(NPY_BOOL),
@@ -2164,7 +2164,7 @@ get_casts() {
     );
 
     PyArray_DTypeMeta **b2s_dtypes =
-            get_dtypes(&PyArray_BoolDType, &PyArray_StringDType);
+            get_dtypes(PyArray_BoolDTypePtr, PyArray_StringDTypePtr);
 
     PyArrayMethod_Spec *BoolToStringCastSpec = get_cast_spec(
         make_type2s_name(NPY_BOOL),
@@ -2175,7 +2175,7 @@ get_casts() {
     );
 
     PyArray_DTypeMeta **s2dt_dtypes = get_dtypes(
-            &PyArray_StringDType, &PyArray_DatetimeDType);
+            PyArray_StringDTypePtr, PyArray_DatetimeDTypePtr);
 
     PyArrayMethod_Spec *StringToDatetimeCastSpec = get_cast_spec(
         make_s2type_name(NPY_DATETIME),
@@ -2186,7 +2186,7 @@ get_casts() {
     );
 
     PyArray_DTypeMeta **dt2s_dtypes = get_dtypes(
-            &PyArray_DatetimeDType, &PyArray_StringDType);
+            PyArray_DatetimeDTypePtr, PyArray_StringDTypePtr);
 
     PyArrayMethod_Spec *DatetimeToStringCastSpec = get_cast_spec(
         make_type2s_name(NPY_DATETIME),
@@ -2197,7 +2197,7 @@ get_casts() {
     );
 
     PyArray_DTypeMeta **s2td_dtypes = get_dtypes(
-            &PyArray_StringDType, &PyArray_TimedeltaDType);
+            PyArray_StringDTypePtr, PyArray_TimedeltaDTypePtr);
 
     PyArrayMethod_Spec *StringToTimedeltaCastSpec = get_cast_spec(
         make_s2type_name(NPY_TIMEDELTA),
@@ -2208,7 +2208,7 @@ get_casts() {
     );
 
     PyArray_DTypeMeta **td2s_dtypes = get_dtypes(
-            &PyArray_TimedeltaDType, &PyArray_StringDType);
+            PyArray_TimedeltaDTypePtr, PyArray_StringDTypePtr);
 
     PyArrayMethod_Spec *TimedeltaToStringCastSpec = get_cast_spec(
         make_type2s_name(NPY_TIMEDELTA),
@@ -2219,7 +2219,7 @@ get_casts() {
     );
 
     PyArray_DTypeMeta **s2v_dtypes = get_dtypes(
-            &PyArray_StringDType, &PyArray_VoidDType);
+            PyArray_StringDTypePtr, PyArray_VoidDTypePtr);
 
     PyArrayMethod_Spec *StringToVoidCastSpec = get_cast_spec(
         make_s2type_name(NPY_VOID),
@@ -2230,7 +2230,7 @@ get_casts() {
     );
 
     PyArray_DTypeMeta **v2s_dtypes = get_dtypes(
-            &PyArray_VoidDType, &PyArray_StringDType);
+            PyArray_VoidDTypePtr, PyArray_StringDTypePtr);
 
     PyArrayMethod_Spec *VoidToStringCastSpec = get_cast_spec(
         make_type2s_name(NPY_VOID),
@@ -2241,7 +2241,7 @@ get_casts() {
     );
 
     PyArray_DTypeMeta **s2bytes_dtypes = get_dtypes(
-            &PyArray_StringDType, &PyArray_BytesDType);
+            PyArray_StringDTypePtr, PyArray_BytesDTypePtr);
 
     PyArrayMethod_Spec *StringToBytesCastSpec = get_cast_spec(
         make_s2type_name(NPY_BYTE),
@@ -2252,7 +2252,7 @@ get_casts() {
     );
 
     PyArray_DTypeMeta **bytes2s_dtypes = get_dtypes(
-            &PyArray_BytesDType, &PyArray_StringDType);
+            PyArray_BytesDTypePtr, PyArray_StringDTypePtr);
 
     PyArrayMethod_Spec *BytesToStringCastSpec = get_cast_spec(
         make_type2s_name(NPY_BYTE),

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -27,7 +27,7 @@ PyObject *
 new_stringdtype_instance(PyObject *na_object, int coerce)
 {
     PyObject *new =
-            PyArrayDescr_Type.tp_new((PyTypeObject *)&PyArray_StringDType, NULL, NULL);
+            PyArrayDescr_Type.tp_new((PyTypeObject *)PyArray_StringDTypePtr, NULL, NULL);
 
     if (new == NULL) {
         return NULL;
@@ -941,11 +941,12 @@ PyArray_DTypeMeta PyArray_StringDType = {
         }},
         /* rest, filled in during DTypeMeta initialization */
 };
+NPY_NO_EXPORT PyArray_DTypeMeta *PyArray_StringDTypePtr = &PyArray_StringDType;
 
 NPY_NO_EXPORT int
 init_stringdtype_sorts(void)
 {
-    PyArray_DTypeMeta *stringdtype = &PyArray_StringDType;
+    PyArray_DTypeMeta *stringdtype = PyArray_StringDTypePtr;
 
     PyArray_DTypeMeta *sort_dtypes[2] = {stringdtype, stringdtype};
     PyType_Slot sort_slots[4] = {
@@ -972,7 +973,7 @@ init_stringdtype_sorts(void)
     Py_INCREF(sort_method->method);
     Py_DECREF(sort_method);
 
-    PyArray_DTypeMeta *argsort_dtypes[2] = {stringdtype, &PyArray_IntpDType};
+    PyArray_DTypeMeta *argsort_dtypes[2] = {stringdtype, PyArray_IntpDTypePtr};
     PyType_Slot argsort_slots[3] = {
             {NPY_METH_get_loop, &stringdtype_get_argsort_loop},
             {_NPY_METH_static_data, &_sort_compare},
@@ -1011,19 +1012,19 @@ init_string_dtype(void)
     };
 
     /* Loaded dynamically, so needs to be set here: */
-    ((PyObject *)&PyArray_StringDType)->ob_type = &PyArrayDTypeMeta_Type;
-    ((PyTypeObject *)&PyArray_StringDType)->tp_base = &PyArrayDescr_Type;
-    if (PyType_Ready((PyTypeObject *)&PyArray_StringDType) < 0) {
+    ((PyObject *)PyArray_StringDTypePtr)->ob_type = PyArrayDTypeMeta_TypePtr;
+    ((PyTypeObject *)PyArray_StringDTypePtr)->tp_base = &PyArrayDescr_Type;
+    if (PyType_Ready((PyTypeObject *)PyArray_StringDTypePtr) < 0) {
         return -1;
     }
 
     if (dtypemeta_initialize_struct_from_spec(
-                &PyArray_StringDType, &PyArray_StringDType_DTypeSpec, 1) < 0) {
+                PyArray_StringDTypePtr, &PyArray_StringDType_DTypeSpec, 1) < 0) {
         return -1;
     }
 
     PyArray_StringDTypeObject *singleton =
-            (PyArray_StringDTypeObject *)NPY_DT_CALL_default_descr(&PyArray_StringDType);
+            (PyArray_StringDTypeObject *)NPY_DT_CALL_default_descr(PyArray_StringDTypePtr);
 
     if (singleton == NULL) {
         return -1;

--- a/numpy/_core/src/multiarray/stringdtype/static_string.c
+++ b/numpy/_core/src/multiarray/stringdtype/static_string.c
@@ -324,7 +324,7 @@ NpyString_acquire_allocators(size_t n_descriptors,
                              npy_string_allocator *allocators[])
 {
     for (size_t i=0; i<n_descriptors; i++) {
-        if (NPY_DTYPE(descrs[i]) != &PyArray_StringDType) {
+        if (NPY_DTYPE(descrs[i]) != PyArray_StringDTypePtr) {
             allocators[i] = NULL;
             continue;
         }

--- a/numpy/_core/src/umath/_scaled_float_dtype.c
+++ b/numpy/_core/src/umath/_scaled_float_dtype.c
@@ -35,6 +35,7 @@ typedef struct {
 
 static PyArray_DTypeMeta PyArray_SFloatDType;
 static PyArray_SFloatDescr SFloatSingleton;
+static PyArray_DTypeMeta *PyArray_SFloatDTypePtr;
 
 
 static int
@@ -150,10 +151,11 @@ static PyArray_SFloatDescr SFloatSingleton = {{
 };
 
 
+
 static PyArray_Descr *
 sfloat_scaled_copy(PyArray_SFloatDescr *self, double factor) {
     PyArray_SFloatDescr *new = PyObject_New(
-            PyArray_SFloatDescr, (PyTypeObject *)&PyArray_SFloatDType);
+            PyArray_SFloatDescr, (PyTypeObject *)PyArray_SFloatDTypePtr);
     if (new == NULL) {
         return NULL;
     }
@@ -253,6 +255,7 @@ static PyArray_DTypeMeta PyArray_SFloatDType = {{{
     .flags = NPY_DT_PARAMETRIC | NPY_DT_NUMERIC,
     .dt_slots = &sfloat_slots,
 };
+static PyArray_DTypeMeta *PyArray_SFloatDTypePtr = &PyArray_SFloatDType;
 
 
 /*
@@ -448,7 +451,7 @@ sfloat_to_bool_resolve_descriptors(
 static int
 sfloat_init_casts(void)
 {
-    PyArray_DTypeMeta *dtypes[2] = {&PyArray_SFloatDType, &PyArray_SFloatDType};
+    PyArray_DTypeMeta *dtypes[2] = {PyArray_SFloatDTypePtr, PyArray_SFloatDTypePtr};
     PyType_Slot slots[4] = {{0, NULL}};
     PyArrayMethod_Spec spec = {
         .name = "sfloat_to_sfloat_cast",
@@ -477,7 +480,7 @@ sfloat_init_casts(void)
     spec.name = "float_to_sfloat_cast";
     /* Technically, it is just a copy currently so this is fine: */
     spec.flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
-    PyArray_DTypeMeta *double_DType = &PyArray_DoubleDType;
+    PyArray_DTypeMeta *double_DType = PyArray_DoubleDTypePtr;
     dtypes[0] = double_DType;
 
     slots[0].slot = NPY_METH_resolve_descriptors;
@@ -492,7 +495,7 @@ sfloat_init_casts(void)
     }
 
     spec.name = "sfloat_to_float_cast";
-    dtypes[0] = &PyArray_SFloatDType;
+    dtypes[0] = PyArray_SFloatDTypePtr;
     dtypes[1] = double_DType;
 
     if (PyArray_AddCastingImplementation_FromSpec(&spec, 0)) {
@@ -507,8 +510,8 @@ sfloat_init_casts(void)
     slots[2].pfunc = NULL;
 
     spec.name = "sfloat_to_bool_cast";
-    dtypes[0] = &PyArray_SFloatDType;
-    dtypes[1] = &PyArray_BoolDType;
+    dtypes[0] = PyArray_SFloatDTypePtr;
+    dtypes[1] = PyArray_BoolDTypePtr;
 
     if (PyArray_AddCastingImplementation_FromSpec(&spec, 0)) {
         return -1;
@@ -745,7 +748,7 @@ sfloat_add_wrapping_loop(const char *ufunc_name, PyArray_DTypeMeta *dtypes[3])
     if (ufunc == NULL) {
         return -1;
     }
-    PyArray_DTypeMeta *double_dt = &PyArray_DoubleDType;
+    PyArray_DTypeMeta *double_dt = PyArray_DoubleDTypePtr;
     PyArray_DTypeMeta *wrapped_dtypes[3] = {double_dt, double_dt, double_dt};
     int res = PyUFunc_AddWrappingLoop(
         ufunc, dtypes, wrapped_dtypes, &translate_given_descrs_to_double,
@@ -766,7 +769,7 @@ promote_to_sfloat(PyUFuncObject *NPY_UNUSED(ufunc),
         PyArray_DTypeMeta *new_dtypes[3])
 {
     for (int i = 0; i < 3; i++) {
-        PyArray_DTypeMeta *new = &PyArray_SFloatDType;
+        PyArray_DTypeMeta *new = PyArray_SFloatDTypePtr;
         if (signature[i] != NULL) {
             new = signature[i];
         }
@@ -961,7 +964,7 @@ sfloat_argsort_resolve_descriptors(
 static int
 sfloat_init_ufuncs(void) {
     PyArray_DTypeMeta *all_sfloat_dtypes[3] = {
-            &PyArray_SFloatDType, &PyArray_SFloatDType, &PyArray_SFloatDType};
+            PyArray_SFloatDTypePtr, PyArray_SFloatDTypePtr, PyArray_SFloatDTypePtr};
     PyType_Slot multiply_slots[3] = {
         {NPY_METH_resolve_descriptors, &multiply_sfloats_resolve_descriptors},
         {NPY_METH_strided_loop, &multiply_sfloats},
@@ -990,7 +993,7 @@ sfloat_init_ufuncs(void) {
         .casting = NPY_SAME_KIND_CASTING,
     };
 
-    PyArray_DTypeMeta *sort_dtypes[2] = {&PyArray_SFloatDType, &PyArray_SFloatDType};
+    PyArray_DTypeMeta *sort_dtypes[2] = {PyArray_SFloatDTypePtr, PyArray_SFloatDTypePtr};
     PyType_Slot sort_slots[3] = {
         {NPY_METH_resolve_descriptors, &sfloat_sort_resolve_descriptors},
         {NPY_METH_get_loop, &sfloat_sort_get_loop},
@@ -1006,7 +1009,7 @@ sfloat_init_ufuncs(void) {
     sort_spec.casting = NPY_NO_CASTING;
     sort_spec.flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
 
-    PyArray_DTypeMeta *argsort_dtypes[2] = {&PyArray_SFloatDType, &PyArray_IntpDType};
+    PyArray_DTypeMeta *argsort_dtypes[2] = {PyArray_SFloatDTypePtr, PyArray_IntpDTypePtr};
     PyType_Slot argsort_slots[3] = {
         {NPY_METH_resolve_descriptors, &sfloat_argsort_resolve_descriptors},
         {NPY_METH_get_loop, &sfloat_argsort_get_loop},
@@ -1044,10 +1047,10 @@ sfloat_init_ufuncs(void) {
      * Add a promoter for both directions of multiply with double.
      */
     int res = -1;
-    PyArray_DTypeMeta *double_DType = &PyArray_DoubleDType;
+    PyArray_DTypeMeta *double_DType = PyArray_DoubleDTypePtr;
 
     PyArray_DTypeMeta *promoter_dtypes[3] = {
-            &PyArray_SFloatDType, double_DType, NULL};
+            PyArray_SFloatDTypePtr, double_DType, NULL};
 
     PyObject *promoter = PyCapsule_New(
             &promote_to_sfloat, "numpy._ufunc_promoter", NULL);
@@ -1060,7 +1063,7 @@ sfloat_init_ufuncs(void) {
         return -1;
     }
     promoter_dtypes[0] = double_DType;
-    promoter_dtypes[1] = &PyArray_SFloatDType;
+    promoter_dtypes[1] = PyArray_SFloatDTypePtr;
     res = sfloat_add_loop("multiply", promoter_dtypes, promoter);
     Py_DECREF(promoter);
     if (res < 0) {
@@ -1079,22 +1082,22 @@ NPY_NO_EXPORT PyObject *
 get_sfloat_dtype(PyObject *NPY_UNUSED(mod), PyObject *NPY_UNUSED(args))
 {
     if (npy_global_state.get_sfloat_dtype_initialized) {
-        Py_INCREF(&PyArray_SFloatDType);
-        return (PyObject *)&PyArray_SFloatDType;
+        Py_INCREF(PyArray_SFloatDTypePtr);
+        return (PyObject *)PyArray_SFloatDTypePtr;
     }
 
     PyArray_SFloatDType.super.ht_type.tp_base = &PyArrayDescr_Type;
 
-    if (PyType_Ready((PyTypeObject *)&PyArray_SFloatDType) < 0) {
+    if (PyType_Ready((PyTypeObject *)PyArray_SFloatDTypePtr) < 0) {
         return NULL;
     }
-    NPY_DT_SLOTS(&PyArray_SFloatDType)->castingimpls = PyDict_New();
-    if (NPY_DT_SLOTS(&PyArray_SFloatDType)->castingimpls == NULL) {
+    NPY_DT_SLOTS(PyArray_SFloatDTypePtr)->castingimpls = PyDict_New();
+    if (NPY_DT_SLOTS(PyArray_SFloatDTypePtr)->castingimpls == NULL) {
         return NULL;
     }
 
     PyObject *o = PyObject_Init(
-            (PyObject *)&SFloatSingleton, (PyTypeObject *)&PyArray_SFloatDType);
+            (PyObject *)&SFloatSingleton, (PyTypeObject *)PyArray_SFloatDTypePtr);
     if (o == NULL) {
         return NULL;
     }
@@ -1108,5 +1111,5 @@ get_sfloat_dtype(PyObject *NPY_UNUSED(mod), PyObject *NPY_UNUSED(args))
     }
 
     npy_global_state.get_sfloat_dtype_initialized = NPY_TRUE;
-    return (PyObject *)&PyArray_SFloatDType;
+    return (PyObject *)PyArray_SFloatDTypePtr;
 }

--- a/numpy/_core/src/umath/_umath_tests.c.src
+++ b/numpy/_core/src/umath/_umath_tests.c.src
@@ -13,7 +13,7 @@
 #undef NPY_INTERNAL_BUILD
 #endif
 // for add_INT32_negative_indexed
-#define NPY_TARGET_VERSION NPY_2_1_API_VERSION
+#define NPY_TARGET_VERSION NPY_2_5_API_VERSION
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
 #include "numpy/ndarrayobject.h"
@@ -742,7 +742,7 @@ add_INT32_negative_indexed(PyObject *module, PyObject *dict) {
     if (negative == NULL) {
         return -1;
     }
-    PyArray_DTypeMeta *dtypes[] = {&PyArray_Int32DType, &PyArray_Int32DType};
+    PyArray_DTypeMeta *dtypes[] = {PyArray_Int32DTypePtr, PyArray_Int32DTypePtr};
 
     PyType_Slot slots[] = {
         {NPY_METH_contiguous_indexed_loop, INT32_negative_indexed},

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -100,7 +100,7 @@ PyUFunc_AddLoop(PyUFuncObject *ufunc, PyObject *info, int ignore_duplicate)
     for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(DType_tuple); i++) {
         PyObject *item = PyTuple_GET_ITEM(DType_tuple, i);
         if (item != Py_None
-                && !PyObject_TypeCheck(item, &PyArrayDTypeMeta_Type)) {
+                && !PyObject_TypeCheck(item, PyArrayDTypeMeta_TypePtr)) {
             PyErr_SetString(PyExc_TypeError,
                     "DType tuple may only contain None and DType classes");
             return -1;
@@ -1253,7 +1253,7 @@ object_only_ufunc_promoter(PyObject *ufunc,
         PyArray_DTypeMeta *signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
-    PyArray_DTypeMeta *object_DType = &PyArray_ObjectDType;
+    PyArray_DTypeMeta *object_DType = PyArray_ObjectDTypePtr;
 
     for (int i = 0; i < ((PyUFuncObject *)ufunc)->nargs; i++) {
         if (signature[i] == NULL) {
@@ -1294,7 +1294,7 @@ logical_ufunc_promoter(PyObject *NPY_UNUSED(ufunc),
         }
         else {
             /* Always override to boolean */
-            item = &PyArray_BoolDType;
+            item = PyArray_BoolDTypePtr;
             Py_INCREF(item);
             if (op_dtypes[i] != NULL && op_dtypes[i]->type_num == NPY_OBJECT) {
                 force_object = 1;
@@ -1319,7 +1319,7 @@ logical_ufunc_promoter(PyObject *NPY_UNUSED(ufunc),
         if (signature[i] != NULL) {
             continue;
         }
-        Py_SETREF(new_op_dtypes[i], NPY_DT_NewRef(&PyArray_ObjectDType));
+        Py_SETREF(new_op_dtypes[i], NPY_DT_NewRef(PyArray_ObjectDTypePtr));
     }
     return 0;
 }

--- a/numpy/_core/src/umath/real_imag_ufuncs.cpp
+++ b/numpy/_core/src/umath/real_imag_ufuncs.cpp
@@ -168,7 +168,7 @@ template <auto component>
 static int
 register_one_object_loop(const char *name)
 {
-    PyArray_DTypeMeta *dtypes[2] = {&PyArray_ObjectDType, &PyArray_ObjectDType};
+    PyArray_DTypeMeta *dtypes[2] = {PyArray_ObjectDTypePtr, PyArray_ObjectDTypePtr};
     PyType_Slot meth_slots[] = {
         {NPY_METH_strided_loop, (void *)&object_get_comp_strided_loop<component>},
         {0, nullptr}
@@ -261,13 +261,13 @@ init_real_imag_ufuncs(PyObject *umath)
         goto finish;
     }
 
-    if (register_both_for_type<npy_float32>(&PyArray_CFloatDType, &PyArray_FloatDType) < 0) {
+    if (register_both_for_type<npy_float32>(PyArray_CFloatDTypePtr, PyArray_FloatDTypePtr) < 0) {
         goto finish;
     }
-    if (register_both_for_type<npy_float64>(&PyArray_CDoubleDType, &PyArray_DoubleDType) < 0) {
+    if (register_both_for_type<npy_float64>(PyArray_CDoubleDTypePtr, PyArray_DoubleDTypePtr) < 0) {
         goto finish;
     }
-    if (register_both_for_type<npy_longdouble>(&PyArray_CLongDoubleDType, &PyArray_LongDoubleDType) < 0) {
+    if (register_both_for_type<npy_longdouble>(PyArray_CLongDoubleDTypePtr, PyArray_LongDoubleDTypePtr) < 0) {
         goto finish;
     }
     if (register_one_object_loop<&npy_interned_str_struct::real>("real") < 0) {

--- a/numpy/_core/src/umath/special_integer_comparisons.cpp
+++ b/numpy/_core/src/umath/special_integer_comparisons.cpp
@@ -177,7 +177,7 @@ resolve_descriptors_with_scalars(
 {
     int value_range = 0;
 
-    npy_bool first_is_pyint = dtypes[0] == &PyArray_PyLongDType;
+    npy_bool first_is_pyint = dtypes[0] == PyArray_PyLongDTypePtr;
     int arr_idx = first_is_pyint? 1 : 0;
     int scalar_idx = first_is_pyint? 0 : 1;
     PyObject *scalar = input_scalars[scalar_idx];
@@ -310,9 +310,9 @@ pyint_comparison_promoter(PyUFuncObject *NPY_UNUSED(ufunc),
         PyArray_DTypeMeta *op_dtypes[], PyArray_DTypeMeta *signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
-    new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_ObjectDType);
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_ObjectDType);
-    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_BoolDType);
+    new_op_dtypes[0] = NPY_DT_NewRef(PyArray_ObjectDTypePtr);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_ObjectDTypePtr);
+    new_op_dtypes[2] = NPY_DT_NewRef(PyArray_BoolDTypePtr);
     return 0;
 }
 
@@ -327,7 +327,7 @@ template<COMP comp>
 static int
 add_dtype_loops(PyObject *umath, PyArrayMethod_Spec *spec, PyObject *info)
 {
-    PyArray_DTypeMeta *PyInt = &PyArray_PyLongDType;
+    PyArray_DTypeMeta *PyInt = PyArray_PyLongDTypePtr;
 
     PyObject *name = PyUnicode_FromString(comp_name(comp));
     if (name == nullptr) {
@@ -413,7 +413,7 @@ init_special_int_comparisons(PyObject *umath)
 {
     int res = -1;
     PyObject *info = NULL, *promoter = NULL;
-    PyArray_DTypeMeta *Bool = &PyArray_BoolDType;
+    PyArray_DTypeMeta *Bool = PyArray_BoolDTypePtr;
 
     /* All loops have a boolean out DType (others filled in later) */
     PyArray_DTypeMeta *dtypes[] = {NULL, NULL, Bool};
@@ -441,7 +441,7 @@ init_special_int_comparisons(PyObject *umath)
      * `np.equal(2, 4)` (with two python integers) use an object loop.
      */
     PyObject *dtype_tuple = PyTuple_Pack(3,
-            &PyArray_PyLongDType, &PyArray_PyLongDType, Bool);
+            PyArray_PyLongDTypePtr, PyArray_PyLongDTypePtr, Bool);
     if (dtype_tuple == NULL) {
         goto finish;
     }

--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -857,8 +857,8 @@ string_findlike_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[0] = op_dtypes[0];
     Py_INCREF(op_dtypes[1]);
     new_op_dtypes[1] = op_dtypes[1];
-    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_Int64DType);
-    new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_Int64DType);
+    new_op_dtypes[2] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
+    new_op_dtypes[3] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
     new_op_dtypes[4] = PyArray_DTypeFromTypeNum(NPY_DEFAULT_INT);
     return 0;
 }
@@ -933,9 +933,9 @@ string_startswith_endswith_promoter(PyObject *NPY_UNUSED(ufunc),
     new_op_dtypes[0] = op_dtypes[0];
     Py_INCREF(op_dtypes[1]);
     new_op_dtypes[1] = op_dtypes[1];
-    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_Int64DType);
-    new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_Int64DType);
-    new_op_dtypes[4] = NPY_DT_NewRef(&PyArray_BoolDType);
+    new_op_dtypes[2] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
+    new_op_dtypes[3] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
+    new_op_dtypes[4] = NPY_DT_NewRef(PyArray_BoolDTypePtr);
     return 0;
 }
 
@@ -947,7 +947,7 @@ string_expandtabs_length_promoter(PyObject *NPY_UNUSED(ufunc),
 {
     Py_XINCREF(op_dtypes[0]);
     new_op_dtypes[0] = op_dtypes[0];
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_Int64DType);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
     new_op_dtypes[2] = PyArray_DTypeFromTypeNum(NPY_DEFAULT_INT);
     return 0;
 }
@@ -960,7 +960,7 @@ string_expandtabs_promoter(PyObject *NPY_UNUSED(ufunc),
 {
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[0] = op_dtypes[0];
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_Int64DType);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[2] = op_dtypes[0];
     return 0;
@@ -1008,7 +1008,7 @@ string_center_ljust_rjust_promoter(PyObject *NPY_UNUSED(ufunc),
 {
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[0] = op_dtypes[0];
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_Int64DType);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[2] = op_dtypes[0];
     Py_INCREF(op_dtypes[0]);
@@ -1063,7 +1063,7 @@ string_zfill_promoter(PyObject *NPY_UNUSED(ufunc),
 {
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[0] = op_dtypes[0];
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_Int64DType);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[2] = op_dtypes[0];
     return 0;
@@ -1114,7 +1114,7 @@ string_partition_promoter(PyObject *NPY_UNUSED(ufunc),
     Py_INCREF(op_dtypes[1]);
     new_op_dtypes[1] = op_dtypes[1];
 
-    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_Int64DType);
+    new_op_dtypes[2] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
 
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[3] = op_dtypes[0];
@@ -1160,9 +1160,9 @@ string_slice_promoter(PyObject *NPY_UNUSED(ufunc),
 {
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[0] = op_dtypes[0];
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_IntpDType);
-    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_IntpDType);
-    new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_IntpDType);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_IntpDTypePtr);
+    new_op_dtypes[2] = NPY_DT_NewRef(PyArray_IntpDTypePtr);
+    new_op_dtypes[3] = NPY_DT_NewRef(PyArray_IntpDTypePtr);
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[4] = op_dtypes[0];
     return 0;
@@ -1278,9 +1278,9 @@ static int
 init_comparison(PyObject *umath)
 {
     int res = -1;
-    PyArray_DTypeMeta *String = &PyArray_BytesDType;
-    PyArray_DTypeMeta *Unicode = &PyArray_UnicodeDType;
-    PyArray_DTypeMeta *Bool = &PyArray_BoolDType;
+    PyArray_DTypeMeta *String = PyArray_BytesDTypePtr;
+    PyArray_DTypeMeta *Unicode = PyArray_UnicodeDTypePtr;
+    PyArray_DTypeMeta *Bool = PyArray_BoolDTypePtr;
 
     /* We start with the string loops: */
     PyArray_DTypeMeta *dtypes[] = {String, String, Bool};
@@ -1371,10 +1371,10 @@ init_ufunc(PyObject *umath, const char *name, int nin, int nout,
 
     for (int i = 0; i < nin+nout; i++) {
         if (typenums[i] == NPY_OBJECT && enc == ENCODING::UTF32) {
-            dtypes[i] = NPY_DT_NewRef(&PyArray_UnicodeDType);
+            dtypes[i] = NPY_DT_NewRef(PyArray_UnicodeDTypePtr);
         }
         else if (typenums[i] == NPY_OBJECT && enc == ENCODING::ASCII) {
-            dtypes[i] = NPY_DT_NewRef(&PyArray_BytesDType);
+            dtypes[i] = NPY_DT_NewRef(PyArray_BytesDTypePtr);
         }
         else {
             dtypes[i] = PyArray_DTypeFromTypeNum(typenums[i]);

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -53,7 +53,7 @@ multiply_resolve_descriptors(
     PyArray_StringDTypeObject *odescr = NULL;
     PyArray_Descr *out_descr = NULL;
 
-    if (dtypes[0] == &PyArray_StringDType) {
+    if (dtypes[0] == PyArray_StringDTypePtr) {
         odescr = (PyArray_StringDTypeObject *)ldescr;
     }
     else {
@@ -769,10 +769,10 @@ string_findlike_promoter(PyObject *NPY_UNUSED(ufunc),
         PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
-    new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_StringDType);
-    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_Int64DType);
-    new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_Int64DType);
+    new_op_dtypes[0] = NPY_DT_NewRef(PyArray_StringDTypePtr);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_StringDTypePtr);
+    new_op_dtypes[2] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
+    new_op_dtypes[3] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
     new_op_dtypes[4] = PyArray_DTypeFromTypeNum(NPY_DEFAULT_INT);
     return 0;
 }
@@ -818,10 +818,10 @@ string_startswith_endswith_promoter(
         PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
-    new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_StringDType);
-    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_Int64DType);
-    new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_Int64DType);
+    new_op_dtypes[0] = NPY_DT_NewRef(PyArray_StringDTypePtr);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_StringDTypePtr);
+    new_op_dtypes[2] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
+    new_op_dtypes[3] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
     new_op_dtypes[4] = PyArray_DTypeFromTypeNum(NPY_BOOL);
     return 0;
 }
@@ -1030,28 +1030,28 @@ all_strings_promoter(PyObject *NPY_UNUSED(ufunc),
                      PyArray_DTypeMeta *const signature[],
                      PyArray_DTypeMeta *new_op_dtypes[])
 {
-    if ((op_dtypes[0] != &PyArray_StringDType &&
-         op_dtypes[1] != &PyArray_StringDType &&
-         op_dtypes[2] != &PyArray_StringDType)) {
+    if ((op_dtypes[0] != PyArray_StringDTypePtr &&
+         op_dtypes[1] != PyArray_StringDTypePtr &&
+         op_dtypes[2] != PyArray_StringDTypePtr)) {
         /*
          * This promoter was triggered with only unicode arguments, so use
          * unicode.  This can happen due to `dtype=` support which sets the
          * output DType/signature.
          */
-        new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_UnicodeDType);
-        new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_UnicodeDType);
-        new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_UnicodeDType);
+        new_op_dtypes[0] = NPY_DT_NewRef(PyArray_UnicodeDTypePtr);
+        new_op_dtypes[1] = NPY_DT_NewRef(PyArray_UnicodeDTypePtr);
+        new_op_dtypes[2] = NPY_DT_NewRef(PyArray_UnicodeDTypePtr);
         return 0;
     }
-    if ((signature[0] == &PyArray_UnicodeDType &&
-         signature[1] == &PyArray_UnicodeDType &&
-         signature[2] == &PyArray_UnicodeDType)) {
+    if ((signature[0] == PyArray_UnicodeDTypePtr &&
+         signature[1] == PyArray_UnicodeDTypePtr &&
+         signature[2] == PyArray_UnicodeDTypePtr)) {
         /* Unicode forced, but didn't override a string input: invalid */
         return -1;
     }
-    new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_StringDType);
-    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_StringDType);
+    new_op_dtypes[0] = NPY_DT_NewRef(PyArray_StringDTypePtr);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_StringDTypePtr);
+    new_op_dtypes[2] = NPY_DT_NewRef(PyArray_StringDTypePtr);
     return 0;
 }
 
@@ -1278,11 +1278,11 @@ string_replace_promoter(PyObject *NPY_UNUSED(ufunc),
                         PyArray_DTypeMeta *const signature[],
                         PyArray_DTypeMeta *new_op_dtypes[])
 {
-    new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_StringDType);
-    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_StringDType);
-    new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_Int64DType);
-    new_op_dtypes[4] = NPY_DT_NewRef(&PyArray_StringDType);
+    new_op_dtypes[0] = NPY_DT_NewRef(PyArray_StringDTypePtr);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_StringDTypePtr);
+    new_op_dtypes[2] = NPY_DT_NewRef(PyArray_StringDTypePtr);
+    new_op_dtypes[3] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
+    new_op_dtypes[4] = NPY_DT_NewRef(PyArray_StringDTypePtr);
     return 0;
 }
 
@@ -1607,10 +1607,10 @@ string_center_ljust_rjust_promoter(
         PyArray_DTypeMeta *const signature[],
         PyArray_DTypeMeta *new_op_dtypes[])
 {
-    new_op_dtypes[0] = NPY_DT_NewRef(&PyArray_StringDType);
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_Int64DType);
-    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_StringDType);
-    new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_StringDType);
+    new_op_dtypes[0] = NPY_DT_NewRef(PyArray_StringDTypePtr);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_Int64DTypePtr);
+    new_op_dtypes[2] = NPY_DT_NewRef(PyArray_StringDTypePtr);
+    new_op_dtypes[3] = NPY_DT_NewRef(PyArray_StringDTypePtr);
     return 0;
 }
 
@@ -2151,9 +2151,9 @@ slice_promoter(PyObject *NPY_UNUSED(ufunc),
 {
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[0] = op_dtypes[0];
-    new_op_dtypes[1] = NPY_DT_NewRef(&PyArray_IntpDType);
-    new_op_dtypes[2] = NPY_DT_NewRef(&PyArray_IntpDType);
-    new_op_dtypes[3] = NPY_DT_NewRef(&PyArray_IntpDType);
+    new_op_dtypes[1] = NPY_DT_NewRef(PyArray_IntpDTypePtr);
+    new_op_dtypes[2] = NPY_DT_NewRef(PyArray_IntpDTypePtr);
+    new_op_dtypes[3] = NPY_DT_NewRef(PyArray_IntpDTypePtr);
     Py_INCREF(op_dtypes[0]);
     new_op_dtypes[4] = op_dtypes[0];
     return 0;
@@ -2330,7 +2330,7 @@ string_object_bool_output_promoter(
 {
     return string_inputs_promoter(
             ufunc, op_dtypes, signature,
-            new_op_dtypes, &PyArray_ObjectDType, &PyArray_BoolDType);
+            new_op_dtypes, PyArray_ObjectDTypePtr, PyArray_BoolDTypePtr);
 }
 
 static int
@@ -2341,74 +2341,74 @@ string_unicode_bool_output_promoter(
 {
     return string_inputs_promoter(
             ufunc, op_dtypes, signature,
-            new_op_dtypes, &PyArray_StringDType, &PyArray_BoolDType);
+            new_op_dtypes, PyArray_StringDTypePtr, PyArray_BoolDTypePtr);
 }
 
 static int
 is_integer_dtype(PyArray_DTypeMeta *DType)
 {
-    if (DType == &PyArray_PyLongDType) {
+    if (DType == PyArray_PyLongDTypePtr) {
         return 1;
     }
-    else if (DType == &PyArray_Int8DType) {
+    else if (DType == PyArray_Int8DTypePtr) {
         return 1;
     }
-    else if (DType == &PyArray_Int16DType) {
+    else if (DType == PyArray_Int16DTypePtr) {
         return 1;
     }
-    else if (DType == &PyArray_Int32DType) {
+    else if (DType == PyArray_Int32DTypePtr) {
         return 1;
     }
     // int64 already has a loop registered for it,
     // so don't need to consider it
 #if NPY_SIZEOF_BYTE == NPY_SIZEOF_SHORT
-    else if (DType == &PyArray_ByteDType) {
+    else if (DType == PyArray_ByteDTypePtr) {
         return 1;
     }
 #endif
 #if NPY_SIZEOF_SHORT == NPY_SIZEOF_INT
-    else if (DType == &PyArray_ShortDType) {
+    else if (DType == PyArray_ShortDTypePtr) {
         return 1;
     }
 #endif
 #if NPY_SIZEOF_INT == NPY_SIZEOF_LONG
-    else if (DType == &PyArray_IntDType) {
+    else if (DType == PyArray_IntDTypePtr) {
         return 1;
     }
 #endif
 #if NPY_SIZEOF_LONGLONG == NPY_SIZEOF_LONG
-    else if (DType == &PyArray_LongLongDType) {
+    else if (DType == PyArray_LongLongDTypePtr) {
         return 1;
     }
 #endif
-    else if (DType == &PyArray_UInt8DType) {
+    else if (DType == PyArray_UInt8DTypePtr) {
         return 1;
     }
-    else if (DType == &PyArray_UInt16DType) {
+    else if (DType == PyArray_UInt16DTypePtr) {
         return 1;
     }
-    else if (DType == &PyArray_UInt32DType) {
+    else if (DType == PyArray_UInt32DTypePtr) {
         return 1;
     }
     // uint64 already has a loop registered for it,
     // so don't need to consider it
 #if NPY_SIZEOF_BYTE == NPY_SIZEOF_SHORT
-    else if (DType == &PyArray_UByteDType) {
+    else if (DType == PyArray_UByteDTypePtr) {
         return 1;
     }
 #endif
 #if NPY_SIZEOF_SHORT == NPY_SIZEOF_INT
-    else if (DType == &PyArray_UShortDType) {
+    else if (DType == PyArray_UShortDTypePtr) {
         return 1;
     }
 #endif
 #if NPY_SIZEOF_INT == NPY_SIZEOF_LONG
-    else if (DType == &PyArray_UIntDType) {
+    else if (DType == PyArray_UIntDTypePtr) {
         return 1;
     }
 #endif
 #if NPY_SIZEOF_LONGLONG == NPY_SIZEOF_LONG
-    else if (DType == &PyArray_ULongLongDType) {
+    else if (DType == PyArray_ULongLongDTypePtr) {
         return 1;
     }
 #endif
@@ -2429,13 +2429,13 @@ string_multiply_promoter(PyObject *ufunc_obj,
             tmp = signature[i];
         }
         else if (is_integer_dtype(op_dtypes[i])) {
-            tmp = &PyArray_Int64DType;
+            tmp = PyArray_Int64DTypePtr;
         }
         else if (op_dtypes[i]) {
             tmp = op_dtypes[i];
         }
         else {
-            tmp = &PyArray_StringDType;
+            tmp = PyArray_StringDTypePtr;
         }
         Py_INCREF(tmp);
         new_op_dtypes[i] = tmp;
@@ -2447,8 +2447,8 @@ string_multiply_promoter(PyObject *ufunc_obj,
             new_op_dtypes[i] = op_dtypes[i];
         }
         else {
-            Py_INCREF(&PyArray_StringDType);
-            new_op_dtypes[i] = &PyArray_StringDType;
+            Py_INCREF(PyArray_StringDTypePtr);
+            new_op_dtypes[i] = PyArray_StringDTypePtr;
         }
     }
     return 0;
@@ -2546,8 +2546,8 @@ add_promoter(PyObject *numpy, const char *ufunc_name,
 
 #define INIT_MULTIPLY(typename, shortname)                                 \
     PyArray_DTypeMeta *multiply_right_##shortname##_types[] = {            \
-        &PyArray_StringDType, &PyArray_##typename##DType,                  \
-        &PyArray_StringDType};                                             \
+        PyArray_StringDTypePtr, PyArray_##typename##DTypePtr,                  \
+        PyArray_StringDTypePtr};                                             \
                                                                            \
     if (init_ufunc(umath, "multiply", multiply_right_##shortname##_types,  \
                    &multiply_resolve_descriptors,                          \
@@ -2557,8 +2557,8 @@ add_promoter(PyObject *numpy, const char *ufunc_name,
     }                                                                      \
                                                                            \
     PyArray_DTypeMeta *multiply_left_##shortname##_types[] = {             \
-            &PyArray_##typename##DType, &PyArray_StringDType,              \
-            &PyArray_StringDType};                                         \
+            PyArray_##typename##DTypePtr, PyArray_StringDTypePtr,              \
+            PyArray_StringDTypePtr};                                         \
                                                                            \
     if (init_ufunc(umath, "multiply", multiply_left_##shortname##_types,   \
                    &multiply_resolve_descriptors,                          \
@@ -2574,7 +2574,7 @@ add_object_and_unicode_promoters(PyObject *umath, const char* ufunc_name,
 {
     {
         PyArray_DTypeMeta *dtypes[] = {
-            &PyArray_StringDType, &PyArray_UnicodeDType, &PyArray_BoolDType};
+            PyArray_StringDTypePtr, PyArray_UnicodeDTypePtr, PyArray_BoolDTypePtr};
         if (add_promoter(umath, ufunc_name, dtypes, 3, unicode_promoter_wrapper) < 0) {
             return -1;
         }
@@ -2582,7 +2582,7 @@ add_object_and_unicode_promoters(PyObject *umath, const char* ufunc_name,
 
     {
         PyArray_DTypeMeta *dtypes[] = {
-            &PyArray_UnicodeDType, &PyArray_StringDType, &PyArray_BoolDType};
+            PyArray_UnicodeDTypePtr, PyArray_StringDTypePtr, PyArray_BoolDTypePtr};
         if (add_promoter(umath, ufunc_name, dtypes, 3, unicode_promoter_wrapper) < 0) {
             return -1;
         }
@@ -2590,7 +2590,7 @@ add_object_and_unicode_promoters(PyObject *umath, const char* ufunc_name,
 
     {
         PyArray_DTypeMeta *dtypes[] = {
-            &PyArray_StringDType, &PyArray_ObjectDType, &PyArray_BoolDType};
+            PyArray_StringDTypePtr, PyArray_ObjectDTypePtr, PyArray_BoolDTypePtr};
         if (add_promoter(umath, ufunc_name, dtypes, 3, object_promoter_wrapper) < 0) {
             return -1;
         }
@@ -2598,7 +2598,7 @@ add_object_and_unicode_promoters(PyObject *umath, const char* ufunc_name,
 
     {
         PyArray_DTypeMeta *dtypes[] = {
-            &PyArray_ObjectDType, &PyArray_StringDType, &PyArray_BoolDType};
+            PyArray_ObjectDTypePtr, PyArray_StringDTypePtr, PyArray_BoolDTypePtr};
         if (add_promoter(umath, ufunc_name, dtypes, 3, object_promoter_wrapper) < 0) {
             return -1;
         }
@@ -2615,8 +2615,8 @@ init_stringdtype_ufuncs(PyObject *umath)
     };
 
     PyArray_DTypeMeta *comparison_dtypes[] = {
-            &PyArray_StringDType,
-            &PyArray_StringDType, &PyArray_BoolDType};
+            PyArray_StringDTypePtr,
+            PyArray_StringDTypePtr, PyArray_BoolDTypePtr};
 
     // eq and ne get recognized in string_cmp_strided_loop by having
     // res_for_lt == res_for_gt.
@@ -2647,8 +2647,8 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *bool_output_dtypes[] = {
-        &PyArray_StringDType,
-        &PyArray_BoolDType
+        PyArray_StringDTypePtr,
+        PyArray_BoolDTypePtr
     };
 
     if (init_ufunc(umath, "isnan", bool_output_dtypes,
@@ -2686,8 +2686,8 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *intp_output_dtypes[] = {
-        &PyArray_StringDType,
-        &PyArray_IntpDType
+        PyArray_StringDTypePtr,
+        PyArray_IntpDTypePtr
     };
 
     if (init_ufunc(umath, "str_len", intp_output_dtypes,
@@ -2698,9 +2698,9 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *binary_dtypes[] = {
-            &PyArray_StringDType,
-            &PyArray_StringDType,
-            &PyArray_StringDType,
+            PyArray_StringDTypePtr,
+            PyArray_StringDTypePtr,
+            PyArray_StringDTypePtr,
     };
 
     const char* minimum_maximum_names[] = {"minimum", "maximum"};
@@ -2724,9 +2724,9 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *rall_strings_promoter_dtypes[] = {
-        &PyArray_StringDType,
-        &PyArray_UnicodeDType,
-        &PyArray_StringDType,
+        PyArray_StringDTypePtr,
+        PyArray_UnicodeDTypePtr,
+        PyArray_StringDTypePtr,
     };
 
     if (add_promoter(umath, "add", rall_strings_promoter_dtypes, 3,
@@ -2735,9 +2735,9 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *lall_strings_promoter_dtypes[] = {
-        &PyArray_UnicodeDType,
-        &PyArray_StringDType,
-        &PyArray_StringDType,
+        PyArray_UnicodeDTypePtr,
+        PyArray_StringDTypePtr,
+        PyArray_StringDTypePtr,
     };
 
     if (add_promoter(umath, "add", lall_strings_promoter_dtypes, 3,
@@ -2746,9 +2746,9 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *out_strings_promoter_dtypes[] = {
-        &PyArray_UnicodeDType,
-        &PyArray_UnicodeDType,
-        &PyArray_StringDType,
+        PyArray_UnicodeDTypePtr,
+        PyArray_UnicodeDTypePtr,
+        PyArray_StringDTypePtr,
     };
 
     if (add_promoter(umath, "add", out_strings_promoter_dtypes, 3,
@@ -2762,27 +2762,27 @@ init_stringdtype_ufuncs(PyObject *umath)
     // all other integer dtypes are handled with a generic promoter
 
     PyArray_DTypeMeta *rdtypes[] = {
-        &PyArray_StringDType,
-        &PyArray_IntAbstractDType,
-        &PyArray_StringDType};
+        PyArray_StringDTypePtr,
+        PyArray_IntAbstractDTypePtr,
+        PyArray_StringDTypePtr};
 
     if (add_promoter(umath, "multiply", rdtypes, 3, string_multiply_promoter) < 0) {
         return -1;
     }
 
     PyArray_DTypeMeta *ldtypes[] = {
-        &PyArray_IntAbstractDType,
-        &PyArray_StringDType,
-        &PyArray_StringDType};
+        PyArray_IntAbstractDTypePtr,
+        PyArray_StringDTypePtr,
+        PyArray_StringDTypePtr};
 
     if (add_promoter(umath, "multiply", ldtypes, 3, string_multiply_promoter) < 0) {
         return -1;
     }
 
     PyArray_DTypeMeta *findlike_dtypes[] = {
-        &PyArray_StringDType, &PyArray_StringDType,
-        &PyArray_Int64DType, &PyArray_Int64DType,
-        &PyArray_DefaultIntDType,
+        PyArray_StringDTypePtr, PyArray_StringDTypePtr,
+        PyArray_Int64DTypePtr, PyArray_Int64DTypePtr,
+        PyArray_DefaultIntDTypePtr,
     };
 
     const char* findlike_names[] = {
@@ -2791,14 +2791,14 @@ init_stringdtype_ufuncs(PyObject *umath)
 
     PyArray_DTypeMeta *findlike_promoter_dtypes[2][5] = {
         {
-            &PyArray_StringDType, &PyArray_UnicodeDType,
-            &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
-            &PyArray_IntAbstractDType,
+            PyArray_StringDTypePtr, PyArray_UnicodeDTypePtr,
+            PyArray_IntAbstractDTypePtr, PyArray_IntAbstractDTypePtr,
+            PyArray_IntAbstractDTypePtr,
         },
         {
-            &PyArray_UnicodeDType, &PyArray_StringDType,
-            &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
-            &PyArray_IntAbstractDType,
+            PyArray_UnicodeDTypePtr, PyArray_StringDTypePtr,
+            PyArray_IntAbstractDTypePtr, PyArray_IntAbstractDTypePtr,
+            PyArray_IntAbstractDTypePtr,
         },
     };
 
@@ -2829,9 +2829,9 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *startswith_endswith_dtypes[] = {
-        &PyArray_StringDType, &PyArray_StringDType,
-        &PyArray_Int64DType, &PyArray_Int64DType,
-        &PyArray_BoolDType,
+        PyArray_StringDTypePtr, PyArray_StringDTypePtr,
+        PyArray_Int64DTypePtr, PyArray_Int64DTypePtr,
+        PyArray_BoolDTypePtr,
     };
 
     const char* startswith_endswith_names[] = {
@@ -2840,14 +2840,14 @@ init_stringdtype_ufuncs(PyObject *umath)
 
     PyArray_DTypeMeta *startswith_endswith_promoter_dtypes[2][5] = {
         {
-            &PyArray_StringDType, &PyArray_UnicodeDType,
-            &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
-            &PyArray_BoolDType,
+            PyArray_StringDTypePtr, PyArray_UnicodeDTypePtr,
+            PyArray_IntAbstractDTypePtr, PyArray_IntAbstractDTypePtr,
+            PyArray_BoolDTypePtr,
         },
         {
-            &PyArray_UnicodeDType, &PyArray_StringDType,
-            &PyArray_IntAbstractDType, &PyArray_IntAbstractDType,
-            &PyArray_BoolDType,
+            PyArray_UnicodeDTypePtr, PyArray_StringDTypePtr,
+            PyArray_IntAbstractDTypePtr, PyArray_IntAbstractDTypePtr,
+            PyArray_BoolDTypePtr,
         },
     };
 
@@ -2875,7 +2875,7 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *strip_whitespace_dtypes[] = {
-        &PyArray_StringDType, &PyArray_StringDType
+        PyArray_StringDTypePtr, PyArray_StringDTypePtr
     };
 
     const char *const strip_whitespace_names[] = {
@@ -2899,7 +2899,7 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *strip_chars_dtypes[] = {
-        &PyArray_StringDType, &PyArray_StringDType, &PyArray_StringDType
+        PyArray_StringDTypePtr, PyArray_StringDTypePtr, PyArray_StringDTypePtr
     };
 
     const char *const strip_chars_names[] = {
@@ -2930,8 +2930,8 @@ init_stringdtype_ufuncs(PyObject *umath)
 
 
     PyArray_DTypeMeta *replace_dtypes[] = {
-        &PyArray_StringDType, &PyArray_StringDType, &PyArray_StringDType,
-        &PyArray_Int64DType, &PyArray_StringDType,
+        PyArray_StringDTypePtr, PyArray_StringDTypePtr, PyArray_StringDTypePtr,
+        PyArray_Int64DTypePtr, PyArray_StringDTypePtr,
     };
 
     if (init_ufunc(umath, "_replace", replace_dtypes,
@@ -2944,28 +2944,28 @@ init_stringdtype_ufuncs(PyObject *umath)
 
     PyArray_DTypeMeta *replace_promoter_unicode_dtypes[6][5] = {
         {
-            &PyArray_StringDType, &PyArray_UnicodeDType, &PyArray_UnicodeDType,
-            &PyArray_IntAbstractDType, &PyArray_StringDType,
+            PyArray_StringDTypePtr, PyArray_UnicodeDTypePtr, PyArray_UnicodeDTypePtr,
+            PyArray_IntAbstractDTypePtr, PyArray_StringDTypePtr,
         },
         {
-            &PyArray_UnicodeDType, &PyArray_StringDType, &PyArray_UnicodeDType,
-            &PyArray_IntAbstractDType, &PyArray_StringDType,
+            PyArray_UnicodeDTypePtr, PyArray_StringDTypePtr, PyArray_UnicodeDTypePtr,
+            PyArray_IntAbstractDTypePtr, PyArray_StringDTypePtr,
         },
         {
-            &PyArray_UnicodeDType, &PyArray_UnicodeDType, &PyArray_StringDType,
-            &PyArray_IntAbstractDType, &PyArray_StringDType,
+            PyArray_UnicodeDTypePtr, PyArray_UnicodeDTypePtr, PyArray_StringDTypePtr,
+            PyArray_IntAbstractDTypePtr, PyArray_StringDTypePtr,
         },
         {
-            &PyArray_StringDType, &PyArray_StringDType, &PyArray_UnicodeDType,
-            &PyArray_IntAbstractDType, &PyArray_StringDType,
+            PyArray_StringDTypePtr, PyArray_StringDTypePtr, PyArray_UnicodeDTypePtr,
+            PyArray_IntAbstractDTypePtr, PyArray_StringDTypePtr,
         },
         {
-            &PyArray_StringDType, &PyArray_UnicodeDType, &PyArray_StringDType,
-            &PyArray_IntAbstractDType, &PyArray_StringDType,
+            PyArray_StringDTypePtr, PyArray_UnicodeDTypePtr, PyArray_StringDTypePtr,
+            PyArray_IntAbstractDTypePtr, PyArray_StringDTypePtr,
         },
         {
-            &PyArray_UnicodeDType, &PyArray_StringDType, &PyArray_StringDType,
-            &PyArray_IntAbstractDType, &PyArray_StringDType,
+            PyArray_UnicodeDTypePtr, PyArray_StringDTypePtr, PyArray_StringDTypePtr,
+            PyArray_IntAbstractDTypePtr, PyArray_StringDTypePtr,
         },
     };
 
@@ -2977,9 +2977,9 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *expandtabs_dtypes[] = {
-        &PyArray_StringDType,
-        &PyArray_Int64DType,
-        &PyArray_StringDType,
+        PyArray_StringDTypePtr,
+        PyArray_Int64DTypePtr,
+        PyArray_StringDTypePtr,
     };
 
     if (init_ufunc(umath, "_expandtabs", expandtabs_dtypes,
@@ -2991,9 +2991,9 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *expandtabs_promoter_dtypes[] = {
-            &PyArray_StringDType,
-            &PyArray_IntAbstractDType,
-            &PyArray_StringDType
+            PyArray_StringDTypePtr,
+            PyArray_IntAbstractDTypePtr,
+            PyArray_StringDTypePtr
     };
 
     if (add_promoter(umath, "_expandtabs", expandtabs_promoter_dtypes,
@@ -3002,10 +3002,10 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *center_ljust_rjust_dtypes[] = {
-        &PyArray_StringDType,
-        &PyArray_Int64DType,
-        &PyArray_StringDType,
-        &PyArray_StringDType,
+        PyArray_StringDTypePtr,
+        PyArray_Int64DTypePtr,
+        PyArray_StringDTypePtr,
+        PyArray_StringDTypePtr,
     };
 
     static const char* center_ljust_rjust_names[3] = {
@@ -3027,22 +3027,22 @@ init_stringdtype_ufuncs(PyObject *umath)
 
         PyArray_DTypeMeta *promoter_dtypes[3][4] = {
             {
-                &PyArray_StringDType,
-                &PyArray_IntAbstractDType,
-                &PyArray_StringDType,
-                &PyArray_StringDType,
+                PyArray_StringDTypePtr,
+                PyArray_IntAbstractDTypePtr,
+                PyArray_StringDTypePtr,
+                PyArray_StringDTypePtr,
             },
             {
-                &PyArray_StringDType,
-                &PyArray_IntAbstractDType,
-                &PyArray_UnicodeDType,
-                &PyArray_StringDType,
+                PyArray_StringDTypePtr,
+                PyArray_IntAbstractDTypePtr,
+                PyArray_UnicodeDTypePtr,
+                PyArray_StringDTypePtr,
             },
             {
-                &PyArray_UnicodeDType,
-                &PyArray_IntAbstractDType,
-                &PyArray_StringDType,
-                &PyArray_StringDType,
+                PyArray_UnicodeDTypePtr,
+                PyArray_IntAbstractDTypePtr,
+                PyArray_StringDTypePtr,
+                PyArray_StringDTypePtr,
             },
         };
 
@@ -3056,9 +3056,9 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *zfill_dtypes[] = {
-        &PyArray_StringDType,
-        &PyArray_Int64DType,
-        &PyArray_StringDType,
+        PyArray_StringDTypePtr,
+        PyArray_Int64DTypePtr,
+        PyArray_StringDTypePtr,
     };
 
     if (init_ufunc(umath, "_zfill", zfill_dtypes, multiply_resolve_descriptors,
@@ -3068,9 +3068,9 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *zfill_promoter_dtypes[] = {
-            &PyArray_StringDType,
-            &PyArray_IntAbstractDType,
-            &PyArray_StringDType,
+            PyArray_StringDTypePtr,
+            PyArray_IntAbstractDTypePtr,
+            PyArray_StringDTypePtr,
     };
 
     if (add_promoter(umath, "_zfill", zfill_promoter_dtypes, 3,
@@ -3079,11 +3079,11 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *partition_dtypes[] = {
-        &PyArray_StringDType,
-        &PyArray_StringDType,
-        &PyArray_StringDType,
-        &PyArray_StringDType,
-        &PyArray_StringDType
+        PyArray_StringDTypePtr,
+        PyArray_StringDTypePtr,
+        PyArray_StringDTypePtr,
+        PyArray_StringDTypePtr,
+        PyArray_StringDTypePtr
     };
 
     const char *const partition_names[] = {"_partition", "_rpartition"};
@@ -3102,11 +3102,11 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *slice_dtypes[] = {
-        &PyArray_StringDType,
-        &PyArray_IntpDType,
-        &PyArray_IntpDType,
-        &PyArray_IntpDType,
-        &PyArray_StringDType,
+        PyArray_StringDTypePtr,
+        PyArray_IntpDTypePtr,
+        PyArray_IntpDTypePtr,
+        PyArray_IntpDTypePtr,
+        PyArray_StringDTypePtr,
     };
 
     if (init_ufunc(umath, "_slice", slice_dtypes, slice_resolve_descriptors,
@@ -3116,11 +3116,11 @@ init_stringdtype_ufuncs(PyObject *umath)
     }
 
     PyArray_DTypeMeta *slice_promoter_dtypes[] = {
-        &PyArray_StringDType,
-        &PyArray_IntAbstractDType,
-        &PyArray_IntAbstractDType,
-        &PyArray_IntAbstractDType,
-        &PyArray_StringDType,
+        PyArray_StringDTypePtr,
+        PyArray_IntAbstractDTypePtr,
+        PyArray_IntAbstractDTypePtr,
+        PyArray_IntAbstractDTypePtr,
+        PyArray_StringDTypePtr,
     };
 
     if (add_promoter(umath, "_slice", slice_promoter_dtypes, 5,

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3828,7 +3828,7 @@ _check_and_copy_sig_to_signature(
  */
 static PyArray_DTypeMeta *
 _get_dtype(PyObject *dtype_obj) {
-    if (PyObject_TypeCheck(dtype_obj, &PyArrayDTypeMeta_Type)) {
+    if (PyObject_TypeCheck(dtype_obj, PyArrayDTypeMeta_TypePtr)) {
         Py_INCREF(dtype_obj);
         return (PyArray_DTypeMeta *)dtype_obj;
     }
@@ -6295,8 +6295,8 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
                 goto finish;
             }
             PyArray_ENABLEFLAGS(dummy_arrays[i], NPY_ARRAY_WAS_PYTHON_INT);
-            Py_INCREF(&PyArray_PyLongDType);
-            DTypes[i] = &PyArray_PyLongDType;
+            Py_INCREF(PyArray_PyLongDTypePtr);
+            DTypes[i] = PyArray_PyLongDTypePtr;
             promoting_pyscalars = NPY_TRUE;
         }
         else if (descr_obj == (PyObject *)&PyFloat_Type) {
@@ -6306,8 +6306,8 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
                 goto finish;
             }
             PyArray_ENABLEFLAGS(dummy_arrays[i], NPY_ARRAY_WAS_PYTHON_FLOAT);
-            Py_INCREF(&PyArray_PyFloatDType);
-            DTypes[i] = &PyArray_PyFloatDType;
+            Py_INCREF(PyArray_PyFloatDTypePtr);
+            DTypes[i] = PyArray_PyFloatDTypePtr;
             promoting_pyscalars = NPY_TRUE;
         }
         else if (descr_obj == (PyObject *)&PyComplex_Type) {
@@ -6317,8 +6317,8 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
                 goto finish;
             }
             PyArray_ENABLEFLAGS(dummy_arrays[i], NPY_ARRAY_WAS_PYTHON_COMPLEX);
-            Py_INCREF(&PyArray_PyComplexDType);
-            DTypes[i] = &PyArray_PyComplexDType;
+            Py_INCREF(PyArray_PyComplexDTypePtr);
+            DTypes[i] = PyArray_PyComplexDTypePtr;
             promoting_pyscalars = NPY_TRUE;
         }
         else if (descr_obj == Py_None) {


### PR DESCRIPTION
### PR summary
Pulled out of #31071.
- Add pointers to the dtype type objects.
- Use the pointers internally
- Create some NUMPY_2_5 api of the pointers, re-casting the existing export table.

This will make it easier to move to heap types.

#### AI Disclosure
Claude helped me fix the fallout of the rough regex replacements I did. I only used AI to find the cause of compilation failures and typos, but fixed the problems myself.

Once this goes in I will rebase #31071 on top of it