### PR TITLE
BUG: handle non-ASCII flags and tofile format strings

### DIFF
--- a/doc/release/upcoming_changes/31257.change.rst
+++ b/doc/release/upcoming_changes/31257.change.rst
@@ -2,4 +2,4 @@ Non-ASCII inputs no longer crash ``flags`` assignment or ``tofile``
 -------------------------------------------------------------------
 Passing a non-ASCII flag key to ``ndarray.flags[...] = ...`` now raises
 ``KeyError`` instead of crashing. Passing a non-ASCII ``format`` argument to
-`numpy.ndarray.tofile` now raises ``ValueError`` instead of crashing.
+``numpy.ndarray.tofile`` now raises ``UnicodeEncodeError`` instead of crashing.

--- a/doc/release/upcoming_changes/31257.change.rst
+++ b/doc/release/upcoming_changes/31257.change.rst
@@ -1,5 +1,0 @@
-Non-ASCII inputs no longer crash ``flags`` assignment or ``tofile``
--------------------------------------------------------------------
-Passing a non-ASCII flag key to ``ndarray.flags[...] = ...`` now raises
-``KeyError`` instead of crashing. Passing a non-ASCII ``format`` argument to
-``numpy.ndarray.tofile`` now raises ``UnicodeEncodeError`` instead of crashing.

--- a/doc/release/upcoming_changes/31257.change.rst
+++ b/doc/release/upcoming_changes/31257.change.rst
@@ -1,0 +1,5 @@
+Non-ASCII inputs no longer crash ``flags`` assignment or ``tofile``
+-------------------------------------------------------------------
+Passing a non-ASCII flag key to ``ndarray.flags[...] = ...`` now raises
+``KeyError`` instead of crashing. Passing a non-ASCII ``format`` argument to
+`numpy.ndarray.tofile` now raises ``ValueError`` instead of crashing.

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -299,6 +299,16 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
                 }
             }
             byteobj = PyUnicode_AsASCIIString(strobj);
+            if (byteobj == NULL) {
+                Py_DECREF(strobj);
+                Py_DECREF(it);
+                if (n4 != 0) {
+                    PyErr_SetString(PyExc_ValueError,
+                            "The `format` parameter must contain only ASCII "
+                            "characters.");
+                }
+                return -1;
+            }
             NPY_BEGIN_ALLOW_THREADS;
             n2 = PyBytes_GET_SIZE(byteobj);
             n = fwrite(PyBytes_AS_STRING(byteobj), 1, n2, fp);

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -141,7 +141,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
     npy_intp n, n2;
     size_t n3, n4;
     PyArrayIterObject *it;
-    PyObject *obj, *strobj, *tupobj, *byteobj;
+    PyObject *obj, *strobj, *tupobj, *byteobj, *formatobj = NULL;
 
     n3 = (sep ? strlen((const char *)sep) : 0);
     if (n3 == 0) {
@@ -251,6 +251,25 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
         it = (PyArrayIterObject *)
             PyArray_IterNew((PyObject *)self);
         n4 = (format ? strlen((const char *)format) : 0);
+        if (n4 != 0) {
+            /*
+             * Validate the explicit format string once so later ASCII
+             * conversion failures continue to reflect element data.
+             */
+            formatobj = PyUnicode_FromString((const char *)format);
+            if (formatobj == NULL) {
+                Py_DECREF(it);
+                return -1;
+            }
+            if (!PyUnicode_IS_ASCII(formatobj)) {
+                Py_DECREF(formatobj);
+                Py_DECREF(it);
+                PyErr_SetString(PyExc_ValueError,
+                        "The `format` parameter must contain only ASCII "
+                        "characters.");
+                return -1;
+            }
+        }
         while (it->index < it->size) {
             /*
              * This is as documented.  If we have a low precision float value
@@ -260,6 +279,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
              */
             obj = PyArray_GETITEM(self, it->dataptr);
             if (obj == NULL) {
+                Py_XDECREF(formatobj);
                 Py_DECREF(it);
                 return -1;
             }
@@ -270,6 +290,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
                 strobj = PyObject_Str(obj);
                 Py_DECREF(obj);
                 if (strobj == NULL) {
+                    Py_XDECREF(formatobj);
                     Py_DECREF(it);
                     return -1;
                 }
@@ -280,20 +301,15 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
                  */
                 tupobj = PyTuple_New(1);
                 if (tupobj == NULL) {
+                    Py_XDECREF(formatobj);
                     Py_DECREF(it);
                     return -1;
                 }
                 PyTuple_SET_ITEM(tupobj,0,obj);
-                obj = PyUnicode_FromString((const char *)format);
-                if (obj == NULL) {
-                    Py_DECREF(tupobj);
-                    Py_DECREF(it);
-                    return -1;
-                }
-                strobj = PyUnicode_Format(obj, tupobj);
-                Py_DECREF(obj);
+                strobj = PyUnicode_Format(formatobj, tupobj);
                 Py_DECREF(tupobj);
                 if (strobj == NULL) {
+                    Py_XDECREF(formatobj);
                     Py_DECREF(it);
                     return -1;
                 }
@@ -301,16 +317,8 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
             byteobj = PyUnicode_AsASCIIString(strobj);
             if (byteobj == NULL) {
                 Py_DECREF(strobj);
+                Py_XDECREF(formatobj);
                 Py_DECREF(it);
-                if (n4 != 0) {
-                    /*
-                     * Without an explicit format string, preserve the
-                     * original UnicodeEncodeError from the element text.
-                     */
-                    PyErr_SetString(PyExc_ValueError,
-                            "The `format` parameter must contain only ASCII "
-                            "characters.");
-                }
                 return -1;
             }
             NPY_BEGIN_ALLOW_THREADS;
@@ -323,6 +331,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
                         "problem writing element %" NPY_INTP_FMT
                         " to file", it->index);
                 Py_DECREF(strobj);
+                Py_XDECREF(formatobj);
                 Py_DECREF(it);
                 return -1;
             }
