### PR TITLE
MAINT: fix implicit conversion warnings

### DIFF
--- a/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
@@ -981,6 +981,7 @@ static GCC_CAST_OPT_LEVEL int
 #   pragma GCC diagnostic push
 #   ifdef __clang__
 #   pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#   pragma GCC diagnostic ignored "-Wimplicit-const-int-float-conversion"
 #   endif
 #   pragma GCC diagnostic ignored "-Wtautological-compare"
 #   endif


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
Fixes #31540


I get a lot of warnings from clang 22 and this PR fixes it:
```console
../numpy/_core/src/multiarray/lowlevel_strided_loops.c.src:988:32: warning: implicit conversion from 'long long' to 'npy_longdouble' (aka 'double') changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-const-int-float-conversion]
  988 |    if (_TO_RTYPE1(src_value) > LLONG_MAX) {
      |                              ~ ^~~~~~~~~
/opt/homebrew/Cellar/llvm/22.1.3/lib/clang/22/include/limits.h:109:20: note: expanded from macro 'LLONG_MAX'
  109 | #define LLONG_MAX  __LONG_LONG_MAX__
      |                    ^~~~~~~~~~~~~~~~~
<built-in>:65:27: note: expanded from macro '__LONG_LONG_MAX__'
   65 | #define __LONG_LONG_MAX__ 9223372036854775807LL
```

No AI used.
