### PR TITLE
DOC/TYP: remove outdated subsection on 0D arrays

### DIFF
--- a/numpy/typing/__init__.py
+++ b/numpy/typing/__init__.py
@@ -157,20 +157,6 @@ The `~numpy.timedelta64` class is not considered a subclass of
 `~numpy.signedinteger`, the former only inheriting from `~numpy.generic`
 while static type checking.
 
-0D arrays
-~~~~~~~~~
-
-During runtime numpy aggressively casts any passed 0D arrays into their
-corresponding `~numpy.generic` instance. Until the introduction of shape
-typing (see :pep:`646`) it is unfortunately not possible to make the
-necessary distinction between 0D and >0D arrays. While thus not strictly
-correct, all operations that can potentially perform a 0D-array -> scalar
-cast are currently annotated as exclusively returning an `~numpy.ndarray`.
-
-If it is known in advance that an operation *will* perform a
-0D-array -> scalar cast, then one can consider manually remedying the
-situation with either `typing.cast` or a ``# type: ignore`` comment.
-
 Record array dtypes
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Because of the recent shape-typing improvements, most functions now return a scalar type (instead of 0D arrays) when they'd return a scalar at runtime.

#### AI Disclosure
N/A