### PR TITLE
MAINT: Replace %-formatting with f-strings in remaining modules (UP031)

### DIFF
--- a/benchmarks/benchmarks/bench_linalg.py
+++ b/benchmarks/benchmarks/bench_linalg.py
@@ -252,7 +252,8 @@ class MatmulStrided(Benchmark):
 
     def __init__(self):
         self.args_map = {
-            'matmul_m%03d_p%03d_n%03d_bs%02d' % arg: arg for arg in self.args
+            f'matmul_m{arg[0]:03}_p{arg[1]:03}_n{arg[2]:03}_bs{arg[3]:02}': arg
+            for arg in self.args
         }
 
         self.params = [list(self.args_map.keys())]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -583,7 +583,7 @@ def linkcode_resolve(domain, info):
         fn = relpath(fn, start=dirname(numpy.__file__))
 
     if lineno:
-        linespec = "#L%d-L%d" % (lineno, lineno + len(source) - 1)
+        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
     else:
         linespec = ""
 
@@ -593,8 +593,8 @@ def linkcode_resolve(domain, info):
     if 'dev' in numpy.__version__:
         return f"https://github.com/numpy/numpy/blob/main/numpy/{fn}{linespec}"
     else:
-        return "https://github.com/numpy/numpy/blob/v%s/numpy/%s%s" % (
-           numpy.__version__, fn, linespec)
+        return (f"https://github.com/numpy/numpy/blob/v{numpy.__version__}/"
+                f"numpy/{fn}{linespec}")
 
 
 from pygments.lexer import inherit

--- a/numpy/ctypeslib/_ctypeslib.py
+++ b/numpy/ctypeslib/_ctypeslib.py
@@ -193,7 +193,7 @@ class _ndptr(_ndptr_base):
             raise TypeError(f"array must have data type {cls._dtype_}")
         if cls._ndim_ is not None \
                and obj.ndim != cls._ndim_:
-            raise TypeError("array must have %d dimension(s)" % cls._ndim_)
+            raise TypeError(f"array must have {cls._ndim_} dimension(s)")
         if cls._shape_ is not None \
                and obj.shape != cls._shape_:
             raise TypeError(f"array must have shape {str(cls._shape_)}")
@@ -333,7 +333,7 @@ def ndpointer(dtype=None, ndim=None, shape=None, flags=None):
     else:
         name = dtype.str
     if ndim is not None:
-        name += "_%dd" % ndim
+        name += f"_{ndim}d"
     if shape is not None:
         name += "_" + "x".join(str(x) for x in shape)
     if flags is not None:

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -1019,7 +1019,7 @@ class TestLoadTxt(LoadTxtBase):
     def test_uint64_type(self):
         tgt = (9223372043271415339, 9223372043271415853)
         c = TextIO()
-        c.write("%s %s" % tgt)
+        c.write(f'{tgt[0]} {tgt[1]}')
         c.seek(0)
         res = np.loadtxt(c, dtype=np.uint64)
         assert_equal(res, tgt)
@@ -1027,7 +1027,7 @@ class TestLoadTxt(LoadTxtBase):
     def test_int64_type(self):
         tgt = (-9223372036854775807, 9223372036854775807)
         c = TextIO()
-        c.write("%s %s" % tgt)
+        c.write(f'{tgt[0]} {tgt[1]}')
         c.seek(0)
         res = np.loadtxt(c, dtype=np.int64)
         assert_equal(res, tgt)
@@ -1069,7 +1069,7 @@ class TestLoadTxt(LoadTxtBase):
     def test_from_complex(self):
         tgt = (complex(1, 1), complex(1, -1))
         c = TextIO()
-        c.write("%s %s" % tgt)
+        c.write(f'{tgt[0]} {tgt[1]}')
         c.seek(0)
         res = np.loadtxt(c, dtype=complex)
         assert_equal(res, tgt)

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -239,22 +239,22 @@ def _to_native_byte_order(*arrays):
 def _assert_2d(*arrays):
     for a in arrays:
         if a.ndim != 2:
-            raise LinAlgError('%d-dimensional array given. Array must be '
-                    'two-dimensional' % a.ndim)
+            raise LinAlgError(f'{a.ndim}-dimensional array given. Array must be '
+                              'two-dimensional')
 
 def _assert_stacked_2d(*arrays):
     for a in arrays:
         if a.ndim < 2:
-            raise LinAlgError('%d-dimensional array given. Array must be '
-                    'at least two-dimensional' % a.ndim)
+            raise LinAlgError(f'{a.ndim}-dimensional array given. Array must be '
+                              'at least two-dimensional')
 
 def _assert_stacked_square(*arrays):
     for a in arrays:
         try:
             m, n = a.shape[-2:]
         except ValueError:
