### PR TITLE
BUG: BLAS FPE check import-time deadlock on macOS ARM64

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -860,8 +860,9 @@ else:
                         "Spurious warnings given by blas but suppression not "
                         "set up on this platform. Please open a NumPy issue.",
                         UserWarning, stacklevel=2)
-
-    blas_fpe_check()
+    
+    if sys.platform == "darwin" and s.uname().machine == "arm64":        
+            blas_fpe_check()
     del blas_fpe_check
 
     def hugepage_setup():


### PR DESCRIPTION
### PR summary
This prevents BLAS from being executed during module import, which can lead to deadlocks when NumPy is imported from within a dlopen-triggered static constructor (OpenMP + MKL + loader lock interaction).

Behavior of BLAS execution is unchanged outside import time.

Related to: https://github.com/numpy/numpy/issues/31284

  

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->AI tools were used to assist with drafting and structuring the explanation, but the analysis, design, and implementation decisions were made and verified by the author.
