### PR TITLE
ENH: Allow downstream to register for DLPack support

### DIFF
--- a/doc/release/upcoming_changes/31256.new_feature.rst
+++ b/doc/release/upcoming_changes/31256.new_feature.rst
@@ -1,0 +1,3 @@
+* It is now possible to register user-dtypes for dlpack export and import
+  via `numpy.dtypes.register_dlpack_dtype`. This functionality is meant to
+  be used with care by user-dtype authors.

--- a/numpy/_core/src/common/npy_dlpack.h
+++ b/numpy/_core/src/common/npy_dlpack.h
@@ -29,4 +29,12 @@ NPY_NO_EXPORT PyObject *
 from_dlpack(PyObject *NPY_UNUSED(self),
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames);
 
+
+NPY_NO_EXPORT PyObject *
+_register_dlpack_dtype(PyObject *NPY_UNUSED(self), PyObject *args);
+
+
+NPY_NO_EXPORT PyObject *
+_dlpack_registry_replace(PyObject *NPY_UNUSED(self), PyObject *args);
+
 #endif

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -69,11 +69,10 @@ dlpack_dtype_registry_lookup(uint8_t code, uint8_t bits)
             npy_static_pydata.dlpack_dtype_registry, key, &reg_val);
     Py_DECREF(key);
     if (gres < 0) {
-        Py_XDECREF(reg_val);
         return NULL;
     }
     if (gres == 0) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_SetString(PyExc_BufferError,
                 "Unsupported dtype in DLTensor.");
         return NULL;
     }
@@ -518,7 +517,7 @@ array_dlpack(PyArrayObject *self,
     }
 
     if (stream != Py_None) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_SetString(PyExc_ValueError,
                 "NumPy only supports stream=None.");
         return NULL;
     }
@@ -823,11 +822,16 @@ _register_dlpack_dtype(PyObject *NPY_UNUSED(self), PyObject *args)
         goto finish;
     }
 
-    if (code < 0 || code > 255 || bits_l < 8 || bits_l > 255
-            || (bits_l % 8) != 0) {
+    /* Sanity check code and bits, if DLPack relaxes this we can do this also. */
+    if (code < 0 || code > 255) {
         PyErr_SetString(PyExc_ValueError,
-                "register_dlpack_dtype: DLPack code must be in 0..255 and "
-                "bits must be a multiple of 8 in 8..255.");
+                "register_dlpack_dtype: DLPack code must be in 0..255.");
+        goto finish;
+    }
+    if (descr->elsize > 255/8 || descr->elsize * 8 != bits_l) {
+        PyErr_SetString(PyExc_ValueError,
+                "register_dlpack_dtype: number of bits must match the "
+                "dtypes and be <=255.");
         goto finish;
     }
 
@@ -898,8 +902,8 @@ _dlpack_registry_replace(PyObject *NPY_UNUSED(self), PyObject *args)
     }
 
     /* Replace the currently used dicts in place. */
-    npy_static_pydata.dlpack_dtype_registry = Py_NewRef(imp);
-    npy_static_pydata.dlpack_export_registry = Py_NewRef(exp);
+    Py_SETREF(npy_static_pydata.dlpack_dtype_registry, Py_NewRef(imp));
+    Py_SETREF(npy_static_pydata.dlpack_export_registry, Py_NewRef(exp));
     return ret;
 }
 

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -54,7 +54,7 @@ dlpack_export_registry_lookup(PyArray_Descr *dtype,
 
 
 /*
- * Return a registered dtype or raise an error if non is found.
+ * Return a registered dtype or raise an error if none is found.
  */
 static PyArray_Descr *
 dlpack_dtype_registry_lookup(uint8_t code, uint8_t bits)
@@ -338,8 +338,8 @@ fill_dl_tensor_information(
         if (!reg_res) {
             PyErr_SetString(PyExc_BufferError,
                     "DLPack only supports signed/unsigned integers, float "
-                    "and complex dtypes (or dtypes registered via "
-                    "by importing external packages).");
+                    "and complex dtypes (or dtypes registered by third-party "
+                    "packages).");
             return -1;
         }
     }

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -818,8 +818,8 @@ _register_dlpack_dtype(PyObject *NPY_UNUSED(self), PyObject *args)
 
     long code = 0;
     long bits_l = 0;
