### PR TITLE
DOC: add examples to polydiv docstring for edge cases

### DIFF
--- a/numpy/lib/_polynomial_impl.py
+++ b/numpy/lib/_polynomial_impl.py
@@ -1042,6 +1042,22 @@ def polydiv(u, v):
     >>> np.polydiv(x, y)
     (array([1.5 , 1.75]), array([0.25]))
 
+    The case where the divisor has higher degree than the dividend returns
+    a zero quotient and the dividend as remainder:
+
+    >>> x = np.array([1.0, 2.0])
+    >>> y = np.array([1.0, 2.0, 3.0])
+    >>> np.polydiv(x, y)
+    (array([0.]), array([1., 2.]))
+
+    A perfect factoring case with zero remainder, since
+    :math:`x^2 - 1 = (x-1)(x+1)`:
+
+    >>> x = np.array([1.0, 0.0, -1.0])
+    >>> y = np.array([1.0, -1.0])
+    >>> np.polydiv(x, y)
+    (array([1., 1.]), array([0.]))
+
     """
     truepoly = (isinstance(u, poly1d) or isinstance(v, poly1d))
     u = atleast_1d(u) + 0.0


### PR DESCRIPTION
Closes #18020

The existing docstring for `np.polydiv` only showed one example. 
This adds two additional cases that users commonly encounter:

1. When the divisor has higher degree than the dividend — the result 
   is a zero quotient with the dividend returned as remainder.

2. A clean zero-remainder case using the factoring x²-1 = (x-1)(x+1), 
   which makes the mathematical meaning of the output clear.