### PR TITLE
BUG: fix heap buffer overflow in timedelta to string casts

### DIFF
--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -4090,6 +4090,9 @@ time_to_string_resolve_descriptors(
         if (loop_descrs[1] == NULL) {
             return -1;
         }
+        if (given_descrs[1] != NULL) {
+            size = (size < given_descrs[1]->elsize) ? size : given_descrs[1]->elsize;
+        }
         loop_descrs[1]->elsize = size;
     }
 

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -2696,6 +2696,10 @@ class TestDateTime:
         limit_via_str = np.datetime64(str(limit), time_unit)
         assert limit_via_str == limit
 
+    def test_cast_to_truncated_string_doesnt_overflow(self):
+        a = np.array([1, -2, 1], dtype='timedelta64[D]')
+        assert_array_equal(a.astype('U1'), ['1', '-', '1'])
+
     def test_datetime_hash_nat(self):
         nat1 = np.datetime64()
         nat2 = np.datetime64()


### PR DESCRIPTION
### PR summary
Fixes #31109.

The `resolve_descriptors` implementation doesn't account for cases where the output string isn't large enough to hold the entire converted string.

The fix is to clamp the output dtype size to the input dtype size, if there's an explicit size.

#### AI Disclosure

No AI used.
