### PR TITLE
ENH: Create a path for legacy dtypes to transition to new DType API

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -360,9 +360,10 @@ jobs:
         python-version: '3.12'
     - name: Install build and test dependencies from PyPI
       run: |
+        python -m pip install --upgrade pip
         python -m pip install -r requirements/build_requirements.txt
         python -m pip install -r requirements/test_requirements.txt
-        python -m pip install scikit-build-core cmake
+        python -m pip install --upgrade scikit-build-core cmake wheel
     - name: Build and install NumPy
       run: |
         python -m pip install . -v -Csetup-args=-Dallow-noblas=true -Csetup-args=-Dcpu-baseline=none -Csetup-args=-Dcpu-dispatch=none

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -350,7 +350,7 @@ jobs:
       with:
         repository: jax-ml/ml_dtypes
         # Current ml_dtypes main, should be updated occasionally:
-        ref: '9fd1a480f1cdb23b3d28dfea5eadf3d84b6dfc62'  # v0.5.4
+        ref: '9b8b2471a5ec5fd4c223693f677fcc2416847970'  # main as of 2026-05-11
         submodules: 'true'
         path: 'ml_dtypes'
         persist-credentials: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -374,6 +374,7 @@ jobs:
     - name: Run ml_dtypes tests with current NumPy
       run: |
         python -m pip show numpy
+        cd ml_dtypes
         python -m pytest -n 2 ml_dtypes/tests
     - name: Replace NumPy with 2.0.x
       run: |
@@ -381,6 +382,7 @@ jobs:
         python -m pip show numpy
     - name: Run ml_dtypes tests with NumPy 2.0.x
       run: |
+        cd ml_dtypes
         python -m pytest -n 2 ml_dtypes/tests
 
   custom_checks:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -332,6 +332,56 @@ jobs:
         cd ${GITHUB_WORKSPACE}/array-api-tests
         pytest array_api_tests -v -c pytest.ini -n 4 --max-examples=1000 --derandomize --disable-deadline --xfails-file ${GITHUB_WORKSPACE}/tools/ci/array-api-xfails.txt
 
+  ml_dtypes_compat:
+    # Check a downstream dtype-extension project on both the current branch
+    # and also NumPy 2.0.x runtime (but still built with current).
+    needs: [smoke_test]
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push'
+    steps:
+    - name: Checkout NumPy
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        submodules: recursive
+        fetch-tags: true
+        persist-credentials: false
+    - name: Checkout ml_dtypes
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: jax-ml/ml_dtypes
+        # Current ml_dtypes main, should be updated occasionally:
+        ref: '9fd1a480f1cdb23b3d28dfea5eadf3d84b6dfc62'  # v0.5.4
+        submodules: 'true'
+        path: 'ml_dtypes'
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.12'
+    - name: Install build and test dependencies from PyPI
+      run: |
+        python -m pip install -r requirements/build_requirements.txt
+        python -m pip install -r requirements/test_requirements.txt
+        python -m pip install scikit-build-core cmake
+    - name: Build and install NumPy
+      run: |
+        python -m pip install . -v -Csetup-args=-Dallow-noblas=true -Csetup-args=-Dcpu-baseline=none -Csetup-args=-Dcpu-dispatch=none
+    - name: Build and install ml_dtypes
+      run: |
+        cd ml_dtypes
+        python -m pip install -e ".[dev]" --no-build-isolation
+    - name: Run ml_dtypes tests with current NumPy
+      run: |
+        python -m pip show numpy
+        python -m pytest -n 2 ml_dtypes/tests
+    - name: Replace NumPy with 2.0.x
+      run: |
+        python -m pip install --force-reinstall "numpy==2.0.*"
+        python -m pip show numpy
+    - name: Run ml_dtypes tests with NumPy 2.0.x
+      run: |
+        python -m pytest -n 2 ml_dtypes/tests
+
   custom_checks:
     needs: [smoke_test]
     runs-on: ubuntu-latest
@@ -377,7 +427,6 @@ jobs:
         rm -rf build-install
         ./vendored-meson/meson/meson.py install -C build --destdir ../build-install --tags=runtime,python-runtime,devel
         python tools/check_installed_files.py $(find ./build-install -path '*/site-packages/numpy') --no-tests
-
 
   Linux_Python_312_32bit_full:
     name: i686, cp312, full

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1243,6 +1243,19 @@ User-defined data types
         The struct is not a valid Python object, so do not use ``Py_DECREF``
         on it.
 
+        **Transitioning to the new DType AP**
+
+        Users currently using the old DType API may not be able to easily
+        transition due to NumPy issues that would cause regressions.
+        While new DTypes may reasonably limit themselves to newer NumPy
+        versions, existing DTypes cannot do so.
+
+        You can transition to the new DType API by using
+        the `NPY_DT_legacy_descriptor_proto` slot when registering.
+        This slot is available when compiling with NumPy 2.5 and provides
+        support for NumPy 2.0 and higher (it can also be vendored to compile
+        on older versions of NumPy).
+
     Register a data-type as a new user-defined data type for
     arrays. The type must have most of its entries filled in. This is
     not always checked and errors can produce segfaults. In
@@ -1277,6 +1290,10 @@ User-defined data types
     *totype*. Any old casting function is over-written. A ``0`` is
     returned on success or a ``-1`` on failure.
 
+    .. note::
+        This function will eventually be deprecated. Please migrate to the new
+        DType API for casts.  See `NPY_DT_legacy_descriptor_proto` for details.
+
     .. c:type:: PyArray_VectorUnaryFunc
 
         The function pointer type for low-level casting functions.
@@ -1289,6 +1306,12 @@ User-defined data types
     *scalar* = :c:data:`NPY_NOSCALAR` to register that an array of data-type
     *descr* can be cast safely to a data-type whose type_number is
     *totype*. The return value is 0 on success or -1 on failure.
+
+    .. note::
+        This function will eventually be deprecated. Please migrate to the new
+        DType API for casts.  See `NPY_DT_legacy_descriptor_proto` for details.
+        The new DType API provides more flexibility and speed even for dtypes
+        compatible with the legacy API.
 
 
 Special functions for NPY_OBJECT
@@ -3571,6 +3594,33 @@ Slot IDs and API Function Typedefs
 These IDs correspond to slots in the DType API and are used to identify
 implementations of each slot from the items of the ``slots`` array
 member of ``PyArrayDTypeMeta_Spec`` struct.
+
+.. c:macro:: NPY_DT_legacy_descriptor_proto
+
+   Compatibility slot to transition legacy dtypes to the new DType API.
+   Existing legacy dtypes that currently use ``PyArray_RegisterDataType``
+   should use this to transition to the new DType API.
+   The value of this slot is the ``PyArray_DescrProto`` struct.
+
+   This slot allows an *existing* legacy DType to use the new DType API
+   without breaking backwards compatibility (or with very minor changes).
+   I.e. NumPy will still consider this a "legacy" DType and use old code paths
+   where applicable, but use new features as they become available.
+
+   If used, this slot is required to be the first slot.
+
+    .. versionadded:: 2.5 (available starting NumPy 2.0)
+      This feature is added in NumPy 2.5, but is backported to be compatible
+      with NumPy 2.0+.  You can vendor this backport from ``npy_2_compat.h``
+      if you wish to compile with older NumPy versions.
+
+   .. note::
+      This slot exists for DTypes that currently use ``PyArray_RegisterDataType``
+      allowing them to transition when otherwise regressions would block
+      them from doing so.
+      It is a path for deprecating ``PyArray_RegisterDataType`` and
+      ``PyArray_RegisterCastFunc`` and ``PyArray_RegisterCanCast`` and further
+      slots in the future.
 
 .. c:macro:: NPY_DT_discover_descr_from_pyobject
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3565,6 +3565,11 @@ Also see :ref:`dtypemeta` for documentation on ``PyArray_DTypeMeta`` and
  the examples in the ``numpy-user-dtypes`` repository for usage with both
  parametric and non-parametric data types.
 
+ .. note::
+
+    Custom DType registration is expected to happen during module import.
+    The registration API mutates global state and is not thread-safe.
+
 .. _dtype-flags:
 
 Flags

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3613,7 +3613,10 @@ member of ``PyArrayDTypeMeta_Spec`` struct.
    I.e. NumPy will still consider this a "legacy" DType and use old code paths
    where applicable, but use new features as they become available.
 
-   If used, this slot is required to be the first slot.
+   If used, this slot is required to be the first slot.  The ``ArrFuncs``
+   fields are copied, but you may also set them via the slots below.
+   (This allows backporting e.g. sorts, although NumPy 2.4+ does support
+   a new way to implement sorts.)
 
    .. versionadded:: 2.5
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1243,15 +1243,15 @@ User-defined data types
         The struct is not a valid Python object, so do not use ``Py_DECREF``
         on it.
 
-        **Transitioning to the new DType AP**
+        **Transitioning to the new DType API**
 
         Users currently using the old DType API may not be able to easily
         transition due to NumPy issues that would cause regressions.
         While new DTypes may reasonably limit themselves to newer NumPy
         versions, existing DTypes cannot do so.
 
-        You can transition to the new DType API by using
-        the `NPY_DT_legacy_descriptor_proto` slot when registering.
+        You can transition to the new DType API by using the
+        :c:macro:`NPY_DT_legacy_descriptor_proto` slot when registering.
         This slot is available when compiling with NumPy 2.5 and provides
         support for NumPy 2.0 and higher (it can also be vendored to compile
         on older versions of NumPy).
@@ -1292,7 +1292,8 @@ User-defined data types
 
     .. note::
         This function will eventually be deprecated. Please migrate to the new
-        DType API for casts.  See `NPY_DT_legacy_descriptor_proto` for details.
+        DType API for casts.  See :c:macro:`NPY_DT_legacy_descriptor_proto`
+        for details.
 
     .. c:type:: PyArray_VectorUnaryFunc
 
@@ -1309,9 +1310,9 @@ User-defined data types
 
     .. note::
         This function will eventually be deprecated. Please migrate to the new
-        DType API for casts.  See `NPY_DT_legacy_descriptor_proto` for details.
-        The new DType API provides more flexibility and speed even for dtypes
-        compatible with the legacy API.
+        DType API for casts.  See :c:macro:`NPY_DT_legacy_descriptor_proto`
+        for details.  The new DType API provides more flexibility and speed
+        even for dtypes compatible with the legacy API.
 
 
 Special functions for NPY_OBJECT
@@ -3609,17 +3610,18 @@ member of ``PyArrayDTypeMeta_Spec`` struct.
 
    If used, this slot is required to be the first slot.
 
-    .. versionadded:: 2.5 (available starting NumPy 2.0)
+   .. versionadded:: 2.5
+
       This feature is added in NumPy 2.5, but is backported to be compatible
       with NumPy 2.0+.  You can vendor this backport from ``npy_2_compat.h``
       if you wish to compile with older NumPy versions.
 
    .. note::
-      This slot exists for DTypes that currently use ``PyArray_RegisterDataType``
-      allowing them to transition when otherwise regressions would block
-      them from doing so.
-      It is a path for deprecating ``PyArray_RegisterDataType`` and
-      ``PyArray_RegisterCastFunc`` and ``PyArray_RegisterCanCast`` and further
+      This slot exists for DTypes that currently use
+      ``PyArray_RegisterDataType`` allowing them to transition when otherwise
+      regressions would block them from doing so.
+      It is a path for deprecating ``PyArray_RegisterDataType``,
+      ``PyArray_RegisterCastFunc``, ``PyArray_RegisterCanCast`` and further
       slots in the future.
 
 .. c:macro:: NPY_DT_discover_descr_from_pyobject