-    if (!PyArg_ParseTuple(args, "(ll)O&:register_dlpack_dtype", &code, &bits_l,
-            PyArray_DescrConverter, &descr)) {
+    if (!PyArg_ParseTuple(args, "(ll)O!:register_dlpack_dtype", &code, &bits_l,
+            &PyArrayDescr_Type, &descr)) {
         goto finish;
     }
 
@@ -874,7 +874,6 @@ _register_dlpack_dtype(PyObject *NPY_UNUSED(self), PyObject *args)
     ret = Py_NewRef(Py_None);
 
 finish:
-    Py_XDECREF((PyObject *)descr);
     Py_XDECREF(dlpack_tuple);
     Py_XDECREF(original);
     return ret;

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -813,7 +813,8 @@ _register_dlpack_dtype(PyObject *NPY_UNUSED(self), PyObject *args)
     PyObject *ret = NULL;
     PyArray_Descr *descr = NULL;
     PyObject *dlpack_tuple = NULL;
-    PyObject *original = NULL;  // Original value if in dict.
+    PyObject *original_tuple = NULL;  // Existing dlpack tuple for export
+    PyObject *original_descr = NULL;  // Existing dtype for import
 
     long code = 0;
     long bits_l = 0;
@@ -828,10 +829,11 @@ _register_dlpack_dtype(PyObject *NPY_UNUSED(self), PyObject *args)
                 "register_dlpack_dtype: DLPack code must be in 0..255.");
         goto finish;
     }
+    // Check bits fit into 255 bytes via elsize to avoid elsize * 8 overflow.
     if (descr->elsize > 255/8 || descr->elsize * 8 != bits_l) {
         PyErr_SetString(PyExc_ValueError,
                 "register_dlpack_dtype: number of bits must match the "
-                "dtypes and be <=255.");
+                "dtype's elsize and be <=255.");
         goto finish;
     }
 
@@ -842,13 +844,13 @@ _register_dlpack_dtype(PyObject *NPY_UNUSED(self), PyObject *args)
 
     int set_res = PyDict_SetDefaultRef(
             npy_static_pydata.dlpack_export_registry, (PyObject *)descr, dlpack_tuple,
-            &original);
+            &original_tuple);
     if (set_res < 0) {
         goto finish;
     }
     else if (set_res == 1) {
         /* Key was present, allow if the value is equal: */
-        int exp_same = PyObject_RichCompareBool(original, dlpack_tuple, Py_EQ);
+        int exp_same = PyObject_RichCompareBool(original_tuple, dlpack_tuple, Py_EQ);
         if (exp_same < 0) {
             goto finish;
         }
@@ -860,18 +862,17 @@ _register_dlpack_dtype(PyObject *NPY_UNUSED(self), PyObject *args)
         }
     }
 
-    Py_CLEAR(original);  // re-use original.
     if (PyDict_SetDefaultRef(
             npy_static_pydata.dlpack_dtype_registry, dlpack_tuple, (PyObject *)descr,
-            &original) < 0) {
+            &original_descr) < 0) {
         goto finish;
     }
-    if ((PyObject *)descr != original) {
+    if ((PyObject *)descr != original_descr) {
         PyErr_Format(PyExc_ValueError,
             "register_dlpack_dtype: the same (code, bits) already maps to a "
             "%R which is not identical (it may be equal). "
             "The dtype->(code, bits) was, however, established.",
-            original);
+            original_descr);
         goto finish;
     }
 
@@ -879,7 +880,8 @@ _register_dlpack_dtype(PyObject *NPY_UNUSED(self), PyObject *args)
 
 finish:
     Py_XDECREF(dlpack_tuple);
-    Py_XDECREF(original);
+    Py_XDECREF(original_tuple);
+    Py_XDECREF(original_descr);
     return ret;
 }
 

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -6,10 +6,86 @@
 
 #include "dlpack/dlpack.h"
 #include "numpy/arrayobject.h"
+#include "npy_pycompat.h"
 #include "npy_argparse.h"
 #include "npy_dlpack.h"
 #include "npy_static_data.h"
