### PR TITLE
 DEP: remove `encoding='bytes'` workaround from `genfromtxt`.

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1970,10 +1970,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         )
 
     if encoding == 'bytes':
-        encoding = None
-        byte_converters = True
-    else:
-        byte_converters = False
+        raise ValueError("encoding=`bytes` is no longer supported.")
 
     # Initialize the filehandle, the LineSplitter and the NameValidator
     if isinstance(fname, os.PathLike):
@@ -2222,15 +2219,6 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                 testing_value = None
             if conv is bytes:
                 user_conv = asbytes
-            elif byte_converters:
-                # Converters may use decode to workaround numpy's old
-                # behavior, so encode the string again before passing
-                # to the user converter.
-                def tobytes_first(x, conv):
-                    if type(x) is bytes:
-                        return conv(x)
-                    return conv(x.encode("latin1"))
-                user_conv = functools.partial(tobytes_first, conv=conv)
             else:
                 user_conv = conv
             converters[i].update(user_conv, locked=True,
@@ -2349,31 +2337,6 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     if dtype is None:
         # Get the dtypes from the types of the converters
         column_types = [conv.type for conv in converters]
-        # Find the columns with strings...
-        strcolidx = [i for (i, v) in enumerate(column_types)
-                     if v == np.str_]
-
-        if byte_converters and strcolidx:
-            # convert strings back to bytes for backward compatibility
-            warnings.warn(
-                "Reading unicode strings without specifying the encoding "
-                "argument is deprecated. Set the encoding, use None for the "
-                "system default.",
-                np.exceptions.VisibleDeprecationWarning, stacklevel=2)
-
-            def encode_unicode_cols(row_tup):
-                row = list(row_tup)
-                for i in strcolidx:
-                    row[i] = row[i].encode('latin1')
-                return tuple(row)
-
-            try:
-                data = [encode_unicode_cols(r) for r in data]
-            except UnicodeEncodeError:
-                pass
-            else:
-                for i in strcolidx:
-                    column_types[i] = np.bytes_
 
         # Update string types to be the right length
         sized_column_types = column_types.copy()

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -19,7 +19,6 @@ import pytest
 import numpy as np
 import numpy.ma as ma
 from numpy._utils import asbytes
-from numpy.exceptions import VisibleDeprecationWarning
 from numpy.lib import _npyio_impl
 from numpy.lib._iotools import ConversionWarning, ConverterError
 from numpy.ma.testutils import assert_equal
@@ -708,8 +707,7 @@ class LoadTxtBase:
         c = TextIO()
         c.write(b'\xcf\x96')
         c.seek(0)
-        x = self.loadfunc(c, dtype=np.str_, encoding="bytes",
-                          converters={0: lambda x: x.decode('UTF-8')})
+        x = self.loadfunc(c, dtype=np.str_, encoding="UTF-8")
         a = np.array([b'\xcf\x96'.decode('UTF-8')])
         assert_array_equal(x, a)
 
@@ -1458,12 +1456,8 @@ class TestFromTxt(LoadTxtBase):
     def test_header(self):
         # Test retrieving a header
         data = TextIO('gender age weight\nM 64.0 75.0\nF 25.0 60.0')
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(data, dtype=None, names=True,
-                                 encoding='bytes')
-            assert_(w[0].category is VisibleDeprecationWarning)
-        control = {'gender': np.array([b'M', b'F']),
+        test = np.genfromtxt(data, dtype=None, names=True, encoding=None)
+        control = {'gender': np.array(['M', 'F']),
                    'age': np.array([64.0, 25.0]),
                    'weight': np.array([75.0, 60.0])}
         assert_equal(test['gender'], control['gender'])
@@ -1473,11 +1467,8 @@ class TestFromTxt(LoadTxtBase):
     def test_auto_dtype(self):
         # Test the automatic definition of the output dtype
         data = TextIO('A 64 75.0 3+4j True\nBCD 25 60.0 5+6j False')
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(data, dtype=None, encoding='bytes')
-            assert_(w[0].category is VisibleDeprecationWarning)
-        control = [np.array([b'A', b'BCD']),
+        test = np.genfromtxt(data, dtype=None, encoding=None)
+        control = [np.array(['A', 'BCD']),
                    np.array([64, 25]),
                    np.array([75.0, 60.0]),
                    np.array([3 + 4j, 5 + 6j]),
@@ -1526,13 +1517,9 @@ F   35  58.330000
 M   33  21.99
         """)
         # The # is part of the first name and should be deleted automatically.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(data, names=True, dtype=None,
-                                 encoding="bytes")
-            assert_(w[0].category is VisibleDeprecationWarning)
+        test = np.genfromtxt(data, names=True, dtype=None, encoding=None)
         ctrl = np.array([('M', 21, 72.1), ('F', 35, 58.33), ('M', 33, 21.99)],
-                        dtype=[('gender', '|S1'), ('age', int), ('weight', float)])
+                        dtype=[('gender', 'U1'), ('age', int), ('weight', float)])
         assert_equal(test, ctrl)
         # Ditto, but we should get rid of the first element
         data = TextIO(b"""
@@ -1541,11 +1528,8 @@ M   21  72.100000
 F   35  58.330000
 M   33  21.99
         """)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(data, names=True, dtype=None,
-                                 encoding="bytes")
-            assert_(w[0].category is VisibleDeprecationWarning)
+
+        test = np.genfromtxt(data, names=True, dtype=None, encoding=None)
         assert_equal(test, ctrl)
 
     def test_names_and_comments_none(self):
@@ -1571,13 +1555,10 @@ M   33  21.99
     def test_autonames_and_usecols(self):
         # Tests names and usecols
         data = TextIO('A B C D\n aaaa 121 45 9.1')
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(data, usecols=('A', 'C', 'D'),
-                                names=True, dtype=None, encoding="bytes")
-            assert_(w[0].category is VisibleDeprecationWarning)
+        test = np.genfromtxt(data, usecols=('A', 'C', 'D'),
+                                names=True, dtype=None, encoding=None)
         control = np.array(('aaaa', 45, 9.1),
-                           dtype=[('A', '|S4'), ('C', int), ('D', float)])
+                           dtype=[('A', 'U4'), ('C', int), ('D', float)])
         assert_equal(test, control)
 
     def test_converters_with_usecols(self):
@@ -1592,14 +1573,11 @@ M   33  21.99
     def test_converters_with_usecols_and_names(self):
         # Tests names and usecols
         data = TextIO('A B C D\n aaaa 121 45 9.1')
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(data, usecols=('A', 'C', 'D'), names=True,
-                                dtype=None, encoding="bytes",
+        test = np.genfromtxt(data, usecols=('A', 'C', 'D'), names=True,
+                                dtype=None, encoding=None,
                                 converters={'C': lambda s: 2 * int(s)})
-            assert_(w[0].category is VisibleDeprecationWarning)
         control = np.array(('aaaa', 90, 9.1),
-                           dtype=[('A', '|S4'), ('C', int), ('D', float)])
+                           dtype=[('A', 'U4'), ('C', int), ('D', float)])
         assert_equal(test, control)
 
     def test_converters_cornercases(self):
@@ -1637,16 +1615,16 @@ M   33  21.99
         assert_equal(test, [33, 66])
 
     def test_invalid_converter(self):
-        strip_rand = lambda x: float((b'r' in x.lower() and x.split()[-1]) or
-                                     ((b'r' not in x.lower() and x.strip()) or 0.0))
-        strip_per = lambda x: float((b'%' in x.lower() and x.split()[0]) or
-                                    ((b'%' not in x.lower() and x.strip()) or 0.0))
+        strip_rand = lambda x: float(('r' in x.lower() and x.split()[-1]) or
+                                     (('r' not in x.lower() and x.strip()) or 0.0))
+        strip_per = lambda x: float(('%' in x.lower() and x.split()[0]) or
+                                    (('%' not in x.lower() and x.strip()) or 0.0))
         s = TextIO("D01N01,10/1/2003 ,1 %,R 75,400,600\r\n"
                    "L24U05,12/5/2003, 2 %,1,300, 150.5\r\n"
                    "D02N03,10/10/2004,R 1,,7,145.55")
         kwargs = {
             "converters": {2: strip_per, 3: strip_rand}, "delimiter": ",",
-            "dtype": None, "encoding": "bytes"}
+            "dtype": None, "encoding": None}
         assert_raises(ConverterError, np.genfromtxt, s, **kwargs)
 
     def test_tricky_converter_bug1666(self):
@@ -1673,16 +1651,16 @@ M   33  21.99
         dstr = "1,5,-1,1:1\n2,8,-1,1:n\n3,3,-2,m:n\n"
         dmap = {'1:1': 0, '1:n': 1, 'm:1': 2, 'm:n': 3}
         dtyp = [('e1', 'i4'), ('e2', 'i4'), ('e3', 'i2'), ('n', 'i1')]
-        conv = {0: int, 1: int, 2: int, 3: lambda r: dmap[r.decode()]}
+        conv = {0: int, 1: int, 2: int, 3: lambda r: dmap[r.decode() if
+                                                          isinstance(r, bytes) else r]}
         test = np.genfromtxt(TextIO(dstr,), dtype=dtyp, delimiter=',',
-                             names=None, converters=conv, encoding="bytes")
+                             names=None, converters=conv, encoding=None)
         control = np.rec.array([(1, 5, -1, 0), (2, 8, -1, 1), (3, 3, -2, 3)],
                                dtype=dtyp)
         assert_equal(test, control)
         dtyp = [('e1', 'i4'), ('e2', 'i4'), ('n', 'i1')]
         test = np.genfromtxt(TextIO(dstr,), dtype=dtyp, delimiter=',',
-                             usecols=(0, 1, 3), names=None, converters=conv,
-                             encoding="bytes")
+                             usecols=(0, 1, 3), names=None, converters=conv)
         control = np.rec.array([(1, 5, 0), (2, 8, 1), (3, 3, 3)], dtype=dtyp)
         assert_equal(test, control)
 
@@ -2065,20 +2043,15 @@ M   33  21.99
     def test_autostrip(self):
         # Test autostrip
         data = "01/01/2003  , 1.3,   abcde"
-        kwargs = {"delimiter": ",", "dtype": None, "encoding": "bytes"}
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            mtest = np.genfromtxt(TextIO(data), **kwargs)
-            assert_(w[0].category is VisibleDeprecationWarning)
+        kwargs = {"delimiter": ",", "dtype": None, "encoding": None}
+        mtest = np.genfromtxt(TextIO(data), **kwargs)
+
         ctrl = np.array([('01/01/2003  ', 1.3, '   abcde')],
-                        dtype=[('f0', '|S12'), ('f1', float), ('f2', '|S8')])
+                        dtype=[('f0', 'U12'), ('f1', float), ('f2', 'U8')])
         assert_equal(mtest, ctrl)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            mtest = np.genfromtxt(TextIO(data), autostrip=True, **kwargs)
-            assert_(w[0].category is VisibleDeprecationWarning)
+        mtest = np.genfromtxt(TextIO(data), autostrip=True, **kwargs)
         ctrl = np.array([('01/01/2003', 1.3, 'abcde')],
-                        dtype=[('f0', '|S10'), ('f1', float), ('f2', '|S5')])
+                        dtype=[('f0', 'U10'), ('f1', float), ('f2', 'U5')])
         assert_equal(mtest, ctrl)
 
     def test_replace_space(self):
@@ -2196,32 +2169,22 @@ M   33  21.99
 
     def test_comments_is_none(self):
         # Github issue 329 (None was previously being converted to 'None').
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(TextIO("test1,testNonetherestofthedata"),
+        test = np.genfromtxt(TextIO("test1,testNonetherestofthedata"),
                                  dtype=None, comments=None, delimiter=',',
-                                 encoding="bytes")
-            assert_(w[0].category is VisibleDeprecationWarning)
-        assert_equal(test[1], b'testNonetherestofthedata')
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(TextIO("test1, testNonetherestofthedata"),
+                                 encoding=None)
+        assert_equal(test[1], 'testNonetherestofthedata')
+        test = np.genfromtxt(TextIO("test1, testNonetherestofthedata"),
                                  dtype=None, comments=None, delimiter=',',
-                                 encoding="bytes")
-            assert_(w[0].category is VisibleDeprecationWarning)
-        assert_equal(test[1], b' testNonetherestofthedata')
+                                 encoding=None)
+        assert_equal(test[1], ' testNonetherestofthedata')
 
     def test_latin1(self):
         latin1 = b'\xf6\xfc\xf6'
         norm = b"norm1,norm2,norm3\n"
         enc = b"test1,testNonethe" + latin1 + b",test3\n"
         s = norm + enc + norm
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(TextIO(s),
-                                 dtype=None, comments=None, delimiter=',',
-                                 encoding="bytes")
-            assert_(w[0].category is VisibleDeprecationWarning)
+        test = np.genfromtxt(TextIO(s),
+                                 dtype="S", comments=None, delimiter=',')
         assert_equal(test[1, 0], b"test1")
         assert_equal(test[1, 1], b"testNonethe" + latin1)
         assert_equal(test[1, 2], b"test3")
@@ -2232,12 +2195,9 @@ M   33  21.99
         assert_equal(test[1, 1], "testNonethe" + latin1.decode('latin1'))
         assert_equal(test[1, 2], "test3")
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(TextIO(b"0,testNonethe" + latin1),
-                                 dtype=None, comments=None, delimiter=',',
-                                 encoding="bytes")
-            assert_(w[0].category is VisibleDeprecationWarning)
+        test = np.genfromtxt(TextIO(b"0,testNonethe" + latin1),
+                                 dtype=[('f0', int), ('f1', 'S14')], comments=None,
+                                 delimiter=',')
         assert_equal(test['f0'], 0)
         assert_equal(test['f1'], b"testNonethe" + latin1)
 
@@ -2251,12 +2211,8 @@ M   33  21.99
         norm = b"norm1,norm2,norm3\n"
         enc = b"test1,testNonethe" + utf8 + b",test3\n"
         s = norm + enc + norm
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', '', VisibleDeprecationWarning)
-            test = np.genfromtxt(TextIO(s),
-                                 dtype=None, comments=None, delimiter=',',
-                                 encoding="bytes")
-            assert_(w[0].category is VisibleDeprecationWarning)
+        test = np.genfromtxt(TextIO(s),
+                                 dtype="S", comments=None, delimiter=',')
         ctl = np.array([
                  [b'norm1', b'norm2', b'norm3'],
                  [b'test1', b'testNonethe' + utf8, b'test3'],
@@ -2305,13 +2261,7 @@ M   33  21.99
                 f.write("norm1,norm2,norm3\n")
                 f.write("norm1," + latin1 + ",norm3\n")
                 f.write("test1,testNonethe" + utf8 + ",test3\n")
-            with warnings.catch_warnings(record=True) as w:
-                warnings.filterwarnings('always', '',
-                                        VisibleDeprecationWarning)
-                test = np.genfromtxt(path, dtype=None, comments=None,
-                                     delimiter=',', encoding="bytes")
-                # Check for warning when encoding not specified.
-                assert_(w[0].category is VisibleDeprecationWarning)
+            test = np.genfromtxt(path, dtype=None, comments=None, delimiter=',')
             ctl = np.array([
                      ["norm1", "norm2", "norm3"],
                      ["norm1", latin1, "norm3"],


### PR DESCRIPTION
The deprecation warning seemed  vague to me. I assumed `encoding=bytes` should no longer be supported since the code would give warning only if `byte_converters` was true.
The helper function `_read`  (and `loadtxt`) also has the same thing but without warnings though, not sure why

Some tests expected byte output, but in the context of the tests themselves, seemed unrelated to it for me, so I changed them (see this  https://github.com/numpy/numpy/issues/30440#issuecomment-3667327856)

I  did not touch any documentation related to this change yet.

### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
Partly fixes https://github.com/numpy/numpy/issues/30440 (there are PRs for all the DEPs now)
### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->
I have done this already, see  https://github.com/numpy/numpy/pull/31113

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
Claude was used as a search tool (basically better search engine) to look at things I did not quite understand . All code, either deleted or modified was done by manually writing by me.
