### PR TITLE
BUG: prevent crash when setting array flags with non-ASCII strings

### DIFF
--- a/numpy/_core/src/multiarray/flagsobject.c
+++ b/numpy/_core/src/multiarray/flagsobject.c
@@ -586,6 +586,9 @@ arrayflags_setitem(PyArrayFlagsObject *self, PyObject *ind, PyObject *item)
     if (PyUnicode_Check(ind)) {
         PyObject *tmp_str;
         tmp_str = PyUnicode_AsASCIIString(ind);
+        if (tmp_str == NULL){
+            goto fail;
+        }
         key = PyBytes_AS_STRING(tmp_str);
         n = PyBytes_GET_SIZE(tmp_str);
         if (n > 16) n = 16;


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->Fix a crash when using non-ASCII keys in:
```py
arr.flags.__setitem__
```

As reported in:
https://gist.github.com/devdanzin/ccc2d9553ca1c90ab1835362ee21a40a#reproducer-2-arrflags-segfault-on-non-ascii-key  
(discussed in #31046)

Using non-ASCII characters as keys could lead to a segmentation fault due to
unsafe handling of Unicode input in the C implementation.

#### Reproducer

```python
import numpy as np

arr = np.array([1, 2, 3])
arr.flags["é"] = True
```
#### Previous behavior
```raw
Segmentation fault    (core dumped)
```

#### New behavior
```raw
KeyError: 'Unknown flag'
```

####

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->AI was used to help me understand the English better and to assist in writing this message. All code and debugging were done by me.