+#include "common.h"
 #include "conversion_utils.h"
+#include "descriptor.h"
+
+
+/*
+ * Find user-registered DLPack dtype mapping (1 if found, -1 on error).
+ */
+static int
+dlpack_export_registry_lookup(PyArray_Descr *dtype,
+        uint8_t *out_code, uint8_t *out_bits)
+{
+    PyObject *val = NULL;
+    int gres = PyDict_GetItemRef(
+            npy_static_pydata.dlpack_export_registry,
+            (PyObject *)dtype,
+            &val);
+    if (gres <= 0) {
+        return gres;
+    }
+    if (!PyTuple_Check(val) || PyTuple_GET_SIZE(val) != 2) {
+        PyErr_SetString(PyExc_RuntimeError,
+                "internal: dlpack export_registry values must be length-2 tuples");
+        Py_DECREF(val);
+        return -1;
+    }
+    long c = PyLong_AsLong(PyTuple_GET_ITEM(val, 0));
+    if (error_converting(c)) {
+        Py_DECREF(val);
+        return -1;
+    }
+    long b = PyLong_AsLong(PyTuple_GET_ITEM(val, 1));
+    if (error_converting(b)) {
+        Py_DECREF(val);
+        return -1;
+    }
+    *out_code = (uint8_t)c;
+    *out_bits = (uint8_t)b;
+    Py_DECREF(val);
+    return 1;
+}
+
+
+/*
+ * Return a registered dtype or raise an error if non is found.
+ */
+static PyArray_Descr *
+dlpack_dtype_registry_lookup(uint8_t code, uint8_t bits)
+{
+    npy_intp key_vals[2] = {code, bits};
+    PyObject *key = PyArray_IntTupleFromIntp(2, key_vals);
+    if (key == NULL) {
+        return NULL;
+    }
+    PyObject *reg_val = NULL;
+    int gres = PyDict_GetItemRef(
+            npy_static_pydata.dlpack_dtype_registry, key, &reg_val);
+    Py_DECREF(key);
+    if (gres < 0) {
+        Py_XDECREF(reg_val);
+        return NULL;
+    }
+    if (gres == 0) {
+        PyErr_SetString(PyExc_RuntimeError,
+                "Unsupported dtype in DLTensor.");
+        return NULL;
+    }
+    if (!PyArray_DescrCheck(reg_val)) {
+        Py_DECREF(reg_val);
+        PyErr_SetString(PyExc_TypeError,
+                "from_dlpack(): DLPack dtype registry must only contain "
+                "numpy.dtype instances; see numpy.dtypes.register_dlpack_dtype.");
+        return NULL;
+    }
+    return (PyArray_Descr *)reg_val;
+}
 
 
 /*
@@ -254,10 +330,18 @@ fill_dl_tensor_information(
         managed_dtype.code = kDLComplex;
     }
     else {
-        PyErr_SetString(PyExc_BufferError,
-                "DLPack only supports signed/unsigned integers, float "
-                "and complex dtypes.");
-        return -1;
+        int reg_res = dlpack_export_registry_lookup(dtype,
+                &managed_dtype.code, &managed_dtype.bits);
+        if (reg_res < 0) {
+            return -1;
+        }
+        if (!reg_res) {
+            PyErr_SetString(PyExc_BufferError,
+                    "DLPack only supports signed/unsigned integers, float "
+                    "and complex dtypes (or dtypes registered via "
+                    "by importing external packages).");
+            return -1;
+        }
     }
 
     /*
@@ -498,7 +582,7 @@ from_dlpack(PyObject *NPY_UNUSED(self),
         return NULL;
     }
 
-    /* 
+    /*
      * Prepare arguments for the full call. We always forward copy and pass
      * our max_version. `device` is always passed as `None`, but if the user
      * provided a device, we will replace it with the "cpu": (1, 0).
@@ -604,7 +688,6 @@ from_dlpack(PyObject *NPY_UNUSED(self),
 
     int typenum = -1;
     const uint8_t bits = dl_tensor.dtype.bits;
-    const npy_intp itemsize = bits / 8;
     switch (dl_tensor.dtype.code) {
     case kDLBool:
         if (bits == 8) {
@@ -646,12 +729,24 @@ from_dlpack(PyObject *NPY_UNUSED(self),
         break;
     }
 
-    if (typenum == -1) {
-        PyErr_SetString(PyExc_BufferError,
-                "Unsupported dtype in DLTensor.");
-        Py_DECREF(capsule);
-        return NULL;
+    PyArray_Descr *descr = NULL;
+    if (typenum != -1) {
+        descr = PyArray_DescrFromType(typenum);
+        if (descr == NULL) {
+            Py_DECREF(capsule);
+            return NULL;
+        }
     }
+    else {
+        descr = dlpack_dtype_registry_lookup(
+                (uint8_t)dl_tensor.dtype.code, bits);
+        if (descr == NULL) {
+            Py_DECREF(capsule);
+            return NULL;
+        }
+    }
+
+    npy_intp itemsize = descr->elsize;
 
     npy_intp shape[NPY_MAXDIMS];
     npy_intp strides[NPY_MAXDIMS];
@@ -665,12 +760,6 @@ from_dlpack(PyObject *NPY_UNUSED(self),
     }
 
     char *data = (char *)dl_tensor.data + dl_tensor.byte_offset;
-
-    PyArray_Descr *descr = PyArray_DescrFromType(typenum);
-    if (descr == NULL) {
-        Py_DECREF(capsule);
-        return NULL;
-    }
 
     PyObject *ret = PyArray_NewFromDescr(&PyArray_Type, descr, ndim, shape,
             dl_tensor.strides != NULL ? strides : NULL, data, readonly ? 0 :
@@ -718,4 +807,100 @@ from_dlpack(PyObject *NPY_UNUSED(self),
     return ret;
 }
 
+
+NPY_NO_EXPORT PyObject *
+_register_dlpack_dtype(PyObject *NPY_UNUSED(self), PyObject *args)
+{
+    PyObject *ret = NULL;
+    PyArray_Descr *descr = NULL;
+    PyObject *dlpack_tuple = NULL;
+    PyObject *original = NULL;  // Original value if in dict.
+
+    long code = 0;
+    long bits_l = 0;
+    if (!PyArg_ParseTuple(args, "(ll)O&:register_dlpack_dtype", &code, &bits_l,
+            PyArray_DescrConverter, &descr)) {
+        goto finish;
+    }
+
+    if (code < 0 || code > 255 || bits_l < 8 || bits_l > 255
+            || (bits_l % 8) != 0) {
+        PyErr_SetString(PyExc_ValueError,
+                "register_dlpack_dtype: DLPack code must be in 0..255 and "
+                "bits must be a multiple of 8 in 8..255.");
+        goto finish;
+    }
+
+    dlpack_tuple = Py_BuildValue("(ll)", code, bits_l);
+    if (dlpack_tuple == NULL) {
+        goto finish;
+    }
+
+    int set_res = PyDict_SetDefaultRef(
+            npy_static_pydata.dlpack_export_registry, (PyObject *)descr, dlpack_tuple,
+            &original);
+    if (set_res < 0) {
+        goto finish;
+    }
+    else if (set_res == 1) {
+        /* Key was present, allow if the value is equal: */
+        int exp_same = PyObject_RichCompareBool(original, dlpack_tuple, Py_EQ);
+        if (exp_same < 0) {
+            goto finish;
+        }
+        if (exp_same == 0) {
+            PyErr_Format(PyExc_ValueError,
+                    "register_dlpack_dtype: this NumPy dtype is already exported "
+                    "with a different DLPack (code, bits).");
+            goto finish;
+        }
+    }
+
+    Py_CLEAR(original);  // re-use original.
+    if (PyDict_SetDefaultRef(
+            npy_static_pydata.dlpack_dtype_registry, dlpack_tuple, (PyObject *)descr,
+            &original) < 0) {
+        goto finish;
+    }
+    if ((PyObject *)descr != original) {
+        PyErr_Format(PyExc_ValueError,
+            "register_dlpack_dtype: the same (code, bits) already maps to a "
+            "%R which is not identical (it may be equal). "
+            "The dtype->(code, bits) was, however, established.",
+            original);
+        goto finish;
+    }
+
+    ret = Py_NewRef(Py_None);
+
+finish:
+    Py_XDECREF((PyObject *)descr);
+    Py_XDECREF(dlpack_tuple);
+    Py_XDECREF(original);
+    return ret;
+}
+
+
+/* Swap out the registry dicts for testing purposes. */
+NPY_NO_EXPORT PyObject *
+_dlpack_registry_replace(PyObject *NPY_UNUSED(self), PyObject *args)
+{
+    PyObject *imp, *exp;
+    if (!PyArg_ParseTuple(args, "O!O!: _dlpack_registry_replace",
+            &PyDict_Type, &imp, &PyDict_Type, &exp)) {
+        return NULL;
+    }
+
+    PyObject *ret = PyTuple_Pack(2,
+        npy_static_pydata.dlpack_dtype_registry,
+        npy_static_pydata.dlpack_export_registry);
+    if (ret == NULL) {
+        return ret;
+    }
+
+    /* Replace the currently used dicts in place. */
+    npy_static_pydata.dlpack_dtype_registry = Py_NewRef(imp);
+    npy_static_pydata.dlpack_export_registry = Py_NewRef(exp);
+    return ret;
+}
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -4730,6 +4730,10 @@ static struct PyMethodDef array_module_methods[] = {
         "Give a warning on reload and big warning in sub-interpreters."},
     {"from_dlpack", (PyCFunction)from_dlpack,
         METH_FASTCALL | METH_KEYWORDS, NULL},
