### PR TITLE
BUG: preserve top-level subarray dtypes in dtype_to_descr

### DIFF
--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -965,12 +965,19 @@ def open_memmap(filename, mode='r+', dtype=None, shape=None,
             msg = "Array can't be memory-mapped: Python objects in dtype."
             raise ValueError(msg)
         if dtype.subdtype is not None:
-            # Top-level subarrays are written canonically as extra array
-            # dimensions plus the base dtype, which keeps the file readable by
-            # the regular .npy loader.
-            base, subshape = dtype.subdtype
-            shape = tuple(shape) + tuple(subshape)
-            dtype = base
+            # Collapse all nested top-level subarray layers so the written
+            # header never retains a top-level subarray descriptor, which
+            # keeps the file readable by the regular .npy loader.
+            if shape is None:
+                shape = ()
+            elif numpy.isscalar(shape):
+                shape = (shape,)
+            else:
+                shape = tuple(shape)
+            while dtype.subdtype is not None:
+                base, subshape = dtype.subdtype
+                shape = shape + tuple(subshape)
+                dtype = base
         d = {
             "descr": dtype_to_descr(dtype),
             "fortran_order": fortran_order,

--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -964,6 +964,13 @@ def open_memmap(filename, mode='r+', dtype=None, shape=None,
         if dtype.hasobject:
             msg = "Array can't be memory-mapped: Python objects in dtype."
             raise ValueError(msg)
+        if dtype.subdtype is not None:
+            # Top-level subarrays are written canonically as extra array
+            # dimensions plus the base dtype, which keeps the file readable by
+            # the regular .npy loader.
+            base, subshape = dtype.subdtype
+            shape = tuple(shape) + tuple(subshape)
+            dtype = base
         d = {
             "descr": dtype_to_descr(dtype),
             "fortran_order": fortran_order,

--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -280,6 +280,11 @@ def dtype_to_descr(dtype):
                       UserWarning, stacklevel=2)
     dtype = new_dtype
 
+    if dtype.subdtype is not None:
+        # Serialize subarray dtypes recursively so they can be reconstructed
+        # from the header instead of being flattened to their void storage.
+        base, shape = dtype.subdtype
+        return dtype_to_descr(base), shape
     if dtype.names is not None:
         # This is a record array. The .descr is fine.  XXX: parts of the
         # record array with an empty name, like padding bytes, still get

--- a/numpy/lib/_format_impl.pyi
+++ b/numpy/lib/_format_impl.pyi
@@ -8,7 +8,13 @@ from numpy.lib._utils_impl import drop_metadata as drop_metadata
 
 __all__: list[str] = []
 
-type _DTypeDescr = list[tuple[str, str]] | list[tuple[str, str, tuple[int, ...]]]
+type _DTypeFieldName = str | tuple[str, str]
+type _DTypeDescr = (
+    str
+    | tuple[_DTypeDescr, tuple[int, ...]]
+    | list[tuple[_DTypeFieldName, _DTypeDescr]]
+    | list[tuple[_DTypeFieldName, _DTypeDescr, tuple[int, ...]]]
+)
 
 ###
 

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -705,30 +705,12 @@ def test_pickle_disallow(tmpdir):
         )))
         ]),
     ])
-def test_descr_to_dtype(dt):
+def test_descr_dtype_roundtrip(dt):
     dt1 = format.descr_to_dtype(format.dtype_to_descr(dt))
     assert_equal_(dt1, dt)
     arr1 = np.zeros(3, dt)
     arr2 = roundtrip(arr1)
     assert_array_equal(arr1, arr2)
-
-
-def test_open_memmap_subarray_dtype(tmpdir):
-    path = os.path.join(tmpdir, "subarray.npy")
-    dtype = np.dtype((np.dtype([('a', 'i1'), ('b', 'i1')]), (3,)))
-
-    memmap = format.open_memmap(path, mode='w+', dtype=dtype, shape=(2,))
-    memmap.flush()
-
-    with open(path, "rb") as f:
-        version = format.read_magic(f)
-        _, _, header_dtype = format._read_array_header(f, version)
-
-    loaded = format.open_memmap(path, mode='r')
-
-    assert_equal_(header_dtype, dtype)
-    assert_equal_(loaded.dtype, dtype.base)
-    assert_equal_(loaded.shape, (2, 3))
 
 
 def test_version_2_0():

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -527,10 +527,26 @@ def test_memmap_roundtrip(tmpdir):
         # Plain top-level subarray dtypes expand into the memmap shape on read.
         (1, np.dtype((np.int64, (8,))), (2,), False, np.dtype(np.int64),
          (2, 8), True, False),
