### PR TITLE
fix: avoid finfo crash when pinv is called with integer array and rtol=None

### DIFF
--- a/doc/release/upcoming_changes/31253.improvement.rst
+++ b/doc/release/upcoming_changes/31253.improvement.rst
@@ -1,0 +1,7 @@
+`numpy.linalg.pinv` with ``rtol=None`` and integer-dtype arrays
+----------------------------------------------------------------
+`numpy.linalg.pinv` no longer raises ``ValueError: data type not inexact``
+when called with an integer-dtype array and ``rtol=None``. The default
+``rcond`` is now computed using the promoted float type that ``pinv``
+actually operates on, matching the existing integer-to-float promotion
+behaviour of the function.

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2238,7 +2238,7 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
         if rtol is _NoValue:
             rcond = 1e-15
         elif rtol is None:
-            rcond = max(a.shape[-2:]) * finfo(a.dtype).eps
+            rcond = max(a.shape[-2:]) * finfo(_commonType(a)[1]).eps
         else:
             rcond = rtol
     elif rtol is not _NoValue:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -917,6 +917,31 @@ def test_pinv_rtol_arg():
         np.linalg.pinv(a, rcond=0.5, rtol=0.5)
 
 
+def test_pinv_rtol_none_integer_dtypes():
+    # gh-30917: pinv with rtol=None should not crash for integer-dtype arrays.
+    # Previously raised: ValueError: data type <class 'numpy.int32'> not inexact
+    for dtype in [np.int16, np.int32, np.int64, np.uint32]:
+        a = np.array([[1, 2, 3], [4, 1, 1], [2, 3, 1]], dtype=dtype)
+        # Must not raise
+        B = np.linalg.pinv(a, rtol=None)
+
+        # Result must satisfy Moore-Penrose conditions (A B A == A)
+        a_f = a.astype(np.float64)
+        assert_almost_equal(a_f @ B @ a_f, a_f, double_decimal=10)
+
+        # Result must match pinv of the float-cast array with same rtol
+        B_ref = np.linalg.pinv(a_f, rtol=None)
+        assert_almost_equal(B, B_ref, double_decimal=10)
+
+
+def test_pinv_rtol_none_float_dtypes_unchanged():
+    # gh-30917: existing float dtype behaviour must be unaffected.
+    for dtype in [np.float32, np.float64]:
+        a = np.array([[1, 2, 3], [4, 1, 1], [2, 3, 1]], dtype=dtype)
+        B = np.linalg.pinv(a, rtol=None)
+        assert_almost_equal(a @ B @ a, a)
+
+
 class DetCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
 
     def do(self, a, b, tags):


### PR DESCRIPTION
## Summary

Fixes #30917

`np.linalg.pinv` with `rtol=None` computes a default `rcond` using `finfo(a.dtype).eps`. `finfo()` only accepts inexact (float/complex) dtypes, so passing an integer-dtype array raises:

```
ValueError: data type <class 'numpy.int32'> not inexact
```

This is a silent footgun — the user passed valid arguments, and `pinv` internally upcasts integers to float anyway, so there is no reason to reject the call.

## Fix

One-line change in `numpy/linalg/_linalg.py`:

```python
# Before
rcond = max(a.shape[-2:]) * finfo(a.dtype).eps

# After
rcond = max(a.shape[-2:]) * finfo(_commonType(a)[1]).eps
```

`_commonType(a)[1]` returns the promoted float type that `pinv` will actually compute with (`double` for integer inputs), which `finfo` handles correctly.

## Tests

Added two new tests after `test_pinv_rtol_arg`:

- `test_pinv_rtol_none_integer_dtypes` — verifies no crash for `int16`, `int32`, `int64`, `uint32`; checks Moore-Penrose condition `A @ pinv(A) @ A ≈ A`; checks result matches `pinv` of the float-cast array
- `test_pinv_rtol_none_float_dtypes_unchanged` — verifies existing `float32`/`float64` behaviour is unaffected

All 469 linalg tests pass.