### PR TITLE
BUG: fix Generator.choice ignoring the shuffle arg

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -946,6 +946,11 @@ cdef class Generator:
                     new = new.take(unique_indices)
                     flat_found[n_uniq:n_uniq + new.size] = new
                     n_uniq += new.size
+                if shuffle:
+                    size_i = size
+                    idx_data = <int64_t*>np.PyArray_DATA(<np.ndarray>found)
+                    with self.lock, nogil:
+                        _shuffle_int(&self._bitgen, size_i, 1, idx_data)
                 idx = found
             else:
                 size_i = size

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -836,9 +836,20 @@ class TestRandomDist:
 
     def test_choice_nonuniform_noreplace(self):
         random = Generator(MT19937(self.seed))
-        actual = random.choice(4, 3, replace=False, p=[0.1, 0.3, 0.5, 0.1])
+        actual = random.choice(
+            4, 3, replace=False, p=[0.1, 0.3, 0.5, 0.1], shuffle=False
+        )
         desired = np.array([0, 2, 3], dtype=np.int64)
         assert_array_equal(actual, desired)
+
+    def test_choice_nonuniform_noreplace_shuffle(self):
+        p = np.ones(1000) / 1000
+        random = Generator(MT19937(self.seed))
+        actual = random.choice(1000, 200, replace=False, p=p, shuffle=True)
+        random = Generator(MT19937(self.seed))
+        desired = random.choice(1000, 200, replace=False, p=p, shuffle=False)
+        assert_(not np.array_equal(actual, desired))
+        assert_array_equal(np.sort(actual), np.sort(desired))
 
     def test_choice_noninteger(self):
         random = Generator(MT19937(self.seed))


### PR DESCRIPTION
### PR summary

Fixes #31210.

This PR fixes a behavioral bug in `Generator.choice` when sampling without replacement with user-provided probabilities.

Before this change, the `shuffle` argument was silently ignored in the `replace=False, p=...` code path. As a result, these two calls produced identical output:

```python
rng.choice(n, k, replace=False, p=p, shuffle=True)
rng.choice(n, k, replace=False, p=p, shuffle=False)
```

This was inconsistent with the unweighted `replace=False` path, where `shuffle` is respected, and it could lead to order-correlated output when the sampled population has structure in index order.

The fix applies the same final shuffle step to the weighted no-replacement path when `shuffle=True`.

This PR also updates and extends test coverage:
- adds a regression test to verify that weighted sampling without replacement respects `shuffle`
- keeps the existing deterministic non-uniform no-replacement test by making it explicit that it is checking the `shuffle=False` path

Validation:
- Focused test:
  - `spin test numpy/random/tests/test_generator_mt19937.py -- -q -k "test_choice_nonuniform_noreplace or test_choice_nonuniform_noreplace_shuffle or test_choice_uniform_noreplace"`
  - Result: `3 passed`
- Full CI-style run:
  - `spin build --clean -- -Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none`
  - `spin test -- --durations=10 --timeout=600`

The full suite completed with one unrelated pre-existing environment-specific failure:
- `numpy/_core/tests/test_cpu_features.py::Test_X86_Features::test_features`

I followed the contribution guidelines by keeping the change small, adding regression coverage for the bug, and running the relevant local tests and the broader test suite in Docker.
