### PR TITLE
TST: parametrize matvec/vecmat out-aliasing test, move to test_ufunc

### DIFF
--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -895,6 +895,19 @@ class TestUfunc:
         expected3 = expected1.astype(object)
         assert_array_equal(actual3, expected3)
 
+    @pytest.mark.parametrize("func", [
+        lambda A, x, **kw: np.matvec(A, x, **kw),
+        lambda A, x, **kw: np.vecmat(x, A, **kw),
+    ])
+    def test_matvec_vecmat_out(self, func):
+        # overlapping memory: out=input should not produce zeros
+        a = np.arange(18, dtype=float).reshape(2, 3, 3)
+        b = np.arange(6, dtype=float).reshape(2, 3)
+        expected = func(a, b)
+        c = func(a, b, out=b)
+        assert c is b
+        assert_allclose(c, expected)
+
     def test_vecdot_subclass(self):
         class MySubclass(np.ndarray):
             pass


### PR DESCRIPTION
Addresses reviewer feedback on #31150:
- Remove \	est_matvec_out\/\	est_vecmat_out\ from \	est_multiarray.py\
- Add parametrized \	est_matvec_vecmat_out\ in \	est_ufunc.py\ using lambdas (per seberg)
- Switch to bare \ssert\ and \ssert_allclose\ (per tylerjereddy)

Made with [Cursor](https://cursor.com)