### PR TITLE
TYP: ``fft.*fft``, ``fft.*fftn`` and ``fft.*fft2`` shape-typing and improved dtype support

### DIFF
--- a/doc/release/upcoming_changes/31226.typing.rst
+++ b/doc/release/upcoming_changes/31226.typing.rst
@@ -1,0 +1,6 @@
+``numpy.fft`` typing improvements and preliminary shape-typing support
+----------------------------------------------------------------------
+The ``numpy.fft`` functions now support non-``float64``/``complex128`` dtypes and gain
+preliminary shape-typing support. For example, the return type of ``numpy.fft.fft`` now
+depends on the shape-type of its inputs, falling back to the backward-compatible return
+type when the shape-types are unknown at type-checking time.

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -494,23 +494,173 @@ def ihfft[ArrayT: NDArray[np.complexfloating]](
     out: ArrayT,
 ) -> ArrayT: ...
 
-#
+# keep in sync with `ifftn`
+@overload  # Nd complexfloating
+def fftn[ShapeT: _Shape, DTypeT: np.dtype[np.complexfloating]](
+    a: np.ndarray[ShapeT, DTypeT],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # Nd float64 | +integer
+def fftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float64 | np.integer | np.bool]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex128]]: ...
+@overload  # Nd float32 | float16
+def fftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float32 | np.float16]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex64]]: ...
+@overload  # Nd longdouble
+def fftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.longdouble]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.clongdouble]]: ...
+@overload  # 1d +complex
 def fftn(
-    a: ArrayLike,
+    a: Sequence[complex],
     s: Sequence[int] | None = None,
     axes: Sequence[int] | None = None,
     norm: _NormKind = None,
-    out: NDArray[complex128] | None = None,
-) -> NDArray[complex128]: ...
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.complex128]]: ...
+@overload  # 2d +complex
+def fftn(
+    a: Sequence[Sequence[complex]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.complex128]]: ...
+@overload  # ?d complexfloating
+def fftn[ScalarT: np.complexfloating](
+    a: _ArrayLike[ScalarT],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[ScalarT]: ...
+@overload  # ?d +complex
+def fftn(
+    a: _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], complex],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # fallback
+def fftn(
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complexfloating]: ...
+@overload  # out: <given>
+def fftn[ArrayT: NDArray[np.complexfloating]](
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
+# keep in sync with `fftn`
+@overload  # Nd complexfloating
+def ifftn[ShapeT: _Shape, DTypeT: np.dtype[np.complexfloating]](
+    a: np.ndarray[ShapeT, DTypeT],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # Nd float64 | +integer
+def ifftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float64 | np.integer | np.bool]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex128]]: ...
+@overload  # Nd float32 | float16
+def ifftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float32 | np.float16]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex64]]: ...
+@overload  # Nd longdouble
+def ifftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.longdouble]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.clongdouble]]: ...
+@overload  # 1d +complex
 def ifftn(
-    a: ArrayLike,
+    a: Sequence[complex],
     s: Sequence[int] | None = None,
     axes: Sequence[int] | None = None,
     norm: _NormKind = None,
-    out: NDArray[complex128] | None = None,
-) -> NDArray[complex128]: ...
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.complex128]]: ...
+@overload  # 2d +complex
+def ifftn(
+    a: Sequence[Sequence[complex]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.complex128]]: ...
+@overload  # ?d complexfloating
+def ifftn[ScalarT: np.complexfloating](
+    a: _ArrayLike[ScalarT],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[ScalarT]: ...
+@overload  # ?d +complex
+def ifftn(
+    a: _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], complex],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # fallback
+def ifftn(
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complexfloating]: ...
+@overload  # out: <given>
+def ifftn[ArrayT: NDArray[np.complexfloating]](
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
+#
 def rfftn(
     a: ArrayLike,
     s: Sequence[int] | None = None,

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from typing import Literal as L, overload
 
 import numpy as np
-from numpy import complex128, float64
+from numpy import float64
 from numpy._typing import _ArrayLike, _ArrayLikeFloat_co, _ArrayLikeNumber_co, _Shape
 from numpy._typing._array_like import _DualArrayLike
 from numpy.typing import ArrayLike, NDArray
@@ -977,13 +977,71 @@ def ifft2[ArrayT: NDArray[np.complexfloating]](
 ) -> ArrayT: ...
 
 #
-def rfft2(
-    a: ArrayLike,
+@overload  # Nd float64 | +integer
+def rfft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float64 | np.integer | np.bool]],
     s: Sequence[int] | None = None,
     axes: Sequence[int] | None = (-2, -1),
     norm: _NormKind = None,
-    out: NDArray[complex128] | None = None,
-) -> NDArray[complex128]: ...
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex128]]: ...
+@overload  # Nd float32 | float16
+def rfft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float32 | np.float16]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex64]]: ...
+@overload  # Nd longdouble
+def rfft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.longdouble]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.clongdouble]]: ...
+@overload  # 1d +float
+def rfft2(
+    a: Sequence[float],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.complex128]]: ...
+@overload  # 2d +float
+def rfft2(
+    a: Sequence[Sequence[float]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.complex128]]: ...
+@overload  # ?d +float
+def rfft2(
+    a: _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], float],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # fallback
+def rfft2(
+    a: _ArrayLikeFloat_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complexfloating]: ...
+@overload  # out: <given>
+def rfft2[ArrayT: NDArray[np.complexfloating]](
+    a: _ArrayLikeFloat_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
 #
 def irfft2(

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -728,14 +728,89 @@ def rfftn[ArrayT: NDArray[np.complexfloating]](
 ) -> ArrayT: ...
 
 #
-def irfftn(
-    a: ArrayLike,
+@overload  # Nd floating
+def irfftn[ShapeT: _Shape, DTypeT: np.dtype[np.floating]](
+    a: np.ndarray[ShapeT, DTypeT],
     s: Sequence[int] | None = None,
     axes: Sequence[int] | None = None,
     norm: _NormKind = None,
-    out: NDArray[float64] | None = None,
-) -> NDArray[float64]: ...
+    out: None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # Nd complex128 | +integer
+def irfftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.complex128 | np.integer | np.bool]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+@overload  # Nd complex64
+def irfftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.complex64]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.float32]]: ...
+@overload  # Nd clongdouble
+def irfftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.clongdouble]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.longdouble]]: ...
+@overload  # 1d +complex
+def irfftn(
+    a: Sequence[complex],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.float64]]: ...
+@overload  # 2d +complex
+def irfftn(
+    a: Sequence[Sequence[complex]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.float64]]: ...
+@overload  # ?d floating
+def irfftn[ScalarT: np.floating](
+    a: _ArrayLike[ScalarT],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[ScalarT]: ...
+@overload  # ?d +complex | complex128 | +integer
+def irfftn(
+    a: _DualArrayLike[np.dtype[np.complex128 | np.integer | np.bool], complex],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.float64]: ...
+@overload  # fallback
+def irfftn(
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.floating]: ...
+@overload  # out: <given>
+def irfftn[ArrayT: NDArray[np.floating]](
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
+#
 def fft2(
     a: ArrayLike,
     s: Sequence[int] | None = None,

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -219,7 +219,7 @@ def rfft[ShapeT: _Shape](
     norm: _NormKind = None,
     out: None = None,
 ) -> np.ndarray[ShapeT, np.dtype[np.clongdouble]]: ...
-@overload  # 1d +complex
+@overload  # 1d +float
 def rfft(
     a: Sequence[float],
     n: int | None = None,
@@ -227,7 +227,7 @@ def rfft(
     norm: _NormKind = None,
     out: None = None,
 ) -> np.ndarray[tuple[int], np.dtype[np.complex128]]: ...
-@overload  # 2d +complex
+@overload  # 2d +float
 def rfft(
     a: Sequence[Sequence[float]],
     n: int | None = None,
@@ -235,7 +235,7 @@ def rfft(
     norm: _NormKind = None,
     out: None = None,
 ) -> np.ndarray[tuple[int, int], np.dtype[np.complex128]]: ...
-@overload  # ?d +complex
+@overload  # ?d +float
 def rfft(
     a: _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], float],
     n: int | None = None,
@@ -262,13 +262,87 @@ def rfft[ArrayT: NDArray[np.complexfloating]](
 ) -> ArrayT: ...
 
 #
-def irfft(
-    a: ArrayLike,
+@overload  # Nd floating
+def irfft[ShapeT: _Shape, DTypeT: np.dtype[np.floating]](
+    a: np.ndarray[ShapeT, DTypeT],
     n: int | None = None,
     axis: int = -1,
     norm: _NormKind = None,
-    out: NDArray[float64] | None = None,
-) -> NDArray[float64]: ...
+    out: None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # Nd complex128 | +integer
+def irfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.complex128 | np.integer | np.bool]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+@overload  # Nd complex64
+def irfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.complex64]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.float32]]: ...
+@overload  # Nd clongdouble
+def irfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.clongdouble]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.longdouble]]: ...
+@overload  # 1d +complex
+def irfft(
+    a: Sequence[complex],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.float64]]: ...
+@overload  # 2d +complex
+def irfft(
+    a: Sequence[Sequence[complex]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.float64]]: ...
+@overload  # ?d floating
+def irfft[ScalarT: np.floating](
+    a: _ArrayLike[ScalarT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[ScalarT]: ...
+@overload  # ?d +complex | complex128 | +integer
+def irfft(
+    a: _DualArrayLike[np.dtype[np.complex128 | np.integer | np.bool], complex],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.float64]: ...
+@overload  # fallback
+def irfft(
+    a: _ArrayLikeNumber_co,
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.floating]: ...
+@overload  # out: <given>
+def irfft[ArrayT: NDArray[np.floating]](
+    a: _ArrayLikeNumber_co,
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
 # Input array must be compatible with `conjugate`
 def hfft(

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -28,7 +28,7 @@ type _NormKind = L["backward", "ortho", "forward"] | None
 
 ###
 
-# keep in sync with `ifft` below
+# keep in sync with `ifft`
 @overload  # Nd complexfloating
 def fft[ShapeT: _Shape, DTypeT: np.dtype[np.complexfloating]](
     a: np.ndarray[ShapeT, DTypeT],
@@ -111,7 +111,7 @@ def fft[ArrayT: NDArray[np.complexfloating]](
     out: ArrayT,
 ) -> ArrayT: ...
 
-# keep in sync with `fft` above
+# keep in sync with `fft`
 @overload  # Nd complexfloating
 def ifft[ShapeT: _Shape, DTypeT: np.dtype[np.complexfloating]](
     a: np.ndarray[ShapeT, DTypeT],
@@ -194,7 +194,7 @@ def ifft[ArrayT: NDArray[np.complexfloating]](
     out: ArrayT,
 ) -> ArrayT: ...
 
-#
+# keep in sync with `ihfft`
 @overload  # Nd float64 | +integer
 def rfft[ShapeT: _Shape](
     a: np.ndarray[ShapeT, np.dtype[np.float64 | np.integer | np.bool]],
@@ -261,7 +261,7 @@ def rfft[ArrayT: NDArray[np.complexfloating]](
     out: ArrayT,
 ) -> ArrayT: ...
 
-#
+# keep in sync with `hfft`
 @overload  # Nd floating
 def irfft[ShapeT: _Shape, DTypeT: np.dtype[np.floating]](
     a: np.ndarray[ShapeT, DTypeT],
@@ -344,14 +344,88 @@ def irfft[ArrayT: NDArray[np.floating]](
     out: ArrayT,
 ) -> ArrayT: ...
 
-# Input array must be compatible with `conjugate`
+# keep in sync with `irfft` above
+@overload  # Nd floating
+def hfft[ShapeT: _Shape, DTypeT: np.dtype[np.floating]](
+    a: np.ndarray[ShapeT, DTypeT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # Nd complex128 | +integer
+def hfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.complex128 | np.integer | np.bool]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+@overload  # Nd complex64
+def hfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.complex64]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.float32]]: ...
+@overload  # Nd clongdouble
+def hfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.clongdouble]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.longdouble]]: ...
+@overload  # 1d +complex
+def hfft(
+    a: Sequence[complex],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.float64]]: ...
+@overload  # 2d +complex
+def hfft(
+    a: Sequence[Sequence[complex]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.float64]]: ...
+@overload  # ?d floating
+def hfft[ScalarT: np.floating](
+    a: _ArrayLike[ScalarT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[ScalarT]: ...
+@overload  # ?d +complex | complex128 | +integer
+def hfft(
+    a: _DualArrayLike[np.dtype[np.complex128 | np.integer | np.bool], complex],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.float64]: ...
+@overload  # fallback
 def hfft(
     a: _ArrayLikeNumber_co,
     n: int | None = None,
     axis: int = -1,
     norm: _NormKind = None,
-    out: NDArray[float64] | None = None,
-) -> NDArray[float64]: ...
+    out: None = None,
+) -> NDArray[np.floating]: ...
+@overload  # out: <given>
+def hfft[ArrayT: NDArray[np.floating]](
+    a: _ArrayLikeNumber_co,
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
 def ihfft(
     a: ArrayLike,

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -2,10 +2,14 @@ from collections.abc import Sequence
 from typing import Literal as L, overload
 
 import numpy as np
-from numpy import float64
-from numpy._typing import _ArrayLike, _ArrayLikeFloat_co, _ArrayLikeNumber_co, _Shape
+from numpy._typing import (
+    NDArray,
+    _ArrayLike,
+    _ArrayLikeFloat_co,
+    _ArrayLikeNumber_co,
+    _Shape,
+)
 from numpy._typing._array_like import _DualArrayLike
-from numpy.typing import ArrayLike, NDArray
 
 __all__ = [
     "fft",
@@ -1044,10 +1048,84 @@ def rfft2[ArrayT: NDArray[np.complexfloating]](
 ) -> ArrayT: ...
 
 #
-def irfft2(
-    a: ArrayLike,
+@overload  # Nd floating
+def irfft2[ShapeT: _Shape, DTypeT: np.dtype[np.floating]](
+    a: np.ndarray[ShapeT, DTypeT],
     s: Sequence[int] | None = None,
     axes: Sequence[int] | None = (-2, -1),
     norm: _NormKind = None,
-    out: NDArray[float64] | None = None,
-) -> NDArray[float64]: ...
+    out: None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # Nd complex128 | +integer
+def irfft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.complex128 | np.integer | np.bool]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+@overload  # Nd complex64
+def irfft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.complex64]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.float32]]: ...
+@overload  # Nd clongdouble
+def irfft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.clongdouble]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.longdouble]]: ...
+@overload  # 1d +complex
+def irfft2(
+    a: Sequence[complex],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.float64]]: ...
+@overload  # 2d +complex
+def irfft2(
+    a: Sequence[Sequence[complex]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.float64]]: ...
+@overload  # ?d floating
+def irfft2[ScalarT: np.floating](
+    a: _ArrayLike[ScalarT],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[ScalarT]: ...
+@overload  # ?d +complex | complex128 | +integer
+def irfft2(
+    a: _DualArrayLike[np.dtype[np.complex128 | np.integer | np.bool], complex],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.float64]: ...
+@overload  # fallback
+def irfft2(
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.floating]: ...
+@overload  # out: <given>
+def irfft2[ArrayT: NDArray[np.floating]](
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -427,14 +427,74 @@ def hfft[ArrayT: NDArray[np.floating]](
     out: ArrayT,
 ) -> ArrayT: ...
 
-def ihfft(
-    a: ArrayLike,
+# keep in sync with `rfft`
+@overload  # Nd float64 | +integer
+def ihfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float64 | np.integer | np.bool]],
     n: int | None = None,
     axis: int = -1,
     norm: _NormKind = None,
-    out: NDArray[complex128] | None = None,
-) -> NDArray[complex128]: ...
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex128]]: ...
+@overload  # Nd float32 | float16
+def ihfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float32 | np.float16]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex64]]: ...
+@overload  # Nd longdouble
+def ihfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.longdouble]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.clongdouble]]: ...
+@overload  # 1d +float
+def ihfft(
+    a: Sequence[float],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.complex128]]: ...
+@overload  # 2d +float
+def ihfft(
+    a: Sequence[Sequence[float]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.complex128]]: ...
+@overload  # ?d +float
+def ihfft(
+    a: _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], float],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # fallback
+def ihfft(
+    a: _ArrayLikeFloat_co,
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complexfloating]: ...
+@overload  # out: <given>
+def ihfft[ArrayT: NDArray[np.complexfloating]](
+    a: _ArrayLikeFloat_co,
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
+#
 def fftn(
     a: ArrayLike,
     s: Sequence[int] | None = None,

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -1,8 +1,11 @@
 from collections.abc import Sequence
-from typing import Literal as L
+from typing import Literal as L, overload
 
+import numpy as np
 from numpy import complex128, float64
-from numpy._typing import ArrayLike, NDArray, _ArrayLikeNumber_co
+from numpy._typing import _ArrayLike, _ArrayLikeNumber_co, _Shape
+from numpy._typing._array_like import _DualArrayLike
+from numpy.typing import ArrayLike, NDArray
 
 __all__ = [
     "fft",
@@ -23,14 +26,91 @@ __all__ = [
 
 type _NormKind = L["backward", "ortho", "forward"] | None
 
+###
+
+@overload  # Nd complexfloating
+def fft[ShapeT: _Shape, DTypeT: np.dtype[np.complexfloating]](
+    a: np.ndarray[ShapeT, DTypeT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # Nd float64 | +integer
+def fft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float64 | np.integer | np.bool]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex128]]: ...
+@overload  # Nd float32 | float16
+def fft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float32 | np.float16]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex64]]: ...
+@overload  # Nd longdouble
+def fft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.longdouble]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.clongdouble]]: ...
+@overload  # 1d +complex
+def fft(
+    a: Sequence[complex],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.complex128]]: ...
+@overload  # 2d +complex
+def fft(
+    a: Sequence[Sequence[complex]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.complex128]]: ...
+@overload  # ?d complexfloating
+def fft[ScalarT: np.complexfloating](
+    a: _ArrayLike[ScalarT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[ScalarT]: ...
+@overload  # ?d +complex
+def fft(
+    a: _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], complex],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # fallback
 def fft(
     a: ArrayLike,
     n: int | None = None,
     axis: int = -1,
     norm: _NormKind = None,
-    out: NDArray[complex128] | None = None,
-) -> NDArray[complex128]: ...
+    out: None = None,
+) -> NDArray[np.complexfloating]: ...
+@overload  # out: <given>
+def fft[ArrayT: NDArray[np.complexfloating]](
+    a: ArrayLike,
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
+#
 def ifft(
     a: ArrayLike,
     n: int | None = None,
@@ -55,7 +135,7 @@ def irfft(
     out: NDArray[float64] | None = None,
 ) -> NDArray[float64]: ...
 
-# Input array must be compatible with `np.conjugate`
+# Input array must be compatible with `conjugate`
 def hfft(
     a: _ArrayLikeNumber_co,
     n: int | None = None,

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -810,23 +810,173 @@ def irfftn[ArrayT: NDArray[np.floating]](
     out: ArrayT,
 ) -> ArrayT: ...
 
-#
+# keep in sync with `ifft2`
+@overload  # Nd complexfloating
+def fft2[ShapeT: _Shape, DTypeT: np.dtype[np.complexfloating]](
+    a: np.ndarray[ShapeT, DTypeT],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # Nd float64 | +integer
+def fft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float64 | np.integer | np.bool]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex128]]: ...
+@overload  # Nd float32 | float16
+def fft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float32 | np.float16]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex64]]: ...
+@overload  # Nd longdouble
+def fft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.longdouble]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.clongdouble]]: ...
+@overload  # 1d +complex
 def fft2(
-    a: ArrayLike,
+    a: Sequence[complex],
     s: Sequence[int] | None = None,
     axes: Sequence[int] | None = (-2, -1),
     norm: _NormKind = None,
-    out: NDArray[complex128] | None = None,
-) -> NDArray[complex128]: ...
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.complex128]]: ...
+@overload  # 2d +complex
+def fft2(
+    a: Sequence[Sequence[complex]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.complex128]]: ...
+@overload  # ?d complexfloating
+def fft2[ScalarT: np.complexfloating](
+    a: _ArrayLike[ScalarT],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[ScalarT]: ...
+@overload  # ?d +complex
+def fft2(
+    a: _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], complex],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # fallback
+def fft2(
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complexfloating]: ...
+@overload  # out: <given>
+def fft2[ArrayT: NDArray[np.complexfloating]](
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
+# keep in sync with `fft2`
+@overload  # Nd complexfloating
+def ifft2[ShapeT: _Shape, DTypeT: np.dtype[np.complexfloating]](
+    a: np.ndarray[ShapeT, DTypeT],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # Nd float64 | +integer
+def ifft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float64 | np.integer | np.bool]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex128]]: ...
+@overload  # Nd float32 | float16
+def ifft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float32 | np.float16]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex64]]: ...
+@overload  # Nd longdouble
+def ifft2[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.longdouble]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.clongdouble]]: ...
+@overload  # 1d +complex
 def ifft2(
-    a: ArrayLike,
+    a: Sequence[complex],
     s: Sequence[int] | None = None,
     axes: Sequence[int] | None = (-2, -1),
     norm: _NormKind = None,
-    out: NDArray[complex128] | None = None,
-) -> NDArray[complex128]: ...
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.complex128]]: ...
+@overload  # 2d +complex
+def ifft2(
+    a: Sequence[Sequence[complex]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.complex128]]: ...
+@overload  # ?d complexfloating
+def ifft2[ScalarT: np.complexfloating](
+    a: _ArrayLike[ScalarT],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[ScalarT]: ...
+@overload  # ?d +complex
+def ifft2(
+    a: _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], complex],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # fallback
+def ifft2(
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complexfloating]: ...
+@overload  # out: <given>
+def ifft2[ArrayT: NDArray[np.complexfloating]](
+    a: _ArrayLikeNumber_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = (-2, -1),
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
+#
 def rfft2(
     a: ArrayLike,
     s: Sequence[int] | None = None,
@@ -835,6 +985,7 @@ def rfft2(
     out: NDArray[complex128] | None = None,
 ) -> NDArray[complex128]: ...
 
+#
 def irfft2(
     a: ArrayLike,
     s: Sequence[int] | None = None,

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -661,14 +661,73 @@ def ifftn[ArrayT: NDArray[np.complexfloating]](
 ) -> ArrayT: ...
 
 #
-def rfftn(
-    a: ArrayLike,
+@overload  # Nd float64 | +integer
+def rfftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float64 | np.integer | np.bool]],
     s: Sequence[int] | None = None,
     axes: Sequence[int] | None = None,
     norm: _NormKind = None,
-    out: NDArray[complex128] | None = None,
-) -> NDArray[complex128]: ...
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex128]]: ...
+@overload  # Nd float32 | float16
+def rfftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float32 | np.float16]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex64]]: ...
+@overload  # Nd longdouble
+def rfftn[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.longdouble]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.clongdouble]]: ...
+@overload  # 1d +float
+def rfftn(
+    a: Sequence[float],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.complex128]]: ...
+@overload  # 2d +float
+def rfftn(
+    a: Sequence[Sequence[float]],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.complex128]]: ...
+@overload  # ?d +float
+def rfftn(
+    a: _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], float],
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # fallback
+def rfftn(
+    a: _ArrayLikeFloat_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complexfloating]: ...
+@overload  # out: <given>
+def rfftn[ArrayT: NDArray[np.complexfloating]](
+    a: _ArrayLikeFloat_co,
+    s: Sequence[int] | None = None,
+    axes: Sequence[int] | None = None,
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
+#
 def irfftn(
     a: ArrayLike,
     s: Sequence[int] | None = None,

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -28,6 +28,7 @@ type _NormKind = L["backward", "ortho", "forward"] | None
 
 ###
 
+# keep in sync with `ifft` below
 @overload  # Nd complexfloating
 def fft[ShapeT: _Shape, DTypeT: np.dtype[np.complexfloating]](
     a: np.ndarray[ShapeT, DTypeT],
@@ -110,15 +111,90 @@ def fft[ArrayT: NDArray[np.complexfloating]](
     out: ArrayT,
 ) -> ArrayT: ...
 
-#
+# keep in sync with `fft` above
+@overload  # Nd complexfloating
+def ifft[ShapeT: _Shape, DTypeT: np.dtype[np.complexfloating]](
+    a: np.ndarray[ShapeT, DTypeT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # Nd float64 | +integer
+def ifft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float64 | np.integer | np.bool]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex128]]: ...
+@overload  # Nd float32 | float16
+def ifft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float32 | np.float16]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex64]]: ...
+@overload  # Nd longdouble
+def ifft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.longdouble]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.clongdouble]]: ...
+@overload  # 1d +complex
+def ifft(
+    a: Sequence[complex],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.complex128]]: ...
+@overload  # 2d +complex
+def ifft(
+    a: Sequence[Sequence[complex]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.complex128]]: ...
+@overload  # ?d complexfloating
+def ifft[ScalarT: np.complexfloating](
+    a: _ArrayLike[ScalarT],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[ScalarT]: ...
+@overload  # ?d +complex
+def ifft(
+    a: _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], complex],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # fallback
 def ifft(
     a: ArrayLike,
     n: int | None = None,
     axis: int = -1,
     norm: _NormKind = None,
-    out: NDArray[complex128] | None = None,
-) -> NDArray[complex128]: ...
+    out: None = None,
+) -> NDArray[np.complexfloating]: ...
+@overload  # out: <given>
+def ifft[ArrayT: NDArray[np.complexfloating]](
+    a: ArrayLike,
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
+#
 def rfft(
     a: ArrayLike,
     n: int | None = None,

--- a/numpy/fft/_pocketfft.pyi
+++ b/numpy/fft/_pocketfft.pyi
@@ -3,7 +3,7 @@ from typing import Literal as L, overload
 
 import numpy as np
 from numpy import complex128, float64
-from numpy._typing import _ArrayLike, _ArrayLikeNumber_co, _Shape
+from numpy._typing import _ArrayLike, _ArrayLikeFloat_co, _ArrayLikeNumber_co, _Shape
 from numpy._typing._array_like import _DualArrayLike
 from numpy.typing import ArrayLike, NDArray
 
@@ -95,7 +95,7 @@ def fft(
 ) -> NDArray[np.complex128]: ...
 @overload  # fallback
 def fft(
-    a: ArrayLike,
+    a: _ArrayLikeNumber_co,
     n: int | None = None,
     axis: int = -1,
     norm: _NormKind = None,
@@ -103,7 +103,7 @@ def fft(
 ) -> NDArray[np.complexfloating]: ...
 @overload  # out: <given>
 def fft[ArrayT: NDArray[np.complexfloating]](
-    a: ArrayLike,
+    a: _ArrayLikeNumber_co,
     n: int | None = None,
     axis: int = -1,
     norm: _NormKind = None,
@@ -178,7 +178,7 @@ def ifft(
 ) -> NDArray[np.complex128]: ...
 @overload  # fallback
 def ifft(
-    a: ArrayLike,
+    a: _ArrayLikeNumber_co,
     n: int | None = None,
     axis: int = -1,
     norm: _NormKind = None,
@@ -186,7 +186,7 @@ def ifft(
 ) -> NDArray[np.complexfloating]: ...
 @overload  # out: <given>
 def ifft[ArrayT: NDArray[np.complexfloating]](
-    a: ArrayLike,
+    a: _ArrayLikeNumber_co,
     n: int | None = None,
     axis: int = -1,
     norm: _NormKind = None,
@@ -195,14 +195,73 @@ def ifft[ArrayT: NDArray[np.complexfloating]](
 ) -> ArrayT: ...
 
 #
-def rfft(
-    a: ArrayLike,
+@overload  # Nd float64 | +integer
+def rfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float64 | np.integer | np.bool]],
     n: int | None = None,
     axis: int = -1,
     norm: _NormKind = None,
-    out: NDArray[complex128] | None = None,
-) -> NDArray[complex128]: ...
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex128]]: ...
+@overload  # Nd float32 | float16
+def rfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.float32 | np.float16]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.complex64]]: ...
+@overload  # Nd longdouble
+def rfft[ShapeT: _Shape](
+    a: np.ndarray[ShapeT, np.dtype[np.longdouble]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.clongdouble]]: ...
+@overload  # 1d +complex
+def rfft(
+    a: Sequence[float],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int], np.dtype[np.complex128]]: ...
+@overload  # 2d +complex
+def rfft(
+    a: Sequence[Sequence[float]],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> np.ndarray[tuple[int, int], np.dtype[np.complex128]]: ...
+@overload  # ?d +complex
+def rfft(
+    a: _DualArrayLike[np.dtype[np.float64 | np.integer | np.bool], float],
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # fallback
+def rfft(
+    a: _ArrayLikeFloat_co,
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    out: None = None,
+) -> NDArray[np.complexfloating]: ...
+@overload  # out: <given>
+def rfft[ArrayT: NDArray[np.complexfloating]](
+    a: _ArrayLikeFloat_co,
+    n: int | None = None,
+    axis: int = -1,
+    norm: _NormKind = None,
+    *,
+    out: ArrayT,
+) -> ArrayT: ...
 
+#
 def irfft(
     a: ArrayLike,
     n: int | None = None,

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -100,6 +100,11 @@ assert_type(np.fft.rfftfreq(5, _c160_nd), npt.NDArray[np.clongdouble])
 # the other fft functions
 
 assert_type(np.fft.fft(_f64_nd), npt.NDArray[np.complex128])
+assert_type(np.fft.fft(_i64_2d), _Array2D[np.complex128])
+assert_type(np.fft.fft(_f32_2d), _Array2D[np.complex64])
+assert_type(np.fft.fft(_c64_2d), _Array2D[np.complex64])
+assert_type(np.fft.fft(_py_float_1d), _Array1D[np.complex128])
+
 assert_type(np.fft.ifft(_f64_nd, axis=1), npt.NDArray[np.complex128])
 assert_type(np.fft.rfft(_f64_nd, n=None), npt.NDArray[np.complex128])
 assert_type(np.fft.irfft(_f64_nd, norm="ortho"), npt.NDArray[np.float64])

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -133,6 +133,9 @@ assert_type(np.fft.hfft(_c64_2d), _Array2D[np.float32])
 assert_type(np.fft.hfft(_py_complex_1d), _Array1D[np.float64])
 
 assert_type(np.fft.ihfft(_f64_nd), npt.NDArray[np.complex128])
+assert_type(np.fft.ihfft(_i64_2d), _Array2D[np.complex128])
+assert_type(np.fft.ihfft(_f32_2d), _Array2D[np.complex64])
+assert_type(np.fft.ihfft(_py_float_1d), _Array1D[np.complex128])
 
 assert_type(np.fft.fftn(_f64_nd), npt.NDArray[np.complex128])
 assert_type(np.fft.ifftn(_f64_nd), npt.NDArray[np.complex128])

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -97,9 +97,8 @@ assert_type(np.fft.rfftfreq(5, _f32_nd), npt.NDArray[np.float64])
 assert_type(np.fft.rfftfreq(5, _f80_nd), npt.NDArray[np.longdouble])
 assert_type(np.fft.rfftfreq(5, _c64_nd), npt.NDArray[np.complex128])
 assert_type(np.fft.rfftfreq(5, _c160_nd), npt.NDArray[np.clongdouble])
-...
 
-# the other fft functions
+# *fft
 
 assert_type(np.fft.fft(_f64_nd), npt.NDArray[np.complex128])
 assert_type(np.fft.fft(_i64_2d), _Array2D[np.complex128])
@@ -137,10 +136,25 @@ assert_type(np.fft.ihfft(_i64_2d), _Array2D[np.complex128])
 assert_type(np.fft.ihfft(_f32_2d), _Array2D[np.complex64])
 assert_type(np.fft.ihfft(_py_float_1d), _Array1D[np.complex128])
 
+# *fftn
+
 assert_type(np.fft.fftn(_f64_nd), npt.NDArray[np.complex128])
+assert_type(np.fft.fftn(_i64_2d), _Array2D[np.complex128])
+assert_type(np.fft.fftn(_f32_2d), _Array2D[np.complex64])
+assert_type(np.fft.fftn(_c64_2d), _Array2D[np.complex64])
+assert_type(np.fft.fftn(_py_float_1d), _Array1D[np.complex128])
+
 assert_type(np.fft.ifftn(_f64_nd), npt.NDArray[np.complex128])
+assert_type(np.fft.ifftn(_i64_2d), _Array2D[np.complex128])
+assert_type(np.fft.ifftn(_f32_2d), _Array2D[np.complex64])
+assert_type(np.fft.ifftn(_c64_2d), _Array2D[np.complex64])
+assert_type(np.fft.ifftn(_py_float_1d), _Array1D[np.complex128])
+
 assert_type(np.fft.rfftn(_f64_nd), npt.NDArray[np.complex128])
+
 assert_type(np.fft.irfftn(_f64_nd), npt.NDArray[np.float64])
+
+# *fft2
 
 assert_type(np.fft.rfft2(_f64_nd), npt.NDArray[np.complex128])
 assert_type(np.fft.ifft2(_f64_nd), npt.NDArray[np.complex128])

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -125,7 +125,13 @@ assert_type(np.fft.irfft(_f32_2d), _Array2D[np.float32])
 assert_type(np.fft.irfft(_c64_2d), _Array2D[np.float32])
 assert_type(np.fft.irfft(_py_complex_1d), _Array1D[np.float64])
 
-assert_type(np.fft.hfft(_f64_nd, n=2), npt.NDArray[np.float64])
+assert_type(np.fft.hfft(_f64_nd), npt.NDArray[np.float64])
+assert_type(np.fft.hfft(_i64_2d), _Array2D[np.float64])
+assert_type(np.fft.hfft(_f16_2d), _Array2D[np.float16])
+assert_type(np.fft.hfft(_f32_2d), _Array2D[np.float32])
+assert_type(np.fft.hfft(_c64_2d), _Array2D[np.float32])
+assert_type(np.fft.hfft(_py_complex_1d), _Array1D[np.float64])
+
 assert_type(np.fft.ihfft(_f64_nd), npt.NDArray[np.complex128])
 
 assert_type(np.fft.fftn(_f64_nd), npt.NDArray[np.complex128])

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -164,7 +164,18 @@ assert_type(np.fft.irfftn(_py_complex_1d), _Array1D[np.float64])
 
 # *fft2
 
-assert_type(np.fft.rfft2(_f64_nd), npt.NDArray[np.complex128])
-assert_type(np.fft.ifft2(_f64_nd), npt.NDArray[np.complex128])
 assert_type(np.fft.fft2(_f64_nd), npt.NDArray[np.complex128])
+assert_type(np.fft.fft2(_i64_2d), _Array2D[np.complex128])
+assert_type(np.fft.fft2(_f32_2d), _Array2D[np.complex64])
+assert_type(np.fft.fft2(_c64_2d), _Array2D[np.complex64])
+assert_type(np.fft.fft2(_py_float_1d), _Array1D[np.complex128])
+
+assert_type(np.fft.ifft2(_f64_nd), npt.NDArray[np.complex128])
+assert_type(np.fft.ifft2(_i64_2d), _Array2D[np.complex128])
+assert_type(np.fft.ifft2(_f32_2d), _Array2D[np.complex64])
+assert_type(np.fft.ifft2(_c64_2d), _Array2D[np.complex64])
+assert_type(np.fft.ifft2(_py_float_1d), _Array1D[np.complex128])
+
+assert_type(np.fft.fft2(_f64_nd), npt.NDArray[np.complex128])
+
 assert_type(np.fft.irfft2(_f64_nd), npt.NDArray[np.float64])

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -182,3 +182,8 @@ assert_type(np.fft.rfft2(_f32_2d), _Array2D[np.complex64])
 assert_type(np.fft.rfft2(_py_float_1d), _Array1D[np.complex128])
 
 assert_type(np.fft.irfft2(_f64_nd), npt.NDArray[np.float64])
+assert_type(np.fft.irfft2(_i64_2d), _Array2D[np.float64])
+assert_type(np.fft.irfft2(_f16_2d), _Array2D[np.float16])
+assert_type(np.fft.irfft2(_f32_2d), _Array2D[np.float32])
+assert_type(np.fft.irfft2(_c64_2d), _Array2D[np.float32])
+assert_type(np.fft.irfft2(_py_complex_1d), _Array1D[np.float64])

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -105,7 +105,12 @@ assert_type(np.fft.fft(_f32_2d), _Array2D[np.complex64])
 assert_type(np.fft.fft(_c64_2d), _Array2D[np.complex64])
 assert_type(np.fft.fft(_py_float_1d), _Array1D[np.complex128])
 
-assert_type(np.fft.ifft(_f64_nd, axis=1), npt.NDArray[np.complex128])
+assert_type(np.fft.ifft(_f64_nd), npt.NDArray[np.complex128])
+assert_type(np.fft.ifft(_i64_2d), _Array2D[np.complex128])
+assert_type(np.fft.ifft(_f32_2d), _Array2D[np.complex64])
+assert_type(np.fft.ifft(_c64_2d), _Array2D[np.complex64])
+assert_type(np.fft.ifft(_py_float_1d), _Array1D[np.complex128])
+
 assert_type(np.fft.rfft(_f64_nd, n=None), npt.NDArray[np.complex128])
 assert_type(np.fft.irfft(_f64_nd, norm="ortho"), npt.NDArray[np.float64])
 assert_type(np.fft.hfft(_f64_nd, n=2), npt.NDArray[np.float64])

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -151,6 +151,9 @@ assert_type(np.fft.ifftn(_c64_2d), _Array2D[np.complex64])
 assert_type(np.fft.ifftn(_py_float_1d), _Array1D[np.complex128])
 
 assert_type(np.fft.rfftn(_f64_nd), npt.NDArray[np.complex128])
+assert_type(np.fft.rfftn(_i64_2d), _Array2D[np.complex128])
+assert_type(np.fft.rfftn(_f32_2d), _Array2D[np.complex64])
+assert_type(np.fft.rfftn(_py_float_1d), _Array1D[np.complex128])
 
 assert_type(np.fft.irfftn(_f64_nd), npt.NDArray[np.float64])
 

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -111,7 +111,11 @@ assert_type(np.fft.ifft(_f32_2d), _Array2D[np.complex64])
 assert_type(np.fft.ifft(_c64_2d), _Array2D[np.complex64])
 assert_type(np.fft.ifft(_py_float_1d), _Array1D[np.complex128])
 
-assert_type(np.fft.rfft(_f64_nd, n=None), npt.NDArray[np.complex128])
+assert_type(np.fft.rfft(_f64_nd), npt.NDArray[np.complex128])
+assert_type(np.fft.rfft(_i64_2d), _Array2D[np.complex128])
+assert_type(np.fft.rfft(_f32_2d), _Array2D[np.complex64])
+assert_type(np.fft.rfft(_py_float_1d), _Array1D[np.complex128])
+
 assert_type(np.fft.irfft(_f64_nd, norm="ortho"), npt.NDArray[np.float64])
 assert_type(np.fft.hfft(_f64_nd, n=2), npt.NDArray[np.float64])
 assert_type(np.fft.ihfft(_f64_nd), npt.NDArray[np.complex128])

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -156,6 +156,11 @@ assert_type(np.fft.rfftn(_f32_2d), _Array2D[np.complex64])
 assert_type(np.fft.rfftn(_py_float_1d), _Array1D[np.complex128])
 
 assert_type(np.fft.irfftn(_f64_nd), npt.NDArray[np.float64])
+assert_type(np.fft.irfftn(_i64_2d), _Array2D[np.float64])
+assert_type(np.fft.irfftn(_f16_2d), _Array2D[np.float16])
+assert_type(np.fft.irfftn(_f32_2d), _Array2D[np.float32])
+assert_type(np.fft.irfftn(_c64_2d), _Array2D[np.float32])
+assert_type(np.fft.irfftn(_py_complex_1d), _Array1D[np.float64])
 
 # *fft2
 

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -11,6 +11,7 @@ type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[Scalar
 _f64_nd: npt.NDArray[np.float64]
 _c128_nd: npt.NDArray[np.complex128]
 _py_float_1d: list[float]
+_py_complex_1d: list[complex]
 
 _i64: np.int64
 _f32: np.float16
@@ -19,6 +20,7 @@ _c64: np.complex64
 _c160: np.clongdouble
 
 _i64_2d: _Array2D[np.int64]
+_f16_2d: _Array2D[np.float16]
 _f32_2d: _Array2D[np.float32]
 _f80_2d: _Array2D[np.longdouble]
 _c64_2d: _Array2D[np.complex64]
@@ -116,7 +118,13 @@ assert_type(np.fft.rfft(_i64_2d), _Array2D[np.complex128])
 assert_type(np.fft.rfft(_f32_2d), _Array2D[np.complex64])
 assert_type(np.fft.rfft(_py_float_1d), _Array1D[np.complex128])
 
-assert_type(np.fft.irfft(_f64_nd, norm="ortho"), npt.NDArray[np.float64])
+assert_type(np.fft.irfft(_f64_nd), npt.NDArray[np.float64])
+assert_type(np.fft.irfft(_i64_2d), _Array2D[np.float64])
+assert_type(np.fft.irfft(_f16_2d), _Array2D[np.float16])
+assert_type(np.fft.irfft(_f32_2d), _Array2D[np.float32])
+assert_type(np.fft.irfft(_c64_2d), _Array2D[np.float32])
+assert_type(np.fft.irfft(_py_complex_1d), _Array1D[np.float64])
+
 assert_type(np.fft.hfft(_f64_nd, n=2), npt.NDArray[np.float64])
 assert_type(np.fft.ihfft(_f64_nd), npt.NDArray[np.complex128])
 

--- a/numpy/typing/tests/data/reveal/fft.pyi
+++ b/numpy/typing/tests/data/reveal/fft.pyi
@@ -176,6 +176,9 @@ assert_type(np.fft.ifft2(_f32_2d), _Array2D[np.complex64])
 assert_type(np.fft.ifft2(_c64_2d), _Array2D[np.complex64])
 assert_type(np.fft.ifft2(_py_float_1d), _Array1D[np.complex128])
 
-assert_type(np.fft.fft2(_f64_nd), npt.NDArray[np.complex128])
+assert_type(np.fft.rfft2(_f64_nd), npt.NDArray[np.complex128])
+assert_type(np.fft.rfft2(_i64_2d), _Array2D[np.complex128])
+assert_type(np.fft.rfft2(_f32_2d), _Array2D[np.complex64])
+assert_type(np.fft.rfft2(_py_float_1d), _Array1D[np.complex128])
 
 assert_type(np.fft.irfft2(_f64_nd), npt.NDArray[np.float64])


### PR DESCRIPTION
This adds support for shape-typing and non-`float64`/`complex128` dtypes to:

- `np.fft.fft`
- `np.fft.ifft`
- `np.fft.rfft`
- `np.fft.irfft`
- `np.fft.hfft`
- `np.fft.ihfft`
- `np.fft.fftn`
- `np.fft.ifftn`
- `np.fft.rfftn`
- `np.fft.irfftn`
- `np.fft.fft2`
- `np.fft.ifft2`
- `np.fft.rfft2`
- `np.fft.irfft2`

#### AI Disclosure
The release note was in part written by copilot (Claude Opus 4.6 - High)