### PR TITLE
ENH, PERF: small arrays/dimensions on array object - with special allocator                           

### DIFF
--- a/numpy/_core/src/multiarray/alloc.cpp
+++ b/numpy/_core/src/multiarray/alloc.cpp
@@ -468,6 +468,97 @@ PyDataMem_Handler default_handler = {
 PyObject *PyDataMem_DefaultHandler;
 PyObject *current_handler;
 
+// For small allocations, we store data on the instance, with the size
+// in bytes stored right in front.
+// If the data is resized to something bigger, we allocate new memory.
+// To distinguish this case, it will also have extra space in front
+// for a size, but set to -1.
+// Note: malloc and calloc are only included for completeness. They
+// are not used in the numpy code
+static inline void *
+on_instance_malloc(void *NPY_UNUSED(ctx), size_t size)
+{
+    const size_t extra = sizeof(npy_intp*);
+    void *base = PyDataMem_NEW(size + extra);
+    if (base == NULL) {
+        return NULL;
+    }
+    *(npy_intp *)base = -1;
+    return (void*)((char*)base + extra);
+}
+
+static inline void *
+on_instance_calloc(void *NPY_UNUSED(ctx), size_t nelem, size_t elsize)
+{
+    const size_t extra = sizeof(npy_intp*);
+    if (npy_mul_with_overflow_size_t(&nelem, nelem, elsize)) {
+        return NULL;
+    }
+    void *base = PyDataMem_NEW_ZEROED(nelem + extra, 1);
+    if (base == NULL) {
+        return NULL;
+    }
+    *(npy_intp *)base = -1;
+    return (void*)((char*)base + extra);
+}
+
+static inline void
+on_instance_free(void *ctx, void *ptr, size_t size)
+{
+    const size_t extra = sizeof(npy_intp*);
+    void *oldbase = (void*)((char*)ptr - extra);
+    if (*(npy_intp*)oldbase < 0) {
+        // Use PyDataMem_FREE to ensure tracking skipped in UserFree.
+        PyDataMem_FREE(oldbase);
+    }
+    // else: data is on instance, nothing to free.
+}
+
+static inline void *
+on_instance_realloc(void *ctx, void *ptr, size_t new_size)
+{
+    void *newbase;
+    const size_t extra = sizeof(npy_intp*);
+    void *oldbase = (void*)((char*)ptr - extra);
+    if (*(npy_intp*)oldbase >= 0) {
+        npy_uintp old_size = *(npy_uintp*)oldbase;
+        if (new_size <= old_size) {
+            *(npy_intp*)oldbase = new_size;  // new size fits, just store it.
+            return ptr;
+        }
+        newbase = PyDataMem_NEW(new_size + extra);
+        if (newbase == NULL) {
+            // malloc failed, nothing more to do.
+            return NULL;
+        }
+        // Move existing data over, past storage for size.
+        memmove((char*)newbase + extra, (char*)ptr, old_size);
+    }
+    else {
+        // Not on instance, so default reallocation, but with extra space.
+        newbase = PyDataMem_RENEW(oldbase, new_size + extra);
+        if (newbase == NULL) {
+            return NULL;
+        }
+    }
+    *(npy_intp*)newbase = -1;
+    return (void *)((char*)newbase + extra);
+}
+
+/* Memory handler global default */
+PyDataMem_Handler on_instance_handler = {
+    "on_instance_allocator",
+    1,
+    {
+        NULL,            /* ctx */
+        on_instance_malloc,  /* not used normally */
+        on_instance_calloc,  /* not used normally */
+        on_instance_realloc, /* realloc */
+        on_instance_free     /* free */
+    }
+};
+
+
 int uo_index=0;   /* user_override index */
 
 /* Wrappers for the default or any user-assigned PyDataMem_Handler */
@@ -485,6 +576,10 @@ PyDataMem_UserNEW(size_t size, PyObject *mem_handler)
     result = handler->allocator.malloc(handler->allocator.ctx, size);
     if (result == NULL) {
         return NULL;
+    }
+    if (handler == &on_instance_handler) {
+        // Since data can be on instance, tracking is done by the handler.
+        return result;
     }
     int ret = PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, size);
     if (ret == -1) {
@@ -507,6 +602,10 @@ PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyObject *mem_handler)
     if (result == NULL) {
         return NULL;
     }
