### PR TITLE
BUG: Remove thread-local allocator cache implementation

### DIFF
--- a/benchmarks/benchmarks/bench_alloc_cache.py
+++ b/benchmarks/benchmarks/bench_alloc_cache.py
@@ -1,0 +1,45 @@
+"""Benchmarks for the NumPy small-allocation cache.
+
+NumPy caches data allocations smaller than 1024 bytes (up to 7 per size
+bucket) to avoid repeated malloc/free calls.  For float64 arrays this
+means arrays with fewer than 128 elements hit the cache.
+
+These benchmarks measure tight create-and-discard loops so that the
+allocator cache is exercised on every iteration after the first.
+"""
+
+import numpy as np
+
+from .common import Benchmark
+
+
+class SmallArrayCreation(Benchmark):
+    # Sizes chosen so that data bytes = size * 8 (float64).
+    # Cached:   1..127  →  8..1016 bytes  (< 1024, hits the cache)
+    # Uncached: 128+    →  1024+ bytes    (bypasses the cache)
+    params = [[1, 4, 16, 64, 127, 128, 256, 512]]
+    param_names = ['size']
+    timeout = 60
+
+    def setup(self, size):
+        self.dtype = np.float64
+
+    def time_empty_loop(self, size):
+        dt = self.dtype
+        for _ in range(10_000):
+            np.empty(size, dtype=dt)
+
+    def time_full_loop(self, size):
+        dt = self.dtype
+        for _ in range(10_000):
+            np.full(size, 1.0, dtype=dt)
+
+    def time_ones_loop(self, size):
+        dt = self.dtype
+        for _ in range(10_000):
+            np.ones(size, dtype=dt)
+
+    def time_zeros_loop(self, size):
+        dt = self.dtype
+        for _ in range(10_000):
+            np.zeros(size, dtype=dt)

--- a/numpy/_core/code_generators/genapi.py
+++ b/numpy/_core/code_generators/genapi.py
@@ -37,7 +37,7 @@ process_c_file = get_processor()
 __docformat__ = 'restructuredtext'
 
 # The files under src/ that are scanned for API functions
