### PR TITLE
MAINT: Use Python 3.12 for dependabot pip updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
     directory: /requirements
     schedule:
       interval: daily
+    python-version: "3.12"  # Dependencies are requiring newer python
     cooldown:
       default-days: 7     # optional
     groups:


### PR DESCRIPTION
Seems pytest has dropped support for older python versions. Make dependabot use a newer version. This is only needed for the pip ecosystem. The suggestion going forward is to always use NumPy's lowest supported version. 

[skip azp] [skip cirrus] [skip actions]

#### AI Disclosure

Grok suggested this fix after looking at the dependabot log.
