### PR TITLE
BUG: fix nanmax/nanmin initial argument misbehaving in slow path

### DIFF
--- a/doc/release/upcoming_changes/31102.improvement.rst
+++ b/doc/release/upcoming_changes/31102.improvement.rst
@@ -1,0 +1,13 @@
+`numpy.nanmin` and `numpy.nanmax` now respect ``initial`` consistently
+----------------------------------------------------------------------
+
+`numpy.nanmin` and `numpy.nanmax` no longer propagate ``NaN`` from the
+``initial`` argument and now use a non-``NaN`` ``initial`` as the result for
+all-``NaN`` (or empty) slices instead of returning ``NaN`` with a
+``RuntimeWarning``. For example, ``np.nanmax([np.nan, np.nan], initial=5.0)``
+now returns ``5.0`` instead of ``NaN``, and ``np.nanmax([1.0, 2.0, 3.0],
+initial=np.nan)`` returns ``3.0`` instead of ``NaN``.
+
+When ``initial`` is ``NaN`` and every element of the slice is also ``NaN`` (or
+masked out by ``where=``), the existing ``RuntimeWarning`` and ``NaN`` return
+value are preserved.

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -360,6 +360,11 @@ def nanmin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     else:
         # Slow, but safe for subclasses of ndarray
         a, mask = _replace_nan(a, +np.inf)
+        # Remove NaN initial to avoid propagation through np.amin
+        # (nanmin should ignore NaN in initial, same as in array elements)
+        initial = kwargs.pop("initial", np._NoValue)
+        if initial is not np._NoValue and not np.isnan(initial):
+            kwargs["initial"] = initial
         res = np.amin(a, axis=axis, out=out, **kwargs)
         if mask is None:
             return res
@@ -368,9 +373,13 @@ def nanmin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
         kwargs.pop("initial", None)
         mask = np.all(mask, axis=axis, **kwargs)
         if np.any(mask):
-            res = _copyto(res, np.nan, mask)
-            warnings.warn("All-NaN axis encountered", RuntimeWarning,
-                          stacklevel=2)
+            if initial is not np._NoValue and not np.isnan(initial):
+                # initial provides a valid fallback for all-NaN slices
+                res = _copyto(res, initial, mask)
+            else:
+                res = _copyto(res, np.nan, mask)
+                warnings.warn("All-NaN axis encountered", RuntimeWarning,
+                              stacklevel=2)
     return res
 
 
@@ -489,6 +498,11 @@ def nanmax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     else:
         # Slow, but safe for subclasses of ndarray
         a, mask = _replace_nan(a, -np.inf)
+        # Remove NaN initial to avoid propagation through np.amax
+        # (nanmax should ignore NaN in initial, same as in array elements)
+        initial = kwargs.pop("initial", np._NoValue)
+        if initial is not np._NoValue and not np.isnan(initial):
+            kwargs["initial"] = initial
         res = np.amax(a, axis=axis, out=out, **kwargs)
         if mask is None:
             return res
@@ -497,9 +511,13 @@ def nanmax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
         kwargs.pop("initial", None)
         mask = np.all(mask, axis=axis, **kwargs)
         if np.any(mask):
-            res = _copyto(res, np.nan, mask)
-            warnings.warn("All-NaN axis encountered", RuntimeWarning,
-                          stacklevel=2)
+            if initial is not np._NoValue and not np.isnan(initial):
+                # initial provides a valid fallback for all-NaN slices
+                res = _copyto(res, initial, mask)
+            else:
+                res = _copyto(res, np.nan, mask)
+                warnings.warn("All-NaN axis encountered", RuntimeWarning,
+                              stacklevel=2)
     return res
 
 

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -360,11 +360,16 @@ def nanmin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     else:
         # Slow, but safe for subclasses of ndarray
         a, mask = _replace_nan(a, +np.inf)
-        # Remove NaN initial to avoid propagation through np.amin
-        # (nanmin should ignore NaN in initial, same as in array elements)
-        initial = kwargs.pop("initial", np._NoValue)
-        if initial is not np._NoValue and not np.isnan(initial):
-            kwargs["initial"] = initial
+        # Replace NaN initial with +inf (identity of min) to avoid NaN
+        # propagation through np.amin. nanmin should ignore NaN in initial
+        # the same way it ignores NaN in array elements.
+        initial_is_nan = (
+            initial is not np._NoValue
+            and np.ndim(initial) == 0
+            and np.isnan(initial)
+        )
+        if initial_is_nan:
+            kwargs["initial"] = +np.inf
         res = np.amin(a, axis=axis, out=out, **kwargs)
         if mask is None:
             return res