-API_FILES = [join('multiarray', 'alloc.cpp'),
+API_FILES = [join('multiarray', 'alloc.c'),
              join('multiarray', 'abstractdtypes.c'),
              join('multiarray', 'arrayfunction_override.c'),
              join('multiarray', 'array_api_standard.c'),

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1106,7 +1106,7 @@ endif
 
 src_multiarray = multiarray_gen_headers + [
   'src/multiarray/abstractdtypes.c',
-  'src/multiarray/alloc.cpp',
+  'src/multiarray/alloc.c',
   'src/multiarray/arrayobject.c',
   'src/multiarray/array_coercion.c',
   'src/multiarray/array_converter.c',

--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -27,9 +27,11 @@
 #endif
 #endif
 
-/* Do not enable the alloc cache if the GIL is disabled, or if ASAN or MSAN
- * instrumentation is enabled. The cache makes ASAN use-after-free or MSAN
- * use-of-uninitialized-memory warnings less useful. */
+/* Do not enable the alloc cache on the free-threaded build, or if ASAN or
+ * MSAN instrumentation is enabled. CPython uses mimalloc on the free-threaded
+ * build, which we trust to cache allocations better than we can. The cache
+ * makes ASAN use-after-free or MSAN use-of-uninitialized-memory warnings less
+ * useful. */
 #ifdef Py_GIL_DISABLED
 #    define USE_ALLOC_CACHE 0
 #elif defined(__has_feature)

--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -27,13 +27,17 @@
 #endif
 #endif
 
-/* Do not enable the alloc cache on the free-threaded build, or if ASAN or
- * MSAN instrumentation is enabled. CPython uses mimalloc on the free-threaded
- * build, which we trust to cache allocations better than we can. The cache
- * makes ASAN use-after-free or MSAN use-of-uninitialized-memory warnings less
- * useful. */
+
+/*
+ * CPython uses mimalloc on the free-threaded build, which we trust to cache
+ * allocations better than we can.
+ */
 #ifdef Py_GIL_DISABLED
 #    define USE_ALLOC_CACHE 0
+/*
+ * The cache makes ASAN use-after-free or MSAN use-of-uninitialized-memory
+ * warnings less useful.
+ */
 #elif defined(__has_feature)
 #    if __has_feature(address_sanitizer) || __has_feature(memory_sanitizer)
 #        define USE_ALLOC_CACHE 0

--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -1,6 +1,5 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
-extern "C" {
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
@@ -28,11 +27,12 @@ extern "C" {
 #endif
 #endif
 
-
-/* Do not enable the alloc cache if ASAN or MSAN instrumentation is enabled.
- * The cache makes ASAN use-after-free or MSAN
+/* Do not enable the alloc cache if the GIL is disabled, or if ASAN or MSAN
+ * instrumentation is enabled. The cache makes ASAN use-after-free or MSAN
  * use-of-uninitialized-memory warnings less useful. */
-#if defined(__has_feature)
+#ifdef Py_GIL_DISABLED
+#    define USE_ALLOC_CACHE 0
+#elif defined(__has_feature)
 #    if __has_feature(address_sanitizer) || __has_feature(memory_sanitizer)
 #        define USE_ALLOC_CACHE 0
 #    endif
@@ -50,26 +50,8 @@ typedef struct {
     npy_uintp available; /* number of cached pointers */
     void * ptrs[NCACHE];
 } cache_bucket;
-
-static NPY_TLS cache_bucket datacache[NBUCKETS];
-static NPY_TLS cache_bucket dimcache[NBUCKETS_DIM];
-
-typedef struct cache_destructor {
-    ~cache_destructor() {
-        for (npy_uint i = 0; i < NBUCKETS; ++i) {
-            while (datacache[i].available > 0) {
-                PyMem_RawFree(datacache[i].ptrs[--datacache[i].available]);
-            }
-        }
-        for (npy_uint i = 0; i < NBUCKETS_DIM; ++i) {
-            while (dimcache[i].available > 0) {
-                PyMem_RawFree(dimcache[i].ptrs[--dimcache[i].available]);
-            }
-        }
-    }
-} cache_destructor;
-
-static NPY_TLS cache_destructor tls_cache_destructor;
+static cache_bucket datacache[NBUCKETS];
+static cache_bucket dimcache[NBUCKETS_DIM];
 
 /*
  * This function tells whether NumPy attempts to call `madvise` with
@@ -674,5 +656,3 @@ _Npy_MallocWithOverflowCheck(npy_intp size, npy_intp elsize)
     }
     return PyMem_MALLOC(total_size);
 }
-
-} /* extern "C" */

--- a/numpy/_core/src/multiarray/alloc.cpp
+++ b/numpy/_core/src/multiarray/alloc.cpp
@@ -51,27 +51,10 @@ typedef struct {
     void * ptrs[NCACHE];
 } cache_bucket;
 
-static NPY_TLS cache_bucket _datacache[NBUCKETS];
-static NPY_TLS cache_bucket _dimcache[NBUCKETS_DIM];
+static NPY_TLS cache_bucket datacache[NBUCKETS];
+static NPY_TLS cache_bucket dimcache[NBUCKETS_DIM];
 
-// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61991
-// gcc has a bug where if the thread local variable
-// is unused then in some cases it's destructor may not get
-// called at thread exit. So to workaround this, we access the
-// datacache and dimcache through this struct so that
-// cache_destructor gets initialized and used, ensuring that
-// the destructor gets called properly at thread exit.
-// The datacache and dimcache are not embedded in this struct
-// because that would make this struct very large and certain
-// platforms like armhf can crash while allocating that large
-// TLS block.
 typedef struct cache_destructor {
-    cache_bucket *dimcache;
-    cache_bucket *datacache;
-    cache_destructor() {
-        dimcache = &_dimcache[0];
-        datacache = &_datacache[0];
-    }
     ~cache_destructor() {
         for (npy_uint i = 0; i < NBUCKETS; ++i) {
             while (datacache[i].available > 0) {
@@ -87,9 +70,6 @@ typedef struct cache_destructor {
 } cache_destructor;
 
 static NPY_TLS cache_destructor tls_cache_destructor;
-
-#define datacache tls_cache_destructor.datacache
-#define dimcache tls_cache_destructor.dimcache
 
 /*
  * This function tells whether NumPy attempts to call `madvise` with

--- a/numpy/_core/src/multiarray/alloc.h
+++ b/numpy/_core/src/multiarray/alloc.h
@@ -1,9 +1,6 @@
 #ifndef NUMPY_CORE_SRC_MULTIARRAY_ALLOC_H_
 #define NUMPY_CORE_SRC_MULTIARRAY_ALLOC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
 #define _MULTIARRAYMODULE
 #include "numpy/ndarraytypes.h"
@@ -118,9 +115,5 @@ _npy_free_workspace(void *buf, void *static_buf)
 /* Free a small workspace allocation (macro to fetch the _static name) */
 #define npy_free_workspace(NAME)  \
     _npy_free_workspace(NAME, NAME##_static)
-
-#ifdef __cplusplus
-}  /* extern "C" */
-#endif
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_ALLOC_H_ */

--- a/numpy/_core/src/multiarray/multiarraymodule.h
+++ b/numpy/_core/src/multiarray/multiarraymodule.h
@@ -1,10 +1,6 @@
 #ifndef NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_
 #define NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /*
  * A struct storing global state for the _multiarray_umath
  * module. The state is initialized when the module is imported
@@ -41,8 +37,5 @@ NPY_VISIBILITY_HIDDEN extern npy_global_state_struct npy_global_state;
 
 NPY_NO_EXPORT int
 get_legacy_print_mode(void);
-#ifdef __cplusplus
-}
-#endif
 
 #endif  /* NUMPY_CORE_SRC_MULTIARRAY_MULTIARRAYMODULE_H_ */


### PR DESCRIPTION
### PR summary

Fixes #31179.

This reverts #30499 and #30673 in favor of the old single global allocator cache on the GIL-enabled build and no cache on the free-threaded build. Since #30499 was merged, CPython has changed `PyMy_RawMalloc` to use mimalloc instead of the system allocator on the free-threaded build. That means we can rely on mimalloc to cache allocations.

The thread-local cache we have currently is complicated and leads to observed races in our CI (#31179).

Using uv's build of Python, I consistently see better allocation performance on the GIL-enabled build:

```

| Change   | Before [7a0dfadc] <main>   | After [be63b9f2] <rm-alloc-cache-ft>   |   Ratio | Benchmark (Parameter)                                    |
|----------|----------------------------|----------------------------------------|---------|----------------------------------------------------------|
| -        | 2.89±0.03ms                | 2.76±0.02ms                            |    0.96 | bench_alloc_cache.SmallArrayCreation.time_full_loop(128) |
| -        | 2.59±0.02ms                | 2.50±0.04ms                            |    0.96 | bench_alloc_cache.SmallArrayCreation.time_full_loop(64)  |
| -        | 2.91±0.03ms                | 2.76±0.02ms                            |    0.95 | bench_alloc_cache.SmallArrayCreation.time_full_loop(256) |
| -        | 2.63±0.03ms                | 2.48±0.02ms                            |    0.94 | bench_alloc_cache.SmallArrayCreation.time_full_loop(16)  |
| -        | 2.62±0.02ms                | 2.47±0.03ms                            |    0.94 | bench_alloc_cache.SmallArrayCreation.time_full_loop(4)   |

```

I see no significant performance change on the free-threaded build.

#### AI Disclosure

I used Claude to help generate the new benchmark. Happy to leave it out if you don't think it's useful.