### PR TITLE
TYP: ``real_if_close`` and ``nan_to_num`` shape-typing

### DIFF
--- a/numpy/lib/_type_check_impl.pyi
+++ b/numpy/lib/_type_check_impl.pyi
@@ -13,6 +13,7 @@ from numpy._typing import (
     _ArrayLike,
     _NestedSequence,
     _ScalarLike_co,
+    _Shape,
     _SupportsArray,
 )
 
@@ -135,15 +136,35 @@ def nan_to_num(
     neginf: float | None = None,
 ) -> Incomplete: ...
 
-# NOTE: The [overload-overlap] mypy error is a false positive
+#
+@overload
+def real_if_close[ShapeT: _Shape, DTypeT: np.dtype[_ToReal]](
+    a: np.ndarray[ShapeT, DTypeT],
+    tol: float = 100,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload
+def real_if_close[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.complex64]],
+    tol: float = 100,
+) -> np.ndarray[ShapeT, np.dtype[np.float32 | np.complex64]]: ...
+@overload
+def real_if_close[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.complex128]],
+    tol: float = 100,
+) -> np.ndarray[ShapeT, np.dtype[np.float64 | np.complex128]]: ...
+@overload
+def real_if_close[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.clongdouble]],
+    tol: float = 100,
+) -> np.ndarray[ShapeT, np.dtype[np.longdouble | np.clongdouble]]: ...
+@overload
+def real_if_close[RealT: _ToReal](a: _ArrayLike[RealT], tol: float = 100) -> NDArray[RealT]: ...
 @overload
 def real_if_close(a: _ArrayLike[np.complex64], tol: float = 100) -> NDArray[np.float32 | np.complex64]: ...
 @overload
 def real_if_close(a: _ArrayLike[np.complex128], tol: float = 100) -> NDArray[np.float64 | np.complex128]: ...
 @overload
 def real_if_close(a: _ArrayLike[np.clongdouble], tol: float = 100) -> NDArray[np.longdouble | np.clongdouble]: ...
-@overload
-def real_if_close[RealT: _ToReal](a: _ArrayLike[RealT], tol: float = 100) -> NDArray[RealT]: ...
 @overload
 def real_if_close(a: ArrayLike, tol: float = 100) -> NDArray[Any]: ...
 

--- a/numpy/lib/_type_check_impl.pyi
+++ b/numpy/lib/_type_check_impl.pyi
@@ -1,4 +1,3 @@
-from _typeshed import Incomplete
 from collections.abc import Container, Iterable
 from typing import Any, Literal as L, Protocol, overload, type_check_only
 from typing_extensions import deprecated
