### PR TITLE
TYP: fix sliding_window_view axis parameter typing

### DIFF
--- a/numpy/lib/_stride_tricks_impl.pyi
+++ b/numpy/lib/_stride_tricks_impl.pyi
@@ -40,7 +40,7 @@ def as_strided(
 def sliding_window_view[ScalarT: np.generic](
     x: _ArrayLike[ScalarT],
     window_shape: int | Iterable[int],
-    axis: SupportsIndex | None = None,
+    axis: int | tuple[int, ...] | None = None,
     *,
     subok: bool = False,
     writeable: bool = False,
@@ -49,7 +49,7 @@ def sliding_window_view[ScalarT: np.generic](
 def sliding_window_view(
     x: ArrayLike,
     window_shape: int | Iterable[int],
-    axis: SupportsIndex | None = None,
+    axis: int | tuple[int, ...] | None = None,
     *,
     subok: bool = False,
     writeable: bool = False,


### PR DESCRIPTION
Good day,

The axis parameter in `sliding_window_view` now accepts `int | tuple[int, ...]` instead of just `SupportsIndex`, matching the documentation and implementation.

This fixes the type inconsistency issue reported in #31233.

**Changes:**
- Changed `axis: SupportsIndex | None` to `axis: int | tuple[int, ...] | None` in both overloads in `numpy/lib/_stride_tricks_impl.pyi`

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there is anything to adjust.

Warmly, RoomWithOutRoof