### PR TITLE
BUG: Fix matvec/vecmat in-place aliasing (out=input produces zeros) (#31150)

### DIFF
--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -142,21 +142,16 @@ PyUFunc_clearfperr()
     NPY_ITER_NO_SUBTYPE | \
     NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE
 
-/* Called at module initialization to set the matmul ufunc output flags */
+/* Called at module initialization to set the matmul family gufunc output flags */
 NPY_NO_EXPORT int
 set_matmul_flags(PyObject *d)
 {
-    PyObject *matmul = NULL;
-    int result = PyDict_GetItemStringRef(d, "matmul", &matmul);
-    if (result <= 0) {
-        // caller sets an error if one isn't already set
-        return -1;
-    }
     /*
      * The default output flag NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE allows
      * perfectly overlapping input and output (in-place operations). While
      * correct for the common mathematical operations, this assumption is
-     * incorrect in the general case and specifically in the case of matmul.
+     * incorrect in the general case and specifically in the case of matmul,
+     * matvec, and vecmat.
      *
      * NPY_ITER_UPDATEIFCOPY is added by default in
      * PyUFunc_GeneralizedFunction, which is the variant called for gufuncs
@@ -164,11 +159,22 @@ set_matmul_flags(PyObject *d)
      *
      * Enabling NPY_ITER_WRITEONLY can prevent a copy in some cases.
      */
-    ((PyUFuncObject *)matmul)->op_flags[2] = (NPY_ITER_WRITEONLY |
-                                         NPY_ITER_UPDATEIFCOPY |
-                                         NPY_UFUNC_DEFAULT_OUTPUT_FLAGS) &
-                                         ~NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
-    Py_DECREF(matmul);
+    npy_uint32 flags = (NPY_ITER_WRITEONLY |
+                        NPY_ITER_UPDATEIFCOPY |
+                        NPY_UFUNC_DEFAULT_OUTPUT_FLAGS) &
+                        ~NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE;
+
+    const char *names[] = {"matmul", "matvec", "vecmat"};
+    for (int i = 0; i < 3; i++) {
+        PyObject *ufunc = NULL;
+        int result = PyDict_GetItemStringRef(d, names[i], &ufunc);
+        if (result <= 0) {
+            // caller sets an error if one isn't already set
+            return -1;
+        }
+        ((PyUFuncObject *)ufunc)->op_flags[2] = flags;
+        Py_DECREF(ufunc);
+    }
     return 0;
 }
 

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -897,6 +897,19 @@ class TestUfunc:
         expected3 = expected1.astype(object)
         assert_array_equal(actual3, expected3)
 
+    @pytest.mark.parametrize("func", [
+        lambda A, x, **kw: np.matvec(A, x, **kw),
+        lambda A, x, **kw: np.vecmat(x, A, **kw),
+    ])
+    def test_matvec_vecmat_out(self, func):
+        # overlapping memory: out=input should not produce zeros
+        a = np.arange(18, dtype=float).reshape(2, 3, 3)
+        b = np.arange(6, dtype=float).reshape(2, 3)
+        expected = func(a, b)
+        c = func(a, b, out=b)
+        assert c is b
+        assert_allclose(c, expected)
+
     def test_vecdot_subclass(self):
         class MySubclass(np.ndarray):
             pass


### PR DESCRIPTION
Backport of #31150.

### PR summary

Fixes #31144.

`np.matvec(A, b, out=b)` returns all zeros because `matvec` and `vecmat` are missing the `~NPY_ITER_OVERLAP_ASSUME_ELEMENTWISE` output flag that `matmul` already has. Without it the iterator ends up skipping the overlap check when `out` is the same array as an input so no temporary copy is made and BLAS `gemv` clobbers the input buffer.

This PR adds the same fix to `matvec` and `vecmat` and adds regression testing for both.

### First time committer introduction

Hi, I'm Ijtihed Kilani ([ijtihed.com](https://ijtihed.com)); I'm an early-career software engineer based in Helsinki, Finland. I work mainly on physics-informed simulations for robotics and autonomy, currently at Supercell working on new games. I've used NumPy heavily for linear algebra in simulation code/studies.

#### AI Disclosure

This fix was made with help from Claude in Cursor. I used it to look over any assumptions I might have missed and draft the basic code changes which I then looked over, then rewrote and verified. All changes were reviewed and verified by me before submission.

Made with [Cursor](https://cursor.com)