-        (2, np.dtype((np.int64, (2, 3))), (4,), True, np.dtype(np.int64),
+        # A missing outer shape is treated as a scalar array whose shape comes
+        # entirely from the top-level subarray dtype.
+        (2, np.dtype((np.int64, (2,))), None, False, np.dtype(np.int64),
+         (2,), True, True),
+        # Scalar outer shapes should normalize the same way as one-element
+        # shape tuples when top-level subarray axes are appended.
+        (3, np.dtype((np.int64, (2,))), 3, False, np.dtype(np.int64),
+         (3, 2), True, False),
+        (4, np.dtype((np.int64, (2, 3))), (4,), True, np.dtype(np.int64),
          (4, 2, 3), False, True),
+        # Nested top-level subarray layers must all be flattened into the
+        # header shape written by open_memmap.
+        (5, np.dtype((np.dtype((np.int64, (2,))), (3,))), None, False,
+         np.dtype(np.int64), (3, 2), True, False),
+        (6, np.dtype((np.dtype((np.int64, (2,))), (3,))), (5,), False,
+         np.dtype(np.int64), (5, 3, 2), True, False),
+        (7, np.dtype((np.dtype((np.int64, (2,))), (3,))), (5,), True,
+         np.dtype(np.int64), (5, 3, 2), False, True),
         (
-            3,
+            8,
             np.dtype([('a', '<i4'), ('b', '<f8')]),
             (4,),
             False,
@@ -542,12 +558,22 @@ def test_memmap_roundtrip(tmpdir):
         # Structured base dtypes should behave the same when wrapped in a
         # top-level subarray.
         (
-            4,
+            9,
             np.dtype(([('a', '<i4'), ('b', '<f8')], (3,))),
             (2,),
             False,
             np.dtype([('a', '<i4'), ('b', '<f8')]),
             (2, 3),
+            True,
+            False,
+        ),
+        (
+            10,
+            np.dtype((np.dtype(([('a', '<i4'), ('b', '<f8')], (3,))), (2,))),
+            (4,),
+            False,
+            np.dtype([('a', '<i4'), ('b', '<f8')]),
+            (4, 2, 3),
             True,
             False,
         ),
@@ -558,7 +584,7 @@ def test_memmap_user_dtype_roundtrip(
     expected_c_contiguous, expected_f_contiguous
 ):
     path = os.path.join(tmpdir, f"user_dtype{i}.npy")
-    # Writing through the explicit `dtype= path is the case that needs the
+    # Writing through the explicit `dtype=` path is the case that needs the
     # top-level subarray normalization in open_memmap.
     memmap = format.open_memmap(
         path, mode='w+', dtype=dtype, shape=shape, fortran_order=fortran_order)
@@ -678,6 +704,8 @@ def test_pickle_disallow(tmpdir):
 
 @pytest.mark.parametrize('dt', [
     np.dtype(('<i8', (8,))),
+    np.dtype((np.dtype((np.int64, (2,))), (3,))),
+    np.dtype((np.dtype((np.dtype((np.int64, (2,))), (3,))), (4,))),
     np.dtype([('a', np.int8),
               ('b', np.int16),
               ('c', np.int32),
@@ -726,8 +754,6 @@ def test_pickle_disallow(tmpdir):
         ]),
     ])
 def test_descr_dtype_roundtrip(dt):
-    # Top-level subarray dtypes cannot be validated through arr.dtype after
-    # array creation, so check the descriptor helper roundtrip directly first.
     dt1 = format.descr_to_dtype(format.dtype_to_descr(dt))
     assert_equal_(dt1, dt)
     arr1 = np.zeros(3, dt)

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -518,6 +518,44 @@ def test_memmap_roundtrip(tmpdir):
         ma.flush()
 
 
+@pytest.mark.skipif(IS_WASM, reason="memmap doesn't work correctly")
+@pytest.mark.parametrize(
+    "i, dtype, shape, expected_dtype, expected_shape",
+    [
+        (0, np.dtype('<i4'), (3,), np.dtype('<i4'), (3,)),
+        # Plain top-level subarray dtypes expand into the memmap shape on read.
+        (1, np.dtype((np.int64, (8,))), (2,), np.dtype(np.int64), (2, 8)),
+        (
+            2,
+            np.dtype([('a', '<i4'), ('b', '<f8')]),
+            (4,),
+            np.dtype([('a', '<i4'), ('b', '<f8')]),
+            (4, ),
+        ),
+        # Structured base dtypes should behave the same when wrapped in a
+        # top-level subarray.
+        (
+            3,
+            np.dtype(([('a', '<i4'), ('b', '<f8')], (3,))),
+            (2,),
+            np.dtype([('a', '<i4'), ('b', '<f8')]),
+            (2, 3),
+        ),
+    ],
+)
+def test_memmap_user_dtype_roundtrip(
+    tmpdir, i, dtype, shape, expected_dtype, expected_shape
+):
+    path = os.path.join(tmpdir, f"user_dtype{i}.npy")
+    memmap = format.open_memmap(path, mode='w+', dtype=dtype, shape=shape)
+    memmap.flush()
+
+    loaded = format.open_memmap(path, mode='r')
+
+    assert_equal_(loaded.dtype, expected_dtype)
+    assert_equal_(loaded.shape, expected_shape)
+
+
 def test_compressed_roundtrip(tmpdir):
     arr = np.random.rand(200, 200)
     npz_file = os.path.join(tmpdir, 'compressed.npz')
@@ -620,14 +658,11 @@ def test_pickle_disallow(tmpdir):
 
 @pytest.mark.parametrize('dt', [
     np.dtype(('<i8', (8,))),
-    np.dtype('(2,3)<f8'),
-    np.dtype((np.dtype([('a', 'i1'), ('b', 'i1')]), (3,))),
-    # Plain subarray dtypes are checked via descriptor/header roundtrips below,
-    # since creating an array with such a dtype expands the subarray into shape.
     np.dtype([('a', np.int8),
               ('b', np.int16),
               ('c', np.int32),
              ], align=True),
+    np.dtype((np.dtype([('a', '<i4'), ('b', '<f8')]), (3,))),
     np.dtype([('x', np.dtype(({'names': ['a', 'b'],
                               'formats': ['i1', 'i1'],
                               'offsets': [0, 4],
@@ -673,10 +708,9 @@ def test_pickle_disallow(tmpdir):
 def test_descr_to_dtype(dt):
     dt1 = format.descr_to_dtype(format.dtype_to_descr(dt))
     assert_equal_(dt1, dt)
-    if dt.subdtype is None:
-        arr1 = np.zeros(3, dt)
-        arr2 = roundtrip(arr1)
-        assert_array_equal(arr1, arr2)
+    arr1 = np.zeros(3, dt)
+    arr2 = roundtrip(arr1)
+    assert_array_equal(arr1, arr2)
 
 
 def test_open_memmap_subarray_dtype(tmpdir):

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -619,8 +619,11 @@ def test_pickle_disallow(tmpdir):
                   allow_pickle=False)
 
 @pytest.mark.parametrize('dt', [
-    # Not testing a subarray only dtype, because it cannot be attached to an array
-    # (and would fail the test as of writing this.)
+    np.dtype(('<i8', (8,))),
+    np.dtype('(2,3)<f8'),
+    np.dtype((np.dtype([('a', 'i1'), ('b', 'i1')]), (3,))),
+    # Plain subarray dtypes are checked via descriptor/header roundtrips below,
+    # since creating an array with such a dtype expands the subarray into shape.
     np.dtype([('a', np.int8),
               ('b', np.int16),
               ('c', np.int32),
@@ -668,11 +671,31 @@ def test_pickle_disallow(tmpdir):
         ]),
     ])
 def test_descr_to_dtype(dt):
-    dt1 = format.descr_to_dtype(dt.descr)
+    dt1 = format.descr_to_dtype(format.dtype_to_descr(dt))
     assert_equal_(dt1, dt)
-    arr1 = np.zeros(3, dt)
-    arr2 = roundtrip(arr1)
-    assert_array_equal(arr1, arr2)
+    if dt.subdtype is None:
+        arr1 = np.zeros(3, dt)
+        arr2 = roundtrip(arr1)
+        assert_array_equal(arr1, arr2)
+
+
+def test_open_memmap_subarray_dtype(tmpdir):
+    path = os.path.join(tmpdir, "subarray.npy")
+    dtype = np.dtype((np.dtype([('a', 'i1'), ('b', 'i1')]), (3,)))
+
+    memmap = format.open_memmap(path, mode='w+', dtype=dtype, shape=(2,))
+    memmap.flush()
+
+    with open(path, "rb") as f:
+        version = format.read_magic(f)
+        _, _, header_dtype = format._read_array_header(f, version)
+
+    loaded = format.open_memmap(path, mode='r')
+
+    assert_equal_(header_dtype, dtype)
+    assert_equal_(loaded.dtype, dtype.base)
+    assert_equal_(loaded.shape, (2, 3))
+
 
 def test_version_2_0():
     f = BytesIO()

--- a/numpy/lib/tests/test_format.py
+++ b/numpy/lib/tests/test_format.py
@@ -520,40 +520,60 @@ def test_memmap_roundtrip(tmpdir):
 
 @pytest.mark.skipif(IS_WASM, reason="memmap doesn't work correctly")
 @pytest.mark.parametrize(
-    "i, dtype, shape, expected_dtype, expected_shape",
+    "i, dtype, shape, fortran_order, expected_dtype, expected_shape, "
+    "expected_c_contiguous, expected_f_contiguous",
     [
-        (0, np.dtype('<i4'), (3,), np.dtype('<i4'), (3,)),
+        (0, np.dtype('<i4'), (3,), False, np.dtype('<i4'), (3,), True, True),
         # Plain top-level subarray dtypes expand into the memmap shape on read.
-        (1, np.dtype((np.int64, (8,))), (2,), np.dtype(np.int64), (2, 8)),
+        (1, np.dtype((np.int64, (8,))), (2,), False, np.dtype(np.int64),
+         (2, 8), True, False),
+        (2, np.dtype((np.int64, (2, 3))), (4,), True, np.dtype(np.int64),
+         (4, 2, 3), False, True),
         (
-            2,
+            3,
             np.dtype([('a', '<i4'), ('b', '<f8')]),
             (4,),
+            False,
             np.dtype([('a', '<i4'), ('b', '<f8')]),
-            (4, ),
+            (4,),
+            True,
+            True,
         ),
         # Structured base dtypes should behave the same when wrapped in a
         # top-level subarray.
         (
-            3,
+            4,
             np.dtype(([('a', '<i4'), ('b', '<f8')], (3,))),
             (2,),
+            False,
             np.dtype([('a', '<i4'), ('b', '<f8')]),
             (2, 3),
+            True,
+            False,
         ),
     ],
 )
 def test_memmap_user_dtype_roundtrip(
-    tmpdir, i, dtype, shape, expected_dtype, expected_shape
+    tmpdir, i, dtype, shape, fortran_order, expected_dtype, expected_shape,
+    expected_c_contiguous, expected_f_contiguous
 ):
     path = os.path.join(tmpdir, f"user_dtype{i}.npy")
-    memmap = format.open_memmap(path, mode='w+', dtype=dtype, shape=shape)
+    # Writing through the explicit `dtype= path is the case that needs the
+    # top-level subarray normalization in open_memmap.
+    memmap = format.open_memmap(
+        path, mode='w+', dtype=dtype, shape=shape, fortran_order=fortran_order)
     memmap.flush()
 
     loaded = format.open_memmap(path, mode='r')
 
     assert_equal_(loaded.dtype, expected_dtype)
     assert_equal_(loaded.shape, expected_shape)
+    assert_equal_(loaded.flags.c_contiguous, expected_c_contiguous)
+    assert_equal_(loaded.flags.f_contiguous, expected_f_contiguous)
+
+    # np.load exercises the regular .npy reader instead of the memmap path.
+    arr = np.load(path)
+    assert_array_equal(arr, loaded)
 
 
 def test_compressed_roundtrip(tmpdir):
@@ -706,12 +726,13 @@ def test_pickle_disallow(tmpdir):
         ]),
     ])
 def test_descr_dtype_roundtrip(dt):
+    # Top-level subarray dtypes cannot be validated through arr.dtype after
+    # array creation, so check the descriptor helper roundtrip directly first.
     dt1 = format.descr_to_dtype(format.dtype_to_descr(dt))
     assert_equal_(dt1, dt)
     arr1 = np.zeros(3, dt)
     arr2 = roundtrip(arr1)
     assert_array_equal(arr1, arr2)
-
 
 def test_version_2_0():
     f = BytesIO()


### PR DESCRIPTION

  This PR addresses #31280.

  It makes two related changes in numpy.lib.format:

  - `dtype_to_descr` now preserves top-level subarray dtypes, so `dtype_to_descr` and `descr_to_dtype` round-trip those dtypes correctly.
  - `open_memmap(..., mode='w+')` now normalizes top-level subarray dtypes when writing .npy headers by recursively folding subarray dimensions into the array shape and writing the base dtype in descr.

  The tests were extended to cover:

  - top-level and nested top-level subarray dtype roundtrips through `dtype_to_descr` / `descr_to_dtype`
  - `open_memmap` roundtrips for user-specified subarray dtypes

  ### First time committer introduction

  I am a C++ and Python developer, and we use NumPy heavily for data processing and for data exchange between C++ and Python (using pybind11). This issue came up while we were looking for a reliable way to serialize and deserialize NumPy dtypes.

  #### AI Disclosure

  I used Codex CLI during the preparation of this PR. It helped inspect the relevant NumPy code, suggest code changes and tests, and help me reason through edge cases. I reviewed the code myself, made additional changes manually, and I am submitting this PR myself.