-            raise LinAlgError('%d-dimensional array given. Array must be '
-                    'at least two-dimensional' % a.ndim)
+            raise LinAlgError(f'{a.ndim}-dimensional array given. Array must be '
+                              'at least two-dimensional')
         if m != n:
             raise LinAlgError('Last 2 dimensions of the array must be square')
 

--- a/numpy/linalg/lapack_lite/fortran.py
+++ b/numpy/linalg/lapack_lite/fortran.py
@@ -104,8 +104,8 @@ def fortranSourceLines(fo):
                     break
             yield numberingiter.lineno, ''.join(lines)
         else:
-            raise ValueError("jammed: continuation line not expected: %s:%d" %
-                             (fo.name, numberingiter.lineno))
+            raise ValueError("jammed: continuation line not expected: "
+                             f"{fo.name}:{numberingiter.lineno}")
 
 def getDependencies(filename):
     """For a Fortran source file, return a list of routines declared as EXTERNAL

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -329,8 +329,7 @@ def _stride_comb_iter(x):
         xi[...] = x
         xi = xi.view(x.__class__)
         assert_(np.all(xi == x))
-        parts = [f"{j:+}" for j in repeats]
-        yield xi, "stride_" + "_".join(parts)
+        yield xi, "stride_" + "_".join(f"{j:+}" for j in repeats)
 
         # generate also zero strides if possible
         if x.ndim >= 1 and x.shape[-1] == 1:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -329,7 +329,8 @@ def _stride_comb_iter(x):
         xi[...] = x
         xi = xi.view(x.__class__)
         assert_(np.all(xi == x))
-        yield xi, "stride_" + "_".join(["%+d" % j for j in repeats])
+        parts = [f"{j:+}" for j in repeats]
+        yield xi, "stride_" + "_".join(parts)
 
         # generate also zero strides if possible
         if x.ndim >= 1 and x.shape[-1] == 1:

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1989,7 +1989,7 @@ def masked_where(condition, a, copy=True):
     (cshape, ashape) = (cond.shape, a.shape)
     if cshape and cshape != ashape:
         raise IndexError("Inconsistent shape between the condition and the input"
-                         " (got %s and %s)" % (cshape, ashape))
+                         f" (got {cshape} and {ashape})")
     if hasattr(a, '_mask'):
         cond = mask_or(cond, a._mask)
         cls = type(a)

--- a/numpy/random/_examples/cffi/extending.py
+++ b/numpy/random/_examples/cffi/extending.py
@@ -32,7 +32,7 @@ state = bit_gen.state
 
 interface = rng.bit_generator.cffi
 n = 100
-vals_cffi = ffi.new('double[%d]' % n)
+vals_cffi = ffi.new(f'double[{n}]')
 lib.random_standard_normal_fill(interface.bit_generator, n, vals_cffi)
 
 # reset the state

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -462,7 +462,7 @@ class TestIntegers:
             except Exception as e:
                 raise AssertionError("No error should have been raised, "
                                      "but one was with the following "
-                                     "message:\n\n%s" % str(e))
+                                     f"message:\n\n{e}")
 
     def test_full_range_array(self, endpoint):
         # Test for ticket #1690
@@ -477,7 +477,7 @@ class TestIntegers:
             except Exception as e:
                 raise AssertionError("No error should have been raised, "
                                      "but one was with the following "
-                                     "message:\n\n%s" % str(e))
+                                     f"message:\n\n{e}")
 
     def test_in_bounds_fuzz(self, endpoint):
         # Don't use fixed seed

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -210,8 +210,7 @@ class TestRandint:
                 rng.randint(lbnd, ubnd, dtype=dt)
             except Exception as e:
                 raise AssertionError("No error should have been raised, "
-                                     "but one was with the following "
-                                     "message:\n\n%s" % str(e))
+                                     f"but one was with the following message:\n\n{e}")
 
     def test_in_bounds_fuzz(self):
         # Don't use fixed seed

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -333,8 +333,7 @@ class TestRandint:
                 rng.randint(lbnd, ubnd, dtype=dt)
             except Exception as e:
                 raise AssertionError("No error should have been raised, "
-                                     "but one was with the following "
-                                     "message:\n\n%s" % str(e))
+                                     f"but one was with the following message:\n\n{e}")
 
     def test_in_bounds_fuzz(self):
         # Don't use fixed seed

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -139,8 +139,7 @@ def _make_methods(functions, modname):
             signature = '(PyObject *self, PyObject *args, PyObject *kwargs)'
         else:
             signature = '(PyObject *self, PyObject *args)'
-        methods_table.append(
-            "{\"%s\", (PyCFunction)%s, %s}," % (funcname, cfuncname, flags))
+        methods_table.append(f'{{"{funcname}", (PyCFunction){cfuncname}, {flags}}},')
         func_code = f"""
         static PyObject* {cfuncname}{signature}
         {{
@@ -149,37 +148,36 @@ def _make_methods(functions, modname):
         """
         codes.append(func_code)
 
-    body = "\n".join(codes) + """
-    static PyMethodDef methods[] = {
-    %(methods)s
-    { NULL }
-    };
-    static struct PyModuleDef moduledef = {
+    methods_str = '\n'.join(methods_table)
+    body = "\n".join(codes) + f"""
+    static PyMethodDef methods[] = {{
+    {methods_str}
+    {{ NULL }}
+    }};
+    static struct PyModuleDef moduledef = {{
         PyModuleDef_HEAD_INIT,
-        "%(modname)s",  /* m_name */
+        "{modname}",    /* m_name */
         NULL,           /* m_doc */
         -1,             /* m_size */
         methods,        /* m_methods */
-    };
-    """ % {'methods': '\n'.join(methods_table), 'modname': modname}
+    }};
+    """
     return body
 
 
 def _make_source(name, init, body):
     """ Combines the code fragments into source code ready to be compiled
     """
-    code = """
+    code = f"""
     #include <Python.h>
 
-    %(body)s
+    {body}
 
     PyMODINIT_FUNC
-    PyInit_%(name)s(void) {
-    %(init)s
-    }
-    """ % {
-        'name': name, 'init': init, 'body': body,
-    }
+    PyInit_{name}(void) {{
+    {init}
+    }}
+    """
     return code
 
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -1223,7 +1223,7 @@ def assert_array_almost_equal(actual, desired, decimal=6, err_msg='',
         return z < 1.5 * 10.0**(-decimal)
 
     assert_array_compare(compare, actual, desired, err_msg=err_msg, verbose=verbose,
-             header=(f'Arrays are not almost equal to {decimal} decimals'),
+             header=f'Arrays are not almost equal to {decimal} decimals',
              precision=decimal)
 
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -589,7 +589,7 @@ def assert_almost_equal(actual, desired, decimal=7, err_msg='', verbose=True):
         usecomplex = False
 
     def _build_err_msg():
-        header = ('Arrays are not almost equal to %d decimals' % decimal)
+        header = (f'Arrays are not almost equal to {decimal} decimals')
         return build_err_msg([actual, desired], err_msg, verbose=verbose,
                              header=header)
 
@@ -712,7 +712,7 @@ def assert_approx_equal(actual, desired, significant=7, err_msg='',
         sc_actual = 0.0
     msg = build_err_msg(
         [actual, desired], err_msg,
-        header='Items are not equal to %d significant digits:' % significant,
+        header=f'Items are not equal to {significant} significant digits:',
         verbose=verbose)
     try:
         # If one of desired/actual is not finite, handle it specially here:
@@ -784,8 +784,8 @@ def assert_array_compare(comparison, x, y, err_msg='', verbose=True, header='',
         if robust_any_difference(x_id, y_id):
             msg = build_err_msg(
                 [x, y],
-                err_msg + '\n%s location mismatch:'
-                % (hasval), verbose=verbose, header=header,
+                err_msg + f'\n{hasval} location mismatch:',
+                verbose=verbose, header=header,
                 names=names,
                 precision=precision)
             raise AssertionError(msg)
@@ -1222,9 +1222,8 @@ def assert_array_almost_equal(actual, desired, decimal=6, err_msg='',
 
         return z < 1.5 * 10.0**(-decimal)
 
-    assert_array_compare(compare, actual, desired, err_msg=err_msg,
-                         verbose=verbose,
-             header=('Arrays are not almost equal to %d decimals' % decimal),
+    assert_array_compare(compare, actual, desired, err_msg=err_msg, verbose=verbose,
+             header=(f'Arrays are not almost equal to {decimal} decimals'),
              precision=decimal)
 
 
@@ -1465,7 +1464,8 @@ def rundocs(filename=None, raise_on_error=True):
         runner.run(test, out=out)
 
     if runner.failures > 0 and raise_on_error:
-        raise AssertionError("Some doctests failed:\n%s" % "\n".join(msg))
+        err_msg = '\n'.join(msg)
+        raise AssertionError(f"Some doctests failed:\n{err_msg}")
 
 
 def check_support_sve(__cache=[]):
@@ -1570,7 +1570,7 @@ def decorate_methods(cls, decorator, testmatch=None):
 
     """
     if testmatch is None:
-        testmatch = re.compile(r'(?:^|[\\b_\\.%s-])[Tt]est' % os.sep)
+        testmatch = re.compile(rf'(?:^|[\\b_\\.{os.sep}-])[Tt]est')
     else:
         testmatch = re.compile(testmatch)
     cls_attr = cls.__dict__
@@ -1887,9 +1887,8 @@ def assert_array_max_ulp(a, b, maxulp=1, dtype=None):
     import numpy as np
     ret = nulp_diff(a, b, dtype)
     if not np.all(ret <= maxulp):
-        raise AssertionError("Arrays are not almost equal up to %g "
-                             "ULP (max difference is %g ULP)" %
-                             (maxulp, np.max(ret)))
+        raise AssertionError(f"Arrays are not almost equal up to {maxulp:g} "
+                             f"ULP (max difference is {np.max(ret):g} ULP)")
     return ret
 
 

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -65,7 +65,7 @@ class TestLoadLibrary:
                          np._core._multiarray_umath.__file__)
         except ImportError as e:
             msg = ("ctypes is not available on this python: skipping the test"
-                   " (import error was: %s)" % str(e))
+                   f" (import error was: {e})")
             print(msg)
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -74,7 +74,6 @@ ignore = [
     "F841",    # Local variable is assigned to but never used
     # pyupgrade
     "UP015" ,  # Unnecessary mode argument
-    "UP031",   # TODO: Use format specifiers instead of percent format
 ]
 
 [lint.per-file-ignores]

