### PR TITLE
TYP: ``pad`` shape-typing

### DIFF
--- a/numpy/lib/_arraypad_impl.pyi
+++ b/numpy/lib/_arraypad_impl.pyi
@@ -1,7 +1,7 @@
 from typing import Any, Literal as L, Protocol, overload, type_check_only
 
 import numpy as np
-from numpy._typing import ArrayLike, NDArray, _ArrayLike, _ArrayLikeInt
+from numpy._typing import ArrayLike, NDArray, _ArrayLike, _ArrayLikeInt, _Shape
 
 __all__ = ["pad"]
 
@@ -44,6 +44,17 @@ type _PadWidth = (
 
 # Expand `**kwargs` into explicit keyword-only arguments
 @overload
+def pad[ShapeT: _Shape, DTypeT: np.dtype](
+    array: np.ndarray[ShapeT, DTypeT],
+    pad_width: _PadWidth,
+    mode: _ModeKind = "constant",
+    *,
+    stat_length: _ArrayLikeInt | None = None,
+    constant_values: ArrayLike = 0,
+    end_values: ArrayLike = 0,
+    reflect_type: L["odd", "even"] = "even",
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload
 def pad[ScalarT: np.generic](
     array: _ArrayLike[ScalarT],
     pad_width: _PadWidth,
@@ -65,6 +76,13 @@ def pad(
     end_values: ArrayLike = 0,
     reflect_type: L["odd", "even"] = "even",
 ) -> NDArray[Any]: ...
+@overload
+def pad[ShapeT: _Shape, DTypeT: np.dtype](
+    array: np.ndarray[ShapeT, DTypeT],
+    pad_width: _PadWidth,
+    mode: _ModeFunc,
+    **kwargs: Any,
+) -> np.ndarray[ShapeT, DTypeT]: ...
 @overload
 def pad[ScalarT: np.generic](
     array: _ArrayLike[ScalarT],

--- a/numpy/typing/tests/data/reveal/arraypad.pyi
+++ b/numpy/typing/tests/data/reveal/arraypad.pyi
@@ -13,6 +13,8 @@ def mode_func(
 
 AR_i8: npt.NDArray[np.int64]
 AR_f8: npt.NDArray[np.float64]
+AR_f8_1d: np.ndarray[tuple[int], np.dtype[np.float64]]
+AR_f8_2d: np.ndarray[tuple[int, int], np.dtype[np.float64]]
 AR_LIKE: list[int]
 
 assert_type(np.pad(AR_i8, (2, 3), "constant"), npt.NDArray[np.int64])
@@ -25,3 +27,6 @@ assert_type(np.pad(AR_i8, {-1: (2, 3)}), npt.NDArray[np.int64])
 assert_type(np.pad(AR_i8, {-2: 4}), npt.NDArray[np.int64])
 pad_width: dict[int, int | tuple[int, int]] = {-1: (2, 3), -2: 4}
 assert_type(np.pad(AR_i8, pad_width), npt.NDArray[np.int64])
+
+assert_type(np.pad(AR_f8_1d, (2, 3)), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.pad(AR_f8_2d, (2, 3)), np.ndarray[tuple[int, int], np.dtype[np.float64]])


### PR DESCRIPTION
The input `ndim` for `np.pad` are the same as the output `ndim`, so this is a pretty straightforward improvement.

Fun fact: "pad" in dutch means "toad".

#### AI Disclosure
N/A
