### PR TITLE
DOC: release notes for the latest shape-typing improvements

### DIFF
--- a/doc/release/upcoming_changes/31172.typing.rst
+++ b/doc/release/upcoming_changes/31172.typing.rst
@@ -1,0 +1,22 @@
+Shape-typing support for many functions and methods
+---------------------------------------------------
+Many functions and methods now have shape-aware return type annotations.
+Type-checkers can now infer the number of dimensions of the returned array
+through common operations. For example, ``np.linspace(0, 1)`` is now typed
+as a 1-d ``float64`` array, and ``np.sum(x, keepdims=True)`` has the same
+number of dimensions as ``x``.
+
+This covers ``numpy.linalg`` functions, array creation functions (like
+``asarray``, ``fromiter``, and ``fromregex``), range functions (``linspace``,
+``logspace``, ``geomspace``), aggregation functions and methods (``sum``,
+``mean``, ``std``, ``var``, ``min``, ``max``, ``all``, ``any``, etc.), sorting
+(``sort``, ``argsort``, ``argpartition``), cumulative operations (``cumsum``,
+``cumprod``, etc.), set operations (``unique_values``, ``intersect1d``,
+``union1d``, etc.), and various other functions including ``nonzero``,
+``transpose``, ``diagonal``, ``atleast_{1,2,3}d``, ``clip``, ``round``,
+``inner``, ``bincount``, and ``fft.fftfreq``. Several of these also gained
+more precise return dtype annotations as part of this work.
+
+Shape-typing is still a work-in-progress, so coverage is not yet complete.
+Because of limitations in Python's type system and current type-checkers,
+shape-typing is often only implemented for the most common lower-rank cases.

--- a/doc/release/upcoming_changes/31172.typing.rst
+++ b/doc/release/upcoming_changes/31172.typing.rst
@@ -7,7 +7,7 @@ as a 1-d ``float64`` array, and ``np.sum(x, keepdims=True)`` has the same
 number of dimensions as ``x``.
 
 This covers ``numpy.linalg`` functions, array creation functions (like
-``asarray``, ``fromiter``, and ``fromregex``), range functions (``linspace``,
+``asarray``, ``from{buffer,string,file,iter,regex}``), range functions (``linspace``,
 ``logspace``, ``geomspace``), aggregation functions and methods (``sum``,
 ``mean``, ``std``, ``var``, ``min``, ``max``, ``all``, ``any``, etc.), sorting
 (``sort``, ``argsort``, ``argpartition``), cumulative operations (``cumsum``,


### PR DESCRIPTION
Here's the promised release note for the recent shape-typing improvements.

#### AI Disclosure

I had copilot (with Claude Opus 4.6 High) write this (in "ask" mode), and made some minor changes afterwards.

<details>
<summary>prompt</summary>

For the upcoming NumPy 2.5.0 release I have contributed a lot of shape-typing improvements in the numpy stubs. Write a .rst release note in the same style as https://github.com/numpy/numpy/pull/30208 and https://github.com/numpy/numpy/pull/30480 . Mention that shape-typing is currently a work-in-progress, so shape-typing support isn't yet complete. With "shape-typing" I mostly refer to the type of ndarray.shape, i.e. some tuple[int, ...] type, usually either tuple[Any, ...] (if unknown), tuple[int] (1d), tuple[int, ...] (2d), etc.

Full list of shape-typing PRs that should be summarized (not enumerated) like I've done before in https://github.com/numpy/numpy/pull/30208.

- #30484
- #30532
- #30536
- #30537
- #30542
- #30714
- #31120
- #31123
- #31124
- #31125
- #31133
- #31134
- #31135
- #31143
- #31147
- #31148
- #31151
- #31154
- #31160
- #31163
- #31164
- #31165
- #31166
- #31170

Keep it concise, don't use emdashes and other classic AI stuff, and instead use my writing style. Don't oversell it, and keep it light and not too formal.

</details>