+    {"_register_dlpack_dtype", (PyCFunction)_register_dlpack_dtype,
+        METH_VARARGS, NULL},
+    {"_dlpack_registry_replace", (PyCFunction)_dlpack_registry_replace,
+        METH_VARARGS, "unsafe testing helper to swap out dlpack registry"},
     {"_unique_hash",  (PyCFunction)array__unique_hash,
         METH_FASTCALL | METH_KEYWORDS, "Collect unique values via a hash map."},
     {NULL, NULL, 0, NULL}                /* sentinel */

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -214,6 +214,16 @@ initialize_static_globals(void)
         return -1;
     }
 
+    npy_static_pydata.dlpack_dtype_registry = PyDict_New();
+    if (npy_static_pydata.dlpack_dtype_registry == NULL) {
+        return -1;
+    }
+
+    npy_static_pydata.dlpack_export_registry = PyDict_New();
+    if (npy_static_pydata.dlpack_export_registry == NULL) {
+        return -1;
+    }
+
     /*
      * Initialize contents of npy_static_cdata struct
      *

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -163,6 +163,9 @@ typedef struct npy_static_pydata_struct {
     PyObject *dl_call_kwnames;
     PyObject *dl_cpu_device_tuple;
     PyObject *dl_max_version;
+    /* dicts for implementing `register_dlpack_dtype` */
+    PyObject *dlpack_dtype_registry;
+    PyObject *dlpack_export_registry;
 } npy_static_pydata_struct;
 
 

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -253,9 +253,9 @@ class TestRegisterDlpackDtype:
         # Register S3 as a nonsensical dtype
         np.dtypes.register_dlpack_dtype((123, 24), dtype)
         # Delete from import but not from export.
