### PR TITLE
DOC: fix article grammar ("a" -> "an") before vowel sounds

### DIFF
--- a/doc/source/release/1.22.0-notes.rst
+++ b/doc/source/release/1.22.0-notes.rst
@@ -191,7 +191,7 @@ New Features
 NEP 49 configurable allocators
 ------------------------------
 As detailed in `NEP 49`_, the function used for allocation of the data segment
-of a ndarray can be changed. The policy can be set globally or in a context.
+of an ndarray can be changed. The policy can be set globally or in a context.
 For more information see the NEP and the :ref:`data_memory` reference docs.
 Also add a ``NUMPY_WARN_IF_NO_MEM_POLICY`` override to warn on dangerous use
 of transferring ownership by setting ``NPY_ARRAY_OWNDATA``.

--- a/doc/source/release/1.23.0-notes.rst
+++ b/doc/source/release/1.23.0-notes.rst
@@ -27,7 +27,7 @@ New functions
 
 * ``numpy.from_dlpack`` has been added to allow easy exchange of data using the
   DLPack protocol.  It accepts Python objects that implement the ``__dlpack__``
-  and ``__dlpack_device__`` methods and returns a ndarray object which is
+  and ``__dlpack_device__`` methods and returns an ndarray object which is
   generally the view of the data of the input object.
 
   (`gh-21145 <https://github.com/numpy/numpy/pull/21145>`__)

--- a/doc/source/release/2.3.0-notes.rst
+++ b/doc/source/release/2.3.0-notes.rst
@@ -212,7 +212,7 @@ Expired deprecations
 
   (`gh-28254 <https://github.com/numpy/numpy/pull/28254>`__)
  
-* Special handling of matrix is in np.outer is removed. Convert to a ndarray
+* Special handling of matrix is in np.outer is removed. Convert to an ndarray
   via ``matrix.A`` (deprecated since 1.20)
 
   (`gh-28254 <https://github.com/numpy/numpy/pull/28254>`__)

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -321,7 +321,7 @@ def nanmin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     Positive infinity is treated as a very large number and negative
     infinity is treated as a very small (i.e. negative) number.
 
-    If the input has a integer type the function is equivalent to np.min.
+    If the input has an integer type the function is equivalent to np.min.
 
     Examples
     --------
@@ -450,7 +450,7 @@ def nanmax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     Positive infinity is treated as a very large number and negative
     infinity is treated as a very small (i.e. negative) number.
 
-    If the input has a integer type the function is equivalent to np.max.
+    If the input has an integer type the function is equivalent to np.max.
 
     Examples
     --------

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2692,7 +2692,7 @@ class TestUfuncs:
         assert_(amask.min(1)[0].mask)
 
     def test_ndarray_mask(self):
-        # Check that the mask of the result is a ndarray (not a MaskedArray...)
+        # Check that the mask of the result is an ndarray (not a MaskedArray...)
         a = masked_array([-1, 0, 1, 2, 3], mask=[0, 0, 0, 0, 1])
         test = np.sqrt(a)
         control = masked_array([-1, 0, 1, np.sqrt(2), -1],
@@ -4305,7 +4305,7 @@ class TestMaskedArrayMathMethods:
             method(out=mout)
             assert_(mout is not masked)
             assert_equal(mout.mask, True)
-            # Using a ndarray as explicit output
+            # Using an ndarray as explicit output
             method(out=nout)
             assert_(np.isnan(nout))
 
@@ -4320,7 +4320,7 @@ class TestMaskedArrayMathMethods:
             method(out=mout, ddof=1)
             assert_(mout is not masked)
             assert_equal(mout.mask, True)
-            # Using a ndarray as explicit output
+            # Using an ndarray as explicit output
             method(out=nout, ddof=1)
             assert_(np.isnan(nout))
 
@@ -4974,7 +4974,7 @@ class TestMaskedArrayFunctions:
         test = make_mask(mask)
         assert_equal(test.dtype, MaskType)
         assert_equal(test, [0, 1])
-        # w/ a ndarray as an input
+        # w/ an ndarray as an input
         mask = np.array([0, 1], dtype=bool)
         test = make_mask(mask)
         assert_equal(test.dtype, MaskType)

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1605,7 +1605,7 @@ class TestArraySetOps:
         assert_equal(test.mask, control.mask)
 
     def test_ediff1d_ndarray(self):
-        # Test ediff1d w/ a ndarray
+        # Test ediff1d w/ an ndarray
         x = np.arange(5)
         test = ediff1d(x)
         control = array([1, 1, 1, 1], mask=[0, 0, 0, 0])


### PR DESCRIPTION
### PR summary
Fixes incorrect indefinite article usage ("a" → "an") before words
starting with vowel sounds across docstrings, release notes, and test
comments.

Changes:
- "a integer" → "an integer" in `nanmin`/`nanmax` docstrings
- "a ndarray" → "an ndarray" in release notes (1.22.0, 1.23.0, 2.3.0)
  and test comments in `numpy/ma/tests/`

### AI Disclosure
No AI tools used.