### PR TITLE
DOC: clarify wording in quickstart ix_() section

### DIFF
--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -1380,8 +1380,8 @@ and then use it as::
 The advantage of this version of reduce compared to the normal
 ufunc.reduce is that it makes use of the
 :ref:`broadcasting rules <broadcasting-rules>`
-in order to avoid creating an argument array the size of the output
-times the number of vectors.
+in order to avoid creating a temporary array that needs as much memory
+as the output array multiplied by the number of vectors.
 
 Indexing with strings
 ---------------------


### PR DESCRIPTION
### PR summary

Clarifies a confusing sentence in the "The ix_() function" section of the
NumPy quickstart tutorial.

The original wording — "creating an argument array the size of the output
times the number of vectors" — was reported as unclear by a user learning
from the quickstart. This rewording follows the suggestion from @ngoldbaum
in the issue discussion.

Closes #31127

### First time committer introduction

Hi! I'm Alejandro Garcia de Paredes, a code enthusiast with a background in data science, data engineering, and AI engineering. I'm looking to contribute to open source projects and this one caught my attention. Happy to receive feedback and iterate on my contribution.

#### AI Disclosure

No AI tools used.