### PR TITLE
ENH: Return rank 0 for empty matrices in matrix_rank (#30422)

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2130,6 +2130,7 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     A = asarray(A)
     if A.ndim < 2:
         return int(not all(A == 0))
+
     S = svd(A, compute_uv=False, hermitian=hermitian)
 
     if tol is None:
@@ -2137,7 +2138,7 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
             rtol = max(A.shape[-2:]) * finfo(S.dtype).eps
         else:
             rtol = asarray(rtol)[..., newaxis]
-        tol = S.max(axis=-1, keepdims=True) * rtol
+        tol = S.max(axis=-1, keepdims=True, initial=0) * rtol
     else:
         tol = asarray(tol)[..., newaxis]
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2440,3 +2440,22 @@ def test_vector_norm_empty():
         assert_equal(np.linalg.vector_norm(x, ord=1), 0)
         assert_equal(np.linalg.vector_norm(x, ord=2), 0)
         assert_equal(np.linalg.vector_norm(x, ord=np.inf), 0)
+
+def test_empty_matrix_rank():
+    assert_equal(matrix_rank(np.zeros((0, 0))), 0)
+    assert_equal(matrix_rank(np.zeros((0, 5))), 0)
+    assert_equal(matrix_rank(np.zeros((5, 0))), 0)
+
+    result = matrix_rank(np.zeros((0, 5, 5)))
+    assert_equal(result.shape, (0,))
+    assert_equal(result.dtype, np.intp)
+
+    result = matrix_rank(np.zeros((3, 0, 5)))
+    assert_equal(result, np.array([0, 0, 0]))
+
+    result = matrix_rank(np.zeros((2, 5, 0)))
+    assert_equal(result, np.array([0, 0]))
+
+    result = matrix_rank(np.zeros((2, 3, 0, 4)))
+    assert_equal(result.shape, (2, 3))
+    assert_equal(result, np.zeros((2, 3), dtype=np.intp))


### PR DESCRIPTION
Backport of #30422.

This PR fixes a bug in `np.linalg.matrix_rank` where empty matrices
(previously with 0 rows or 0 columns) would raise a ValueError due to 
attempting a reduction operation on a zero-size array.

Changes include:
- Return 0 for all empty matrices in `matrix_rank`.
- Added tests covering all empty matrix shapes to ensure the correct behavior.

Files modified:
- `numpy/linalg/_linalg.py`
- `numpy/linalg/tests/test_linalg.py`

Closes #30421