### PR TITLE
TYP: ``ix_`` shape-typing and fix for boolean input

### DIFF
--- a/numpy/lib/_index_tricks_impl.pyi
+++ b/numpy/lib/_index_tricks_impl.pyi
@@ -23,8 +23,8 @@ from numpy._typing import (
     _AnyShape,
     _ArrayLike,
     _DTypeLike,
-    _HasDType,
     _NestedSequence,
+    _ScalarLike_co,
     _SupportsArray,
 )
 
@@ -53,6 +53,12 @@ _AxisT_co = TypeVar("_AxisT_co", bound=int, default=L[0], covariant=True)
 _MatrixT_co = TypeVar("_MatrixT_co", bound=bool, default=L[False], covariant=True)
 _NDMinT_co = TypeVar("_NDMinT_co", bound=int, default=L[1], covariant=True)
 _Trans1DT_co = TypeVar("_Trans1DT_co", bound=int, default=L[-1], covariant=True)
+
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
+type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
+
+type _ToArray1D[ScalarT: np.generic] = _Array1D[ScalarT] | Sequence[ScalarT]
 
 ###
 
@@ -230,22 +236,73 @@ class IndexExpression(Generic[_BoolT_co]):
     @overload
     def __getitem__[T](self: IndexExpression[L[False]], item: T) -> T: ...
 
-@overload
-def ix_[DTypeT: np.dtype](
-    *args: _NestedSequence[_HasDType[DTypeT]] | _HasDType[DTypeT]
-) -> tuple[np.ndarray[_AnyShape, DTypeT], ...]: ...
-@overload
-def ix_(*args: str | _NestedSequence[str]) -> tuple[NDArray[np.str_], ...]: ...
-@overload
-def ix_(*args: bytes | _NestedSequence[bytes]) -> tuple[NDArray[np.bytes_], ...]: ...
-@overload
-def ix_(*args: bool | _NestedSequence[bool]) -> tuple[NDArray[np.bool], ...]: ...
-@overload
-def ix_(*args: int | _NestedSequence[int]) -> tuple[NDArray[np.intp], ...]: ...
-@overload
-def ix_(*args: float | _NestedSequence[float]) -> tuple[NDArray[np.float64], ...]: ...
-@overload
-def ix_(*args: complex | _NestedSequence[complex]) -> tuple[NDArray[np.complex128], ...]: ...
+# only the `int` sequences have special-cased shape-type overloads, because this is the
+# most common use case and the others would require too many overloads to be worth it.
+@overload  # 0
+def ix_() -> tuple[()]: ...
+@overload  # 1 +int
+def ix_(arg0: Sequence[int], /) -> tuple[_Array1D[np.int_]]: ...
+@overload  # 1 ScalarT
+def ix_[ScalarT: np.generic](
+    arg0: _ToArray1D[ScalarT],
+    /,
+) -> tuple[_Array1D[ScalarT]]: ...
+@overload  # 2 +int
+def ix_(
+    arg0: Sequence[int],
+    arg1: Sequence[int],
+    /,
+) -> tuple[_Array2D[np.int_], _Array2D[np.int_]]: ...
+@overload  # 2 ScalarT
+def ix_[ScalarT: np.generic](
+    arg0: _ToArray1D[ScalarT],
+    arg1: _ToArray1D[ScalarT],
+    /,
+) -> tuple[_Array2D[ScalarT], _Array2D[ScalarT]]: ...
+@overload  # 3 +int
+def ix_(
+    arg0: Sequence[int],
+    arg1: Sequence[int],
+    arg2: Sequence[int],
+    /,
+) -> tuple[_Array3D[np.int_], _Array3D[np.int_], _Array3D[np.int_]]: ...
+@overload  # 3 ScalarT
+def ix_[ScalarT: np.generic](
+    arg0: _ToArray1D[ScalarT],
+    arg1: _ToArray1D[ScalarT],
+    arg2: _ToArray1D[ScalarT],
+    /,
+) -> tuple[_Array3D[ScalarT], _Array3D[ScalarT], _Array3D[ScalarT]]: ...
+@overload  # N +int
+def ix_(
+    arg0: Sequence[int],
+    arg1: Sequence[int],
+    arg2: Sequence[int],
+    /,
+    *args: Sequence[int],
+) -> tuple[NDArray[np.int_], ...]: ...
+@overload  # N ScalarT
+def ix_[ScalarT: np.generic](
+    arg0: _ToArray1D[ScalarT],
+    arg1: _ToArray1D[ScalarT],
+    arg2: _ToArray1D[ScalarT],
+    /,
+    *args: _ToArray1D[ScalarT],
+) -> tuple[NDArray[ScalarT], ...]: ...
+@overload  # N float
+def ix_(arg0: list[float], /, *args: Sequence[float]) -> tuple[NDArray[np.float64], ...]: ...
+@overload  # N complex
+def ix_(arg0: list[complex], /, *args: Sequence[complex]) -> tuple[NDArray[np.complex128], ...]: ...
+@overload  # N bytes
+def ix_(arg0: Sequence[bytes], /, *args: Sequence[bytes]) -> tuple[NDArray[np.bytes_], ...]: ...
+@overload  # N str
+def ix_(arg0: Sequence[str], /, *args: Sequence[str]) -> tuple[NDArray[np.str_], ...]: ...
+@overload  # fallback
+def ix_(
+    arg0: Sequence[_ScalarLike_co] | _Array1D[Any],
+    /,
+    *args: Sequence[_ScalarLike_co] | _Array1D[Any],
+) -> tuple[NDArray[Any], ...]: ...
 
 #
 def fill_diagonal(a: NDArray[Any], val: object, wrap: bool = False) -> None: ...