+    if (handler == &on_instance_handler) {
+        // Since data can be on instance, tracking is done by the handler.
+        return result;
+    }
     int ret = PyTraceMalloc_Track(NPY_TRACE_DOMAIN, (npy_uintp)result, nmemb * size);
     if (ret == -1) {
         handler->allocator.free(handler->allocator.ctx, result, size);
@@ -524,6 +623,11 @@ PyDataMem_UserFREE(void *ptr, size_t size, PyObject *mem_handler)
     if (handler == NULL) {
         WARN_NO_RETURN(PyExc_RuntimeWarning,
                      "Could not get pointer to 'mem_handler' from PyCapsule");
+        return;
+    }
+    if (handler == &on_instance_handler) {
+        // Since data can be on instance, tracking is done by the handler.
+        handler->allocator.free(handler->allocator.ctx, ptr, size);
         return;
     }
     // ignore -2 return when tracemalloc is disabled
@@ -546,6 +650,10 @@ PyDataMem_UserRENEW(void *ptr, size_t size, PyObject *mem_handler)
     if (result == NULL) {
         // ptr is still valid here
         return NULL;
+    }
+    if (handler == &on_instance_handler) {
+        // Since data can be on instance, tracking is done by the handler.
+        return result;
     }
     int ret = PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
     if (ret == -2) {

--- a/numpy/_core/src/multiarray/alloc.h
+++ b/numpy/_core/src/multiarray/alloc.h
@@ -44,7 +44,12 @@ npy_free_cache_dim_obj(PyArray_Dims dims)
 static inline void
 npy_free_cache_dim_array(PyArrayObject * arr)
 {
-    npy_free_cache_dim(PyArray_DIMS(arr), PyArray_NDIM(arr));
+    /* deallocate if not part of the array instance */
+    if ((PyArray_DIMS(arr) != NULL)
+        && (PyArray_DIMS(arr) !=
+            (npy_intp *)((char*)arr + Py_TYPE(arr)->tp_basicsize))) {
+        npy_free_cache_dim(PyArray_DIMS(arr), PyArray_NDIM(arr));
+    }
 }
 
 extern PyDataMem_Handler default_handler;

--- a/numpy/_core/src/multiarray/alloc.h
+++ b/numpy/_core/src/multiarray/alloc.h
@@ -54,6 +54,7 @@ npy_free_cache_dim_array(PyArrayObject * arr)
 
 extern PyDataMem_Handler default_handler;
 extern PyObject *current_handler; /* PyContextVar/PyCapsule */
+extern PyDataMem_Handler on_instance_handler;
 
 NPY_NO_EXPORT PyObject *
 get_handler_name(PyObject *NPY_UNUSED(self), PyObject *obj);

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -455,7 +455,7 @@ _clear_array_attributes(PyArrayObject *self, npy_bool unraisable)
     }
 
     /* must match allocation in PyArray_NewFromDescr */
-    npy_free_cache_dim(fa->dimensions, 2 * fa->nd);
+    npy_free_cache_dim_array(self); // frees it if not on instance.
     fa->dimensions = NULL;
     Py_CLEAR(fa->descr);
     return 0;

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -744,10 +744,46 @@ PyArray_NewFromDescr_int(
         }
     }
     /*
+     * Check dimensions and find total array size `nbytes`.
+     */
+    int is_zero = 0;
+    for (int i = 0; i < nd; i++) {
+        if (dims[i] == 0) {
+            /*
+             * Continue calculating the max size "as if" this were 1
+             * to get the proper overflow error
+             */
+            is_zero = 1;
+            continue;
+        }
+        if (dims[i] < 0) {
+            PyErr_SetString(PyExc_ValueError,
+                            "negative dimensions are not allowed");
+            Py_DECREF(descr);
+            return NULL;
+        }
+        /*
+         * Care needs to be taken to avoid integer overflow when multiplying
+         * the dimensions together to get the total size of the array.
+         */
+        if (npy_mul_sizes_with_overflow(&nbytes, nbytes, dims[i])) {
+            PyErr_SetString(PyExc_ValueError,
+                            "array is too big; `arr.size * arr.dtype.itemsize` "
+                            "is larger than the maximum possible size.");
+            Py_DECREF(descr);
+            return NULL;
+        }
+    }
+    if (is_zero) {
+        nbytes = 0;
+    }
+    /*
      * Create the array instance.
      *
-     * For standard arrays, we allocate extra memory for the dimensions and
-     * strides, to avoid the overhead of another allocation.
+     * For standard, non-subclassed arrays, we allocate extra memory for
+     * the dimensions and strides, as well as the data themselves if small
+     * enough (and the default memory handler is used), to avoid the
+     * overhead of allocating tracked memory with PyDataMem_UserNew.
      *
      * We do this bypassing the standard tp_alloc, basically copying the
      * relevant code from PyType_GenericAlloc in Objects/typeobject.c.
@@ -755,40 +791,78 @@ PyArray_NewFromDescr_int(
      * instances, as this would change the array object structure order.
      *
      * TODO: possible extensions:
-     * - Also store small bits of data.
-     * - Maybe extend to subtype as long as tp_itemsize == 0
+     * - Maybe extend to subclasses as long as tp_itemsize == 0
      *   && tp_alloc == PyObject_GenericAlloc?
+     * - If one exposed the on-instance handler, one could always store
+     *   data on the instance if that is set.
      */
