### PR TITLE
BUG: pinv crashes with rtol=None on integer-dtype input

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2238,7 +2238,9 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
         if rtol is _NoValue:
             rcond = 1e-15
         elif rtol is None:
-            rcond = max(a.shape[-2:]) * finfo(a.dtype).eps
+            # Use the common float dtype rather than ``a.dtype`` directly,
+            # so that integer inputs (which have no ``finfo``) work too.
+            rcond = max(a.shape[-2:]) * finfo(_commonType(a)[1]).eps
         else:
             rcond = rtol
     elif rtol is not _NoValue:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -917,6 +917,24 @@ def test_pinv_rtol_arg():
         np.linalg.pinv(a, rcond=0.5, rtol=0.5)
 
 
+@pytest.mark.parametrize("dtype", [np.int32, np.int64])
+def test_pinv_int_dtype(dtype):
+    # gh-30917: pinv used to crash with ``rtol=None`` on integer inputs
+    # because ``finfo`` was called on the original int dtype.  The result
+    # should match ``pinv`` on the same matrix cast to ``float64``.
+    a = np.array([[1, 2, 3], [4, 1, 1], [2, 3, 1]], dtype=dtype)
+    expected = np.linalg.pinv(a.astype(np.float64), rtol=None)
+
+    # ``rtol=None`` path (the one that was crashing).
+    assert_almost_equal(np.linalg.pinv(a, rtol=None), expected)
+
+    # Default path (no ``rtol`` kwarg) should also work on int input.
+    assert_almost_equal(
+        np.linalg.pinv(a),
+        np.linalg.pinv(a.astype(np.float64)),
+    )
+
+
 class DetCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
 
     def do(self, a, b, tags):


### PR DESCRIPTION
### PR summary

Fixes gh-30917.

`np.linalg.pinv(a, rtol=None)` raised `ValueError: data type <class 'numpy.int32'> not inexact` on integer-dtype input because the `rtol=None` branch called `finfo(a.dtype)` on the original array. Route the dtype through `_commonType` so we use the float type `pinv` will actually run the SVD in — same dtype handling the rest of the function already relies on. `rtol=None` is the Array API standard default, so it should work on any numeric input.

Added a regression test in `TestLinalg` that exercises both `int32` and `int64` on the `rtol=None` path and the no-kwarg default path, cross-checking against the same matrix cast to `float64`.

### First time committer introduction

Hi, I'm Barry, based in Los Angeles. I've been using NumPy for a while now for numerics work and wanted to start contributing back.

#### AI Disclosure

No AI tools used.