### PR TITLE
TYP: ``fromregex`` shape-typing

### DIFF
--- a/numpy/lib/_npyio_impl.pyi
+++ b/numpy/lib/_npyio_impl.pyi
@@ -48,6 +48,8 @@ type _FNameRead = StrPath | SupportsRead[str] | SupportsRead[bytes]
 type _FNameWriteBytes = StrPath | SupportsWrite[bytes]
 type _FNameWrite = _FNameWriteBytes | SupportsWrite[str]
 
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+
 @type_check_only
 class _SupportsReadSeek[T](SupportsRead[T], Protocol):
     def seek(self, offset: int, whence: int, /) -> object: ...
@@ -186,14 +188,14 @@ def fromregex[ScalarT: np.generic](
     regexp: str | bytes | Pattern[Any],
     dtype: _DTypeLike[ScalarT],
     encoding: str | None = None,
-) -> NDArray[ScalarT]: ...
+) -> _Array1D[ScalarT]: ...
 @overload
 def fromregex(
     file: _FNameRead,
     regexp: str | bytes | Pattern[Any],
     dtype: DTypeLike | None,
     encoding: str | None = None,
-) -> NDArray[Any]: ...
+) -> _Array1D[Any]: ...
 
 @overload
 def genfromtxt(

--- a/numpy/typing/tests/data/reveal/npyio.pyi
+++ b/numpy/typing/tests/data/reveal/npyio.pyi
@@ -18,6 +18,8 @@ npz_file: np.lib.npyio.NpzFile
 AR_i8: npt.NDArray[np.int64]
 AR_LIKE_f8: list[float]
 
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+
 class BytesWriter:
     def write(self, data: bytes) -> None: ...
 
@@ -68,11 +70,11 @@ assert_type(np.loadtxt(str_path, delimiter="\n"), npt.NDArray[np.float64])
 assert_type(np.loadtxt(str_path, ndmin=2), npt.NDArray[np.float64])
 assert_type(np.loadtxt(["1", "2", "3"]), npt.NDArray[np.float64])
 
-assert_type(np.fromregex(bytes_file, "test", np.float64), npt.NDArray[np.float64])
-assert_type(np.fromregex(str_file, b"test", dtype=float), npt.NDArray[Any])
-assert_type(np.fromregex(str_path, re.compile("test"), dtype=np.str_, encoding="utf8"), npt.NDArray[np.str_])
-assert_type(np.fromregex(pathlib_path, "test", np.float64), npt.NDArray[np.float64])
-assert_type(np.fromregex(bytes_reader, "test", np.float64), npt.NDArray[np.float64])
+assert_type(np.fromregex(bytes_file, "test", np.float64), _Array1D[np.float64])
+assert_type(np.fromregex(str_file, b"test", dtype=float), _Array1D[Any])
+assert_type(np.fromregex(str_path, re.compile("test"), dtype=np.str_, encoding="utf8"), _Array1D[np.str_])
+assert_type(np.fromregex(pathlib_path, "test", np.float64), _Array1D[np.float64])
+assert_type(np.fromregex(bytes_reader, "test", np.float64), _Array1D[np.float64])
 
 assert_type(np.genfromtxt(bytes_file), npt.NDArray[Any])
 assert_type(np.genfromtxt(pathlib_path, dtype=np.str_), npt.NDArray[np.str_])


### PR DESCRIPTION
It always returns a 1d array, so it's a straighforward change.

#### AI Disclosure

I am not a robot :ballot_box_with_check: 