### PR TITLE
ENH: fast path for full contiguous reductions

### DIFF
--- a/benchmarks/benchmarks/bench_reduce.py
+++ b/benchmarks/benchmarks/bench_reduce.py
@@ -112,8 +112,26 @@ class ArgMin(Benchmark):
 
 
 class SmallReduction(Benchmark):
-    def setup(self):
-        self.d = np.ones(100, dtype=np.float32)
+    params = [[4, 100]]
+    param_names = ['size']
 
-    def time_small(self):
+    def setup(self, size):
+        self.d = np.ones(size, dtype=np.float32)
+        self.b = np.ones(size, dtype=bool)
+
+    def time_sum(self, size):
         np.sum(self.d)
+
+    def time_any(self, size):
+        np.any(self.b)
+
+    def time_max(self, size):
+        np.max(self.d)
+
+
+class SmallReduction2D(Benchmark):
+    def setup(self):
+        self.d = np.ones((4, 4), dtype=np.float32)
+
+    def time_sum_axis_1(self):
+        np.sum(self.d, axis=1)

--- a/doc/release/upcoming_changes/31274.performance.rst
+++ b/doc/release/upcoming_changes/31274.performance.rst
@@ -1,0 +1,8 @@
+Faster reductions on small/medium contiguous arrays
+---------------------------------------------------
+`numpy.sum`, `numpy.prod`, `numpy.any`, `numpy.all`, and other reductions
+with an identity value now use a fast path when the input is a contiguous,
+aligned, non-object array and the reduction covers all axes
+(``axis=None``) with no special arguments. Typical speedup is ~1.3x on small
+arrays; `numpy.any` / `numpy.all` on contiguous boolean arrays can see speedup
+up to 1.9x.

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2525,17 +2525,6 @@ finish_loop:
  * loop is called directly on the input buffer and writes into a freshly
  * allocated 0-d result.
  *
