### PR TITLE
BUG: add ``sorted=False`` to ``unique_all``, ``unique_counts``, ``unique_inverse``

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -493,6 +493,7 @@ def unique_all(x):
         return_inverse=True,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueAllResult(*result)
 
@@ -549,6 +550,7 @@ def unique_counts(x):
         return_inverse=False,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueCountsResult(*result)
 
@@ -606,6 +608,7 @@ def unique_inverse(x):
         return_inverse=True,
         return_counts=False,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueInverseResult(*result)
 


### PR DESCRIPTION
Good day,

The docstrings claim equivalence to `np.unique(..., sorted=False)`, but the source was missing the `sorted=False` parameter. This fix adds it to `unique_all`, `unique_counts`, and `unique_inverse` to match `unique_values`, which was fixed in NumPy 2.3.

See: numpy/numpy/issues/31241

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof