### PR TITLE
BUG: fix result_type for Python type objects (#31037)

### DIFF
--- a/doc/release/upcoming_changes/31037.change.rst
+++ b/doc/release/upcoming_changes/31037.change.rst
@@ -1,0 +1,5 @@
+``np.result_type`` treats Python type objects as weak scalars
+
+-------------------------------------------------------------
+
+``np.result_type`` now treats Python builtin types (``int``, ``float``, ``complex``) as weak/abstract scalars under NEP 50, consistent with how their instances already behave, so ``np.result_type(np.int32, int)`` now returns ``int32`` instead of ``int64``.

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3660,6 +3660,35 @@ array_result_type(PyObject *NPY_UNUSED(dummy), PyObject *const *args, Py_ssize_t
             npy_mark_tmp_array_if_pyscalar(obj, arr[narr], NULL);
             ++narr;
         }
+        else if (obj == (PyObject *)&PyLong_Type ||
+                 obj == (PyObject *)&PyFloat_Type ||
+                 obj == (PyObject *)&PyComplex_Type) {
+            /*
+             * Builtin Python type objects should behave like their
+             * zero-value instances for NEP 50 weak promotion (gh-31037).
+             */
+            PyObject *zero;
+            if (obj == (PyObject *)&PyLong_Type) {
+                zero = PyLong_FromLong(0);
+            }
+            else if (obj == (PyObject *)&PyFloat_Type) {
+                zero = PyFloat_FromDouble(0.0);
+            }
+            else {
+                zero = PyComplex_FromDoubles(0.0, 0.0);
+            }
+            if (zero == NULL) {
+                goto finish;
+            }
+            arr[narr] = (PyArrayObject *)PyArray_FROM_O(zero);
+            if (arr[narr] == NULL) {
+                Py_DECREF(zero);
+                goto finish;
+            }
+            npy_mark_tmp_array_if_pyscalar(zero, arr[narr], NULL);
+            Py_DECREF(zero);
+            ++narr;
+        }
         else {
             if (!PyArray_DescrConverter(obj, &dtypes[ndtypes])) {
                 goto finish;

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1194,6 +1194,27 @@ class TestTypes:
         self.check_promotion_cases(np.result_type)
         assert_(np.result_type(None) == np.dtype(None))
 
+    @pytest.mark.parametrize("py_type, zero", [
+        (int, 0), (float, 0.0), (complex, 0j),
+    ])
+    @pytest.mark.parametrize("np_dtype", [
+        np.int8, np.int16, np.int32, np.int64,
+        np.float16, np.float32, np.float64,
+        np.complex64, np.complex128,
+    ])
+    def test_result_type_python_type_weak_promotion(self, np_dtype, py_type,
+                                                    zero):
+        # gh-31037: passing a Python builtin type (int/float/complex) to
+        # result_type should behave like passing its zero-value instance,
+        # i.e. as weak/abstract under NEP 50 promotion rules.
+        from_type = np.result_type(np_dtype, py_type)
+        from_instance = np.result_type(np_dtype, zero)
+        assert from_type == from_instance, (
+            f"result_type({np_dtype.__name__}, {py_type.__name__}) = "
+            f"{from_type} but result_type({np_dtype.__name__}, "
+            f"{py_type.__name__}({zero!r})) = {from_instance}"
+        )
+
     def test_promote_types_endian(self):
         # promote_types should always return native-endian types
         assert_equal(np.promote_types('<i8', '<i8'), np.dtype('i8'))


### PR DESCRIPTION

### PR summary

Under NEP 50 `np.result_type(np.int32, 1)` correctly returns `int32` (weak promotion) but `np.result_type(np.int32, int)` returns `int64` because the typee object falls through to `PyArray_DescrConverter`, which maps to a concrete default dtype. There's also the same inconsistency for `float` -> `float64` and `complex` -> `complex128`.

As seberg noted in #31037, this looks like a pre-NEP 50 holdout to me, the type objects just never got a special handling path. The PR intercepts `int`/`float`/`complex` type objects in `array_result_type` and then creates a zero-value instance, converts it to a 0-D array and marks it with the `NPY_ARRAY_WAS_PYTHON_*` flag.

Note: should also help with array API alignment (data-apis/array-api#873).

Closes #31037

*ps: I've never done a upcoming changes doc so I hope it's accurate

#### AI Disclosure
I used Cursor to help run tests quickly and double check I hadn't missed anything. I went over everything myself (esp the code)
-->