@@ -10,6 +9,7 @@ from numpy._typing import (
     _16Bit,
     _32Bit,
     _64Bit,
+    _AnyShape,
     _ArrayLike,
     _NestedSequence,
     _ScalarLike_co,
@@ -95,46 +95,110 @@ def iscomplexobj(x: _HasDType[Any] | ArrayLike) -> bool: ...
 def isrealobj(x: _HasDType[Any] | ArrayLike) -> bool: ...
 
 #
-@overload
-def nan_to_num[ScalarT: np.generic](
-    x: ScalarT,
+@overload  # np.generic | np.ndarray  (`ndarray` subclasses pass through)
+def nan_to_num[ScalarOrArrayT: np.generic | np.ndarray](
+    x: ScalarOrArrayT,
     copy: bool = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
-) -> ScalarT: ...
-@overload
+) -> ScalarOrArrayT: ...
+@overload  # >0-d <known dtype>
 def nan_to_num[ScalarT: np.generic](
-    x: NDArray[ScalarT] | _NestedSequence[_ArrayLike[ScalarT]],
+    x: _NestedSequence[_ArrayLike[ScalarT]],
     copy: bool = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> NDArray[ScalarT]: ...
-@overload
-def nan_to_num[ScalarT: np.generic](
-    x: _SupportsArray[np.dtype[ScalarT]],
+@overload  # ?-d <known dtype>
+def nan_to_num[DTypeT: np.dtype](
+    x: _SupportsArray[DTypeT],
     copy: bool = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
-) -> ScalarT | NDArray[ScalarT]: ...
-@overload
+) -> np.ndarray[_AnyShape, DTypeT] | Any: ...
+@overload  # 0-d ~bool
+def nan_to_num(
+    x: bool,
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> np.bool: ...
+@overload  # 0-d +int
+def nan_to_num(
+    x: int,
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> np.int_ | Any: ...
+@overload  # 0-d +float
+def nan_to_num(
+    x: float,
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> np.float64 | Any: ...
+@overload  # 0-d +complex
+def nan_to_num(
+    x: complex,
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> np.complex128 | Any: ...
+@overload  # >0-d ~bool
+def nan_to_num(
+    x: _NestedSequence[bool],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> NDArray[np.bool]: ...
+@overload  # >0-d ~int
+def nan_to_num(
+    x: _NestedSequence[list[int]] | list[int],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> NDArray[np.int_]: ...
+@overload  # >0-d ~float
+def nan_to_num(
+    x: _NestedSequence[list[float]] | list[float],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> NDArray[np.float64]: ...
+@overload  # >0-d ~complex
+def nan_to_num(
+    x: _NestedSequence[list[complex]] | list[complex],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # >0-d <unknown dtype>
 def nan_to_num(
     x: _NestedSequence[ArrayLike],
     copy: bool = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
-) -> NDArray[Incomplete]: ...
-@overload
+) -> np.ndarray: ...
+@overload  # ?-d <unknown dtype>
 def nan_to_num(
     x: ArrayLike,
     copy: bool = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
-) -> Incomplete: ...
+) -> np.ndarray | Any: ...
 
 #
 @overload

--- a/numpy/typing/tests/data/reveal/type_check.pyi
+++ b/numpy/typing/tests/data/reveal/type_check.pyi
@@ -3,8 +3,10 @@ from typing import Any, Literal, assert_type
 import numpy as np
 import numpy.typing as npt
 
+i4: np.int32
 f8: np.float64
-f: float
+m8_ns: np.timedelta64[int]
+M8_ns: np.datetime64[int]
 
 AR_i8: npt.NDArray[np.int64]
 AR_i4: npt.NDArray[np.int32]
@@ -19,7 +21,10 @@ AR_f8_2d: np.ndarray[tuple[int, int], np.dtype[np.float64]]
 AR_c16_1d: np.ndarray[tuple[int], np.dtype[np.complex128]]
 AR_c16_2d: np.ndarray[tuple[int, int], np.dtype[np.complex128]]
 
+AR_LIKE_b: list[bool]
+AR_LIKE_i: list[int]
 AR_LIKE_f: list[float]
+AR_LIKE_c: list[complex]
 
 class ComplexObj:
     real: slice
@@ -48,10 +53,24 @@ assert_type(np.isreal(AR_LIKE_f), npt.NDArray[np.bool])
 assert_type(np.iscomplexobj(f8), bool)
 assert_type(np.isrealobj(f8), bool)
 
+assert_type(np.nan_to_num(True), np.bool)
+assert_type(np.nan_to_num(0), np.int_ | Any)
+assert_type(np.nan_to_num(0.0), np.float64 | Any)
+assert_type(np.nan_to_num(0j), np.complex128 | Any)
+assert_type(np.nan_to_num(i4), np.int32)
 assert_type(np.nan_to_num(f8), np.float64)
-assert_type(np.nan_to_num(f, copy=True), Any)
-assert_type(np.nan_to_num(AR_f8, nan=1.5), npt.NDArray[np.float64])
-assert_type(np.nan_to_num(AR_LIKE_f, posinf=9999), npt.NDArray[Any])
+assert_type(np.nan_to_num(m8_ns), np.timedelta64[int])
+assert_type(np.nan_to_num(M8_ns), np.datetime64[int])
+assert_type(np.nan_to_num(AR_LIKE_b), npt.NDArray[np.bool])
+assert_type(np.nan_to_num(AR_LIKE_i), npt.NDArray[np.int_])
+assert_type(np.nan_to_num(AR_LIKE_f), npt.NDArray[np.float64])
+assert_type(np.nan_to_num(AR_LIKE_c), npt.NDArray[np.complex128])
+assert_type(np.nan_to_num(AR_f8), npt.NDArray[np.float64])
+assert_type(np.nan_to_num(AR_c16), npt.NDArray[np.complex128])
+assert_type(np.nan_to_num(AR_f8_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.nan_to_num(AR_f8_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.nan_to_num(AR_c16_1d), np.ndarray[tuple[int], np.dtype[np.complex128]])
+assert_type(np.nan_to_num(AR_c16_2d), np.ndarray[tuple[int, int], np.dtype[np.complex128]])
 
 assert_type(np.real_if_close(AR_LIKE_f), npt.NDArray[Any])
 assert_type(np.real_if_close(AR_f8), npt.NDArray[np.float64])

--- a/numpy/typing/tests/data/reveal/type_check.pyi
+++ b/numpy/typing/tests/data/reveal/type_check.pyi
@@ -6,7 +6,6 @@ import numpy.typing as npt
 f8: np.float64
 f: float
 
-# NOTE: Avoid importing the platform specific `np.float128` type
 AR_i8: npt.NDArray[np.int64]
 AR_i4: npt.NDArray[np.int32]
 AR_f2: npt.NDArray[np.float16]
@@ -14,6 +13,11 @@ AR_f8: npt.NDArray[np.float64]
 AR_f16: npt.NDArray[np.longdouble]
 AR_c8: npt.NDArray[np.complex64]
 AR_c16: npt.NDArray[np.complex128]
+
+AR_f8_1d: np.ndarray[tuple[int], np.dtype[np.float64]]
+AR_f8_2d: np.ndarray[tuple[int, int], np.dtype[np.float64]]
+AR_c16_1d: np.ndarray[tuple[int], np.dtype[np.complex128]]
+AR_c16_2d: np.ndarray[tuple[int, int], np.dtype[np.complex128]]
 
 AR_LIKE_f: list[float]
 
@@ -49,10 +53,14 @@ assert_type(np.nan_to_num(f, copy=True), Any)
 assert_type(np.nan_to_num(AR_f8, nan=1.5), npt.NDArray[np.float64])
 assert_type(np.nan_to_num(AR_LIKE_f, posinf=9999), npt.NDArray[Any])
 
-assert_type(np.real_if_close(AR_f8), npt.NDArray[np.float64])
-assert_type(np.real_if_close(AR_c16), npt.NDArray[np.float64 | np.complex128])
-assert_type(np.real_if_close(AR_c8), npt.NDArray[np.float32 | np.complex64])
 assert_type(np.real_if_close(AR_LIKE_f), npt.NDArray[Any])
+assert_type(np.real_if_close(AR_f8), npt.NDArray[np.float64])
+assert_type(np.real_if_close(AR_c8), npt.NDArray[np.float32 | np.complex64])
+assert_type(np.real_if_close(AR_c16), npt.NDArray[np.float64 | np.complex128])
+assert_type(np.real_if_close(AR_f8_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.real_if_close(AR_f8_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.real_if_close(AR_c16_1d), np.ndarray[tuple[int], np.dtype[np.float64 | np.complex128]])
+assert_type(np.real_if_close(AR_c16_2d), np.ndarray[tuple[int, int], np.dtype[np.float64 | np.complex128]])
 
 assert_type(np.typename("h"), Literal["short"])  # type: ignore[deprecated]
 assert_type(np.typename("B"), Literal["unsigned char"])  # type: ignore[deprecated]


### PR DESCRIPTION
Both are elementwise functions (for the most part), so shape-typing is pretty straightforward because the shapes aren't modified. 

For `np.nan_to_num` I also added some additional overloads for specific non-numpy array-likes. I only did this for `nan_to_num` because it, unlike `real_to_close`, return bare scalars for 0-d input.

```
In [1]: np.real_if_close(1)
Out[1]: array(1)

In [2]: np.nan_to_num(1)
Out[2]: np.int64(1)
```

And since `ArrayLike` and `_SupportsArray` accept both scalars and arrays, this often resulted in `Any` as return type. The new overloads cover the (I think) most commonly used "array-like" cases, for which `nan_to_num` will now return fully static array or scalar types with specialized dtypes.

#### AI Disclosure
N/A