-        exp, imp = np._core._multiarray_umath._dlpack_registry_replace({}, {})
-        exp.pop((123, 24))
-        np._core._multiarray_umath._dlpack_registry_replace(exp, imp)
+        imp, exp = np._core._multiarray_umath._dlpack_registry_replace({}, {})
+        imp.pop((123, 24))
+        np._core._multiarray_umath._dlpack_registry_replace(imp, exp)
 
         arr = np.array(["1", "2"], dtype=dtype)
         arr.__dlpack__()  # passes

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -186,3 +186,62 @@ class TestDLPack:
             x.__dlpack__(dl_device=(10, 0))
         with pytest.raises(ValueError):
             np.from_dlpack(x, device="gpu")
+
+
+class TestRegisterDlpackDtype:
+    @pytest.fixture(scope="class", autouse=True)
+    @staticmethod
+    def dlpack_registry_clear():
+        prev = np._core._multiarray_umath._dlpack_registry_replace({}, {})
+        yield
+        np._core._multiarray_umath._dlpack_registry_replace(*prev)
+
+    @pytest.mark.parametrize("key,dtype", [
+        ((2,), np.dtype("f4")),
+        ((2, 2, 2), np.dtype(np.float16)),
+        (None, np.dtype(np.float16)),
+    ])
+    def test_register_bad_dlpack_tuple(self, key, dtype):
+        with pytest.raises(TypeError):
+            np.dtypes.register_dlpack_dtype(key, dtype)
+
+    @pytest.mark.parametrize("key,dtype", [
+        ((-1, 16), np.dtype(np.float16)),
+        ((256, 16), np.dtype(np.float16)),
+        ((4, 15), np.dtype(np.float16)),
+        ((4, 256), np.dtype(np.float16)),
+        ((4, 15), np.dtype(np.float32)),
+    ])
+    def test_register_bad_code_or_bits(self, key, dtype):
+        with pytest.raises(ValueError, match="0..255"):
+            np.dtypes.register_dlpack_dtype(key, dtype)
+
+    def test_register_idempotent(self):
+        dt = np.dtype(np.float16)
+        np.dtypes.register_dlpack_dtype((4, 16), dt)
+        np.dtypes.register_dlpack_dtype((4, 16), dt)
+
+    def test_roundtrip(self, dtype=np.dtype("S1")):
+        # Register "S1" as kDLFloat8_e3m4 == 7
+        # (use of kwarg ensure singleton in free-threading)
+        np.dtypes.register_dlpack_dtype((7, 8), dtype)
+        x = np.array([1.0, 2.0], dtype="S1")
+        y = np.from_dlpack(x)
+        assert y.dtype == "S1"
+        assert_array_equal(x, y)
+
+    def test_register_conflict(self):
+        np.dtypes.register_dlpack_dtype((4, 16), np.dtype(np.float16))
+        with pytest.raises(ValueError, match="already exported"):
+            np.dtypes.register_dlpack_dtype((5, 16), np.dtype(np.float16))
+
+        a = np.array(["12", "23"])
+        with pytest.raises(BufferError):
+            np.from_dlpack(a)  # dtype not yet registered
+
+        with pytest.raises(ValueError, match="already maps"):
+            np.dtypes.register_dlpack_dtype((4, 16), "S2")
+
+        # But... accept that this now does get exported (but won't roundtrip)
+        arr = np.from_dlpack(np.array(["12", "23"], dtype="S2"))
+        assert arr.dtype == np.float16

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -222,7 +222,7 @@ class TestRegisterDlpackDtype:
         np.dtypes.register_dlpack_dtype((4, 16), dt)
         np.dtypes.register_dlpack_dtype((4, 16), dt)
 
