### PR TITLE
BUG: incorrect temp elision for new-style (NEP 43) user-defined dtypes

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1669,8 +1669,9 @@ PyArray_CLEARFLAGS(PyArrayObject *arr, int flags)
                               ((type) <= NPY_LONGDOUBLE)) || \
                               ((type) == NPY_HALF))
 
-#define PyTypeNum_ISNUMBER(type) (((type) <= NPY_CLONGDOUBLE) || \
-                                  ((type) == NPY_HALF))
+#define PyTypeNum_ISNUMBER(type) (((type) >= 0) && \
+                                  (((type) <= NPY_CLONGDOUBLE) || \
+                                   ((type) == NPY_HALF)))
 
 #define PyTypeNum_ISSTRING(type) (((type) == NPY_STRING) ||    \
                                   ((type) == NPY_UNICODE))

--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -829,7 +829,7 @@ NPY_NO_EXPORT PyObject *
 PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
 {
     if (PyArray_ISCOMPLEX(self) || PyArray_ISOBJECT(self) ||
-            PyArray_ISUSERDEF(self)) {
+            PyArray_ISUSERDEF(self) || !NPY_DT_is_legacy(PyArray_DESCR(self))) {
         if (out == NULL) {
             return PyArray_GenericUnaryFunction(self,
                                                 n_ops.conjugate);


### PR DESCRIPTION
### PR summary

`can_elide_temp()` in `temp_elide.c` incorrectly identifies new-style user-defined dtypes as numeric types eligible for in-place buffer reuse.  For large arrays this silently rewrites `a*a + b*b` into `(a*a) += (b*b)`, which raises a `TypeError` when the result dtype of the in-place add does not match the pre-allocated buffer.

I encountered this bug while implementing a custom fixed-point dtype, which automatically increases its bit width on every operation as required to avoid overflow. Since addition increases the bit width by one, attempting to reuse the temporary buffer results in an incompatible destination dtype being provided to the `add` ufunc and raises a `TypeError`.

The root cause is that `PyArray_ISNUMBER` evaluates to `true` for new-style user dtypes since it checks `(type) <= NPY_CLONGDOUBLE` and `type_num = -1` for these types.

This could be fixed either in `PyArray_ISNUMBER` (probably more correct, but may have unexpected side effects) or with a minimal extra check in `can_elide_temp` (the approach used by the PR). Let me know if you'd like me to fix `PyArray_ISNUMBER` instead.

#### AI Disclosure

This bug was identified and fixed by Claude Sonnet 4.6, and then reviewed by me.
Full AI-generated explanation: https://gist.github.com/MaartenBaert/7540176c4005d26a0b292baefbec8519