### PR TITLE
DEP: make deprecation visible for `__array_wrap__`

### DIFF
--- a/doc/release/upcoming_changes/31194.deprecation.rst
+++ b/doc/release/upcoming_changes/31194.deprecation.rst
@@ -1,0 +1,2 @@
+* ``numpy.ndarray.__array_wrap__`` now raises ``VisibleDeprecationWarning``
+  if ``return_scalar`` and ``context`` is not passed.

--- a/numpy/_core/src/multiarray/arraywrap.c
+++ b/numpy/_core/src/multiarray/arraywrap.c
@@ -278,7 +278,7 @@ npy_apply_wrap(
   deprecation_warning:
     /* If we reach here, the original error is still stored. */
     /* Deprecated 2024-01-17, NumPy 2.0 */
-    if (DEPRECATE(
+    if (PyErr_WarnFormat(npy_static_pydata.VisibleDeprecationWarning, 1,
             "__array_wrap__ must accept context and return_scalar arguments "
             "(positionally) in the future. (Deprecated NumPy 2.0)") < 0) {
         npy_PyErr_ChainExceptionsCause(err_type, err_value, traceback);

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -219,7 +219,7 @@ class TestDeprecatedDTypeAliases(_DeprecationTestCase):
             np.dtype(dtype_code)
 
 
-class TestDeprecatedArrayWrap(_DeprecationTestCase):
+class TestDeprecatedArrayWrap(_VisibleDeprecationTestCase):
     message = "__array_wrap__.*"
 
     def test_deprecated(self):


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
This PR convert current `DeprecationWarning` to `VisibleDeprecationWarning` for `numpy.ndarray.__array_wrap__`.
This PR was made related to this [comment](https://github.com/numpy/numpy/pull/31119#issuecomment-4216654012).

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
No AI tools used.