### PR TITLE
TYP: ``atleast_{1,2,3}d`` shape-typing

### DIFF
--- a/numpy/_core/shape_base.pyi
+++ b/numpy/_core/shape_base.pyi
@@ -16,7 +16,18 @@ __all__ = [
     "vstack",
 ]
 
+type _Array0D[ScalarT: np.generic] = np.ndarray[tuple[()], np.dtype[ScalarT]]
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
+type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
+
 # keep in sync with `numpy.ma.extras.atleast_1d`
+@overload
+def atleast_1d[ArrayT: _Array1D[Any] | _Array2D[Any] | _Array3D[Any]](a0: ArrayT, /) -> ArrayT: ...
+@overload
+def atleast_1d[ScalarT: np.generic](a0: _Array0D[ScalarT], /) -> _Array1D[ScalarT]: ...
+@overload
+def atleast_1d[ScalarT: np.generic](a0: ScalarT, /) -> _Array1D[ScalarT]: ...
 @overload
 def atleast_1d[ScalarT: np.generic](a0: _ArrayLike[ScalarT], /) -> NDArray[ScalarT]: ...
 @overload
@@ -36,6 +47,12 @@ def atleast_1d(a0: ArrayLike, a1: ArrayLike, /, *ai: ArrayLike) -> tuple[NDArray
 
 # keep in sync with `numpy.ma.extras.atleast_2d`
 @overload
+def atleast_2d[ArrayT: _Array2D[Any] | _Array3D[Any]](a0: ArrayT, /) -> ArrayT: ...
+@overload
+def atleast_2d[ScalarT: np.generic](a0: _Array0D[ScalarT] | _Array1D[ScalarT], /) -> _Array2D[ScalarT]: ...
+@overload
+def atleast_2d[ScalarT: np.generic](a0: ScalarT, /) -> _Array2D[ScalarT]: ...
+@overload
 def atleast_2d[ScalarT: np.generic](a0: _ArrayLike[ScalarT], /) -> NDArray[ScalarT]: ...
 @overload
 def atleast_2d[ScalarT1: np.generic, ScalarT2: np.generic](
@@ -53,6 +70,12 @@ def atleast_2d(a0: ArrayLike, a1: ArrayLike, /) -> tuple[NDArray[Any], NDArray[A
 def atleast_2d(a0: ArrayLike, a1: ArrayLike, /, *ai: ArrayLike) -> tuple[NDArray[Any], ...]: ...
 
 # keep in sync with `numpy.ma.extras.atleast_3d`
+@overload
+def atleast_3d[ArrayT: _Array3D[Any]](a0: ArrayT, /) -> ArrayT: ...
+@overload
+def atleast_3d[ScalarT: np.generic](a0: _Array0D[ScalarT] | _Array1D[ScalarT] | _Array2D[ScalarT], /) -> _Array3D[ScalarT]: ...
+@overload
+def atleast_3d[ScalarT: np.generic](a0: ScalarT, /) -> _Array3D[ScalarT]: ...
 @overload
 def atleast_3d[ScalarT: np.generic](a0: _ArrayLike[ScalarT], /) -> NDArray[ScalarT]: ...
 @overload

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -8,6 +8,7 @@ from numpy._typing import _AnyShape
 
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
+type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
 
 class SubClass[ScalarT: np.generic](np.ndarray[_AnyShape, np.dtype[ScalarT]]): ...
 
@@ -22,7 +23,11 @@ C: list[int]
 D: SubClass[np.float64 | np.int64]
 E: IntoSubClass[np.float64 | np.int64]
 
+_f32_0d: np.float32
 _f32_1d: _Array1D[np.float32]
+_f32_2d: _Array2D[np.float32]
+_f32_3d: _Array3D[np.float32]
+
 _py_b_1d: list[bool]
 _py_b_2d: list[list[bool]]
 _py_i_1d: list[int]
@@ -270,6 +275,10 @@ assert_type(np.identity(3, dtype="complex"), np.ndarray[tuple[int, int], np.dtyp
 assert_type(np.identity(3, dtype="c16"), np.ndarray[tuple[int, int], np.dtype[np.complex128 | Any]])
 assert_type(np.identity(3, dtype="D"), np.ndarray[tuple[int, int], np.dtype[np.complex128 | Any]])
 
+assert_type(np.atleast_1d(_f32_0d), _Array1D[np.float32])
+assert_type(np.atleast_1d(_f32_1d), _Array1D[np.float32])
+assert_type(np.atleast_1d(_f32_2d), _Array2D[np.float32])
+assert_type(np.atleast_1d(_f32_3d), _Array3D[np.float32])
 assert_type(np.atleast_1d(A), npt.NDArray[np.float64])
 assert_type(np.atleast_1d(C), npt.NDArray[Any])
 assert_type(np.atleast_1d(A, A), tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]])
@@ -278,10 +287,18 @@ assert_type(np.atleast_1d(C, C), tuple[npt.NDArray[Any], npt.NDArray[Any]])
 assert_type(np.atleast_1d(A, A, A), tuple[npt.NDArray[np.float64], ...])
 assert_type(np.atleast_1d(C, C, C), tuple[npt.NDArray[Any], ...])
 
+assert_type(np.atleast_2d(_f32_0d), _Array2D[np.float32])
+assert_type(np.atleast_2d(_f32_1d), _Array2D[np.float32])
+assert_type(np.atleast_2d(_f32_2d), _Array2D[np.float32])
+assert_type(np.atleast_2d(_f32_3d), _Array3D[np.float32])
 assert_type(np.atleast_2d(A), npt.NDArray[np.float64])
 assert_type(np.atleast_2d(A, A), tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]])
 assert_type(np.atleast_2d(A, A, A), tuple[npt.NDArray[np.float64], ...])
 
+assert_type(np.atleast_3d(_f32_0d), _Array3D[np.float32])
+assert_type(np.atleast_3d(_f32_1d), _Array3D[np.float32])
+assert_type(np.atleast_3d(_f32_2d), _Array3D[np.float32])
+assert_type(np.atleast_3d(_f32_3d), _Array3D[np.float32])
 assert_type(np.atleast_3d(A), npt.NDArray[np.float64])
 assert_type(np.atleast_3d(A, A), tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]])
 assert_type(np.atleast_3d(A, A, A), tuple[npt.NDArray[np.float64], ...])


### PR DESCRIPTION
This adds shape-typing support for single-argument calls to 

- `np.atleast_1d`
- `np.atleast_2d`
- `np.atleast_3d`

#### AI Disclosure

I am not a robot :ballot_box_with_check: 