### PR TITLE
BUG: Raise warning for integer arithmetic with timedelta64/datetime64 arrays

### DIFF
--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -818,6 +818,12 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
         /* m8[<A>] + int => m8[<A>] + m8[<A>] */
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                                     PyTypeNum_ISBOOL(type_num2)) {
+            if (DEPRECATE(
+                    "Addition of integers to timedelta64 arrays is deprecated, "
+                    "and will raise an error in the future. "
+                    "Please convert the integer with an explicit unit.") < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[0]));
             if (out_dtypes[0] == NULL) {
@@ -855,6 +861,12 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
         /* M8[<A>] + int => M8[<A>] + m8[<A>] */
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                     PyTypeNum_ISBOOL(type_num2)) {
+            if (DEPRECATE(
+                    "Addition of integers to datetime64 arrays is deprecated, "
+                    "and will raise an error in the future. "
+                    "Please convert the integer with an explicit unit.") < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[0]));
             if (out_dtypes[0] == NULL) {
@@ -880,6 +892,12 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
     else if (PyTypeNum_ISINTEGER(type_num1) || PyTypeNum_ISBOOL(type_num1)) {
         /* int + m8[<A>] => m8[<A>] + m8[<A>] */
         if (type_num2 == NPY_TIMEDELTA) {
+            if (DEPRECATE(
+                    "Addition of integers to timedelta64 arrays is deprecated, "
+                    "and will raise an error in the future. "
+                    "Please convert the integer with an explicit unit.") < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[1]));
             if (out_dtypes[0] == NULL) {
@@ -893,6 +911,12 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
             type_num1 = NPY_TIMEDELTA;
         }
         else if (type_num2 == NPY_DATETIME) {
+            if (DEPRECATE(
+                    "Addition of integers to datetime64 arrays is deprecated, "
+                    "and will raise an error in the future. "
+                    "Please convert the integer with an explicit unit.") < 0) {
+                return -1;
+            }
             /* Make a new NPY_TIMEDELTA, and copy type2's metadata */
             out_dtypes[0] = timedelta_dtype_with_copied_meta(
                                             PyArray_DESCR(operands[1]));
@@ -991,6 +1015,12 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
         /* m8[<A>] - int => m8[<A>] - m8[<A>] */
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                                         PyTypeNum_ISBOOL(type_num2)) {
+            if (DEPRECATE(
+                    "Subtraction of integers from timedelta64 arrays is deprecated, "
+                    "and will raise an error in the future. "
+                    "Please convert the integer with an explicit unit.") < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[0]));
             if (out_dtypes[0] == NULL) {
@@ -1028,6 +1058,12 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
         /* M8[<A>] - int => M8[<A>] - m8[<A>] */
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                     PyTypeNum_ISBOOL(type_num2)) {
+            if (DEPRECATE(
+                    "Subtraction of integers from datetime64 arrays is deprecated, "
+                    "and will raise an error in the future. "
+                    "Please convert the integer with an explicit unit.") < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[0]));
             if (out_dtypes[0] == NULL) {
@@ -1069,6 +1105,12 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
     else if (PyTypeNum_ISINTEGER(type_num1) || PyTypeNum_ISBOOL(type_num1)) {
         /* int - m8[<A>] => m8[<A>] - m8[<A>] */
         if (type_num2 == NPY_TIMEDELTA) {
+            if (DEPRECATE(
+                    "Subtraction of integers from timedelta64 arrays is deprecated, "
+                    "and will raise an error in the future. "
+                    "Please convert the integer with an explicit unit.") < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[1]));
             if (out_dtypes[0] == NULL) {

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -819,7 +819,7 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                                     PyTypeNum_ISBOOL(type_num2)) {
             if (DEPRECATE(
-                    "Addition of integers to timedelta64 arrays is deprecated, "
+                    "The 'generic' unit for NumPy timedelta is deprecated, "
                     "and will raise an error in the future. "
                     "Please convert the integer with an explicit unit.") < 0) {
                 return -1;
@@ -862,7 +862,7 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                     PyTypeNum_ISBOOL(type_num2)) {
             if (DEPRECATE(
-                    "Addition of integers to datetime64 arrays is deprecated, "
+                    "The 'generic' unit for NumPy timedelta is deprecated, "
                     "and will raise an error in the future. "
                     "Please convert the integer with an explicit unit.") < 0) {
                 return -1;
@@ -893,7 +893,7 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
         /* int + m8[<A>] => m8[<A>] + m8[<A>] */
         if (type_num2 == NPY_TIMEDELTA) {
             if (DEPRECATE(
-                    "Addition of integers to timedelta64 arrays is deprecated, "
+                    "The 'generic' unit for NumPy timedelta is deprecated, "
                     "and will raise an error in the future. "
                     "Please convert the integer with an explicit unit.") < 0) {
                 return -1;
@@ -912,7 +912,7 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
         }
         else if (type_num2 == NPY_DATETIME) {
             if (DEPRECATE(
-                    "Addition of integers to datetime64 arrays is deprecated, "
+                    "The 'generic' unit for NumPy timedelta is deprecated, "
                     "and will raise an error in the future. "
                     "Please convert the integer with an explicit unit.") < 0) {
                 return -1;
@@ -1016,7 +1016,7 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                                         PyTypeNum_ISBOOL(type_num2)) {
             if (DEPRECATE(
-                    "Subtraction of integers from timedelta64 arrays is deprecated, "
+                    "The 'generic' unit for NumPy timedelta is deprecated, "
                     "and will raise an error in the future. "
                     "Please convert the integer with an explicit unit.") < 0) {
                 return -1;
@@ -1059,7 +1059,7 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                     PyTypeNum_ISBOOL(type_num2)) {
             if (DEPRECATE(
-                    "Subtraction of integers from datetime64 arrays is deprecated, "
+                    "The 'generic' unit for NumPy timedelta is deprecated, "
                     "and will raise an error in the future. "
                     "Please convert the integer with an explicit unit.") < 0) {
                 return -1;
@@ -1106,7 +1106,7 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
         /* int - m8[<A>] => m8[<A>] - m8[<A>] */
         if (type_num2 == NPY_TIMEDELTA) {
             if (DEPRECATE(
-                    "Subtraction of integers from timedelta64 arrays is deprecated, "
+                    "The 'generic' unit for NumPy timedelta is deprecated, "
                     "and will raise an error in the future. "
                     "Please convert the integer with an explicit unit.") < 0) {
                 return -1;

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -2375,7 +2375,11 @@ class TestDateTime:
             dtype="m8",
         )
         assert_equal(a.dtype, np.dtype('m8[s]'))
-        assert_equal(a, np.timedelta64(0, 's') + np.arange(3, 10, 2))
+        with pytest.warns(
+            DeprecationWarning,
+            match=self.generic_unit_deprecation_message
+        ):
+            assert_equal(a, np.timedelta64(0, 's') + np.arange(3, 10, 2))
 
         # Step of 0 is disallowed
         assert_raises(ValueError, np.arange, np.timedelta64(0, 's'),

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -486,7 +486,7 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
     ):
         """Test that timedelta64 array + integer array triggers deprecation."""
         # timedelta op int
-        self.assert_deprecated(op, num=1, args=(timedelta_arr, int_arr))
+        self.assert_deprecated(op, num=None, args=(timedelta_arr, int_arr))
         # int op timedelta
         self.assert_deprecated(op, num=None, args=(int_arr, timedelta_arr))
 
@@ -504,7 +504,7 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
     ):
         """Test that datetime64 array + integer array triggers deprecation."""
         # datetime op int
-        self.assert_deprecated(op, num=1, args=(datetime_arr, int_arr))
+        self.assert_deprecated(op, num=None, args=(datetime_arr, int_arr))
         # int op datetime
         if op == np.add:
             self.assert_deprecated(op, num=None, args=(int_arr, datetime_arr))
@@ -516,7 +516,7 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
         c = np.array([1], dtype="m8[ms]")
 
         # Both intermediate operations should trigger warnings
-        self.assert_deprecated(np.add, num=1, args=(a, b))
+        self.assert_deprecated(np.add, num=None, args=(a, b))
         self.assert_deprecated(np.add, num=None, args=(b, c))
 
 

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -461,7 +461,7 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
     def test_raise_warning_for_operation_with_generic_unit(
         self, value: int, generic_value: int, op: Callable
     ):
-        self.assert_deprecated(op, num=None, args=(value, generic_value))
+        self.assert_deprecated(op, num=2, args=(value, generic_value))
 
     def test_raise_warning_for_default_constructor(self):
         self.assert_deprecated(lambda: np.timedelta64())
@@ -486,9 +486,9 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
     ):
         """Test that timedelta64 array + integer array triggers deprecation."""
         # timedelta op int
-        self.assert_deprecated(op, num=None, args=(timedelta_arr, int_arr))
+        self.assert_deprecated(op, num=1, args=(timedelta_arr, int_arr))
         # int op timedelta
-        self.assert_deprecated(op, num=None, args=(int_arr, timedelta_arr))
+        self.assert_deprecated(op, num=1, args=(int_arr, timedelta_arr))
 
     @pytest.mark.parametrize('datetime_arr', [
         np.array(['2020-01-01', '2020-01-02'], dtype="M8[D]"),
@@ -504,10 +504,10 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
     ):
         """Test that datetime64 array + integer array triggers deprecation."""
         # datetime op int
-        self.assert_deprecated(op, num=None, args=(datetime_arr, int_arr))
+        self.assert_deprecated(op, num=1, args=(datetime_arr, int_arr))
         # int op datetime
         if op == np.add:
-            self.assert_deprecated(op, num=None, args=(int_arr, datetime_arr))
+            self.assert_deprecated(op, num=1, args=(int_arr, datetime_arr))
 
     def test_non_associative_case_warns(self):
         """Verify the specific non-associative case from gh-31255 warns."""
@@ -516,8 +516,8 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
         c = np.array([1], dtype="m8[ms]")
 
         # Both intermediate operations should trigger warnings
-        self.assert_deprecated(np.add, num=None, args=(a, b))
-        self.assert_deprecated(np.add, num=None, args=(b, c))
+        self.assert_deprecated(np.add, num=1, args=(a, b))
+        self.assert_deprecated(np.add, num=1, args=(b, c))
 
 
 class TestTriDeprecationWithNonInteger(_DeprecationTestCase):

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -461,7 +461,7 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
     def test_raise_warning_for_operation_with_generic_unit(
         self, value: int, generic_value: int, op: Callable
     ):
-        self.assert_deprecated(op, num=2, args=(value, generic_value))
+        self.assert_deprecated(op, num=1, args=(value, generic_value))
 
     def test_raise_warning_for_default_constructor(self):
         self.assert_deprecated(lambda: np.timedelta64())
@@ -488,7 +488,7 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
         # timedelta op int
         self.assert_deprecated(op, num=1, args=(timedelta_arr, int_arr))
         # int op timedelta
-        self.assert_deprecated(op, num=1, args=(int_arr, timedelta_arr))
+        self.assert_deprecated(op, num=None, args=(int_arr, timedelta_arr))
 
     @pytest.mark.parametrize('datetime_arr', [
         np.array(['2020-01-01', '2020-01-02'], dtype="M8[D]"),
@@ -507,7 +507,7 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
         self.assert_deprecated(op, num=1, args=(datetime_arr, int_arr))
         # int op datetime
         if op == np.add:
-            self.assert_deprecated(op, num=1, args=(int_arr, datetime_arr))
+            self.assert_deprecated(op, num=None, args=(int_arr, datetime_arr))
 
     def test_non_associative_case_warns(self):
         """Verify the specific non-associative case from gh-31255 warns."""
@@ -517,7 +517,7 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
 
         # Both intermediate operations should trigger warnings
         self.assert_deprecated(np.add, num=1, args=(a, b))
-        self.assert_deprecated(np.add, num=1, args=(b, c))
+        self.assert_deprecated(np.add, num=None, args=(b, c))
 
 
 class TestTriDeprecationWithNonInteger(_DeprecationTestCase):

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -473,7 +473,7 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
 
 class TestDeprecatedIntegerTimedeltaArrayArithmetic(_DeprecationTestCase):
     # Deprecation in NumPy 2.5, 2026-04
-    message = "Addition of integers to (timedelta64|datetime64) arrays is deprecated"
+    message = "The 'generic' unit for NumPy timedelta is deprecated"
 
     @pytest.mark.parametrize('timedelta_arr', [
         np.array([1, 2, 3], dtype="m8[s]"),

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -471,6 +471,60 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.datetime64(None))
 
 
+class TestDeprecatedIntegerTimedeltaArrayArithmetic(_DeprecationTestCase):
+    # Deprecation in NumPy 2.5, 2026-04
+    message = "Addition of integers to (timedelta64|datetime64) arrays is deprecated"
+
+    @pytest.mark.parametrize('timedelta_arr', [
+        np.array([1, 2, 3], dtype="m8[s]"),
+        np.array([1], dtype="m8[ms]"),
+    ])
+    @pytest.mark.parametrize('int_arr', [
+        np.array([1, 2, 3]),
+        np.array([1]),
+    ])
+    @pytest.mark.parametrize("op", [np.add, np.subtract])
+    def test_timedelta_array_integer_array_arithmetic(
+        self, timedelta_arr, int_arr, op
+    ):
+        """Test that timedelta64 array + integer array triggers deprecation."""
+        # timedelta + int (num=None allows any number of warnings)
+        self.assert_deprecated(op, num=None, args=(timedelta_arr, int_arr))
+        # int + timedelta (for add only, subtract is different)
+        if op == np.add:
+            self.assert_deprecated(op, num=None, args=(int_arr, timedelta_arr))
+
+    @pytest.mark.parametrize('datetime_arr', [
+        np.array(['2020-01-01', '2020-01-02'], dtype="M8[D]"),
+        np.array(['2020-01-01T00:00:00'], dtype="M8[s]"),
+    ])
+    @pytest.mark.parametrize('int_arr', [
+        np.array([1, 2]),
+        np.array([1]),
+    ])
+    @pytest.mark.parametrize("op", [np.add, np.subtract])
+    def test_datetime_array_integer_array_arithmetic(
+        self, datetime_arr, int_arr, op
+    ):
+        """Test that datetime64 array + integer array triggers deprecation."""
+        # datetime + int (num=None allows any number of warnings)
+        self.assert_deprecated(op, num=None, args=(datetime_arr, int_arr))
+        # int + datetime (for add only)
+        if op == np.add:
+            self.assert_deprecated(op, num=None, args=(int_arr, datetime_arr))
+
+    def test_non_associative_case_warns(self):
+        """Verify the specific non-associative case."""
+        a = np.array([1], dtype="m8[s]")
+        b = np.array([1])
+        c = np.array([1], dtype="m8[ms]")
+
+        # Both intermediate operations should trigger warnings
+        self.assert_deprecated(np.add, num=None, args=(a, b))
+        self.assert_deprecated(np.add, num=None, args=(b, c))
+        
+
+
 class TestTriDeprecationWithNonInteger(_DeprecationTestCase):
     # Deprecation in NumPy 2.5, 2026-03
 

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -435,7 +435,8 @@ class TestRoundDeprecation(_DeprecationTestCase):
 
 class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
     # Deprecated in Numpy 2.5, 2025-11
-    # See gh-29619
+    # See gh-29619 for scalar operations
+    # See gh-31255 for array operations
     message = "The 'generic' unit for NumPy timedelta is deprecated"
 
     @pytest.mark.parametrize('value', [
@@ -460,7 +461,7 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
     def test_raise_warning_for_operation_with_generic_unit(
         self, value: int, generic_value: int, op: Callable
     ):
-        self.assert_deprecated(op, args=(value, generic_value))
+        self.assert_deprecated(op, num=None, args=(value, generic_value))
 
     def test_raise_warning_for_default_constructor(self):
         self.assert_deprecated(lambda: np.timedelta64())
@@ -470,11 +471,7 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
         self.assert_deprecated(lambda: np.datetime64('NaT'))
         self.assert_deprecated(lambda: np.datetime64(None))
 
-
-class TestDeprecatedIntegerTimedeltaArrayArithmetic(_DeprecationTestCase):
-    # Deprecation in NumPy 2.5, 2026-04
-    message = "The 'generic' unit for NumPy timedelta is deprecated"
-
+    # Array operations
     @pytest.mark.parametrize('timedelta_arr', [
         np.array([1, 2, 3], dtype="m8[s]"),
         np.array([1], dtype="m8[ms]"),
@@ -488,11 +485,10 @@ class TestDeprecatedIntegerTimedeltaArrayArithmetic(_DeprecationTestCase):
         self, timedelta_arr, int_arr, op
     ):
         """Test that timedelta64 array + integer array triggers deprecation."""
-        # timedelta + int (num=None allows any number of warnings)
+        # timedelta op int
         self.assert_deprecated(op, num=None, args=(timedelta_arr, int_arr))
-        # int + timedelta (for add only, subtract is different)
-        if op == np.add:
-            self.assert_deprecated(op, num=None, args=(int_arr, timedelta_arr))
+        # int op timedelta
+        self.assert_deprecated(op, num=None, args=(int_arr, timedelta_arr))
 
     @pytest.mark.parametrize('datetime_arr', [
         np.array(['2020-01-01', '2020-01-02'], dtype="M8[D]"),
@@ -507,14 +503,14 @@ class TestDeprecatedIntegerTimedeltaArrayArithmetic(_DeprecationTestCase):
         self, datetime_arr, int_arr, op
     ):
         """Test that datetime64 array + integer array triggers deprecation."""
-        # datetime + int (num=None allows any number of warnings)
+        # datetime op int
         self.assert_deprecated(op, num=None, args=(datetime_arr, int_arr))
-        # int + datetime (for add only)
+        # int op datetime
         if op == np.add:
             self.assert_deprecated(op, num=None, args=(int_arr, datetime_arr))
 
     def test_non_associative_case_warns(self):
-        """Verify the specific non-associative case."""
+        """Verify the specific non-associative case from gh-31255 warns."""
         a = np.array([1], dtype="m8[s]")
         b = np.array([1])
         c = np.array([1], dtype="m8[ms]")
@@ -522,7 +518,6 @@ class TestDeprecatedIntegerTimedeltaArrayArithmetic(_DeprecationTestCase):
         # Both intermediate operations should trigger warnings
         self.assert_deprecated(np.add, num=None, args=(a, b))
         self.assert_deprecated(np.add, num=None, args=(b, c))
-        
 
 
 class TestTriDeprecationWithNonInteger(_DeprecationTestCase):

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -303,8 +303,8 @@ class TestHistogram:
 
     def test_datetime(self):
         begin = np.datetime64('2000-01-01', 'D')
-        offsets = np.array([0, 0, 1, 1, 2, 3, 5, 10, 20])
-        bins = np.array([0, 2, 7, 20])
+        offsets = np.array([0, 0, 1, 1, 2, 3, 5, 10, 20], dtype='m8[D]')
+        bins = np.array([0, 2, 7, 20], dtype='m8[D]')
         dates = begin + offsets
         date_bins = begin + bins
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -3376,7 +3376,7 @@ class TestMaskedArrayMethods:
         # Allclose currently works for timedelta64 as long as `atol` is
         # an integer or also a timedelta64
         a = np.array([[1, 2, 3, 4]], dtype="m8[ns]")
-        assert allclose(a, a, atol=0)
+        assert allclose(a, a, atol=np.timedelta64(0, "ns"))
         assert allclose(a, a, atol=np.timedelta64(1, "ns"))
 
     def test_allany(self):


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
Adds deprecation warning for arithmetic between integer arrays and timedelta64 arrays.
Same issue was found in datetime64, added deprecation there too. Happy to revert if out of scope.
Fixes #31255
### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->
Hi, was going through internals of numpy and saw the issue. Wanted to contribute and I'll be happy to receive feedback.


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
Took minimal help from Claude in writing test cases.