--- a/tools/c_coverage/c_coverage_report.py
+++ b/tools/c_coverage/c_coverage_report.py
@@ -32,9 +32,9 @@ class FunctionHtmlFormatter(HtmlFormatter):
         for i, (c, t) in enumerate(HtmlFormatter.wrap(self, source, outfile)):
             as_functions = self.lines.get(i - 1, None)
             if as_functions is not None:
-                yield 0, ('<div title=%s style="background: #ccffcc">[%2d]' %
-                          (quoteattr('as ' + ', '.join(as_functions)),
-                           len(as_functions)))
+                title = quoteattr('as ' + ', '.join(as_functions))
+                count = len(as_functions)
+                yield 0, f'<div title={title} style="background: #ccffcc">[{count:2}]'
             else:
                 yield 0, '    '
             yield c, t
@@ -107,9 +107,9 @@ class SourceFiles:
             fd.write("<html>")
             paths = sorted(self.files.keys())
             for path in paths:
-                fd.write('<p><a href="%s.html">%s</a></p>' %
-                         (self.clean_path(path),
-                          escape(path[len(self.prefix):])))
+                href = self.clean_path(path)
+                label = escape(path[len(self.prefix):])
+                fd.write(f'<p><a href="{href}.html">{label}</a></p>')
             fd.write("</html>")
 
 