+    PyObject *mem_handler = NULL;
+    if (data == NULL) {
+        mem_handler = PyDataMem_GetHandler();
+        if (mem_handler == NULL) {
+            Py_DECREF(descr);
+            return NULL;
+        }
+    }
+
     if (subtype == &PyArray_Type) {
         size_t size = subtype->tp_basicsize;
+        size_t dim_offset = size;
         /* Alignment to intp should be guaranteed (last item is a pointer). */
-        assert(size % NPY_ALIGNOF(npy_intp) == 0);
+        assert(dim_offset % NPY_ALIGNOF(npy_intp) == 0);
         /* Add space for dimensions and strides. */
         size += sizeof(npy_intp) * nd * 2;
+        /* Possibly, add space for data. */
+        size_t data_offset = 0;
+        if (data == NULL && nbytes < size
+                && mem_handler == PyDataMem_DefaultHandler) {
+            /* Add space for the number of bytes (needed for possible resize) */
+            size += sizeof(npy_intp);
+            /* Round up if needed to ensure data will be aligned */
+            size_t align = NPY_ALIGNOF(npy_clongdouble);
+            data_offset = ((size + align - 1) / align) * align;
+            /* Always allocate at least one byte for the data. */
+            size = data_offset + (nbytes == 0 ? 1 : nbytes);
+        }
         /* Allocate the object and extra space */
         char *alloc = PyObject_Malloc(size);
         if (alloc == NULL) {
+            Py_XDECREF(mem_handler);
             Py_DECREF(descr);
             return PyErr_NoMemory();
         }
-        /* PyType_GenericAlloc zeroes the extra bytes, but we don't need to. */
+        /*
+         * PyType_GenericAlloc zeroes the extra bytes, but we don't need to,
+         * since we initialize below.  (Side note: Init cannot fail.)
+         */
         fa = (PyArrayObject_fields *)PyObject_Init((PyObject *)alloc, subtype);
         fa->dimensions = nd == 0 ? NULL :
             (npy_intp*)((char*)fa + subtype->tp_basicsize);
+        if (data_offset) {
+            fa->data = (char*)fa + data_offset;
+            /* Store number of bytes right before data */
+            *(npy_intp*)((char*)fa + data_offset - sizeof(npy_intp)) = nbytes;
+            Py_INCREF(npy_static_pydata.on_instance_handler);
+            Py_SETREF(mem_handler, npy_static_pydata.on_instance_handler);
+        }
+        else {
+            fa->data = NULL;
+        }
     }
     else {
         /* For subtypes, do not presume tp_alloc is the same. */
         fa = (PyArrayObject_fields *) subtype->tp_alloc(subtype, 0);
         if (fa == NULL) {
+            Py_XDECREF(mem_handler);
             Py_DECREF(descr);
             return NULL;
         }
         fa->dimensions = NULL;
+        fa->data = NULL;
     }
     fa->_buffer_info = NULL;
     fa->nd = nd;
