### PR TITLE
fix: add missing sorted=False to unique_all, unique_counts, unique_inverse

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -493,6 +493,7 @@ def unique_all(x):
         return_inverse=True,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueAllResult(*result)
 
@@ -549,6 +550,7 @@ def unique_counts(x):
         return_inverse=False,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueCountsResult(*result)
 
@@ -606,6 +608,7 @@ def unique_inverse(x):
         return_inverse=True,
         return_counts=False,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueInverseResult(*result)
 


### PR DESCRIPTION
## Summary

`np.unique_all`, `np.unique_counts`, and `np.unique_inverse` all document themselves as equivalent to `np.unique(..., sorted=False)`, but their implementations were calling `np.unique(...)` without passing `sorted=False`, inheriting the default `sorted=True`.

This was an oversight from the NumPy 2.3 update that correctly added `sorted=False` to `np.unique_values` but missed the other three Array API helpers.

## Changes

Added `sorted=False` to the `unique()` call in:
- `unique_all` 
- `unique_counts`
- `unique_inverse`

## Testing

No behavioral change today since `sorted=False` currently only takes effect for the values-only case. This fix ensures:
1. Source code matches the documented equivalence
2. Future hash-based fast paths for these return modes will work correctly

Closes #31241