--- a/tools/check_installed_files.py
+++ b/tools/check_installed_files.py
@@ -46,8 +46,8 @@ def main(install_dir, tests_check):
 
     if tests_check == "--no-tests":
         if len(installed_test_files) > 0:
-            raise Exception("Test files aren't expected to be installed in %s"
-                        ", found %s" % (INSTALLED_DIR, installed_test_files))
+            raise Exception("Test files aren't expected to be installed in "
+                            f"{INSTALLED_DIR}, found {installed_test_files}")
         print("----------- No test files were installed --------------")
     else:
         # Check test files detected in repo are installed

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -460,7 +460,7 @@ def validate_rst_syntax(text, name, dots=True):
     if not success:
         output += "    " + "-" * 72 + "\n"
         for lineno, line in enumerate(text.splitlines()):
-            output += "    %-4d    %s\n" % (lineno + 1, line)
+            output += f"    {lineno + 1:<4}    {line}\n"
         output += "    " + "-" * 72 + "\n\n"
 
     if dots:
@@ -522,8 +522,8 @@ def check_rest(module, names, dots=True):
 
         m = re.search("([\x00-\x09\x0b-\x1f])", text)
         if m:
-            msg = ("Docstring contains a non-printable character %r! "
-                   "Maybe forgot r\"\"\"?" % (m.group(1),))
+            msg = (f"Docstring contains a non-printable character {m.group(1)!r}! "
+                   "Maybe forgot r\"\"\"?")
             results.append((full_name, False, msg))
             continue
 


### PR DESCRIPTION
Closes #30785

This is the final PR to complete the UP031 migration.