### PR TITLE
DOC: fix grammar in isrealobj docstring

### DIFF
--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -307,7 +307,7 @@ def iscomplexobj(x):
 @array_function_dispatch(_is_type_dispatcher)
 def isrealobj(x):
     """
-    Return True if x is a not complex type or an array of complex numbers.
+    Return True if x is not a complex type or an array of complex numbers.
 
     The type of the input is checked, not the value. So even if the input
     has an imaginary part equal to zero, `isrealobj` evaluates to False


### PR DESCRIPTION

**Repo:** numpy/numpy (⭐ 27000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Fix a small grammatical error in the one-line summary of `numpy.isrealobj` in `numpy/lib/_type_check_impl.py`. The phrase "Return True if x is a not complex type" is reordered to "Return True if x is not a complex type", which both reads naturally and correctly describes the function's behavior (it returns `not iscomplexobj(x)`).

## Why
The current phrasing is ungrammatical and slightly confusing — a reader scanning the API reference may parse "a not complex type" as awkward or even invert the intended meaning. This is a zero-risk wording fix to user-facing API documentation that gets rendered on the NumPy reference site.

## Testing
Pure docstring change — no behavior change. Verified the original misphrasing was unique to this location via grep across the repo. No tests touch the docstring text.

## Risk
Low — single-character whitespace shift in a docstring; no code paths affected.
