### PR TITLE
ENH: added Support for scalar operations against python datetime and …

### DIFF
--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -67,7 +67,6 @@
 #include "multiarraymodule.h"
 #include "number.h"
 #include "scalartypes.h"  // for is_anyscalar_exact and scalar_value
-#include "_datetime.h"
 
 /********** PRINTF DEBUG TRACING **************/
 #define NPY_UF_DBG_TRACING 0
@@ -632,13 +631,10 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
     int nout = ufunc->nout;
     int nop = ufunc->nargs;
     PyObject *obj;
-    PyArray_Descr *first_datetime_descr = NULL;
-    PyArray_Descr *first_timedelta_descr = NULL;
 
     /* Convert and fill in input arguments */
     npy_bool all_scalar = NPY_TRUE;
     npy_bool any_scalar = NPY_FALSE;
-    npy_bool has_array_datetime_or_timedelta = NPY_FALSE;
     *force_legacy_promotion = NPY_FALSE;
     *promoting_pyscalars = NPY_FALSE;
     for (int i = 0; i < nin; i++) {
@@ -678,19 +674,6 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
         }
         else {
             all_scalar = NPY_FALSE;
-            if (PyArray_ISDATETIME(out_op[i])) {
-                has_array_datetime_or_timedelta = NPY_TRUE;
-                if (PyArray_TYPE(out_op[i]) == NPY_DATETIME &&
-                        first_datetime_descr == NULL) {
-                    first_datetime_descr = PyArray_DESCR(out_op[i]);
-                    Py_INCREF(first_datetime_descr);
-                }
-                else if (PyArray_TYPE(out_op[i]) == NPY_TIMEDELTA &&
-                        first_timedelta_descr == NULL) {
-                    first_timedelta_descr = PyArray_DESCR(out_op[i]);
-                    Py_INCREF(first_timedelta_descr);
-                }
-            }
             continue;
         }
 
@@ -727,78 +710,6 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
     }
     if ((!all_scalar && any_scalar)) {
         *force_legacy_promotion = should_use_min_scalar(nin, out_op, 0, NULL);
-
-        /*
-         * If we have at least one datetime/timedelta array operand and a
-         * scalar Python datetime-like object, avoid keeping that scalar as
-         * object-dtype. Otherwise datetime/timedelta loops are never selected.
-         */
-        if (has_array_datetime_or_timedelta) {
-            for (int i = 0; i < nin; i++) {
-                PyArrayObject *arr = out_op[i];
-                if (arr == NULL || PyArray_NDIM(arr) != 0 || PyArray_TYPE(arr) != NPY_OBJECT) {
-                    continue;
-                }
-
-                PyObject *input = PyTuple_GET_ITEM(full_args.in, i);
-                if (!is_any_numpy_datetime_or_timedelta(input)) {
-                    continue;
-                }
-
-                PyArrayObject *tmp = NULL;
-                PyArray_Descr *timedelta_descr = NULL;
-                PyArray_Descr *datetime_descr = NULL;
-
-                if (first_timedelta_descr != NULL) {
-                    timedelta_descr = first_timedelta_descr;
-                    Py_INCREF(timedelta_descr);
-                }
-                else if (first_datetime_descr != NULL) {
-                    PyArray_DatetimeMetaData *meta =
-                            get_datetime_metadata_from_dtype(first_datetime_descr);
-                    if (meta != NULL) {
-                        timedelta_descr = create_datetime_dtype(NPY_TIMEDELTA, meta);
-                    }
-                }
-                if (timedelta_descr == NULL) {
-                    timedelta_descr = PyArray_DescrFromType(NPY_TIMEDELTA);
-                }
-
-                if (first_datetime_descr != NULL) {
-                    datetime_descr = first_datetime_descr;
-                    Py_INCREF(datetime_descr);
-                }
-                else {
-                    datetime_descr = PyArray_DescrFromType(NPY_DATETIME);
-                }
-
-                /* Try timedelta first to cover python datetime.timedelta. */
-                tmp = (PyArrayObject *)PyArray_FromAny(
-                        input, timedelta_descr,
-                        0, 0, 0, NULL);
-                timedelta_descr = NULL;
-                if (tmp == NULL) {
-                    PyErr_Clear();
-                    tmp = (PyArrayObject *)PyArray_FromAny(
-                            input, datetime_descr,
-                            0, 0, 0, NULL);
-                    datetime_descr = NULL;
-                }
-                if (tmp == NULL) {
-                    PyErr_Clear();
-                    Py_XDECREF(timedelta_descr);
-                    Py_XDECREF(datetime_descr);
-                    continue;
-                }
-
-                Py_XDECREF(timedelta_descr);
-                Py_XDECREF(datetime_descr);
-                Py_SETREF(out_op[i], tmp);
-                Py_DECREF(out_op_DTypes[i]);
-                out_op_DTypes[i] = NPY_DTYPE(PyArray_DESCR(out_op[i]));
-                Py_INCREF(out_op_DTypes[i]);
-            }
-        }
     }
 
     /* Convert and fill in output arguments */
