### PR TITLE
TYP: fix ``np.shape`` assignability issue for python lists (#31171)

### DIFF
--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -133,6 +133,7 @@ _T = TypeVar("_T")
 _PyArray: TypeAlias = list[_T] | tuple[_T, ...]
 # `int` also covers `bool`
 _PyScalar: TypeAlias = complex | bytes | str
+_PyScalarT = TypeVar("_PyScalarT", bound=_PyScalar)
 
 # TODO: Fix overlapping overloads: https://github.com/numpy/numpy/issues/27032
 @overload
@@ -571,21 +572,21 @@ def ravel(a: ArrayLike, order: _OrderKACF = "C") -> np.ndarray[tuple[int], np.dt
 
 def nonzero(a: _ArrayLike[Any]) -> tuple[np.ndarray[tuple[int], np.dtype[intp]], ...]: ...
 
-# this prevents `Any` from being returned with Pyright
-@overload
+# `collections.abc.Sequence` can't be used here because `bytes` and `str` are
+# subtypes of it, which would make the return types incompatible.
+@overload  # this prevents `Any` from being returned with Pyright
 def shape(a: _SupportsShape[Never]) -> _AnyShape: ...
 @overload
 def shape(a: _SupportsShape[_ShapeT]) -> _ShapeT: ...
 @overload
 def shape(a: _PyScalar) -> tuple[()]: ...
-# `collections.abc.Sequence` can't be used hesre, since `bytes` and `str` are
-# subtypes of it, which would make the return types incompatible.
+@overload  # an unbound type variable is used because `list` is invariant
+def shape(a: _PyArray[_PyScalarT]) -> tuple[int]: ...
 @overload
-def shape(a: _PyArray[_PyScalar]) -> tuple[int]: ...
+def shape(a: Sequence[_PyArray[_PyScalarT]]) -> tuple[int, int]: ...
 @overload
-def shape(a: _PyArray[_PyArray[_PyScalar]]) -> tuple[int, int]: ...
-# this overload will be skipped by typecheckers that don't support PEP 688
-@overload
+def shape(a: Sequence[Sequence[_PyArray[_PyScalarT]]]) -> tuple[int, int, int]: ...
+@overload  # this will be skipped by typecheckers that don't support PEP 688
 def shape(a: memoryview | bytearray) -> tuple[int]: ...
 @overload
 def shape(a: ArrayLike) -> _AnyShape: ...

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -24,6 +24,10 @@ f4: np.float32
 i8: np.int64
 f: float
 
+_py_list_1d: list[int]
+_py_list_2d: list[list[int]]
+_py_list_3d: list[list[list[int]]]
+
 # integer‑dtype subclass for argmin/argmax
 class NDArrayIntSubclass(npt.NDArray[np.intp]): ...
 AR_sub_i: NDArrayIntSubclass
@@ -140,7 +144,10 @@ assert_type(np.shape(b), tuple[()])
 assert_type(np.shape(f), tuple[()])
 assert_type(np.shape([1]), tuple[int])
 assert_type(np.shape([[2]]), tuple[int, int])
-assert_type(np.shape([[[3]]]), tuple[Any, ...])
+assert_type(np.shape([[[3]]]), tuple[int, int, int])
+assert_type(np.shape(_py_list_1d), tuple[int])
+assert_type(np.shape(_py_list_2d), tuple[int, int])
+assert_type(np.shape(_py_list_3d), tuple[int, int, int])
 assert_type(np.shape(AR_b), tuple[Any, ...])
 assert_type(np.shape(AR_nd), tuple[Any, ...])
 # these fail on mypy, but it works as expected with pyright/pylance


### PR DESCRIPTION
Backport of https://github.com/numpy/numpy/pull/31171.

---

It was working fine when a list literal (e.g. `[1, 2]`) was passed, but some type-checkers would reject it when not passed directly, e.g. `a: list[int] = [1, 2]; np.shape(a)`. This has the do with `list` having an invariant generic type parameter. The solution is to use a type variable, so that the item type can "vary" in the function scope.

#### AI Disclosure
N/A
