### PR TITLE
TYP: ``arg{min,max}`` shape-typing

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2268,6 +2268,93 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     @overload
     def transpose(self, /, *axes: SupportsIndex) -> Self: ...
 
+    # keep in sync with `ndarray.argmin` (below) and `ma.MaskedArray.argmax`
+    @override  # type: ignore[override]
+    @overload
+    def argmax(
+        self,
+        axis: None = None,
+        out: None = None,
+        *,
+        keepdims: L[False] = False,
+    ) -> intp: ...
+    @overload  # axis: <given>
+    def argmax(
+        self,
+        axis: SupportsIndex,
+        out: None = None,
+        *,
+        keepdims: L[False] = False,
+    ) -> NDArray[intp]: ...
+    @overload  # keepdims: True
+    def argmax(
+        self,
+        axis: SupportsIndex | None = None,
+        out: None = None,
+        *,
+        keepdims: L[True],
+    ) -> ndarray[_ShapeT_co, dtype[intp]]: ...
+    @overload  # out: <given>  (keyword)
+    def argmax[ArrayT: NDArray[intp]](
+        self,
+        axis: SupportsIndex | None = None,
+        *,
+        out: ArrayT,
+        keepdims: py_bool = False,
+    ) -> ArrayT: ...
+    @overload  # out: <given>  (positional)
+    def argmax[ArrayT: NDArray[intp]](  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        axis: SupportsIndex | None,
+        out: ArrayT,
+        *,
+        keepdims: py_bool = False,
+    ) -> ArrayT: ...
+
+    # keep in sync with `ndarray.argmax` (above) and `ma.MaskedArray.argmin`
+    @override  # type: ignore[override]
+    @overload
+    def argmin(
+        self,
+        axis: None = None,
+        out: None = None,
+        *,
+        keepdims: L[False] = False,
+    ) -> intp: ...
+    @overload  # axis: <given>
+    def argmin(
+        self,
+        axis: SupportsIndex,
+        out: None = None,
+        *,
+        keepdims: L[False] = False,
+    ) -> NDArray[intp]: ...
+    @overload  # keepdims: True
+    def argmin(
+        self,
+        axis: SupportsIndex | None = None,
+        out: None = None,
+        *,
+        keepdims: L[True],
+    ) -> ndarray[_ShapeT_co, dtype[intp]]: ...
+    @overload  # out: <given>  (keyword)
+    def argmin[ArrayT: NDArray[intp]](
+        self,
+        axis: SupportsIndex | None = None,
+        *,
+        out: ArrayT,
+        keepdims: py_bool = False,
+    ) -> ArrayT: ...
+    @overload  # out: <given>  (positional)
+    def argmin[ArrayT: NDArray[intp]](  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        axis: SupportsIndex | None,
+        out: ArrayT,
+        *,
+        keepdims: py_bool = False,
+    ) -> ArrayT: ...
+
+    #
     @overload
     def all(
         self,

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -1,4 +1,4 @@
-from _typeshed import Incomplete
+from _typeshed import Incomplete, SupportsBool
 from collections.abc import Sequence
 from typing import (
     Any,
@@ -136,6 +136,16 @@ type _ToArray3D[ScalarT: np.generic] = _Array3D[ScalarT] | Sequence[Sequence[Seq
 
 type _ArrayLikeMultiplicative_co = _DualArrayLike[np.dtype[np.number | np.bool | np.object_], complex]
 type _ArrayLikeNumeric_co = _DualArrayLike[np.dtype[np.number | np.bool | np.object_ | np.timedelta64], complex]
+
+@type_check_only
+class _CanLE(Protocol):
+    def __le__(self, other: Any, /) -> SupportsBool: ...
+
+@type_check_only
+class _CanGE(Protocol):
+    def __ge__(self, other: Any, /) -> SupportsBool: ...
+
+type _Orderable = _CanLE | _CanGE
 
 ###
 
@@ -494,72 +504,89 @@ def argsort(
     stable: bool | None = None,
 ) -> _Array1D[np.intp]: ...
 
-#
-@overload
+# keep in sync with `argmin` below
+@overload  # ?d
 def argmax(
-    a: ArrayLike,
+    a: ArrayLike | _NestedSequence[_Orderable],
     axis: None = None,
     out: None = None,
     *,
     keepdims: Literal[False] | _NoValueType = ...,
-) -> intp: ...
-@overload
+) -> np.intp: ...
+@overload  # ?d, axis: <given>
 def argmax(
-    a: ArrayLike,
+    a: ArrayLike | _NestedSequence[_Orderable],
+    axis: SupportsIndex,
+    out: None = None,
+    *,
+    keepdims: Literal[False] | _NoValueType = ...,
+) -> NDArray[np.intp]: ...
+@overload  # Nd, keepdims=True
+def argmax[ShapeT: _Shape](
+    a: np.ndarray[ShapeT],
     axis: SupportsIndex | None = None,
     out: None = None,
     *,
-    keepdims: bool | _NoValueType = ...,
-) -> Any: ...
-@overload
-def argmax[BoolOrIntArrayT: NDArray[np.integer | np.bool]](
-    a: ArrayLike,
-    axis: SupportsIndex | None,
-    out: BoolOrIntArrayT,
+    keepdims: Literal[True],
+) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...
+@overload  # ?d, keepdims=True
+def argmax(
+    a: ArrayLike | _NestedSequence[_Orderable],
+    axis: SupportsIndex | None = None,
+    out: None = None,
     *,
-    keepdims: bool | _NoValueType = ...,
-) -> BoolOrIntArrayT: ...
-@overload
-def argmax[BoolOrIntArrayT: NDArray[np.integer | np.bool]](
-    a: ArrayLike,
+    keepdims: Literal[True],
+) -> NDArray[np.intp]: ...
+@overload  # ?d, out: ArrayT
+def argmax[ArrayT: NDArray[np.intp]](
+    a: ArrayLike | _NestedSequence[_Orderable],
     axis: SupportsIndex | None = None,
     *,
-    out: BoolOrIntArrayT,
+    out: ArrayT,
     keepdims: bool | _NoValueType = ...,
-) -> BoolOrIntArrayT: ...
+) -> ArrayT: ...
 
-@overload
+# keep in sync with `argmax` above
+@overload  # ?d
 def argmin(
-    a: ArrayLike,
+    a: ArrayLike | _NestedSequence[_Orderable],
     axis: None = None,
     out: None = None,
     *,
     keepdims: Literal[False] | _NoValueType = ...,
-) -> intp: ...
-@overload
+) -> np.intp: ...
+@overload  # ?d, axis: <given>
 def argmin(
-    a: ArrayLike,
+    a: ArrayLike | _NestedSequence[_Orderable],
+    axis: SupportsIndex,
+    out: None = None,
+    *,
+    keepdims: Literal[False] | _NoValueType = ...,
+) -> NDArray[np.intp]: ...
+@overload  # Nd, keepdims=True
+def argmin[ShapeT: _Shape](
+    a: np.ndarray[ShapeT],
     axis: SupportsIndex | None = None,
     out: None = None,
     *,
-    keepdims: bool | _NoValueType = ...,
-) -> Any: ...
-@overload
-def argmin[BoolOrIntArrayT: NDArray[np.integer | np.bool]](
-    a: ArrayLike,
-    axis: SupportsIndex | None,
-    out: BoolOrIntArrayT,
+    keepdims: Literal[True],
+) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...
+@overload  # ?d, keepdims=True
+def argmin(
+    a: ArrayLike | _NestedSequence[_Orderable],
+    axis: SupportsIndex | None = None,
+    out: None = None,
     *,
-    keepdims: bool | _NoValueType = ...,
-) -> BoolOrIntArrayT: ...
-@overload
-def argmin[BoolOrIntArrayT: NDArray[np.integer | np.bool]](
-    a: ArrayLike,
+    keepdims: Literal[True],
+) -> NDArray[np.intp]: ...
+@overload  # ?d, out: ArrayT
+def argmin[ArrayT: NDArray[np.intp]](
+    a: ArrayLike | _NestedSequence[_Orderable],
     axis: SupportsIndex | None = None,
     *,
-    out: BoolOrIntArrayT,
+    out: ArrayT,
     keepdims: bool | _NoValueType = ...,
-) -> BoolOrIntArrayT: ...
+) -> ArrayT: ...
 
 # TODO: Fix overlapping overloads: https://github.com/numpy/numpy/issues/27032
 @overload

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -2222,9 +2222,10 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         stable: bool = False,
     ) -> _MaskedArray[intp]: ...
 
