### PR TITLE
ENH: add string bin support for multivariate histograms

### DIFF
--- a/doc/release/upcoming_changes/31276.new_feature.rst
+++ b/doc/release/upcoming_changes/31276.new_feature.rst
@@ -1,0 +1,4 @@
+``histogramdd`` and ``histogram2d`` now supports string ``bins`` values similar to ``histogram``
+------------------------------------------------------------------------------------------------
+The string values such as ``bins='auto'`` are now possible to use in ``histogramdd`` and ``histogram2d``.
+

--- a/doc/release/upcoming_changes/31276.new_feature.rst
+++ b/doc/release/upcoming_changes/31276.new_feature.rst
@@ -1,4 +1,4 @@
 ``histogramdd`` and ``histogram2d`` now supports string ``bins`` values similar to ``histogram``
 ------------------------------------------------------------------------------------------------
-The string values such as ``bins='auto'`` are now possible to use in ``histogramdd`` and ``histogram2d``.
+The string values such as ``bins='auto'`` are now possible to use in ``histogramdd`` and ``histogram2d``. Moreover, ``histogram_bin_edges`` is now generalized for N dimensions.
 

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -998,15 +998,23 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
         weights = np.asarray(weights)
 
     try:
-        M = len(bins)
         if isinstance(bins, str):
             raise TypeError
+        M = len(bins)
         if M != D:
-            raise ValueError(
-                'The dimension of bins must be equal to the dimension of the '
-                'sample x.')
+            if any(isinstance(b, str) for b in bins):
+                raise ValueError(
+                        'If string values are used in ArrayLike, dimension of bins must be equal'
+                        'to the dimension of the sample x.'
+                        )
+            if np.ndim(bins) <= 1:
+                    raise TypeError
+            else:
+                raise ValueError(
+                    'The dimension of bins must be equal to the dimension of the '
+                    'sample x.')
     except TypeError:
-        # bins is an integer or a string
+        # bins is an integer or a string or an ArrayLike of edges.
         bins = D * [bins]
 
     # normalize the range argument

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -355,14 +355,15 @@ def _unsigned_subtract(a, b):
 
 def _get_bin_edges(a, bins, range, weights):
     """
-    Computes the bins used internally by `histogram`.
+    Computes the bins used internally by `histogram`, `histogramdd` and `histogram2d`.
 
     Parameters
     ==========
     a : ndarray
         Ravelled data array
     bins, range
-        Forwarded arguments from `histogram`.
+        Forwarded arguments from `histogram` or from current dimension of `histogramdd`
+        or `histogram2d`
     weights : ndarray, optional
         Ravelled weights array, or None
 
@@ -929,13 +930,17 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
 
         The first form should be preferred.
 
-    bins : sequence or int, optional
+    bins : sequence or int or str, optional
         The bin specification:
 
         * A sequence of arrays describing the monotonically increasing bin
           edges along each dimension.
         * The number of bins for each dimension (nx, ny, ... =bins)
         * The number of bins for all dimensions (nx=ny=...=bins).
+        * A sequence of strings defining the method to calculate the optimal
+          bin width for each dimension as defined by `histogram_bin_edges`.
+        * A string defining the methodused to calculate the
+          optimal bin width, as defined by `histogram_bin_edges`.
 
     range : sequence, optional
         A sequence of length D, each an optional (lower, upper) tuple giving

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -997,20 +997,23 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
     if weights is not None:
         weights = np.asarray(weights)
 
-    try:
-        if isinstance(bins, str):
-            raise TypeError
-        M = len(bins)
-        if M != D:
-            if np.ndim(bins) <= 1:
-                raise TypeError
-            else:
-                raise ValueError(
-                    'The dimension of bins must be equal to the dimension of the '
-                    'sample x.')
-    except TypeError:
-        # bins is an integer or a string or an ArrayLike of edges.
+    if isinstance(bins, str):
+        # bins is a string
         bins = D * [bins]
+    else:
+        try:
+            M = len(bins)
+            if M != D:
+                if np.ndim(bins) == 1:
+                    # bins is an arraylike
+                    bins = D * [bins]
+                else:
+                    raise ValueError(
+                        'The dimension of bins must be equal to the dimension of the '
+                        'sample x.')
+        except TypeError:
+            # bins is an integer
+            bins = D * [bins]
 
     # normalize the range argument
     if range is None:

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -980,11 +980,11 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
 
     try:
         # Sample is an ND-array.
-        N, D = sample.shape
+        _, D = sample.shape
     except (AttributeError, ValueError):
         # Sample is a sequence of 1D arrays.
         sample = np.atleast_2d(sample).T
-        N, D = sample.shape
+        _, D = sample.shape
 
     nbin = np.empty(D, np.intp)
     edges = D * [None]
@@ -994,12 +994,14 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
 
     try:
         M = len(bins)
+        if isinstance(bins, str):
+            raise TypeError
         if M != D:
             raise ValueError(
                 'The dimension of bins must be equal to the dimension of the '
                 'sample x.')
     except TypeError:
-        # bins is an integer
+        # bins is an integer or a string
         bins = D * [bins]
 
     # normalize the range argument
@@ -1010,29 +1012,7 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
 
     # Create edge arrays
     for i in _range(D):
-        if np.ndim(bins[i]) == 0:
-            if bins[i] < 1:
-                raise ValueError(
-                    f'`bins[{i}]` must be positive, when an integer')
-            smin, smax = _get_outer_edges(sample[:, i], range[i])
-            try:
-                n = operator.index(bins[i])
-
-            except TypeError as e:
-                raise TypeError(
-                    f"`bins[{i}]` must be an integer, when a scalar"
-                ) from e
-
-            edges[i] = np.linspace(smin, smax, n + 1)
-        elif np.ndim(bins[i]) == 1:
-            edges[i] = np.asarray(bins[i])
-            if np.any(edges[i][:-1] > edges[i][1:]):
-                raise ValueError(
-                    f'`bins[{i}]` must be monotonically increasing, when an array')
-        else:
-            raise ValueError(
-                f'`bins[{i}]` must be a scalar or 1d array')
-
+        edges[i], _ = _get_bin_edges(sample[:, i], bins[i], range[i], weights)
         nbin[i] = len(edges[i]) + 1  # includes an outlier on each end
         dedges[i] = np.diff(edges[i])
 

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -1002,11 +1002,6 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
             raise TypeError
         M = len(bins)
         if M != D:
-            if any(isinstance(b, str) for b in bins):
-                raise ValueError(
-                        'If string values are used in ArrayLike, dimension of bins'
-                        'must be equal to the dimension of the sample x.'
-                        )
             if np.ndim(bins) <= 1:
                 raise TypeError
             else:

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -1004,11 +1004,11 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
         if M != D:
             if any(isinstance(b, str) for b in bins):
                 raise ValueError(
-                        'If string values are used in ArrayLike, dimension of bins must be equal'
-                        'to the dimension of the sample x.'
+                        'If string values are used in ArrayLike, dimension of bins'
+                        'must be equal to the dimension of the sample x.'
                         )
             if np.ndim(bins) <= 1:
-                    raise TypeError
+                raise TypeError
             else:
                 raise ValueError(
                     'The dimension of bins must be equal to the dimension of the '

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -434,28 +434,18 @@ def _get_bin_edges(a, bins, range, weights):
     uniform_bins = [None] * D
     first_edge = [None] * D
     last_edge = [None] * D
-    cols = [d for d in _range(D)
-            if isinstance(bins[d], str) or np.ndim(bins[d]) == 0]
-    if cols:
-        first_edg, last_edg = _get_outer_edges(a[:, cols], [range[dim] for dim in cols])
-        for k, d in enumerate(cols):
-            first_edge[d] = first_edg[k]
-            last_edge[d] = last_edg[k]
 
-    if isinstance(bins[0], str):
-        estimator_name = bins[0]
-        if estimator_name not in _hist_bin_selectors:
+    if isinstance(bins, str):
+        if bins not in _hist_bin_selectors:
             raise ValueError(
-                f"{estimator_name!r} is not a valid estimator for `bins`")
+                f"{bins!r} is not a valid estimator for `bins`")
         if weights is not None:
             raise TypeError("Automated estimation of the number of "
                             "bins is not supported for weighted data")
 
-        keep = np.ones(len(a), dtype=bool)
-        for d in _range(D):
-            if range[d] is not None:
-                keep &= (a[:, d] >= first_edge[d]) & (a[:, d] <= last_edge[d])
+        first_edge, last_edge = _get_outer_edges(a, range)
 
+        keep = ((a >= first_edge) & (a <= last_edge)).all(axis=1)
         data = a[keep] if not keep.all() else a
 
         if data.shape[0] == 0:
@@ -464,8 +454,7 @@ def _get_bin_edges(a, bins, range, weights):
         else:
             range_arg = (float(first_edge[0]), float(last_edge[0])) if D == 1 else None
             widths = np.broadcast_to(
-                np.atleast_1d(
-                    _hist_bin_selectors[estimator_name](data, range_arg)),
+                np.atleast_1d(_hist_bin_selectors[bins](data, range_arg)),
                 (D,))
             for d in _range(D):
                 width = float(widths[d])
@@ -479,29 +468,49 @@ def _get_bin_edges(a, bins, range, weights):
                     # the IQR of the data is zero.
                     n_equal_bins[d] = 1
 
-    for d in _range(D):
-        b = bins[d]
-        if isinstance(b, str):
-            continue  # handled in the pre-pass above
-        elif np.ndim(b) == 0:
-            try:
-                n = operator.index(b)
-            except TypeError as e:
-                raise TypeError(
-                    '`bins` must be an integer, a string, or an array') from e
-            if n < 1:
-                raise ValueError('`bins` must be positive, when an integer')
-            n_equal_bins[d] = n
+    else:
+        try:
+            M = len(bins)
+            if M != D:
+                if np.ndim(bins) == 1:
+                    bins = D * [bins]
+                else:
+                    raise ValueError(
+                        'The dimension of bins must be equal to the '
+                        'dimension of the sample x.')
+        except TypeError:
+            bins = D * [bins]
 
-        elif np.ndim(b) == 1:
-            edges = np.asarray(b)
-            if np.any(edges[:-1] > edges[1:]):
-                raise ValueError(
-                    '`bins` must increase monotonically, when an array')
-            bin_edges[d] = edges
+        cols = [d for d in _range(D) if np.ndim(bins[d]) == 0]
+        if cols:
+            first_edg, last_edg = _get_outer_edges(
+                a[:, cols], [range[dim] for dim in cols])
+            for k, d in enumerate(cols):
+                first_edge[d] = first_edg[k]
+                last_edge[d] = last_edg[k]
 
-        else:
-            raise ValueError('`bins` must be 1d, when an array')
+    if not isinstance(bins, str):
+        for d in _range(D):
+            b = bins[d]
+            if np.ndim(b) == 0:
+                try:
+                    n = operator.index(b)
+                except TypeError as e:
+                    raise TypeError(
+                        '`bins` must be an integer, a string, or an array') from e
+                if n < 1:
+                    raise ValueError('`bins` must be positive, when an integer')
+                n_equal_bins[d] = n
+
+            elif np.ndim(b) == 1:
+                edges = np.asarray(b)
+                if np.any(edges[:-1] > edges[1:]):
+                    raise ValueError(
+                        '`bins` must increase monotonically, when an array')
+                bin_edges[d] = edges
+
+            else:
+                raise ValueError('`bins` must be 1d, when an array')
 
     for d in _range(D):
         n = n_equal_bins[d]
@@ -516,10 +525,7 @@ def _get_bin_edges(a, bins, range, weights):
         if np.issubdtype(bin_type, np.integer):
             bin_type = np.result_type(bin_type, float)
 
-        # bin edges must be computed
-        edges = np.linspace(
-            f_edge, l_edge, n + 1,
-            endpoint=True, dtype=bin_type)
+        edges = np.linspace(f_edge, l_edge, n + 1, dtype=bin_type)
         if np.any(edges[:-1] >= edges[1:]):
             raise ValueError(
                 f'Too many bins for data range. Cannot create {n} '
@@ -749,7 +755,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
 
     """
     a, weights = _ravel_and_check_weights(a, weights)
-    bin_edges, _ = _get_bin_edges(a[:, np.newaxis], [bins], [range], weights)
+    bin_edges, _ = _get_bin_edges(a[:, np.newaxis], bins, [range], weights)
     return bin_edges[0]
 
 
@@ -866,7 +872,7 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     a, weights = _ravel_and_check_weights(a, weights)
 
     bin_edges, uniform_bins = _get_bin_edges(
-        a[:, np.newaxis], [bins], [range], weights)
+        a[:, np.newaxis], bins, [range], weights)
     bin_edges = bin_edges[0]
     uniform_bins = uniform_bins[0]
 
