### PR TITLE
ENH: Removed remnants of Python 2 buffer protocol from NumPy internals

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3921,19 +3921,20 @@ to.
 
 .. c:function:: int PyArray_BufferConverter(PyObject* obj, PyArray_Chunk* buf)
 
-    Convert any Python object, *obj*, with a (single-segment) buffer
-    interface to a variable with members that detail the object's use
-    of its chunk of memory. The *buf* variable is a pointer to a
-    structure with base, ptr, len, and flags members. The
-    :c:type:`PyArray_Chunk` structure is binary compatible with the
-    Python's buffer object (through its len member on 32-bit platforms
-    and its ptr member on 64-bit platforms). On return, the base member
-    is set to *obj* (or its base if *obj* is already a buffer object
+    .. deprecated:: 2.5
+
+       Use the standard Python buffer protocol directly instead.
+
+    Convert any Python object, *obj*, that exports a buffer to a
+    variable with members that describe the exported memory. The
+    *buf* variable is a pointer to a structure with base, ptr, len,
+    and flags members. On return, the base member is set to *obj*
+    (or its base if *obj* is already a buffer-exporting object
     pointing to another object). If you need to hold on to the memory
     be sure to INCREF the base member. The chunk of memory is pointed
     to by *buf* ->ptr member and has length *buf* ->len. The flags
     member of *buf* is :c:data:`NPY_ARRAY_ALIGNED` with the
-    :c:data:`NPY_ARRAY_WRITEABLE` flag set if *obj* has a writeable
+    :c:data:`NPY_ARRAY_WRITEABLE` flag set if *obj* has a writable
     buffer interface.
 
 .. c:function:: int PyArray_AxisConverter(PyObject* obj, int* axis)

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -1460,11 +1460,9 @@ PyArray_Chunk
 
 .. c:type:: PyArray_Chunk
 
-   This is equivalent to the buffer object structure in Python up to
-   the ptr member. On 32-bit platforms (*i.e.* if :c:data:`NPY_SIZEOF_INT`
-   == :c:data:`NPY_SIZEOF_INTP`), the len member also matches an equivalent
-   member of the buffer object. It is useful to represent a generic
-   single-segment chunk of memory.
+    This helper structure stores the metadata needed by the ndarray buffer
+    constructor. It represents a generic chunk of memory together with the
+    exporting object that owns it.
 
    .. code-block:: c
 
@@ -1480,9 +1478,7 @@ PyArray_Chunk
 
    .. c:macro: PyObject_HEAD
 
-       Necessary for all Python objects. Included here so that the
-       :c:type:`PyArray_Chunk` structure matches that of the buffer object
-       (at least to the len member).
+       Necessary for all Python objects.
 
    .. c:member:: PyObject *base
 

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -849,8 +849,21 @@ typedef struct tagPyArrayObject {
  * compatible with multiple NumPy versions.
  */
 
-/* Mirrors buffer object to ptr */
-
+/*
+ * Buffer-converter metadata used by ndarray construction.
+ *
+ * The public API keeps PyArray_Chunk available, while internal code uses the
+ * private _PyArray_Chunk name to avoid relying on the public alias.
+ */
+#if defined(NPY_INTERNAL_BUILD) && NPY_INTERNAL_BUILD
+typedef struct _PyArray_Chunk {
+        PyObject_HEAD
+        PyObject *base;
+        void *ptr;
+        npy_intp len;
+        int flags;
+} _PyArray_Chunk;
+#else
 typedef struct {
         PyObject_HEAD
         PyObject *base;
@@ -858,6 +871,7 @@ typedef struct {
         npy_intp len;
         int flags;
 } PyArray_Chunk;
+#endif
 
 typedef struct {
     NPY_DATETIMEUNIT base;

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -1116,7 +1116,7 @@ array_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
     int itemsize;
     PyArray_Dims dims = {NULL, 0};
     PyArray_Dims strides = {NULL, -1};
-    PyArray_Chunk buffer;
+    _PyArray_Chunk buffer;
     npy_longlong offset = 0;
     NPY_ORDER order = NPY_CORDER;
     int is_f_order = 0;

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -283,8 +283,8 @@ PyArray_AsTypeCopyConverter(PyObject *obj, NPY_ASTYPECOPYMODE *copymode)
 /*NUMPY_API
  * Get buffer chunk from object
  *
- * this function takes a Python object which exposes the (single-segment)
- * buffer interface and returns a pointer to the data segment
+ * this function takes a Python object which exposes the buffer interface
+ * and returns a pointer to the data segment
  *
  * You should increment the reference count by one of buf->base
  * if you will hang on to a reference
@@ -293,9 +293,13 @@ PyArray_AsTypeCopyConverter(PyObject *obj, NPY_ASTYPECOPYMODE *copymode)
  * memory...
  */
 NPY_NO_EXPORT int
-PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
+PyArray_BufferConverter(PyObject *obj, _PyArray_Chunk *buf)
 {
     Py_buffer view;
+
+    if (DEPRECATE("PyArray_BufferConverter is deprecated and will be removed in a future version. Use the standard Python buffer protocol instead.") < 0) {
+        return NPY_FAIL;
+    }
 
     buf->ptr = NULL;
     buf->flags = NPY_ARRAY_BEHAVED;

--- a/numpy/_core/src/multiarray/conversion_utils.h
+++ b/numpy/_core/src/multiarray/conversion_utils.h
@@ -30,7 +30,7 @@ NPY_NO_EXPORT int
 PyArray_AsTypeCopyConverter(PyObject *obj, NPY_ASTYPECOPYMODE *copyflag);
 
 NPY_NO_EXPORT int
-PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf);
+PyArray_BufferConverter(PyObject *obj, _PyArray_Chunk *buf);
 
 NPY_NO_EXPORT int
 PyArray_BoolConverter(PyObject *object, npy_bool *val);

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -262,6 +262,17 @@ class TestDeprecatedDTypeParenthesizedRepeatCount(_DeprecationTestCase):
         self.assert_deprecated(np.dtype, args=(string,))
 
 
+class TestDeprecatedBufferConverter(_DeprecationTestCase):
+    message = r"PyArray_BufferConverter is deprecated"
+
+    def test_ndarray_buffer_kwarg_deprecated(self):
+        def make_array():
+            arr = np.ndarray((2,), dtype=np.uint8, buffer=b"\x01\x02")
+            assert arr.tolist() == [1, 2]
+
+        self.assert_deprecated(make_array)
+
+
 class TestDTypeAlignBool(_VisibleDeprecationTestCase):
     # Deprecated in Numpy 2.4, 2025-07
     # NOTE: As you can see, finalizing this deprecation breaks some (very) old


### PR DESCRIPTION
fixes #30813

## Summary

It makes three main changes:

- Adds a [DeprecationWarning] when [PyArray_BufferConverter] is used.

- Moves internal ndarray construction to a private [_PyArray_Chunk] typedef so internal code no longer depends on the public alias.

- Updates the C-API reference docs for [PyArray_BufferConverter] and [PyArray_Chunk] to describe the modern buffer-protocol behavior instead of the old single-segment/Python 2 framing.