### PR TITLE
MAINT: use new dtype in view creation rather than going through two views

### DIFF
--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -371,6 +371,103 @@ _may_have_objects(PyArray_Descr *dtype)
 }
 
 /*
+ * Check whether self can be viewed with the given dtype.
+ * If so, return a new reference to the dtype (possibly changed).
+ * If needed, also determine new dimensions and strides for the last axis.
+ * If no change is needed, newlastdim is set to -1.
+ */
+NPY_NO_EXPORT PyArray_Descr*
+_check_compatibility_with_new_dtype(
+    PyArrayObject *self, PyArray_Descr *type,
+    npy_intp *newlastdim, npy_intp *newlaststride)
+{
+    PyArray_Descr *dtype = PyArray_DESCR(self);
+    *newlastdim = -1;  /* By default, no change needed. */
+
+    /* Check that we are not reinterpreting memory containing Objects. */
+    if (_may_have_objects(dtype) || _may_have_objects(type)) {
+        if (npy_cache_import_runtime(
+                "numpy._core._internal", "_view_is_safe",
+                &npy_runtime_imports._view_is_safe) == -1) {
+            return NULL;
+        }
+        PyObject *safe = PyObject_CallFunctionObjArgs(
+                npy_runtime_imports._view_is_safe, dtype, type, NULL);
+        if (safe == NULL) {
+            return NULL;
+        }
+        Py_DECREF(safe);
+    }
+
+    if (type->elsize != dtype->elsize) {
+        /*
+         * Viewing as an unsized void implies a void dtype matching
+         * the size of the current dtype.
+         */
+        if (type->type_num == NPY_VOID && PyDataType_ISUNSIZED(type)) {
+            PyArray_Descr *newtype = PyArray_DescrNew(type);
+            if (newtype == NULL) {
+                return NULL;
+            }
+            newtype->elsize = dtype->elsize;
+            return newtype;
+        }
+        /*
+         * Otherwise, changing the size of the dtype results in a shape change,
+         * which we signal by setting newlastdim and newlaststride.
+         */
+        /* Check forbidden cases. */
+        if (PyDataType_HASSUBARRAY(type)) {
+            PyErr_SetString(PyExc_ValueError,
+                    "Changing the dtype to a subarray type is only supported "
+                    "if the total itemsize is unchanged");
+            return NULL;
+        }
+        int nd = PyArray_NDIM(self);
+        if (nd == 0) {
+            PyErr_SetString(PyExc_ValueError,
+                    "Changing the dtype of a 0d array is only supported "
+                    "if the itemsize is unchanged");
+            return NULL;
+        }
+        /* Resize on last axis only (we have nd>0 here). */
+        npy_intp lastdim = PyArray_DIMS(self)[nd-1];
+        if (lastdim != 1 && PyArray_SIZE(self) != 0 &&
+                PyArray_STRIDES(self)[nd-1] != dtype->elsize) {
+            PyErr_SetString(PyExc_ValueError,
+                    "To change to a dtype of a different size, the last axis "
+                    "must be contiguous");
+            return NULL;
+        }
+        if (type->elsize < dtype->elsize) {
+            /* If it is compatible, increase the size of the last axis. */
+            if (type->elsize == 0 || dtype->elsize % type->elsize != 0) {
+                PyErr_SetString(PyExc_ValueError,
+                        "When changing to a smaller dtype, its size must be a "
+                        "divisor of the size of original dtype");
+                return NULL;
+            }
+            *newlastdim = (dtype->elsize / type->elsize) * lastdim;
+        }
+        else /* type->elsize > dtype->elsize */ {
+            /* If it is compatible, decrease the size of the relevant axis. */
+            npy_intp lastsize = lastdim * dtype->elsize;
+            if (lastsize % type->elsize != 0) {
+                PyErr_SetString(PyExc_ValueError,
+                        "When changing to a larger dtype, its size must be a "
+                        "divisor of the total size in bytes of the last axis "
+                        "of the array.");
+                return NULL;
+            }
+            *newlastdim = lastsize / type->elsize;
+        }
+        *newlaststride = type->elsize;
+    }
+    Py_INCREF(type);
+    return type;
+}
+
+/*
  * Make a new empty array, of the passed size, of a type that takes the
  * priority of ap1 and ap2 into account.
  *

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -96,6 +96,17 @@ NPY_NO_EXPORT int
 _may_have_objects(PyArray_Descr *dtype);
 
 /*
+ * Check whether self can be viewed with the given dtype.
+ * If so, return a new reference to the dtype (possibly changed).
+ * If needed, also determine new dimensions and strides for the last axis.
+ * If no change is needed, newlastdim is set to -1.
+ */
+NPY_NO_EXPORT PyArray_Descr*
+_check_compatibility_with_new_dtype(
+    PyArrayObject *self, PyArray_Descr *type,
+    npy_intp *newlastdim, npy_intp *newlaststride);
+
+/*
  * Returns -1 and sets an exception if *index is an invalid index for
  * an array of size max_item, otherwise adjusts it in place to be
  * 0 <= *index < max_item, and returns 0.

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -533,10 +533,13 @@ PyArray_NewCopy(PyArrayObject *obj, NPY_ORDER order)
 NPY_NO_EXPORT PyObject *
 PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
 {
-    PyArrayObject *ret = NULL;
-    PyArray_Descr *dtype;
+    PyObject *ret = NULL;
+    int nd = PyArray_NDIM(self);
+    npy_intp *dims = PyArray_DIMS(self);
+    npy_intp *strides = PyArray_STRIDES(self);
+    PyArray_Descr *dtype = PyArray_DESCR(self);
+    int flags = PyArray_FLAGS(self);
     PyTypeObject *subtype;
-    int flags;
 
     if (pytype) {
         subtype = pytype;
@@ -545,42 +548,35 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
         subtype = Py_TYPE(self);
     }
 
-    dtype = PyArray_DESCR(self);
-    flags = PyArray_FLAGS(self);
-
     if (type == NULL) {
         /* No dtype change: just create the view */
         Py_INCREF(dtype);
