### PR TITLE
DOC: clarify that read_array_header requires prior read_magic call

### DIFF
--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -519,6 +519,9 @@ def read_array_header_1_0(fp, max_header_size=_MAX_HEADER_SIZE):
     ----------
     fp : filelike object
         A file object or something with a `.read()` method like a file.
+        Must be positioned at the start of the header, just after the
+        magic string and version bytes. This can be done by calling
+        `read_magic` on ``fp`` first.
 
     Returns
     -------
@@ -557,6 +560,9 @@ def read_array_header_2_0(fp, max_header_size=_MAX_HEADER_SIZE):
     ----------
     fp : filelike object
         A file object or something with a `.read()` method like a file.
+        Must be positioned at the start of the header, just after the
+        magic string and version bytes. This can be done by calling
+        `read_magic` on ``fp`` first.
     max_header_size : int, optional
         Maximum allowed size of the header.  Large headers may not be safe
         to load securely and thus require explicitly passing a larger value.


### PR DESCRIPTION
### PR summary

Update the docstrings for `read_array_header_1_0` and
`read_array_header_2_0` to note that the file object must be positioned
after the magic string and version bytes, e.g. by calling `read_magic`
first.

Closes #29159

#### AI Disclosure

No AI tools used