@@ -1072,24 +1078,6 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
     dedges = D * [None]
     if weights is not None:
         weights = np.asarray(weights)
-
-    if isinstance(bins, str):
-        # bins is a string
-        bins = D * [bins]
-    else:
-        try:
-            M = len(bins)
-            if M != D:
-                if np.ndim(bins) == 1:
-                    # bins is an arraylike
-                    bins = D * [bins]
-                else:
-                    raise ValueError(
-                        'The dimension of bins must be equal to the dimension of the '
-                        'sample x.')
-        except TypeError:
-            # bins is an integer
-            bins = D * [bins]
 
     # normalize the range argument
     if range is None:

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -393,106 +393,127 @@ def _unsigned_subtract(a, b):
 
 def _get_bin_edges(a, bins, range, weights):
     """
-    Computes the bins used internally by `histogram`, `histogramdd` and `histogram2d`.
+    Compute the bin edges used internally by `histogram`, `histogramdd` and
+    `histogram2d`.
 
     Parameters
-    ==========
-    a : ndarray
-        Ravelled data array
-    bins, range
-        Forwarded arguments from `histogram` or from current dimension of `histogramdd`
-        or `histogram2d`
+    ----------
+    a : ndarray, shape (M, D)
+        Sample of M points in D dimensions.
+    bins : sequence of length D
+        Per-dimension ``bins`` specification. Each entry is a string naming an
+        automatic estimator, an integer number of equal-width bins, or a 1D
+        array of explicit bin edges.
+    range : sequence of length D
+        Per-dimension ``(lower, upper)`` pairs, or ``None`` to autodetect that
+        dimension from the data.
     weights : ndarray, optional
-        Ravelled weights array, or None
+        Ravelled weights array, or None.
 
     Returns
-    =======
-    bin_edges : ndarray
-        Array of bin edges
-    uniform_bins : (Number, Number, int):
-        The upper bound, lowerbound, and number of bins, used in the optimized
-        implementation of `histogram` that works on uniform bins.
+    -------
+    bin_edges : list of D ndarrays
+        Per-dimension array of bin edges.
+    uniform_bins : list of D tuples or None
+        For each dimension with equal-width bins, the ``(first_edge,
+        last_edge, n_equal_bins)`` triple used by the optimized `histogram`
+        implementation; ``None`` for dimensions given explicit edges.
     """
-    # parse the overloaded bins argument
-    n_equal_bins = None
-    bin_edges = None
+    _, D = a.shape
 
-    if isinstance(bins, str):
-        bin_name = bins
-        # if `bins` is a string for an automatic method,
-        # this will replace it with the number of bins calculated
-        if bin_name not in _hist_bin_selectors:
-            raise ValueError(
-                f"{bin_name!r} is not a valid estimator for `bins`")
-        if weights is not None:
-            raise TypeError("Automated estimation of the number of "
-                            "bins is not supported for weighted data")
+    n_equal_bins = [None] * D
+    bin_edges = [None] * D
+    uniform_bins = [None] * D
+    first_edge = [None] * D
+    last_edge = [None] * D
+    cols = [d for d in _range(D)
+            if isinstance(bins[d], str) or np.ndim(bins[d]) == 0]
+    if cols:
+        first_edg, last_edg = _get_outer_edges(a[:, cols], [range[dim] for dim in cols])
+        for k, d in enumerate(cols):
+            first_edge[d] = first_edg[k]
+            last_edge[d] = last_edg[k]
 
-        first_edge, last_edge = _get_outer_edges(a[:, np.newaxis], [range])
-        first_edge, last_edge = first_edge[0], last_edge[0]
+    for d in _range(D):
+        b = bins[d]
+        if isinstance(b, str):
+            if b not in _hist_bin_selectors:
+                raise ValueError(
+                    f"{b!r} is not a valid estimator for `bins`")
+            if weights is not None:
+                raise TypeError("Automated estimation of the number of "
+                                "bins is not supported for weighted data")
 
-        # truncate the range if needed
-        if range is not None:
-            keep = (a >= first_edge)
-            keep &= (a <= last_edge)
-            if not np.logical_and.reduce(keep):
-                a = a[keep]
+            col = a[:, d]
+            f_edge, l_edge = first_edge[d], last_edge[d]
 
-        if a.size == 0:
-            n_equal_bins = 1
-        else:
-            # Do not call selectors on empty arrays
-            width = _hist_bin_selectors[bin_name](a, (first_edge, last_edge))
-            if width:
-                if np.issubdtype(a.dtype, np.integer) and width < 1:
-                    width = 1
-                delta = _unsigned_subtract(last_edge, first_edge)
-                n_equal_bins = int(np.ceil(delta / width))
+            # truncate the range if possible
+            if range[d] is not None:
+                keep = (col >= f_edge)
+                keep &= (col <= l_edge)
+                if not np.logical_and.reduce(keep):
+                    col = col[keep]
+
+            if col.size == 0:
+                n_equal_bins[d] = 1
             else:
-                # Width can be zero for some estimators, e.g. FD when
-                # the IQR of the data is zero.
-                n_equal_bins = 1
+                # Do not call selectors on empty arrays
+                width = _hist_bin_selectors[b](col, (f_edge, l_edge))
+                if width:
+                    if np.issubdtype(col.dtype, np.integer) and width < 1:
+                        width = 1
+                    delta = _unsigned_subtract(l_edge, f_edge)
+                    n_equal_bins[d] = int(np.ceil(delta / width))
+                else:
+                    # Width can be zero for some estimators, e.g. FD when
+                    # the IQR of the data is zero.
+                    n_equal_bins[d] = 1
 
-    elif np.ndim(bins) == 0:
-        try:
-            n_equal_bins = operator.index(bins)
-        except TypeError as e:
-            raise TypeError(
-                '`bins` must be an integer, a string, or an array') from e
-        if n_equal_bins < 1:
-            raise ValueError('`bins` must be positive, when an integer')
+        elif np.ndim(b) == 0:
+            try:
+                n = operator.index(b)
+            except TypeError as e:
+                raise TypeError(
+                    '`bins` must be an integer, a string, or an array') from e
+            if n < 1:
+                raise ValueError('`bins` must be positive, when an integer')
+            n_equal_bins[d] = n
 
-        first_edge, last_edge = _get_outer_edges(a[:, np.newaxis], [range])
-        first_edge, last_edge = first_edge[0], last_edge[0]
+        elif np.ndim(b) == 1:
+            edges = np.asarray(b)
+            if np.any(edges[:-1] > edges[1:]):
+                raise ValueError(
+                    '`bins` must increase monotonically, when an array')
+            bin_edges[d] = edges
 
-    elif np.ndim(bins) == 1:
-        bin_edges = np.asarray(bins)
-        if np.any(bin_edges[:-1] > bin_edges[1:]):
-            raise ValueError(
-                '`bins` must increase monotonically, when an array')
+        else:
+            raise ValueError('`bins` must be 1d, when an array')
 
-    else:
-        raise ValueError('`bins` must be 1d, when an array')
+    for d in _range(D):
+        n = n_equal_bins[d]
+        if n is None:
+            continue
+        f_edge, l_edge = first_edge[d], last_edge[d]
 
-    if n_equal_bins is not None:
         # gh-10322 means that type resolution rules are dependent on array
         # shapes. To avoid this causing problems, we pick a type now and stick
         # with it throughout.
-        bin_type = np.result_type(first_edge, last_edge, a)
+        bin_type = np.result_type(f_edge, l_edge, a)
         if np.issubdtype(bin_type, np.integer):
             bin_type = np.result_type(bin_type, float)
 
         # bin edges must be computed
-        bin_edges = np.linspace(
-            first_edge, last_edge, n_equal_bins + 1,
+        edges = np.linspace(
+            f_edge, l_edge, n + 1,
             endpoint=True, dtype=bin_type)
-        if np.any(bin_edges[:-1] >= bin_edges[1:]):
+        if np.any(edges[:-1] >= edges[1:]):
             raise ValueError(
-                f'Too many bins for data range. Cannot create {n_equal_bins} '
+                f'Too many bins for data range. Cannot create {n} '
                 f'finite-sized bins.')
-        return bin_edges, (first_edge, last_edge, n_equal_bins)
-    else:
-        return bin_edges, None
+        bin_edges[d] = edges
+        uniform_bins[d] = (f_edge, l_edge, n)
+
+    return bin_edges, uniform_bins
 
 
 def _search_sorted_inclusive(a, v):
@@ -714,8 +735,8 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
 
     """
     a, weights = _ravel_and_check_weights(a, weights)
-    bin_edges, _ = _get_bin_edges(a, bins, range, weights)
-    return bin_edges
+    bin_edges, _ = _get_bin_edges(a[:, np.newaxis], [bins], [range], weights)
+    return bin_edges[0]
 
 
 def _histogram_dispatcher(
@@ -830,7 +851,10 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     """
     a, weights = _ravel_and_check_weights(a, weights)
 
-    bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)
+    bin_edges, uniform_bins = _get_bin_edges(
+        a[:, np.newaxis], [bins], [range], weights)
+    bin_edges = bin_edges[0]
+    uniform_bins = uniform_bins[0]
 
     # Histogram is an integer or a float array depending on the weights.
     if weights is None:
@@ -1062,8 +1086,8 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
         raise ValueError('range argument must have one entry per dimension')
 
     # Create edge arrays
+    edges, _ = _get_bin_edges(sample, bins, range, weights)
     for i in _range(D):
-        edges[i], _ = _get_bin_edges(sample[:, i], bins[i], range[i], weights)
         nbin[i] = len(edges[i]) + 1  # includes an outlier on each end
         dedges[i] = np.diff(edges[i])
 

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -584,11 +584,13 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
     ----------
     a : array_like
         Input data. The histogram is computed over the flattened array.
-    bins : int or sequence of scalars or str, optional
+    bins : int or sequence or str, optional
         If `bins` is an int, it defines the number of equal-width
-        bins in the given range (10, by default). If `bins` is a
-        sequence, it defines the bin edges, including the rightmost
-        edge, allowing for non-uniform bin widths.
+        bins in the given range (10, by default) for each dimension.
+        If `bins` is a sequence of scalars, it defines the bin edges, including the rightmost
+        edge, for all the dimensions, allowing for non-uniform bin widths.
+        If `bins` is a sequence of sequence of scalars, it defines the bin edges,
+        icnluding the rightmost edge, for each dimension seperately.
 
         If `bins` is a string from the list below, `histogram_bin_edges` will
         use the method chosen to calculate the optimal bin width and
@@ -601,12 +603,14 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
         supported for automated bin size selection.
 
         'auto'
-            Minimum bin width between the 'sturges' and 'fd' estimators.
+            In 1-D, minimum bin width between the 'sturges' and 'fd' estimators.
             Provides good all-around performance.
+            In D>1, minimum bin width between the "scott" and an heuristic
+            on each dimension.
 
         'fd' (Freedman Diaconis Estimator)
             Robust (resilient to outliers) estimator that takes into
-            account data variability and data size.
+            account data variability and data size. Works on any dimensions.
 
         'doane'
             An improved version of Sturges' estimator that works better
@@ -614,7 +618,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
 
         'scott'
             Less robust estimator that takes into account data variability
-            and data size.
+            and data size. Works on any dimensions.
 
         'stone'
             Estimator based on leave-one-out cross-validation estimate of
@@ -634,7 +638,10 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
             Square root (of data size) estimator, used by Excel and
             other programs for its speed and simplicity.
 
-    range : (float, float), optional
+    range : sequence, optional
+        A sequence of length D, each an optional (lower, upper) tuple giving
+        the outer bin edges to be used if the edges are not given explicitly in
+        `bins`.
         The lower and upper range of the bins.  If not provided, range
         is simply ``(a.min(), a.max())``.  Values outside the range are
         ignored. The first element of the range must be less than or
@@ -651,12 +658,12 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
 
     Returns
     -------
-    bin_edges : array of dtype float
-        The edges to pass into `histogram`
+    bin_edges : tuple of ndarrays.
+        The edges to pass into `histogram`, `histogram2d` or `histogramdd`
 
     See Also
     --------
