### PR TITLE
MAINT: f2py: Stop setting re._MAXCACHE to 50.

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -243,7 +243,6 @@ def outmess(line, flag=1):
         sys.stdout.write(line)
 
 
-re._MAXCACHE = 50
 defaultimplicitrules = {}
 for c in "abcdefghopqrstuvwxyz$_":
     defaultimplicitrules[c] = {'typespec': 'real'}


### PR DESCRIPTION
Backport of #31105.

The value has been set to 50 for more than 20 years.  Computers generally have much more memory now than they did 20 years ago, so we should be able to let `re` use the default.

Closes gh-31104.

#### AI Disclosure

No AI tools used.