### PR TITLE
DEP: Undo deprecation for ``np.dtype()`` signature used by old pickles

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2553,13 +2553,21 @@ arraydescr_new(PyTypeObject *subtype,
         /*
          * In the future, reject non Python (or NumPy) boolean, including integers to avoid any
          * possibility of thinking that an integer alignment makes sense here.
+         * We omit the case of `oalign == 0` and `ocopy == 1` if there are exact ints.
+         * This can fail, in which case res is -1 and we enter the deprecation path.
          */
+        int res = 0;
+        int overflow;
         if (!PyBool_Check(oalign) && !PyArray_IsScalar(oalign, Bool) && !(
                 // Some old pickles use 0, 1 exactly, assume no user passes it
                 // (It may also be possible to use `copyreg` instead.)
-                PyLong_CheckExact(oalign) &&  PyLong_AsLong(oalign) == 0 &&
-                ocopy != NULL && PyLong_CheckExact(ocopy) && PyLong_AsLong(ocopy) == 1)) {
+                PyLong_CheckExact(oalign) && (res = PyLong_IsZero(oalign)) == 1 &&
+                ocopy != NULL && PyLong_CheckExact(ocopy) &&
+                (res = PyLong_AsLongAndOverflow(ocopy, &overflow)) == 1)) {
             /* Deprecated 2025-07-01: NumPy 2.4 */
+            if (res == -1 && PyErr_Occurred()) {
+                return NULL;  // Should actually be impossible (as inputs are `long`)
+            }
             if (PyErr_WarnFormat(npy_static_pydata.VisibleDeprecationWarning, 1,
                         "dtype(): align should be passed as Python or NumPy boolean but got `align=%.100R`. "
                         "Did you mean to pass a tuple to create a subarray type? (Deprecated NumPy 2.4)",

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2529,6 +2529,7 @@ arraydescr_new(PyTypeObject *subtype,
 
     PyObject *odescr;
     PyObject *oalign = NULL;
+    PyObject *ocopy = NULL;
     PyObject *metadata = NULL;
     PyArray_Descr *conv;
     npy_bool align = NPY_FALSE;
@@ -2537,20 +2538,27 @@ arraydescr_new(PyTypeObject *subtype,
 
     static char *kwlist[] = {"dtype", "align", "copy", "metadata", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO&O!:dtype", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OOO!:dtype", kwlist,
                 &odescr,
                 &oalign,
-                PyArray_BoolConverter, &copy,
+                &ocopy,
                 &PyDict_Type, &metadata)) {
         return NULL;
     }
 
+    if (ocopy != NULL && !PyArray_BoolConverter(ocopy, &copy)) {
+        return NULL;
+    }
     if (oalign != NULL) {
         /*
          * In the future, reject non Python (or NumPy) boolean, including integers to avoid any
          * possibility of thinking that an integer alignment makes sense here.
          */
-        if (!PyBool_Check(oalign) && !PyArray_IsScalar(oalign, Bool)) {
+        if (!PyBool_Check(oalign) && !PyArray_IsScalar(oalign, Bool) && !(
+                // Some old pickles use 0, 1 exactly, assume no user passes it
+                // (It may also be possible to use `copyreg` instead.)
+                PyLong_CheckExact(oalign) &&  PyLong_AsLong(oalign) == 0 &&
+                ocopy != NULL && PyLong_CheckExact(ocopy) && PyLong_AsLong(ocopy) == 1)) {
             /* Deprecated 2025-07-01: NumPy 2.4 */
             if (PyErr_WarnFormat(npy_static_pydata.VisibleDeprecationWarning, 1,
                         "dtype(): align should be passed as Python or NumPy boolean but got `align=%.100R`. "

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -906,20 +906,18 @@ class TestDateTime:
                          delta)
 
         # Check that loading pickles from 1.6 works
-        with pytest.warns(np.exceptions.VisibleDeprecationWarning,
-                match=r".*align should be passed"):
-            pkl = b"cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n"\
-                b"(I4\nS'<'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'D'\np6\n"\
-                b"I7\nI1\nI1\ntp7\ntp8\ntp9\nb."
-            assert_equal(pickle.loads(pkl), np.dtype('<M8[7D]'))
-            pkl = b"cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n"\
-                b"(I4\nS'<'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'W'\np6\n"\
-                b"I1\nI1\nI1\ntp7\ntp8\ntp9\nb."
-            assert_equal(pickle.loads(pkl), np.dtype('<M8[W]'))
-            pkl = b"cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n"\
-                b"(I4\nS'>'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'us'\np6\n"\
-                b"I1\nI1\nI1\ntp7\ntp8\ntp9\nb."
-            assert_equal(pickle.loads(pkl), np.dtype('>M8[us]'))
+        pkl = b"cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n"\
+            b"(I4\nS'<'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'D'\np6\n"\
+            b"I7\nI1\nI1\ntp7\ntp8\ntp9\nb."
+        assert_equal(pickle.loads(pkl), np.dtype('<M8[7D]'))
+        pkl = b"cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n"\
+            b"(I4\nS'<'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'W'\np6\n"\
+            b"I1\nI1\nI1\ntp7\ntp8\ntp9\nb."
+        assert_equal(pickle.loads(pkl), np.dtype('<M8[W]'))
+        pkl = b"cnumpy\ndtype\np0\n(S'M8'\np1\nI0\nI1\ntp2\nRp3\n"\
+            b"(I4\nS'>'\np4\nNNNI-1\nI-1\nI0\n((dp5\n(S'us'\np6\n"\
+            b"I1\nI1\nI1\ntp7\ntp8\ntp9\nb."
+        assert_equal(pickle.loads(pkl), np.dtype('>M8[us]'))
 
     def test_gh_29555(self):
         # check that dtype metadata round-trips when none

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -280,11 +280,18 @@ class TestDTypeAlignBool(_VisibleDeprecationTestCase):
         # alignment, or pass them accidentally as a subarray shape (meaning to pass
         # a tuple).
         self.assert_deprecated(lambda: np.dtype("f8", align=3))
+        self.assert_deprecated(lambda: np.dtype("f8", align=0, copy=10**100))
+        self.assert_deprecated(lambda: np.dtype("f8", align=10**100, copy=0))
+        # Subclasses of ints don't hit the below pickle code path:
+        self.assert_deprecated(
+            lambda: np.dtype("f8", align=np.long(0), copy=np.long(1)))
 
     @pytest.mark.parametrize("align", [True, False, np.True_, np.False_])
     def test_not_deprecated(self, align):
         # if the user passes a bool, it is accepted.
         self.assert_not_deprecated(lambda: np.dtype("f8", align=align))
+        # The following specific case is used by old pickles:
+        self.assert_not_deprecated(lambda: np.dtype("f8", align=0, copy=1))
 
 
 class TestFlatiterIndexing0dBoolIndex(_DeprecationTestCase):

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -4729,9 +4729,6 @@ class TestPickling:
 
     # version 0 pickles, using protocol=2 to pickle
     # version 0 doesn't have a version field
-    @pytest.mark.filterwarnings(
-        "ignore:.*align should be passed:numpy.exceptions.VisibleDeprecationWarning",
-    )
     def test_version0_int8(self):
         s = (
             b"\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\n"
@@ -4743,9 +4740,6 @@ class TestPickling:
         p = self._loads(s)
         assert_equal(a, p)
 
-    @pytest.mark.filterwarnings(
-        "ignore:.*align should be passed:numpy.exceptions.VisibleDeprecationWarning",
-    )
     def test_version0_float32(self):
         s = (
             b"\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\n"
@@ -4758,9 +4752,6 @@ class TestPickling:
         p = self._loads(s)
         assert_equal(a, p)
 
-    @pytest.mark.filterwarnings(
-        "ignore:.*align should be passed:numpy.exceptions.VisibleDeprecationWarning",
-    )
     def test_version0_object(self):
         s = (
             b"\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\n"
@@ -4774,9 +4765,6 @@ class TestPickling:
         assert_equal(a, p)
 
     # version 1 pickles, using protocol=2 to pickle
-    @pytest.mark.filterwarnings(
-        "ignore:.*align should be passed:numpy.exceptions.VisibleDeprecationWarning",
-    )
     def test_version1_int8(self):
         s = (
             b"\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\n"
@@ -4788,9 +4776,6 @@ class TestPickling:
         p = self._loads(s)
         assert_equal(a, p)
 
-    @pytest.mark.filterwarnings(
-        "ignore:.*align should be passed:numpy.exceptions.VisibleDeprecationWarning",
-    )
     def test_version1_float32(self):
         s = (
             b"\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\n"
@@ -4803,9 +4788,6 @@ class TestPickling:
         p = self._loads(s)
         assert_equal(a, p)
 
-    @pytest.mark.filterwarnings(
-        "ignore:.*align should be passed:numpy.exceptions.VisibleDeprecationWarning",
-    )
     def test_version1_object(self):
         s = (
             b"\x80\x02cnumpy.core._internal\n_reconstruct\nq\x01cnumpy\n"
@@ -4818,9 +4800,6 @@ class TestPickling:
         p = self._loads(s)
         assert_equal(a, p)
 
-    @pytest.mark.filterwarnings(
-        "ignore:.*align should be passed:numpy.exceptions.VisibleDeprecationWarning",
-    )
     def test_subarray_int_shape(self):
         s = (
             b"cnumpy.core.multiarray\n_reconstruct\np0\n"


### PR DESCRIPTION
Some (very) old pickles pass align=0, copy=1 as integers rather than bools.
This just assumes no user will really do that, and allows it.

It may be possible to also use `copyreg` to work around it, but since it is a rather specific signature this seems easier/just as well.

(No special tooling)

Closes gh-30786