### PR TITLE
REV: Manual revert of float16 svml use (#31178)

### DIFF
--- a/numpy/_core/src/umath/loops_half.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_half.dispatch.c.src
@@ -12,7 +12,7 @@
   #define NPY__SVML_IS_ENABLED 0
 #endif
 
-#if NPY__SVML_IS_ENABLED && !defined(NPY_HAVE_AVX512_SPR)
+#if NPY__SVML_IS_ENABLED
 
 typedef __m256i npyvh_f16;
 #define npyv_cvt_f16_f32 _mm512_cvtph_ps
@@ -80,11 +80,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(HALF_@func@)
     if (!is_mem_overlap(src, steps[0], dst, steps[1], len) &&
         (steps[0] == sizeof(npy_half)) &&
         (steps[1] == sizeof(npy_half))) {
-    #ifdef NPY_HAVE_AVX512_SPR
-        __svml_@intrin@s32(src, dst, len);
-    #else
         avx512_@intrin@_f16(src, dst, len);
-    #endif
         return;
     }
 #endif // NPY__SVML_IS_ENABLED

--- a/numpy/_core/tests/test_umath_accuracy.py
+++ b/numpy/_core/tests/test_umath_accuracy.py
@@ -21,8 +21,6 @@ UNARY_OBJECT_UFUNCS.remove(np.bitwise_count)
 IS_AVX = __cpu_features__.get('AVX512F', False) or \
         (__cpu_features__.get('FMA3', False) and __cpu_features__.get('AVX2', False))
 
-IS_AVX512FP16 = __cpu_features__.get('AVX512FP16', False)
-
 # only run on linux with AVX, also avoid old glibc (numpy/numpy#20448).
 runtest = (sys.platform.startswith('linux')
            and IS_AVX and not _glibc_older_than("2.17"))
@@ -84,8 +82,6 @@ class TestAccuracy:
                         maxulperr = data_subset['ulperr'].max()
                         assert_array_max_ulp(npfunc(inval), outval, maxulperr)
 
-    @pytest.mark.skipif(IS_AVX512FP16,
-            reason="SVML FP16 have slightly higher ULP errors")
     @pytest.mark.parametrize("ufunc", UNARY_OBJECT_UFUNCS)
     def test_validate_fp16_transcendentals(self, ufunc):
         with np.errstate(all='ignore'):
@@ -94,39 +90,3 @@ class TestAccuracy:
             datafp32 = datafp16.astype(np.float32)
             assert_array_max_ulp(ufunc(datafp16), ufunc(datafp32),
                     maxulp=1, dtype=np.float16)
-
-    @pytest.mark.skipif(not IS_AVX512FP16,
-                               reason="lower ULP only apply for SVML FP16")
-    def test_validate_svml_fp16(self):
-        max_ulp_err = {
-                "arccos": 2.54,
-                "arccosh": 2.09,
-                "arcsin": 3.06,
-                "arcsinh": 1.51,
-                "arctan": 2.61,
-                "arctanh": 1.88,
-                "cbrt": 1.57,
-                "cos": 1.43,
-                "cosh": 1.33,
-                "exp2": 1.33,
-                "exp": 1.27,
-                "expm1": 0.53,
-                "log": 1.80,
-                "log10": 1.27,
-                "log1p": 1.88,
-                "log2": 1.80,
-                "sin": 1.88,
-                "sinh": 2.05,
-                "tan": 2.26,
-                "tanh": 3.00,
-                }
-
-        with np.errstate(all='ignore'):
-            arr = np.arange(65536, dtype=np.int16)
-            datafp16 = np.frombuffer(arr.tobytes(), dtype=np.float16)
-            datafp32 = datafp16.astype(np.float32)
-            for func in max_ulp_err:
-                ufunc = getattr(np, func)
-                ulp = np.ceil(max_ulp_err[func])
-                assert_array_max_ulp(ufunc(datafp16), ufunc(datafp32),
-                        maxulp=ulp, dtype=np.float16)


### PR DESCRIPTION
Backport of #31178.

This is a manual revert of gh-23351 since things were moved around quite a lot since then.

Closes gh-30821.