### PR TITLE
TYP: ``tile``: accept numpy scalars and arrays as second argument

### DIFF
--- a/numpy/lib/_shape_base_impl.pyi
+++ b/numpy/lib/_shape_base_impl.pyi
@@ -18,6 +18,7 @@ from numpy._typing import (
     _ArrayLikeBool_co,
     _ArrayLikeComplex_co,
     _ArrayLikeFloat_co,
+    _ArrayLikeInt,
     _ArrayLikeInt_co,
     _ArrayLikeObject_co,
     _ArrayLikeUInt_co,
@@ -202,6 +203,6 @@ def kron(a: object, b: _ArrayLikeObject_co) -> NDArray[np.object_]: ...
 
 #
 @overload
-def tile[ScalarT: np.generic](A: _ArrayLike[ScalarT], reps: int | Sequence[int]) -> NDArray[ScalarT]: ...
+def tile[ScalarT: np.generic](A: _ArrayLike[ScalarT], reps: _ArrayLikeInt) -> NDArray[ScalarT]: ...
 @overload
-def tile(A: ArrayLike, reps: int | Sequence[int]) -> NDArray[Incomplete]: ...
+def tile(A: ArrayLike, reps: _ArrayLikeInt) -> NDArray[Incomplete]: ...


### PR DESCRIPTION
This fixes an issue in `np.tile` where it incorrectly rejected numpy `integer` scalars or arrays as second (`reps`) argument.

ref: https://github.com/numpy/numpy/pull/31160#issuecomment-4189492521

I'm not sure if there'll be a 2.4.5, so I marked this as backport candidate just in case there will be. It's not a very big issue though, so it's also fine to instead wait for 2.5.0 if that's easier.

#### AI Disclosure
N/A