@@ -835,13 +746,9 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
     if (subok_obj && !_subok_converter(subok_obj, out_subok)) {
         goto fail;
     }
-    Py_XDECREF(first_datetime_descr);
-    Py_XDECREF(first_timedelta_descr);
     return 0;
 
 fail:
-    Py_XDECREF(first_datetime_descr);
-    Py_XDECREF(first_timedelta_descr);
     if (out_wheremask != NULL) {
         Py_XSETREF(*out_wheremask, NULL);
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -67,6 +67,7 @@
 #include "multiarraymodule.h"
 #include "number.h"
 #include "scalartypes.h"  // for is_anyscalar_exact and scalar_value
+#include "_datetime.h"
 
 /********** PRINTF DEBUG TRACING **************/
 #define NPY_UF_DBG_TRACING 0
@@ -631,10 +632,13 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
     int nout = ufunc->nout;
     int nop = ufunc->nargs;
     PyObject *obj;
+    PyArray_Descr *first_datetime_descr = NULL;
+    PyArray_Descr *first_timedelta_descr = NULL;
 
     /* Convert and fill in input arguments */
     npy_bool all_scalar = NPY_TRUE;
     npy_bool any_scalar = NPY_FALSE;
+    npy_bool has_array_datetime_or_timedelta = NPY_FALSE;
     *force_legacy_promotion = NPY_FALSE;
     *promoting_pyscalars = NPY_FALSE;
     for (int i = 0; i < nin; i++) {
@@ -674,6 +678,19 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
         }
         else {
             all_scalar = NPY_FALSE;
+            if (PyArray_ISDATETIME(out_op[i])) {
+                has_array_datetime_or_timedelta = NPY_TRUE;
+                if (PyArray_TYPE(out_op[i]) == NPY_DATETIME &&
+                        first_datetime_descr == NULL) {
+                    first_datetime_descr = PyArray_DESCR(out_op[i]);
+                    Py_INCREF(first_datetime_descr);
+                }
+                else if (PyArray_TYPE(out_op[i]) == NPY_TIMEDELTA &&
+                        first_timedelta_descr == NULL) {
+                    first_timedelta_descr = PyArray_DESCR(out_op[i]);
+                    Py_INCREF(first_timedelta_descr);
+                }
+            }
             continue;
         }
 
@@ -710,6 +727,78 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
     }
     if ((!all_scalar && any_scalar)) {
         *force_legacy_promotion = should_use_min_scalar(nin, out_op, 0, NULL);
+
+        /*
+         * If we have at least one datetime/timedelta array operand and a
+         * scalar Python datetime-like object, avoid keeping that scalar as
+         * object-dtype. Otherwise datetime/timedelta loops are never selected.
+         */
+        if (has_array_datetime_or_timedelta) {
+            for (int i = 0; i < nin; i++) {
+                PyArrayObject *arr = out_op[i];
+                if (arr == NULL || PyArray_NDIM(arr) != 0 || PyArray_TYPE(arr) != NPY_OBJECT) {
+                    continue;
+                }
+
+                PyObject *input = PyTuple_GET_ITEM(full_args.in, i);
+                if (!is_any_numpy_datetime_or_timedelta(input)) {
+                    continue;
+                }
+
+                PyArrayObject *tmp = NULL;
+                PyArray_Descr *timedelta_descr = NULL;
+                PyArray_Descr *datetime_descr = NULL;
+
+                if (first_timedelta_descr != NULL) {
+                    timedelta_descr = first_timedelta_descr;
+                    Py_INCREF(timedelta_descr);
+                }
+                else if (first_datetime_descr != NULL) {
+                    PyArray_DatetimeMetaData *meta =
+                            get_datetime_metadata_from_dtype(first_datetime_descr);
+                    if (meta != NULL) {
+                        timedelta_descr = create_datetime_dtype(NPY_TIMEDELTA, meta);
+                    }
+                }
+                if (timedelta_descr == NULL) {
+                    timedelta_descr = PyArray_DescrFromType(NPY_TIMEDELTA);
+                }
+
+                if (first_datetime_descr != NULL) {
+                    datetime_descr = first_datetime_descr;
+                    Py_INCREF(datetime_descr);
+                }
+                else {
+                    datetime_descr = PyArray_DescrFromType(NPY_DATETIME);
+                }
+
+                /* Try timedelta first to cover python datetime.timedelta. */
+                tmp = (PyArrayObject *)PyArray_FromAny(
+                        input, timedelta_descr,
+                        0, 0, 0, NULL);
+                timedelta_descr = NULL;
+                if (tmp == NULL) {
+                    PyErr_Clear();
+                    tmp = (PyArrayObject *)PyArray_FromAny(
+                            input, datetime_descr,
+                            0, 0, 0, NULL);
+                    datetime_descr = NULL;
+                }
+                if (tmp == NULL) {
+                    PyErr_Clear();
+                    Py_XDECREF(timedelta_descr);
+                    Py_XDECREF(datetime_descr);
+                    continue;
+                }
+
+                Py_XDECREF(timedelta_descr);
+                Py_XDECREF(datetime_descr);
+                Py_SETREF(out_op[i], tmp);
+                Py_DECREF(out_op_DTypes[i]);
+                out_op_DTypes[i] = NPY_DTYPE(PyArray_DESCR(out_op[i]));
+                Py_INCREF(out_op_DTypes[i]);
+            }
+        }
     }
 
     /* Convert and fill in output arguments */
