### PR TITLE
ENH: tweak timedelta deprecation message 

### DIFF
--- a/doc/source/reference/arrays.datetime.rst
+++ b/doc/source/reference/arrays.datetime.rst
@@ -284,6 +284,8 @@ Datetime units
 The Datetime and Timedelta data types support a large number of time
 units, as well as generic units which can be coerced into any of the
 other units based on input data.
+The generic units are deprecated since NumPy 2.5
+and will raise an error in the future. Migration guidance is provided in the `migration guide for deprecation of generic units`_ section below.
 
 Datetimes are always stored with
 an epoch of 1970-01-01T00:00. This means the supported dates are
@@ -344,6 +346,12 @@ The protocol is described in the following table:
     Y/M (Non-linear units)                 `datetime.date`                       ``int``
         Generic units                      `datetime.date`                       ``int``
 ================================ ================================= ==================================
+
+
+.. deprecated:: 2.5
+  The generic units of `timedelta64` are deprecated since NumPy 2.5 and
+  will raise an error in the future.
+
 
 .. admonition:: Example
 
@@ -635,3 +643,46 @@ given below.
       A 472, by Stephenson et.al. <https://doi.org/10.1098/rspa.2016.0404>`_. A
       sensible estimate is `50491112870 ± 90` seconds, with a difference of 10330
       seconds.
+
+
+.. _migration_guide_generic_units:
+
+Migration guide for deprecation of generic units
+================================================
+
+The generic units of `timedelta64` are deprecated since NumPy 2.5 
+and will raise an error in the future.
+This section provides guidance on how to update code
+that uses generic units of `timedelta64` to avoid future errors.
+
+The straight forward way is to replace the generic unit with a specific time unit such as 'D' (day), 'h' (hour), 'm' (minute), 's' (second), etc. The choice of the specific time unit will depend on the context of your code and the level of precision you require.
+
+
+.. admonition:: Example
+
+  .. try_examples::
+
+    >>> import numpy as np
+
+    >>> # Old code using generic units of timedelta64
+    >>> np.timedelta64(5, "s") + 1
+    DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.
+
+    >>> # Updated code using a specific time unit
+    >>> np.timedelta64(5, "s") + np.timedelta64(1, "s")
+    np.timedelta64(6,'s')
+
+
+    When comparing `timedelta64` objects, make sure to use the same specific time unit for both operands even if they are representing ``0``.
+
+    >>> np.timedelta64(0, "s") == 0
+    DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `== 0`).Please use a specific unit instead.
+    np.True_
+
+    >>> np.timedelta64(0, "s") == np.timedelta64(0, "s")
+    np.True_
+
+    When using ``numpy.testing.assert_allclose`` to compare `timedelta64` objects, ensure to set a specific time unit to ``atol`` parameter as well.
+
+    >>> arr = np.ones(5, dtype='m8[s]')
+    >>> np.testing.assert_allclose(arr, np.timedelta64(1, "s"), atol=np.timedelta64(0, "s"))

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2562,10 +2562,10 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
             /* If output is NaT, skip this warning. */
             if(meta->base == NPY_FR_GENERIC) {
                 if (DEPRECATE(
-                            "Using 'generic' unit for NumPy timedelta is deprecated, "
+                            "The 'generic' unit for NumPy timedelta is deprecated, "
                             "and will raise an error in the future. "
                             "This includes implicit conversion of bare integers (e.g. `+ 1`)."
-                            "Please use a specific units instead.") < 0) {
+                            "Please use a specific unit instead.") < 0) {
                     return -1;
                 }
             }
@@ -2588,10 +2588,10 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
 
         if (meta->base == NPY_FR_GENERIC) {
             if (DEPRECATE(
-                    "Using 'generic' unit for NumPy timedelta is deprecated, "
+                    "The 'generic' unit for NumPy timedelta is deprecated, "
                     "and will raise an error in the future. "
                     "This includes implicit conversion of bare integers (e.g. `+ 1`)."
-                    "Please use a specific units instead.") < 0) {
+                    "Please use a specific unit instead.") < 0) {
                 return -1;
             }
         }

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2563,8 +2563,9 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
             if(meta->base == NPY_FR_GENERIC) {
                 if (DEPRECATE(
                             "Using 'generic' unit for NumPy timedelta is deprecated, "
-                            "and will raise an error in the future. Please use a "
-                            "specific units instead.") < 0) {
+                            "and will raise an error in the future. "
+                            "This includes implicit conversion of bare integers (e.g. `+ 1`)."
+                            "Please use a specific units instead.") < 0) {
                     return -1;
                 }
             }