-        ret = (PyArrayObject *)PyArray_NewFromDescr_int(
-                subtype, dtype,
-                PyArray_NDIM(self), PyArray_DIMS(self),
-                PyArray_STRIDES(self), PyArray_DATA(self),
+        return PyArray_NewFromDescr_int(
+                subtype, dtype, nd, dims, strides, PyArray_DATA(self),
                 flags, (PyObject *)self, (PyObject *)self,
                 _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
-        return (PyObject *)ret;
     }
 
     /*
      * Changing dtype on a subclass.  We support 4 paths:
      *
-     * 1. subclass overrides _set_dtype: create subclass view first,
+     * 1. If _set_dtype is None: create a new view with the new dtype.
+     *    This is the future: __array_finalize__ sees final dtype and shape.
+     * 2. subclass overrides _set_dtype: create subclass view first,
      *    then call _set_dtype (subclass handles dtype change).
-     *    If _set_dtype is set to None, we use path 3 below.
-     * 2. subclass overrides the dtype descriptor (e.g. property with
+     * 3. subclass overrides the dtype descriptor (e.g. property with
      *    setter): create subclass view first, use the setter, but
      *    emit a deprecation asking to implement _set_dtype instead.
-     * 3. If _set_dtype is None: create an ndarray base view, set dtype
-     *    internally, then create the subclass view if needed:
-     *    __array_finalize__ sees the final dtype+shape.
-     * 4. If _set_dtype (and dtype) are not set, call `__array_finalize__`
+     * 4. If _set_dtype and dtype are not set, call `__array_finalize__`
      *    with the old dtype and forcibly update the dtype (a subclass will be
-     *    unaware of the change) which is the unfortunate historic behavior.
+     *    unaware of the change). This is the unfortunate historic behavior.
      *
-     * (Base class ndarray has no __array_finalize__ so effectively uses path 4.)
+     * (Base class ndarray uses path 1, but has no __array_finalize__,
+     *  so it is the same as paths 2 and 4.)
      */
-    int use_dtype_in_finalize = 0;
-    int use_set_dtype = 0;
-    int use_dtype_prop = 0;
+    npy_bool use_dtype_in_finalize = NPY_TRUE;
+    npy_bool use_set_dtype = NPY_FALSE;
+    npy_bool use_dtype_prop = NPY_FALSE;
 
     if (subtype != &PyArray_Type) {
         PyObject *sub_set_dtype;
@@ -589,10 +585,8 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
                 npy_interned_str._set_dtype, &sub_set_dtype) < 0) {
             goto finish;
         }
