### PR TITLE
BUG: Prevent deadlock due to downstream importing NumPy in dlopen

### DIFF
--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -848,7 +848,14 @@ else:
     del _mac_os_check
 
     def blas_fpe_check():
-        # Check if BLAS adds spurious FPEs, mostly seen on M4 arms with Accelerate.
+        if sys.platform != "darwin":
+            # We currently assume this is limited to MacOS as downstream NumPy
+            # import during dlopen caused a deadlock regression: gh-31284
+            return
+
+        # Check if BLAS adds spurious FPEs, seen on M4 arms with Accelerate.
+        # In this case we disable FPE reporting since the use of SME poisons
+        # it and Accelerate doesn't sanitize them.
         with errstate(all='raise'):
             x = ones((20, 20))
             try:


### PR DESCRIPTION
Downstream should probably never import numpy (i.e. activate the C-API) during dlopen (rather than the Python module init function).

But if it does so, this check introduced a deadlock regression because dlopen has a recursive lock, but this breaks if the matmul is called and causes threads to spawn that also need to dlopen.

So, as a hot-fix, just only run the check on MacOS, since we are not currently aware of reports on other system (possible or not), although this did happen with certain OpenBLAS versions (and not just accelerate).

(I cannot fully rule out that there won't be regressions on some linux setups, but they were not yet reported. -- The "limit to 1 thread" solution is an alternative as well.)

EDIT: addresses gh-31284. Should be backported for 2.4.5