@@ -2587,9 +2588,10 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
 
         if (meta->base == NPY_FR_GENERIC) {
             if (DEPRECATE(
-                        "Using 'generic' unit for NumPy timedelta is deprecated, "
-                        "and will raise an error in the future. "
-                        "Please use a specific units instead.") < 0) {
+                    "Using 'generic' unit for NumPy timedelta is deprecated, "
+                    "and will raise an error in the future. "
+                    "This includes implicit conversion of bare integers (e.g. `+ 1`)."
+                    "Please use a specific units instead.") < 0) {
                 return -1;
             }
         }

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -440,7 +440,7 @@ class TestTimeScalars:
     def test_coercion_generic_timedelta_convert_to_number(self, dtype, value, unit):
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             scalar = np.timedelta64(value, unit)
             arr = np.array(scalar, dtype=dtype)

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -88,7 +88,7 @@ def test_is_timedelta64_object(install_temp):
 
     with pytest.warns(
         DeprecationWarning,
-        match="Using 'generic' unit for NumPy timedelta is deprecated",
+        match="The 'generic' unit for NumPy timedelta is deprecated",
     ):
         assert checks.is_td64(np.timedelta64(1234))
 
@@ -113,7 +113,7 @@ def test_is_datetime64_object(install_temp):
 
     with pytest.warns(
         DeprecationWarning,
-        match="Using 'generic' unit for NumPy timedelta is deprecated",
+        match="The 'generic' unit for NumPy timedelta is deprecated",
     ):
         assert not checks.is_dt64(np.timedelta64(1234))
 

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -204,7 +204,7 @@ class TestDateTime:
         # regression tests for gh-6452
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             assert_(
                 np.datetime64("NaT") != np.datetime64("2000") + np.timedelta64("NaT")
@@ -396,7 +396,7 @@ class TestDateTime:
         else:
             with pytest.warns(
                 DeprecationWarning,
-                match="Using 'generic' unit for NumPy timedelta is deprecated",
+                match="The 'generic' unit for NumPy timedelta is deprecated",
             ):
                 assert_equal(np.timedelta64(np.int64(123)), np.timedelta64(123))
 
@@ -409,7 +409,7 @@ class TestDateTime:
 
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             # Default construction means 0
             assert_equal(np.timedelta64(), np.timedelta64(0))
@@ -421,7 +421,7 @@ class TestDateTime:
         assert_equal(str(np.timedelta64('NaT', 'ns')), 'NaT')
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             assert_equal(repr(np.timedelta64("NaT")), "np.timedelta64('NaT')")
         assert_equal(str(np.timedelta64(3, 's')), '3 seconds')
@@ -430,7 +430,7 @@ class TestDateTime:
 
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             assert_equal(repr(np.timedelta64(12)),
                         "np.timedelta64(12)")
@@ -521,7 +521,7 @@ class TestDateTime:
         # gh-17552
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             assert_equal('NaT', f'{np.timedelta64("nat")}')
 
@@ -872,7 +872,7 @@ class TestDateTime:
         # Regression test for gh-29497.
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             x = np.array(
                 [
@@ -1185,7 +1185,7 @@ class TestDateTime:
 
             with pytest.warns(
                 DeprecationWarning,
-                match="Using 'generic' unit for NumPy timedelta is deprecated",
+                match="The 'generic' unit for NumPy timedelta is deprecated",
             ):
                 # m8 + bool
                 assert_equal(tdb + True, tdb + 1)
@@ -1265,7 +1265,7 @@ class TestDateTime:
             assert_equal((tdb - tda).dtype, np.dtype("m8[h]"))
             with pytest.warns(
                 DeprecationWarning,
-                match="Using 'generic' unit for NumPy timedelta is deprecated",
+                match="The 'generic' unit for NumPy timedelta is deprecated",
             ):
                 # m8 - bool
                 assert_equal(tdc - True, tdc - 1)
@@ -1404,7 +1404,7 @@ class TestDateTime:
     def test_generic_timedelta_floor_divide(self):
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             assert_equal(np.timedelta64(1890) // np.timedelta64(31), 60)
 
@@ -1439,7 +1439,7 @@ class TestDateTime:
     def test_timedelta_floor_div_precision(self, val1, val2):
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             op1 = np.timedelta64(val1)
             op2 = np.timedelta64(val2)
@@ -1491,7 +1491,7 @@ class TestDateTime:
     def test_generic_timedelta_divmod(self, op1, op2):
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             op1 = np.timedelta64(op1)
             op2 = np.timedelta64(op2)
@@ -1580,7 +1580,7 @@ class TestDateTime:
                 'ignore', r".*encountered in divide", RuntimeWarning)
             warnings.filterwarnings(
                 "ignore",
-                "Using 'generic' unit for NumPy timedelta is deprecated",
+                "The 'generic' unit for NumPy timedelta is deprecated",
                 DeprecationWarning,
             )
             nat = np.timedelta64('NaT', 's')
@@ -2048,7 +2048,7 @@ class TestDateTime:
 
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             # Unit should be detected as months here
             a = np.arange("1969-05", "1970-05", 2, dtype="M8")
@@ -2752,7 +2752,7 @@ class TestDateTime:
     def test_timedelta_hash_generic(self):
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             assert_raises(ValueError, hash, np.timedelta64(123))  # generic
 

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1,6 +1,7 @@
 import datetime
 import pickle
 import warnings
+from typing import Final
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import pytest
@@ -34,6 +35,9 @@ def _assert_equal_hash(v1, v2):
 
 
 class TestDateTime:
+    generic_unit_deprecation_message: Final[str] = (
+        "The 'generic' unit for NumPy timedelta is deprecated"
+    )
 
     def test_string(self):
         msg = "no explicit representation of timezones available for " \
@@ -204,7 +208,7 @@ class TestDateTime:
         # regression tests for gh-6452
         with pytest.warns(
             DeprecationWarning,
-            match="The 'generic' unit for NumPy timedelta is deprecated",
+            match=self.generic_unit_deprecation_message,
         ):
             assert_(
                 np.datetime64("NaT") != np.datetime64("2000") + np.timedelta64("NaT")
@@ -396,7 +400,7 @@ class TestDateTime:
         else:
             with pytest.warns(
                 DeprecationWarning,
-                match="The 'generic' unit for NumPy timedelta is deprecated",
+                match=self.generic_unit_deprecation_message
             ):
                 assert_equal(np.timedelta64(np.int64(123)), np.timedelta64(123))
 
@@ -409,7 +413,7 @@ class TestDateTime:
 
         with pytest.warns(
             DeprecationWarning,
-            match="The 'generic' unit for NumPy timedelta is deprecated",
+            match=self.generic_unit_deprecation_message,
         ):
             # Default construction means 0
             assert_equal(np.timedelta64(), np.timedelta64(0))
@@ -421,7 +425,7 @@ class TestDateTime:
         assert_equal(str(np.timedelta64('NaT', 'ns')), 'NaT')
         with pytest.warns(
             DeprecationWarning,
-            match="The 'generic' unit for NumPy timedelta is deprecated",
+            match=self.generic_unit_deprecation_message,
         ):
             assert_equal(repr(np.timedelta64("NaT")), "np.timedelta64('NaT')")
         assert_equal(str(np.timedelta64(3, 's')), '3 seconds')
@@ -430,7 +434,7 @@ class TestDateTime:
 
         with pytest.warns(
             DeprecationWarning,
-            match="The 'generic' unit for NumPy timedelta is deprecated",
+            match=self.generic_unit_deprecation_message,
         ):
             assert_equal(repr(np.timedelta64(12)),
                         "np.timedelta64(12)")
@@ -521,7 +525,7 @@ class TestDateTime:
         # gh-17552
         with pytest.warns(
             DeprecationWarning,
-            match="The 'generic' unit for NumPy timedelta is deprecated",
+            match=self.generic_unit_deprecation_message,
         ):
             assert_equal('NaT', f'{np.timedelta64("nat")}')
 
@@ -872,7 +876,7 @@ class TestDateTime:
         # Regression test for gh-29497.
         with pytest.warns(
             DeprecationWarning,
-            match="The 'generic' unit for NumPy timedelta is deprecated",
+            match=self.generic_unit_deprecation_message,
         ):
             x = np.array(
                 [
@@ -1185,7 +1189,7 @@ class TestDateTime:
 
             with pytest.warns(
                 DeprecationWarning,
-                match="The 'generic' unit for NumPy timedelta is deprecated",
+                match=self.generic_unit_deprecation_message,
             ):
                 # m8 + bool
                 assert_equal(tdb + True, tdb + 1)
@@ -1265,7 +1269,7 @@ class TestDateTime:
             assert_equal((tdb - tda).dtype, np.dtype("m8[h]"))
             with pytest.warns(
                 DeprecationWarning,
-                match="The 'generic' unit for NumPy timedelta is deprecated",
+                match=self.generic_unit_deprecation_message,
             ):
                 # m8 - bool
                 assert_equal(tdc - True, tdc - 1)
@@ -1404,7 +1408,7 @@ class TestDateTime:
     def test_generic_timedelta_floor_divide(self):
         with pytest.warns(
             DeprecationWarning,
-            match="The 'generic' unit for NumPy timedelta is deprecated",
+            match=self.generic_unit_deprecation_message,
         ):
             assert_equal(np.timedelta64(1890) // np.timedelta64(31), 60)
 
@@ -1439,7 +1443,7 @@ class TestDateTime:
     def test_timedelta_floor_div_precision(self, val1, val2):
         with pytest.warns(
             DeprecationWarning,
-            match="The 'generic' unit for NumPy timedelta is deprecated",
+            match=self.generic_unit_deprecation_message,
         ):
             op1 = np.timedelta64(val1)
             op2 = np.timedelta64(val2)
@@ -1491,7 +1495,7 @@ class TestDateTime:
     def test_generic_timedelta_divmod(self, op1, op2):
         with pytest.warns(
             DeprecationWarning,
-            match="The 'generic' unit for NumPy timedelta is deprecated",
+            match=self.generic_unit_deprecation_message,
         ):
             op1 = np.timedelta64(op1)
             op2 = np.timedelta64(op2)
@@ -1580,7 +1584,7 @@ class TestDateTime:
                 'ignore', r".*encountered in divide", RuntimeWarning)
             warnings.filterwarnings(
                 "ignore",
-                "The 'generic' unit for NumPy timedelta is deprecated",
+                self.generic_unit_deprecation_message,
                 DeprecationWarning,
             )
             nat = np.timedelta64('NaT', 's')
@@ -2048,7 +2052,7 @@ class TestDateTime:
 
         with pytest.warns(
             DeprecationWarning,
-            match="The 'generic' unit for NumPy timedelta is deprecated",
+            match=self.generic_unit_deprecation_message,
         ):
             # Unit should be detected as months here
             a = np.arange("1969-05", "1970-05", 2, dtype="M8")
@@ -2752,7 +2756,7 @@ class TestDateTime:
     def test_timedelta_hash_generic(self):
         with pytest.warns(
             DeprecationWarning,
-            match="The 'generic' unit for NumPy timedelta is deprecated",
+            match=self.generic_unit_deprecation_message,
         ):
             assert_raises(ValueError, hash, np.timedelta64(123))  # generic
 

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -371,7 +371,7 @@ class TestRoundDeprecation(_DeprecationTestCase):
 class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
     # Deprecated in Numpy 2.5, 2025-11
     # See gh-29619
-    message = "Using 'generic' unit for NumPy timedelta is deprecated"
+    message = "The 'generic' unit for NumPy timedelta is deprecated"
 
     @pytest.mark.parametrize('value', [
         3, 10, "NaT"

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1973,7 +1973,7 @@ def test_result_type_integers_and_unitless_timedelta64():
     # would cause a seg. fault.
     with pytest.warns(
         DeprecationWarning,
-        match="Using 'generic' unit for NumPy timedelta is deprecated",
+        match="The 'generic' unit for NumPy timedelta is deprecated",
     ):
         td = np.timedelta64(4)
         result = np.result_type(0, td)

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1784,7 +1784,7 @@ class TestNonzero:
                 elif dt == 'm':
                     with pytest.warns(
                         DeprecationWarning,
-                        match="Using 'generic' unit for NumPy timedelta is deprecated",
+                        match="The 'generic' unit for NumPy timedelta is deprecated",
                     ):
                         m = np.zeros((3, 3), dtype=dt)
                         n = np.ones(1, dtype=dt)

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2860,7 +2860,7 @@ def test_ufunc_types(ufunc):
         if 'm' in inp:
             with pytest.warns(
                 DeprecationWarning,
-                match="Using 'generic' unit for NumPy timedelta is deprecated",
+                match="The 'generic' unit for NumPy timedelta is deprecated",
             ):
                 args = [np.ones((3, 3), t) for t in inp]
         else:

--- a/numpy/polynomial/tests/test_classes.py
+++ b/numpy/polynomial/tests/test_classes.py
@@ -336,7 +336,7 @@ def test_truediv(Poly):
         s = stype(5, 'D')
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             assert_poly_almost_equal(op.truediv(p2, s), p1)
         assert_raises(TypeError, op.truediv, s, p2)

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -434,7 +434,7 @@ class TestEqual(TestArrayEqual):
         # not a timedelta
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             natd_no_unit = np.timedelta64("NaT")
         natd_s = np.timedelta64("NaT", "s")
@@ -1343,7 +1343,7 @@ class TestAssertAllclose:
         # see gh-18286
         with pytest.warns(
             DeprecationWarning,
-            match="Using 'generic' unit for NumPy timedelta is deprecated",
+            match="The 'generic' unit for NumPy timedelta is deprecated",
         ):
             a = np.array([[1, 2, 3, "NaT"]], dtype="m8[ns]")
             assert_allclose(a, a)


### PR DESCRIPTION

### PR summary

This PR is based on the discussion below.
https://github.com/numpy/numpy/pull/29619#issuecomment-4150483161

This aims to clarify that operations using bare integer (e.g.  `+1` ) are also treated as generic timedelta.

#### AI Disclosure

No AI tool is used.