### PR TITLE
MAINT: pass sorted=False in unique_{all,counts,inverse} to match docstring

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -493,6 +493,7 @@ def unique_all(x):
         return_inverse=True,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueAllResult(*result)
 
@@ -549,6 +550,7 @@ def unique_counts(x):
         return_inverse=False,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueCountsResult(*result)
 
@@ -606,6 +608,7 @@ def unique_inverse(x):
         return_inverse=True,
         return_counts=False,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueInverseResult(*result)
 


### PR DESCRIPTION
## Summary

`np.unique_all`, `np.unique_counts`, and `np.unique_inverse` document themselves as equivalent to `np.unique(..., sorted=False)`, but their implementations don't pass `sorted=False` to the underlying `np.unique` call, so they inherit the default `sorted=True`.

This PR adds the missing `sorted=False` argument to all three calls, mirroring what was already done for `np.unique_values` in NumPy 2.3.

Fixes #31241

## Behavior change

None observable today. `np.unique(..., sorted=False)` currently still returns sorted output when `return_index/inverse/counts` is True — only the values-only case takes the unsorted hash path. The existing `.. note::` in each docstring already covers this:

> This function currently always returns a sorted result, however, this could change in any NumPy minor release.

The patch makes the source honor the documented contract, so a future hash-path optimization for these return modes will be picked up automatically without further code changes.

## Test plan

- [ ] CI passes existing `_arraysetops_impl` tests (output unchanged)
- [ ] No docstring changes required
