### PR TITLE
MAINT: Expose ufunc vectorcall function on Limited API >= 3.12

### DIFF
--- a/numpy/_core/include/numpy/ufuncobject.h
+++ b/numpy/_core/include/numpy/ufuncobject.h
@@ -179,7 +179,7 @@ typedef struct _tagPyUFuncObject {
          * but this was never implemented. (This is also why the above
          * selector is called the "legacy" selector.)
          */
-        #ifndef Py_LIMITED_API
+        #if !defined(Py_LIMITED_API) || Py_LIMITED_API >= 0x030C0000
             vectorcallfunc vectorcall;
         #else
             void *vectorcall;


### PR DESCRIPTION
### PR summary

Minor improvement to the Limited API - `vectorcallfunc` is part of the Limited API from Python 3.12 onwards so the guard can be adjusted to account for that. I doubt that anyone particularly wants to modify it but there's no reason to specifically hide it.

### First time committer introduction

I spotted this while trying to work out what changes in the Limited API. I'm not planning to regularly contribute directly to Numpy right now, but it's a simple enough fix that it seemed worth doing.

#### AI Disclosure

No AI tools used.  Not a lot of human intelligence used for this either.