### PR TITLE
TYP: ``fromiter`` shape-typing and more dtype overloads

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -994,23 +994,65 @@ def fromfile(
     like: _SupportsArrayFunc | None = ...,
 ) -> _Array1D[Any]: ...
 
-@overload
+#
+@overload  # dtype=<known>
 def fromiter[ScalarT: np.generic](
-    iter: Iterable[Any],
+    iter: Iterable[_ScalarLike_co],
     dtype: _DTypeLike[ScalarT],
-    count: SupportsIndex = ...,
+    count: SupportsIndex = -1,
     *,
-    like: _SupportsArrayFunc | None = ...,
-) -> NDArray[ScalarT]: ...
-@overload
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[ScalarT]: ...
+@overload  # dtype=None
 def fromiter(
-    iter: Iterable[Any],
-    dtype: DTypeLike | None,
-    count: SupportsIndex = ...,
+    iter: Iterable[_ScalarLike_co],
+    dtype: None,
+    count: SupportsIndex = -1,
     *,
-    like: _SupportsArrayFunc | None = ...,
-) -> NDArray[Any]: ...
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[np.float64]: ...
+@overload  # dtype=bool
+def fromiter(
+    iter: Iterable[_ScalarLike_co],
+    dtype: type[bool],
+    count: SupportsIndex = -1,
+    *,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[np.bool]: ...
+@overload  # dtype=int
+def fromiter(
+    iter: Iterable[_ScalarLike_co],
+    dtype: type[int],
+    count: SupportsIndex = -1,
+    *,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[np.int_ | Any]: ...
+@overload  # dtype=float
+def fromiter(
+    iter: Iterable[_ScalarLike_co],
+    dtype: type[float],
+    count: SupportsIndex = -1,
+    *,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[np.float64 | Any]: ...
+@overload  # dtype=complex
+def fromiter(
+    iter: Iterable[_ScalarLike_co],
+    dtype: type[complex],
+    count: SupportsIndex = -1,
+    *,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[np.complex128 | Any]: ...
+@overload  # dtype=<unknown>
+def fromiter(
+    iter: Iterable[_ScalarLike_co],
+    dtype: DTypeLike,
+    count: SupportsIndex = -1,
+    *,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[Any]: ...
 
+#
 @overload
 def frombuffer(
     buffer: Buffer,

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -107,8 +107,14 @@ with open("test.txt") as f:
     assert_type(np.fromfile(b"test.txt", sep=" "), _Array1D[np.float64])
     assert_type(np.fromfile(Path("test.txt"), sep=" "), _Array1D[np.float64])
 
-assert_type(np.fromiter("12345", np.float64), npt.NDArray[np.float64])
-assert_type(np.fromiter("12345", float), npt.NDArray[Any])
+assert_type(np.fromiter("12345", np.float32), _Array1D[np.float32])
+assert_type(np.fromiter("12345", np.float64), _Array1D[np.float64])
+assert_type(np.fromiter("12345", bool), _Array1D[np.bool])
+assert_type(np.fromiter("12345", int), _Array1D[np.int_ | Any])
+assert_type(np.fromiter("12345", float), _Array1D[np.float64 | Any])
+assert_type(np.fromiter("12345", complex), _Array1D[np.complex128 | Any])
+assert_type(np.fromiter("12345", None), _Array1D[np.float64])
+assert_type(np.fromiter("12345", object), _Array1D[Any])
 
 assert_type(np.frombuffer(A), _Array1D[np.float64])
 assert_type(np.frombuffer(A, dtype=np.int64), _Array1D[np.int64])


### PR DESCRIPTION
`numpy.fromiter` always returns a 1-d array, and now the stubs reflect this.
This also adds overloads for specific non-numpy-like `dtype` types such as `dtype=float` and `dtype=None`. Note that because of the static overlap in `bool`, `int`, `float`, and `complex`,  the output types of these overloads must be compatible, which is what the `| Any` is for.

#### AI Disclosure

I am not a robot :ballot_box_with_check: 