-    histogram
+    histogram, `histogram2d, `histogramdd`
 
     Notes
     -----
@@ -680,7 +687,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
         Switchover point is usually :math:`a.size \approx 1000`.
 
     'fd' (Freedman Diaconis Estimator)
-        .. math:: h = 2 \frac{IQR}{n^{1/3}}
+        .. math:: h = 2 \frac{IQR_i}{n^{1/(D+2)}}
 
         The binwidth is proportional to the interquartile range (IQR)
         and inversely proportional to cube root of a.size. Can be too
@@ -688,7 +695,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
         datasets. The IQR is very robust to outliers.
 
     'scott'
-        .. math:: h = \sigma \sqrt[3]{\frac{24 \sqrt{\pi}}{n}}
+        .. math:: h = \sigma_i \sqrt[D+2]{\frac{24 \sqrt{\pi}}{n}}
 
         The binwidth is proportional to the standard deviation of the
         data and inversely proportional to cube root of ``x.size``. Can

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -216,22 +216,26 @@ def _hist_bin_fd(x, range):
     long tailed distributions.
 
     If the IQR is 0, this function returns 0 for the bin width.
-    Binwidth is inversely proportional to the cube root of data size
-    (asymptotically optimal).
+    Binwidth is inversely proportional to a power of data size that depends on
+    the number of dimensions (asymptotically optimal).
 
     Parameters
     ----------
-    x : array_like
+    x : ndarray, shape (N, D)
         Input data that is to be histogrammed, trimmed to range. May not
         be empty.
 
     Returns
     -------
-    h : An estimate of the optimal bin width for the given data.
+    h : ndarray, shape (D,)
+        Per-dimension estimates of the optimal bin widths.
     """
     del range  # unused
-    iqr = np.subtract(*np.percentile(x, [75, 25]))
-    return 2.0 * iqr * x.size ** (-1.0 / 3.0)
+    x = x.reshape(-1, 1) if x.ndim == 1 else x
+    N, D = x.shape
+    iqr = np.subtract(*np.percentile(x, [75, 25], axis=0))
+    h = 2.0 * iqr * N ** (-1.0 / (D + 2))
+    return h[0] if D == 1 else h
 
 
 def _hist_bin_auto(x, range):

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -784,6 +784,13 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
     array([0.  , 1.25, 2.5 , 3.75, 5.  ])
 
     """
+    a = np.asarray(a)
+    if a.ndim == 2 and a.shape[1] > 1:
+        if weights is not None:
+            weights = np.asarray(weights)
+        bin_edges, _ = _get_bin_edges(a, bins, range, weights)
+        return bin_edges
+
     a, weights = _ravel_and_check_weights(a, weights)
     bin_edges, _ = _get_bin_edges(a[:, np.newaxis], bins, [range], weights)
     return bin_edges[0]

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -587,10 +587,11 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
     bins : int or sequence or str, optional
         If `bins` is an int, it defines the number of equal-width
         bins in the given range (10, by default) for each dimension.
-        If `bins` is a sequence of scalars, it defines the bin edges, including the rightmost
-        edge, for all the dimensions, allowing for non-uniform bin widths.
-        If `bins` is a sequence of sequence of scalars, it defines the bin edges,
-        icnluding the rightmost edge, for each dimension seperately.
+        If `bins` is a sequence of scalars, it defines the bin edges,
+        including the rightmost edge, for all the dimensions, allowing
+        for non-uniform bin widths. If `bins` is a sequence of sequence of
+        scalars, it defines the bin edges, including the rightmost edge,
+        for each dimension seperately.
 
         If `bins` is a string from the list below, `histogram_bin_edges` will
         use the method chosen to calculate the optimal bin width and

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -321,14 +321,9 @@ def _get_outer_edges(a, range):
         Lower and upper outer edge for each dimension.
     """
     N, D = a.shape
-    edge_dtype = a.dtype if np.issubdtype(a.dtype, np.floating) else np.float64
-
-    if range is not None:
-        bounds = [b for r in range if r is not None for b in r]
-        if bounds:
-            edge_dtype = np.result_type(edge_dtype, *bounds)
-            if not np.issubdtype(edge_dtype, np.floating):
-                edge_dtype = np.float64
+    bounds = [r[0] for r in range if r is not None] if range is not None else []
+    dt = np.result_type(a.dtype, *bounds) if bounds else a.dtype
+    edge_dtype = dt if np.issubdtype(dt, np.floating) else np.float64
 
     first_edge = np.empty(D, dtype=edge_dtype)
     last_edge = np.empty(D, dtype=edge_dtype)

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -120,10 +120,8 @@ def _hist_bin_scott(x, range):
         Per-dimension estimates of the optimal bin widths.
     """
     del range  # unused
-    x = x.reshape(-1, 1) if x.ndim == 1 else x
     N, D = x.shape
-    h = 2 * (3 * np.pi**(D/2) / N)**(1/(D+2)) * np.std(x, axis=0)
-    return h[0] if D == 1 else h
+    return 2 * (3 * np.pi**(D/2) / N)**(1/(D+2)) * np.std(x, axis=0)
 
 
 def _hist_bin_stone(x, range):
@@ -234,8 +232,7 @@ def _hist_bin_fd(x, range):
     x = x.reshape(-1, 1) if x.ndim == 1 else x
     N, D = x.shape
     iqr = np.subtract(*np.percentile(x, [75, 25], axis=0))
-    h = 2.0 * iqr * N ** (-1.0 / (D + 2))
-    return h[0] if D == 1 else h
+    return 2.0 * iqr * N ** (-1.0 / (D + 2))
 
 
 def _hist_bin_auto(x, range):
@@ -445,41 +442,47 @@ def _get_bin_edges(a, bins, range, weights):
             first_edge[d] = first_edg[k]
             last_edge[d] = last_edg[k]
 
-    for d in _range(D):
-        b = bins[d]
-        if isinstance(b, str):
-            if b not in _hist_bin_selectors:
-                raise ValueError(
-                    f"{b!r} is not a valid estimator for `bins`")
-            if weights is not None:
-                raise TypeError("Automated estimation of the number of "
-                                "bins is not supported for weighted data")
+    if isinstance(bins[0], str):
+        estimator_name = bins[0]
+        if estimator_name not in _hist_bin_selectors:
+            raise ValueError(
+                f"{estimator_name!r} is not a valid estimator for `bins`")
+        if weights is not None:
+            raise TypeError("Automated estimation of the number of "
+                            "bins is not supported for weighted data")
 
-            col = a[:, d]
-            f_edge, l_edge = first_edge[d], last_edge[d]
-
-            # truncate the range if possible
+        keep = np.ones(len(a), dtype=bool)
+        for d in _range(D):
             if range[d] is not None:
-                keep = (col >= f_edge)
-                keep &= (col <= l_edge)
-                if not np.logical_and.reduce(keep):
-                    col = col[keep]
+                keep &= (a[:, d] >= first_edge[d]) & (a[:, d] <= last_edge[d])
 
-            if col.size == 0:
+        data = a[keep] if not keep.all() else a
+
+        if data.shape[0] == 0:
+            for d in _range(D):
                 n_equal_bins[d] = 1
-            else:
-                # Do not call selectors on empty arrays
-                width = _hist_bin_selectors[b](col, (f_edge, l_edge))
+        else:
+            range_arg = (float(first_edge[0]), float(last_edge[0])) if D == 1 else None
+            widths = np.broadcast_to(
+                np.atleast_1d(
+                    _hist_bin_selectors[estimator_name](data, range_arg)),
+                (D,))
+            for d in _range(D):
+                width = float(widths[d])
                 if width:
-                    if np.issubdtype(col.dtype, np.integer) and width < 1:
+                    if np.issubdtype(a.dtype, np.integer) and width < 1:
                         width = 1
-                    delta = _unsigned_subtract(l_edge, f_edge)
+                    delta = _unsigned_subtract(last_edge[d], first_edge[d])
                     n_equal_bins[d] = int(np.ceil(delta / width))
                 else:
                     # Width can be zero for some estimators, e.g. FD when
                     # the IQR of the data is zero.
                     n_equal_bins[d] = 1
 
+    for d in _range(D):
+        b = bins[d]
+        if isinstance(b, str):
+            continue  # handled in the pre-pass above
         elif np.ndim(b) == 0:
             try:
                 n = operator.index(b)
@@ -1012,10 +1015,8 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
           edges along each dimension.
         * The number of bins for each dimension (nx, ny, ... =bins)
         * The number of bins for all dimensions (nx=ny=...=bins).
-        * A sequence of strings defining the method to calculate the optimal
-          bin width for each dimension as defined by `histogram_bin_edges`.
-        * A string defining the methodused to calculate the
-          optimal bin width, as defined by `histogram_bin_edges`.
+        * A string defining the method used to calculate the optimal bin
+          width for all dimensions, as defined by `histogram_bin_edges`.
 
     range : sequence, optional
         A sequence of length D, each an optional (lower, upper) tuple giving

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -105,6 +105,9 @@ def _hist_bin_scott(x, range):
     and inversely proportional to a power of data size that depends on
     the number of dimensions (asymptotically optimal).
 
+    The rule comes from the book Multivariate Density Estimation: Theory, Practice,
+    and Visualization by David W. Scott.
+
     Parameters
     ----------
     x : ndarray, shape (N, D)
@@ -118,7 +121,7 @@ def _hist_bin_scott(x, range):
     """
     del range  # unused
     N, D = x.shape
-    return (12 * 2**D * np.pi**(D / 2) / N)**(1 / (D + 2)) * np.std(x, axis=0)
+    return 3.5 * np.std(x, axis=0) * N**(-1/(2+D))
 
 
 def _hist_bin_stone(x, range):

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -509,7 +509,7 @@ def _get_bin_edges(a, bins, range, weights):
                 if n < 1:
                     raise ValueError('`bins` must be positive, when an integer')
                 n_equal_bins[d] = n
-                f_edg, l_edg = _get_outer_edges(a[:, d:d+1], [range[d]])
+                f_edg, l_edg = _get_outer_edges(a[:, d:d + 1], [range[d]])
                 first_edge[d], last_edge[d] = f_edg[0], l_edg[0]
 
             elif np.ndim(b) == 1:

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -121,7 +121,7 @@ def _hist_bin_scott(x, range):
     """
     del range  # unused
     N, D = x.shape
-    return 2 * (3 * np.pi**(D/2) / N)**(1/(D+2)) * np.std(x, axis=0)
+    return 2 * (3 * np.pi**(D / 2) / N)**(1 / (D + 2)) * np.std(x, axis=0)
 
 
 def _hist_bin_stone(x, range):

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -475,21 +475,13 @@ def _get_bin_edges(a, bins, range, weights):
         except TypeError:
             bins = D * [bins]
 
-        cols = [d for d in _range(D) if np.ndim(bins[d]) == 0]
-        if cols:
-            first_edg, last_edg = _get_outer_edges(
-                a[:, cols], [range[dim] for dim in cols])
-            for k, d in enumerate(cols):
-                first_edge[d] = first_edg[k]
-                last_edge[d] = last_edg[k]
-
-    if not isinstance(bins, str):
         for d in _range(D):
             b = bins[d]
-            if np.ndim(b) == 0:
-                if isinstance(b, str):
-                    raise ValueError(
-                        'bins must not contain a strig, when an array')
+            if isinstance(b, str):
+                raise ValueError(
+                        '`bins` cannot contain a string, when an array'
+                        )
+            elif np.ndim(b) == 0:
                 try:
                     n = operator.index(b)
                 except TypeError as e:
@@ -498,6 +490,8 @@ def _get_bin_edges(a, bins, range, weights):
                 if n < 1:
                     raise ValueError('`bins` must be positive, when an integer')
                 n_equal_bins[d] = n
+                f_edg, l_edg = _get_outer_edges(a[:, d:d+1], [range[d]])
+                first_edge[d], last_edge[d] = f_edg[0], l_edg[0]
 
             elif np.ndim(b) == 1:
                 edges = np.asarray(b)

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -266,10 +266,15 @@ def _hist_bin_auto(x, range):
     and is the default in the R language. This method gives good off-the-shelf
     behaviour.
 
+    For multidimensional data (D > 1), the Sturges and sqrt estimators are
+    replaced by Scott's rule. Because of the curse of dimensionaly, i.e as dimension
+    increases the data needs to increase exponentionally for bins to be meaningful,
+    in higher dimensions the type of data does not matter as long as the data is not
+    large.
 
     Parameters
     ----------
-    x : ndarray, shape (N, 1)
+    x : ndarray, shape (N, D)
         Input data that is to be histogrammed, trimmed to range. May not
         be empty.
     range : sequence of (float, float)
@@ -277,20 +282,27 @@ def _hist_bin_auto(x, range):
 
     Returns
     -------
-    h : ndarray, shape (1,)
-        An estimate of the optimal bin width for the given data.
+    h : ndarray, shape (D,)
+        Per-dimension estimates of the optimal bin widths.
 
     See Also
     --------
-    _hist_bin_fd, _hist_bin_sturges
+    _hist_bin_fd, _hist_bin_sturges, _hist_bin_scott
     """
-    _check_1d(x, 'auto')
+    N, D = x.shape
+    if D == 1:
+        _check_1d(x, 'auto')
+        fd_bw = _hist_bin_fd(x, range)
+        sturges_bw = _hist_bin_sturges(x, range)
+        sqrt_bw = _hist_bin_sqrt(x, range)
+        # heuristic to limit the maximal number of bins
+        fd_bw_corrected = np.maximum(fd_bw, sqrt_bw / 2)
+        return np.minimum(fd_bw_corrected, sturges_bw)
     fd_bw = _hist_bin_fd(x, range)
-    sturges_bw = _hist_bin_sturges(x, range)
-    sqrt_bw = _hist_bin_sqrt(x, range)
-    # heuristic to limit the maximal number of bins
-    fd_bw_corrected = np.maximum(fd_bw, sqrt_bw / 2)
-    return np.minimum(fd_bw_corrected, sturges_bw)
+    scott_bw = _hist_bin_scott(x, range)
+    # heuristic to limit the maximal number of bins, similar to 1-D
+    floor_bw = (x.max(axis=0) - x.min(axis=0)) / (2 * N ** (1/(D+2)))
+    return np.minimum(np.maximum(fd_bw, floor_bw), scott_bw)
 
 
 # Private dict initialized at module load time

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -308,7 +308,7 @@ def _get_outer_edges(a, range):
 
     Parameters
     ----------
-    a : ndarray, shape (M, D)
+    a : ndarray, shape (N, D)
         Sample of M points in D dimensions.
     range : sequence of length D, or None
         Per-dimension ``(lower, upper)`` pairs. The whole argument, or any
@@ -320,7 +320,7 @@ def _get_outer_edges(a, range):
     first_edge, last_edge : ndarray, shape (D,)
         Lower and upper outer edge for each dimension.
     """
-    M, D = a.shape
+    N, D = a.shape
     edge_dtype = a.dtype if np.issubdtype(a.dtype, np.floating) else np.float64
 
     if range is not None:
@@ -348,7 +348,7 @@ def _get_outer_edges(a, range):
             no_rangeval[dim] = False
 
     if no_rangeval.any():
-        if M == 0:
+        if N == 0:
             first_edge[no_rangeval] = 0
             last_edge[no_rangeval] = 1
         else:

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -29,6 +29,13 @@ def _ptp(x):
     return _unsigned_subtract(x.max(), x.min())
 
 
+def _check_1d(x, name):
+    if x.shape[1] > 1:
+        raise NotImplementedError(
+            f"the {name!r} bin estimator is not implemented for "
+            "multidimensional data")
+
+
 def _hist_bin_sqrt(x, range):
     """
     Square root histogram bin estimator.
@@ -38,16 +45,18 @@ def _hist_bin_sqrt(x, range):
 
     Parameters
     ----------
-    x : array_like
+    x : ndarray, shape (N, 1)
         Input data that is to be histogrammed, trimmed to range. May not
         be empty.
 
     Returns
     -------
-    h : An estimate of the optimal bin width for the given data.
+    h : ndarray, shape (1,)
+        An estimate of the optimal bin width for the given data.
     """
     del range  # unused
-    return _ptp(x) / np.sqrt(x.size)
+    _check_1d(x, 'sqrt')
+    return np.array([_ptp(x) / np.sqrt(x.size)])
 
 
 def _hist_bin_sturges(x, range):
@@ -61,16 +70,18 @@ def _hist_bin_sturges(x, range):
 
     Parameters
     ----------
-    x : array_like
+    x : ndarray, shape (N, 1)
         Input data that is to be histogrammed, trimmed to range. May not
         be empty.
 
     Returns
     -------
-    h : An estimate of the optimal bin width for the given data.
+    h : ndarray, shape (1,)
+        An estimate of the optimal bin width for the given data.
     """
     del range  # unused
-    return _ptp(x) / (np.log2(x.size) + 1.0)
+    _check_1d(x, 'sturges')
+    return np.array([_ptp(x) / (np.log2(x.size) + 1.0)])
 
 
 def _hist_bin_rice(x, range):
@@ -85,16 +96,18 @@ def _hist_bin_rice(x, range):
 
     Parameters
     ----------
-    x : array_like
+    x : ndarray, shape (N, 1)
         Input data that is to be histogrammed, trimmed to range. May not
         be empty.
 
     Returns
     -------
-    h : An estimate of the optimal bin width for the given data.
+    h : ndarray, shape (1,)
+        An estimate of the optimal bin width for the given data.
     """
     del range  # unused
-    return _ptp(x) / (2.0 * x.size ** (1.0 / 3))
+    _check_1d(x, 'rice')
+    return np.array([_ptp(x) / (2.0 * x.size ** (1.0 / 3))])
 
 
 def _hist_bin_scott(x, range):
@@ -138,25 +151,29 @@ def _hist_bin_stone(x, range):
 
     Parameters
     ----------
-    x : array_like
+    x : ndarray, shape (N, 1)
         Input data that is to be histogrammed, trimmed to range. May not
         be empty.
-    range : (float, float)
-        The lower and upper range of the bins.
+    range : sequence of (float, float)
+        Per-dimension ``(lower, upper)`` ranges for the bins.
 
     Returns
     -------
-    h : An estimate of the optimal bin width for the given data.
+    h : ndarray, shape (1,)
+        An estimate of the optimal bin width for the given data.
     """  # noqa: E501
 
+    _check_1d(x, 'stone')
     n = x.size
     ptp_x = _ptp(x)
     if n <= 1 or ptp_x == 0:
-        return 0
+        return np.array([0])
+
+    rang = range[0] if range is not None else None
 
     def jhat(nbins):
         hh = ptp_x / nbins
-        p_k = np.histogram(x, bins=nbins, range=range)[0] / n
+        p_k = np.histogram(x, bins=nbins, range=rang)[0] / n
         return (2 - (n + 1) * p_k.dot(p_k)) / hh
 
     nbins_upper_bound = max(100, int(np.sqrt(n)))
@@ -164,7 +181,7 @@ def _hist_bin_stone(x, range):
     if nbins == nbins_upper_bound:
         warnings.warn("The number of bins estimated may be suboptimal.",
                       RuntimeWarning, stacklevel=3)
-    return ptp_x / nbins
+    return np.array([ptp_x / nbins])
 
 
 def _hist_bin_doane(x, range):
@@ -177,15 +194,17 @@ def _hist_bin_doane(x, range):
 
     Parameters
     ----------
-    x : array_like
+    x : ndarray, shape (N, 1)
         Input data that is to be histogrammed, trimmed to range. May not
         be empty.
 
     Returns
     -------
-    h : An estimate of the optimal bin width for the given data.
+    h : ndarray, shape (1,)
+        An estimate of the optimal bin width for the given data.
     """
     del range  # unused
+    _check_1d(x, 'doane')
     if x.size > 2:
         sg1 = np.sqrt(6.0 * (x.size - 2) / ((x.size + 1.0) * (x.size + 3)))
         sigma = np.std(x)
@@ -197,9 +216,9 @@ def _hist_bin_doane(x, range):
             np.true_divide(temp, sigma, temp)
             np.power(temp, 3, temp)
             g1 = np.mean(temp)
-            return _ptp(x) / (1.0 + np.log2(x.size) +
-                                    np.log2(1.0 + np.absolute(g1) / sg1))
-    return 0.0
+            return np.array([_ptp(x) / (1.0 + np.log2(x.size) +
+                                    np.log2(1.0 + np.absolute(g1) / sg1))])
+    return np.array([0.0])
 
 
 def _hist_bin_fd(x, range):
@@ -250,25 +269,28 @@ def _hist_bin_auto(x, range):
 
     Parameters
     ----------
-    x : array_like
+    x : ndarray, shape (N, 1)
         Input data that is to be histogrammed, trimmed to range. May not
         be empty.
-    range : Tuple with range for the histogram
+    range : sequence of (float, float)
+        Per-dimension ``(lower, upper)`` ranges for the bins.
 
     Returns
     -------
-    h : An estimate of the optimal bin width for the given data.
+    h : ndarray, shape (1,)
+        An estimate of the optimal bin width for the given data.
 
     See Also
     --------
     _hist_bin_fd, _hist_bin_sturges
     """
+    _check_1d(x, 'auto')
     fd_bw = _hist_bin_fd(x, range)
     sturges_bw = _hist_bin_sturges(x, range)
     sqrt_bw = _hist_bin_sqrt(x, range)
     # heuristic to limit the maximal number of bins
-    fd_bw_corrected = max(fd_bw, sqrt_bw / 2)
-    return min(fd_bw_corrected, sturges_bw)
+    fd_bw_corrected = np.maximum(fd_bw, sqrt_bw / 2)
+    return np.minimum(fd_bw_corrected, sturges_bw)
 
 
 # Private dict initialized at module load time
@@ -446,10 +468,7 @@ def _get_bin_edges(a, bins, range, weights):
             for d in _range(D):
                 n_equal_bins[d] = 1
         else:
-            range_arg = (float(first_edge[0]), float(last_edge[0])) if D == 1 else None
-            widths = np.broadcast_to(
-                np.atleast_1d(_hist_bin_selectors[bins](data, range_arg)),
-                (D,))
+            widths = _hist_bin_selectors[bins](data, range)
             for d in _range(D):
                 width = float(widths[d])
                 if width:

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -301,7 +301,7 @@ def _hist_bin_auto(x, range):
     fd_bw = _hist_bin_fd(x, range)
     scott_bw = _hist_bin_scott(x, range)
     # heuristic to limit the maximal number of bins, similar to 1-D
-    floor_bw = (x.max(axis=0) - x.min(axis=0)) / (2 * N ** (1/(D+2)))
+    floor_bw = (x.max(axis=0) - x.min(axis=0)) / (2 * N ** (1 / (D + 2)))
     return np.minimum(np.maximum(fd_bw, floor_bw), scott_bw)
 
 

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -493,6 +493,9 @@ def _get_bin_edges(a, bins, range, weights):
         for d in _range(D):
             b = bins[d]
             if np.ndim(b) == 0:
+                if isinstance(b, str):
+                    raise ValueError(
+                        'bins must not contain a strig, when an array')
                 try:
                     n = operator.index(b)
                 except TypeError as e:

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -664,7 +664,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
 
     See Also
     --------
-    histogram, `histogram2d, `histogramdd`
+    histogram, histogram2d, histogramdd
 
     Notes
     -----

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -297,30 +297,68 @@ def _ravel_and_check_weights(a, weights):
 
 def _get_outer_edges(a, range):
     """
-    Determine the outer bin edges to use, from either the data or the range
-    argument
-    """
-    if range is not None:
-        first_edge, last_edge = range
-        if first_edge > last_edge:
-            raise ValueError(
-                'max must be larger than min in range parameter.')
-        if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
-            raise ValueError(
-                f"supplied range of [{first_edge}, {last_edge}] is not finite")
-    elif a.size == 0:
-        # handle empty arrays. Can't determine range, so use 0-1.
-        first_edge, last_edge = 0, 1
-    else:
-        first_edge, last_edge = a.min(), a.max()
-        if not (np.isfinite(first_edge) and np.isfinite(last_edge)):
-            raise ValueError(
-                f"autodetected range of [{first_edge}, {last_edge}] is not finite")
+    Determine the outer bin edges to use for each dimension.
 
