### PR TITLE
Pass sorted=False in unique_all, unique_counts, and unique_inverse

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -493,6 +493,7 @@ def unique_all(x):
         return_inverse=True,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueAllResult(*result)
 
@@ -549,6 +550,7 @@ def unique_counts(x):
         return_inverse=False,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueCountsResult(*result)
 
@@ -606,6 +608,7 @@ def unique_inverse(x):
         return_inverse=True,
         return_counts=False,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueInverseResult(*result)
 


### PR DESCRIPTION
## Summary

The Array API helpers `unique_all`, `unique_counts`, and `unique_inverse` document themselves as equivalent to `np.unique(..., sorted=False)` but were omitting the `sorted=False` flag in the underlying `unique()` call. This matches the behavior of `unique_values` which was already fixed in NumPy 2.3.

## Changes

- Add `sorted=False` to the `unique()` call in `unique_all`
- Add `sorted=False` to the `unique()` call in `unique_counts`
- Add `sorted=False` to the `unique()` call in `unique_inverse`

Fixes #31241