### PR TITLE
ENH: Allow user-dtypes return views on `.conjugate()`

### DIFF
--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -841,7 +841,7 @@ PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
         }
     }
     else {
-        if (!NPY_DT_is_numeric(NPY_DTYPE(PyArray_DESCR(self)))) {
+        if (!NPY_DT_is_numeric(PyArray_DTYPE(self))) {
             PyErr_SetString(PyExc_TypeError,
                             "cannot conjugate non-numeric dtype");
             return NULL;

--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -828,8 +828,8 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
 NPY_NO_EXPORT PyObject *
 PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
 {
-    if (PyArray_ISCOMPLEX(self) || PyArray_ISOBJECT(self) ||
-            PyArray_ISUSERDEF(self) || !NPY_DT_is_legacy(PyArray_DESCR(self))) {
+    if (NPY_DT_SLOTS(NPY_DTYPE(PyArray_DTYPE(self)))->imag_meth != NULL) {
+        /* The dtype has `arr.imag` so `conjugate` must exist (or error) */
         if (out == NULL) {
             return PyArray_GenericUnaryFunction(self,
                                                 n_ops.conjugate);
@@ -841,12 +841,14 @@ PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
         }
     }
     else {
-        PyArrayObject *ret;
-        if (!PyArray_ISNUMBER(self)) {
+        if (!NPY_DT_is_numeric(NPY_DTYPE(PyArray_DESCR(self)))) {
             PyErr_SetString(PyExc_TypeError,
-                "cannot conjugate non-numeric dtype");
+                            "cannot conjugate non-numeric dtype");
             return NULL;
         }
+
+        /* Numeric but no `.imag`: real-valued (or `.imag` should error) */
+        PyArrayObject *ret;
         if (out) {
             if (PyArray_AssignArray(out, self,
                         NULL, NPY_DEFAULT_ASSIGN_CASTING) < 0) {

--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -841,7 +841,7 @@ PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
         }
     }
     else {
-        if (!NPY_DT_is_numeric(PyArray_DTYPE(self))) {
+        if (!NPY_DT_is_numeric(NPY_DTYPE(PyArray_DTYPE(self)))) {
             PyErr_SetString(PyExc_TypeError,
                             "cannot conjugate non-numeric dtype");
             return NULL;

--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -373,6 +373,12 @@ class TestSFloat:
         np.testing.assert_array_equal(
             arr.view(np.float64), arr2.view(np.float64))
 
+    def test_conjugate(self):
+        # Also user dtype can just return self if conjugate should be no-op.
+        arr = np.array([1.0, 2.0, 3.0], dtype=SF(1.0))
+        assert arr.conjugate() is arr
+
+
 @pytest.mark.thread_unsafe(
     reason="_ScaledFloatTestDType setup is thread-unsafe (gh-29850)"
 )


### PR DESCRIPTION
This uses the fact that if something _doesn't_ define an imag, then `conjugate()` should be defined as a simple view (similar to `.real`).

This is a follow-up of a previous PR, where I didn't implement this isn't really backportable.

With this, QuadDType for example does return a view (and a complex new-style dtype can opt out this).

This _doesn't_ yet support for `.conjugate()` to return a view for complex numbers (which would make a lot of sense and could be added but take a bit more effort).

CC @SwayamInSync in case you have time to do the main review maybe, follow up to that other PR (but not backportable, IMO -- I really don't mind adding that `.conj()` could be a view eventually).