-    def test_roundtrip(self, dtype=np.dtype("S1")):
+    def test_roundtrip(self, dtype=np.dtype("S1")):  # noqa: B008
         # Register "S1" as kDLFloat8_e3m4 == 7
         # (use of kwarg ensure singleton in free-threading)
         np.dtypes.register_dlpack_dtype((7, 8), dtype)

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -30,7 +30,8 @@ class TestDLPack:
         x = np.arange(5)
         x.__dlpack__(stream=None)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(
+                ValueError, match="NumPy only supports stream=None."):
             x.__dlpack__(stream=1)
 
     def test_dunder_dlpack_copy(self):
@@ -210,11 +211,11 @@ class TestRegisterDlpackDtype:
         ((-1, 16), np.dtype(np.float16)),
         ((256, 16), np.dtype(np.float16)),
         ((4, 15), np.dtype(np.float16)),
-        ((4, 256), np.dtype(np.float16)),
+        ((4, 256), np.dtype("V256")),
         ((4, 15), np.dtype(np.float32)),
     ])
     def test_register_bad_code_or_bits(self, key, dtype):
-        with pytest.raises(ValueError, match="0..255"):
+        with pytest.raises(ValueError, match="(0..255|must match the dtype)"):
             np.dtypes.register_dlpack_dtype(key, dtype)
 
     def test_register_idempotent(self):
@@ -246,3 +247,17 @@ class TestRegisterDlpackDtype:
         # But... accept that this now does get exported (but won't roundtrip)
         arr = np.from_dlpack(np.array(["12", "23"], dtype="S2"))
         assert arr.dtype == np.float16
