### PR TITLE
DEP: Correct dtype in `__array_finalize__` if _set_dtype=None

### DIFF
--- a/doc/release/upcoming_changes/31293.deprecation.rst
+++ b/doc/release/upcoming_changes/31293.deprecation.rst
@@ -7,11 +7,12 @@ that do not see this ``DeprecationWarning`` may wish to update their code.
 
 A subclass that does any ``dtype`` specific logic (i.e. verifying the dtype
 in ``__array_finalize__`` or has a ``dtype`` property) should now:
+
 * Set ``_set_dtype = None`` in which case ``arr.view(dtype=new_dtype)``
   will call ``__array_finalize__`` with the new dtype, ensuring that
   any validation ``__array_finalize__`` will run is done.
-* Define ``_set_dtype`` as a function (calling ``ndarray._set_dtype()``
-  to avoid ``DeprecationWarnings`` as a quick fix.
+* Or, for a quick fix, define ``_set_dtype`` as a function (calling
+  ``ndarray._set_dtype()`` to avoid ``DeprecationWarnings``.
   (Future versions might migrate towards the ``_set_dtype = None`` path.)
 
 Ideally, follow NumPy's deprecation to prevent ``dtype`` mutation by users.

--- a/doc/release/upcoming_changes/31293.deprecation.rst
+++ b/doc/release/upcoming_changes/31293.deprecation.rst
@@ -1,0 +1,19 @@
+Custom ``dtype`` property and ``__array_finalize__``
+----------------------------------------------------
+Previously ``arr.view(dtype=new_dtype)`` called ``arr.dtype = new_dtype``
+also for subclasses (i.e. the attribute setting).
+This path is now deprecated and refined, meaning that even subclasses
+that do not see this ``DeprecationWarning`` may wish to update their code.
+
+A subclass that does any ``dtype`` specific logic (i.e. verifying the dtype
+in ``__array_finalize__`` or has a ``dtype`` property) should now:
+* Set ``_set_dtype = None`` in which case ``arr.view(dtype=new_dtype)``
+  will call ``__array_finalize__`` with the new dtype, ensuring that
+  any validation ``__array_finalize__`` will run is done.
+* Define ``_set_dtype`` as a function (calling ``ndarray._set_dtype()``
+  to avoid ``DeprecationWarnings`` as a quick fix.
+  (Future versions might migrate towards the ``_set_dtype = None`` path.)
+
+Ideally, follow NumPy's deprecation to prevent ``dtype`` mutation by users.
+The use of ``ndarray._set_dtype()`` may be necessary for some subclass
+finalization patterns, but should otherwise be avoided.

--- a/numpy/_core/records.py
+++ b/numpy/_core/records.py
@@ -402,11 +402,13 @@ class recarray(ndarray):
             )
         return self
 
+    _set_dtype = None  # __array_finalize__ can deal with dtype changes
+
     def __array_finalize__(self, obj):
-        if self.dtype.type is not record and self.dtype.names is not None:
+        if issubclass(self.dtype.type, nt.void) and self.dtype.names is not None:
             # if self.dtype is not np.record, invoke __setattr__ which will
             # convert it to a record if it is a void dtype.
-            self.dtype = self.dtype
+            ndarray._set_dtype(self, sb.dtype((record, self.dtype)))
 
     def __getattribute__(self, attr):
         # See if ndarray has this attr, and return it if so. (note that this
@@ -455,11 +457,7 @@ class recarray(ndarray):
 
         newattr = attr not in self.__dict__
         try:
-            if attr == 'dtype':
-                # gh-29244
-                ret = self._set_dtype(val)
-            else:
-                ret = object.__setattr__(self, attr, val)
+            ret = object.__setattr__(self, attr, val)
         except Exception:
             fielddict = ndarray.__getattribute__(self, 'dtype').fields or {}
             if attr not in fielddict:

--- a/numpy/_core/records.py
+++ b/numpy/_core/records.py
@@ -405,7 +405,9 @@ class recarray(ndarray):
     _set_dtype = None  # __array_finalize__ can deal with dtype changes
 
     def __array_finalize__(self, obj):
-        if issubclass(self.dtype.type, nt.void) and self.dtype.names is not None:
+        if (self.dtype.type is not record and
+                issubclass(self.dtype.type, nt.void) and
+                self.dtype.names is not None):
             # if self.dtype is not np.record, invoke __setattr__ which will
             # convert it to a record if it is a void dtype.
             ndarray._set_dtype(self, sb.dtype((record, self.dtype)))

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -561,17 +561,22 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
     }
 
     /*
-     * Changing dtype on a subclass.  We support three paths:
+     * Changing dtype on a subclass.  We support 4 paths:
      *
      * 1. subclass overrides _set_dtype: create subclass view first,
      *    then call _set_dtype (subclass handles dtype change).
+     *    If _set_dtype is set to None, we use path 3 below.
      * 2. subclass overrides the dtype descriptor (e.g. property with
      *    setter): create subclass view first, use the setter, but
      *    emit a deprecation asking to implement _set_dtype instead.
-     * 3. Otherwise (including plain ndarray): create an ndarray base
+     * 3. If _set_dtype is None (or base-class): create an ndarray base
      *    view, set dtype internally, then create the subclass view
      *    if needed.  __array_finalize__ sees the final dtype+shape.
+     * 4. Otherwise, call `__array_finalize__` with old dtype and forcibly
+     *    update the dtype (the subclass will be unaware of the change) which
+     *    is the unfortunate historic behavior.
      */
+    int use_dtype_in_finalize = 0;
     int use_set_dtype = 0;
     int use_dtype_prop = 0;
 
@@ -582,11 +587,16 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
                 npy_interned_str._set_dtype, &sub_set_dtype) < 0) {
             goto finish;
         }
