### PR TITLE
DEP: remove warnings from `read_rows`

### DIFF
--- a/numpy/_core/src/multiarray/textreading/rows.c
+++ b/numpy/_core/src/multiarray/textreading/rows.c
@@ -186,9 +186,6 @@ read_rows(stream *s,
     size_t rows_per_block = 1;  /* will be increased depending on row size */
     npy_intp data_allocated_rows = 0;
 
-    /* We give a warning if max_rows is used and an empty line is encountered */
-    bool give_empty_row_warning = max_rows >= 0;
-
     int ts_result = 0;
     tokenizer_state ts;
     if (npy_tokenizer_init(&ts, pconfig) < 0) {
@@ -226,29 +223,8 @@ read_rows(stream *s,
         }
         current_num_fields = ts.num_fields;
         field_info *fields = ts.fields;
+
         if (NPY_UNLIKELY(ts.num_fields == 0)) {
-            /*
-             * Deprecated NumPy 1.23, 2021-01-13 (not really a deprecation,
-             * but similar policy should apply to removing the warning again)
-             */
-             /* Tokenizer may give a final "empty line" even if there is none */
-            if (give_empty_row_warning && ts_result == 0) {
-                give_empty_row_warning = false;
-                if (PyErr_WarnFormat(PyExc_UserWarning, 3,
-                        "Input line %zd contained no data and will not be "
-                        "counted towards `max_rows=%zd`.  This differs from "
-                        "the behaviour in NumPy <=1.22 which counted lines "
-                        "rather than rows.  If desired, the previous behaviour "
-                        "can be achieved by using `itertools.islice`.\n"
-                        "Please see the 1.23 release notes for an example on "
-                        "how to do this.  If you wish to ignore this warning, "
-                        "use `warnings.filterwarnings`.  This warning is "
-                        "expected to be removed in the future and is given "
-                        "only once per `loadtxt` call.",
-                        row_count + skiplines + 1, max_rows) < 0) {
-                    goto error;
-                }
-            }
             continue;  /* Ignore empty line */
         }
 

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1269,20 +1269,12 @@ class TestLoadTxt(LoadTxtBase):
         if callable(data):
             data = data()
 
-        with pytest.warns(UserWarning,
-                    match=f"Input line 3.*max_rows={3 - skip}"):
-            res = np.loadtxt(data, dtype=int, skiprows=skip, delimiter=",",
-                             max_rows=3 - skip)
-            assert_array_equal(res, [[-1, 0], [1, 2], [3, 4]][skip:])
+        res = np.loadtxt(data, dtype=int, skiprows=skip, delimiter=",",
+                         max_rows=3 - skip)
+        assert_array_equal(res, [[-1, 0], [1, 2], [3, 4]][skip:])
 
         if isinstance(data, StringIO):
             data.seek(0)
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            with pytest.raises(UserWarning):
-                np.loadtxt(data, dtype=int, skiprows=skip, delimiter=",",
-                           max_rows=3 - skip)
 
 class Testfromregex:
     def test_record(self):

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1275,6 +1275,10 @@ class TestLoadTxt(LoadTxtBase):
 
         if isinstance(data, StringIO):
             data.seek(0)
+        # gh-31113 old test checked the warning twice on `StringIO` inputs
+        x = np.loadtxt(data, dtype=int, skiprows=skip, delimiter=",",
+                       max_rows=3 - skip)
+        assert_array_equal(x, [[-1, 0], [1, 2], [3, 4]][skip:])
 
 class Testfromregex:
     def test_record(self):


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
Partly fixes https://github.com/numpy/numpy/issues/30440
Removed a warning from `read_rows` and its related tests.
I am not sure if the tests I have removed was only for this case, the match seemed like it was just for this removed warning. 

I will open more PRs to close https://github.com/numpy/numpy/issues/30440

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->
Hey, I am an undergrad maths & stats student at uni of Glasgow. I am starting to contribute PRs to stuff I occasionally use mainly for educational reasons. I like numerical and symbolic methods and computational statistics.
 You should be seeing me occasionally in PRs and Discussions from now on here.


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
No AI tools were used in this PR.