-    # expand empty range to avoid divide by zero
-    if first_edge == last_edge:
-        first_edge = first_edge - 0.5
-        last_edge = last_edge + 0.5
+    Parameters
+    ----------
+    a : ndarray, shape (M, D)
+        Sample of M points in D dimensions.
+    range : sequence of length D, or None
+        Per-dimension ``(lower, upper)`` pairs. The whole argument, or any
+        individual entry, may be ``None`` to autodetect that dimension from
+        the data.
+
+    Returns
+    -------
+    first_edge, last_edge : ndarray, shape (D,)
+        Lower and upper outer edge for each dimension.
+    """
+    M, D = a.shape
+    edge_dtype = a.dtype if np.issubdtype(a.dtype, np.floating) else np.float64
+
+    if range is not None:
+        bounds = [b for r in range if r is not None for b in r]
+        if bounds:
+            edge_dtype = np.result_type(edge_dtype, *bounds)
+            if not np.issubdtype(edge_dtype, np.floating):
+                edge_dtype = np.float64
+
+    first_edge = np.empty(D, dtype=edge_dtype)
+    last_edge = np.empty(D, dtype=edge_dtype)
+    no_rangeval = np.ones(D, dtype=bool)
+
+    if range is not None:
+        for dim, r in enumerate(range):
+            if r is None:
+                continue
+            lo, hi = r
+            if lo > hi:
+                raise ValueError(
+                    'max must be larger than min in range parameter '
+                    f'(dimension {dim}).')
+            first_edge[dim] = lo
+            last_edge[dim] = hi
+            no_rangeval[dim] = False
+
+    if no_rangeval.any():
+        if M == 0:
+            first_edge[no_rangeval] = 0
+            last_edge[no_rangeval] = 1
+        else:
+            first_edge[no_rangeval] = a[:, no_rangeval].min(axis=0)
+            last_edge[no_rangeval] = a[:, no_rangeval].max(axis=0)
+
+    finite = np.isfinite(first_edge) & np.isfinite(last_edge)
+    if not finite.all():
+        dim = int(np.argmin(finite))
+        raise ValueError(
+            f"range of [{first_edge[dim]}, {last_edge[dim]}] is not finite "
+            f"(dimension {dim})")
+
+    # expand empty ranges to avoid divide by zero
+    empty = first_edge == last_edge
+    first_edge[empty] -= 0.5
+    last_edge[empty] += 0.5
 
     return first_edge, last_edge
 
@@ -390,7 +428,8 @@ def _get_bin_edges(a, bins, range, weights):
             raise TypeError("Automated estimation of the number of "
                             "bins is not supported for weighted data")
 
-        first_edge, last_edge = _get_outer_edges(a, range)
+        first_edge, last_edge = _get_outer_edges(a[:, np.newaxis], [range])
+        first_edge, last_edge = first_edge[0], last_edge[0]
 
         # truncate the range if needed
         if range is not None:
@@ -423,7 +462,8 @@ def _get_bin_edges(a, bins, range, weights):
         if n_equal_bins < 1:
             raise ValueError('`bins` must be positive, when an integer')
 
-        first_edge, last_edge = _get_outer_edges(a, range)
+        first_edge, last_edge = _get_outer_edges(a[:, np.newaxis], [range])
+        first_edge, last_edge = first_edge[0], last_edge[0]
 
     elif np.ndim(bins) == 1:
         bin_edges = np.asarray(bins)

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -120,8 +120,10 @@ def _hist_bin_scott(x, range):
         Per-dimension estimates of the optimal bin widths.
     """
     del range  # unused
