### PR TITLE
DEP: expire deprecation for null handling of `context` and `return_scalar` in `arraywrap`

### DIFF
--- a/doc/release/upcoming_changes/31119.expired.rst
+++ b/doc/release/upcoming_changes/31119.expired.rst
@@ -1,0 +1,1 @@
+* ``__array_wrap__`` implementations must now accept ``context`` and ``return_scalar`` positional arguments; support for legacy signatures has been removed (deprecated since 2.0).

--- a/numpy/_core/src/multiarray/arraywrap.c
+++ b/numpy/_core/src/multiarray/arraywrap.c
@@ -137,7 +137,6 @@ npy_apply_wrap(
     PyObject *res = NULL;
     PyObject *new_wrap = NULL;
     PyArrayObject *arr = NULL;
-    PyObject *err_type, *err_value, *traceback;
 
     /* If provided, we prefer the actual out objects wrap: */
     if (original_out != NULL && original_out != Py_None) {
@@ -236,59 +235,6 @@ npy_apply_wrap(
             wrap, arr, py_context,
             (return_scalar && PyArray_NDIM(arr) == 0) ? Py_True : Py_False,
             NULL);
-    if (res != NULL) {
-        goto finish;
-    }
-    else if (!PyErr_ExceptionMatches(PyExc_TypeError)) {
-        goto finish;
-    }
-
-    /*
-     * Retry without passing return_scalar.  If that succeeds give a
-     * Deprecation warning.
-     * When context is None, there is no reason to try this, though.
-     */
-    if (py_context != Py_None) {
-        PyErr_Fetch(&err_type, &err_value, &traceback);
-        res = PyObject_CallFunctionObjArgs(wrap, arr, py_context, NULL);
-        if (res != NULL) {
-            goto deprecation_warning;
-        }
-        Py_DECREF(err_type);
-        Py_XDECREF(err_value);
-        Py_XDECREF(traceback);
-        if (!PyErr_ExceptionMatches(PyExc_TypeError)) {
-            goto finish;
-        }
-    }
-
-    /*
-     * Retry without passing context and return_scalar parameters.
-     * If that succeeds, we give a DeprecationWarning.
-     */
-    PyErr_Fetch(&err_type, &err_value, &traceback);
-    res = PyObject_CallFunctionObjArgs(wrap, arr, NULL);
-    if (res == NULL) {
-        Py_DECREF(err_type);
-        Py_XDECREF(err_value);
-        Py_XDECREF(traceback);
-        goto finish;
-    }
-
-  deprecation_warning:
-    /* If we reach here, the original error is still stored. */
-    /* Deprecated 2024-01-17, NumPy 2.0 */
-    if (DEPRECATE(
-            "__array_wrap__ must accept context and return_scalar arguments "
-            "(positionally) in the future. (Deprecated NumPy 2.0)") < 0) {
-        npy_PyErr_ChainExceptionsCause(err_type, err_value, traceback);
-        Py_CLEAR(res);
-    }
-    else {
-        Py_DECREF(err_type);
-        Py_XDECREF(err_value);
-        Py_XDECREF(traceback);
-    }
 
   finish:
     Py_XDECREF(py_context);

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -219,30 +219,6 @@ class TestDeprecatedDTypeAliases(_DeprecationTestCase):
             np.dtype(dtype_code)
 
 
-class TestDeprecatedArrayWrap(_DeprecationTestCase):
-    message = "__array_wrap__.*"
-
-    def test_deprecated(self):
-        class Test1:
-            def __array__(self, dtype=None, copy=None):
-                return np.arange(4)
-
-            def __array_wrap__(self, arr, context=None):
-                self.called = True
-                return 'pass context'
-
-        class Test2(Test1):
-            def __array_wrap__(self, arr):
-                self.called = True
-                return 'pass'
-
-        test1 = Test1()
-        test2 = Test2()
-        self.assert_deprecated(lambda: np.negative(test1))
-        assert test1.called
-        self.assert_deprecated(lambda: np.negative(test2))
-        assert test2.called
-
 class TestDeprecatedArrayAttributeSetting(_DeprecationTestCase):
     message = "Setting the .*on a NumPy array has been deprecated.*"
 


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

Progresses #30440



#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
No AI tools used