-    # Keep in-sync with np.ma.argmin
-    @overload  # type: ignore[override]
-    def argmin(  # pyrefly: ignore[bad-param-name-override]
+    # keep in sync with `MaskedArray.argmin` (below) and `ndarray.argmax`
+    @override  # type: ignore[override]
+    @overload
+    def argmax(
         self,
         axis: None = None,
         fill_value: _ScalarLike_co | None = None,
@@ -2232,17 +2233,26 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         *,
         keepdims: Literal[False] | _NoValueType = ...,
     ) -> intp: ...
-    @overload
-    def argmin(
+    @overload  # axis: <given>
+    def argmax(
+        self,
+        axis: SupportsIndex,
+        fill_value: _ScalarLike_co | None = None,
+        out: None = None,
+        *,
+        keepdims: Literal[False] | _NoValueType = ...,
+    ) -> _MaskedArray[intp]: ...
+    @overload  # keepdims: True
+    def argmax(
         self,
         axis: SupportsIndex | None = None,
         fill_value: _ScalarLike_co | None = None,
         out: None = None,
         *,
-        keepdims: bool | _NoValueType = ...,
-    ) -> Any: ...
-    @overload
-    def argmin[ArrayT: np.ndarray](
+        keepdims: Literal[True],
+    ) -> MaskedArray[_ShapeT_co, dtype[intp]]: ...
+    @overload  # out: <given>  (keyword)
+    def argmax[ArrayT: NDArray[intp]](
         self,
         axis: SupportsIndex | None = None,
         fill_value: _ScalarLike_co | None = None,
@@ -2250,8 +2260,8 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         out: ArrayT,
         keepdims: bool | _NoValueType = ...,
     ) -> ArrayT: ...
-    @overload
-    def argmin[ArrayT: np.ndarray](
+    @overload  # out: <given>  (positional)
+    def argmax[ArrayT: NDArray[intp]](  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         axis: SupportsIndex | None,
         fill_value: _ScalarLike_co | None,
@@ -2260,9 +2270,10 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         keepdims: bool | _NoValueType = ...,
     ) -> ArrayT: ...
 
-    # Keep in-sync with np.ma.argmax
-    @overload  # type: ignore[override]
-    def argmax(  # pyrefly: ignore[bad-param-name-override]
+    # keep in sync with `MaskedArray.argmax` (above) and `ndarray.argmin`
+    @override  # type: ignore[override]
+    @overload
+    def argmin(
         self,
         axis: None = None,
         fill_value: _ScalarLike_co | None = None,
@@ -2270,17 +2281,26 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         *,
         keepdims: Literal[False] | _NoValueType = ...,
     ) -> intp: ...
-    @overload
-    def argmax(
+    @overload  # axis: <given>
+    def argmin(
+        self,
+        axis: SupportsIndex,
+        fill_value: _ScalarLike_co | None = None,
+        out: None = None,
+        *,
+        keepdims: Literal[False] | _NoValueType = ...,
+    ) -> _MaskedArray[intp]: ...
+    @overload  # keepdims: True
+    def argmin(
         self,
         axis: SupportsIndex | None = None,
         fill_value: _ScalarLike_co | None = None,
         out: None = None,
         *,
-        keepdims: bool | _NoValueType = ...,
-    ) -> Any: ...
-    @overload
-    def argmax[ArrayT: np.ndarray](
+        keepdims: Literal[True],
+    ) -> MaskedArray[_ShapeT_co, dtype[intp]]: ...
+    @overload  # out: <given>  (keyword)
+    def argmin[ArrayT: NDArray[intp]](
         self,
         axis: SupportsIndex | None = None,
         fill_value: _ScalarLike_co | None = None,
@@ -2288,8 +2308,8 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         out: ArrayT,
         keepdims: bool | _NoValueType = ...,
     ) -> ArrayT: ...
-    @overload
-    def argmax[ArrayT: np.ndarray](
+    @overload  # out: <given>  (positional)
+    def argmin[ArrayT: NDArray[intp]](  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         axis: SupportsIndex | None,
         fill_value: _ScalarLike_co | None,

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -116,16 +116,22 @@ assert_type(np.argsort(AR_f4, axis=None), np.ndarray[tuple[int], np.dtype[np.int
 assert_type(np.argsort(AR_f4_1d, axis=None), np.ndarray[tuple[int], np.dtype[np.intp]])
 assert_type(np.argsort(AR_f4_2d, axis=None), np.ndarray[tuple[int], np.dtype[np.intp]])
 
-assert_type(np.argmax(AR_b), np.intp)
+# same as below
 assert_type(np.argmax(AR_f4), np.intp)
-assert_type(np.argmax(AR_b, axis=0), Any)
-assert_type(np.argmax(AR_f4, axis=0), Any)
+assert_type(np.argmax(AR_f4, axis=0), npt.NDArray[np.intp])
+assert_type(np.argmax(AR_f4, keepdims=True), npt.NDArray[np.intp])
+assert_type(np.argmax(AR_f4_1d, keepdims=True), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(np.argmax(AR_f4_2d, keepdims=True), np.ndarray[tuple[int, int], np.dtype[np.intp]])
+assert_type(np.argmax(AR_f4_3d, keepdims=True), np.ndarray[tuple[int, int, int], np.dtype[np.intp]])
 assert_type(np.argmax(AR_f4, out=AR_sub_i), NDArrayIntSubclass)
 
-assert_type(np.argmin(AR_b), np.intp)
+# same as above
 assert_type(np.argmin(AR_f4), np.intp)
-assert_type(np.argmin(AR_b, axis=0), Any)
-assert_type(np.argmin(AR_f4, axis=0), Any)
+assert_type(np.argmin(AR_f4, axis=0), npt.NDArray[np.intp])
+assert_type(np.argmin(AR_f4, keepdims=True), npt.NDArray[np.intp])
+assert_type(np.argmin(AR_f4_1d, keepdims=True), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(np.argmin(AR_f4_2d, keepdims=True), np.ndarray[tuple[int, int], np.dtype[np.intp]])
+assert_type(np.argmin(AR_f4_3d, keepdims=True), np.ndarray[tuple[int, int, int], np.dtype[np.intp]])
 assert_type(np.argmin(AR_f4, out=AR_sub_i), NDArrayIntSubclass)
 
 assert_type(np.searchsorted(AR_b[0], 0), np.intp)

--- a/numpy/typing/tests/data/reveal/ma.pyi
+++ b/numpy/typing/tests/data/reveal/ma.pyi
@@ -15,6 +15,7 @@ class IntoMaskedArraySubClass[ScalarT: np.generic]:
     def __array__(self) -> MaskedArraySubclass[ScalarT]: ...
 
 type MaskedArraySubclassC = MaskedArraySubclass[np.complex128]
+type MaskedArraySubclassI = MaskedArraySubclass[np.intp]
 
 AR_b: NDArray[np.bool]
 AR_f4: NDArray[np.float32]
@@ -51,6 +52,7 @@ MAR_floating: MaskedArray[np.floating]
 MAR_number: MaskedArray[np.number]
 
 MAR_subclass: MaskedArraySubclassC
+MAR_subclass_i: MaskedArraySubclassI
 MAR_into_subclass: IntoMaskedArraySubClass[np.float32]
 
 MAR_1d: np.ma.MaskedArray[tuple[int], np.dtype]
@@ -131,12 +133,12 @@ assert_type(MAR_f4.ptp(None, MAR_subclass), MaskedArraySubclassC)
 
 assert_type(MAR_b.argmin(), np.intp)
 assert_type(MAR_f4.argmin(), np.intp)
-assert_type(MAR_f4.argmax(fill_value=6.28318, keepdims=False), np.intp)
-assert_type(MAR_b.argmin(axis=0), Any)
-assert_type(MAR_f4.argmin(axis=0), Any)
-assert_type(MAR_b.argmin(keepdims=True), Any)
-assert_type(MAR_f4.argmin(out=MAR_subclass), MaskedArraySubclassC)
-assert_type(MAR_f4.argmin(None, None, out=MAR_subclass), MaskedArraySubclassC)
+assert_type(MAR_f4.argmin(fill_value=6.28318, keepdims=False), np.intp)
+assert_type(MAR_b.argmin(axis=0), MaskedArray[np.intp])
+assert_type(MAR_f4.argmin(axis=0), MaskedArray[np.intp])
+assert_type(MAR_b.argmin(keepdims=True), MaskedArray[np.intp])
+assert_type(MAR_f4.argmin(out=MAR_subclass_i), MaskedArraySubclassI)
+assert_type(MAR_f4.argmin(None, None, out=MAR_subclass_i), MaskedArraySubclassI)
 
 assert_type(np.ma.argmin(MAR_b), np.intp)
 assert_type(np.ma.argmin(MAR_f4), np.intp)
@@ -150,11 +152,11 @@ assert_type(np.ma.argmin(MAR_f4, None, None, out=MAR_subclass), MaskedArraySubcl
 assert_type(MAR_b.argmax(), np.intp)
 assert_type(MAR_f4.argmax(), np.intp)
 assert_type(MAR_f4.argmax(fill_value=6.28318, keepdims=False), np.intp)
-assert_type(MAR_b.argmax(axis=0), Any)
-assert_type(MAR_f4.argmax(axis=0), Any)
-assert_type(MAR_b.argmax(keepdims=True), Any)
-assert_type(MAR_f4.argmax(out=MAR_subclass), MaskedArraySubclassC)
-assert_type(MAR_f4.argmax(None, None, out=MAR_subclass), MaskedArraySubclassC)
+assert_type(MAR_b.argmax(axis=0), MaskedArray[np.intp])
+assert_type(MAR_f4.argmax(axis=0), MaskedArray[np.intp])
+assert_type(MAR_b.argmax(keepdims=True), MaskedArray[np.intp])
+assert_type(MAR_f4.argmax(out=MAR_subclass_i), MaskedArraySubclassI)
+assert_type(MAR_f4.argmax(None, None, out=MAR_subclass_i), MaskedArraySubclassI)
 
 assert_type(np.ma.argmax(MAR_b), np.intp)
 assert_type(np.ma.argmax(MAR_f4), np.intp)

--- a/numpy/typing/tests/data/reveal/ndarray_misc.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.pyi
@@ -68,15 +68,25 @@ assert_type(AR_f8.any(axis=0), np.bool | npt.NDArray[np.bool])
 assert_type(AR_f8.any(keepdims=True), np.bool | npt.NDArray[np.bool])
 assert_type(AR_f8.any(out=B), SubClass)
 
+# same as below
 assert_type(f8.argmax(), np.intp)
 assert_type(AR_f8.argmax(), np.intp)
-assert_type(AR_f8.argmax(axis=0), Any)
+assert_type(AR_f8.argmax(axis=0), npt.NDArray[np.intp])
 assert_type(AR_f8.argmax(out=AR_i8), npt.NDArray[np.int64])
+assert_type(AR_f8.argmax(keepdims=True), npt.NDArray[np.intp])
+assert_type(AR_f8_1d.argmax(keepdims=True), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(AR_f8_2d.argmax(keepdims=True), np.ndarray[tuple[int, int], np.dtype[np.intp]])
+assert_type(AR_f8_3d.argmax(keepdims=True), np.ndarray[tuple[int, int, int], np.dtype[np.intp]])
 
+# same as above
 assert_type(f8.argmin(), np.intp)
 assert_type(AR_f8.argmin(), np.intp)
-assert_type(AR_f8.argmin(axis=0), Any)
+assert_type(AR_f8.argmin(axis=0), npt.NDArray[np.intp])
 assert_type(AR_f8.argmin(out=AR_i8), npt.NDArray[np.int64])
+assert_type(AR_f8.argmin(keepdims=True), npt.NDArray[np.intp])
+assert_type(AR_f8_1d.argmin(keepdims=True), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(AR_f8_2d.argmin(keepdims=True), np.ndarray[tuple[int, int], np.dtype[np.intp]])
+assert_type(AR_f8_3d.argmin(keepdims=True), np.ndarray[tuple[int, int, int], np.dtype[np.intp]])
 
 assert_type(f8.argsort(), npt.NDArray[np.intp])
 assert_type(AR_f8.argsort(), npt.NDArray[np.intp])


### PR DESCRIPTION
Dual to #31163, this improves the shape-typing of 

- `np.arg{min,max}`
- `np.ndarray.arg{min,max}`
- `np.ma.MaskedArray.arg{min,max}`

#### AI Disclosure
N/A