@@ -746,9 +835,13 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
     if (subok_obj && !_subok_converter(subok_obj, out_subok)) {
         goto fail;
     }
+    Py_XDECREF(first_datetime_descr);
+    Py_XDECREF(first_timedelta_descr);
     return 0;
 
 fail:
+    Py_XDECREF(first_datetime_descr);
+    Py_XDECREF(first_timedelta_descr);
     if (out_wheremask != NULL) {
         Py_XSETREF(*out_wheremask, NULL);
     }

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -742,6 +742,103 @@ timedelta_dtype_with_copied_meta(PyArray_Descr *dtype)
 }
 
 /*
+ * Creates a new NPY_DATETIME dtype, copying the datetime metadata
+ * from the given dtype.
+ */
+static PyArray_Descr *
+datetime_dtype_with_copied_meta(PyArray_Descr *dtype)
+{
+    PyArray_Descr *ret;
+    PyArray_DatetimeMetaData *dst, *src;
+    PyArray_DatetimeDTypeMetaData *dst_dtmd, *src_dtmd;
+
+    ret = PyArray_DescrNewFromType(NPY_DATETIME);
+    if (ret == NULL) {
+        return NULL;
+    }
+
+    src_dtmd = (PyArray_DatetimeDTypeMetaData *)((_PyArray_LegacyDescr *)dtype)->c_metadata;
+    dst_dtmd = (PyArray_DatetimeDTypeMetaData *)((_PyArray_LegacyDescr *)ret)->c_metadata;
+    src = &(src_dtmd->meta);
+    dst = &(dst_dtmd->meta);
+
+    *dst = *src;
+
+    return ret;
+}
+
+/*
+ * For add/subtract resolvers only: if one operand is a datetime/timedelta
+ * array and the other is a 0-D object scalar, try coercing that scalar to
+ * datetime64/timedelta64 based on the datetime metadata of the other operand.
+ */
+static int
+maybe_coerce_object_datetime_scalar_operand(
+        PyArrayObject **operand, PyArrayObject *other_operand)
+{
+    if (PyArray_NDIM(*operand) != 0 || PyArray_TYPE(*operand) != NPY_OBJECT) {
+        return 0;
+    }
+
+    int other_type_num = PyArray_DESCR(other_operand)->type_num;
+    if (!PyTypeNum_ISDATETIME(other_type_num)) {
+        return 0;
+    }
+
+    PyObject *value = *(PyObject **)PyArray_DATA(*operand);
+    if (value == NULL) {
+        return 0;
+    }
+
+    PyArray_Descr *timedelta_descr = NULL;
+    PyArray_Descr *datetime_descr = NULL;
+
+    if (other_type_num == NPY_TIMEDELTA) {
+        timedelta_descr = PyArray_DescrNew(PyArray_DESCR(other_operand));
+        if (timedelta_descr == NULL) {
+            return -1;
+        }
+        datetime_descr = datetime_dtype_with_copied_meta(PyArray_DESCR(other_operand));
+        if (datetime_descr == NULL) {
+            Py_DECREF(timedelta_descr);
+            return -1;
+        }
+    }
+    else {
+        datetime_descr = PyArray_DescrNew(PyArray_DESCR(other_operand));
+        if (datetime_descr == NULL) {
+            return -1;
+        }
+        timedelta_descr = timedelta_dtype_with_copied_meta(PyArray_DESCR(other_operand));
+        if (timedelta_descr == NULL) {
+            Py_DECREF(datetime_descr);
+            return -1;
+        }
+    }
+
+    PyArrayObject *tmp = (PyArrayObject *)PyArray_FromAny(
+            value, timedelta_descr, 0, 0, 0, NULL);
+    timedelta_descr = NULL;  /* stolen by PyArray_FromAny */
+    if (tmp == NULL) {
+        PyErr_Clear();
+        tmp = (PyArrayObject *)PyArray_FromAny(
+                value, datetime_descr, 0, 0, 0, NULL);
+        datetime_descr = NULL;  /* stolen by PyArray_FromAny */
+    }
+
+    Py_XDECREF(timedelta_descr);
+    Py_XDECREF(datetime_descr);
+
+    if (tmp == NULL) {
+        PyErr_Clear();
+        return 0;
+    }
+
+    Py_SETREF(*operand, tmp);
+    return 1;
+}
+
+/*
  * This function applies the type resolution rules for addition.
  * In particular, there's special cases for string and unicodes, as
  * well as a number of special cases with datetime:
@@ -765,6 +862,13 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
 {
     int type_num1, type_num2;
     int i;
+
+    if (maybe_coerce_object_datetime_scalar_operand(&operands[0], operands[1]) < 0) {
+        return -1;
+    }
+    if (maybe_coerce_object_datetime_scalar_operand(&operands[1], operands[0]) < 0) {
+        return -1;
+    }
 
     type_num1 = PyArray_DESCR(operands[0])->type_num;
     type_num2 = PyArray_DESCR(operands[1])->type_num;
@@ -951,6 +1055,13 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
 {
     int type_num1, type_num2;
     int i;
+
+    if (maybe_coerce_object_datetime_scalar_operand(&operands[0], operands[1]) < 0) {
+        return -1;
+    }
+    if (maybe_coerce_object_datetime_scalar_operand(&operands[1], operands[0]) < 0) {
+        return -1;
+    }
 
     type_num1 = PyArray_DESCR(operands[0])->type_num;
     type_num2 = PyArray_DESCR(operands[1])->type_num;

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -2994,3 +2994,30 @@ def test_comparisons_return_not_implemented():
         assert item.__lt__(obj) is NotImplemented
         assert item.__ge__(obj) is NotImplemented
         assert item.__gt__(obj) is NotImplemented
+
+
+def test_array_timedelta_add_python_timedelta():
+    # gh-29201
+    arr = np.array([np.timedelta64(1, "D"), np.timedelta64(2, "D")])
+    py_td = datetime.timedelta(days=1)
+
+    expected = np.array([np.timedelta64(2, "D"), np.timedelta64(3, "D")])
+
+    assert_equal(arr + py_td, expected)
+    assert_equal(py_td + arr, expected)
+
+
+def test_array_datetime_ops_with_python_datetime_types():
+    # gh-29201
+    arr = np.array([np.datetime64("2000-01-01"), np.datetime64("2000-01-02")])
+    py_td = datetime.timedelta(days=1)
+    py_dt = datetime.datetime(2000, 1, 1)
+
+    assert_equal(
+        arr + py_td,
+        np.array([np.datetime64("2000-01-02"), np.datetime64("2000-01-03")]),
+    )
+    assert_equal(
+        arr - py_dt,
+        np.array([np.timedelta64(0, "D"), np.timedelta64(1, "D")]),
+    )


### PR DESCRIPTION
…timedelta
fixes #29201 

### PR summary

- Updated ufunc argument conversion so Python datetime-like scalars are no longer kept as object scalars when mixed with datetime/timedelta ndarrays.

- The coercion is targeted to mixed scalar/array operations and preserves scalar-only behavior.

- Added regression tests for the reported ndarray cases.

#### AI Disclosure
"No AI tools used" 
