### PR TITLE
DOC: fix project name capitalization (Numpy -> NumPy)

### DIFF
--- a/benchmarks/benchmarks/bench_app.py
+++ b/benchmarks/benchmarks/bench_app.py
@@ -70,7 +70,7 @@ class MaxesOfDots(Benchmark):
 
         Arrays must agree only on the first dimension.
 
-        Numpy uses this as a simultaneous benchmark of 1) dot products
+        NumPy uses this as a simultaneous benchmark of 1) dot products
         and 2) max(<array>, axis=<int>).
         """
         feature_scores = ([0] * len(arrays))

--- a/doc/source/dev/development_advanced_debugging.rst
+++ b/doc/source/dev/development_advanced_debugging.rst
@@ -72,7 +72,7 @@ e.g. ``pythond -m sysconfig`` to get the build configuration for the Python
 executable. A debug build will be built with debug compiler options in
 ``CFLAGS`` (e.g. ``-g -Og``).
 
-Running the Numpy tests or an interactive terminal is usually as easy as::
+Running the NumPy tests or an interactive terminal is usually as easy as::
 
     python3.8d runtests.py
     # or
@@ -231,7 +231,7 @@ crash. The call stack often provides valuable context to understand the nature
 of a crash. C debuggers are also very useful during development, allowing
 interactive debugging in the C implementation of NumPy.
 
-The NumPy developers often use both ``gdb`` and ``lldb`` to debug Numpy. As a
+The NumPy developers often use both ``gdb`` and ``lldb`` to debug NumPy. As a
 rule of thumb, ``gdb`` is often easier to use on Linux while ``lldb`` is easier
 to use on a Mac environment. They have disjoint user interfaces, so you will need to
 learn how to use whichever one you land on. The ``gdb`` to ``lldb`` `command map

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -223,7 +223,7 @@ these fragments in each commit message of a PR:
 Test building wheels
 ~~~~~~~~~~~~~~~~~~~~
 
-Numpy currently uses `cibuildwheel <https://cibuildwheel.readthedocs.io/en/stable/>`_
+NumPy currently uses `cibuildwheel <https://cibuildwheel.readthedocs.io/en/stable/>`_
 in order to build wheels through continuous integration services. To save resources, the
 cibuildwheel wheel builders are not run by default on every single PR or commit to main.
 

--- a/doc/source/user/theory.broadcasting.rst
+++ b/doc/source/user/theory.broadcasting.rst
@@ -1,7 +1,7 @@
 :orphan:
 
 ===========================
-Array broadcasting in Numpy
+Array broadcasting in NumPy
 ===========================
 
 .. 


### PR DESCRIPTION
PR summary
Fixes inconsistent capitalization of the project name ("Numpy" → "NumPy")
across developer docs, user docs, and benchmarks.

Changes:

- "Numpy" → "NumPy" in `benchmarks/benchmarks/bench_app.py`
- "Numpy" → "NumPy" in `doc/source/dev/development_advanced_debugging.rst`
- "Numpy" → "NumPy" in `doc/source/dev/development_workflow.rst`
- "Numpy" → "NumPy" in `doc/source/user/theory.broadcasting.rst`

AI Disclosure
No AI tools used.