### PR TITLE
TYP: ``fft.[i]fftshift`` shape-typing

### DIFF
--- a/numpy/fft/_helper.pyi
+++ b/numpy/fft/_helper.pyi
@@ -22,12 +22,23 @@ type _1D = tuple[int]
 
 integer_types: Final[tuple[type[int], type[np.integer]]] = ...
 
+# keep in sync with `ifftshift` below
+@overload
+def fftshift[ShapeT: _Shape, DTypeT: np.dtype](
+    x: np.ndarray[ShapeT, DTypeT],
+    axes: _ShapeLike | None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
 @overload
 def fftshift[ScalarT: np.generic](x: _ArrayLike[ScalarT], axes: _ShapeLike | None = None) -> NDArray[ScalarT]: ...
 @overload
 def fftshift(x: ArrayLike, axes: _ShapeLike | None = None) -> NDArray[Any]: ...
 
-#
+# keep in sync with `fftshift` above
+@overload
+def ifftshift[ShapeT: _Shape, DTypeT: np.dtype](
+    x: np.ndarray[ShapeT, DTypeT],
+    axes: _ShapeLike | None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
 @overload
 def ifftshift[ScalarT: np.generic](x: _ArrayLike[ScalarT], axes: _ShapeLike | None = None) -> NDArray[ScalarT]: ...
 @overload

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -19,13 +19,13 @@ _c64: np.complex64
 _c160: np.clongdouble
 
 _i64_2d: _Array2D[np.int64]
-_f32_2d: _Array2D[np.float16]
+_f32_2d: _Array2D[np.float32]
 _f80_2d: _Array2D[np.longdouble]
 _c64_2d: _Array2D[np.complex64]
 _c160_2d: _Array2D[np.clongdouble]
 
 _i64_nd: npt.NDArray[np.int64]
-_f32_nd: npt.NDArray[np.float16]
+_f32_nd: npt.NDArray[np.float32]
 _f80_nd: npt.NDArray[np.longdouble]
 _c64_nd: npt.NDArray[np.complex64]
 _c160_nd: npt.NDArray[np.clongdouble]
@@ -34,12 +34,14 @@ _c160_nd: npt.NDArray[np.clongdouble]
 
 # fftshift
 
-assert_type(np.fft.fftshift(_f64_nd), npt.NDArray[np.float64])
 assert_type(np.fft.fftshift(_py_float_1d, axes=0), npt.NDArray[Any])
+assert_type(np.fft.fftshift(_f32_2d), _Array2D[np.float32])
+assert_type(np.fft.fftshift(_f64_nd), npt.NDArray[np.float64])
 
 # ifftshift
 
 assert_type(np.fft.ifftshift(_f64_nd), npt.NDArray[np.float64])
+assert_type(np.fft.ifftshift(_f32_2d), _Array2D[np.float32])
 assert_type(np.fft.ifftshift(_py_float_1d, axes=0), npt.NDArray[Any])
 
 # fftfreq


### PR DESCRIPTION
`np.fft.fftshift` and `np.fft.ifftshift` retain shapes (but not `ndarray` subtype), which makes this pretty straighforward.

#### AI Disclosure
N/A
