### PR TITLE
TYP: ``sort`` and ``argsort`` shape-typing

### DIFF
--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -414,33 +414,81 @@ def argpartition[ShapeT: _Shape](
 
 #
 @overload
+def sort[ArrayT: np.ndarray](
+    a: ArrayT,
+    axis: SupportsIndex = -1,
+    kind: _SortKind | None = None,
+    order: str | Sequence[str] | None = None,
+    *,
+    stable: bool | None = None,
+) -> ArrayT: ...
+@overload
 def sort[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
-    axis: SupportsIndex | None = -1,
+    axis: SupportsIndex = -1,
     kind: _SortKind | None = None,
     order: str | Sequence[str] | None = None,
     *,
     stable: bool | None = None,
 ) -> NDArray[ScalarT]: ...
 @overload
+def sort[ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    axis: None,
+    kind: _SortKind | None = None,
+    order: str | Sequence[str] | None = None,
+    *,
+    stable: bool | None = None,
+) -> _Array1D[ScalarT]: ...
+@overload
 def sort(
     a: ArrayLike,
-    axis: SupportsIndex | None = -1,
+    axis: SupportsIndex = -1,
     kind: _SortKind | None = None,
     order: str | Sequence[str] | None = None,
     *,
     stable: bool | None = None,
 ) -> NDArray[Any]: ...
-
-def argsort(
+@overload
+def sort(
     a: ArrayLike,
-    axis: SupportsIndex | None = -1,
+    axis: None,
     kind: _SortKind | None = None,
     order: str | Sequence[str] | None = None,
     *,
     stable: bool | None = None,
-) -> NDArray[intp]: ...
+) -> _Array1D[Any]: ...
 
+#
+@overload
+def argsort[ShapeT: _Shape](
+    a: np.ndarray[ShapeT],
+    axis: SupportsIndex = -1,
+    kind: _SortKind | None = None,
+    order: str | Sequence[str] | None = None,
+    *,
+    stable: bool | None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...
+@overload
+def argsort(
+    a: ArrayLike,
+    axis: SupportsIndex = -1,
+    kind: _SortKind | None = None,
+    order: str | Sequence[str] | None = None,
+    *,
+    stable: bool | None = None,
+) -> NDArray[np.intp]: ...
+@overload
+def argsort(
+    a: ArrayLike,
+    axis: None,
+    kind: _SortKind | None = None,
+    order: str | Sequence[str] | None = None,
+    *,
+    stable: bool | None = None,
+) -> _Array1D[np.intp]: ...
+
+#
 @overload
 def argmax(
     a: ArrayLike,

--- a/numpy/typing/tests/data/fail/fromnumeric.pyi
+++ b/numpy/typing/tests/data/fail/fromnumeric.pyi
@@ -46,8 +46,8 @@ np.sort(A, axis="bob")  # type: ignore[call-overload]
 np.sort(A, kind="bob")  # type: ignore[call-overload]
 np.sort(A, order=range(5))  # type: ignore[arg-type]
 
-np.argsort(A, axis="bob")  # type: ignore[arg-type]
-np.argsort(A, kind="bob")  # type: ignore[arg-type]
+np.argsort(A, axis="bob")  # type: ignore[call-overload]
+np.argsort(A, kind="bob")  # type: ignore[call-overload]
 np.argsort(A, order=range(5))  # type: ignore[arg-type]
 
 np.argmax(A, axis="bob")  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -9,6 +9,8 @@ class NDArraySubclass(np.ndarray[tuple[Any, ...], np.dtype[np.complex128]]): ...
 
 AR_b: npt.NDArray[np.bool]
 AR_f4: npt.NDArray[np.float32]
+AR_f4_1d: np.ndarray[tuple[int], np.dtype[np.float32]]
+AR_f4_2d: np.ndarray[tuple[int, int], np.dtype[np.float32]]
 AR_c16: npt.NDArray[np.complex128]
 AR_u8: npt.NDArray[np.uint64]
 AR_i8: npt.NDArray[np.int64]
@@ -86,12 +88,27 @@ assert_type(np.argpartition(f, 0, axis=None), np.ndarray[tuple[int], np.dtype[np
 assert_type(np.argpartition(AR_b, 0, axis=None), np.ndarray[tuple[int], np.dtype[np.intp]])
 assert_type(np.argpartition(AR_f4, 0, axis=None), np.ndarray[tuple[int], np.dtype[np.intp]])
 
-assert_type(np.sort([2, 1], 0), npt.NDArray[Any])
-assert_type(np.sort(AR_b, 0), npt.NDArray[np.bool])
-assert_type(np.sort(AR_f4, 0), npt.NDArray[np.float32])
+assert_type(np.sort([2, 1]), npt.NDArray[Any])
+assert_type(np.sort(AR_b), npt.NDArray[np.bool])
+assert_type(np.sort(AR_f4), npt.NDArray[np.float32])
+assert_type(np.sort(AR_f4_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.sort(AR_f4_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.sort([2, 1], axis=None), np.ndarray[tuple[int]])
+assert_type(np.sort(AR_b, axis=None), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.sort(AR_f4, axis=None), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.sort(AR_f4_1d, axis=None), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.sort(AR_f4_2d, axis=None), np.ndarray[tuple[int], np.dtype[np.float32]])
 
-assert_type(np.argsort(AR_b, 0), npt.NDArray[np.intp])
-assert_type(np.argsort(AR_f4, 0), npt.NDArray[np.intp])
+assert_type(np.argsort([2, 1]), npt.NDArray[np.intp])
+assert_type(np.argsort(AR_b), npt.NDArray[np.intp])
+assert_type(np.argsort(AR_f4), npt.NDArray[np.intp])
+assert_type(np.argsort(AR_f4_1d), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(np.argsort(AR_f4_2d), np.ndarray[tuple[int, int], np.dtype[np.intp]])
+assert_type(np.argsort([2, 1], axis=None), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(np.argsort(AR_b, axis=None), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(np.argsort(AR_f4, axis=None), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(np.argsort(AR_f4_1d, axis=None), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(np.argsort(AR_f4_2d, axis=None), np.ndarray[tuple[int], np.dtype[np.intp]])
 
 assert_type(np.argmax(AR_b), np.intp)
 assert_type(np.argmax(AR_f4), np.intp)


### PR DESCRIPTION
This adds shape-typing support for 

- `sort`
- `argsort`

For `axis=-1` (default), the shape-type is preserved. Otherwise, for `axis=None`, these always return a 1-d array.

Related to #31120

(last PR for the day)

#### AI Disclosure

I am not a robot :ballot_box_with_check: 