@@ -373,8 +378,8 @@ def nanmin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
         kwargs.pop("initial", None)
         mask = np.all(mask, axis=axis, **kwargs)
         if np.any(mask):
-            if initial is not np._NoValue and not np.isnan(initial):
-                # initial provides a valid fallback for all-NaN slices
+            if initial is not np._NoValue and not initial_is_nan:
+                # Non-NaN initial provides a valid fallback for all-NaN slices
                 res = _copyto(res, initial, mask)
             else:
                 res = _copyto(res, np.nan, mask)
@@ -498,11 +503,16 @@ def nanmax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     else:
         # Slow, but safe for subclasses of ndarray
         a, mask = _replace_nan(a, -np.inf)
-        # Remove NaN initial to avoid propagation through np.amax
-        # (nanmax should ignore NaN in initial, same as in array elements)
-        initial = kwargs.pop("initial", np._NoValue)
-        if initial is not np._NoValue and not np.isnan(initial):
-            kwargs["initial"] = initial
+        # Replace NaN initial with -inf (identity of max) to avoid NaN
+        # propagation through np.amax. nanmax should ignore NaN in initial
+        # the same way it ignores NaN in array elements.
+        initial_is_nan = (
+            initial is not np._NoValue
+            and np.ndim(initial) == 0
+            and np.isnan(initial)
+        )
+        if initial_is_nan:
+            kwargs["initial"] = -np.inf
         res = np.amax(a, axis=axis, out=out, **kwargs)
         if mask is None:
             return res
@@ -511,8 +521,8 @@ def nanmax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
         kwargs.pop("initial", None)
         mask = np.all(mask, axis=axis, **kwargs)
         if np.any(mask):
-            if initial is not np._NoValue and not np.isnan(initial):
-                # initial provides a valid fallback for all-NaN slices
+            if initial is not np._NoValue and not initial_is_nan:
+                # Non-NaN initial provides a valid fallback for all-NaN slices
                 res = _copyto(res, initial, mask)
             else:
                 res = _copyto(res, np.nan, mask)

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -362,12 +362,10 @@ def nanmin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
         a, mask = _replace_nan(a, +np.inf)
         # Replace NaN initial with +inf (identity of min) to avoid NaN
         # propagation through np.amin. nanmin should ignore NaN in initial
-        # the same way it ignores NaN in array elements.
-        initial_is_nan = (
-            initial is not np._NoValue
-            and np.ndim(initial) == 0
-            and np.isnan(initial)
-        )
+        # the same way it ignores NaN in array elements. Comparing initial to
+        # itself detects NaN without going through np.isnan, which raises on
+        # non-numeric scalars such as decimal.Decimal.
+        initial_is_nan = initial is not np._NoValue and initial != initial
         if initial_is_nan:
             kwargs["initial"] = +np.inf
         res = np.amin(a, axis=axis, out=out, **kwargs)
@@ -505,12 +503,10 @@ def nanmax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
         a, mask = _replace_nan(a, -np.inf)
         # Replace NaN initial with -inf (identity of max) to avoid NaN
         # propagation through np.amax. nanmax should ignore NaN in initial
-        # the same way it ignores NaN in array elements.
-        initial_is_nan = (
-            initial is not np._NoValue
-            and np.ndim(initial) == 0
-            and np.isnan(initial)
-        )
+        # the same way it ignores NaN in array elements. Comparing initial to
+        # itself detects NaN without going through np.isnan, which raises on
+        # non-numeric scalars such as decimal.Decimal.
+        initial_is_nan = initial is not np._NoValue and initial != initial
         if initial_is_nan:
             kwargs["initial"] = -np.inf
         res = np.amax(a, axis=axis, out=out, **kwargs)

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -270,13 +270,21 @@ class TestNanFunctions_MinMax:
         # should ignore a NaN ``initial`` and use a non-NaN ``initial``
         # as the fallback value for all-NaN or empty slices.
 