--- a/numpy/_core/code_generators/cversions.txt
+++ b/numpy/_core/code_generators/cversions.txt
@@ -84,5 +84,6 @@
 # Add 'same_value' casting, header additions.
 # General loop registration for ufuncs, sort, and argsort
 0x00000015 = fbd24fc5b2ba4f7cd3606ec6128de7a5
-# Version 22 (NumPy 2.5.0) Opaque PyObject ABI support
+# Version 22 (NumPy 2.5.0) Opaque PyObject ABI support and
+# NPY_DT_legacy_descriptor_proto support.
 0x00000016 = cdfba10e4e01454262d2293c394cbed5

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -407,6 +407,16 @@ typedef int (PyArrayMethod_PromoterFunction)(PyObject *ufunc,
 // intended only for internal use but defined here for clarity
 #define _NPY_DT_ARRFUNCS_OFFSET (1 << 11)
 
+/*
+ * Special slot (must be the first slot if used) to indicate that this DType
+ * is a "simple legacy" dtype backed by a PyArray_DescrProto.  When present,
+ * pfunc must point to a PyArray_DescrProto.  NumPy will create a
+ * _PyArray_LegacyDescr singleton, assign a type number, and set the
+ * NPY_DT_LEGACY flag.  Legacy-appropriate defaults are used for slots that
+ * the user does not override.
+ */
+ #define NPY_DT_legacy_descriptor_proto _NPY_DT_ARRFUNCS_OFFSET - 1
+
 // Cast is disabled
 // #define NPY_DT_PyArray_ArrFuncs_cast 0 + _NPY_DT_ARRFUNCS_OFFSET
 
@@ -439,7 +449,6 @@ typedef int (PyArrayMethod_PromoterFunction)(PyObject *ufunc,
 // #define NPY_DT_PyArray_ArrFuncs_fastputmask 20 + _NPY_DT_ARRFUNCS_OFFSET
 // #define NPY_DT_PyArray_ArrFuncs_fasttake 21 + _NPY_DT_ARRFUNCS_OFFSET
 #define NPY_DT_PyArray_ArrFuncs_argmin 22 + _NPY_DT_ARRFUNCS_OFFSET
-
 
 // TODO: These slots probably still need some thought, and/or a way to "grow"?
 typedef struct {

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -415,7 +415,7 @@ typedef int (PyArrayMethod_PromoterFunction)(PyObject *ufunc,
  * NPY_DT_LEGACY flag.  Legacy-appropriate defaults are used for slots that
  * the user does not override.
  */
- #define NPY_DT_legacy_descriptor_proto _NPY_DT_ARRFUNCS_OFFSET - 1
+#define NPY_DT_legacy_descriptor_proto (_NPY_DT_ARRFUNCS_OFFSET - 1)
 
 // Cast is disabled
 // #define NPY_DT_PyArray_ArrFuncs_cast 0 + _NPY_DT_ARRFUNCS_OFFSET

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1487,7 +1487,7 @@ typedef struct {
      * it is a fairly complex construct which may be better to allow
      * refactoring of.
      */
-    typedef struct {
+    typedef struct PyArray_DTypeMeta_tag {
         PyHeapTypeObject super;
 
         /*

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -253,17 +253,30 @@ DESCR_ACCESSOR(TYPEOBJ, typeobj, PyTypeObject *, 0)
  * Backport of `NPY_DT_legacy_descriptor_proto` (and ABI fix for slot IDs).
  * This backport allows dtypes that are currently implemented as legacy
  * (i.e. have a kind, char, a character code, and only the byte-order parameter)
- * to work without only minor changes on NumPy 2.0+ but use any part of the new
+ * to work with only minor changes on NumPy 2.0+ but use any part of the new
  * DType API they want to.
  * This also will allow us to deprecate the weirder parts of it, i.e. cast
  * registration.
- * (Possible the only change may be poor `dtype=` printing in arrays, which can
- * be worked around possibly.)
+ * (Possibly the only remaining change may be poor `dtype=` printing in
+ * arrays, which can be worked around.)
  */
-#if NPY_TARGET_VERSION < 0x16 && NPY_TARGET_VERSION >= NPY_2_0_API_VERSION
+/*
+ * `NPY_2_4_API_VERSION` and `NPY_2_5_API_VERSION` may not be defined when
+ * this header is vendored alongside an older `numpyconfig.h`.  Provide
+ * fallback definitions so the rest of the backport can use named constants.
+ */
+#ifndef NPY_2_4_API_VERSION
+#define NPY_2_4_API_VERSION 0x00000015
+#endif
+#ifndef NPY_2_5_API_VERSION
+#define NPY_2_5_API_VERSION 0x00000016
+#endif
+
+#if NPY_TARGET_VERSION < NPY_2_5_API_VERSION \
+        && NPY_TARGET_VERSION >= NPY_2_0_API_VERSION
 
 #ifndef NPY_DT_legacy_descriptor_proto
-#define NPY_DT_legacy_descriptor_proto (1 << 11) - 1
+#define NPY_DT_legacy_descriptor_proto ((1 << 11) - 1)
 #endif
 
 #define _PyArrayInitDTypeMeta_FromSpec \
@@ -274,15 +287,17 @@ static inline int PyArrayInitDTypeMeta_FromSpec(
         PyArray_DTypeMeta *DType, PyArrayDTypeMeta_Spec *spec)
 {
     PyArray_DescrProto *proto = NULL;
-    if (spec->slots[0].slot == (1 << 11) - 1) {
+    if (spec->slots[0].slot == NPY_DT_legacy_descriptor_proto) {
         proto = (PyArray_DescrProto *)spec->slots[0].pfunc;
     }
 
-#if NPY_TARGET_VERSION < 0x15  /* < NumPy 2.4, slot IDs accidentally changed */
+#if NPY_TARGET_VERSION < NPY_2_4_API_VERSION
+    /* < NumPy 2.4, slot IDs accidentally changed: translate them. */
     PyType_Slot *slot = spec->slots;
-    /* Make copy-pastable for compiling with NumPy < 2.4: */
-    int bad_offset = (PyArray_RUNTIME_VERSION >= 0x15) ? (1 << 10) : (1 << 11);
-    int good_offset = (PyArray_RUNTIME_VERSION >= 0x15) ? (1 << 11) : (1 << 10);
+    int bad_offset = (PyArray_RUNTIME_VERSION >= NPY_2_4_API_VERSION)
+            ? (1 << 10) : (1 << 11);
+    int good_offset = (PyArray_RUNTIME_VERSION >= NPY_2_4_API_VERSION)
+            ? (1 << 11) : (1 << 10);
     while (slot->slot != 0 || slot->pfunc != NULL) {
         if (slot->slot >= bad_offset && slot->slot < bad_offset + 30) {
             slot->slot += good_offset - bad_offset;
@@ -291,7 +306,7 @@ static inline int PyArrayInitDTypeMeta_FromSpec(
     }
 #endif
 
-    if (proto == NULL || PyArray_RUNTIME_VERSION >= 0x16) {
+    if (proto == NULL || PyArray_RUNTIME_VERSION >= NPY_2_5_API_VERSION) {
         return _PyArrayInitDTypeMeta_FromSpec(DType, spec);
     }
 

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -249,6 +249,133 @@ DESCR_ACCESSOR(TYPEOBJ, typeobj, PyTypeObject *, 0)
 #endif
 
 
+/*
+ * Backport of `NPY_DT_legacy_descriptor_proto` (and ABI fix for slot IDs).
+ * This backport allows dtypes that are currently implemented as legacy
+ * (i.e. have a kind, char, a character code, and only the byte-order parameter)
+ * to work without only minor changes on NumPy 2.0+ but use any part of the new
+ * DType API they want to.
+ * This also will allow us to deprecate the weirder parts of it, i.e. cast
+ * registration.
+ * (Possible the only change may be poor `dtype=` printing in arrays, which can
+ * be worked around possibly.)
+ */
+#if NPY_TARGET_VERSION < 0x16 && NPY_TARGET_VERSION >= NPY_2_0_API_VERSION
+
+#ifndef NPY_DT_legacy_descriptor_proto
+#define NPY_DT_legacy_descriptor_proto (1 << 11) - 1
+#endif
+
+#define _PyArrayInitDTypeMeta_FromSpec \
+    (*(int (*)(PyArray_DTypeMeta *, PyArrayDTypeMeta_Spec *))PyArray_API[362])
+#undef PyArrayInitDTypeMeta_FromSpec
+
+static inline int PyArrayInitDTypeMeta_FromSpec(
+        PyArray_DTypeMeta *DType, PyArrayDTypeMeta_Spec *spec)
+{
+    PyArray_DescrProto *proto = NULL;
+    if (spec->slots[0].slot == (1 << 11) - 1) {
+        proto = (PyArray_DescrProto *)spec->slots[0].pfunc;
+    }
+
+#if NPY_TARGET_VERSION < 0x15  /* < NumPy 2.4, slot IDs accidentally changed */
+    PyType_Slot *slot = spec->slots;
+    /* Make copy-pastable for compiling with NumPy < 2.4: */
+    int bad_offset = (PyArray_RUNTIME_VERSION >= 0x15) ? (1 << 10) : (1 << 11);
+    int good_offset = (PyArray_RUNTIME_VERSION >= 0x15) ? (1 << 11) : (1 << 10);
+    while (slot->slot != 0 || slot->pfunc != NULL) {
+        if (slot->slot >= bad_offset && slot->slot < bad_offset + 30) {
+            slot->slot += good_offset - bad_offset;
+        }
+        slot++;
+    }
+#endif
+
+    if (proto == NULL || PyArray_RUNTIME_VERSION >= 0x16) {
+        return _PyArrayInitDTypeMeta_FromSpec(DType, spec);
+    }
+
+#if defined(Py_LIMITED_API)
+    PyErr_SetString(PyExc_RuntimeError,
+        "NPY_DT_legacy_descriptor_proto backport not supported in Python limited API");
+    return -1;
+#else
+
+    /*
+     * Step 1: Register old-style with a garbage typeobj so that
+     * _PyArray_MapPyTypeToDType does NOT add the auto-DTypeMeta to the
+     * pytype-to-DType dict (it bails out on NPY_DT_is_legacy for non-generic
+     * types), regardless of whether the real scalar subclasses np.generic.
+     */
+    PyArray_DescrProto new_proto = *proto;
+    new_proto.typeobj = &PyBaseObject_Type;
+    int typenum = PyArray_RegisterDataType(&new_proto);
+    if (typenum < 0) {
+        return -1;
+    }
+
+    /*
+     * Step 2: Initialise the user's DType with new-style slots and casts.
+     * type_num stays at -1 / 0 for now; we fix it in step 3.
+     */
+    PyArrayDTypeMeta_Spec new_spec = *spec;
+    new_spec.slots = &spec->slots[1];  /* skip proto slot */
+    if (_PyArrayInitDTypeMeta_FromSpec(DType, &new_spec) < 0) {
+        return -1;
+    }
+
+    /*
+     * Step 3: Steal the singleton descriptor and type_num from the legacy
+     * registration.  Point the descriptor's Python type at the user's DType
+     * and fix up its typeobj field (which we temporarily set to
+     * PyBaseObject_Type in step 1).
+     */
+    PyArray_Descr *descr = PyArray_DescrFromType(typenum);
+    if (descr == NULL) {
+        return -1;
+    }
+
+    /* Save the auto-DTypeMeta so we can decref it after the swap. */
+    PyObject *old_meta = (PyObject *)Py_TYPE(descr);
+
+    DType->type_num = typenum;
+    /* PyArray_DescrFromType returns a new reference; transfer ownership. */
+    DType->singleton = descr;
+    /*
+     * Set the legacy flag (bit 0 == _NPY_DT_LEGACY_FLAG) so NumPy uses
+     * legacy code paths (copyswap, ArrFuncs, etc.) where the new-style API
+     * doesn't cover them yet.
+     */
+    DType->flags |= 1;
+
+    /* Re-type the descriptor so it belongs to the user's DType class. */
+    Py_INCREF(DType);
+    Py_SET_TYPE(descr, (PyTypeObject *)(DType));
+    Py_DECREF(old_meta);
+
+    /*
+     * Fix the descriptor's scalar-type field (it was set to
+     * PyBaseObject_Type in step 1 by PyArray_RegisterDataType copying
+     * proto->typeobj).
+     */
+    Py_INCREF(proto->typeobj);
+    Py_XDECREF(descr->typeobj);
+    descr->typeobj = proto->typeobj;
+
+    /*
+     * Patch copyswap/copyswapn into the new DType's legacy f-slots.
+     */
+    if (proto->f != NULL) {
+        PyArray_ArrFuncs *f = _PyDataType_GetArrFuncs(descr);
+        f->copyswap = proto->f->copyswap;
+        f->copyswapn = proto->f->copyswapn;
+    }
+#endif  /* Py_LIMITED_API */
+    return 0;
+}
+#endif
+
+
 #endif  /* not internal build */
 
 #endif  /* NUMPY_CORE_INCLUDE_NUMPY_NPY_2_COMPAT_H_ */

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -378,12 +378,42 @@ static inline int PyArrayInitDTypeMeta_FromSpec(
     descr->typeobj = proto->typeobj;
 
     /*
-     * Patch copyswap/copyswapn into the new DType's legacy f-slots.
+     * Initialize legacy ArrFuncs from the descriptor prototype.
      */
     if (proto->f != NULL) {
         PyArray_ArrFuncs *f = _PyDataType_GetArrFuncs(descr);
-        f->copyswap = proto->f->copyswap;
-        f->copyswapn = proto->f->copyswapn;
+        /*
+         * Preserve ArrFuncs that were explicitly set via the new API slots
+         * (step 2), and fill missing ones from the legacy prototype.
+         * getitem/setitem always come from the legacy descriptor path.
+         */
+         if (proto->f->getitem != NULL) {
+            f->getitem = proto->f->getitem;
+        }
+        if (proto->f->setitem != NULL) {
+            f->setitem = proto->f->setitem;
+        }
+#define NPY_PROTO_FILL_IF_NULL(FIELD) \
+        if (f->FIELD == NULL) { \
+            f->FIELD = proto->f->FIELD; \
+        }
+        NPY_PROTO_FILL_IF_NULL(copyswap);
+        NPY_PROTO_FILL_IF_NULL(copyswapn);
+        NPY_PROTO_FILL_IF_NULL(compare);
+        NPY_PROTO_FILL_IF_NULL(argmax);
+        NPY_PROTO_FILL_IF_NULL(dotfunc);
+        NPY_PROTO_FILL_IF_NULL(scanfunc);
+        NPY_PROTO_FILL_IF_NULL(fromstr);
+        NPY_PROTO_FILL_IF_NULL(nonzero);
+        NPY_PROTO_FILL_IF_NULL(fill);
+        NPY_PROTO_FILL_IF_NULL(fillwithscalar);
+        NPY_PROTO_FILL_IF_NULL(scalarkind);
+        NPY_PROTO_FILL_IF_NULL(argmin);
+#undef NPY_PROTO_FILL_IF_NULL
+        for (int i = 0; i < NPY_NSORTS; i++) {
+            f->sort[i] = proto->f->sort[i];
+            f->argsort[i] = proto->f->argsort[i];
+        }
     }
 #endif  /* Py_LIMITED_API */
     return 0;

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -287,12 +287,16 @@ static inline int PyArrayInitDTypeMeta_FromSpec(
         PyArray_DTypeMeta *DType, PyArrayDTypeMeta_Spec *spec)
 {
     PyArray_DescrProto *proto = NULL;
-    if (spec->slots[0].slot == NPY_DT_legacy_descriptor_proto) {
+    if (spec->slots != NULL && spec->slots[0].slot == NPY_DT_legacy_descriptor_proto) {
         proto = (PyArray_DescrProto *)spec->slots[0].pfunc;
     }
 
 #if NPY_TARGET_VERSION < NPY_2_4_API_VERSION
-    /* < NumPy 2.4, slot IDs accidentally changed: translate them. */
+    /*
+     * In NumPy 2.4 the slot IDs ABI was accidentally changed, so we translate
+     * them even if `NPY_DT_legacy_descriptor_proto` is unused. The translation
+     * is idempotent.
+     */
     PyType_Slot *slot = spec->slots;
     int bad_offset = (PyArray_RUNTIME_VERSION >= NPY_2_4_API_VERSION)
             ? (1 << 10) : (1 << 11);

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -142,7 +142,6 @@ legacy_fallback_setitem(PyArray_Descr *descr, PyObject *value, char *data)
     return PyDataType_GetArrFuncs(descr)->setitem(value, data, &arr_fields);
 }
 
-
 static int
 legacy_setitem_using_DType(PyObject *obj, void *data, void *arr)
 {
@@ -249,6 +248,11 @@ dtypemeta_initialize_struct_from_spec(
         DType->flags |= NPY_DT_LEGACY;
         ((PyTypeObject *)DType)->tp_basicsize = sizeof(_PyArray_LegacyDescr);
         ((PyTypeObject *)DType)->tp_new = (newfunc)legacy_dtype_default_new;
+        /*
+         * The type object is mutable during initialization, so update CPython's
+         * internal caches after changing slots inherited from np.dtype.
+         */
+        PyType_Modified((PyTypeObject *)DType);
 
         NPY_DT_SLOTS(DType)->discover_descr_from_pyobject =
                 nonparametric_discover_descr_from_pyobject;
@@ -256,15 +260,12 @@ dtypemeta_initialize_struct_from_spec(
         NPY_DT_SLOTS(DType)->common_dtype =
                 legacy_userdtype_common_dtype_function;
         NPY_DT_SLOTS(DType)->ensure_canonical = ensure_native_byteorder;
-        NPY_DT_SLOTS(DType)->setitem = legacy_fallback_setitem;
 
-        /* Only take copyswap/copyswapn from the proto's arrfuncs */
+        /* Initialize full legacy ArrFuncs from the descriptor prototype. */
         if (legacy_proto->f != NULL) {
-            NPY_DT_SLOTS(DType)->f.copyswap = legacy_proto->f->copyswap;
-            if (legacy_proto->f->copyswapn != NULL) {
-                NPY_DT_SLOTS(DType)->f.copyswapn = legacy_proto->f->copyswapn;
-            }
-            else if (legacy_proto->f->copyswap != NULL) {
+            NPY_DT_SLOTS(DType)->f = *(legacy_proto->f);
+            if (NPY_DT_SLOTS(DType)->f.copyswapn == NULL
+                    && NPY_DT_SLOTS(DType)->f.copyswap != NULL) {
                 NPY_DT_SLOTS(DType)->f.copyswapn = _default_copyswapn;
             }
         }
@@ -408,42 +409,24 @@ dtypemeta_initialize_struct_from_spec(
             return -1;
         }
 
-        _PyArray_LegacyDescr *descr = PyObject_Malloc(
-                sizeof(_PyArray_LegacyDescr));
-        if (descr == NULL) {
-            PyErr_NoMemory();
-            return -1;
-        }
-        PyObject_INIT(descr, (PyTypeObject *)DType);
-
-        Py_XINCREF(legacy_proto->typeobj);
-        descr->typeobj = legacy_proto->typeobj;
-        descr->kind = legacy_proto->kind;
-        descr->type = legacy_proto->type;
-        descr->byteorder = legacy_proto->byteorder;
-        descr->_former_flags = 0;
-        descr->flags = legacy_proto->flags;
-        descr->elsize = legacy_proto->elsize;
-        descr->alignment = legacy_proto->alignment;
-        descr->metadata = NULL;
-        descr->hash = -1;
-        descr->reserved_null[0] = NULL;
-        descr->reserved_null[1] = NULL;
-        descr->subarray = legacy_proto->subarray;
-        Py_XINCREF(legacy_proto->fields);
-        descr->fields = legacy_proto->fields;
-        Py_XINCREF(legacy_proto->names);
-        descr->names = legacy_proto->names;
-        descr->c_metadata = NULL;
-
+        /*
+         * Like PyArray_RegisterDataType, this mutates global userdescrs state
+         * and is expected to run during module import while single-threaded.
+         */
         _PyArray_LegacyDescr **tmp = realloc(userdescrs,
                 (NPY_NUMUSERTYPES + 1) * sizeof(void *));
         if (tmp == NULL) {
-            Py_DECREF(descr);
             PyErr_NoMemory();
             return -1;
         }
         userdescrs = tmp;
+
+        _PyArray_LegacyDescr *descr = _PyArray_LegacyDescrNewFromPrototype(
+                (PyTypeObject *)DType, legacy_proto, 0);
+        if (descr == NULL) {
+            return -1;
+        }
+
         userdescrs[NPY_NUMUSERTYPES++] = descr;
 
         descr->type_num = typenum;

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -233,15 +233,19 @@ dtypemeta_initialize_struct_from_spec(
     NPY_DT_SLOTS(DType)->get_constant = default_get_constant;
     NPY_DT_SLOTS(DType)->f = default_funcs;
 
+    PyType_Slot *spec_slot = spec->slots;
+    PyType_Slot null_slot = {0, NULL};
+    /* If user passes slots == NULL translate to finish sentinel slot. */
+    if (spec_slot == NULL) {
+        spec_slot = &null_slot;
+    }
     /*
      * If the first slot is NPY_DT_legacy_descriptor_proto, this DType will
      * be set up as a legacy dtype.  Consume that slot and amend the defaults
      * to match the legacy path (dtypemeta_wrap_legacy_descriptor).
      */
     PyArray_DescrProto *legacy_proto = NULL;
-    PyType_Slot *spec_slot = spec->slots;
-    if (spec_slot != NULL
-            && spec_slot->slot == NPY_DT_legacy_descriptor_proto) {
+    if (spec_slot->slot == NPY_DT_legacy_descriptor_proto) {
         legacy_proto = (PyArray_DescrProto *)spec_slot->pfunc;
         spec_slot++;  /* consumed; the slot loop starts after this one */
 

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -179,6 +179,18 @@ PyArray_ArrFuncs default_funcs = {
         .setitem = &legacy_setitem_using_DType,
 };
 
+/* Forward declarations for functions used in the legacy proto path */
+static PyObject *
+legacy_dtype_default_new(PyArray_DTypeMeta *self,
+        PyObject *args, PyObject *kwargs);
+static PyArray_Descr *
+nonparametric_discover_descr_from_pyobject(
+        PyArray_DTypeMeta *cls, PyObject *obj);
+static PyArray_Descr *
+nonparametric_default_descr(PyArray_DTypeMeta *cls);
+static PyArray_Descr *
+ensure_native_byteorder(PyArray_Descr *descr);
+
 /*
  * Internal version of PyArrayInitDTypeMeta_FromSpec.
  *
@@ -222,7 +234,43 @@ dtypemeta_initialize_struct_from_spec(
     NPY_DT_SLOTS(DType)->get_constant = default_get_constant;
     NPY_DT_SLOTS(DType)->f = default_funcs;
 
+    /*
+     * If the first slot is NPY_DT_legacy_descriptor_proto, this DType will
+     * be set up as a legacy dtype.  Consume that slot and amend the defaults
+     * to match the legacy path (dtypemeta_wrap_legacy_descriptor).
+     */
+    PyArray_DescrProto *legacy_proto = NULL;
     PyType_Slot *spec_slot = spec->slots;
+    if (spec_slot != NULL
+            && spec_slot->slot == NPY_DT_legacy_descriptor_proto) {
+        legacy_proto = (PyArray_DescrProto *)spec_slot->pfunc;
+        spec_slot++;  /* consumed; the slot loop starts after this one */
+
+        DType->flags |= NPY_DT_LEGACY;
+        ((PyTypeObject *)DType)->tp_basicsize = sizeof(_PyArray_LegacyDescr);
+        ((PyTypeObject *)DType)->tp_new = (newfunc)legacy_dtype_default_new;
+
+        NPY_DT_SLOTS(DType)->discover_descr_from_pyobject =
+                nonparametric_discover_descr_from_pyobject;
+        NPY_DT_SLOTS(DType)->default_descr = nonparametric_default_descr;
+        NPY_DT_SLOTS(DType)->common_dtype =
+                legacy_userdtype_common_dtype_function;
+        NPY_DT_SLOTS(DType)->ensure_canonical = ensure_native_byteorder;
+        NPY_DT_SLOTS(DType)->setitem = legacy_fallback_setitem;
+
+        /* Only take copyswap/copyswapn from the proto's arrfuncs */
+        if (legacy_proto->f != NULL) {
+            NPY_DT_SLOTS(DType)->f.copyswap = legacy_proto->f->copyswap;
+            if (legacy_proto->f->copyswapn != NULL) {
+                NPY_DT_SLOTS(DType)->f.copyswapn = legacy_proto->f->copyswapn;
+            }
+            else if (legacy_proto->f->copyswap != NULL) {
+                NPY_DT_SLOTS(DType)->f.copyswapn = _default_copyswapn;
+            }
+        }
+    }
+
+    /* Walk the remaining slots and fill in function pointers */
     while (1) {
         int slot = spec_slot->slot;
         void *pfunc = spec_slot->pfunc;
@@ -324,8 +372,89 @@ dtypemeta_initialize_struct_from_spec(
         }
     }
 
-    /* invalid type num. Ideally, we get away with it! */
-    DType->type_num = -1;
+    if (legacy_proto != NULL) {
+        /*
+         * Create the _PyArray_LegacyDescr singleton from the proto, assign
+         * a type number, and register in userdescrs.
+         */
+        if (spec->flags & NPY_DT_PARAMETRIC) {
+            PyErr_SetString(PyExc_TypeError,
+                    "legacy dtypes via NPY_DT_legacy_descriptor_proto "
+                    "must not be parametric");
+            return -1;
+        }
+        if (legacy_proto->metadata != NULL || legacy_proto->c_metadata != NULL) {
+            PyErr_SetString(PyExc_TypeError,
+                    "legacy dtypes via NPY_DT_legacy_descriptor_proto "
+                    "do not support metadata or c_metadata");
+            return -1;
+        }
+        if (legacy_proto->elsize == 0) {
+            PyErr_SetString(PyExc_ValueError,
+                    "legacy DType must have a fixed element size (elsize > 0)");
+            return -1;
+        }
+        if (legacy_proto->flags & (NPY_ITEM_IS_POINTER | NPY_ITEM_REFCOUNT)) {
+            PyErr_SetString(PyExc_ValueError,
+                    "legacy dtypes via NPY_DT_legacy_descriptor_proto "
+                    "do not support NPY_ITEM_IS_POINTER or NPY_ITEM_REFCOUNT");
+            return -1;
+        }
+
+        int typenum = NPY_USERDEF + NPY_NUMUSERTYPES;
+        if (typenum >= NPY_VSTRING) {
+            PyErr_SetString(PyExc_ValueError,
+                    "Too many user defined dtypes registered");
+            return -1;
+        }
+
+        _PyArray_LegacyDescr *descr = PyObject_Malloc(
+                sizeof(_PyArray_LegacyDescr));
+        if (descr == NULL) {
+            PyErr_NoMemory();
+            return -1;
+        }
+        PyObject_INIT(descr, (PyTypeObject *)DType);
+
+        Py_XINCREF(legacy_proto->typeobj);
+        descr->typeobj = legacy_proto->typeobj;
+        descr->kind = legacy_proto->kind;
+        descr->type = legacy_proto->type;
+        descr->byteorder = legacy_proto->byteorder;
+        descr->_former_flags = 0;
+        descr->flags = legacy_proto->flags;
+        descr->elsize = legacy_proto->elsize;
+        descr->alignment = legacy_proto->alignment;
+        descr->metadata = NULL;
+        descr->hash = -1;
+        descr->reserved_null[0] = NULL;
+        descr->reserved_null[1] = NULL;
+        descr->subarray = legacy_proto->subarray;
+        Py_XINCREF(legacy_proto->fields);
+        descr->fields = legacy_proto->fields;
+        Py_XINCREF(legacy_proto->names);
+        descr->names = legacy_proto->names;
+        descr->c_metadata = NULL;
+
+        _PyArray_LegacyDescr **tmp = realloc(userdescrs,
+                (NPY_NUMUSERTYPES + 1) * sizeof(void *));
+        if (tmp == NULL) {
+            Py_DECREF(descr);
+            PyErr_NoMemory();
+            return -1;
+        }
+        userdescrs = tmp;
+        userdescrs[NPY_NUMUSERTYPES++] = descr;
+
+        descr->type_num = typenum;
+        legacy_proto->type_num = typenum;
+        DType->type_num = typenum;
+        DType->singleton = (PyArray_Descr *)descr;
+    }
+    else {
+        /* invalid type num. Ideally, we get away with it! */
+        DType->type_num = -1;
+    }
 
     /*
      * Handle the scalar type mapping.
@@ -339,7 +468,8 @@ dtypemeta_initialize_struct_from_spec(
             return -1;
         }
     }
-    if (_PyArray_MapPyTypeToDType(DType, DType->scalar_type, 0) < 0) {
+    if (_PyArray_MapPyTypeToDType(DType, DType->scalar_type,
+            legacy_proto != NULL) < 0) {
         Py_DECREF(DType);
         return -1;
     }

--- a/numpy/_core/src/multiarray/public_dtype_api.c
+++ b/numpy/_core/src/multiarray/public_dtype_api.c
@@ -79,14 +79,12 @@ PyArrayInitDTypeMeta_FromSpec(
         return -1;
     }
 
-    if (!NPY_DT_is_legacy(DType)) {
-        if (NPY_DT_SLOTS(DType)->setitem == NULL
-                || NPY_DT_SLOTS(DType)->getitem == NULL) {
-            PyErr_SetString(PyExc_RuntimeError,
-                    "A DType must provide a getitem/setitem (there may be an "
-                    "exception here in the future if no scalar type is provided)");
-            return -1;
-        }
+    if (NPY_DT_SLOTS(DType)->setitem == NULL
+            || NPY_DT_SLOTS(DType)->getitem == NULL) {
+        PyErr_SetString(PyExc_RuntimeError,
+                "A DType must provide a getitem/setitem (there may be an "
+                "exception here in the future if no scalar type is provided)");
+        return -1;
     }
 
     if (NPY_DT_SLOTS(DType)->ensure_canonical == NULL) {

--- a/numpy/_core/src/multiarray/public_dtype_api.c
+++ b/numpy/_core/src/multiarray/public_dtype_api.c
@@ -36,8 +36,12 @@ PyArrayInitDTypeMeta_FromSpec(
         return -1;
     }
 
-    if (((PyTypeObject *)DType)->tp_repr == PyArrayDescr_Type.tp_repr
-            || ((PyTypeObject *)DType)->tp_str == PyArrayDescr_Type.tp_str) {
+    int is_legacy = (spec->slots != NULL
+            && spec->slots[0].slot == NPY_DT_legacy_descriptor_proto);
+
+    if (!is_legacy
+            && (((PyTypeObject *)DType)->tp_repr == PyArrayDescr_Type.tp_repr
+                || ((PyTypeObject *)DType)->tp_str == PyArrayDescr_Type.tp_str)) {
         PyErr_SetString(PyExc_TypeError,
                 "A custom DType must implement `__repr__` and `__str__` since "
                 "the default inherited version (currently) fails.");
@@ -75,12 +79,14 @@ PyArrayInitDTypeMeta_FromSpec(
         return -1;
     }
 
-    if (NPY_DT_SLOTS(DType)->setitem == NULL
-            || NPY_DT_SLOTS(DType)->getitem == NULL) {
-        PyErr_SetString(PyExc_RuntimeError,
-                "A DType must provide a getitem/setitem (there may be an "
-                "exception here in the future if no scalar type is provided)");
-        return -1;
+    if (!NPY_DT_is_legacy(DType)) {
+        if (NPY_DT_SLOTS(DType)->setitem == NULL
+                || NPY_DT_SLOTS(DType)->getitem == NULL) {
+            PyErr_SetString(PyExc_RuntimeError,
+                    "A DType must provide a getitem/setitem (there may be an "
+                    "exception here in the future if no scalar type is provided)");
+            return -1;
+        }
     }
 
     if (NPY_DT_SLOTS(DType)->ensure_canonical == NULL) {

--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -83,7 +83,7 @@ _default_nonzero(void *ip, void *arr)
     return NPY_FALSE;
 }
 
-static void
+NPY_NO_EXPORT void
 _default_copyswapn(void *dst, npy_intp dstride, void *src,
                    npy_intp sstride, npy_intp n, int swap, void *arr)
 {

--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -139,6 +139,60 @@ PyArray_InitArrFuncs(PyArray_ArrFuncs *f)
 }
 
 
+NPY_NO_EXPORT _PyArray_LegacyDescr *
+_PyArray_LegacyDescrNewFromPrototype(
+        PyTypeObject *descr_type, PyArray_DescrProto *descr_proto,
+        npy_bool copy_metadata)
+{
+    _PyArray_LegacyDescr *descr = PyObject_Malloc(sizeof(_PyArray_LegacyDescr));
+    if (descr == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    PyObject_INIT(descr, descr_type);
+
+    /* Copy all fields by name from the user-provided legacy prototype. */
+    Py_XINCREF(descr_proto->typeobj);
+    descr->typeobj = descr_proto->typeobj;
+    descr->kind = descr_proto->kind;
+    descr->type = descr_proto->type;
+    descr->byteorder = descr_proto->byteorder;
+    descr->_former_flags = 0;
+    descr->flags = descr_proto->flags;
+    descr->elsize = descr_proto->elsize;
+    descr->alignment = descr_proto->alignment;
+    descr->subarray = descr_proto->subarray;
+    Py_XINCREF(descr_proto->fields);
+    descr->fields = descr_proto->fields;
+    Py_XINCREF(descr_proto->names);
+    descr->names = descr_proto->names;
+    descr->hash = -1;
+    descr->reserved_null[0] = NULL;
+    descr->reserved_null[1] = NULL;
+
+    if (copy_metadata) {
+        Py_XINCREF(descr_proto->metadata);
+        descr->metadata = descr_proto->metadata;
+        if (descr_proto->c_metadata != NULL) {
+            descr->c_metadata = NPY_AUXDATA_CLONE(descr_proto->c_metadata);
+            if (descr->c_metadata == NULL) {
+                Py_DECREF(descr);
+                return NULL;
+            }
+        }
+        else {
+            descr->c_metadata = NULL;
+        }
+    }
+    else {
+        descr->metadata = NULL;
+        descr->c_metadata = NULL;
+    }
+
+    return descr;
+}
+
+
 /*
   returns typenum to associate with this type >=NPY_USERDEF.
   needs the userdecrs table and PyArray_NUMUSER variables
@@ -268,38 +322,12 @@ PyArray_RegisterDataType(PyArray_DescrProto *descr_proto)
      * Copy the user provided descriptor struct into a new one.  This is done
      * in order to allow different layout between the two.
      */
-    _PyArray_LegacyDescr *descr = PyObject_Malloc(sizeof(_PyArray_LegacyDescr));
+    _PyArray_LegacyDescr *descr = _PyArray_LegacyDescrNewFromPrototype(
+            Py_TYPE(descr_proto), descr_proto, 1);
     if (descr == NULL) {
         PyMem_FREE(name);
-        PyErr_NoMemory();
         return -1;
     }
-    PyObject_INIT(descr, Py_TYPE(descr_proto));
-
-    /* Simply copy all fields by name: */
-    Py_XINCREF(descr_proto->typeobj);
-    descr->typeobj = descr_proto->typeobj;
-    descr->kind = descr_proto->kind;
-    descr->type = descr_proto->type;
-    descr->byteorder = descr_proto->byteorder;
-    descr->flags = descr_proto->flags;
-    descr->elsize = descr_proto->elsize;
-    descr->alignment = descr_proto->alignment;
-    descr->subarray = descr_proto->subarray;
-    Py_XINCREF(descr_proto->fields);
-    descr->fields = descr_proto->fields;
-    Py_XINCREF(descr_proto->names);
-    descr->names = descr_proto->names;
-    Py_XINCREF(descr_proto->metadata);
-    descr->metadata = descr_proto->metadata;
-    if (descr_proto->c_metadata != NULL) {
-        descr->c_metadata = NPY_AUXDATA_CLONE(descr_proto->c_metadata);
-    }
-    else {
-        descr->c_metadata = NULL;
-    }
-    /* And invalidate cached hash value (field assumed to be not set) */
-    descr->hash = -1;
 
     userdescrs[NPY_NUMUSERTYPES++] = descr;
 

--- a/numpy/_core/src/multiarray/usertypes.h
+++ b/numpy/_core/src/multiarray/usertypes.h
@@ -5,6 +5,11 @@
 
 extern NPY_NO_EXPORT _PyArray_LegacyDescr **userdescrs;
 
+NPY_NO_EXPORT _PyArray_LegacyDescr *
+_PyArray_LegacyDescrNewFromPrototype(
+        PyTypeObject *descr_type, PyArray_DescrProto *descr_proto,
+        npy_bool copy_metadata);
+
 NPY_NO_EXPORT void
 PyArray_InitArrFuncs(PyArray_ArrFuncs *f);
 

--- a/numpy/_core/src/multiarray/usertypes.h
+++ b/numpy/_core/src/multiarray/usertypes.h
@@ -8,6 +8,10 @@ extern NPY_NO_EXPORT _PyArray_LegacyDescr **userdescrs;
 NPY_NO_EXPORT void
 PyArray_InitArrFuncs(PyArray_ArrFuncs *f);
 
+NPY_NO_EXPORT void
+_default_copyswapn(void *dst, npy_intp dstride, void *src,
+                   npy_intp sstride, npy_intp n, int swap, void *arr);
+
 NPY_NO_EXPORT int
 PyArray_RegisterCanCast(PyArray_Descr *descr, int totype,
                         NPY_SCALARKIND scalar);

--- a/numpy/_core/src/umath/_rational_tests.c
+++ b/numpy/_core/src/umath/_rational_tests.c
@@ -998,6 +998,23 @@ rational2_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
     return (PyArray_DTypeMeta *)Py_NotImplemented;
 }
 
+/*
+ * Minimal new-style getitem/setitem required by PyArrayInitDTypeMeta_FromSpec.
+ * Reuse the legacy rational conversion logic for now.
+ */
+static PyObject *
+rational2_getitem(PyArray_Descr *NPY_UNUSED(descr), char *data)
+{
+    return npyrational_getitem(data, NULL);
+}
+
+static int
+rational2_setitem(
+        PyArray_Descr *NPY_UNUSED(descr), PyObject *item, char *data)
+{
+    return npyrational_setitem(item, data, NULL);
+}
+
 #define DEFINE_CAST(From,To,statement) \
     static void \
     npycast_##From##_##To(void* from_, void* to_, npy_intp n, \
@@ -1391,6 +1408,8 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
         PyType_Slot dtype_slots[] = {
             {NPY_DT_legacy_descriptor_proto, &npyrational_descr_proto},
             {NPY_DT_common_dtype, rational2_common_dtype},
+            {NPY_DT_getitem, rational2_getitem},
+            {NPY_DT_setitem, rational2_setitem},
             {0, NULL},
         };
 
@@ -1434,10 +1453,6 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
     npy_rational2 = NPY_Rational2DType.type_num;
     npyrational2_descr = NPY_Rational2DType.singleton;
     Py_INCREF(npyrational2_descr);
-
-    /* The new path only propagates copyswap/copyswapn from the proto;
-     * install the remaining ArrFuncs (getitem/setitem, compare, etc.). */
-    *PyDataType_GetArrFuncs(npyrational2_descr) = npyrational_arrfuncs;
 
     /* Support `dtype(rational2)` */
     if (PyDict_SetItemString(PyRational2_Type.tp_dict, "dtype",

--- a/numpy/_core/src/umath/_rational_tests.c
+++ b/numpy/_core/src/umath/_rational_tests.c
@@ -4,10 +4,20 @@
 #include <structmember.h>
 
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
+/* Build as a downstream module targeting NumPy 2.0 to exercise the
+ * public DType API and the `NPY_DT_legacy_descriptor_proto` backport. */
+#if defined(NPY_INTERNAL_BUILD)
+#undef NPY_INTERNAL_BUILD
+#endif
+#define NPY_TARGET_VERSION NPY_2_0_API_VERSION
+
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
+#include "numpy/dtype_api.h"
 #include "numpy/npy_3kcompat.h"
-#include "common.h"  /* for error_converting */
+
+#define error_converting(x)  (((x) == -1) && PyErr_Occurred())
 
 #include <math.h>
 
@@ -373,8 +383,8 @@ PyRational_Check(PyObject* object) {
 }
 
 static PyObject*
-PyRational_FromRational(rational x) {
-    PyRational* p = (PyRational*)PyRational_Type.tp_alloc(&PyRational_Type,0);
+PyRational_FromRational(PyTypeObject* type, rational x) {
+    PyRational* p = (PyRational*)type->tp_alloc(type, 0);
     if (p) {
         p->r = x;
     }
@@ -403,21 +413,23 @@ pyrational_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
     if (size == 1) {
         x[0] = PyTuple_GET_ITEM(args, 0);
         if (PyRational_Check(x[0])) {
-            Py_INCREF(x[0]);
-            return x[0];
+            if (Py_TYPE(x[0]) == type) {
+                Py_INCREF(x[0]);
+                return x[0];
+            }
+            return PyRational_FromRational(type, ((PyRational*)x[0])->r);
         }
         // TODO: allow construction from unicode strings
         else if (PyBytes_Check(x[0])) {
             const char* s = PyBytes_AS_STRING(x[0]);
-            rational x;
-            if (scan_rational(&s,&x)) {
+            if (scan_rational(&s,&r)) {
                 const char* p;
                 for (p = s; *p; p++) {
                     if (!isspace(*p)) {
                         goto bad;
                     }
                 }
-                return PyRational_FromRational(x);
+                return PyRational_FromRational(type, r);
             }
             bad:
             PyErr_Format(PyExc_ValueError,
@@ -462,7 +474,7 @@ pyrational_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
     if (PyErr_Occurred()) {
         return 0;
     }
-    return PyRational_FromRational(r);
+    return PyRational_FromRational(type, r);
 }
 
 /*
@@ -568,7 +580,7 @@ pyrational_hash(PyObject* self) {
         if (PyErr_Occurred()) { \
             return 0; \
         } \
-        return PyRational_FromRational(z); \
+        return PyRational_FromRational(&PyRational_Type, z); \
     }
 #define RATIONAL_BINOP(name) RATIONAL_BINOP_2(name,rational_##name(x,y))
 RATIONAL_BINOP(add)
@@ -589,8 +601,18 @@ RATIONAL_BINOP_2(floor_divide,
         } \
         return convert(y); \
     }
-RATIONAL_UNOP(negative,rational,rational_negative(x),PyRational_FromRational)
-RATIONAL_UNOP(absolute,rational,rational_abs(x),PyRational_FromRational)
+#define RATIONAL_UNOP_RAT(name,exp) \
+    static PyObject* \
+    pyrational_##name(PyObject* self) { \
+        rational x = ((PyRational*)self)->r; \
+        rational y = exp; \
+        if (PyErr_Occurred()) { \
+            return 0; \
+        } \
+        return PyRational_FromRational(&PyRational_Type, y); \
+    }
+RATIONAL_UNOP_RAT(negative,rational_negative(x))
+RATIONAL_UNOP_RAT(absolute,rational_abs(x))
 RATIONAL_UNOP(int,long,rational_int(x),PyLong_FromLong)
 RATIONAL_UNOP(float,double,rational_double(x),PyFloat_FromDouble)
 
@@ -717,7 +739,7 @@ static PyObject*
 npyrational_getitem(void* data, void* arr) {
     rational r;
     memcpy(&r,data,sizeof(rational));
-    return PyRational_FromRational(r);
+    return PyRational_FromRational(&PyRational_Type, r);
 }
 
 static int
@@ -910,6 +932,72 @@ PyArray_DescrProto npyrational_descr_proto = {
     &npyrational_arrfuncs,  /* f */
 };
 
+/*
+ * A second rational variant registered via `PyArrayInitDTypeMeta_FromSpec`
+ * with `NPY_DT_legacy_descriptor_proto`.  Same data layout as `rational`
+ * (Python subclass of `PyRational_Type`), so all the existing C helpers,
+ * casts, and ufunc loops can be reused for the new typenum/descr.
+ */
+static PyTypeObject PyRational2_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "numpy._core._rational_tests.rational2",
+    sizeof(PyRational),
+    /* the rest is inherited from PyRational_Type via tp_base */
+};
+
+static PyArray_DTypeMeta NPY_Rational2DType = {{{
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "numpy._core._rational_tests.Rational2DType",
+}}};
+
+/*
+ * Within-DType identity cast (memcpy).  Required by
+ * `PyArrayInitDTypeMeta_FromSpec` since it rejects a NULL `casts`; for
+ * full legacy registrations this is otherwise built lazily from `copyswap`.
+ */
+static int
+rational2_within_dtype_loop(
+        PyArrayMethod_Context *NPY_UNUSED(context),
+        char *const data[], npy_intp const dimensions[],
+        npy_intp const strides[], NpyAuxData *NPY_UNUSED(auxdata))
+{
+    char *src = data[0], *dst = data[1];
+    npy_intp src_stride = strides[0], dst_stride = strides[1];
+    npy_intp N = dimensions[0];
+    for (npy_intp i = 0; i < N; i++) {
+        memcpy(dst, src, sizeof(rational));
+        src += src_stride;
+        dst += dst_stride;
+    }
+    return 0;
+}
+
+/*
+ * `common_dtype` slot offered only by the new DType API.  Promotes
+ * `rational2` with itself or any integer dtype to `rational2`; everything
+ * else returns `Py_NotImplemented`.
+ */
+static PyArray_DTypeMeta *
+rational2_common_dtype(PyArray_DTypeMeta *cls, PyArray_DTypeMeta *other)
+{
+    if (cls == other) {
+        Py_INCREF(cls);
+        return cls;
+    }
+    int t = other->type_num;
+    if (t == NPY_BOOL
+            || t == NPY_BYTE || t == NPY_UBYTE
+            || t == NPY_SHORT || t == NPY_USHORT
+            || t == NPY_INT || t == NPY_UINT
+            || t == NPY_LONG || t == NPY_ULONG
+            || t == NPY_LONGLONG || t == NPY_ULONGLONG) {
+        Py_INCREF(cls);
+        return cls;
+    }
+    Py_INCREF(Py_NotImplemented);
+    return (PyArray_DTypeMeta *)Py_NotImplemented;
+}
+
 #define DEFINE_CAST(From,To,statement) \
     static void \
     npycast_##From##_##To(void* from_, void* to_, npy_intp n, \
@@ -1097,6 +1185,106 @@ rational_ufunc_test_add_rationals(char** args, npy_intp const *dimensions,
 }
 
 
+/* Register the rational <-> builtin casts and ufunc loops for `typenum`.
+ * Called once per variant since the data layout is identical. */
+static int
+register_rational_casts_and_ufuncs(int typenum,
+                                   PyArray_Descr *descr,
+                                   PyObject *numpy)
+{
+    #define REGISTER_CAST(From,To,from_descr,to_typenum,safe) { \
+            PyArray_Descr* from_descr_##From##_##To = (from_descr); \
+            if (PyArray_RegisterCastFunc(from_descr_##From##_##To, \
+                                         (to_typenum), \
+                                         npycast_##From##_##To) < 0) { \
+                return -1; \
+            } \
+            if (safe && PyArray_RegisterCanCast(from_descr_##From##_##To, \
+                                                (to_typenum), \
+                                                NPY_NOSCALAR) < 0) { \
+                return -1; \
+            } \
+        }
+    #define REGISTER_INT_CASTS(bits) \
+        REGISTER_CAST(npy_int##bits, rational, \
+                      PyArray_DescrFromType(NPY_INT##bits), typenum, 1) \
+        REGISTER_CAST(rational, npy_int##bits, descr, NPY_INT##bits, 0)
+    REGISTER_INT_CASTS(8)
+    REGISTER_INT_CASTS(16)
+    REGISTER_INT_CASTS(32)
+    REGISTER_INT_CASTS(64)
+    REGISTER_CAST(rational, float, descr, NPY_FLOAT, 0)
+    REGISTER_CAST(rational, double, descr, NPY_DOUBLE, 1)
+    REGISTER_CAST(npy_bool, rational,
+                  PyArray_DescrFromType(NPY_BOOL), typenum, 1)
+    REGISTER_CAST(rational, npy_bool, descr, NPY_BOOL, 0)
+    #undef REGISTER_CAST
+    #undef REGISTER_INT_CASTS
+
+    #define REGISTER_UFUNC(name,...) { \
+        PyUFuncObject* ufunc = \
+            (PyUFuncObject*)PyObject_GetAttrString(numpy, #name); \
+        int _types[] = __VA_ARGS__; \
+        if (!ufunc) { \
+            return -1; \
+        } \
+        if (sizeof(_types)/sizeof(int)!=ufunc->nargs) { \
+            PyErr_Format(PyExc_AssertionError, \
+                         "ufunc %s takes %d arguments, our loop takes %lu", \
+                         #name, ufunc->nargs, (unsigned long) \
+                         (sizeof(_types)/sizeof(int))); \
+            Py_DECREF(ufunc); \
+            return -1; \
+        } \
+        if (PyUFunc_RegisterLoopForType((PyUFuncObject*)ufunc, typenum, \
+                rational_ufunc_##name, _types, 0) < 0) { \
+            Py_DECREF(ufunc); \
+            return -1; \
+        } \
+        Py_DECREF(ufunc); \
+    }
+    #define REGISTER_UFUNC_BINARY_RATIONAL(name) \
+        REGISTER_UFUNC(name, {typenum, typenum, typenum})
+    #define REGISTER_UFUNC_BINARY_COMPARE(name) \
+        REGISTER_UFUNC(name, {typenum, typenum, NPY_BOOL})
+    #define REGISTER_UFUNC_UNARY(name) \
+        REGISTER_UFUNC(name, {typenum, typenum})
+    /* Binary */
+    REGISTER_UFUNC_BINARY_RATIONAL(add)
+    REGISTER_UFUNC_BINARY_RATIONAL(subtract)
+    REGISTER_UFUNC_BINARY_RATIONAL(multiply)
+    REGISTER_UFUNC_BINARY_RATIONAL(divide)
+    REGISTER_UFUNC_BINARY_RATIONAL(remainder)
+    REGISTER_UFUNC_BINARY_RATIONAL(true_divide)
+    REGISTER_UFUNC_BINARY_RATIONAL(floor_divide)
+    REGISTER_UFUNC_BINARY_RATIONAL(minimum)
+    REGISTER_UFUNC_BINARY_RATIONAL(maximum)
+    /* Comparisons */
+    REGISTER_UFUNC_BINARY_COMPARE(equal)
+    REGISTER_UFUNC_BINARY_COMPARE(not_equal)
+    REGISTER_UFUNC_BINARY_COMPARE(less)
+    REGISTER_UFUNC_BINARY_COMPARE(greater)
+    REGISTER_UFUNC_BINARY_COMPARE(less_equal)
+    REGISTER_UFUNC_BINARY_COMPARE(greater_equal)
+    /* Unary */
+    REGISTER_UFUNC_UNARY(negative)
+    REGISTER_UFUNC_UNARY(absolute)
+    REGISTER_UFUNC_UNARY(floor)
+    REGISTER_UFUNC_UNARY(ceil)
+    REGISTER_UFUNC_UNARY(trunc)
+    REGISTER_UFUNC_UNARY(rint)
+    REGISTER_UFUNC_UNARY(square)
+    REGISTER_UFUNC_UNARY(reciprocal)
+    REGISTER_UFUNC_UNARY(sign)
+    #undef REGISTER_UFUNC
+    #undef REGISTER_UFUNC_BINARY_RATIONAL
+    #undef REGISTER_UFUNC_BINARY_COMPARE
+    #undef REGISTER_UFUNC_UNARY
+
+    return 0;
+}
+
+
 static PyMethodDef module_methods[] = {
     {0} /* sentinel */
 };
@@ -1118,6 +1306,8 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
     PyObject* numpy_str;
     PyObject* numpy;
     int npy_rational;
+    int npy_rational2;
+    PyArray_Descr *npyrational2_descr = NULL;
 
     import_array();
     if (PyErr_Occurred()) {
@@ -1172,91 +1362,93 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
         goto fail;
     }
 
-    /* Register casts to and from rational */
-    #define REGISTER_CAST(From,To,from_descr,to_typenum,safe) { \
-            PyArray_Descr* from_descr_##From##_##To = (from_descr); \
-            if (PyArray_RegisterCastFunc(from_descr_##From##_##To, \
-                                         (to_typenum), \
-                                         npycast_##From##_##To) < 0) { \
-                goto fail; \
-            } \
-            if (safe && PyArray_RegisterCanCast(from_descr_##From##_##To, \
-                                                (to_typenum), \
-                                                NPY_NOSCALAR) < 0) { \
-                goto fail; \
-            } \
-        }
-    #define REGISTER_INT_CASTS(bits) \
-        REGISTER_CAST(npy_int##bits, rational, \
-                      PyArray_DescrFromType(NPY_INT##bits), npy_rational, 1) \
-        REGISTER_CAST(rational, npy_int##bits, npyrational_descr, \
-                      NPY_INT##bits, 0)
-    REGISTER_INT_CASTS(8)
-    REGISTER_INT_CASTS(16)
-    REGISTER_INT_CASTS(32)
-    REGISTER_INT_CASTS(64)
-    REGISTER_CAST(rational,float,npyrational_descr,NPY_FLOAT,0)
-    REGISTER_CAST(rational,double,npyrational_descr,NPY_DOUBLE,1)
-    REGISTER_CAST(npy_bool,rational, PyArray_DescrFromType(NPY_BOOL),
-                  npy_rational,1)
-    REGISTER_CAST(rational,npy_bool,npyrational_descr,NPY_BOOL,0)
-
-    /* Register ufuncs */
-    #define REGISTER_UFUNC(name,...) { \
-        PyUFuncObject* ufunc = \
-            (PyUFuncObject*)PyObject_GetAttrString(numpy, #name); \
-        int _types[] = __VA_ARGS__; \
-        if (!ufunc) { \
-            goto fail; \
-        } \
-        if (sizeof(_types)/sizeof(int)!=ufunc->nargs) { \
-            PyErr_Format(PyExc_AssertionError, \
-                         "ufunc %s takes %d arguments, our loop takes %lu", \
-                         #name, ufunc->nargs, (unsigned long) \
-                         (sizeof(_types)/sizeof(int))); \
-            Py_DECREF(ufunc); \
-            goto fail; \
-        } \
-        if (PyUFunc_RegisterLoopForType((PyUFuncObject*)ufunc, npy_rational, \
-                rational_ufunc_##name, _types, 0) < 0) { \
-            Py_DECREF(ufunc); \
-            goto fail; \
-        } \
-        Py_DECREF(ufunc); \
+    /* Register casts and ufunc loops for the legacy `rational` dtype. */
+    if (register_rational_casts_and_ufuncs(
+            npy_rational, npyrational_descr, numpy) < 0) {
+        goto fail;
     }
-    #define REGISTER_UFUNC_BINARY_RATIONAL(name) \
-        REGISTER_UFUNC(name, {npy_rational, npy_rational, npy_rational})
-    #define REGISTER_UFUNC_BINARY_COMPARE(name) \
-        REGISTER_UFUNC(name, {npy_rational, npy_rational, NPY_BOOL})
-    #define REGISTER_UFUNC_UNARY(name) \
-        REGISTER_UFUNC(name, {npy_rational, npy_rational})
-    /* Binary */
-    REGISTER_UFUNC_BINARY_RATIONAL(add)
-    REGISTER_UFUNC_BINARY_RATIONAL(subtract)
-    REGISTER_UFUNC_BINARY_RATIONAL(multiply)
-    REGISTER_UFUNC_BINARY_RATIONAL(divide)
-    REGISTER_UFUNC_BINARY_RATIONAL(remainder)
-    REGISTER_UFUNC_BINARY_RATIONAL(true_divide)
-    REGISTER_UFUNC_BINARY_RATIONAL(floor_divide)
-    REGISTER_UFUNC_BINARY_RATIONAL(minimum)
-    REGISTER_UFUNC_BINARY_RATIONAL(maximum)
-    /* Comparisons */
-    REGISTER_UFUNC_BINARY_COMPARE(equal)
-    REGISTER_UFUNC_BINARY_COMPARE(not_equal)
-    REGISTER_UFUNC_BINARY_COMPARE(less)
-    REGISTER_UFUNC_BINARY_COMPARE(greater)
-    REGISTER_UFUNC_BINARY_COMPARE(less_equal)
-    REGISTER_UFUNC_BINARY_COMPARE(greater_equal)
-    /* Unary */
-    REGISTER_UFUNC_UNARY(negative)
-    REGISTER_UFUNC_UNARY(absolute)
-    REGISTER_UFUNC_UNARY(floor)
-    REGISTER_UFUNC_UNARY(ceil)
-    REGISTER_UFUNC_UNARY(trunc)
-    REGISTER_UFUNC_UNARY(rint)
-    REGISTER_UFUNC_UNARY(square)
-    REGISTER_UFUNC_UNARY(reciprocal)
-    REGISTER_UFUNC_UNARY(sign)
+
+    /*
+     * Register a second rational dtype through the new DType API using the
+     * `NPY_DT_legacy_descriptor_proto` slot.  We reuse the proto above
+     * (already copied out by `PyArray_RegisterDataType`) and only patch
+     * the fields that must differ for the new variant.
+     *
+     * NOTE(seberg): Once parts of the legacy API are deprecated (e.g.
+     * adding casts) we can clean this up to only use the rational2 path.
+     */
+    PyRational2_Type.tp_base = &PyRational_Type;
+    PyRational2_Type.tp_basicsize = sizeof(PyRational);
+    if (PyType_Ready(&PyRational2_Type) < 0) {
+        goto fail;
+    }
+
+    npyrational_descr_proto.typeobj = &PyRational2_Type;
+    npyrational_descr_proto.type = 'R';
+    npyrational_descr_proto.type_num = 0;
+
+    {
+        PyType_Slot dtype_slots[] = {
+            {NPY_DT_legacy_descriptor_proto, &npyrational_descr_proto},
+            {NPY_DT_common_dtype, rational2_common_dtype},
+            {0, NULL},
+        };
+
+        /* Within-DType identity cast (NULL `dtypes` slots are filled in
+         * by `PyArrayInitDTypeMeta_FromSpec`). */
+        static PyType_Slot within_dtype_slots[] = {
+            {NPY_METH_strided_loop, rational2_within_dtype_loop},
+            {NPY_METH_unaligned_strided_loop, rational2_within_dtype_loop},
+            {0, NULL},
+        };
+        static PyArray_DTypeMeta *within_dtype_dtypes[2] = {NULL, NULL};
+        static PyArrayMethod_Spec within_dtype_cast = {
+            .name = "cast_rational2_within_dtype",
+            .nin = 1,
+            .nout = 1,
+            .casting = NPY_NO_CASTING,
+            .flags = NPY_METH_SUPPORTS_UNALIGNED,
+            .dtypes = within_dtype_dtypes,
+            .slots = within_dtype_slots,
+        };
+        static PyArrayMethod_Spec *casts[] = {&within_dtype_cast, NULL};
+
+        PyArrayDTypeMeta_Spec dtype_spec = {
+            .typeobj = &PyRational2_Type,
+            .flags = 0,
+            .casts = casts,
+            .slots = dtype_slots,
+            .baseclass = NULL,
+        };
+
+        Py_SET_TYPE(&NPY_Rational2DType, &PyArrayDTypeMeta_Type);
+        ((PyTypeObject *)&NPY_Rational2DType)->tp_base = &PyArrayDescr_Type;
+        if (PyType_Ready((PyTypeObject *)&NPY_Rational2DType) < 0) {
+            goto fail;
+        }
+        if (PyArrayInitDTypeMeta_FromSpec(
+                &NPY_Rational2DType, &dtype_spec) < 0) {
+            goto fail;
+        }
+    }
+    npy_rational2 = NPY_Rational2DType.type_num;
+    npyrational2_descr = NPY_Rational2DType.singleton;
+    Py_INCREF(npyrational2_descr);
+
+    /* The new path only propagates copyswap/copyswapn from the proto;
+     * install the remaining ArrFuncs (getitem/setitem, compare, etc.). */
+    *PyDataType_GetArrFuncs(npyrational2_descr) = npyrational_arrfuncs;
+
+    /* Support `dtype(rational2)` */
+    if (PyDict_SetItemString(PyRational2_Type.tp_dict, "dtype",
+            (PyObject *)npyrational2_descr) < 0) {
+        goto fail;
+    }
+
+    if (register_rational_casts_and_ufuncs(
+            npy_rational2, npyrational2_descr, numpy) < 0) {
+        goto fail;
+    }
 
     /* Create module */
     m = PyModule_Create(&moduledef);
@@ -1268,6 +1460,12 @@ PyMODINIT_FUNC PyInit__rational_tests(void) {
     /* Add rational type */
     Py_INCREF(&PyRational_Type);
     PyModule_AddObject(m,"rational",(PyObject*)&PyRational_Type);
+
+    /* Add the new-API rational variant (subclass of `rational`) */
+    Py_INCREF(&PyRational2_Type);
+    PyModule_AddObject(m, "rational2", (PyObject *)&PyRational2_Type);
+    Py_INCREF((PyObject *)&NPY_Rational2DType);
+    PyModule_AddObject(m, "Rational2DType", (PyObject *)&NPY_Rational2DType);
 
     /* Create matrix multiply generalized ufunc */
     {

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -4,7 +4,7 @@ import pytest
 
 import numpy as np
 import numpy._core.umath as ncu
-from numpy._core._rational_tests import rational
+from numpy._core._rational_tests import rational, rational2
 from numpy.lib import stride_tricks
 from numpy.testing import (
     HAS_REFCOUNT,
@@ -190,11 +190,12 @@ def test___array___refcount():
     assert_equal(old_refcount2, sys.getrefcount(dt2))
 
 
+@pytest.mark.parametrize("rat_cls", [rational, rational2])
 @pytest.mark.parametrize("array", [True, False])
-def test_array_impossible_casts(array):
+def test_array_impossible_casts(array, rat_cls):
     # All builtin types can be forcibly cast, at least theoretically,
     # but user dtypes cannot necessarily.
-    rt = rational(1, 2)
+    rt = rat_cls(1, 2)
     if array:
         rt = np.array(rt)
     with assert_raises(TypeError):

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -11,7 +11,7 @@ from pytest import param
 
 import numpy as np
 import numpy._core._multiarray_umath as ncu
-from numpy._core._rational_tests import rational
+from numpy._core._rational_tests import rational, rational2
 from numpy.testing import IS_64BIT, assert_array_equal
 
 
@@ -112,6 +112,7 @@ def scalar_instances(times=True, extended_precision=True, user_dtype=True):
     # Rational:
     if user_dtype:
         yield param(rational(1, 2), id="rational")
+        yield param(rational2(1, 2), id="rational2")
 
     # Cannot create a structured void scalar directly:
     structured = np.array([(1, 3)], "i,i")[0]

--- a/numpy/_core/tests/test_arrayobject.py
+++ b/numpy/_core/tests/test_arrayobject.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 import numpy as np
-from numpy._core._rational_tests import rational
+from numpy._core._rational_tests import rational, rational2
 from numpy.testing import HAS_REFCOUNT, assert_array_equal
 
 
@@ -97,7 +97,8 @@ def test_cleanup_with_refs_non_contig():
 
 
 @pytest.mark.parametrize("dtype",
-    list("?bhilqnpBHILQNPefdgSUV") + ["M8[ns]", "m8[ns]", rational])
+    list("?bhilqnpBHILQNPefdgSUV") +
+    ["M8[ns]", "m8[ns]", rational, rational2])
 def test_real_imag_attributes_non_complex(dtype):
     dtype = np.dtype(dtype)
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -17,7 +17,7 @@ from hypothesis.extra import numpy as hynp
 import numpy as np
 import numpy.dtypes
 from numpy._core._multiarray_tests import create_custom_field_dtype
-from numpy._core._rational_tests import rational
+from numpy._core._rational_tests import rational, rational2
 from numpy.testing import (
     HAS_REFCOUNT,
     IS_64BIT,
@@ -1338,7 +1338,7 @@ class TestPickling:
 
     @pytest.mark.parametrize("DType",
         [type(np.dtype(t)) for t in np.typecodes['All']] +
-        [type(np.dtype(rational)), np.dtype])
+        [type(np.dtype(rational)), type(np.dtype(rational2)), np.dtype])
     def test_pickle_dtype_class(self, DType):
         # Check that DTypes (the classes/types) roundtrip when pickling
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1347,7 +1347,7 @@ class TestPickling:
 
     @pytest.mark.parametrize("dt",
         [np.dtype(t) for t in np.typecodes['All']] +
-        [np.dtype(rational)])
+        [np.dtype(rational), np.dtype(rational2)])
     def test_pickle_dtype(self, dt):
         # Check that dtype instances roundtrip when pickling and that pickling
         # doesn't change the hash value
@@ -1434,14 +1434,15 @@ class TestPromotion:
         res = np.minimum(np.ones(3, dtype=other), complex_scalar).dtype
         assert res == expected
 
-    def test_complex_pyscalar_promote_rational(self):
+    @pytest.mark.parametrize("rat_cls", [rational, rational2])
+    def test_complex_pyscalar_promote_rational(self, rat_cls):
         with pytest.raises(TypeError,
                 match=r".* no common DType exists for the given inputs"):
-            np.result_type(1j, rational)
+            np.result_type(1j, rat_cls)
 
         with pytest.raises(TypeError,
                 match=r".* no common DType exists for the given inputs"):
-            np.result_type(1j, rational(1, 2))
+            np.result_type(1j, rat_cls(1, 2))
 
     @pytest.mark.parametrize("val", [2, 2**32, 2**63, 2**64, 2 * 100])
     def test_python_integer_promotion(self, val):
@@ -1484,14 +1485,24 @@ class TestPromotion:
             assert np.result_type(*perm) == expected
 
 
-def test_rational_dtype():
+def test_rational2_uses_new_dtype_api():
+    # ``rational2`` provides its own ``common_dtype`` slot (which the
+    # legacy ``rational`` cannot), and that slot rejects floats.
+    assert np.result_type(rational, 1.0) == np.float64
+    with pytest.raises(TypeError,
+            match=r".* no common DType exists for the given inputs"):
+        np.result_type(rational2, 1.0)
+
+
+@pytest.mark.parametrize("rat_cls", [rational, rational2])
+def test_rational_dtype(rat_cls):
     # test for bug gh-5719
-    a = np.array([1111], dtype=rational).astype
+    a = np.array([1111], dtype=rat_cls).astype
     assert_raises(OverflowError, a, 'int8')
 
     # test that dtype detection finds user-defined types
-    x = rational(1)
-    assert_equal(np.array([x, x]).dtype, np.dtype(rational))
+    x = rat_cls(1)
+    assert np.array([x, x]).dtype.type is rat_cls
 
 
 def test_dtypes_are_true():
@@ -1599,14 +1610,15 @@ class TestFromDTypeProtocol:
 
 
 class TestDTypeClasses:
-    @pytest.mark.parametrize("dtype", list(np.typecodes['All']) + [rational])
+    @pytest.mark.parametrize(
+        "dtype", list(np.typecodes['All']) + [rational, rational2])
     def test_basic_dtypes_subclass_properties(self, dtype):
         # Note: Except for the isinstance and type checks, these attributes
         #       are considered currently private and may change.
         dtype = np.dtype(dtype)
         assert isinstance(dtype, np.dtype)
         assert type(dtype) is not np.dtype
-        if dtype.type.__name__ != "rational":
+        if dtype.type.__name__ not in ("rational", "rational2"):
             dt_name = type(dtype).__name__.lower().removesuffix("dtype")
             if dt_name in {"uint", "int"}:
                 # The scalar names has a `c` attached because "int" is Python
@@ -1617,7 +1629,7 @@ class TestDTypeClasses:
             assert type(dtype).__module__ == "numpy.dtypes"
 
             assert getattr(numpy.dtypes, type(dtype).__name__) is type(dtype)
-        else:
+        elif dtype.type.__name__ == "rational":
             assert type(dtype).__name__ == "dtype[rational]"
             assert type(dtype).__module__ == "numpy"
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -30,7 +30,7 @@ import pytest
 
 import numpy as np
 import numpy._core._multiarray_tests as _multiarray_tests
-from numpy._core._rational_tests import rational
+from numpy._core._rational_tests import rational, rational2
 from numpy._core.multiarray import _get_ndarray_c_version, dot
 from numpy._core.tests._locales import CommaDecimalPointLocale
 from numpy.exceptions import AxisError, ComplexWarning
@@ -8725,7 +8725,11 @@ class TestNewBufferProtocol:
 
     @pytest.mark.parametrize(["obj", "error"], [
             pytest.param(np.array([1, 2], dtype=rational), ValueError, id="array"),
-            pytest.param(rational(1, 2), TypeError, id="scalar")])
+            pytest.param(rational(1, 2), TypeError, id="scalar"),
+            pytest.param(np.array([1, 2], dtype=rational2),
+                         ValueError, id="array_new_api"),
+            pytest.param(rational2(1, 2), TypeError,
+                         id="scalar_new_api")])
     def test_export_and_pickle_user_dtype(self, obj, error):
         # User dtypes should export successfully when FORMAT was not requested.
         with pytest.raises(error):

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -272,10 +272,12 @@ def test_stringdtype_multithreaded_access_and_mutation():
     not IS_64BIT,
     reason="Sometimes causes failures or crashes due to OOM on 32 bit runners"
 )
-def test_legacy_usertype_cast_init_thread_safety():
+@pytest.mark.parametrize("rat_cls", [
+    _rational_tests.rational, _rational_tests.rational2])
+def test_legacy_usertype_cast_init_thread_safety(rat_cls):
     def closure(b):
         b.wait()
-        np.full((10, 10), 1, _rational_tests.rational)
+        np.full((10, 10), 1, rat_cls)
 
     run_threaded(closure, 250, pass_barrier=True)
 

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -13,7 +13,7 @@ from hypothesis.extra import numpy as hynp
 import numpy as np
 from numpy import ma
 from numpy._core import sctypes
-from numpy._core._rational_tests import rational
+from numpy._core._rational_tests import rational, rational2
 from numpy._core.numerictypes import obj2sctype
 from numpy.exceptions import AxisError
 from numpy.random import rand, randint, randn
@@ -1298,7 +1298,8 @@ class TestTypes:
 
     @pytest.mark.parametrize("dtype",
             list(np.typecodes["All"]) +
-            ["i,i", "10i", "S3", "S100", "U3", "U100", rational])
+            ["i,i", "10i", "S3", "S100", "U3", "U100",
+             rational, rational2])
     def test_promote_identical_types_metadata(self, dtype):
         # The same type passed in twice to promote types always
         # preserves metadata
@@ -1329,7 +1330,8 @@ class TestTypes:
     @pytest.mark.parametrize(["dtype1", "dtype2"],
             itertools.product(
                 list(np.typecodes["All"]) +
-                ["i,i", "S3", "S100", "U3", "U100", rational],
+                ["i,i", "S3", "S100", "U3", "U100",
+                 rational, rational2],
                 repeat=2))
     def test_promote_types_metadata(self, dtype1, dtype2):
         """Metadata handling in promotion does not appear formalized
@@ -1506,7 +1508,7 @@ class TestTypes:
             np.can_cast(4j, "complex128", casting="unsafe")
 
     @pytest.mark.parametrize("dtype",
-            list("?bhilqBHILQefdgFDG") + [rational])
+            list("?bhilqBHILQefdgFDG") + [rational, rational2])
     def test_can_cast_scalars(self, dtype):
         # Basic test to ensure that scalars are supported in can-cast
         # (does not check behavior exhaustively).

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -507,9 +507,11 @@ class Test_sctype2char:
         assert_equal(sctype2char(np.ndarray), 'O')
 
     def test_third_party_scalar_type(self):
-        from numpy._core._rational_tests import rational
+        from numpy._core._rational_tests import rational, rational2
         assert_raises(KeyError, sctype2char, rational)
         assert_raises(KeyError, sctype2char, rational(1))
+        assert_raises(KeyError, sctype2char, rational2)
+        assert_raises(KeyError, sctype2char, rational2(1))
 
     def test_array_instance(self):
         assert_equal(sctype2char(np.array([1.0, 2.0])), 'd')

--- a/numpy/_core/tests/test_scalarbuffer.py
+++ b/numpy/_core/tests/test_scalarbuffer.py
@@ -5,7 +5,7 @@ import pytest
 
 import numpy as np
 from numpy._core._multiarray_tests import get_buffer_info
-from numpy._core._rational_tests import rational
+from numpy._core._rational_tests import rational, rational2
 from numpy.testing import assert_, assert_equal, assert_raises
 
 # PEP3118 format strings for native (standard alignment and byteorder) types
@@ -143,8 +143,9 @@ class TestScalarPEP3118:
         with pytest.raises(BufferError, match="scalar buffer is readonly"):
             get_buffer_info(s, ["WRITABLE"])
 
-    def test_user_scalar_fails_buffer(self):
-        r = rational(1)
+    @pytest.mark.parametrize("rat_cls", [rational, rational2])
+    def test_user_scalar_fails_buffer(self, rat_cls):
+        r = rat_cls(1)
         with assert_raises(TypeError):
             memoryview(r)
 

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -11,7 +11,7 @@ from hypothesis.extra import numpy as hynp
 from hypothesis.strategies import sampled_from
 
 import numpy as np
-from numpy._core._rational_tests import rational
+from numpy._core._rational_tests import rational, rational2
 from numpy._utils import _pep440
 from numpy.exceptions import ComplexWarning
 from numpy.testing import (
@@ -869,7 +869,7 @@ def recursionlimit(n):
 
 @given(sampled_from(objecty_things),
        sampled_from(binary_operators_for_scalar_ints),
-       sampled_from(types + [rational]))
+       sampled_from(types + [rational, rational2]))
 @pytest.mark.thread_unsafe(reason="sets recursion limit globally")
 def test_operator_object_left(o, op, type_):
     try:
@@ -881,7 +881,7 @@ def test_operator_object_left(o, op, type_):
 
 @given(sampled_from(objecty_things),
        sampled_from(binary_operators_for_scalar_ints),
-       sampled_from(types + [rational]))
+       sampled_from(types + [rational, rational2]))
 @pytest.mark.thread_unsafe(reason="sets recursion limit globally")
 def test_operator_object_right(o, op, type_):
     try:

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2169,6 +2169,7 @@ class TestUfunc:
     @pytest.mark.parametrize("a", (
                              np.arange(10, dtype=int),
                              np.arange(10, dtype=_rational_tests.rational),
+                             np.arange(10, dtype=_rational_tests.rational2),
                              ))
     def test_ufunc_at_basic(self, a):
 

--- a/numpy/lib/tests/test_stride_tricks.py
+++ b/numpy/lib/tests/test_stride_tricks.py
@@ -1,7 +1,7 @@
 import pytest
 
 import numpy as np
-from numpy._core._rational_tests import rational
+from numpy._core._rational_tests import rational, rational2
 from numpy.lib._stride_tricks_impl import (
     _broadcast_shape,
     as_strided,
@@ -400,6 +400,13 @@ def test_as_strided():
     # Custom dtypes should not be lost (gh-9161)
     r = [rational(i) for i in range(4)]
     a = np.array(r, dtype=rational)
+    a_view = as_strided(a, shape=(3, 4), strides=(0, a.itemsize))
+    assert_equal(a.dtype, a_view.dtype)
+    assert_array_equal([r] * 3, a_view)
+
+    # Also exercise the new-DType-API rational variant.
+    r = [rational2(i) for i in range(4)]
+    a = np.array(r, dtype=rational2)
     a_view = as_strided(a, shape=(3, 4), strides=(0, a.itemsize))
     assert_equal(a.dtype, a_view.dtype)
     assert_array_equal([r] * 3, a_view)


### PR DESCRIPTION
This adds and importantly *backports* a way for legacy dtypes to transition to the new API.
I.e. with one caveat I found for now (array dtype printing prints as `np.array([1.0], dtype=repr(dtype))` and the repr now shouldn't be `bfloat16` for an `ml_dtype` bfloat16), this allows transitioning a package like `ml_dtypes` over.

Sure... For now it effectively just keep using some old code paths, but:
* It allows us to seriously start tthinking to deprecate old registration paths (and importantly casts)!
* It allows `ml_dtypes` to use new features they should want:
  * New-style `common_dtype` allows to fix most promotions, e.g. with Python integers (but also between their own dtypes).
  * `np.finfo` support (NumPy 2.4+).
  * ... I am missing something probably, plus anything else we add in future versions can be used if the runtime NumPy is new enough (with some manual header vendoring).

I am still thinking about how to test this and possibly adding some more sanity checks.
But: I have tested this with `ml_dtypes` and especially if the larger google tests run with that; that is presumably more thorough than anything we can do.

Yes, the backport is a bit of a hack (and in one place hinges on a very fun little implementation detail), but the important thing is that it works...

---

I think this is a good way to move forward, otherwise any single small issue in NumPy can be a regression for `ml_dtypes` and while for e.g. `quaddtype` that type of thing isn't all that bad (fix it, require newer NumPy version), for `ml_dtypes` it prevents a smooth transition.

This enables that transition, and if we are a bit agressive, dtypes are niche enough that I would be up for deprecating the old API functions soon unless some larger issue pops up.

(Did use a bit of claude to get started on the code.)