-        use_set_dtype = (sub_set_dtype != NULL &&
-                sub_set_dtype != npy_static_pydata.ndarray_set_dtype);
+        if (sub_set_dtype == Py_None) {
+            use_dtype_in_finalize = 1;
+        }
+        else {
+            use_set_dtype = (sub_set_dtype != NULL &&
+                    sub_set_dtype != npy_static_pydata.ndarray_set_dtype);
+        }
         Py_XDECREF(sub_set_dtype);
 
-        if (!use_set_dtype) {
+        if (!use_set_dtype && !use_dtype_in_finalize) {
             PyObject *sub_dtype_descr;
             if (PyObject_GetOptionalAttr(
                     (PyObject *)subtype,
@@ -644,10 +654,10 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
         goto finish;
     }
 
-    /* Path 3: create ndarray base view and set dtype internally */
+    /* Path 3+4: create view and set dtype internally */
     Py_INCREF(dtype);
     ret = (PyArrayObject *)PyArray_NewFromDescr_int(
-            &PyArray_Type, dtype,
+            use_dtype_in_finalize ? &PyArray_Type : subtype, dtype,
             PyArray_NDIM(self), PyArray_DIMS(self),
             PyArray_STRIDES(self), PyArray_DATA(self),
             flags, (PyObject *)self, (PyObject *)self,
@@ -660,7 +670,12 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
         goto finish;
     }
 
-    if (subtype != &PyArray_Type) {
+    /*
+     * Path 3: `_set_dtype is None` and `ret` is a base-class array
+     * with correct dtype+shape, this will call `__array_finalize__`
+     * with the final dtype+shape.
+     */
+    if (use_dtype_in_finalize && subtype != &PyArray_Type) {
         Py_INCREF(PyArray_DESCR(ret));
         Py_SETREF(ret, (PyArrayObject *)PyArray_NewFromDescr_int(
                 subtype, PyArray_DESCR(ret),

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -569,12 +569,14 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
      * 2. subclass overrides the dtype descriptor (e.g. property with
      *    setter): create subclass view first, use the setter, but
      *    emit a deprecation asking to implement _set_dtype instead.
-     * 3. If _set_dtype is None (or base-class): create an ndarray base
-     *    view, set dtype internally, then create the subclass view
-     *    if needed.  __array_finalize__ sees the final dtype+shape.
-     * 4. Otherwise, call `__array_finalize__` with old dtype and forcibly
-     *    update the dtype (the subclass will be unaware of the change) which
-     *    is the unfortunate historic behavior.
+     * 3. If _set_dtype is None: create an ndarray base view, set dtype
+     *    internally, then create the subclass view if needed:
+     *    __array_finalize__ sees the final dtype+shape.
+     * 4. If _set_dtype (and dtype) are not set, call `__array_finalize__`
+     *    with the old dtype and forcibly update the dtype (a subclass will be
+     *    unaware of the change) which is the unfortunate historic behavior.
+     *
+     * (Base class ndarray has no __array_finalize__ so effectively uses path 4.)
      */
     int use_dtype_in_finalize = 0;
     int use_set_dtype = 0;
@@ -675,7 +677,7 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
      * with correct dtype+shape, this will call `__array_finalize__`
      * with the final dtype+shape.
      */
-    if (use_dtype_in_finalize && subtype != &PyArray_Type) {
+    if (use_dtype_in_finalize) {
         Py_INCREF(PyArray_DESCR(ret));
         Py_SETREF(ret, (PyArrayObject *)PyArray_NewFromDescr_int(
                 subtype, PyArray_DESCR(ret),

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -255,6 +255,10 @@ class TestDeprecatedArrayAttributeSetting(_DeprecationTestCase):
         x = np.eye(2)
         self.assert_deprecated(setattr, args=(x, "dtype", int))
 
+    def test_deprecated_dtype_set_record(self):
+        x = np.zeros(2, dtype="i4,i4").view(np.recarray)
+        self.assert_deprecated(setattr, args=(x, "dtype", np.dtype("f4,f4")))
+
     def test_deprecated_shape_set(self):
         x = np.eye(2)
         self.assert_deprecated(setattr, args=(x, "shape", (4, 1)))

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6610,6 +6610,8 @@ class TestView:
         # __array_finalize__ and return the correct subclass type.
 
         class MyArray(np.ndarray):
+            _set_dtype = None
+
             def __array_finalize__(self, obj):
                 self.finalized_from = obj
                 self._dtype_at_finalize = self.dtype

--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -497,7 +497,8 @@ class TestRecord:
         assert dt.type != np.record
 
         # ensure that the dtype remains a record even when assigned
-        data.dtype = dt
+        with pytest.warns(DeprecationWarning, match="Setting the dtype"):
+            data.dtype = dt
         assert data.dtype.type == np.record
 
     @pytest.mark.parametrize('nfields', [0, 1, 2])


### PR DESCRIPTION
This avoids using the correct dtype in __array_finalize__ *unless* `_set_dtype = None` is set on the class.
We also use this new path to make record arrays follow the main class deprecation correctly.

This means that `recarray` does live in the future.

CC @mhvk, hopefully the last iteration (unless the larger `view` change works out)...

(no AI tool use)

Closes gh-31281