### PR TITLE
BUG: fix Generator.choice ignoring the shuffle arg

### DIFF
--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -946,6 +946,11 @@ cdef class Generator:
                     new = new.take(unique_indices)
                     flat_found[n_uniq:n_uniq + new.size] = new
                     n_uniq += new.size
+                if shuffle:
+                    size_i = size
+                    idx_data = <int64_t*>np.PyArray_DATA(<np.ndarray>found)
+                    with self.lock, nogil:
+                        _shuffle_int(&self._bitgen, size_i, 1, idx_data)
                 idx = found
             else:
                 size_i = size

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -836,9 +836,20 @@ class TestRandomDist:
 
     def test_choice_nonuniform_noreplace(self):
         random = Generator(MT19937(self.seed))
-        actual = random.choice(4, 3, replace=False, p=[0.1, 0.3, 0.5, 0.1])
+        actual = random.choice(
+            4, 3, replace=False, p=[0.1, 0.3, 0.5, 0.1], shuffle=False
+        )
         desired = np.array([0, 2, 3], dtype=np.int64)
         assert_array_equal(actual, desired)
+
+    def test_choice_nonuniform_noreplace_shuffle(self):
+        p = np.ones(1000) / 1000
+        random = Generator(MT19937(self.seed))
+        actual = random.choice(1000, 200, replace=False, p=p, shuffle=True)
+        random = Generator(MT19937(self.seed))
+        desired = random.choice(1000, 200, replace=False, p=p, shuffle=False)
+        assert_(not np.array_equal(actual, desired))
+        assert_array_equal(np.sort(actual), np.sort(desired))
 
     def test_choice_noninteger(self):
         random = Generator(MT19937(self.seed))


### PR DESCRIPTION
### PR summary

Closes #31210.

This PR fixes `Generator.choice(..., replace=False, p=..., shuffle=...)` so that `shuffle` is respected in the weighted sampling path.

Right now, when `replace=False` and `p` is provided, `shuffle=True` and `shuffle=False` produce the same ordering. That is different from the unweighted path, where `shuffle` does affect the output order. In practice, this means the draw order can reflect the internal weighted sampling order instead of being randomized, which is exactly the behavior reported in the issue.

The code change is small: after the weighted no-replacement sampler finishes building the selected indices, it now applies the same final shuffle step that is already used in the unweighted no-replacement path when `shuffle=True`.

I also added a regression test to check that:
- weighted sampling without replacement now changes order when `shuffle=True`
- the selected elements are still the same set
- the existing deterministic test for the non-shuffled weighted path continues to work by making it explicitly use `shuffle=False`

Tests run in Docker:
- `spin test numpy/random/tests/test_generator_mt19937.py -- -q -k "test_choice_nonuniform_noreplace or test_choice_nonuniform_noreplace_shuffle or test_choice_uniform_noreplace"`
- full Docker test run with:
  - `spin build --clean -- -Dallow-noblas=true -Dcpu-baseline=none -Dcpu-dispatch=none`
  - `spin test -- --durations=10 --timeout=600`

The focused random tests passed. The full test run completed except for the known environment-specific failure in `numpy/_core/tests/test_cpu_features.py::Test_X86_Features::test_features`.

I also reproduced the issue visually using the same kind of setup described in the issue report and confirmed that the fixed `shuffle=True` behavior removes the order correlation, while preserving the sampled set.

### AI Disclosure

I used ChatGPT in preparing this pull request.

AI was used for grammar and wording fixes in PR text, and earlier I did not fully disclose that use. I’m sorry about that. It was not intentional.

For completeness: AI was also used to help inspect the code path and help draft text while I was working on the issue. The actual code changes, testing, and submission are being handled by me.