### PR TITLE
BUG: fix np.linalg.pinv(rtol=None) for integer input

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2238,7 +2238,7 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
         if rtol is _NoValue:
             rcond = 1e-15
         elif rtol is None:
-            rcond = max(a.shape[-2:]) * finfo(a.dtype).eps
+            rcond = max(a.shape[-2:]) * finfo(_commonType(a)[1]).eps
         else:
             rcond = rtol
     elif rtol is not _NoValue:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -917,6 +917,15 @@ def test_pinv_rtol_arg():
         np.linalg.pinv(a, rcond=0.5, rtol=0.5)
 
 
+def test_pinv_integer_input_rtol_none():
+    a = np.array([[1, 2], [3, 4]], dtype=np.int32)
+
+    assert_almost_equal(
+        np.linalg.pinv(a, rtol=None),
+        np.linalg.pinv(a),
+    )
+
+
 class DetCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
 
     def do(self, a, b, tags):


### PR DESCRIPTION
## Summary
- fix `np.linalg.pinv(..., rtol=None)` for integer-dtype inputs
- compute the default tolerance from the promoted inexact linalg dtype instead of the original integer dtype
- add a regression test covering integer input with `rtol=None`

## Testing
- `python -m py_compile numpy/linalg/_linalg.py numpy/linalg/tests/test_linalg.py`
- verified the patched `pinv` returns the same result as default `pinv(a)` for an `int32` matrix

### PR summary

Fix `np.linalg.pinv(..., rtol=None)` for integer-dtype inputs.

When `rtol=None`, `pinv` currently computes the default tolerance using
`finfo(a.dtype).eps`. That fails for integer arrays because `finfo` requires an
inexact dtype, so calls such as `np.linalg.pinv(np.array([[1, 2], [3, 4]], dtype=np.int32), rtol=None)`
raise `ValueError`.

This PR computes the default tolerance from the promoted inexact linalg dtype
instead, which matches the actual computation path used by `pinv`. A regression
test is included to verify that integer input with `rtol=None` behaves the same
as the default `pinv(a)` call.

Closes gh-30917.

### First time committer introduction

I’m a NumPy user contributing this fix after noticing that `np.linalg.pinv`
fails on integer input when `rtol=None`. I traced the issue to the tolerance
calculation and put together a small fix with a regression test.

#### AI Disclosure

AI tool used: OpenAI Codex.

How it was used:
- to inspect the local checkout and identify a suitable issue to fix
- to propose and apply the code change
- to draft the regression test
- to help write this PR text

AI-generated content:
- the code change in `numpy/linalg/_linalg.py`
- the regression test added to `numpy/linalg/tests/test_linalg.py`
- this PR description text


All review, validation, and final submission decisions are made by me.
