### PR TITLE
ENH: Removed remnants of Python 2 buffer protocol from NumPy internals

### DIFF
--- a/doc/release/upcoming_changes/31176.deprecation.rst
+++ b/doc/release/upcoming_changes/31176.deprecation.rst
@@ -1,0 +1,4 @@
+``PyArray_BufferConverter`` is deprecated
+-----------------------------------------
+``PyArray_BufferConverter`` is now deprecated. Use the standard Python buffer
+protocol directly instead.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3921,19 +3921,20 @@ to.
 
 .. c:function:: int PyArray_BufferConverter(PyObject* obj, PyArray_Chunk* buf)
 
-    Convert any Python object, *obj*, with a (single-segment) buffer
-    interface to a variable with members that detail the object's use
-    of its chunk of memory. The *buf* variable is a pointer to a
-    structure with base, ptr, len, and flags members. The
-    :c:type:`PyArray_Chunk` structure is binary compatible with the
-    Python's buffer object (through its len member on 32-bit platforms
-    and its ptr member on 64-bit platforms). On return, the base member
-    is set to *obj* (or its base if *obj* is already a buffer object
+    .. deprecated:: 2.5
+
+       Use the standard Python buffer protocol directly instead.
+
+    Convert any Python object, *obj*, that exports a buffer to a
+    variable with members that describe the exported memory. The
+    *buf* variable is a pointer to a structure with base, ptr, len,
+    and flags members. On return, the base member is set to *obj*
+    (or its base if *obj* is already a buffer-exporting object
     pointing to another object). If you need to hold on to the memory
     be sure to INCREF the base member. The chunk of memory is pointed
     to by *buf* ->ptr member and has length *buf* ->len. The flags
     member of *buf* is :c:data:`NPY_ARRAY_ALIGNED` with the
-    :c:data:`NPY_ARRAY_WRITEABLE` flag set if *obj* has a writeable
+    :c:data:`NPY_ARRAY_WRITEABLE` flag set if *obj* has a writable
     buffer interface.
 
 .. c:function:: int PyArray_AxisConverter(PyObject* obj, int* axis)

--- a/doc/source/reference/c-api/types-and-structures.rst
+++ b/doc/source/reference/c-api/types-and-structures.rst
@@ -1460,11 +1460,9 @@ PyArray_Chunk
 
 .. c:type:: PyArray_Chunk
 
-   This is equivalent to the buffer object structure in Python up to
-   the ptr member. On 32-bit platforms (*i.e.* if :c:data:`NPY_SIZEOF_INT`
-   == :c:data:`NPY_SIZEOF_INTP`), the len member also matches an equivalent
-   member of the buffer object. It is useful to represent a generic
-   single-segment chunk of memory.
+    This helper structure stores the metadata needed by the ndarray buffer
+    constructor. It represents a generic chunk of memory together with the
+    exporting object that owns it.
 
    .. code-block:: c
 
@@ -1480,9 +1478,7 @@ PyArray_Chunk
 
    .. c:macro: PyObject_HEAD
 
-       Necessary for all Python objects. Included here so that the
-       :c:type:`PyArray_Chunk` structure matches that of the buffer object
-       (at least to the len member).
+       Necessary for all Python objects.
 
    .. c:member:: PyObject *base
 

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -849,8 +849,6 @@ typedef struct tagPyArrayObject {
  * compatible with multiple NumPy versions.
  */
 
-/* Mirrors buffer object to ptr */
-
 typedef struct {
         PyObject_HEAD
         PyObject *base;

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -2227,6 +2227,17 @@ run_intp_converter(PyObject* NPY_UNUSED(self), PyObject *args)
     return tup;
 }
 
+static PyObject *
+run_buffer_converter(PyObject* NPY_UNUSED(self), PyObject *args)
+{
+    PyArray_Chunk buffer;
+
+    if (!PyArg_ParseTuple(args, "O&", PyArray_BufferConverter, &buffer)) {
+        return NULL;
+    }
+    return PyLong_FromSsize_t((Py_ssize_t)buffer.len);
+}
+
 /* used to test NPY_ARRAY_ENSURENOCOPY raises ValueError */
 static PyObject*
 npy_ensurenocopy(PyObject* NPY_UNUSED(self), PyObject* args)
@@ -2462,6 +2473,9 @@ static PyMethodDef Multiarray_TestsMethods[] = {
         METH_O, NULL},
     {"run_intp_converter",
         run_intp_converter,
+        METH_VARARGS, NULL},
+    {"run_buffer_converter",
+        run_buffer_converter,
         METH_VARARGS, NULL},
     {"npy_import_entry_point",
         _npy_import_entry_point,

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -1133,7 +1133,7 @@ array_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
                                      &dims,
                                      PyArray_DescrConverter,
                                      &descr,
-                                     PyArray_BufferConverter,
+                                     PyArray_BufferConverterInternal,
                                      &buffer,
                                      &offset,
                                      &PyArray_OptionalIntpConverter,

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -280,11 +280,11 @@ PyArray_AsTypeCopyConverter(PyObject *obj, NPY_ASTYPECOPYMODE *copymode)
     return NPY_SUCCEED;
 }
 
-/*NUMPY_API
+/*
  * Get buffer chunk from object
  *
- * this function takes a Python object which exposes the (single-segment)
- * buffer interface and returns a pointer to the data segment
+ * this function takes a Python object which exposes the buffer interface
+ * and returns a pointer to the data segment
  *
  * You should increment the reference count by one of buf->base
  * if you will hang on to a reference
@@ -293,7 +293,7 @@ PyArray_AsTypeCopyConverter(PyObject *obj, NPY_ASTYPECOPYMODE *copymode)
  * memory...
  */
 NPY_NO_EXPORT int
-PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
+PyArray_BufferConverterInternal(PyObject *obj, PyArray_Chunk *buf)
 {
     Py_buffer view;
 
@@ -333,6 +333,18 @@ PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
         buf->base = obj;
     }
     return NPY_SUCCEED;
+}
+
+/*NUMPY_API
+ * Deprecated API wrapper around the internal buffer converter.
+ */
+NPY_NO_EXPORT int
+PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf)
+{
+    if (DEPRECATE("PyArray_BufferConverter is deprecated and will be removed in a future version. Use the standard Python buffer protocol instead.") < 0) {
+        return NPY_FAIL;
+    }
+    return PyArray_BufferConverterInternal(obj, buf);
 }
 
 /*NUMPY_API

--- a/numpy/_core/src/multiarray/conversion_utils.h
+++ b/numpy/_core/src/multiarray/conversion_utils.h
@@ -33,6 +33,9 @@ NPY_NO_EXPORT int
 PyArray_BufferConverter(PyObject *obj, PyArray_Chunk *buf);
 
 NPY_NO_EXPORT int
+PyArray_BufferConverterInternal(PyObject *obj, PyArray_Chunk *buf);
+
+NPY_NO_EXPORT int
 PyArray_BoolConverter(PyObject *object, npy_bool *val);
 
 NPY_NO_EXPORT int

--- a/numpy/_core/tests/test_conversion_utils.py
+++ b/numpy/_core/tests/test_conversion_utils.py
@@ -207,3 +207,12 @@ class TestIntpConverter:
         assert self.conv([1] * 64) == (1,) * 64
         with pytest.raises(ValueError):
             self.conv([1] * 65)
+
+
+class TestBufferConverterDeprecation:
+    def test_deprecated(self):
+        with pytest.warns(
+            DeprecationWarning,
+            match="PyArray_BufferConverter is deprecated",
+        ):
+            assert mt.run_buffer_converter(b"\x01\x02") == 2


### PR DESCRIPTION
fixes #30813 

### First time committer introduction
Hi NumPy team, I’m a first-time contributor. I use NumPy regularly for array-heavy Python work, mainly for data processing and numerical experimentation. While working with NumPy internals/C-API docs, I noticed issue #30813 around legacy Python 2 buffer-protocol language and wanted to help modernize and clarify that path. This contribution is my attempt to reduce confusion for future contributors and keep the API/docs aligned with current behavior.


#### AI Disclosure
no AI tools were used