--- a/numpy/typing/tests/data/reveal/index_tricks.pyi
+++ b/numpy/typing/tests/data/reveal/index_tricks.pyi
@@ -7,10 +7,13 @@ import numpy.typing as npt
 AR_LIKE_b: list[bool]
 AR_LIKE_i: list[int]
 AR_LIKE_f: list[float]
+AR_LIKE_c: list[complex]
+AR_LIKE_S: list[bytes]
 AR_LIKE_U: list[str]
 AR_LIKE_O: list[object]
 
 AR_i8: npt.NDArray[np.int64]
+AR_f4: npt.NDArray[np.float32]
 AR_O: npt.NDArray[np.object_]
 
 assert_type(np.ndenumerate(AR_i8), np.ndenumerate[np.int64])
@@ -58,9 +61,70 @@ assert_type(np.s_[0:1], slice[int, int, None])
 assert_type(np.s_[0:1, None:3], tuple[slice[int, int, None], slice[None, int, None]])
 assert_type(np.s_[0, 0:1, ..., [0, 1, 3]], tuple[Literal[0], slice[int, int, None], EllipsisType, list[int]])
 
-assert_type(np.ix_(AR_LIKE_b), tuple[npt.NDArray[np.bool], ...])
-assert_type(np.ix_(AR_LIKE_i, AR_LIKE_f), tuple[npt.NDArray[np.float64], ...])
-assert_type(np.ix_(AR_i8), tuple[npt.NDArray[np.int64], ...])
+assert_type(np.ix_(AR_LIKE_b), tuple[np.ndarray[tuple[int], np.dtype[np.int_]]])
+assert_type(np.ix_(AR_LIKE_i), tuple[np.ndarray[tuple[int], np.dtype[np.int_]]])
+assert_type(np.ix_(AR_f4), tuple[np.ndarray[tuple[int], np.dtype[np.float32]]])
+assert_type(
+    np.ix_(AR_LIKE_b, AR_LIKE_b),
+    tuple[
+        np.ndarray[tuple[int, int], np.dtype[np.int_]],
+        np.ndarray[tuple[int, int], np.dtype[np.int_]],
+    ],
+)
+assert_type(
+    np.ix_(AR_LIKE_i, AR_LIKE_i),
+    tuple[
+        np.ndarray[tuple[int, int], np.dtype[np.int_]],
+        np.ndarray[tuple[int, int], np.dtype[np.int_]],
+    ],
+)
+assert_type(
+    np.ix_(AR_f4, AR_f4),
+    tuple[
+        np.ndarray[tuple[int, int], np.dtype[np.float32]],
+        np.ndarray[tuple[int, int], np.dtype[np.float32]],
+    ],
+)
+assert_type(
+    np.ix_(AR_LIKE_b, AR_LIKE_b, AR_LIKE_b),
+    tuple[
+        np.ndarray[tuple[int, int, int], np.dtype[np.int_]],
+        np.ndarray[tuple[int, int, int], np.dtype[np.int_]],
+        np.ndarray[tuple[int, int, int], np.dtype[np.int_]],
+    ],
+)
+assert_type(
+    np.ix_(AR_LIKE_i, AR_LIKE_i, AR_LIKE_i),
+    tuple[
+        np.ndarray[tuple[int, int, int], np.dtype[np.int_]],
+        np.ndarray[tuple[int, int, int], np.dtype[np.int_]],
+        np.ndarray[tuple[int, int, int], np.dtype[np.int_]],
+    ],
+)
+assert_type(
+    np.ix_(AR_f4, AR_f4, AR_f4),
+    tuple[
+        np.ndarray[tuple[int, int, int], np.dtype[np.float32]],
+        np.ndarray[tuple[int, int, int], np.dtype[np.float32]],
+        np.ndarray[tuple[int, int, int], np.dtype[np.float32]],
+    ],
+)
+assert_type(
+    np.ix_(AR_LIKE_b, AR_LIKE_b, AR_LIKE_b, AR_LIKE_b),
+    tuple[npt.NDArray[np.int_], ...],
+)
+assert_type(
+    np.ix_(AR_LIKE_i, AR_LIKE_i, AR_LIKE_i, AR_LIKE_b),
+    tuple[npt.NDArray[np.int_], ...],
+)
+assert_type(
+    np.ix_(AR_f4, AR_f4, AR_f4, AR_f4),
+    tuple[npt.NDArray[np.float32], ...],
+)
+assert_type(np.ix_(AR_LIKE_f), tuple[npt.NDArray[np.float64], ...])
+assert_type(np.ix_(AR_LIKE_c), tuple[npt.NDArray[np.complex128], ...])
+assert_type(np.ix_(AR_LIKE_S), tuple[npt.NDArray[np.bytes_], ...])
+assert_type(np.ix_(AR_LIKE_U), tuple[npt.NDArray[np.str_], ...])
 
 assert_type(np.fill_diagonal(AR_i8, 5), None)
 


### PR DESCRIPTION
Calling `np.ix_` with N arrays returns an N-tuple of N-d arrays with same dtype as input, **except in case of `bool`, because that is upcasted to `int_`**. This exception is what wasn't correct before, because `bool` input were annotated to return `bool` output.

Since this boolean behavior is also mentioned in the docs, I'm thinking of partially backporting this.

#### AI Disclosure
N/A