@@ -332,6 +341,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
                     PyErr_Format(PyExc_OSError,
                             "problem writing separator to file");
                     Py_DECREF(strobj);
+                    Py_XDECREF(formatobj);
                     Py_DECREF(it);
                     return -1;
                 }
@@ -339,6 +349,7 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
             Py_DECREF(strobj);
             PyArray_ITER_NEXT(it);
         }
+        Py_XDECREF(formatobj);
         Py_DECREF(it);
     }
     return 0;

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -303,6 +303,10 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
                 Py_DECREF(strobj);
                 Py_DECREF(it);
                 if (n4 != 0) {
+                    /*
+                     * Without an explicit format string, preserve the
+                     * original UnicodeEncodeError from the element text.
+                     */
                     PyErr_SetString(PyExc_ValueError,
                             "The `format` parameter must contain only ASCII "
                             "characters.");

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -252,21 +252,9 @@ PyArray_ToFile(PyArrayObject *self, FILE *fp, char *sep, char *format)
             PyArray_IterNew((PyObject *)self);
         n4 = (format ? strlen((const char *)format) : 0);
         if (n4 != 0) {
-            /*
-             * Validate the explicit format string once so later ASCII
-             * conversion failures continue to reflect element data.
-             */
             formatobj = PyUnicode_FromString((const char *)format);
             if (formatobj == NULL) {
                 Py_DECREF(it);
-                return -1;
-            }
-            if (!PyUnicode_IS_ASCII(formatobj)) {
-                Py_DECREF(formatobj);
-                Py_DECREF(it);
-                PyErr_SetString(PyExc_ValueError,
-                        "The `format` parameter must contain only ASCII "
-                        "characters.");
                 return -1;
             }
         }

--- a/numpy/_core/src/multiarray/flagsobject.c
+++ b/numpy/_core/src/multiarray/flagsobject.c
@@ -586,6 +586,9 @@ arrayflags_setitem(PyArrayFlagsObject *self, PyObject *ind, PyObject *item)
     if (PyUnicode_Check(ind)) {
         PyObject *tmp_str;
         tmp_str = PyUnicode_AsASCIIString(ind);
+        if (tmp_str == NULL) {
+            goto fail;
+        }
         key = PyBytes_AS_STRING(tmp_str);
         n = PyBytes_GET_SIZE(tmp_str);
         if (n > 16) n = 16;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -270,6 +270,11 @@ class TestFlags:
         assert_equal(arr.flags['X'], False)
         assert_equal(arr.flags['WRITEBACKIFCOPY'], False)
 
+    def test_non_ascii_flag_setitem_raises_keyerror(self):
+        arr = np.arange(10)
+        with pytest.raises(KeyError, match="Unknown flag"):
+            arr.flags["\N{MICRO SIGN}"] = True
+
     def test_string_align(self):
         a = np.zeros(4, dtype=np.dtype('|S4'))
         assert_(a.flags.aligned)
@@ -6172,6 +6177,18 @@ class TestIO:
         with open(tmp_filename, 'r') as f:
             s = f.read()
         assert_equal(s, '1.51,2.00,3.51,4.00')
+
+    def test_tofile_non_ascii_format_raises_valueerror(self, tmp_path,
+                                                        param_filename):
+        tmp_filename = normalize_filename(tmp_path, param_filename)
+        x = np.array([1.51, 2, 3.51, 4], dtype=float)
+        with open(tmp_filename, 'w') as f:
+            with pytest.raises(
+                ValueError,
+                match="The `format` parameter must contain only ASCII "
+                      "characters.",
+            ):
+                x.tofile(f, sep=',', format='\N{MICRO SIGN}%.2f')
 
     def test_tofile_cleanup(self, tmp_path, param_filename):
         tmp_filename = normalize_filename(tmp_path, param_filename)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6198,6 +6198,14 @@ class TestIO:
             with pytest.raises(UnicodeEncodeError):
                 x.tofile(f, sep=',')
 
+    def test_tofile_non_ascii_element_with_ascii_format_raises_unicodeencodeerror(
+            self, tmp_path, param_filename):
+        tmp_filename = normalize_filename(tmp_path, param_filename)
+        x = np.array(['\N{MICRO SIGN}123'])
+        with open(tmp_filename, 'w') as f:
+            with pytest.raises(UnicodeEncodeError):
+                x.tofile(f, sep=',', format='%s')
+
     def test_tofile_cleanup(self, tmp_path, param_filename):
         tmp_filename = normalize_filename(tmp_path, param_filename)
         x = np.zeros((10), dtype=object)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6190,6 +6190,14 @@ class TestIO:
             ):
                 x.tofile(f, sep=',', format='\N{MICRO SIGN}%.2f')
 
+    def test_tofile_non_ascii_element_without_format_raises_unicodeencodeerror(
+            self, tmp_path, param_filename):
+        tmp_filename = normalize_filename(tmp_path, param_filename)
+        x = np.array(['\N{MICRO SIGN}'])
+        with open(tmp_filename, 'w') as f:
+            with pytest.raises(UnicodeEncodeError):
+                x.tofile(f, sep=',')
+
     def test_tofile_cleanup(self, tmp_path, param_filename):
         tmp_filename = normalize_filename(tmp_path, param_filename)
         x = np.zeros((10), dtype=object)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6178,16 +6178,12 @@ class TestIO:
             s = f.read()
         assert_equal(s, '1.51,2.00,3.51,4.00')
 
-    def test_tofile_non_ascii_format_raises_valueerror(self, tmp_path,
-                                                        param_filename):
+    def test_tofile_non_ascii_format_raises_unicodeencodeerror(
+            self, tmp_path, param_filename):
         tmp_filename = normalize_filename(tmp_path, param_filename)
         x = np.array([1.51, 2, 3.51, 4], dtype=float)
         with open(tmp_filename, 'w') as f:
-            with pytest.raises(
-                ValueError,
-                match="The `format` parameter must contain only ASCII "
-                      "characters.",
-            ):
+            with pytest.raises(UnicodeEncodeError):
                 x.tofile(f, sep=',', format='\N{MICRO SIGN}%.2f')
 
     def test_tofile_non_ascii_element_without_format_raises_unicodeencodeerror(


### PR DESCRIPTION

### PR summary

As described in #31254, non-ASCII strings are not handled 
safely by `arrayflags_setitem` and `PyArray_ToFile`.

What to do with Unicode strings elsewhere upstream / downstream
is a complicated question that has design consequences, so 
@WarrenWeckesser suggested reasonable error handling in the bug
report comments to provide the user with useful, non-segfaulting
execptions.

This PR simply implements those recommendations and adds coverage
to ensure `KeyError` / `ValueError` are properly raised when 
ecnountered.


#### First-time contributor introduction
Hi there! Numeric/numarray user who has been on the long journey
after switching from Matlab and Fortran a long time ago...thank you
for all of your work - I know how much went into 2.0!


#### AI Disclosure

The original C issue was detected using Claude Agent SDK and a variety of
tools like semgrep / ast-grep / libclang.  

Claude Code (Opus 4.6) and Codex CLI were used to prepare the PR branch,
although the credit for the proposed fixes themselves really go to 
@WarrenWeckesser.


PS: sorry again for earlier auto-submission.