### PR TITLE
ENH: use existing SIMD reduction for reversed unit-stride integer min/max 

### DIFF
--- a/numpy/_core/src/umath/loops_minmax.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_minmax.dispatch.c.src
@@ -332,6 +332,14 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
             );
             goto clear_fp;
         }
+    #if !@is_fp@
+        if (is2 == -(npy_intp)sizeof(@type@)) {
+            TO_SIMD_SFX(simd_reduce_c_@intrin@)(
+                (STYPE*)(ip2 + (len - 1) * is2), (STYPE*)op1, len
+            );
+            goto clear_fp;
+        }
+    #endif
     }
     else if (!is_mem_overlap(ip1, is1, op1, os1, len) &&
         !is_mem_overlap(ip2, is2, op1, os1, len)
@@ -473,4 +481,3 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
 #endif // !fp_only || (is_fp && fp_only)
 /**end repeat1**/
 /**end repeat**/
-


### PR DESCRIPTION
### PR summary

This closes issue #31232 :

> `.min()` and `.max()` currently have a SIMD fast path for contiguous integer reductions when the input stride is `+itemsize`, but not for the equivalent reversed case where the stride is `-itemsize`.

> This means that a 1D integer array like `a[::-1].min()` falls back to a slow scalar reduction even though the data is still contiguous.

> I understand this behavior is important for correctness with floating point values, but seems needlessly cautious for integers where the reduction is truly commutative.

C++ has the "as-if" rule, which states: 

> The compiler may make any and all code transformations that do not change the observable behavior of the program.

In that spirit, I propose we use the the existing SIMD forward pass when the user requests iterating on contiguous integers in reverse for the `min` and `max` reductions, instead of falling back to scalar `min` and `max` as there is no observable difference to the user _for integer dtypes_.

This change implements that proposal by conditionally calling `simd_reduce_c_*` with its first element shifted by the transform `(ip2 + (len - 1) * is2)`.

I ran benchmarks on my Mac Studio: 20,000,000 elements, 10 warm-up calls, 21 timed repeats, median time reported. I see ~ 1.6x speedup on 64 bit dtypes, and ~ 20x speedup on 8 bit.

| dtype | fwd min [ms] | rev min [ms] | patched rev min [ms] | patch speedup | fwd max [ms] | rev max [ms] | patched rev max [ms] | patch speedup |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| int8 | 0.200459 | 2.924667 | 0.169417 | 17.263x | 0.205333 | 4.644792 | 0.174375 | 26.637x |
| uint8 | 0.176292 | 4.080917 | 0.189709 | 21.511x | 0.183292 | 4.675375 | 0.181917 | 25.701x |
| int16 | 0.417833 | 3.034208 | 0.377666 | 8.034x | 0.431625 | 3.709583 | 0.379958 | 9.763x |
| uint16 | 0.393083 | 4.033042 | 0.394250 | 10.230x | 0.397667 | 3.529959 | 0.359875 | 9.809x |
| int32 | 0.830833 | 4.606459 | 0.800792 | 5.752x | 0.815125 | 4.112834 | 0.796958 | 5.161x |
| uint32 | 0.815708 | 4.441083 | 0.788792 | 5.630x | 0.920000 | 4.148792 | 0.795417 | 5.216x |
| int64 | 1.854583 | 2.767125 | 1.717417 | 1.611x | 1.843084 | 2.817541 | 1.684375 | 1.673x |
| uint64 | 1.870584 | 2.771667 | 1.742750 | 1.590x | 1.890250 | 2.837917 | 1.721167 | 1.649x |
| intp | 1.819167 | 2.885333 | 1.796000 | 1.607x | 1.880542 | 2.806375 | 1.794333 | 1.564x |
| uintp | 1.834666 | 2.895708 | 1.794292 | 1.614x | 1.832417 | 2.781458 | 1.742666 | 1.596x |

I have not added any new tests because I believe extant tests cover correctness, and I think adding new benchmark tests would do more to add noise than guard against performance regression. However, I can gladly add these tests if required.

### First time committer introduction
I'm a computational physicist with 10+ years professional experience as a senior C++ systems engineer working on robotics and augmented reality. I have been using Python professionally part time for the last year, with numpy as the base for all the numerics. I have recently begun porting a legacy Matlab and Fortran scientific codebase to Python. 

#### AI Disclosure
I used GPT-5.4 High through Codex for everything except communication through PRs, issues, etc. I used AI to familiarize myself with the codebase, identify the missed optimization, and write all the code. I have reviewed every line of code and understand it all.

I have endeavored to not waste the maintainers' time with slop.