### PR TITLE
CI/BUG: add native jobs for s390x, fix bug in `pack_inner` (#30819)

### DIFF
--- a/.github/workflows/linux-ppc64le.yml
+++ b/.github/workflows/linux-ppc64le.yml
@@ -1,4 +1,4 @@
-name: Native ppc64le Linux Test
+name: Linux IBM tests
 
 on:
   pull_request:
@@ -19,22 +19,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  native_ppc64le:
-    # This job runs only in the main NumPy repository.
-    # It requires a native ppc64le GHA runner, which is not available on forks.
+  native_ibm:
+    # These jobs runs only in the main NumPy repository.
+    # It requires a native ppc64le and s390x GHA runners, which are not available on forks.
     # For more details, see: https://github.com/numpy/numpy/issues/29125
     if: github.repository == 'numpy/numpy'
-    runs-on: ubuntu-24.04-ppc64le-p10
-  
+    runs-on: ${{ matrix.config.runner }}
+
     strategy:
       fail-fast: false
       matrix:
         config:
-          - name: "GCC"
+          - name: "ppc64le/gcc - baseline(default)"
             args: "-Dallow-noblas=false"
-          - name: "clang"
+            runner: ubuntu-24.04-ppc64le-p10
+            compiler: "gcc"
+          - name: "ppc64le/clang - baseline(default)"
             args: "-Dallow-noblas=false"
-    
+            runner: ubuntu-24.04-ppc64le-p10
+            compiler: "clang"
+          - name: "s390x/gcc - baseline(default)"
+            args: "-Dallow-noblas=false"
+            runner: ubuntu-24.04-s390x
+            compiler: "gcc"
+          - name: "s390x/clang - baseline(default)"
+            args: "-Dallow-noblas=false"
+            runner: ubuntu-24.04-s390x
+            compiler: "clang"
+          - name: "s390x/gcc - baseline(Z15/VXE2)"
+            args: "-Dallow-noblas=false -Dcpu-baseline=vxe2"
+            runner: ubuntu-24.04-s390x
+            compiler: "gcc"
+          - name: "s390x/clang - baseline(Z15/VXE2)"
+            args: "-Dallow-noblas=false -Dcpu-baseline=vxe2"
+            runner: ubuntu-24.04-s390x
+            compiler: "clang"
+
     name: "${{ matrix.config.name }}"
     steps:
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -52,11 +72,11 @@ jobs:
         echo "/home/runner/.local/bin" >> $GITHUB_PATH
 
     - name: Install clang
-      if: matrix.config.name == 'clang'
+      if: matrix.config.compiler == 'clang'
       run: |
-        sudo apt install -y clang
-        export CC=clang
-        export CXX=clang++
+        sudo apt install -y clang-20
+        echo CC=clang-20 >> $GITHUB_ENV
+        echo CXX=clang++-20 >> $GITHUB_ENV
 
     - name: Meson Build
       run: |

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -43,41 +43,6 @@ jobs:
       matrix:
         BUILD_PROP:
           - [
-              "ppc64le",
-              "powerpc64le-linux-gnu",
-              "ppc64le/ubuntu:22.04",
-              "-Dallow-noblas=true",
-              "test_kind or test_multiarray or test_simd or test_umath or test_ufunc",
-              "ppc64le"
-            ]
-          - [
-              "ppc64le - baseline(Power9)",
-              "powerpc64le-linux-gnu",
-              "ppc64le/ubuntu:22.04",
-              "-Dallow-noblas=true -Dcpu-baseline=vsx3",
-              "test_kind or test_multiarray or test_simd or test_umath or test_ufunc",
-              "ppc64le"
-            ]
-          - [
-              "s390x",
-              "s390x-linux-gnu",
-              "s390x/ubuntu:22.04",
-              "-Dallow-noblas=true",
-              # Skipping TestRationalFunctions.test_gcd_overflow test
-              # because of a possible qemu bug that appears to be related to int64 overflow in absolute operation.
-              # TODO(@seiko2plus): Confirm the bug and provide a minimal reproducer, then report it to upstream.
-              "(test_kind or test_multiarray or test_simd or test_umath or test_ufunc) and not test_gcd_overflow",
-              "s390x"
-            ]
-          - [
-              "s390x - baseline(Z13)",
-              "s390x-linux-gnu",
-              "s390x/ubuntu:22.04",
-              "-Dallow-noblas=true -Dcpu-baseline=vx",
-              "(test_kind or test_multiarray or test_simd or test_umath or test_ufunc) and not test_gcd_overflow",
-              "s390x"
-            ]
-          - [
               "riscv64",
               "riscv64-linux-gnu",
               "riscv64/ubuntu:22.04",

--- a/numpy/_core/src/common/simd/vec/arithmetic.h
+++ b/numpy/_core/src/common/simd/vec/arithmetic.h
@@ -286,7 +286,7 @@ NPY_FINLINE npyv_u64 npyv_divc_u64(npyv_u64 a, const npyv_u64x3 divisor)
 // divide each signed 64-bit element by a precomputed divisor (round towards zero)
 NPY_FINLINE npyv_s64 npyv_divc_s64(npyv_s64 a, const npyv_s64x3 divisor)
 {
-    npyv_b64 overflow = npyv_and_b64(vec_cmpeq(a, npyv_setall_s64(-1LL << 63)), (npyv_b64)divisor.val[1]);
+    npyv_b64 overflow = npyv_and_b64(vec_cmpeq(a, npyv_setall_s64(0x8000000000000000LL)), (npyv_b64)divisor.val[1]);
     npyv_s64 d = vec_sel(divisor.val[0], npyv_setall_s64(1), overflow);
     return vec_div(a, d);
 }

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -1628,9 +1628,29 @@ pack_inner(const char *inptr,
             #else
                 npy_uint64 arr[4] = {bb[0], bb[1], bb[2], bb[3]};
             #endif
+
+            #if NPY_BYTE_ORDER == NPY_BIG_ENDIAN
+                #if NPY_SIMD_WIDTH == 16
+                arr[0] = npy_bswap8(arr[0]);
+                #elif NPY_SIMD_WIDTH == 32
+                arr[0] = npy_bswap8(arr[0]);
+                arr[1] = npy_bswap8(arr[1]);
+                #else
+                arr[0] = npy_bswap8(arr[0]);
+                arr[1] = npy_bswap8(arr[1]);
+                arr[2] = npy_bswap8(arr[2]);
+                arr[3] = npy_bswap8(arr[3]);
+                #endif
+            #endif
                 memcpy(outptr, arr, sizeof(arr));
                 outptr += vstepx4;
             } else {
+                #if NPY_BYTE_ORDER == NPY_BIG_ENDIAN
+                bb[0] = npy_bswap8(bb[0]);
+                bb[1] = npy_bswap8(bb[1]);
+                bb[2] = npy_bswap8(bb[2]);
+                bb[3] = npy_bswap8(bb[3]);
+                #endif
                 for(int i = 0; i < 4; i++) {
                     for (int j = 0; j < vstep; j++) {
                         memcpy(outptr, (char*)&bb[i] + j, 1);
@@ -1645,6 +1665,11 @@ pack_inner(const char *inptr,
                 va = npyv_rev64_u8(va);
             }
             npy_uint64 bb = npyv_tobits_b8(npyv_cmpneq_u8(va, v_zero));
+
+            #if NPY_BYTE_ORDER == NPY_BIG_ENDIAN
+            bb = npy_bswap8(bb);
+            #endif
+
             for (int i = 0; i < vstep; ++i) {
                 memcpy(outptr, (char*)&bb + i, 1);
                 outptr += out_stride;

--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -423,7 +423,7 @@ class Test_ZARCH_Features(AbstractTest):
     features = ["VX", "VXE", "VXE2"]
 
     def load_flags(self):
-        self.load_flags_auxv()
+        self.load_flags_cpuinfo("features")
 
 
 is_arm = re.match(r"^(arm|aarch64)", machine, re.IGNORECASE)

--- a/numpy/f2py/_backends/meson.build.template
+++ b/numpy/f2py/_backends/meson.build.template
@@ -7,6 +7,11 @@ project('${modulename}',
                             'buildtype=${buildtype}'
                           ])
 fc = meson.get_compiler('fortran')
+cc = meson.get_compiler('c')
+
+add_project_arguments(
+  cc.get_supported_arguments( '-fno-strict-aliasing'), language : 'c'
+)
 
 py = import('python').find_installation('''${python}''', pure: false)
 py_dep = py.dependency()


### PR DESCRIPTION
Rename workflow linux-ppc64le.yml into linux-actionspz.yml.
Copy and update ppc64le workflow for s390x.
Disable qemu-based workflows for s390x.

Fix big endian issue in `pack_inner`.

Closes: https://github.com/numpy/numpy/issues/30817

-->

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
