### PR TITLE
BUG: fix ptp nan in masked arrays

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3000,6 +3000,14 @@ def ptp(a, axis=None, out=None, keepdims=np._NoValue):
     kwargs = {}
     if keepdims is not np._NoValue:
         kwargs['keepdims'] = keepdims
+
+    if type(a) is not mu.ndarray:
+        return um.subtract(
+            max(a, axis=axis, **kwargs),
+            min(a, axis=axis, **kwargs),
+            out=out,
+        )
+
     return _methods._ptp(a, axis=axis, out=out, **kwargs)
 
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4144,14 +4144,21 @@ class TestMaskedArrayMathMethods:
         _, X, _, m, mx, mX, _, _, _, _ = self._create_data()
         (n, m) = X.shape
         assert_equal(mx.ptp(), np.ptp(mx.compressed()))
+        assert_equal(np.ptp(mx), mx.ptp())
         rows = np.zeros(n, float)
         cols = np.zeros(m, float)
         for k in range(m):
             cols[k] = np.ptp(mX[:, k].compressed())
         for k in range(n):
             rows[k] = np.ptp(mX[k].compressed())
+        assert_equal(np.ptp(mX, axis=0), cols)
+        assert_equal(np.ptp(mX, axis=1), rows)
         assert_equal(mX.ptp(0), cols)
         assert_equal(mX.ptp(1), rows)
+
+    def test_ptp_masked_invalid_matches_masked_array_method(self):
+        arr = np.ma.masked_invalid([np.nan, 5, 10, 5, 10])
+        assert_equal(np.ptp(arr), arr.ptp())
 
     def test_add_object(self):
         x = masked_array(['a', 'b'], mask=[1, 0], dtype=object)

--- a/numpy/matrixlib/defmatrix.py
+++ b/numpy/matrixlib/defmatrix.py
@@ -793,7 +793,14 @@ class matrix(N.ndarray):
                 [3]])
 
         """
-        return N.ptp(self, axis, out)._align(axis)
+        result = N.subtract(
+            N.ndarray.max(self, axis, None, keepdims=True),
+            N.ndarray.min(self, axis, None, keepdims=True),
+            out=out,
+        )
+        if isinstance(result, N.ndarray):
+            return result._collapse(axis)
+        return result
 
     @property
     def I(self):  # noqa: E743


### PR DESCRIPTION
### PR summary

Resolves #27674 .

This PR fixes a regression in `np.ptp` for non-`ndarray` inputs, specifically masked arrays. In NumPy 2, `np.ptp(masked_array)` could return `nan` instead of matching `MaskedArray.ptp()` and ignoring masked invalid values.

The fix updates `np.ptp` to preserve subclass-aware behavior for non-plain `ndarray` inputs by computing the result through `np.max` and `np.min`, while keeping the existing fast path for plain `ndarray` inputs. This restores the expected masked-array behavior without changing the standard ndarray implementation.

The PR also adds regression coverage for masked arrays, including the reported `masked_invalid([np.nan, 5, 10, 5, 10])` case. While validating the change, matrix-specific `ptp` behavior needed an adjustment as well, so `matrix.ptp()` is now computed directly from `ndarray.max`/`ndarray.min` to preserve its existing return-shape semantics.

Validation:
- Focused tests:
  - `spin test numpy/ma/tests/test_core.py numpy/matrixlib/tests/test_defmatrix.py -- -q -k "test_ptp or test_ptp_masked_invalid_matches_masked_array_method"`
  - Result: `3 passed`
- Full test run:
  - `spin build --clean -- -Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none`
  - `spin test -- --durations=10 --timeout=600`

The full suite passed except for the pre-existing environment-specific failure:
- `numpy/_core/tests/test_cpu_features.py::Test_X86_Features::test_features`