+    x = x.reshape(-1, 1) if x.ndim == 1 else x
     N, D = x.shape
-    return 3.5 * np.std(x, axis=0) * N**(-1/(2+D))
+    h = 2 * (3 * np.pi**(D/2) / N)**(1/(D+2)) * np.std(x, axis=0)
+    return h[0] if D == 1 else h
 
 
 def _hist_bin_stone(x, range):

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -229,7 +229,6 @@ def _hist_bin_fd(x, range):
         Per-dimension estimates of the optimal bin widths.
     """
     del range  # unused
-    x = x.reshape(-1, 1) if x.ndim == 1 else x
     N, D = x.shape
     iqr = np.subtract(*np.percentile(x, [75, 25], axis=0))
     return 2.0 * iqr * N ** (-1.0 / (D + 2))

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -102,21 +102,23 @@ def _hist_bin_scott(x, range):
     Scott histogram bin estimator.
 
     The binwidth is proportional to the standard deviation of the data
-    and inversely proportional to the cube root of data size
-    (asymptotically optimal).
+    and inversely proportional to a power of data size that depends on
+    the number of dimensions (asymptotically optimal).
 
     Parameters
     ----------
-    x : array_like
+    x : ndarray, shape (N, D)
         Input data that is to be histogrammed, trimmed to range. May not
         be empty.
 
     Returns
     -------
-    h : An estimate of the optimal bin width for the given data.
+    h : ndarray, shape (D,)
+        Per-dimension estimates of the optimal bin widths.
     """
     del range  # unused
-    return (24.0 * np.pi**0.5 / x.size)**(1.0 / 3.0) * np.std(x)
+    N, D = x.shape
+    return (12 * 2**D * np.pi**(D / 2) / N)**(1 / (D + 2)) * np.std(x, axis=0)
 
 
 def _hist_bin_stone(x, range):

