### PR TITLE
MAINT: Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 7
+      default-days: 7     # optional
     commit-message:
       prefix: "MAINT"
     labels:
@@ -17,7 +17,12 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 7
+      default-days: 7     # optional
+    groups:
+      python-deps:
+        patterns:
+          - "*"           # catches EVERY dependency in ALL requirements files
+        applies-to: "version-updates"
     commit-message:
       prefix: "MAINT"
     labels:


### PR DESCRIPTION
Dependabot is not updating pytest even though pytest 9.0.3 was released April 7. Grok suggests this is a known dependabot problem with multiple files pinning the same dependency and suggests using groups to help it along. The same problem doesn't appear for actions, just the pip ecosystem.

[skip azp] [skip actions] [skip cirrus]

#### AI Disclosure

Grok read the numpy requirements files and suggested the fix.  This is a direct copy.