-        if (sub_set_dtype == Py_None) {
-            use_dtype_in_finalize = 1;
-        }
-        else {
+        if (sub_set_dtype != Py_None) {
+            use_dtype_in_finalize = NPY_FALSE;
             use_set_dtype = (sub_set_dtype != NULL &&
                     sub_set_dtype != npy_static_pydata.ndarray_set_dtype);
         }
@@ -612,82 +606,95 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
         }
     }
 
-    if (use_set_dtype || use_dtype_prop) {
+    if (use_dtype_in_finalize) {
         /*
-         * Paths 1 & 2: create subclass view with original dtype,
-         * then let the subclass handle the dtype change.
+         * Path 1: subclass lives in the future and its __array_finalize__
+         * can handle getting the correct dtype+shape.
          */
-        Py_INCREF(dtype);
-        ret = (PyArrayObject *)PyArray_NewFromDescr_int(
-                subtype, dtype,
-                PyArray_NDIM(self), PyArray_DIMS(self),
-                PyArray_STRIDES(self), PyArray_DATA(self),
-                flags, (PyObject *)self, (PyObject *)self,
-                _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
-        if (ret == NULL) {
-            goto finish;
+        npy_intp newlastdim, newlaststride;
+        /* Check whether the type is compatible. */
+        Py_SETREF(type, _check_compatibility_with_new_dtype(
+                      self, type, &newlastdim, &newlaststride));
+        if (type == NULL) {
+            return NULL;
         }
-        if (use_set_dtype) {
-            PyObject *res = PyObject_CallMethodOneArg(
-                    (PyObject *)ret,
-                    npy_interned_str._set_dtype, (PyObject *)type);
-            if (res == NULL) {
-                Py_CLEAR(ret);
-                goto finish;
-            }
-            Py_DECREF(res);
+        /* Take view with old or adjusted dims (steals reference to type) */
+        if (newlastdim < 0) {
+            return PyArray_NewFromDescr_int(subtype, type,
+                    nd, dims, strides, PyArray_DATA(self),
+                    flags, (PyObject *)self, (PyObject *)self, 0);
         }
         else {
-            if (PyObject_GenericSetAttr(
-                    (PyObject *)ret, npy_interned_str.dtype,
-                    (PyObject *)type) < 0) {
-                Py_CLEAR(ret);
+            NPY_ALLOC_WORKSPACE(newdims, npy_intp, 2 * 4, 2 * nd);
+            if (newdims == NULL) {
                 goto finish;
             }
-            /* DEPRECATED 2026-04-13, NumPy 2.5 */
-            if (DEPRECATE(
-                    "numpy.ndarray.view() used a custom `dtype` setter "
-                    "to change the dtype of the view.  Subclasses should "
-                    "implement `_set_dtype` instead.") < 0) {
-                Py_CLEAR(ret);
-                goto finish;
-            }
+            npy_intp *newstrides = newdims + nd;
+            memcpy(newdims, dims, (nd-1)*sizeof(npy_intp));
+            memcpy(newstrides, strides, (nd-1)*sizeof(npy_intp));
+            newdims[nd-1] = newlastdim;
+            newstrides[nd-1] = newlaststride;
+            ret = PyArray_NewFromDescr_int(subtype, type,
+                    nd, newdims, newstrides, PyArray_DATA(self),
+                    flags, (PyObject *)self, (PyObject *)self, 0);
+            npy_free_workspace(newdims);
+            return ret;
         }
-        goto finish;
     }
-
-    /* Path 3+4: create view and set dtype internally */
+    /*
+     * Other paths: first create a view with the old dtype.
+     */
     Py_INCREF(dtype);
-    ret = (PyArrayObject *)PyArray_NewFromDescr_int(
-            use_dtype_in_finalize ? &PyArray_Type : subtype, dtype,
-            PyArray_NDIM(self), PyArray_DIMS(self),
-            PyArray_STRIDES(self), PyArray_DATA(self),
+    ret = PyArray_NewFromDescr_int(
+            subtype, dtype, nd, dims, strides, PyArray_DATA(self),
             flags, (PyObject *)self, (PyObject *)self,
             _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
     if (ret == NULL) {
         goto finish;
     }
-    if (array_descr_set_internal(ret, (PyObject *)type) < 0) {
-        Py_CLEAR(ret);
-        goto finish;
-    }
 
-    /*
-     * Path 3: `_set_dtype is None` and `ret` is a base-class array
-     * with correct dtype+shape, this will call `__array_finalize__`
-     * with the final dtype+shape.
-     */
-    if (use_dtype_in_finalize) {
-        Py_INCREF(PyArray_DESCR(ret));
-        Py_SETREF(ret, (PyArrayObject *)PyArray_NewFromDescr_int(
-                subtype, PyArray_DESCR(ret),
-                PyArray_NDIM(ret), PyArray_DIMS(ret),
-                PyArray_STRIDES(ret), PyArray_DATA(ret),
-                PyArray_FLAGS(ret), (PyObject *)self, (PyObject *)self,
-                _NPY_ARRAY_ENSURE_DTYPE_IDENTITY));
+    if (use_set_dtype) {
+        /*
+         * Path 2: subclass lives in future but needs to set dtype itself.
+         */
+        PyObject *res = PyObject_CallMethodOneArg(
+                ret, npy_interned_str._set_dtype, (PyObject *)type);
+        if (res == NULL) {
+            Py_CLEAR(ret);
+            goto finish;
+        }
+        Py_DECREF(res);
+    }
+    else if (use_dtype_prop) {
+        /*
+         * Path 3: subclass overrides dtype property.
+         */
+        if (PyObject_GenericSetAttr(
+                ret, npy_interned_str.dtype, (PyObject *)type) < 0) {
+            Py_CLEAR(ret);
+            goto finish;
+        }
+        /* DEPRECATED 2026-04-13, NumPy 2.5 */
+        if (DEPRECATE(
+                "numpy.ndarray.view() used a custom `dtype` setter "
+                "to change the dtype of the view.  Subclasses should "
+                "implement `_set_dtype` instead.") < 0) {
+            Py_CLEAR(ret);
+            goto finish;
+        }
+    }
+    else {
+        /*
+         * Path 4: set dtype internally.
+         */
+        if (array_descr_set_internal(
+                (PyArrayObject*)ret, (PyObject *)type) < 0) {
+            Py_CLEAR(ret);
+            goto finish;
+        }
     }
 
 finish:
     Py_DECREF(type);
-    return (PyObject *)ret;
+    return ret;
 }

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -353,98 +353,17 @@ array_descr_set_internal(PyArrayObject *self, PyObject *arg)
                 "invalid data-type for array");
         return -1;
     }
-
-    /* check that we are not reinterpreting memory containing Objects. */
-    if (_may_have_objects(PyArray_DESCR(self)) || _may_have_objects(newtype)) {
-        PyObject *safe;
-
-        if (npy_cache_import_runtime(
-                "numpy._core._internal", "_view_is_safe",
-                &npy_runtime_imports._view_is_safe) == -1) {
-            goto fail;
-        }
-
-        safe = PyObject_CallFunction(npy_runtime_imports._view_is_safe,
-                                     "OO", PyArray_DESCR(self), newtype);
-        if (safe == NULL) {
-            goto fail;
-        }
-        Py_DECREF(safe);
-    }
-
-    /*
-     * Viewing as an unsized void implies a void dtype matching the size of the
-     * current dtype.
-     */
-    if (newtype->type_num == NPY_VOID &&
-            PyDataType_ISUNSIZED(newtype) &&
-            newtype->elsize != PyArray_ITEMSIZE(self)) {
-        PyArray_DESCR_REPLACE(newtype);
-        if (newtype == NULL) {
-            return -1;
-        }
-        newtype->elsize = PyArray_ITEMSIZE(self);
-    }
-
-    /* Changing the size of the dtype results in a shape change */
-    if (newtype->elsize != PyArray_ITEMSIZE(self)) {
-        /* forbidden cases */
-        if (PyArray_NDIM(self) == 0) {
-            PyErr_SetString(PyExc_ValueError,
-                    "Changing the dtype of a 0d array is only supported "
-                    "if the itemsize is unchanged");
-            goto fail;
-        }
-        else if (PyDataType_HASSUBARRAY(newtype)) {
-            PyErr_SetString(PyExc_ValueError,
-                    "Changing the dtype to a subarray type is only supported "
-                    "if the total itemsize is unchanged");
-            goto fail;
-        }
-
-        /* resize on last axis only */
-        int axis = PyArray_NDIM(self) - 1;
-        if (PyArray_DIMS(self)[axis] != 1 &&
-                PyArray_SIZE(self) != 0 &&
-                PyArray_STRIDES(self)[axis] != PyArray_ITEMSIZE(self)) {
-            PyErr_SetString(PyExc_ValueError,
-                    "To change to a dtype of a different size, the last axis "
-                    "must be contiguous");
-            goto fail;
-        }
-
-        npy_intp newdim;
-
-        if (newtype->elsize < PyArray_ITEMSIZE(self)) {
-            /* if it is compatible, increase the size of the last axis */
-            if (newtype->elsize == 0 ||
-                    PyArray_ITEMSIZE(self) % newtype->elsize != 0) {
-                PyErr_SetString(PyExc_ValueError,
-                        "When changing to a smaller dtype, its size must be a "
-                        "divisor of the size of original dtype");
-                goto fail;
-            }
-            newdim = PyArray_ITEMSIZE(self) / newtype->elsize;
-            PyArray_DIMS(self)[axis] *= newdim;
-            PyArray_STRIDES(self)[axis] = newtype->elsize;
-        }
-        else /* newtype->elsize > PyArray_ITEMSIZE(self) */ {
-            /* if it is compatible, decrease the size of the relevant axis */
-            newdim = PyArray_DIMS(self)[axis] * PyArray_ITEMSIZE(self);
-            if ((newdim % newtype->elsize) != 0) {
-                PyErr_SetString(PyExc_ValueError,
-                        "When changing to a larger dtype, its size must be a "
-                        "divisor of the total size in bytes of the last axis "
-                        "of the array.");
-                goto fail;
-            }
-            PyArray_DIMS(self)[axis] = newdim / newtype->elsize;
-            PyArray_STRIDES(self)[axis] = newtype->elsize;
-        }
+    /* Check dtype and possibly give new dim & stride for last axis */
+    npy_intp newlastdim, newlaststride;
+    Py_SETREF(newtype, _check_compatibility_with_new_dtype(
+                  self, newtype, &newlastdim, &newlaststride));
+    if (newtype == NULL) {
+        return -1;
     }
 
     /* Viewing as a subarray increases the number of dimensions */
     if (PyDataType_HASSUBARRAY(newtype)) {
+        assert(newlastdim < 0);  /* not allowed for subarrays */
         /*
          * create new array object from data and update
          * dimensions, strides and descr from it
@@ -480,15 +399,15 @@ array_descr_set_internal(PyArrayObject *self, PyObject *arg)
         Py_INCREF(newtype);
         Py_DECREF(temp);
     }
-
+    else if (newlastdim >= 0) {
+        int lastaxis = PyArray_NDIM(self) - 1;
+        PyArray_DIMS(self)[lastaxis] = newlastdim;
+        PyArray_STRIDES(self)[lastaxis] = newlaststride;
+    }
     Py_DECREF(PyArray_DESCR(self));
     ((PyArrayObject_fields *)self)->descr = newtype;
     PyArray_UpdateFlags(self, NPY_ARRAY_UPDATE_ALL);
     return 0;
-
- fail:
-    Py_DECREF(newtype);
-    return -1;
 }
 
 static int


### PR DESCRIPTION
EDITED since now follow-up rather than an alternative to #31234.

This PR lets `PyArray_View()` do a one-step view of both a possibly new subtype and a new dtype. To avoid duplicated checks on the dtype, I factored out that piece of the internal `_set_dtype`.

No AI was used.