+
+    @pytest.mark.thread_unsafe(reason="dlpack registry is thread-unsafe")
+    def test_buffererror_bad_dtype(self, dtype=np.dtype("S3")):  # noqa: B008
+        # Register S3 as a nonsensical dtype
+        np.dtypes.register_dlpack_dtype((123, 24), dtype)
+        # Delete from import but not from export.
+        exp, imp = np._core._multiarray_umath._dlpack_registry_replace({}, {})
+        exp.pop((123, 24))
+        np._core._multiarray_umath._dlpack_registry_replace(exp, imp)
+
+        arr = np.array(["1", "2"], dtype=dtype)
+        arr.__dlpack__()  # passes
+        with pytest.raises(BufferError):
+            np.from_dlpack(arr)  # doesn't round-trip

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -200,6 +200,7 @@ class TestRegisterDlpackDtype:
         ((2,), np.dtype("f4")),
         ((2, 2, 2), np.dtype(np.float16)),
         (None, np.dtype(np.float16)),
+        ((4, 16), "S2"),  # not a dtype instance
     ])
     def test_register_bad_dlpack_tuple(self, key, dtype):
         with pytest.raises(TypeError):
@@ -240,7 +241,7 @@ class TestRegisterDlpackDtype:
             np.from_dlpack(a)  # dtype not yet registered
 
         with pytest.raises(ValueError, match="already maps"):
-            np.dtypes.register_dlpack_dtype((4, 16), "S2")
+            np.dtypes.register_dlpack_dtype((4, 16), np.dtype("S2"))
 
         # But... accept that this now does get exported (but won't roundtrip)
         arr = np.from_dlpack(np.array(["12", "23"], dtype="S2"))

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1670,6 +1670,9 @@ class TestDTypeClasses:
 
     def test_scalar_helper_all_dtypes(self):
         for dtype in np.dtypes.__all__:
+            if dtype == "register_dlpack_dtype":
+                continue
+
             dt_class = getattr(np.dtypes, dtype)
             dt = np.dtype(dt_class)
             if dt.char not in 'OTVM':
@@ -2039,7 +2042,9 @@ class TestDTypeSignatures:
         assert sig.parameters["new_order"].kind is inspect.Parameter.POSITIONAL_ONLY
         assert sig.parameters["new_order"].default == "S"
 
-    @pytest.mark.parametrize("typename", np.dtypes.__all__)
+    @pytest.mark.parametrize("typename", [
+        n for n in np.dtypes.__all__ if n != "register_dlpack_dtype"
+    ])
     def test_signature_dtypes_classes(self, typename: str):
         dtype_type = getattr(np.dtypes, typename)
         sig = inspect.signature(dtype_type)

--- a/numpy/dtypes.py
+++ b/numpy/dtypes.py
@@ -26,10 +26,8 @@ like ``"float64"`` can be used.
 __all__ = ["register_dlpack_dtype"]
 
 
-def register_dlpack_dtype(dlpack_key, dtype):
+def register_dlpack_dtype(dlpack_key, dtype, /):
     """
-    register_dlpack_dtype(dlpack_key, dtype, /)
-
     Register a NumPy dtype for a DLPack ``(code, bits)`` pair so that
     `numpy.from_dlpack` can import it and ``ndarray.__dlpack__`` can export
     it.  Built-in dtype mappings take priority on import.

--- a/numpy/dtypes.py
+++ b/numpy/dtypes.py
@@ -33,7 +33,12 @@ def register_dlpack_dtype(dlpack_key, dtype, /):
     it.  Built-in dtype mappings take priority on import.
 
     If you think a conflict is possible but unproblematic you may wrap this
-    into a try/except block.
+    into a try/except block as NumPy will raise an error if another DType
+    is already registered for the same (code, bits) pair.
+    While an error is raised, the export is registered even on error.
+
+    Registering an identical (not equal) dtype multiple times is allowed but
+    normally registration should happen at import time.
 
     .. warning::
         It is the responsibility of the registering user to ensure that the
@@ -41,7 +46,8 @@ def register_dlpack_dtype(dlpack_key, dtype, /):
 
     .. note::
         This function was added primarily for ``ml_dtypes`` and may be
-        replaced with a different mechanism in the future.
+        replaced with a different mechanism in the future.  It is intended
+        to be used by authors of user-defined dtypes and not end-users.
 
     Parameters
     ----------

--- a/numpy/dtypes.py
+++ b/numpy/dtypes.py
@@ -23,8 +23,49 @@ like ``"float64"`` can be used.
 """
 
 # See doc/source/reference/routines.dtypes.rst for module-level docs
