### PR TITLE
DOC/TYP: Improved typing docs for ``ndarray``

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -64,10 +64,24 @@ or explicitly type the array like object as `~typing.Any`:
 ndarray
 ~~~~~~~
 
-It's possible (but deprecated) to mutate the dtype of an array at runtime.
-This sort of mutation is not allowed by the types. Users who want to
-write statically typed code should instead use the `numpy.ndarray.view`
-method to create a view of the array with a different dtype.
+The `numpy.ndarray` class is a `generic type`_ that accepts two type arguments:
+
+1. The type of `numpy.ndarray.shape`, which must be a `tuple` of `int`, e.g.
+   ``tuple[int, int]`` (2-D shape) or ``tuple[()]`` (0-D shape).
+   The default shape is ``tuple[Any, ...]``, which represents an unknown shape with
+   *any* number of dimensions.
+   Currently, ``Literal`` ints or other more specific types are not supported.
+2. The type of `numpy.ndarray.dtype`, which must be a subtype of `numpy.dtype` such as
+   ``numpy.dtype[numpy.float64]``. If omitted, it will default to ``numpy.dtype[Any]``.
+
+.. code-block:: python
+
+    >>> import numpy as np
+
+    >>> type ImageRGB = np.ndarray[tuple[int, int, int], np.dtype[np.uint8]]
+    >>> type Vector[S: np.generic] = np.ndarray[tuple[int], np.dtype[S]]
+
+.. _generic type: https://typing.python.org/en/latest/spec/generics.html
 
 DTypeLike
 ~~~~~~~~~


### PR DESCRIPTION
These docs were outdated and did not describe how  `numpy.ndarray` can be used in a static typing context.

#### AI Disclosure
N/A