-    fa->data = NULL;
-    fa->mem_handler = NULL;
+    fa->mem_handler = mem_handler;  /* NULL if it will not be needed */
 
     if (data == NULL) {
         fa->flags = NPY_ARRAY_DEFAULT;
@@ -824,49 +898,25 @@ PyArray_NewFromDescr_int(
             assert(fa->dimensions != (npy_intp*)((char*)fa + subtype->tp_basicsize));
         }
         fa->strides = fa->dimensions + nd;
-
-        /*
-         * Copy dimensions, check them, and find total array size `nbytes`
-         */
-        int is_zero = 0;
+        /* Fill dimensions. */
         for (int i = 0; i < nd; i++) {
             fa->dimensions[i] = dims[i];
-
-            if (fa->dimensions[i] == 0) {
-                /*
-                 * Continue calculating the max size "as if" this were 1
-                 * to get the proper overflow error
-                 */
-                is_zero = 1;
-                continue;
-            }
-
-            if (fa->dimensions[i] < 0) {
-                PyErr_SetString(PyExc_ValueError,
-                        "negative dimensions are not allowed");
-                goto fail;
-            }
-
-            /*
-             * Care needs to be taken to avoid integer overflow when multiplying
-             * the dimensions together to get the total size of the array.
-             */
-            if (npy_mul_sizes_with_overflow(&nbytes, nbytes, fa->dimensions[i])) {
-                PyErr_SetString(PyExc_ValueError,
-                        "array is too big; `arr.size * arr.dtype.itemsize` "
-                        "is larger than the maximum possible size.");
-                goto fail;
-            }
-        }
-        if (is_zero) {
-            nbytes = 0;
         }
 
         /* Fill the strides (or copy them if they were passed in) */
         if (strides == NULL) {
-            /* fill the strides and set the contiguity flags */
-            _array_fill_strides(fa->strides, dims, nd, descr->elsize,
-                                flags, &(fa->flags));
+            if (nbytes > 0) {
+                /* fill the strides and set the contiguity flags */
+                _array_fill_strides(fa->strides, dims, nd, descr->elsize,
+                                    flags, &(fa->flags));
+            }
+            else {
+                /* All strides are 0 */
+                for (int i = 0; i < nd; i++) {
+                    fa->strides[i] = 0;
+                }
+                fa->flags |= NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_F_CONTIGUOUS;
+            }
         }
         else {
             /* User to provided strides (user is responsible for correctness) */
@@ -883,7 +933,6 @@ PyArray_NewFromDescr_int(
         fa->strides = NULL;
         fa->flags |= NPY_ARRAY_C_CONTIGUOUS|NPY_ARRAY_F_CONTIGUOUS;
     }
-
 
     if (data == NULL) {
         /* This closely follows PyArray_ZeroContiguousBuffer. We can't use
@@ -918,33 +967,33 @@ PyArray_NewFromDescr_int(
                 PyDataType_FLAGCHK(descr, NPY_NEEDS_INIT) ||
                 ((cflags & _NPY_ARRAY_ZEROED) && (fill_zero_info.func == NULL)));
 
-        /* Store the handler in case the default is modified */
-        fa->mem_handler = PyDataMem_GetHandler();
-        if (fa->mem_handler == NULL) {
-            goto fail;
-        }
-        /*
-         * Allocate something even for zero-space arrays
-         * e.g. shape=(0,) -- otherwise buffer exposure
-         * (a.data) doesn't work as it should.
-         */
-        if (nbytes == 0) {
-            nbytes = 1;
-            /* Make sure all the strides are 0 */
-            for (int i = 0; i < nd; i++) {
-                fa->strides[i] = 0;
+        if (fa->data != NULL) {
+            /* data on instance; zero if needed. */
+            data = fa->data;
+            if (use_calloc) {
+                memset(data, 0, nbytes);
             }
         }
-
-        if (use_calloc) {
-            data = PyDataMem_UserNEW_ZEROED(nbytes, 1, fa->mem_handler);
-        }
         else {
-            data = PyDataMem_UserNEW(nbytes, fa->mem_handler);
-        }
-        if (data == NULL) {
-            raise_memory_error(fa->nd, fa->dimensions, descr);
-            goto fail;
+            /*
+             * Allocate something even for zero-space arrays
+             * e.g. shape=(0,) -- otherwise buffer exposure
+             * (a.data) doesn't work as it should.
+             */
+            if (nbytes == 0) {
+                nbytes = 1;
+            }
+
+            if (use_calloc) {
+                data = PyDataMem_UserNEW_ZEROED(nbytes, 1, fa->mem_handler);
+            }
+            else {
+                data = PyDataMem_UserNEW(nbytes, fa->mem_handler);
+            }
+            if (data == NULL) {
+                raise_memory_error(fa->nd, fa->dimensions, descr);
+                goto fail;
+            }
         }
 
         /*
@@ -1038,7 +1087,6 @@ PyArray_NewFromDescr_int(
 
  fail:
     NPY_traverse_info_xfree(&fill_zero_info);
-    Py_XDECREF(fa->mem_handler);
     Py_DECREF(fa);
     return NULL;
 }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -743,15 +743,50 @@ PyArray_NewFromDescr_int(
             }
         }
     }
-
-    fa = (PyArrayObject_fields *) subtype->tp_alloc(subtype, 0);
-    if (fa == NULL) {
-        Py_DECREF(descr);
-        return NULL;
+    /*
+     * Create the array instance.
+     *
+     * For standard arrays, we allocate extra memory for the dimensions and
+     * strides, to avoid the overhead of another allocation.
+     *
+     * We do this bypassing the standard tp_alloc, basically copying the
+     * relevant code from PyType_GenericAlloc in Objects/typeobject.c.
+     * Note that we cannot use the standard machinery for variable size
+     * instances, as this would change the array object structure order.
+     *
+     * TODO: possible extensions:
+     * - Also store small bits of data.
+     * - Maybe extend to subtype as long as tp_itemsize == 0
+     *   && tp_alloc == PyObject_GenericAlloc?
+     */
+    if (subtype == &PyArray_Type) {
+        size_t size = subtype->tp_basicsize;
+        /* Alignment to intp should be guaranteed (last item is a pointer). */
+        assert(size % NPY_ALIGNOF(npy_intp) == 0);
+        /* Add space for dimensions and strides. */
+        size += sizeof(npy_intp) * nd * 2;
+        /* Allocate the object and extra space */
+        char *alloc = PyObject_Malloc(size);
+        if (alloc == NULL) {
+            Py_DECREF(descr);
+            return PyErr_NoMemory();
+        }
+        /* PyType_GenericAlloc zeroes the extra bytes, but we don't need to. */
+        fa = (PyArrayObject_fields *)PyObject_Init((PyObject *)alloc, subtype);
+        fa->dimensions = nd == 0 ? NULL :
+            (npy_intp*)((char*)fa + subtype->tp_basicsize);
+    }
+    else {
+        /* For subtypes, do not presume tp_alloc is the same. */
+        fa = (PyArrayObject_fields *) subtype->tp_alloc(subtype, 0);
+        if (fa == NULL) {
+            Py_DECREF(descr);
+            return NULL;
+        }
+        fa->dimensions = NULL;
     }
     fa->_buffer_info = NULL;
     fa->nd = nd;
-    fa->dimensions = NULL;
     fa->data = NULL;
     fa->mem_handler = NULL;
 
@@ -778,10 +813,15 @@ PyArray_NewFromDescr_int(
     NPY_traverse_info_init(&fill_zero_info);
 
     if (nd > 0) {
-        fa->dimensions = npy_alloc_cache_dim(2 * nd);
         if (fa->dimensions == NULL) {
-            PyErr_NoMemory();
-            goto fail;
+            /* Not on instance, so allocate space here. */
+            fa->dimensions = npy_alloc_cache_dim(2 * nd);
+            if (fa->dimensions == NULL) {
+                PyErr_NoMemory();
+                goto fail;
+            }
+            /* Ensure this doesn't look like on-instance. */
+            assert(fa->dimensions != (npy_intp*)((char*)fa + subtype->tp_basicsize));
         }
         fa->strides = fa->dimensions + nd;
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -5182,8 +5182,17 @@ _multiarray_umath_exec(PyObject *m) {
     if (PyDataMem_DefaultHandler == NULL) {
         return -1;
     }
+    /*
+     * Initialize the private on-instance PyDataMem_Handler singleton.
+     */
+    npy_static_pydata.on_instance_handler = PyCapsule_New(
+            &on_instance_handler, MEM_HANDLER_CAPSULE_NAME, NULL);
+    if (npy_static_pydata.on_instance_handler == NULL) {
+        return -1;
+    }
 #ifdef Py_GIL_DISABLED
-    if (PyUnstable_SetImmortal(PyDataMem_DefaultHandler) == 0) {
+    if (PyUnstable_SetImmortal(PyDataMem_DefaultHandler) == 0
+        || PyUnstable_SetImmortal(npy_static_pydata.on_instance_handler) == 0) {
         PyErr_SetString(PyExc_RuntimeError,
                         "Could not mark memory handler capsule as immortal");
         return -1;

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -151,6 +151,10 @@ typedef struct npy_static_pydata_struct {
     PyObject *dl_call_kwnames;
     PyObject *dl_cpu_device_tuple;
     PyObject *dl_max_version;
+    /*
+     * Used for helping with storing small arrays as part of the instance
+     */
+    PyObject *on_instance_handler;
 } npy_static_pydata_struct;
 
 

--- a/numpy/_core/src/multiarray/shape.c
+++ b/numpy/_core/src/multiarray/shape.c
@@ -142,10 +142,10 @@ PyArray_Resize_int(PyArrayObject *self, PyArray_Dims *newshape, int refcheck)
 
     if (new_nd > 0) {
         if (PyArray_NDIM(self) != new_nd) {
-            /* Different number of dimensions. */
+            /* Different number of dimensions: need new dims & strides. */
+            npy_free_cache_dim_array(self);
             ((PyArrayObject_fields *)self)->nd = new_nd;
-            /* Need new dimensions and strides arrays */
-            dimptr = PyDimMem_RENEW(PyArray_DIMS(self), 3*new_nd);
+            dimptr = npy_alloc_cache_dim(2 * new_nd);
             if (dimptr == NULL) {
                 PyErr_SetString(PyExc_MemoryError,
                                 "cannot allocate memory for array");

--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -9,7 +9,7 @@ import pytest
 
 import numpy as np
 from numpy._core.multiarray import get_handler_name
-from numpy.testing import IS_EDITABLE, IS_WASM, extbuild
+from numpy.testing import IS_EDITABLE, IS_WASM, assert_array_equal, extbuild
 
 
 @pytest.fixture
@@ -102,6 +102,30 @@ def get_module(tmp_path):
             }
             return arr;
 
+         """),
+        ("get_handler_from_array", "METH_O", """
+            if (!PyArray_Check(args)) {
+                PyErr_SetString(PyExc_ValueError,
+                             "need an ndarray");
+                return NULL;
+            }
+            PyObject *mem_handler = ((PyArrayObject_fields *)args)->mem_handler;
+            Py_INCREF(mem_handler);
+            return mem_handler;
+
+         """),
+        ("is_data_on_instance", "METH_O", """
+            /* Only works for on_instance_handler!!! */
+            if (!PyArray_Check(args)) {
+                PyErr_SetString(PyExc_ValueError,
+                             "need an ndarray");
+                return NULL;
+            }
+            char *data = (char *)PyArray_DATA((PyArrayObject*)args);
+            npy_intp size = *(npy_intp*)(data-sizeof(npy_intp));
+            PyObject *result = size > 0 ? Py_True : Py_False;
+            Py_INCREF(result);
+            return result;
          """),
     ]
     prologue = '''
@@ -237,7 +261,8 @@ def test_set_policy(get_module):
     get_handler_version = np._core.multiarray.get_handler_version
     orig_policy_name = get_handler_name()
 
-    a = np.arange(10).reshape((2, 5))  # a doesn't own its own data
+    # Large array so we are sure not to store on the instance.
+    a = np.empty(1000).reshape((-1, 5))  # a doesn't own its own data
     assert get_handler_name(a) is None
     assert get_handler_version(a) is None
     assert get_handler_name(a.base) == orig_policy_name
@@ -292,7 +317,8 @@ def test_policy_propagation(get_module):
 
     get_handler_name = np._core.multiarray.get_handler_name
     orig_policy_name = get_handler_name()
-    a = np.arange(10).view(MyArr).reshape((2, 5))
+    # Large array so we for sure do not store on the instance.
+    a = np.empty(1000).view(MyArr).reshape((-1, 5))
     assert get_handler_name(a) is None
     assert a.flags.owndata is False
 
@@ -385,7 +411,7 @@ def test_new_policy(get_module):
 
     orig_policy = get_module.set_secret_data_policy()
 
-    b = np.arange(10)
+    b = np.arange(10)  # Small array will now not be on instance.
     assert np._core.multiarray.get_handler_name(b) == 'secret_data_allocator'
 
     # test array manipulation. This is slow
@@ -445,3 +471,58 @@ def test_owner_is_base(get_module):
         del a
         gc.collect()
         gc.collect()
+
+
+def test_on_instance_handler(get_module):
+    """Test the allocator for data on instances.
+
+    Note that the on-instance allocator is meant for internal use only,
+    but internally no actual allocations are done (only reallocation
+    and freeing), so this adds a few tests that those do work.
+
+    """
+
+    get_handler_name = np._core.multiarray.get_handler_name
+    get_handler_version = np._core.multiarray.get_handler_version
+    orig_policy_name = get_handler_name()
+
+    # Small array so we will store on the instance.
+    a = np.empty(4)  # a owns its data.
+    assert get_handler_name(a) == "on_instance_allocator"
+    assert get_module.is_data_on_instance(a)
+    # Making it smaller, data should remain on instance.
+    a.resize(2)
+    assert get_module.is_data_on_instance(a)
+    # But not if we make it bigger (even if it would still fit).
+    a.resize(3)
+    assert not get_module.is_data_on_instance(a)
+
+    b = np.empty(1000)  # b is too large for on-instance
+    assert get_handler_name(b) == "default_allocator"
+
+    on_instance_handler = get_module.get_handler_from_array(a)
+    try:
+        get_module.set_old_policy(on_instance_handler)
+        assert get_handler_name() == 'on_instance_allocator'
+        # Large array now uses this allocator too (though it not
+        # actually on the instance, at least not as implemented).
+        c = np.ones(499)
+        assert get_handler_name(c) == "on_instance_allocator"
+        assert not get_module.is_data_on_instance(c)
+        # Check going through calloc instead of malloc.
+        d = np.zeros(500)
+        assert get_handler_name(d) == "on_instance_allocator"
+        assert not get_module.is_data_on_instance(d)
+        # Check resize up and down.
+        c.resize(50)
+        assert c.shape == (50,)
+        assert_array_equal(c, 1.0)
+        assert get_handler_name(c) == "on_instance_allocator"
+        c.resize(100)
+        assert get_handler_name(c) == "on_instance_allocator"
+        assert_array_equal(c[:50], 1.0)
+        assert_array_equal(c[50:], 0.0)
+        assert not get_module.is_data_on_instance(c)
+    finally:
+        get_module.set_old_policy(None)
+    assert get_handler_name() == orig_policy_name

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6372,6 +6372,13 @@ class TestResize:
                 np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]).flat)
         assert_array_equal(x[9:].flat, 0)
 
+    def test_scalar(self):
+        x = np.array(1.5)
+        x.resize((5, 5))
+        expected = np.zeros((5, 5))
+        expected[0, 0] = 1.5
+        assert_array_equal(x, expected)
+
     def test_check_reference(self):
         x = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
         y = x


### PR DESCRIPTION
This is an alternative to gh-31092 (and shares essentially the same first commit).

### Details
This PR stores the dimensions, strides, and small arrays on the instance, and uses a new allocator to deal with possible resizes. This is less intrusive than gh-31092 in the rest of the code, as the custom memory allocator can be used as normal. But the performance is slightly worse because of slower checks that freeing memory is not needed.

### Timings
Timings relative to having dimensions, strides and data not on the object (results for gh-31092 in parenthesis)
```
%timeit np.empty(())
133->73 ns (68)

a = 1.6
%timeit np.array(a)
151->92 ns (83)

%timeit np.add(a, a)
581->431 ns (423)

b = np.array(a)
%timeit np.add(b, b)
293->248 ns (225)
```

EDIT: storing the strides helps also for arrays that are views (so independent of how data allocation is done):
```
a = np.arange(10.)

%timeit a.view()
49.9 -> 36 ns

%timeit a.reshape((2, 5))
114 -> 97 ns

b = np.ones((5, 2))
%timeit b[0]
67 -> 49 ns

```
