### PR TITLE
MAINT: rename parameters in ``tensordot`` function

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -3400,13 +3400,13 @@ def matmul(x1, x2, /):
 
 # tensordot
 
-def _tensordot_dispatcher(x1, x2, /, *, axes=None):
-    return (x1, x2)
+def _tensordot_dispatcher(a, b, /, *, axes=None):
+    return (a, b)
 
 
 @array_function_dispatch(_tensordot_dispatcher)
-def tensordot(x1, x2, /, *, axes=2):
-    return _core_tensordot(x1, x2, axes=axes)
+def tensordot(a, b, /, *, axes=2):
+    return _core_tensordot(a, b, axes=axes)
 
 
 tensordot.__doc__ = _core_tensordot.__doc__


### PR DESCRIPTION

### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
The function signature of `tensordot` called the two inputs x1 and x2 but docs call them a and b.

You can see this here
(https://numpy.org/doc/stable/reference/generated/numpy.linalg.tensordot.html#numpy.linalg.tensordot)
### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
No AI tools used
