### PR TITLE
BUG: preserve datetime.date scalar comparison transitivity

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2,6 +2,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <structmember.h>
+#include <datetime.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #ifndef _MULTIARRAYMODULE
@@ -218,6 +219,33 @@ find_binary_operation_path(
     else if (attr != NULL) {
         Py_DECREF(attr);
         *other_op = Py_NewRef(other);
+        return 0;
+    }
+
+    if (PyArray_IsScalar(self, Datetime)) {
+        if (PyDateTimeAPI == NULL) {
+            PyDateTime_IMPORT;
+            if (PyDateTimeAPI == NULL) {
+                return -1;
+            }
+        }
+    }
+    if (PyArray_IsScalar(self, Datetime) &&
+            PyType_IsSubtype(Py_TYPE(other), PyDateTimeAPI->DateType) &&
+            !PyType_IsSubtype(Py_TYPE(other), PyDateTimeAPI->DateTimeType)) {
+        /*
+         * Preserve datetime.date comparisons in the datetime64 scalar unit
+         * instead of falling back through `.item()`, which depends on the
+         * scalar resolution.
+         */
+        PyArray_Descr *descr = PyArray_DescrFromScalar(self);
+        if (descr == NULL) {
+            return -1;
+        }
+        *other_op = PyArray_FromAny(other, descr, 0, 0, 0, NULL);
+        if (*other_op == NULL) {
+            return -1;
+        }
         return 0;
     }
 

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -185,10 +185,14 @@ gentype_generic_method(PyObject *self, PyObject *args, PyObject *kwds,
  *
  * It is not possible for both to be filled.  If `other` is also a generics,
  * it is returned.
+ *
+ * When `datetime_date_comparison` is set, Python date objects are converted
+ * to the datetime64 scalar unit for rich comparison only.
  */
 static inline int
 find_binary_operation_path(
-    PyObject *self, PyObject *other, PyObject **self_op, PyObject **other_op)
+    PyObject *self, PyObject *other, PyObject **self_op, PyObject **other_op,
+    int datetime_date_comparison)
 {
     *other_op = NULL;
     *self_op = NULL;
@@ -222,7 +226,7 @@ find_binary_operation_path(
         return 0;
     }
 
-    if (PyArray_IsScalar(self, Datetime)) {
+    if (datetime_date_comparison && PyArray_IsScalar(self, Datetime)) {
         if (PyDateTimeAPI == NULL) {
             PyDateTime_IMPORT;
             if (PyDateTimeAPI == NULL) {
@@ -230,7 +234,8 @@ find_binary_operation_path(
             }
         }
     }
-    if (PyArray_IsScalar(self, Datetime) &&
+    if (datetime_date_comparison &&
+            PyArray_IsScalar(self, Datetime) &&
             PyType_IsSubtype(Py_TYPE(other), PyDateTimeAPI->DateType) &&
             !PyType_IsSubtype(Py_TYPE(other), PyDateTimeAPI->DateTimeType)) {
         /*
@@ -342,7 +347,7 @@ gentype_@name@@suff@(PyObject *m1, PyObject *m2)
         self = m2;
         other = m1;
     }
-    if (find_binary_operation_path(self, other, &self_op, &other_op) < 0) {
+    if (find_binary_operation_path(self, other, &self_op, &other_op, 0) < 0) {
         return NULL;
     }
     if (self_op != NULL) {
@@ -452,7 +457,7 @@ gentype_power(PyObject *m1, PyObject *m2, PyObject *modulo)
         self = m2;
         other = m1;
     }
-    if (find_binary_operation_path(self, other, &self_op, &other_op) < 0) {
+    if (find_binary_operation_path(self, other, &self_op, &other_op, 0) < 0) {
         return NULL;
     }
     if (self_op != NULL) {
@@ -1642,7 +1647,7 @@ gentype_richcompare(PyObject *self, PyObject *other, int cmp_op)
 
     PyObject *self_op;
     PyObject *other_op;
-    if (find_binary_operation_path(self, other, &self_op, &other_op) < 0) {
+    if (find_binary_operation_path(self, other, &self_op, &other_op, 1) < 0) {
         return NULL;
     }
 

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1718,9 +1718,15 @@ class TestDateTime:
         assert dt_day == pydate
         assert dt_day == dt_ns
         assert dt_ns == pydate
+        assert pydate == dt_ns
 
         # Keep the documented datetime.datetime behavior unchanged.
         assert not (dt_day == pydatetime)
+
+        # The coercion is limited to comparisons; keep arithmetic unchanged.
+        assert dt_day - pydate == datetime.timedelta(0)
+        with pytest.raises(TypeError):
+            dt_ns - pydate
 
     def test_datetime_compare_nat(self):
         dt_nat = np.datetime64('NaT', 'D')

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1708,6 +1708,20 @@ class TestDateTime:
         assert_equal(np.greater(a, b), [0, 1, 0, 1, 0])
         assert_equal(np.greater_equal(a, b), [1, 1, 0, 1, 0])
 
+    def test_datetime_compare_python_date_transitivity(self):
+        pydate = datetime.date(2026, 3, 28)
+        pydatetime = datetime.datetime(2026, 3, 28)
+
+        dt_day = np.datetime64(pydate, 'D')
+        dt_ns = dt_day.astype('datetime64[ns]')
+
+        assert dt_day == pydate
+        assert dt_day == dt_ns
+        assert dt_ns == pydate
+
+        # Keep the documented datetime.datetime behavior unchanged.
+        assert not (dt_day == pydatetime)
+
     def test_datetime_compare_nat(self):
         dt_nat = np.datetime64('NaT', 'D')
         dt_other = np.datetime64('2000-01-01')


### PR DESCRIPTION
Closes #31086