### PR TITLE
BUG: fix spurious dtype deprecation in ndarray.view() for subclasses

### DIFF
--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -23,6 +23,7 @@
 
 #include "convert.h"
 #include "array_coercion.h"
+#include "getset.h"
 #include "refcount.h"
 
 #if defined(HAVE_FALLOCATE) && defined(__linux__)
@@ -558,8 +559,11 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
     }
 
     if (type != NULL) {
-        if (PyObject_SetAttrString((PyObject *)ret, "dtype",
-                                   (PyObject *)type) < 0) {
+        _numpy_view_dtype_set_in_progress = 1;
+        int set_ret = PyObject_SetAttrString((PyObject *)ret, "dtype",
+                                             (PyObject *)type);
+        _numpy_view_dtype_set_in_progress = 0;
+        if (set_ret < 0) {
             Py_DECREF(ret);
             Py_DECREF(type);
             return NULL;

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -29,6 +29,8 @@
 #include "multiarraymodule.h"
 #include "array_api_standard.h"
 
+NPY_NO_EXPORT int _numpy_view_dtype_set_in_progress = 0;
+
 /*******************  array attribute get and set routines ******************/
 
 static PyObject *
@@ -512,10 +514,13 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
         return -1;
     }
 
-    if (non_unique_reference((PyObject *)self)) {
-         // this will not emit deprecation warnings for all cases, but for most it will
-         // we skip unique references, so that we will not get a deprecation warning
-         // when array.view(new_dtype) is called
+    /*
+     * Skip the deprecation when PyArray_View is setting .dtype internally
+     * Subclass __setattr__ adds extra refcounts during dispatch, which
+     * makes non_unique_reference() give a false positive (gh-31192).
+     */
+    if (!_numpy_view_dtype_set_in_progress
+            && non_unique_reference((PyObject *)self)) {
          /* DEPRECATED 2026-02-06, NumPy 2.5 */
          int ret = PyErr_WarnEx(PyExc_DeprecationWarning,
                     "Setting the dtype on a NumPy array has been deprecated in NumPy 2.5.\n"

--- a/numpy/_core/src/multiarray/getset.h
+++ b/numpy/_core/src/multiarray/getset.h
@@ -6,4 +6,10 @@ extern NPY_NO_EXPORT PyGetSetDef array_getsetlist[];
 NPY_NO_EXPORT int array_descr_set_internal(PyArrayObject *self, PyObject *arg);
 NPY_NO_EXPORT int array_shape_set_internal(PyArrayObject *self, PyObject *val);
 
+/*
+ * Set by PyArray_View to suppress the dtype-setting deprecation
+ * in array_descr_set().  See gh-31192.
+ */
+extern NPY_NO_EXPORT int _numpy_view_dtype_set_in_progress;
+
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_GETSET_H_ */

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -259,6 +259,16 @@ class TestDeprecatedArrayAttributeSetting(_DeprecationTestCase):
         x = np.eye(2)
         self.assert_deprecated(setattr, args=(x, "shape", (4, 1)))
 
+    def test_view_no_deprecation_on_subclass_with_setattr(self):
+        # gh-31192
+        class SubArray(np.ndarray):
+            def __setattr__(self, name, value):
+                super().__setattr__(name, value)
+
+        a = np.array([1, 2, 3]).view(SubArray)
+        self.assert_not_deprecated(lambda: a.view(np.int8))
+        assert a.view(np.int8).dtype == np.int8
+
 class TestDeprecatedDTypeParenthesizedRepeatCount(_DeprecationTestCase):
     message = "Passing in a parenthesized single number"
 


### PR DESCRIPTION
Closes #31192

### PR summary

`PyArray_View` sets `.dtype` on the new view by `PyObject_SetAttrString`. for subclasses that define `__setattr__`, python's method dispatch add a temporary refcounts to `self` during the call so `non_unique_reference()` returns  `true ` and the deprecation from gh-29575 happens even though the user never actually set `.dtype` directly 

the PR adds a module-level flag that `PyArray_View` sets around the `PyObject_SetAttrString` call. `array_descr_set` checks the flag and skips the deprecation for the internal assignment. the full attribute protocol is the same so subclass hooks like MaskedArray's dtype property setter should still work alright.

#### AI Disclosure

I used cursor (claude) to check I didn't miss anything important + to double check my code's accuracy + run tests for me. I double checked everything before the PR