- * Conditions checked here (each one is required for correctness):
- *   - no `out=`, `wheremask=`, `initial=`, `keepdims=True`
- *   - `naxes == ndim` (full reduction)
- *   - input is C- or F-contiguous and aligned (`*ARRAY_RO` checks both)
- *   - input dtype already matches the loop's input dtype (no cast)
- *   - the op exposes an identity (`get_reduction_initial`)
- *   - output dtype has no Python references
- *   - for multi-axis reductions, the op is reorderable (the fast path
- *     visits elements in memory order, which differs from the iterator
- *     order for F-contiguous multi-D inputs)
- *
  * Returns:
  *      1 on success; ``*out_result`` holds the new 0-d result.
  *      0 if any precondition is unmet (caller should run the slow path);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2580,10 +2580,14 @@ PyUFunc_Reduce(PyUFuncObject *ufunc,
     context.caller = (PyObject *)ufunc;
     context.method = ufuncimpl;
 
-    PyArrayObject *result = PyUFunc_ReduceWrapper(&context,
+    PyArrayObject *result = NULL;
+
+    result = PyUFunc_ReduceWrapper(&context,
             arr, out, wheremask, axis_flags, keepdims,
             initial, reduce_loop, buffersize, ufunc_name, errormask);
+    /* Fall through to shared cleanup of `descrs`. */
 
+  cleanup:
     for (int i = 0; i < 3; i++) {
         Py_DECREF(descrs[i]);
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2620,7 +2620,7 @@ try_reduce_contiguous(
         res = -1;
     }
     if (res == 0 && needs_fperr) {
-        res = _check_ufunc_fperr(errormask, ufunc_name);
+        res = _check_ufunc_fperr(errormask, "reduce");
     }
     if (res < 0) {
         Py_DECREF(result);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2520,10 +2520,13 @@ finish_loop:
 
 /*
  * Try a fast path that bypasses NpyIter / PyUFunc_ReduceWrapper for full
- * reductions (axis=None) over a contiguous, aligned input where no casting
- * is required and the operation has an identity value.  The strided reduce
- * loop is called directly on the input buffer and writes into a freshly
- * allocated 0-d result.
+ * reductions (axis=None) over a trivially iterable, aligned input where no
+ * casting is required and the operation has an identity value.  The strided
+ * reduce loop is called directly on the input buffer and writes into a
+ * freshly allocated 0-d result.
+ *
+ * "Trivially iterable" covers any 1-D array (including non-contiguous slices
+ * such as ``a[::2]``) and any C/F-contiguous N-D array.
  *
  * Returns:
  *      1 on success; ``*out_result`` holds the new 0-d result.
@@ -2546,7 +2549,8 @@ try_reduce_contiguous(
     PyArrayMethodObject *ufuncimpl = context->method;
     if (!(out == NULL && wheremask == NULL && initial == NULL && keepdims == 0
             && naxes == ndim
-            && (PyArray_ISCARRAY_RO(arr) || PyArray_ISFARRAY_RO(arr))
+            && PyArray_TRIVIALLY_ITERABLE(arr)
+            && PyArray_ISALIGNED(arr)
             && PyArray_DESCR(arr) == descrs[1]
             && ufuncimpl->get_reduction_initial != NULL
             && !PyDataType_REFCHK(descrs[0])
@@ -2580,7 +2584,12 @@ try_reduce_contiguous(
         return 0;
     }
 
-    npy_intp strides[3] = {0, descrs[1]->elsize, 0};
+    /*
+     * For C/F-contiguous N-D arrays the stride is always elsize; for 1-D
+     * arrays we need the actual stride to handle non-contiguous slices.
+     */
+    npy_intp arr_stride = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(count, arr);
+    npy_intp strides[3] = {0, arr_stride, 0};
     PyArrayMethod_StridedLoop *strided_loop;
     NpyAuxData *auxdata = NULL;
     NPY_ARRAYMETHOD_FLAGS flags = 0;

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2521,12 +2521,8 @@ finish_loop:
 /*
  * Try a fast path that bypasses NpyIter / PyUFunc_ReduceWrapper for full
  * reductions (axis=None) over a trivially iterable, aligned input where no
- * casting is required and the operation has an identity value.  The strided
- * reduce loop is called directly on the input buffer and writes into a
- * freshly allocated 0-d result.
- *
- * "Trivially iterable" covers any 1-D array (including non-contiguous slices
- * such as ``a[::2]``) and any C/F-contiguous N-D array.
+ * casting is required.  The strided reduce loop is called directly on the
+ * input buffer and writes into a freshly allocated 0-d result.
  *
  * Returns:
  *      1 on success; ``*out_result`` holds the new 0-d result.
@@ -2552,7 +2548,7 @@ try_reduce_contiguous(
             && PyArray_TRIVIALLY_ITERABLE(arr)
             && PyArray_ISALIGNED(arr)
             && PyArray_DESCR(arr) == descrs[1]
-            && ufuncimpl->get_reduction_initial != NULL
+            && descrs[0] == descrs[1]
             && !PyDataType_REFCHK(descrs[0])
             && (ndim <= 1
                 || (ufuncimpl->flags & NPY_METH_IS_REORDERABLE)))) {
@@ -2572,16 +2568,14 @@ try_reduce_contiguous(
         return -1;
     }
     char *accum = PyArray_BYTES(result);
-    int has_initial = ufuncimpl->get_reduction_initial(
-            context, /*reduction_is_empty=*/0, accum);
-    if (has_initial < 0) {
-        Py_DECREF(result);
-        return -1;
-    }
-    if (!has_initial) {
-        /* No identity available -- fall back to the slow path. */
-        Py_DECREF(result);
-        return 0;
+    int has_initial = 0;
+    if (ufuncimpl->get_reduction_initial != NULL) {
+        has_initial = ufuncimpl->get_reduction_initial(
+                context, /*reduction_is_empty=*/0, accum);
+        if (has_initial < 0) {
+            Py_DECREF(result);
+            return -1;
+        }
     }
 
     /*
@@ -2589,6 +2583,22 @@ try_reduce_contiguous(
      * arrays we need the actual stride to handle non-contiguous slices.
      */
     npy_intp arr_stride = PyArray_TRIVIAL_PAIR_ITERATION_STRIDE(count, arr);
+    char *src = PyArray_BYTES(arr);
+    if (!has_initial) {
+        /*
+         * No identity available -- seed the accumulator with arr[0] and
+         * reduce over arr[1:].
+         */
+        memcpy(accum, src, descrs[1]->elsize);
+        src += arr_stride;
+        count -= 1;
+    }
+    if (count == 0) {
+        /* Single-element input with no identity -- accum already holds arr[0]. */
+        *out_result = result;
+        return 1;
+    }
+
     npy_intp strides[3] = {0, arr_stride, 0};
     PyArrayMethod_StridedLoop *strided_loop;
     NpyAuxData *auxdata = NULL;
@@ -2603,7 +2613,7 @@ try_reduce_contiguous(
     if (needs_fperr) {
         npy_clear_floatstatus_barrier((char *)context);
     }
-    char *data[3] = {accum, PyArray_BYTES(arr), accum};
+    char *data[3] = {accum, src, accum};
     int res = strided_loop(context, data, &count, strides, auxdata);
     NPY_AUXDATA_FREE(auxdata);
     if (res == 0 && PyErr_Occurred()) {

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2535,6 +2535,112 @@ finish_loop:
  * The axes must already be bounds-checked by the calling function,
  * this function does not validate them.
  */
+
+/*
+ * Try a fast path that bypasses NpyIter / PyUFunc_ReduceWrapper for full
+ * reductions (axis=None) over a contiguous, aligned input where no casting
+ * is required and the operation has an identity value.  The strided reduce
+ * loop is called directly on the input buffer and writes into a freshly
+ * allocated 0-d result.
+ *
+ * Conditions checked here (each one is required for correctness):
+ *   - no `out=`, `wheremask=`, `initial=`, `keepdims=True`
+ *   - `naxes == ndim` (full reduction)
+ *   - input is C- or F-contiguous and aligned (`*ARRAY_RO` checks both)
+ *   - input dtype already matches the loop's input dtype (no cast)
+ *   - the op exposes an identity (`get_reduction_initial`)
+ *   - output dtype has no Python references
+ *   - for multi-axis reductions, the op is reorderable (the fast path
+ *     visits elements in memory order, which differs from the iterator
+ *     order for F-contiguous multi-D inputs)
+ *
+ * Returns:
+ *      1 on success; ``*out_result`` holds the new 0-d result.
+ *      0 if any precondition is unmet (caller should run the slow path);
+ *        ``*out_result`` is NULL and no error is set.
+ *     -1 on hard error during the fast path; ``*out_result`` is NULL and
+ *        a Python error is set.
+ */
+static int
+try_reduce_contiguous(
+        PyArrayMethod_Context *context, PyArrayObject *arr,
+        PyArray_Descr *const *descrs,
+        PyArrayObject *out, PyArrayObject *wheremask, PyObject *initial,
+        int ndim, int naxes, int keepdims,
+        int errormask, const char *ufunc_name,
+        PyArrayObject **out_result)
+{
+    *out_result = NULL;
+
+    PyArrayMethodObject *ufuncimpl = context->method;
+    if (!(out == NULL && wheremask == NULL && initial == NULL && keepdims == 0
+            && naxes == ndim
+            && (PyArray_ISCARRAY_RO(arr) || PyArray_ISFARRAY_RO(arr))
+            && PyArray_DESCR(arr) == descrs[1]
+            && ufuncimpl->get_reduction_initial != NULL
+            && !PyDataType_REFCHK(descrs[0])
+            && (ndim <= 1
+                || (ufuncimpl->flags & NPY_METH_IS_REORDERABLE)))) {
+        return 0;
+    }
+    npy_intp count = PyArray_SIZE(arr);
+    if (count == 0) {
+        /* Let the slow path handle empty (it knows the proper semantics). */
+        return 0;
+    }
+
+    /* Allocate the 0-d result first so the loop can write into it. */
+    Py_INCREF(descrs[0]);
+    PyArrayObject *result = (PyArrayObject *)PyArray_NewFromDescr(
+            &PyArray_Type, descrs[0], 0, NULL, NULL, NULL, 0, NULL);
+    if (result == NULL) {
+        return -1;
+    }
+    char *accum = PyArray_BYTES(result);
+    int has_initial = ufuncimpl->get_reduction_initial(
+            context, /*reduction_is_empty=*/0, accum);
+    if (has_initial < 0) {
+        Py_DECREF(result);
+        return -1;
+    }
+    if (!has_initial) {
+        /* No identity available -- fall back to the slow path. */
+        Py_DECREF(result);
+        return 0;
+    }
+
+    npy_intp strides[3] = {0, descrs[1]->elsize, 0};
+    PyArrayMethod_StridedLoop *strided_loop;
+    NpyAuxData *auxdata = NULL;
+    NPY_ARRAYMETHOD_FLAGS flags = 0;
+    if (ufuncimpl->get_strided_loop(context, /*aligned=*/1,
+            /*move_references=*/0, strides,
+            &strided_loop, &auxdata, &flags) < 0) {
+        Py_DECREF(result);
+        return -1;
+    }
+    int needs_fperr = !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS);
+    if (needs_fperr) {
+        npy_clear_floatstatus_barrier((char *)context);
+    }
+    char *data[3] = {accum, PyArray_BYTES(arr), accum};
+    int res = strided_loop(context, data, &count, strides, auxdata);
+    NPY_AUXDATA_FREE(auxdata);
+    if (res == 0 && PyErr_Occurred()) {
+        res = -1;
+    }
+    if (res == 0 && needs_fperr) {
+        res = _check_ufunc_fperr(errormask, ufunc_name);
+    }
+    if (res < 0) {
+        Py_DECREF(result);
+        return -1;
+    }
+    *out_result = result;
+    return 1;
+}
+
+
 static PyArrayObject *
 PyUFunc_Reduce(PyUFuncObject *ufunc,
         PyArrayObject *arr, PyArrayObject *out,
@@ -2582,76 +2688,15 @@ PyUFunc_Reduce(PyUFuncObject *ufunc,
 
     PyArrayObject *result = NULL;
 
-    /*
-     * Fast path: full reduction (axis=None) over a contiguous, aligned,
-     * non-object input where the matching dtype is identical to the input
-     * dtype and the operation has an identity value.  In that case we can
-     * call the strided reduce loop directly on the input buffer and skip
-     * NpyIter / PyUFunc_ReduceWrapper entirely.
-     *
-     * Falls through to the slow path on any failure or unmet condition.
-     */
-    if (out == NULL && wheremask == NULL && initial == NULL && keepdims == 0
-            && naxes == ndim
-            && PyArray_ISCARRAY_RO(arr)
-            && PyArray_DESCR(arr) == descrs[1]
-            && ufuncimpl->get_reduction_initial != NULL
-            && !PyDataType_REFCHK(descrs[0])) {
-        npy_intp count = PyArray_SIZE(arr);
-        if (count > 0) {
-            /* Allocate the 0-d result first so the loop can write into it. */
-            Py_INCREF(descrs[0]);
-            result = (PyArrayObject *)PyArray_NewFromDescr(
-                    &PyArray_Type, descrs[0],
-                    0, NULL, NULL, NULL, 0, NULL);
-            if (result == NULL) {
-                goto cleanup;
-            }
-            char *accum = PyArray_BYTES(result);
-            int has_initial = ufuncimpl->get_reduction_initial(
-                    &context, /*reduction_is_empty=*/0, accum);
-            if (has_initial < 0) {
-                Py_CLEAR(result);
-                goto cleanup;
-            }
-            if (has_initial) {
-                npy_intp strides[3] = {0, descrs[1]->elsize, 0};
-                PyArrayMethod_StridedLoop *strided_loop;
-                NpyAuxData *auxdata = NULL;
-                NPY_ARRAYMETHOD_FLAGS flags = 0;
-                if (ufuncimpl->get_strided_loop(&context, /*aligned=*/1,
-                        /*move_references=*/0, strides,
-                        &strided_loop, &auxdata, &flags) < 0) {
-                    Py_CLEAR(result);
-                    goto cleanup;
-                }
-                int needs_fperr = !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS);
-                if (needs_fperr) {
-                    npy_clear_floatstatus_barrier((char *)&context);
-                }
-                char *data[3] = {accum, PyArray_BYTES(arr), accum};
-                int res = strided_loop(
-                        &context, data, &count, strides, auxdata);
-                NPY_AUXDATA_FREE(auxdata);
-                if (res == 0 && PyErr_Occurred()) {
-                    res = -1;
-                }
-                if (res == 0 && needs_fperr) {
-                    res = _check_ufunc_fperr(errormask, ufunc_name);
-                }
-                if (res < 0) {
-                    Py_CLEAR(result);
-                }
-                goto cleanup;
-            }
-            /* No identity available -- discard partial result and fall back. */
-            Py_CLEAR(result);
-        }
+    int fast_status = try_reduce_contiguous(
+            &context, arr, descrs, out, wheremask, initial,
+            ndim, naxes, keepdims, errormask, ufunc_name, &result);
+    if (fast_status == 0) {
+        /* Fast path did not apply; run the full reduction. */
+        result = PyUFunc_ReduceWrapper(&context,
+                arr, out, wheremask, axis_flags, keepdims,
+                initial, reduce_loop, buffersize, ufunc_name, errormask);
     }
-
-    result = PyUFunc_ReduceWrapper(&context,
-            arr, out, wheremask, axis_flags, keepdims,
-            initial, reduce_loop, buffersize, ufunc_name, errormask);
     /* Fall through to shared cleanup of `descrs`. */
 
   cleanup:

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2537,9 +2537,10 @@ try_reduce_contiguous(
         PyArray_Descr *const *descrs,
         PyArrayObject *out, PyArrayObject *wheremask, PyObject *initial,
         int ndim, int naxes, int keepdims,
-        int errormask, const char *ufunc_name,
+        int errormask,
         PyArrayObject **out_result)
 {
+    NPY_BEGIN_THREADS_DEF;
     *out_result = NULL;
 
     PyArrayMethodObject *ufuncimpl = context->method;
@@ -2613,8 +2614,12 @@ try_reduce_contiguous(
     if (needs_fperr) {
         npy_clear_floatstatus_barrier((char *)context);
     }
+    if (!(flags & NPY_METH_REQUIRES_PYAPI)) {
+        NPY_BEGIN_THREADS_THRESHOLDED(count);
+    }
     char *data[3] = {accum, src, accum};
     int res = strided_loop(context, data, &count, strides, auxdata);
+    NPY_END_THREADS;
     NPY_AUXDATA_FREE(auxdata);
     if (res == 0 && PyErr_Occurred()) {
         res = -1;
@@ -2680,7 +2685,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc,
 
     int fast_status = try_reduce_contiguous(
             &context, arr, descrs, out, wheremask, initial,
-            ndim, naxes, keepdims, errormask, ufunc_name, &result);
+            ndim, naxes, keepdims, errormask, &result);
     if (fast_status == 0) {
         /* Fast path did not apply; run the full reduction. */
         result = PyUFunc_ReduceWrapper(&context,

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2561,7 +2561,7 @@ finish_loop:
  *     -1 on hard error during the fast path; ``*out_result`` is NULL and
  *        a Python error is set.
  */
-static int
+static inline int
 try_reduce_contiguous(
         PyArrayMethod_Context *context, PyArrayObject *arr,
         PyArray_Descr *const *descrs,

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2680,8 +2680,6 @@ PyUFunc_Reduce(PyUFuncObject *ufunc,
                 initial, reduce_loop, buffersize, ufunc_name, errormask);
     }
     /* Fall through to shared cleanup of `descrs`. */
-
-  cleanup:
     for (int i = 0; i < 3; i++) {
         Py_DECREF(descrs[i]);
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2582,6 +2582,73 @@ PyUFunc_Reduce(PyUFuncObject *ufunc,
 
     PyArrayObject *result = NULL;
 
+    /*
+     * Fast path: full reduction (axis=None) over a contiguous, aligned,
+     * non-object input where the matching dtype is identical to the input
+     * dtype and the operation has an identity value.  In that case we can
+     * call the strided reduce loop directly on the input buffer and skip
+     * NpyIter / PyUFunc_ReduceWrapper entirely.
+     *
+     * Falls through to the slow path on any failure or unmet condition.
+     */
+    if (out == NULL && wheremask == NULL && initial == NULL && keepdims == 0
+            && naxes == ndim
+            && PyArray_ISCARRAY_RO(arr)
+            && PyArray_DESCR(arr) == descrs[1]
+            && ufuncimpl->get_reduction_initial != NULL
+            && !PyDataType_REFCHK(descrs[0])) {
+        npy_intp count = PyArray_SIZE(arr);
+        if (count > 0) {
+            /* Allocate the 0-d result first so the loop can write into it. */
+            Py_INCREF(descrs[0]);
+            result = (PyArrayObject *)PyArray_NewFromDescr(
+                    &PyArray_Type, descrs[0],
+                    0, NULL, NULL, NULL, 0, NULL);
+            if (result == NULL) {
+                goto cleanup;
+            }
+            char *accum = PyArray_BYTES(result);
+            int has_initial = ufuncimpl->get_reduction_initial(
+                    &context, /*reduction_is_empty=*/0, accum);
+            if (has_initial < 0) {
+                Py_CLEAR(result);
+                goto cleanup;
+            }
+            if (has_initial) {
+                npy_intp strides[3] = {0, descrs[1]->elsize, 0};
+                PyArrayMethod_StridedLoop *strided_loop;
+                NpyAuxData *auxdata = NULL;
+                NPY_ARRAYMETHOD_FLAGS flags = 0;
+                if (ufuncimpl->get_strided_loop(&context, /*aligned=*/1,
+                        /*move_references=*/0, strides,
+                        &strided_loop, &auxdata, &flags) < 0) {
+                    Py_CLEAR(result);
+                    goto cleanup;
+                }
+                int needs_fperr = !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS);
+                if (needs_fperr) {
+                    npy_clear_floatstatus_barrier((char *)&context);
+                }
+                char *data[3] = {accum, PyArray_BYTES(arr), accum};
+                int res = strided_loop(
+                        &context, data, &count, strides, auxdata);
+                NPY_AUXDATA_FREE(auxdata);
+                if (res == 0 && PyErr_Occurred()) {
+                    res = -1;
+                }
+                if (res == 0 && needs_fperr) {
+                    res = _check_ufunc_fperr(errormask, ufunc_name);
+                }
+                if (res < 0) {
+                    Py_CLEAR(result);
+                }
+                goto cleanup;
+            }
+            /* No identity available -- discard partial result and fall back. */
+            Py_CLEAR(result);
+        }
+    }
+
     result = PyUFunc_ReduceWrapper(&context,
             arr, out, wheremask, axis_flags, keepdims,
             initial, reduce_loop, buffersize, ufunc_name, errormask);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2519,24 +2519,6 @@ finish_loop:
 }
 
 /*
- * The implementation of the reduction operators with the new iterator
- * turned into a bit of a long function here, but I think the design
- * of this part needs to be changed to be more like einsum, so it may
- * not be worth refactoring it too much.  Consider this timing:
- *
- * >>> a = arange(10000)
- *
- * >>> timeit sum(a)
- * 10000 loops, best of 3: 17 us per loop
- *
- * >>> timeit einsum("i->",a)
- * 100000 loops, best of 3: 13.5 us per loop
- *
- * The axes must already be bounds-checked by the calling function,
- * this function does not validate them.
- */
-
-/*
  * Try a fast path that bypasses NpyIter / PyUFunc_ReduceWrapper for full
  * reductions (axis=None) over a contiguous, aligned input where no casting
  * is required and the operation has an identity value.  The strided reduce


### PR DESCRIPTION
### PR summary

Adds a fast path in `PyUFunc_Reduce` for the common case of a full reduction (`axis=None`) over a contiguous, aligned, non-object input where the matching dtype equals the input dtype and the operation has an identity value (e.g. `np.sum`, `np.prod`, `np.any`, `np.all`).

(EDIT: Seberg, later broadened to include any 1-D arrays and no identity value.)

### Benchmark results

| Benchmark              | main    | branch              |
|------------------------|---------|---------------------|
| `np.sum(array_4)`      | 1.47 us | 1.09 us (1.36x)     |
| `np.sum(array_20)`     | 1.47 us | 1.10 us (1.34x)     |
| `np.sum(array_100)`    | 1.47 us | 1.10 us (1.34x)     |
| `np.prod(array_20)`    | 1.43 us | 1.07 us (1.34x)     |
| `np.sum(10x10)`        | 1.51 us | 1.11 us (1.36x)     |
| `np.sum(2x2)`          | 1.51 us | 1.09 us (1.38x)     |
| `np.any(bool_20)`      | 1.33 us | 926 ns (1.44x)      |
| `np.all(bool_20)`      | 1.33 us | 937 ns (1.42x)      |
| `np.array_equal(a,b)`  | 1.39 us | 1.06 us (1.31x)     |
| `np.allclose(a,b)`     | 12.4 us | 11.2 us (1.10x)     |
| `np.max(array_20)`     | n/s     | n/s (correctly bypassed: no identity) |
| `np.sum(10x10,axis=0)` | n/s     | n/s (correctly bypassed: axis-reduction) |
| `np.sin(array_20)`     | 400 ns  | 396 ns (≈noise, control) |
| **Geometric mean**     | (ref)   | **1.25x faster**    |

`np.array_equal` and `np.allclose` benefit indirectly: both internally call `.all()` on a contiguous boolean array.


<details><summary>Benchmark script</summary>

```python
"""Benchmark script for the contiguous-reduction fast path PR."""
import pyperf
import numpy as np

runner = pyperf.Runner()

# Direct fast-path targets (axis=None reductions, contiguous, identity op)
a4 = np.ones(4)
a20 = np.ones(20)
a100 = np.ones(100)
runner.bench_func('np.sum(array_4)', np.sum, a4)
runner.bench_func('np.sum(array_20)', np.sum, a20)
runner.bench_func('np.sum(array_100)', np.sum, a100)
runner.bench_func('np.prod(array_20)', np.prod, a20)

# 2D, full reduction (still contiguous → fast path)
a10x10 = np.ones((10, 10))
runner.bench_func('np.sum(10x10)', np.sum, a10x10)
runner.bench_func('np.sum(2x2)', np.sum, np.ones((2, 2)))

# Boolean reductions
abool20 = np.ones(20, dtype=bool)
runner.bench_func('np.any(bool_20)', np.any, abool20)
runner.bench_func('np.all(bool_20)', np.all, abool20)

# Indirect beneficiaries (numpy functions that internally do .all())
ai = np.arange(20, dtype=np.float64)
bi = ai.copy()
runner.bench_func('np.array_equal(a,b)', np.array_equal, ai, bi)
runner.bench_func('np.allclose(a,b)', np.allclose, ai, bi)

# Cases that should NOT take the fast path (sanity / regression watch)
runner.bench_func('np.max(array_20)', np.max, a20)
runner.bench_func('np.sum(10x10,axis=0)', np.sum, a10x10, 0)

# Pure baseline (ufunc, not a reduction → not affected by this PR)
runner.bench_func('np.sin(array_20)', np.sin, a20)
```

</details>

#### AI Disclosure

Claude code was used to identify performance bottlenecks for the reductions. Improvement of the general case is also possible, but requires many changes for a much smaller gain. The fast path was written by Claude and manually refined.

