### PR TITLE
TYP: ``diagonal`` and ``ndarray.diagonal`` shape-typing

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3273,6 +3273,28 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     ) -> ndarray[_ShapeT_co, _dtype[intp]]: ...
 
     # keep in sync with `ma.MaskedArray.diagonal`
+    @overload  # ?d  (workaround)
+    def diagonal[DTypeT: dtype](
+        self: ndarray[tuple[Never, Never, Never, Never], DTypeT],
+        offset: SupportsIndex = 0,
+        axis1: SupportsIndex = 0,
+        axis2: SupportsIndex = 1,
+    ) -> ndarray[_AnyShape, DTypeT]: ...
+    @overload  # 2d
+    def diagonal[DTypeT: dtype](
+        self: ndarray[tuple[int, int], DTypeT],
+        offset: SupportsIndex = 0,
+        axis1: SupportsIndex = 0,
+        axis2: SupportsIndex = 1,
+    ) -> ndarray[tuple[int], DTypeT]: ...
+    @overload  # 3d
+    def diagonal[DTypeT: dtype](
+        self: ndarray[tuple[int, int, int], DTypeT],
+        offset: SupportsIndex = 0,
+        axis1: SupportsIndex = 0,
+        axis2: SupportsIndex = 1,
+    ) -> ndarray[tuple[int, int], DTypeT]: ...
+    @overload  # Nd  (fallback)
     def diagonal(
         self,
         offset: SupportsIndex = 0,

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -603,19 +603,40 @@ def squeeze[ScalarT: np.generic](a: _ArrayLike[ScalarT], axis: _ShapeLike | None
 def squeeze(a: ArrayLike, axis: _ShapeLike | None = None) -> NDArray[Any]: ...
 
 # keep in sync with `ma.core.diagonal`
-@overload
+@overload  # ?d  (workaround)
+def diagonal[ScalarT: np.generic](
+    a: _ArrayJustND[ScalarT],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+) -> NDArray[ScalarT]: ...
+@overload  # 2d
+def diagonal[ScalarT: np.generic](
+    a: _ToArray2D[ScalarT],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+) -> _Array1D[ScalarT]: ...
+@overload  # 3d
+def diagonal[ScalarT: np.generic](
+    a: _ToArray3D[ScalarT],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+) -> _Array2D[ScalarT]: ...
+@overload  # Nd
 def diagonal[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
     offset: SupportsIndex = 0,
     axis1: SupportsIndex = 0,
-    axis2: SupportsIndex = 1,  # >= 2D array
+    axis2: SupportsIndex = 1,
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # fallback
 def diagonal(
     a: ArrayLike,
     offset: SupportsIndex = 0,
     axis1: SupportsIndex = 0,
-    axis2: SupportsIndex = 1,  # >= 2D array
+    axis2: SupportsIndex = 1,
 ) -> NDArray[Any]: ...
 
 # keep in sync with `ma.core.trace`

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -2511,9 +2511,30 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
 
     # keep in sync with `ndarray.diagonal`
     @override
+    @overload  # ?d  (workaround)
+    def diagonal[DTypeT: dtype](
+        self: MaskedArray[tuple[Never, Never, Never, Never], DTypeT],
+        offset: SupportsIndex = 0,
+        axis1: SupportsIndex = 0,
+        axis2: SupportsIndex = 1,
+    ) -> MaskedArray[_AnyShape, DTypeT]: ...
+    @overload  # 2d
+    def diagonal[DTypeT: dtype](
+        self: MaskedArray[tuple[int, int], DTypeT],
+        offset: SupportsIndex = 0,
+        axis1: SupportsIndex = 0,
+        axis2: SupportsIndex = 1,
+    ) -> MaskedArray[tuple[int], DTypeT]: ...
+    @overload  # 3d
+    def diagonal[DTypeT: dtype](
+        self: MaskedArray[tuple[int, int, int], DTypeT],
+        offset: SupportsIndex = 0,
+        axis1: SupportsIndex = 0,
+        axis2: SupportsIndex = 1,
+    ) -> MaskedArray[tuple[int, int], DTypeT]: ...
+    @overload  # Nd  (fallback)
     def diagonal(
         self,
-        /,
         offset: SupportsIndex = 0,
         axis1: SupportsIndex = 0,
         axis2: SupportsIndex = 1,

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -147,6 +147,8 @@ assert_type(np.squeeze(AR_f4), npt.NDArray[np.float32])
 
 assert_type(np.diagonal(AR_b), npt.NDArray[np.bool])
 assert_type(np.diagonal(AR_f4), npt.NDArray[np.float32])
+assert_type(np.diagonal(AR_f4_2d), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.diagonal(AR_f4_3d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
 
 assert_type(np.trace(AR_b), Any)
 assert_type(np.trace(AR_f4), Any)

--- a/numpy/typing/tests/data/reveal/ndarray_misc.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.pyi
@@ -262,6 +262,8 @@ assert_type(AR_f8.argpartition([0]), npt.NDArray[np.intp])
 assert_type(AR_f8.argpartition(0, axis=None), np.ndarray[tuple[int], np.dtype[np.intp]])
 
 assert_type(AR_f8.diagonal(), npt.NDArray[np.float64])
+assert_type(AR_f8_2d.diagonal(), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(AR_f8_3d.diagonal(), np.ndarray[tuple[int, int], np.dtype[np.float64]])
 
 assert_type(AR_f8.dot(1), npt.NDArray[Any])
 assert_type(AR_f8.dot([1]), Any)


### PR DESCRIPTION
This adds shape-typing overloads to `np.diagonal`, `np.ndarray.diagonal`, and `np.ma.MaskedArray.diagonal` for the 2d -> 1d and 3d  -> 2d cases.

#### AI Disclosure
N/A