--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -242,7 +242,7 @@ def histogram(
 @overload  # dtype +float64
 def histogramdd(
     sample: _ArrayLikeInt_co | _NestedSequence[float] | _ArrayLikeObject_co,
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[_BinKind | SupportsIndex | ArrayLike] = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -250,7 +250,7 @@ def histogramdd(
 @overload  # dtype ~complex
 def histogramdd(
     sample: _NestedList[complex],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[_BinKind | SupportsIndex | ArrayLike] = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -258,7 +258,7 @@ def histogramdd(
 @overload  # dtype known
 def histogramdd[ScalarT: np.inexact](
     sample: _ArrayLike[ScalarT],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[_BinKind | SupportsIndex | ArrayLike] = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -266,7 +266,7 @@ def histogramdd[ScalarT: np.inexact](
 @overload  # dtype unknown
 def histogramdd(
     sample: _ArrayLikeComplex_co,
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[_BinKind | SupportsIndex | ArrayLike] = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,

--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -242,7 +242,7 @@ def histogram(
 @overload  # dtype +float64
 def histogramdd(
     sample: _ArrayLikeInt_co | _NestedSequence[float] | _ArrayLikeObject_co,
-    bins: SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -250,7 +250,7 @@ def histogramdd(
 @overload  # dtype ~complex
 def histogramdd(
     sample: _NestedList[complex],
-    bins: SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -258,7 +258,7 @@ def histogramdd(
 @overload  # dtype known
 def histogramdd[ScalarT: np.inexact](
     sample: _ArrayLike[ScalarT],
-    bins: SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -266,7 +266,7 @@ def histogramdd[ScalarT: np.inexact](
 @overload  # dtype unknown
 def histogramdd(
     sample: _ArrayLikeComplex_co,
-    bins: SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,

--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -242,7 +242,7 @@ def histogram(
 @overload  # dtype +float64
 def histogramdd(
     sample: _ArrayLikeInt_co | _NestedSequence[float] | _ArrayLikeObject_co,
-    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[SupportsIndex | ArrayLike] = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -250,7 +250,7 @@ def histogramdd(
 @overload  # dtype ~complex
 def histogramdd(
     sample: _NestedList[complex],
-    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[SupportsIndex | ArrayLike] = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -258,7 +258,7 @@ def histogramdd(
 @overload  # dtype known
 def histogramdd[ScalarT: np.inexact](
     sample: _ArrayLike[ScalarT],
-    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[SupportsIndex | ArrayLike] = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -266,7 +266,7 @@ def histogramdd[ScalarT: np.inexact](
 @overload  # dtype unknown
 def histogramdd(
     sample: _ArrayLikeComplex_co,
-    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[SupportsIndex | ArrayLike] = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,

--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -242,7 +242,7 @@ def histogram(
 @overload  # dtype +float64
 def histogramdd(
     sample: _ArrayLikeInt_co | _NestedSequence[float] | _ArrayLikeObject_co,
-    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[_BinKind | SupportsIndex | ArrayLike] = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[SupportsIndex | ArrayLike] = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -250,7 +250,7 @@ def histogramdd(
 @overload  # dtype ~complex
 def histogramdd(
     sample: _NestedList[complex],
-    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[_BinKind | SupportsIndex | ArrayLike] = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[SupportsIndex | ArrayLike] = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -258,7 +258,7 @@ def histogramdd(
 @overload  # dtype known
 def histogramdd[ScalarT: np.inexact](
     sample: _ArrayLike[ScalarT],
-    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[_BinKind | SupportsIndex | ArrayLike] = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[SupportsIndex | ArrayLike] = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -266,7 +266,7 @@ def histogramdd[ScalarT: np.inexact](
 @overload  # dtype unknown
 def histogramdd(
     sample: _ArrayLikeComplex_co,
-    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[_BinKind | SupportsIndex | ArrayLike] = 10,
+    bins: SupportsIndex | _BinKind | ArrayLike | Sequence[SupportsIndex | ArrayLike] = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,

--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -4,7 +4,6 @@ from typing import Any, Literal as L, SupportsIndex, overload
 
 import numpy as np
 from numpy._typing import (
-    ArrayLike,
     NDArray,
     _ArrayLike,
     _ArrayLikeComplex_co,

--- a/numpy/lib/_histograms_impl.pyi
+++ b/numpy/lib/_histograms_impl.pyi
@@ -34,28 +34,28 @@ type _HistogramResult[HistT: np.generic, EdgeT: np.generic] = tuple[_Array1D[His
 @overload  # dtype +float64
 def histogram_bin_edges(
     a: _ArrayLikeInt_co | _NestedSequence[float],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     weights: _WeightsLike | None = None,
 ) -> _Array1D[np.float64]: ...
 @overload  # dtype ~complex
 def histogram_bin_edges(
     a: _NestedList[complex],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     weights: _WeightsLike | None = None,
 ) -> _Array1D[np.complex128]: ...
 @overload  # dtype known
 def histogram_bin_edges[ScalarT: np.inexact | np.object_](
     a: _ArrayLike[ScalarT],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     weights: _WeightsLike | None = None,
 ) -> _Array1D[ScalarT]: ...
 @overload  # dtype unknown
 def histogram_bin_edges(
     a: _ArrayLikeComplex_co,
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     weights: _WeightsLike | None = None,
 ) -> _Array1D[Incomplete]: ...
@@ -64,7 +64,7 @@ def histogram_bin_edges(
 @overload  # a: +float64, density: True (keyword), weights: +float | None (default)
 def histogram(
     a: _ArrayLikeInt_co | _NestedSequence[float],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     *,
     density: L[True],
@@ -73,7 +73,7 @@ def histogram(
 @overload  # a: +float64, density: True (keyword), weights: +complex
 def histogram(
     a: _ArrayLikeInt_co | _NestedSequence[float],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     *,
     density: L[True],
@@ -82,7 +82,7 @@ def histogram(
 @overload  # a: +float64, density: False (default), weights: ~int | None (default)
 def histogram(
     a: _ArrayLikeInt_co | _NestedSequence[float],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     weights: _NestedSequence[int] | None = None,
@@ -90,7 +90,7 @@ def histogram(
 @overload  # a: +float64, density: False (default), weights: known (keyword)
 def histogram[WeightsT: np.bool | np.number | np.timedelta64](
     a: _ArrayLikeInt_co | _NestedSequence[float],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     *,
@@ -99,7 +99,7 @@ def histogram[WeightsT: np.bool | np.number | np.timedelta64](
 @overload  # a: +float64, density: False (default), weights: unknown (keyword)
 def histogram(
     a: _ArrayLikeInt_co | _NestedSequence[float],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     *,
@@ -108,7 +108,7 @@ def histogram(
 @overload  # a: ~complex, density: True (keyword), weights: +float | None (default)
 def histogram(
     a: _NestedList[complex],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     *,
     density: L[True],
@@ -117,7 +117,7 @@ def histogram(
 @overload  # a: ~complex, density: True (keyword), weights: +complex
 def histogram(
     a: _NestedList[complex],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     *,
     density: L[True],
@@ -126,7 +126,7 @@ def histogram(
 @overload  # a: ~complex, density: False (default), weights: ~int | None (default)
 def histogram(
     a: _NestedList[complex],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     weights: _NestedSequence[int] | None = None,
@@ -134,7 +134,7 @@ def histogram(
 @overload  # a: ~complex, density: False (default), weights: known (keyword)
 def histogram[WeightsT: np.bool | np.number | np.timedelta64](
     a: _NestedList[complex],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     *,
@@ -143,7 +143,7 @@ def histogram[WeightsT: np.bool | np.number | np.timedelta64](
 @overload  # a: ~complex, density: False (default), weights: unknown (keyword)
 def histogram(
     a: _NestedList[complex],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     *,
@@ -152,7 +152,7 @@ def histogram(
 @overload  # a: known, density: True (keyword), weights: +float | None (default)
 def histogram[ScalarT: np.inexact | np.object_](
     a: _ArrayLike[ScalarT],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     *,
     density: L[True],
@@ -161,7 +161,7 @@ def histogram[ScalarT: np.inexact | np.object_](
 @overload  # a: known, density: True (keyword), weights: +complex
 def histogram[ScalarT: np.inexact | np.object_](
     a: _ArrayLike[ScalarT],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     *,
     density: L[True],
@@ -170,7 +170,7 @@ def histogram[ScalarT: np.inexact | np.object_](
 @overload  # a: known, density: False (default), weights: ~int | None (default)
 def histogram[ScalarT: np.inexact | np.object_](
     a: _ArrayLike[ScalarT],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     weights: _NestedSequence[int] | None = None,
@@ -178,7 +178,7 @@ def histogram[ScalarT: np.inexact | np.object_](
 @overload  # a: known, density: False (default), weights: known (keyword)
 def histogram[ScalarT: np.inexact | np.object_, WeightsT: np.bool | np.number | np.timedelta64](
     a: _ArrayLike[ScalarT],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     *,
@@ -187,7 +187,7 @@ def histogram[ScalarT: np.inexact | np.object_, WeightsT: np.bool | np.number | 
 @overload  # a: known, density: False (default), weights: unknown (keyword)
 def histogram[ScalarT: np.inexact | np.object_](
     a: _ArrayLike[ScalarT],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     *,
@@ -196,7 +196,7 @@ def histogram[ScalarT: np.inexact | np.object_](
 @overload  # a: unknown, density: True (keyword), weights: +float | None (default)
 def histogram(
     a: _ArrayLikeComplex_co,
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     *,
     density: L[True],
@@ -205,7 +205,7 @@ def histogram(
 @overload  # a: unknown, density: True (keyword), weights: +complex
 def histogram(
     a: _ArrayLikeComplex_co,
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     *,
     density: L[True],
@@ -214,7 +214,7 @@ def histogram(
 @overload  # a: unknown, density: False (default), weights: int | None (default)
 def histogram(
     a: _ArrayLikeComplex_co,
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     weights: _NestedSequence[int] | None = None,
@@ -222,7 +222,7 @@ def histogram(
 @overload  # a: unknown, density: False (default), weights: known (keyword)
 def histogram[WeightsT: np.bool | np.number | np.timedelta64](
     a: _ArrayLikeComplex_co,
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     *,
@@ -231,7 +231,7 @@ def histogram[WeightsT: np.bool | np.number | np.timedelta64](
 @overload  # a: unknown, density: False (default), weights: unknown (keyword)
 def histogram(
     a: _ArrayLikeComplex_co,
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | SupportsIndex | _ArrayLikeFloat_co = 10,
     range: _Range | None = None,
     density: L[False] | None = None,
     *,
@@ -242,7 +242,7 @@ def histogram(
 @overload  # dtype +float64
 def histogramdd(
     sample: _ArrayLikeInt_co | _NestedSequence[float] | _ArrayLikeObject_co,
-    bins: SupportsIndex | _BinKind | ArrayLike = 10,
+    bins: SupportsIndex | _BinKind | _ArrayLikeFloat_co = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -250,7 +250,7 @@ def histogramdd(
 @overload  # dtype ~complex
 def histogramdd(
     sample: _NestedList[complex],
-    bins: SupportsIndex | _BinKind | ArrayLike = 10,
+    bins: SupportsIndex | _BinKind | _ArrayLikeFloat_co = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -258,7 +258,7 @@ def histogramdd(
 @overload  # dtype known
 def histogramdd[ScalarT: np.inexact](
     sample: _ArrayLike[ScalarT],
-    bins: SupportsIndex | _BinKind | ArrayLike = 10,
+    bins: SupportsIndex | _BinKind | _ArrayLikeFloat_co = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,
@@ -266,7 +266,7 @@ def histogramdd[ScalarT: np.inexact](
 @overload  # dtype unknown
 def histogramdd(
     sample: _ArrayLikeComplex_co,
-    bins: SupportsIndex | _BinKind | ArrayLike = 10,
+    bins: SupportsIndex | _BinKind | _ArrayLikeComplex_co = 10,
     range: Sequence[_Range] | None = None,
     density: bool | None = None,
     weights: _ArrayLikeFloat64_co | None = None,

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -856,14 +856,6 @@ def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
     if len(x) != len(y):
         raise ValueError('x and y must have the same length.')
 
-    try:
-        N = len(bins)
-    except TypeError:
-        N = 1
-
-    if N not in {1, 2}:
-        xedges = yedges = asarray(bins)
-        bins = [xedges, yedges]
     hist, edges = histogramdd([x, y], bins, range, density, weights)
     return hist, edges[0], edges[1]
 

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -705,18 +705,24 @@ def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
     y : array_like, shape (N,)
         An array containing the y coordinates of the points to be
         histogrammed.
-    bins : int or array_like or [int, int] or [array, array], optional
+    bins : int or array_like or str or [int, int] or [array, array] or
+        [str, str], optional
         The bin specification:
 
         * If int, the number of bins for the two dimensions (nx=ny=bins).
         * If array_like, the bin edges for the two dimensions
           (x_edges=y_edges=bins).
+        * If str, the method used to calculate optimal bin width for
+          the two dimensions as defined by `histogram_bin_edges`
         * If [int, int], the number of bins in each dimension
           (nx, ny = bins).
         * If [array, array], the bin edges in each dimension
           (x_edges, y_edges = bins).
-        * A combination [int, array] or [array, int], where int
-          is the number of bins and array is the bin edges.
+        * If [str, str], the method used to calculate optimal bin
+            width for each dimension as defined by `histogram_bin_edges`
+        * A combination of the above like [int, array] or [array, str],
+            where int is the number of bins, array is the bin edges and str
+            is the bin width estimator.
 
     range : array_like, shape(2,2), optional
         The leftmost and rightmost edges of the bins along each dimension

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -705,8 +705,7 @@ def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
     y : array_like, shape (N,)
         An array containing the y coordinates of the points to be
         histogrammed.
-    bins : int or array_like or str or [int, int] or [array, array] or
-        [str, str], optional
+    bins : int or array_like or str or [int, int] or [array, array], optional
         The bin specification:
 
         * If int, the number of bins for the two dimensions (nx=ny=bins).
@@ -718,11 +717,8 @@ def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
           (nx, ny = bins).
         * If [array, array], the bin edges in each dimension
           (x_edges, y_edges = bins).
-        * If [str, str], the method used to calculate optimal bin
-            width for each dimension as defined by `histogram_bin_edges`
-        * A combination of the above like [int, array] or [array, str],
-            where int is the number of bins, array is the bin edges and str
-            is the bin width estimator.
+        * A combination of the above like [int, array],
+            where int is the number of bins, array is the bin edges.
 
     range : array_like, shape(2,2), optional
         The leftmost and rightmost edges of the bins along each dimension

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -717,8 +717,8 @@ def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
           (nx, ny = bins).
         * If [array, array], the bin edges in each dimension
           (x_edges, y_edges = bins).
-        * A combination of the above like [int, array],
-            where int is the number of bins, array is the bin edges.
+        * A combination [int, array] or [array, int], where int
+          is the number of bins and array is the bin edges.
 
     range : array_like, shape(2,2), optional
         The leftmost and rightmost edges of the bins along each dimension

--- a/numpy/lib/_twodim_base_impl.pyi
+++ b/numpy/lib/_twodim_base_impl.pyi
@@ -1,14 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Callable, Sequence
-from typing import (
-    Any,
-    Literal as L,
-    Never,
-    Protocol,
-    SupportsIndex,
-    overload,
-    type_check_only,
-)
+from typing import Any, Literal as L, Never, Protocol, overload, type_check_only
 
 import numpy as np
 from numpy import _OrderCF
@@ -233,7 +225,7 @@ def vander(x: Sequence[_NumberLike_co], N: int | None = None, increasing: bool =
 def histogram2d[ScalarT: np.complexfloating](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT | _Float_co],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: int | Sequence[int] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -242,7 +234,7 @@ def histogram2d[ScalarT: np.complexfloating](
 def histogram2d[ScalarT: np.complexfloating](
     x: _ArrayLike1D[ScalarT | _Float_co],
     y: _ArrayLike1D[ScalarT],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: int | Sequence[int] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -251,7 +243,7 @@ def histogram2d[ScalarT: np.complexfloating](
 def histogram2d[ScalarT: np.inexact](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT | _Int_co],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | int | Sequence[int | _BinKind] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -260,7 +252,7 @@ def histogram2d[ScalarT: np.inexact](
 def histogram2d[ScalarT: np.inexact](
     x: _ArrayLike1D[ScalarT | _Int_co],
     y: _ArrayLike1D[ScalarT],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | int | Sequence[int | _BinKind] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -269,7 +261,7 @@ def histogram2d[ScalarT: np.inexact](
 def histogram2d(
     x: _ArrayLike1DInt_co | Sequence[float],
     y: _ArrayLike1DInt_co | Sequence[float],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: _BinKind | int | Sequence[int | _BinKind] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -278,7 +270,7 @@ def histogram2d(
 def histogram2d(
     x: Sequence[complex],
     y: Sequence[complex],
-    bins: _BinKind | SupportsIndex | ArrayLike = 10,
+    bins: int | Sequence[int] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -296,7 +288,7 @@ def histogram2d[ScalarT: _Number_co](
 def histogram2d[ScalarT: np.inexact, BinsScalarT: _Number_co](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT],
-    bins: Sequence[_ArrayLike1D[BinsScalarT] | SupportsIndex | _BinKind],
+    bins: Sequence[_ArrayLike1D[BinsScalarT] | int | _BinKind],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -305,7 +297,7 @@ def histogram2d[ScalarT: np.inexact, BinsScalarT: _Number_co](
 def histogram2d[ScalarT: np.inexact](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT],
-    bins: Sequence[_ArrayLike1DNumber_co | SupportsIndex | _BinKind],
+    bins: Sequence[_ArrayLike1DNumber_co | int | _BinKind],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -314,7 +306,7 @@ def histogram2d[ScalarT: np.inexact](
 def histogram2d[ScalarT: _Number_co](
     x: _ArrayLike1DInt_co | Sequence[float],
     y: _ArrayLike1DInt_co | Sequence[float],
-    bins: Sequence[_ArrayLike1D[ScalarT] | SupportsIndex | _BinKind],
+    bins: Sequence[_ArrayLike1D[ScalarT] | int | _BinKind],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -323,7 +315,7 @@ def histogram2d[ScalarT: _Number_co](
 def histogram2d(
     x: _ArrayLike1DInt_co | Sequence[float],
     y: _ArrayLike1DInt_co | Sequence[float],
-    bins: Sequence[_ArrayLike1DNumber_co | SupportsIndex | _BinKind],
+    bins: Sequence[_ArrayLike1DNumber_co | int | _BinKind],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -332,7 +324,7 @@ def histogram2d(
 def histogram2d[ScalarT: _Number_co](
     x: Sequence[complex],
     y: Sequence[complex],
-    bins: Sequence[_ArrayLike1D[ScalarT] | SupportsIndex | _BinKind],
+    bins: Sequence[_ArrayLike1D[ScalarT] | int],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -341,7 +333,7 @@ def histogram2d[ScalarT: _Number_co](
 def histogram2d(
     x: Sequence[complex],
     y: Sequence[complex],
-    bins: Sequence[_ArrayLike1DNumber_co | SupportsIndex | _BinKind],
+    bins: Sequence[_ArrayLike1DNumber_co | int],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -350,7 +342,7 @@ def histogram2d(
 def histogram2d(
     x: _ArrayLike1DNumber_co,
     y: _ArrayLike1DNumber_co,
-    bins: Sequence[Sequence[SupportsIndex]],
+    bins: Sequence[Sequence[int]],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -377,7 +369,7 @@ def histogram2d(
 def histogram2d(
     x: _ArrayLike1DNumber_co,
     y: _ArrayLike1DNumber_co,
-    bins: Sequence[_ArrayLike1DNumber_co | SupportsIndex | _BinKind] | SupportsIndex | _BinKind,
+    bins: Sequence[_ArrayLike1DNumber_co | int | _BinKind] | int | _BinKind,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,

--- a/numpy/lib/_twodim_base_impl.pyi
+++ b/numpy/lib/_twodim_base_impl.pyi
@@ -1,6 +1,6 @@
 from _typeshed import Incomplete
 from collections.abc import Callable, Sequence
-from typing import Any, Literal as L, Never, Protocol, overload, type_check_only
+from typing import Any, Literal as L, Never,  SupportsIndex, Protocol, overload, type_check_only
 
 import numpy as np
 from numpy import _OrderCF
@@ -58,6 +58,7 @@ type _MaskFunc[_T] = Callable[[NDArray[np.int_], _T], NDArray[_Number_co | np.ti
 
 type _Indices2D = tuple[_Array1D[np.intp], _Array1D[np.intp]]
 type _Histogram2D[ScalarT: np.generic] = tuple[_Array2D[np.float64], _Array1D[ScalarT], _Array1D[ScalarT]]
+type _BinKind = L["auto", "fd", "doane", "scott", "stone", "rice", "sturges", "sqrt"]
 
 @type_check_only
 class _HasShapeAndNDim(Protocol):
@@ -224,7 +225,7 @@ def vander(x: Sequence[_NumberLike_co], N: int | None = None, increasing: bool =
 def histogram2d[ScalarT: np.complexfloating](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT | _Float_co],
-    bins: int | Sequence[int] = 10,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -233,7 +234,7 @@ def histogram2d[ScalarT: np.complexfloating](
 def histogram2d[ScalarT: np.complexfloating](
     x: _ArrayLike1D[ScalarT | _Float_co],
     y: _ArrayLike1D[ScalarT],
-    bins: int | Sequence[int] = 10,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -242,7 +243,7 @@ def histogram2d[ScalarT: np.complexfloating](
 def histogram2d[ScalarT: np.inexact](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT | _Int_co],
-    bins: int | Sequence[int] = 10,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -251,7 +252,7 @@ def histogram2d[ScalarT: np.inexact](
 def histogram2d[ScalarT: np.inexact](
     x: _ArrayLike1D[ScalarT | _Int_co],
     y: _ArrayLike1D[ScalarT],
-    bins: int | Sequence[int] = 10,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -260,7 +261,7 @@ def histogram2d[ScalarT: np.inexact](
 def histogram2d(
     x: _ArrayLike1DInt_co | Sequence[float],
     y: _ArrayLike1DInt_co | Sequence[float],
-    bins: int | Sequence[int] = 10,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -269,7 +270,7 @@ def histogram2d(
 def histogram2d(
     x: Sequence[complex],
     y: Sequence[complex],
-    bins: int | Sequence[int] = 10,
+    bins: _BinKind | SupportsIndex | ArrayLike = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -287,7 +288,7 @@ def histogram2d[ScalarT: _Number_co](
 def histogram2d[ScalarT: np.inexact, BinsScalarT: _Number_co](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT],
-    bins: Sequence[_ArrayLike1D[BinsScalarT] | int],
+    bins: Sequence[_ArrayLike1D[BinsScalarT] | SupportsIndex | _BinKind],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -296,7 +297,7 @@ def histogram2d[ScalarT: np.inexact, BinsScalarT: _Number_co](
 def histogram2d[ScalarT: np.inexact](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT],
-    bins: Sequence[_ArrayLike1DNumber_co | int],
+    bins: Sequence[_ArrayLike1DNumber_co | SupportsIndex | _BinKind],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -305,7 +306,7 @@ def histogram2d[ScalarT: np.inexact](
 def histogram2d[ScalarT: _Number_co](
     x: _ArrayLike1DInt_co | Sequence[float],
     y: _ArrayLike1DInt_co | Sequence[float],
-    bins: Sequence[_ArrayLike1D[ScalarT] | int],
+    bins: Sequence[_ArrayLike1D[ScalarT] | SupportsIndex | _BinKind],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -314,7 +315,7 @@ def histogram2d[ScalarT: _Number_co](
 def histogram2d(
     x: _ArrayLike1DInt_co | Sequence[float],
     y: _ArrayLike1DInt_co | Sequence[float],
-    bins: Sequence[_ArrayLike1DNumber_co | int],
+    bins: Sequence[_ArrayLike1DNumber_co | SupportsIndex | _BinKind],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -323,7 +324,7 @@ def histogram2d(
 def histogram2d[ScalarT: _Number_co](
     x: Sequence[complex],
     y: Sequence[complex],
-    bins: Sequence[_ArrayLike1D[ScalarT] | int],
+    bins: Sequence[_ArrayLike1D[ScalarT] | SupportsIndex | _BinKind],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -332,7 +333,7 @@ def histogram2d[ScalarT: _Number_co](
 def histogram2d(
     x: Sequence[complex],
     y: Sequence[complex],
-    bins: Sequence[_ArrayLike1DNumber_co | int],
+    bins: Sequence[_ArrayLike1DNumber_co | SupportsIndex | _BinKind],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -341,7 +342,7 @@ def histogram2d(
 def histogram2d(
     x: _ArrayLike1DNumber_co,
     y: _ArrayLike1DNumber_co,
-    bins: Sequence[Sequence[int]],
+    bins: Sequence[Sequence[SupportsIndex]],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -368,7 +369,7 @@ def histogram2d(
 def histogram2d(
     x: _ArrayLike1DNumber_co,
     y: _ArrayLike1DNumber_co,
-    bins: Sequence[_ArrayLike1DNumber_co | int] | int,
+    bins: Sequence[_ArrayLike1DNumber_co | SupportsIndex | _BinKind] | SupportsIndex | _BinKind,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,

--- a/numpy/lib/_twodim_base_impl.pyi
+++ b/numpy/lib/_twodim_base_impl.pyi
@@ -1,6 +1,14 @@
 from _typeshed import Incomplete
 from collections.abc import Callable, Sequence
-from typing import Any, Literal as L, Never,  SupportsIndex, Protocol, overload, type_check_only
+from typing import (
+    Any,
+    Literal as L,
+    Never,
+    Protocol,
+    SupportsIndex,
+    overload,
+    type_check_only,
+)
 
 import numpy as np
 from numpy import _OrderCF

--- a/numpy/lib/_twodim_base_impl.pyi
+++ b/numpy/lib/_twodim_base_impl.pyi
@@ -243,7 +243,7 @@ def histogram2d[ScalarT: np.complexfloating](
 def histogram2d[ScalarT: np.inexact](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT | _Int_co],
-    bins: _BinKind | int | Sequence[int | _BinKind] = 10,
+    bins: int | _BinKind | Sequence[int | _BinKind] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -252,7 +252,7 @@ def histogram2d[ScalarT: np.inexact](
 def histogram2d[ScalarT: np.inexact](
     x: _ArrayLike1D[ScalarT | _Int_co],
     y: _ArrayLike1D[ScalarT],
-    bins: _BinKind | int | Sequence[int | _BinKind] = 10,
+    bins: int | _BinKind | Sequence[int | _BinKind] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -261,7 +261,7 @@ def histogram2d[ScalarT: np.inexact](
 def histogram2d(
     x: _ArrayLike1DInt_co | Sequence[float],
     y: _ArrayLike1DInt_co | Sequence[float],
-    bins: _BinKind | int | Sequence[int | _BinKind] = 10,
+    bins: int | _BinKind | Sequence[int | _BinKind] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,

--- a/numpy/lib/_twodim_base_impl.pyi
+++ b/numpy/lib/_twodim_base_impl.pyi
@@ -243,7 +243,7 @@ def histogram2d[ScalarT: np.complexfloating](
 def histogram2d[ScalarT: np.inexact](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT | _Int_co],
-    bins: int | _BinKind | Sequence[int | _BinKind] = 10,
+    bins: int | _BinKind | Sequence[int] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -252,7 +252,7 @@ def histogram2d[ScalarT: np.inexact](
 def histogram2d[ScalarT: np.inexact](
     x: _ArrayLike1D[ScalarT | _Int_co],
     y: _ArrayLike1D[ScalarT],
-    bins: int | _BinKind | Sequence[int | _BinKind] = 10,
+    bins: int | _BinKind | Sequence[int] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -261,7 +261,7 @@ def histogram2d[ScalarT: np.inexact](
 def histogram2d(
     x: _ArrayLike1DInt_co | Sequence[float],
     y: _ArrayLike1DInt_co | Sequence[float],
-    bins: int | _BinKind | Sequence[int | _BinKind] = 10,
+    bins: int | _BinKind | Sequence[int] = 10,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -288,7 +288,7 @@ def histogram2d[ScalarT: _Number_co](
 def histogram2d[ScalarT: np.inexact, BinsScalarT: _Number_co](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT],
-    bins: Sequence[_ArrayLike1D[BinsScalarT] | int | _BinKind],
+    bins: Sequence[_ArrayLike1D[BinsScalarT] | int],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -297,7 +297,7 @@ def histogram2d[ScalarT: np.inexact, BinsScalarT: _Number_co](
 def histogram2d[ScalarT: np.inexact](
     x: _ArrayLike1D[ScalarT],
     y: _ArrayLike1D[ScalarT],
-    bins: Sequence[_ArrayLike1DNumber_co | int | _BinKind],
+    bins: Sequence[_ArrayLike1DNumber_co | int],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -306,7 +306,7 @@ def histogram2d[ScalarT: np.inexact](
 def histogram2d[ScalarT: _Number_co](
     x: _ArrayLike1DInt_co | Sequence[float],
     y: _ArrayLike1DInt_co | Sequence[float],
-    bins: Sequence[_ArrayLike1D[ScalarT] | int | _BinKind],
+    bins: Sequence[_ArrayLike1D[ScalarT] | int],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -315,7 +315,7 @@ def histogram2d[ScalarT: _Number_co](
 def histogram2d(
     x: _ArrayLike1DInt_co | Sequence[float],
     y: _ArrayLike1DInt_co | Sequence[float],
-    bins: Sequence[_ArrayLike1DNumber_co | int | _BinKind],
+    bins: Sequence[_ArrayLike1DNumber_co | int],
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,
@@ -369,7 +369,7 @@ def histogram2d(
 def histogram2d(
     x: _ArrayLike1DNumber_co,
     y: _ArrayLike1DNumber_co,
-    bins: Sequence[_ArrayLike1DNumber_co | int | _BinKind] | int | _BinKind,
+    bins: Sequence[_ArrayLike1DNumber_co | int] | int | _BinKind,
     range: _ArrayLike2DFloat_co | None = None,
     density: bool | None = None,
     weights: _ArrayLike1DFloat_co | None = None,

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -706,6 +706,27 @@ class TestHistogramdd:
             H, edges = histogramdd(r, b)
             assert_(H.shape == b)
 
+    def test_bin_strings(self):
+        # These tests checks whether if histogramdd behaves like histogram
+        # in simple cases i.e data behaves like 1D
+        x = np.arange(10)
+        x_2d = x[:, None]
+        for estimator in ['auto', 'fd', 'scott', 'rice', 'sturges', 'doane', 'sqrt', 'stone']:
+            res, _ = histogramdd(x_2d, bins=estimator)
+            res1, _ = histogramdd(x_2d, bins = [estimator])
+            ans, _ = histogram(x, bins=estimator)
+            assert_array_equal(res.astype(int), ans)
+            assert_array_equal(res1.astype(int), ans)
+
+        x_3d = np.stack([x,x,x], axis=1)
+        x_3d_ans = 2 * np.eye(5)[..., None] * np.eye(5)
+        res, _ = histogramdd(x_3d, bins='auto')
+        assert_array_equal(res, x_3d_ans)
+        res, _ = histogramdd(x_3d, bins=['auto']*3)
+        assert_array_equal(res, x_3d_ans)
+
+
+
     def test_weights(self):
         v = np.random.rand(100, 2)
         hist, edges = histogramdd(v)
@@ -729,14 +750,23 @@ class TestHistogramdd:
         assert_array_max_ulp(a, np.zeros((2, 2, 2)))
 
     def test_bins_errors(self):
-        # There are two ways to specify bins. Check for the right errors
-        # when mixing those.
+        # There are three ways to specify bins:
+        # integers, strings and arraylike where it describes the edges
+        # Check for the right errors when mixing those.
         x = np.arange(8).reshape(2, 4)
         assert_raises(ValueError, np.histogramdd, x, bins=[-1, 2, 4, 5])
         assert_raises(TypeError, np.histogramdd, x, bins=[1, 0.99, 1, 1])
         assert_raises(
             ValueError, np.histogramdd, x, bins=[1, 1, 1, [1, 2, 3, -3]])
+        assert_raises(ValueError, np.histogramdd, x, bins="gibberish")
+        assert_raises(ValueError, np.histogramdd, x, bins=["gibberish",2])
+        assert_raises(ValueError, np.histogramdd, x, bins=["auto",2])
+
         assert_(np.histogramdd(x, bins=[1, 1, 1, [1, 2, 3, 4]]))
+        assert_(np.histogramdd(x, bins=["auto", 1, 1, [1, 2, 3, 4]]))
+        assert_(np.histogramdd(x, bins=[1, 2, 3, 4]))
+        assert_(np.histogramdd(x, bins="auto"))
+        assert_(np.histogramdd(x, bins=25))
 
     def test_inf_edges(self):
         # Test using +/-inf bin edges works. See #1788.

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -733,7 +733,7 @@ class TestHistogramdd:
         # when mixing those.
         x = np.arange(8).reshape(2, 4)
         assert_raises(ValueError, np.histogramdd, x, bins=[-1, 2, 4, 5])
-        assert_raises(ValueError, np.histogramdd, x, bins=[1, 0.99, 1, 1])
+        assert_raises(TypeError, np.histogramdd, x, bins=[1, 0.99, 1, 1])
         assert_raises(
             ValueError, np.histogramdd, x, bins=[1, 1, 1, [1, 2, 3, -3]])
         assert_(np.histogramdd(x, bins=[1, 1, 1, [1, 2, 3, 4]]))

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -711,21 +711,20 @@ class TestHistogramdd:
         # in simple cases i.e data behaves like 1D
         x = np.arange(10)
         x_2d = x[:, None]
-        for estimator in ['auto', 'fd', 'scott', 'rice', 'sturges', 'doane', 'sqrt', 'stone']:
+        for estimator in ['auto', 'fd', 'scott', 'rice', 'sturges',
+                          'doane', 'sqrt', 'stone']:
             res, _ = histogramdd(x_2d, bins=estimator)
-            res1, _ = histogramdd(x_2d, bins = [estimator])
+            res1, _ = histogramdd(x_2d, bins=[estimator])
             ans, _ = histogram(x, bins=estimator)
             assert_array_equal(res.astype(int), ans)
             assert_array_equal(res1.astype(int), ans)
 
-        x_3d = np.stack([x,x,x], axis=1)
+        x_3d = np.stack([x, x, x], axis=1)
         x_3d_ans = 2 * np.eye(5)[..., None] * np.eye(5)
         res, _ = histogramdd(x_3d, bins='auto')
         assert_array_equal(res, x_3d_ans)
-        res, _ = histogramdd(x_3d, bins=['auto']*3)
+        res, _ = histogramdd(x_3d, bins=['auto'] * 3)
         assert_array_equal(res, x_3d_ans)
-
-
 
     def test_weights(self):
         v = np.random.rand(100, 2)
@@ -759,8 +758,8 @@ class TestHistogramdd:
         assert_raises(
             ValueError, np.histogramdd, x, bins=[1, 1, 1, [1, 2, 3, -3]])
         assert_raises(ValueError, np.histogramdd, x, bins="gibberish")
-        assert_raises(ValueError, np.histogramdd, x, bins=["gibberish",2])
-        assert_raises(ValueError, np.histogramdd, x, bins=["auto",2])
+        assert_raises(ValueError, np.histogramdd, x, bins=["gibberish", 2])
+        assert_raises(ValueError, np.histogramdd, x, bins=["auto", 2])
 
         assert_(np.histogramdd(x, bins=[1, 1, 1, [1, 2, 3, 4]]))
         assert_(np.histogramdd(x, bins=["auto", 1, 1, [1, 2, 3, 4]]))

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -706,9 +706,7 @@ class TestHistogramdd:
             H, edges = histogramdd(r, b)
             assert_(H.shape == b)
 
-    def test_bin_strings(self):
-        # These tests checks whether if histogramdd behaves like histogram
-        # in simple cases i.e data behaves like 1D
+    def test_bin_strings_simple(self):
         x = np.arange(10)
         x_2d = x[:, None]
         for estimator in ['auto', 'fd', 'scott', 'rice', 'sturges',
@@ -725,6 +723,20 @@ class TestHistogramdd:
         assert_array_equal(res, x_3d_ans)
         res, _ = histogramdd(x_3d, bins=['auto'] * 3)
         assert_array_equal(res, x_3d_ans)
+
+    def test_bin_strings_multi_dim(self):
+        x = np.array([[-.5, .5, 1.5], [-.5, 1.5, 2.5], [-.5, 2.5, .5],
+                      [.5,  .5, 1.5], [.5,  1.5, 2.5], [.5,  2.5, 2.5]])
+        # stone gives runtime warning about optimal bins,
+        # so it is skipped here since it is unrelated
+        for estimator in ['auto', 'fd', 'scott', 'rice', 'sturges',
+                          'doane', 'sqrt']:
+            _, edges_1 = histogram(x.T[2], estimator)
+            _, edges = histogramdd(x, (2, 3, estimator))
+            assert_array_equal(edges[2], edges_1)
+            _, edges = histogramdd(x, (2, [2, 3, 5, 21, 35, 123], estimator))
+            assert_array_equal(edges[2], edges_1)
+            assert_array_equal(edges[1], np.array([2, 3, 5, 21, 35, 123]))
 
     def test_weights(self):
         v = np.random.rand(100, 2)

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -255,7 +255,8 @@ class TestHistogram:
         # gracefully handle bins object > 1 dimension
         vals = np.linspace(0.0, 1.0, num=100)
         bins = np.array([[0, 0.5], [0.6, 1.0]])
-        with assert_raises_regex(ValueError, "The dimension of bins must be equal to the "
+        with assert_raises_regex(ValueError, "The dimension of bins must be "
+                                             "equal to the "
                                              "dimension of the sample x"):
             np.histogram(vals, bins=bins)
 

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -707,38 +707,6 @@ class TestHistogramdd:
             H, edges = histogramdd(r, b)
             assert_(H.shape == b)
 
-    def test_bin_strings_simple(self):
-        x = np.arange(10)
-        x_2d = x[:, None]
-        for estimator in ['auto', 'fd', 'scott', 'rice', 'sturges',
-                          'doane', 'sqrt', 'stone']:
-            res, _ = histogramdd(x_2d, bins=estimator)
-            res1, _ = histogramdd(x_2d, bins=[estimator])
-            ans, _ = histogram(x, bins=estimator)
-            assert_array_equal(res.astype(int), ans)
-            assert_array_equal(res1.astype(int), ans)
-
-        x_3d = np.stack([x, x, x], axis=1)
-        x_3d_ans = 2 * np.eye(5)[..., None] * np.eye(5)
-        res, _ = histogramdd(x_3d, bins='auto')
-        assert_array_equal(res, x_3d_ans)
-        res, _ = histogramdd(x_3d, bins=['auto'] * 3)
-        assert_array_equal(res, x_3d_ans)
-
-    def test_bin_strings_multi_dim(self):
-        x = np.array([[-.5, .5, 1.5], [-.5, 1.5, 2.5], [-.5, 2.5, .5],
-                      [.5,  .5, 1.5], [.5,  1.5, 2.5], [.5,  2.5, 2.5]])
-        # stone gives runtime warning about optimal bins,
-        # so it is skipped here since it is unrelated
-        for estimator in ['auto', 'fd', 'scott', 'rice', 'sturges',
-                          'doane', 'sqrt']:
-            _, edges_1 = histogram(x.T[2], estimator)
-            _, edges = histogramdd(x, (2, 3, estimator))
-            assert_array_equal(edges[2], edges_1)
-            _, edges = histogramdd(x, (2, [2, 3, 5, 21, 35, 123], estimator))
-            assert_array_equal(edges[2], edges_1)
-            assert_array_equal(edges[1], np.array([2, 3, 5, 21, 35, 123]))
-
     def test_weights(self):
         v = np.random.rand(100, 2)
         hist, edges = histogramdd(v)
@@ -773,11 +741,9 @@ class TestHistogramdd:
         assert_raises(ValueError, np.histogramdd, x, bins="gibberish")
         assert_raises(ValueError, np.histogramdd, x, bins=["gibberish", 2])
         assert_raises(ValueError, np.histogramdd, x, bins=["auto", 2])
-
+        assert_raises(ValueError, np.histogramdd, x, bins=["auto", 1, 1, [1, 2, 3, 4]])
         assert_(np.histogramdd(x, bins=[1, 1, 1, [1, 2, 3, 4]]))
-        assert_(np.histogramdd(x, bins=["auto", 1, 1, [1, 2, 3, 4]]))
         assert_(np.histogramdd(x, bins=[1, 2, 3, 4]))
-        assert_(np.histogramdd(x, bins="auto"))
         assert_(np.histogramdd(x, bins=25))
 
     def test_inf_edges(self):

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -255,7 +255,8 @@ class TestHistogram:
         # gracefully handle bins object > 1 dimension
         vals = np.linspace(0.0, 1.0, num=100)
         bins = np.array([[0, 0.5], [0.6, 1.0]])
-        with assert_raises_regex(ValueError, "must be 1d"):
+        with assert_raises_regex(ValueError, "The dimension of bins must be equal to the "
+                                             "dimension of the sample x"):
             np.histogram(vals, bins=bins)
 
     def test_unsigned_monotonicity_check(self):

--- a/numpy/typing/tests/data/reveal/histograms.pyi
+++ b/numpy/typing/tests/data/reveal/histograms.pyi
@@ -67,3 +67,6 @@ assert_type(np.histogramdd(AR_i8), tuple[npt.NDArray[np.float64], tuple[_Array1D
 assert_type(np.histogramdd(AR_f4), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float32], ...]])
 assert_type(np.histogramdd(AR_c8), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.complex64], ...]])
 assert_type(np.histogramdd(AR_c16), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.complex128], ...]])
+assert_type(np.histogramdd(AR_i8, bins="auto"), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])
+assert_type(np.histogramdd(AR_i8, bins="rice"), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])
+assert_type(np.histogramdd(AR_i8, bins="scott"), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])

--- a/numpy/typing/tests/data/reveal/histograms.pyi
+++ b/numpy/typing/tests/data/reveal/histograms.pyi
@@ -68,5 +68,5 @@ assert_type(np.histogramdd(AR_f4), tuple[npt.NDArray[np.float64], tuple[_Array1D
 assert_type(np.histogramdd(AR_c8), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.complex64], ...]])
 assert_type(np.histogramdd(AR_c16), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.complex128], ...]])
 assert_type(np.histogramdd(AR_i8, bins="auto"), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])
-assert_type(np.histogramdd(AR_i8, bins="rice"), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])
+assert_type(np.histogramdd(AR_i8, bins="fd"), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])
 assert_type(np.histogramdd(AR_i8, bins="scott"), tuple[npt.NDArray[np.float64], tuple[_Array1D[np.float64], ...]])

--- a/numpy/typing/tests/data/reveal/twodim_base.pyi
+++ b/numpy/typing/tests/data/reveal/twodim_base.pyi
@@ -170,6 +170,30 @@ assert_type(
     ],
 )
 assert_type(
+    np.histogram2d(_nd_f64, _nd_f64, bins="auto"),
+    tuple[
+        np.ndarray[_2D, np.dtype[np.float64]],
+        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_1D, np.dtype[np.float64]],
+    ],
+)
+assert_type(
+    np.histogram2d(_nd_f64, _nd_f64, bins=("auto", "auto")),
+    tuple[
+        np.ndarray[_2D, np.dtype[np.float64]],
+        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_1D, np.dtype[np.float64]],
+    ],
+)
+assert_type(
+    np.histogram2d(_nd_f64, _nd_f64, bins=("auto", 5)),
+    tuple[
+        np.ndarray[_2D, np.dtype[np.float64]],
+        np.ndarray[_1D, np.dtype[np.float64]],
+        np.ndarray[_1D, np.dtype[np.float64]],
+    ],
+)
+assert_type(
     np.histogram2d(_nd_c128, _nd_i64, bins=_nd_u64),
     tuple[
         np.ndarray[_2D, np.dtype[np.float64]],

--- a/numpy/typing/tests/data/reveal/twodim_base.pyi
+++ b/numpy/typing/tests/data/reveal/twodim_base.pyi
@@ -178,22 +178,6 @@ assert_type(
     ],
 )
 assert_type(
-    np.histogram2d(_nd_f64, _nd_f64, bins=("auto", "auto")),
-    tuple[
-        np.ndarray[_2D, np.dtype[np.float64]],
-        np.ndarray[_1D, np.dtype[np.float64]],
-        np.ndarray[_1D, np.dtype[np.float64]],
-    ],
-)
-assert_type(
-    np.histogram2d(_nd_f64, _nd_f64, bins=("auto", 5)),
-    tuple[
-        np.ndarray[_2D, np.dtype[np.float64]],
-        np.ndarray[_1D, np.dtype[np.float64]],
-        np.ndarray[_1D, np.dtype[np.float64]],
-    ],
-)
-assert_type(
     np.histogram2d(_nd_c128, _nd_i64, bins=_nd_u64),
     tuple[
         np.ndarray[_2D, np.dtype[np.float64]],


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
fixes #20215
1) Adds multi dimensional bin width histogram algorithm(s)
    also generalizes existing bin width histogram algorithms to arrays (for dimensionality)
    majority of them will throw not implemented error when D>1
2) Generalizes some helper functions to multi dimensions
3) Adds string support for multi dimensional histograms
### Other comments
I am not content with "auto" choice but it should be practical enough.

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
~I used Claude as sanity check on my fixes. All modifications etc are done solely by my decisions and manually typed or copy pasted documentation from the related PR above.~
Claude was used extensively on some parts of the code, especially on `_get_bin_edges`. Other than that I do not remember to be honest.
