### PR TITLE
TYP: ``expand_dims`` shape-typing

### DIFF
--- a/numpy/lib/_shape_base_impl.pyi
+++ b/numpy/lib/_shape_base_impl.pyi
@@ -3,6 +3,7 @@ from collections.abc import Callable, Sequence
 from typing import (
     Any,
     Concatenate,
+    Never,
     Protocol,
     Self,
     SupportsIndex,
@@ -14,6 +15,7 @@ import numpy as np
 from numpy._typing import (
     ArrayLike,
     NDArray,
+    _AnyShape,
     _ArrayLike,
     _ArrayLikeBool_co,
     _ArrayLikeComplex_co,
@@ -22,6 +24,7 @@ from numpy._typing import (
     _ArrayLikeInt_co,
     _ArrayLikeObject_co,
     _ArrayLikeUInt_co,
+    _Shape,
     _ShapeLike,
 )
 
@@ -70,6 +73,8 @@ class _SupportsSplitOps(Protocol):
     def swapaxes(self, axis1: int, axis2: int, /) -> Self: ...
     def __getitem__(self, key: Any, /) -> Self: ...
 
+type _JustAnyShape = tuple[Never, Never, Never]  # workaround for microsoft/pyright#10232
+
 ###
 
 def take_along_axis[ScalarT: np.generic](
@@ -112,10 +117,53 @@ def apply_over_axes[ScalarT: np.generic](
 ) -> NDArray[ScalarT]: ...
 
 #
-@overload
-def expand_dims[ScalarT: np.generic](a: _ArrayLike[ScalarT], axis: _ShapeLike) -> NDArray[ScalarT]: ...
-@overload
-def expand_dims(a: ArrayLike, axis: _ShapeLike) -> NDArray[Incomplete]: ...
+@overload  # Nd -> Nd
+def expand_dims[ShapeT: _Shape, DTypeT: np.dtype](
+    a: np.ndarray[ShapeT, DTypeT],
+    axis: tuple[()],
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # ?d -> ?d  (workaround)
+def expand_dims[DTypeT: np.dtype](
+    a: np.ndarray[_JustAnyShape, DTypeT],
+    axis: int | tuple[int, ...],
+) -> np.ndarray[_AnyShape, DTypeT]: ...
+@overload  # 0d -> 1d
+def expand_dims[ScalarT: np.generic](
+    a: ScalarT | np.ndarray[tuple[()], np.dtype[ScalarT]],
+    axis: int | tuple[int],
+) -> np.ndarray[tuple[int], np.dtype[ScalarT]]: ...
+@overload  # 0d -> 2d
+def expand_dims[ScalarT: np.generic](
+    a: ScalarT | np.ndarray[tuple[()], np.dtype[ScalarT]],
+    axis: tuple[int, int],
+) -> np.ndarray[tuple[int, int], np.dtype[ScalarT]]: ...
+@overload  # 1d -> 2d
+def expand_dims[DTypeT: np.dtype](
+    a: np.ndarray[tuple[int], DTypeT],
+    axis: int | tuple[int],
+) -> np.ndarray[tuple[int, int], DTypeT]: ...
+@overload  # 1d -> 3d
+def expand_dims[DTypeT: np.dtype](
+    a: np.ndarray[tuple[int], DTypeT],
+    axis: tuple[int, int],
+) -> np.ndarray[tuple[int, int, int], DTypeT]: ...
+@overload  # 2d -> 3d
+def expand_dims[DTypeT: np.dtype](
+    a: np.ndarray[tuple[int, int], DTypeT],
+    axis: int | tuple[int],
+) -> np.ndarray[tuple[int, int, int], DTypeT]: ...
+@overload  # 2d -> 4d
+def expand_dims[DTypeT: np.dtype](
+    a: np.ndarray[tuple[int, int], DTypeT],
+    axis: tuple[int, int],
+) -> np.ndarray[tuple[int, int, int, int], DTypeT]: ...
+@overload  # Nd -> ?d
+def expand_dims[ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    axis: int | tuple[int, ...],
+) -> NDArray[ScalarT]: ...
+@overload  # fallback
+def expand_dims(a: ArrayLike, axis: int | tuple[int, ...]) -> NDArray[Any]: ...
 
 # keep in sync with `numpy.ma.extras.column_stack`
 @overload

--- a/numpy/typing/tests/data/reveal/shape_base.pyi
+++ b/numpy/typing/tests/data/reveal/shape_base.pyi
@@ -8,6 +8,9 @@ f8: np.float64
 
 AR_b: npt.NDArray[np.bool]
 AR_i8: npt.NDArray[np.int64]
+AR_i8_0d: np.ndarray[tuple[()], np.dtype[np.int64]]
+AR_i8_1d: np.ndarray[tuple[int], np.dtype[np.int64]]
+AR_i8_2d: np.ndarray[tuple[int, int], np.dtype[np.int64]]
 AR_f8: npt.NDArray[np.float64]
 
 AR_LIKE_f8: list[float]
@@ -26,8 +29,23 @@ assert_type(np.take_along_axis(f8, AR_i8, axis=None), npt.NDArray[np.float64])
 
 assert_type(np.put_along_axis(AR_f8, AR_i8, "1.0", axis=1), None)
 
-assert_type(np.expand_dims(AR_i8, 2), npt.NDArray[np.int64])
-assert_type(np.expand_dims(AR_LIKE_f8, 2), npt.NDArray[Any])
+assert_type(np.expand_dims(AR_LIKE_f8, 0), np.ndarray)
+assert_type(np.expand_dims(AR_i8, ()), npt.NDArray[np.int64])
+assert_type(np.expand_dims(AR_i8, 0), npt.NDArray[np.int64])
+assert_type(np.expand_dims(AR_i8, (0,)), npt.NDArray[np.int64])
+assert_type(np.expand_dims(AR_i8, (0, 1)), npt.NDArray[np.int64])
+assert_type(np.expand_dims(AR_i8_0d, ()), np.ndarray[tuple[()], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_0d, 0), np.ndarray[tuple[int], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_0d, (0,)), np.ndarray[tuple[int], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_0d, (0, 1)), np.ndarray[tuple[int, int], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_1d, ()), np.ndarray[tuple[int], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_1d, 0), np.ndarray[tuple[int, int], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_1d, (0,)), np.ndarray[tuple[int, int], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_1d, (0, 1)), np.ndarray[tuple[int, int, int], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_2d, ()), np.ndarray[tuple[int, int], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_2d, 0), np.ndarray[tuple[int, int, int], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_2d, (0,)), np.ndarray[tuple[int, int, int], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_2d, (0, 1)), np.ndarray[tuple[int, int, int, int], np.dtype[np.int64]])
 
 assert_type(np.column_stack([AR_i8]), npt.NDArray[np.int64])
 assert_type(np.column_stack([AR_LIKE_f8]), npt.NDArray[Any])


### PR DESCRIPTION
This adds shape typing overloads for `np.expand_dims` for `{0,1,2}-d` input arrays with axis as either an int, empty tuple, 1-tuple, or 2-tuple.

#### AI Disclosure
N/A