+__all__ = ["register_dlpack_dtype"]
 
-__all__ = []
+
+def register_dlpack_dtype(dlpack_key, dtype):
+    """
+    register_dlpack_dtype(dlpack_key, dtype, /)
+
+    Register a NumPy dtype for a DLPack ``(code, bits)`` pair so that
+    `numpy.from_dlpack` can import it and ``ndarray.__dlpack__`` can export
+    it.  Built-in dtype mappings take priority on import.
+
+    If you think a conflict is possible but unproblematic you may wrap this
+    into a try/except block.
+
+    .. warning::
+        It is the responsibility of the registering user to ensure that the
+        mapping is valid.
+
+    .. note::
+        This function was added primarily for ``ml_dtypes`` and may be
+        replaced with a different mechanism in the future.
+
+    Parameters
+    ----------
+    dlpack_key : tuple of int
+        ``(dl_dtype_code, dl_bits)`` matching the DLPack ``DLDataType``,
+        lanes is assumed to be always 1, currently.
+    dtype : dtype
+        A NumPy dtype instance.
+
+    Raises
+    ------
+    ValueError : If a conflicting registration was already done.
+
+    See Also
+    --------
+    numpy.from_dlpack
+
+    """
+    # Deferred to avoid circular import.
+    from numpy._core._multiarray_umath import _register_dlpack_dtype
+
+    return _register_dlpack_dtype(dlpack_key, dtype)
 
 
 def _add_dtype_helper(DType, alias):

--- a/numpy/dtypes.pyi
+++ b/numpy/dtypes.pyi
@@ -15,8 +15,10 @@ from typing import (
 from typing_extensions import TypeVar
 
 import numpy as np
+from numpy._typing import _DTypeLike
 
 __all__ = [
+    "register_dlpack_dtype",
     "BoolDType",
     "Int8DType",
     "ByteDType",
@@ -622,3 +624,5 @@ class StringDType(  # type: ignore[misc]
     def isalignedstruct(self) -> L[False]: ...
     @property
     def isnative(self) -> L[True]: ...
+
+def register_dlpack_dtype(dlpack_key: tuple[int, int], dtype: _DTypeLike[ScalarT], /) -> None: ...

--- a/numpy/dtypes.pyi
+++ b/numpy/dtypes.pyi
@@ -15,7 +15,6 @@ from typing import (
 from typing_extensions import TypeVar
 
 import numpy as np
-from numpy._typing import _DTypeLike
 
 __all__ = [
     "register_dlpack_dtype",
@@ -625,4 +624,4 @@ class StringDType(  # type: ignore[misc]
     @property
     def isnative(self) -> L[True]: ...
 
-def register_dlpack_dtype(dlpack_key: tuple[int, int], dtype: _DTypeLike[ScalarT], /) -> None: ...
+def register_dlpack_dtype(dlpack_key: tuple[int, int], dtype: np.dtype, /) -> None: ...


### PR DESCRIPTION
This basically allows `ml_dtypes` to add something like:
```
np.dtypes.register_dlpack_dtype((4, 16), np.dtype("bfloat16"))
```
after defining their bfloat16 dtype.  After that import and export will work.  (And of course the same for all other dtypes.)

This is a pragmatic version just using dicts internally.  The code is slightly longer then I had hoped, but straight forward.

Now, generally, I don't like registering on the dtype instances, but:
* It seems simple and focused enough that it isn't a big long-term burden.
* The more proper "put it on the DType class" style is actually a bit more complex because it would need either need two full methods (and a loop to ask all DTypes or so) or assumptions around dtypes being non-parametric.

In the end, basically, I suspect this is good enough for all we need and not bad enough that need to worry a lot that it might stand in the way one day.

(I had an agent execute much of this, but all my design and all audited, just not all typed out by hand really...)