### PR TITLE
BUG,DEP: Change logic for ``arr.view()`` to use ``_set_dtype``

### DIFF
--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -6,6 +6,7 @@
 #include <structmember.h>
 
 #include "npy_config.h"
+#include "npy_pycompat.h"  // PyObject_GetOptionalAttr
 
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -24,6 +24,8 @@
 #include "convert.h"
 #include "array_coercion.h"
 #include "refcount.h"
+#include "getset.h"
+#include "npy_static_data.h"
 
 #if defined(HAVE_FALLOCATE) && defined(__linux__)
 #include <fcntl.h>
@@ -352,17 +354,17 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
         || (PyArray_IS_F_CONTIGUOUS(self) && (order == NPY_FORTRANORDER))) {
         return PyBytes_FromStringAndSize(PyArray_DATA(self), (Py_ssize_t) numbytes);
     }
-    
+
     /* Avoid Ravel where possible for fewer copies. */
-    if (!PyDataType_REFCHK(PyArray_DESCR(self)) && 
+    if (!PyDataType_REFCHK(PyArray_DESCR(self)) &&
         ((PyArray_DESCR(self)->flags & NPY_NEEDS_INIT) == 0)) {
-        
+
         /* Allocate final Bytes Object */
         ret = PyBytes_FromStringAndSize(NULL, (Py_ssize_t) numbytes);
         if (ret == NULL) {
             return NULL;
         }
-        
+
         /* Writable Buffer */
         char* dest = PyBytes_AS_STRING(ret);
 
@@ -388,14 +390,14 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
             Py_DECREF(ret);
             return NULL;
         }
-        
+
         /* Copy directly from source to destination with proper ordering */
         if (PyArray_CopyInto(dest_array, self) < 0) {
             Py_DECREF(dest_array);
             Py_DECREF(ret);
             return NULL;
         }
-        
+
         Py_DECREF(dest_array);
         return ret;
 
@@ -406,7 +408,7 @@ PyArray_ToString(PyArrayObject *self, NPY_ORDER order)
     if (contig == NULL) {
         return NULL;
     }
-    
+
     ret = PyBytes_FromStringAndSize(PyArray_DATA(contig), numbytes);
     Py_DECREF(contig);
     return ret;
@@ -545,26 +547,129 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
     dtype = PyArray_DESCR(self);
     flags = PyArray_FLAGS(self);
 
+    if (type == NULL) {
+        /* No dtype change: just create the view */
+        Py_INCREF(dtype);
+        ret = (PyArrayObject *)PyArray_NewFromDescr_int(
+                subtype, dtype,
+                PyArray_NDIM(self), PyArray_DIMS(self),
+                PyArray_STRIDES(self), PyArray_DATA(self),
+                flags, (PyObject *)self, (PyObject *)self,
+                _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
+        return (PyObject *)ret;
+    }
+
+    /*
+     * Changing dtype on a subclass.  We support three paths:
+     *
+     * 1. subclass overrides _set_dtype: create subclass view first,
+     *    then call _set_dtype (subclass handles dtype change).
+     * 2. subclass overrides the dtype descriptor (e.g. property with
+     *    setter): create subclass view first, use the setter, but
+     *    emit a deprecation asking to implement _set_dtype instead.
+     * 3. Otherwise (including plain ndarray): create an ndarray base
+     *    view, set dtype internally, then create the subclass view
+     *    if needed.  __array_finalize__ sees the final dtype+shape.
+     */
+    int use_set_dtype = 0;
+    int use_dtype_prop = 0;
+
+    if (subtype != &PyArray_Type) {
+        PyObject *sub_set_dtype;
+        if (PyObject_GetOptionalAttr(
+                (PyObject *)subtype,
+                npy_interned_str._set_dtype, &sub_set_dtype) < 0) {
+            goto finish;
+        }
+        use_set_dtype = (sub_set_dtype != NULL &&
+                sub_set_dtype != npy_static_pydata.ndarray_set_dtype);
+        Py_XDECREF(sub_set_dtype);
+
+        if (!use_set_dtype) {
+            PyObject *sub_dtype_descr;
+            if (PyObject_GetOptionalAttr(
+                    (PyObject *)subtype,
+                    npy_interned_str.dtype, &sub_dtype_descr) < 0) {
+                goto finish;
+            }
+            use_dtype_prop = (sub_dtype_descr != NULL &&
+                    sub_dtype_descr != npy_static_pydata.ndarray_dtype_descr &&
+                    Py_TYPE(sub_dtype_descr)->tp_descr_set != NULL);
+            Py_XDECREF(sub_dtype_descr);
+        }
+    }
+
+    if (use_set_dtype || use_dtype_prop) {
+        /*
+         * Paths 1 & 2: create subclass view with original dtype,
+         * then let the subclass handle the dtype change.
+         */
+        Py_INCREF(dtype);
+        ret = (PyArrayObject *)PyArray_NewFromDescr_int(
+                subtype, dtype,
+                PyArray_NDIM(self), PyArray_DIMS(self),
+                PyArray_STRIDES(self), PyArray_DATA(self),
+                flags, (PyObject *)self, (PyObject *)self,
+                _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
+        if (ret == NULL) {
+            goto finish;
+        }
+        if (use_set_dtype) {
+            PyObject *res = PyObject_CallMethodOneArg(
+                    (PyObject *)ret,
+                    npy_interned_str._set_dtype, (PyObject *)type);
+            if (res == NULL) {
+                Py_CLEAR(ret);
+                goto finish;
+            }
+            Py_DECREF(res);
+        }
+        else {
+            if (PyObject_GenericSetAttr(
+                    (PyObject *)ret, npy_interned_str.dtype,
+                    (PyObject *)type) < 0) {
+                Py_CLEAR(ret);
+                goto finish;
+            }
+            /* DEPRECATED 2026-04-13, NumPy 2.5 */
+            if (DEPRECATE(
+                    "numpy.ndarray.view() used a custom `dtype` setter "
+                    "to change the dtype of the view.  Subclasses should "
+                    "implement `_set_dtype` instead.") < 0) {
+                Py_CLEAR(ret);
+                goto finish;
+            }
+        }
+        goto finish;
+    }
+
+    /* Path 3: create ndarray base view and set dtype internally */
     Py_INCREF(dtype);
     ret = (PyArrayObject *)PyArray_NewFromDescr_int(
-            subtype, dtype,
-            PyArray_NDIM(self), PyArray_DIMS(self), PyArray_STRIDES(self),
-            PyArray_DATA(self),
+            &PyArray_Type, dtype,
+            PyArray_NDIM(self), PyArray_DIMS(self),
+            PyArray_STRIDES(self), PyArray_DATA(self),
             flags, (PyObject *)self, (PyObject *)self,
             _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
     if (ret == NULL) {
-        Py_XDECREF(type);
-        return NULL;
+        goto finish;
+    }
+    if (array_descr_set_internal(ret, (PyObject *)type) < 0) {
+        Py_CLEAR(ret);
+        goto finish;
     }
 
-    if (type != NULL) {
-        if (PyObject_SetAttrString((PyObject *)ret, "dtype",
-                                   (PyObject *)type) < 0) {
-            Py_DECREF(ret);
-            Py_DECREF(type);
-            return NULL;
-        }
-        Py_DECREF(type);
+    if (subtype != &PyArray_Type) {
+        Py_INCREF(PyArray_DESCR(ret));
+        Py_SETREF(ret, (PyArrayObject *)PyArray_NewFromDescr_int(
+                subtype, PyArray_DESCR(ret),
+                PyArray_NDIM(ret), PyArray_DIMS(ret),
+                PyArray_STRIDES(ret), PyArray_DATA(ret),
+                PyArray_FLAGS(ret), (PyObject *)self, (PyObject *)self,
+                _NPY_ARRAY_ENSURE_DTYPE_IDENTITY));
     }
+
+finish:
+    Py_DECREF(type);
     return (PyObject *)ret;
 }

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -492,18 +492,6 @@ array_descr_set_internal(PyArrayObject *self, PyObject *arg)
 }
 
 static int
-non_unique_reference(PyObject *lhs)
-{
-    // Return 1 if we have a guaranteed non-unique reference
-    // When 0 is returned, the object can be unique or non-unique
-#if defined(PYPY_VERSION)
-    // on pypy we cannot use reference counting
-    return 0;
-#endif
-    return Py_REFCNT(lhs) > 1;
-}
-
-static int
 array_descr_set(PyArrayObject *self, PyObject *arg)
 {
     if (arg == NULL) {
@@ -512,18 +500,12 @@ array_descr_set(PyArrayObject *self, PyObject *arg)
         return -1;
     }
 
-    if (non_unique_reference((PyObject *)self)) {
-         // this will not emit deprecation warnings for all cases, but for most it will
-         // we skip unique references, so that we will not get a deprecation warning
-         // when array.view(new_dtype) is called
-         /* DEPRECATED 2026-02-06, NumPy 2.5 */
-         int ret = PyErr_WarnEx(PyExc_DeprecationWarning,
-                    "Setting the dtype on a NumPy array has been deprecated in NumPy 2.5.\n"
-                    "Instead of changing the dtype on an array x, create a new array with x.view(new_dtype)",
-                    1);
-        if (ret) {
-            return -1;
-        }
+    /* DEPRECATED 2026-02-06, NumPy 2.5 */
+    if (DEPRECATE(
+            "Setting the dtype on a NumPy array has been deprecated in NumPy 2.5.\n"
+            "Instead of changing the dtype on an array x, create a new array "
+            "with x.view(new_dtype)") < 0) {
+        return -1;
     }
     return array_descr_set_internal(self, arg);
 }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1983,7 +1983,7 @@ array_copyto(PyObject *NPY_UNUSED(ignored),
         PyArray_DTypeMeta *dst_DType = NPY_DTYPE(PyArray_DESCR(dst));
         bool is_npy_nan = PyFloat_Check(src_obj) && npy_isnan(PyFloat_AsDouble(src_obj));
         if (!is_npy_nan && dst_DType->type_num == NPY_TIMEDELTA) {
-            descr = PyArray_DESCR(dst); 
+            descr = PyArray_DESCR(dst);
             Py_INCREF(descr);
         } else {
             descr = npy_find_descr_for_scalar(src_obj, PyArray_DESCR(src), DType,
@@ -5227,6 +5227,16 @@ _multiarray_umath_exec(PyObject *m) {
     npy_static_pydata.ndarray_array_function = PyObject_GetAttrString(
             (PyObject *)&PyArray_Type, "__array_function__");
     if (npy_static_pydata.ndarray_array_function == NULL) {
+        return -1;
+    }
+    npy_static_pydata.ndarray_set_dtype = PyObject_GetAttrString(
+            (PyObject *)&PyArray_Type, "_set_dtype");
+    if (npy_static_pydata.ndarray_set_dtype == NULL) {
+        return -1;
+    }
+    npy_static_pydata.ndarray_dtype_descr = PyObject_GetAttrString(
+            (PyObject *)&PyArray_Type, "dtype");
+    if (npy_static_pydata.ndarray_dtype_descr == NULL) {
         return -1;
     }
 

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -74,6 +74,7 @@ intern_strings(void)
     INTERN_STRING(imag, "imag");
     INTERN_STRING(sort, "sort");
     INTERN_STRING(argsort, "argsort");
+    INTERN_STRING(_set_dtype, "_set_dtype");
     return 0;
 }
 

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -53,6 +53,7 @@ typedef struct npy_interned_str_struct {
     PyObject *imag;
     PyObject *sort;
     PyObject *argsort;
+    PyObject *_set_dtype;
 } npy_interned_str_struct;
 
 /*
@@ -89,6 +90,13 @@ typedef struct npy_static_pydata_struct {
     PyObject *ndarray_array_ufunc;
     PyObject *ndarray_array_finalize;
     PyObject *ndarray_array_function;
+
+    /*
+     * References to ndarray._set_dtype and ndarray.dtype descriptor,
+     * used in PyArray_View to detect subclass overrides.
+     */
+    PyObject *ndarray_set_dtype;
+    PyObject *ndarray_dtype_descr;
 
     /*
      * References to the '1' and '0' PyLong objects

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -250,7 +250,6 @@ class TestDeprecatedArrayAttributeSetting(_DeprecationTestCase):
         x = np.eye(2)
         self.assert_deprecated(setattr, args=(x, 'strides', x.strides))
 
-    @pytest.mark.skipif(IS_PYPY, reason="PyPy handles refcounts differently")
     def test_deprecated_dtype_set(self):
         x = np.eye(2)
         self.assert_deprecated(setattr, args=(x, "dtype", int))
@@ -258,6 +257,25 @@ class TestDeprecatedArrayAttributeSetting(_DeprecationTestCase):
     def test_deprecated_shape_set(self):
         x = np.eye(2)
         self.assert_deprecated(setattr, args=(x, "shape", (4, 1)))
+
+class TestDeprecatedViewDtypePropertySetter(_DeprecationTestCase):
+    # gh-31192: view() with dtype change on a subclass that overrides the
+    # dtype property should warn to implement _set_dtype instead.
+    message = r"numpy.ndarray.view\(\) used a custom `dtype` setter.*"
+
+    def test_view_dtype_property_setter(self):
+        class MyArray(np.ndarray):
+            @property
+            def dtype(self):
+                return super().dtype
+
+            @dtype.setter
+            def dtype(self, dtype):
+                super(MyArray, type(self)).dtype.__set__(self, dtype)
+
+        arr = np.arange(6).view(MyArray)
+        self.assert_deprecated(arr.view, args=(np.float64,))
+
 
 class TestDeprecatedDTypeParenthesizedRepeatCount(_DeprecationTestCase):
     message = "Passing in a parenthesized single number"

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -11,7 +11,7 @@ import pytest
 
 import numpy as np
 from numpy._core._multiarray_tests import fromstring_null_term_c_api  # noqa: F401
-from numpy.testing import IS_PYPY, assert_raises
+from numpy.testing import assert_raises
 
 
 class _DeprecationTestCase:
@@ -243,6 +243,7 @@ class TestDeprecatedArrayWrap(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.negative(test2))
         assert test2.called
 
+
 class TestDeprecatedArrayAttributeSetting(_DeprecationTestCase):
     message = "Setting the .*on a NumPy array has been deprecated.*"
 
@@ -257,6 +258,7 @@ class TestDeprecatedArrayAttributeSetting(_DeprecationTestCase):
     def test_deprecated_shape_set(self):
         x = np.eye(2)
         self.assert_deprecated(setattr, args=(x, "shape", (4, 1)))
+
 
 class TestDeprecatedViewDtypePropertySetter(_DeprecationTestCase):
     # view() with dtype change on a subclass that overrides the

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -259,7 +259,7 @@ class TestDeprecatedArrayAttributeSetting(_DeprecationTestCase):
         self.assert_deprecated(setattr, args=(x, "shape", (4, 1)))
 
 class TestDeprecatedViewDtypePropertySetter(_DeprecationTestCase):
-    # gh-31192: view() with dtype change on a subclass that overrides the
+    # view() with dtype change on a subclass that overrides the
     # dtype property should warn to implement _set_dtype instead.
     message = r"numpy.ndarray.view\(\) used a custom `dtype` setter.*"
 
@@ -271,7 +271,7 @@ class TestDeprecatedViewDtypePropertySetter(_DeprecationTestCase):
 
             @dtype.setter
             def dtype(self, dtype):
-                super(MyArray, type(self)).dtype.__set__(self, dtype)
+                super(MyArray, type(self))._set_dtype(self, dtype)
 
         arr = np.arange(6).view(MyArray)
         self.assert_deprecated(arr.view, args=(np.float64,))

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6612,11 +6612,13 @@ class TestView:
         class MyArray(np.ndarray):
             def __array_finalize__(self, obj):
                 self.finalized_from = obj
+                self._dtype_at_finalize = self.dtype
 
         arr = np.arange(6).view(MyArray)
         result = arr.view("i1")
         assert isinstance(result, MyArray)
         assert result.dtype == np.dtype("i1")
+        assert result._dtype_at_finalize == np.dtype("i1")
         assert result.finalized_from is arr
 
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6605,6 +6605,20 @@ class TestView:
         assert_array_equal(y, z)
         assert_array_equal(y, [67305985, 134678021])
 
+    def test_view_dtype_change_subclass_finalize(self):
+        # gh-31192: view() with dtype change on a subclass must call
+        # __array_finalize__ and return the correct subclass type.
+
+        class MyArray(np.ndarray):
+            def __array_finalize__(self, obj):
+                self.finalized_from = obj
+
+        arr = np.arange(6).view(MyArray)
+        result = arr.view("i1")
+        assert isinstance(result, MyArray)
+        assert result.dtype == np.dtype("i1")
+        assert result.finalized_from is arr
+
 
 def _mean(a, **args):
     return a.mean(**args)

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3488,6 +3488,15 @@ class MaskedArray(ndarray):
             _mask[indx] = mindx
         return
 
+    def _set_dtype(self, dtype):
+        super()._set_dtype(dtype)
+        if self._mask is not nomask:
+            self._mask = self._mask.view(make_mask_descr(dtype), ndarray)
+            try:
+                self._mask = self._mask.reshape(self.shape)
+            except (AttributeError, TypeError):
+                pass
+
     # Define so that we can overwrite the setter.
     @property
     def dtype(self):
@@ -3495,15 +3504,13 @@ class MaskedArray(ndarray):
 
     @dtype.setter
     def dtype(self, dtype):
+        # DEPRECATED 2026-02-06, NumPy 2.5
+        warnings.warn(
+            "Setting the dtype on a MaskedArray has been deprecated in "
+            "NumPy 2.5.\nInstead of changing the dtype on an array x, "
+            "create a new array with x.view(new_dtype)",
+            DeprecationWarning, stacklevel=2)
         self._set_dtype(dtype)
-        if self._mask is not nomask:
-            self._mask = self._mask.view(make_mask_descr(dtype), ndarray)
-            # Try to reset the shape of the mask (if we don't have a void).
-            # This raises a ValueError if the dtype change won't work.
-            try:
-                self._mask = self._mask.reshape(self.shape)
-            except (AttributeError, TypeError):
-                pass
 
     @property
     def shape(self):

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2242,7 +2242,8 @@ class TestMaskedArrayAttributes:
         a = np.zeros(4, dtype='f4,i4')
 
         m = np.ma.array(a)
-        m.dtype = np.dtype('f4')
+        with pytest.warns(DeprecationWarning, match="Setting the dtype.*MaskedArray"):
+            m.dtype = np.dtype('f4')
         repr(m)  # raises?
         assert_equal(m.dtype, np.dtype('f4'))
 
@@ -2250,7 +2251,9 @@ class TestMaskedArrayAttributes:
         # are not allowed
         def assign():
             m = np.ma.array(a)
-            m.dtype = np.dtype('f8')
+            with pytest.warns(DeprecationWarning,
+                              match="Setting the dtype.*MaskedArray"):
+                m.dtype = np.dtype('f8')
         assert_raises(ValueError, assign)
 
         b = a.view(dtype='f4', type=np.ma.MaskedArray)  # raises?
@@ -2259,7 +2262,8 @@ class TestMaskedArrayAttributes:
         # check that nomask is preserved
         a = np.zeros(4, dtype='f4')
         m = np.ma.array(a)
-        m.dtype = np.dtype('f4,i4')
+        with pytest.warns(DeprecationWarning, match="Setting the dtype.*MaskedArray"):
+            m.dtype = np.dtype('f4,i4')
         assert_equal(m.dtype, np.dtype('f4,i4'))
         assert_equal(m._mask, np.ma.nomask)
 

--- a/numpy/ma/tests/test_deprecations.py
+++ b/numpy/ma/tests/test_deprecations.py
@@ -63,3 +63,11 @@ class TestMinimumMaximum:
         result = ma_max(data1d)
         assert_equal(result, ma_max(data1d, axis=None))
         assert_equal(result, ma_max(data1d, axis=0))
+
+
+class TestDtypeSet:
+    def test_deprecated_dtype_set(self):
+        # gh-31192: setting dtype on a MaskedArray should emit DeprecationWarning
+        x = np.ma.array([1, 2, 3], mask=[0, 1, 0], dtype=np.float64)
+        with pytest.warns(DeprecationWarning, match="Setting the dtype"):
+            x.dtype = np.int64


### PR DESCRIPTION
This modifies the logic for `arr.view()` to:
1. Use `arr._set_dtype(new_dtype)` for subclasses to have a simple way to migrate away from 2.
2. Keep using `arr.dtype = new_dtype` if dtype is a setter property.
3. If neither is defined, we now call `__array_finalize__` with a new array that has the new dtype+shape. (Previously `__array_finalize__` was skipped, a subclass that wanted to know this happened had to implememt a `dtype` attribute setter).

The first two should be completely safe, with the only downside that we have to support `_set_dtype()` indefinitely :(.
(Maybe a NumPy 3 can switch over to just using step 3 always, but that would be a big transition).

OTOH, calling `__array_finalize__` with mismatching dtypes _could_ fail admitted.  I.e. `MaskedArrays` would fail for non-trivial cases (same itemsize, no structured dtypes) and even the trivial ones may give "invalid value" warnings due to the `_fill_value`.

However, this is also arguably a fix.  If a class dealt with it before correctly, it implemented `.dtype` attribute setting.  And if not and it stumbles on it, it was likely subtly broken around `dtype` handling with views.

(Claude used to execute much of this, but everything is very precisely how I want it.)

Closes gh-31192

Also CC @mhvk, you might be interested and have the right eye to look closely at this.