### PR TITLE
BUG: handle infinities in np.sinc

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3815,6 +3815,25 @@ def sinc(x):
         y = where(is_inf, 1, y)
         return where(is_inf, 0.0, sin(y) / y)
     
+    if x.dtype.kind == "c":
+        real_inf = np.isinf(x.real)
+        imag_inf = np.isinf(x.imag)
+
+        # Case 1: infinite real part, finite imaginary part -> 0 
+        real_inf_only = real_inf & ~imag_inf
+        y = where(real_inf_only, 1.0 + 0.0j, y)
+        out = sin(y) / y
+        out = where(real_inf_only, 0.0 + 0.0j, out)
+
+        # Case 2: infinite imaginary part -> magnitude blows up
+        imag_pos = imag_inf & (x.imag > 0)
+        imag_neg = imag_inf & (x.imag < 0)
+
+        # Use a simple infinite complex formula.
+        out = where(imag_pos, np.inf + 1j * np.inf, out)
+        out = where(imag_neg, np.inf - 1j * np.inf, out)
+
+        return out
     return sin(y) / y
 
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3810,6 +3810,11 @@ def sinc(x):
     # Hope that 1e-20 is sufficient for objects...
     eps = np.finfo(x.dtype).eps if x.dtype.kind == "f" else 1e-20
     y = where(x, x, eps)
+    if x.dtype.kind == "f":
+        is_inf = np.isinf(x)
+        y = where(is_inf, 1, y)
+        return where(is_inf, 0.0, sin(y) / y)
+    
     return sin(y) / y
 
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2472,6 +2472,10 @@ class TestSinc:
         # resulting in nan
         assert_array_equal(sinc(x), np.asarray(1.0))
 
+    def test_inf(self):
+        assert(sinc(np.inf) == 0)
+        assert(sinc(-np.inf) == 0)
+
 
 class TestUnique:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2473,9 +2473,16 @@ class TestSinc:
         assert_array_equal(sinc(x), np.asarray(1.0))
 
     def test_inf(self):
-        assert(sinc(np.inf) == 0)
-        assert(sinc(-np.inf) == 0)
+        assert sinc(np.inf) == 0.0
+        assert sinc(-np.inf) == 0.0
+        assert sinc(np.inf + 0j) == 0.0 + 0.0j
+        assert sinc(-np.inf + 0j) == 0.0 + 0.0j
 
+    def test_complex_imag_inf(self):
+        out1 = sinc(1j * np.inf)
+        out2 = sinc(-1j * np.inf)
+        assert np.isinf(out1.real) or np.isinf(out1.imag)
+        assert np.isinf(out2.real) or np.isinf(out2.imag)
 
 class TestUnique:
 


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.


  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->The initial issue was this one https://github.com/numpy/numpy/issues/31027
initial bug : np.sinc(np.inf) returned nan
correction : I wrote a condition to verifiy this case

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->it's my first contribution. It's for a homework for my school : Telecom Paris in France. thank you for your welcome

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
--> I used AI to find where is the function sunc is written, and to help me navigate in documentation. It's all. I wrote this few code by myself.