-        # NaN initial must not propagate.
+        # NaN initial must not propagate, including with multi-element input.
         assert np.nanmax([1.0], initial=np.nan) == 1.0
         assert np.nanmin([1.0], initial=np.nan) == 1.0
+        assert np.nanmax([1.0, 2.0, 3.0], initial=np.nan) == 3.0
+        assert np.nanmin([1.0, 2.0, 3.0], initial=np.nan) == 1.0
 
-        # Non-NaN initial provides a fallback for empty input.
+        # Non-NaN initial provides a fallback for empty or all-NaN input,
+        # without a RuntimeWarning.
         assert np.nanmax([], initial=1.0) == 1.0
         assert np.nanmin([], initial=1.0) == 1.0
+        for f in self.nanfuncs:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                assert f([np.nan, np.nan], initial=5.0) == 5.0
+                assert len(w) == 0
 
         # Empty input with a NaN initial preserves the existing
         # all-NaN behaviour: a RuntimeWarning is raised and NaN is returned.

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -309,6 +309,12 @@ class TestNanFunctions_MinMax:
                 assert len(w) == 1
                 assert issubclass(w[0].category, RuntimeWarning)
 
+        # A non-floating scalar such as ``decimal.Decimal`` should not raise
+        # in the NaN detection path.
+        from decimal import Decimal
+        assert np.nanmin([Decimal(1), Decimal(2)], initial=Decimal(0)) == Decimal(0)
+        assert np.nanmax([Decimal(1), Decimal(2)], initial=Decimal(0)) == Decimal(2)
+
 
 class TestNanFunctions_ArgminArgmax:
 

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -265,6 +265,42 @@ class TestNanFunctions_MinMax:
             assert ret2.dtype == dtype
             assert ret2 == reference
 
+    def test_initial_slow_path(self):
+        # gh-31087: in the slow path (non-ndarray input), nanmin/nanmax
+        # should ignore a NaN ``initial`` and use a non-NaN ``initial``
+        # as the fallback value for all-NaN or empty slices.
+
+        # NaN initial must not propagate.
+        assert np.nanmax([1.0], initial=np.nan) == 1.0
+        assert np.nanmin([1.0], initial=np.nan) == 1.0
+
+        # Non-NaN initial provides a fallback for empty input.
+        assert np.nanmax([], initial=1.0) == 1.0
+        assert np.nanmin([], initial=1.0) == 1.0
+
+        # Empty input with a NaN initial preserves the existing
+        # all-NaN behaviour: a RuntimeWarning is raised and NaN is returned.
+        for f in self.nanfuncs:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                res = f([], initial=np.nan)
+                assert np.isnan(res)
+                assert len(w) == 1
+                assert issubclass(w[0].category, RuntimeWarning)
+
+        # A ``where`` mask that excludes every element behaves like an
+        # empty input: non-NaN initial is returned, NaN initial yields a
+        # RuntimeWarning and NaN.
+        where_none = np.array([False, False, False])
+        for f in self.nanfuncs:
+            assert f([1.0, 2.0, 3.0], where=where_none, initial=5.0) == 5.0
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                res = f([1.0, 2.0, 3.0], where=where_none, initial=np.nan)
+                assert np.isnan(res)
+                assert len(w) == 1
+                assert issubclass(w[0].category, RuntimeWarning)
+
 
 class TestNanFunctions_ArgminArgmax:
 


### PR DESCRIPTION
Fixes #31087.

`nanmin`/`nanmax` misbehave with the `initial` argument in the slow path (non-ndarray input like lists). Two issues:

1. `nanmax([1.0], initial=nan)` returns `nan` because the slow path uses `np.amax` which propagates NaN from `initial`, unlike `np.fmax.reduce` used in the fast path. Fixed by stripping NaN `initial` before passing to `amax`/`amin`, since `nanmax`/`nanmin` should ignore NaN in `initial` the same way they ignore NaN in array elements.

2. `nanmax([], initial=1.0)` returns `nan` because the all-NaN check (`np.all(mask)`) returns `True` on an empty mask and unconditionally overwrites the result with NaN. Fixed by using `initial` as the result for all-NaN slices when it's a valid (non-NaN) value.