### PR TITLE
Fix recarray._set_dtype being None instead of callable

### DIFF
--- a/numpy/_core/records.py
+++ b/numpy/_core/records.py
@@ -402,7 +402,13 @@ class recarray(ndarray):
             )
         return self
 
-    _set_dtype = None  # __array_finalize__ can deal with dtype changes
+    def _set_dtype(self, dtype):
+        """Set the dtype, wrapping in record type if needed."""
+        if (dtype.type is not record and
+                issubclass(dtype.type, nt.void) and
+                dtype.names is not None):
+            dtype = sb.dtype((record, dtype))
+        ndarray._set_dtype(self, dtype)
 
     def __array_finalize__(self, obj):
         if (self.dtype.type is not record and


### PR DESCRIPTION
## Summary

The `recarray` class assigns `_set_dtype = None` as a class attribute (line 405), with the comment that `__array_finalize__` handles dtype changes. However, external code such as astropy calls `_set_dtype` directly on recarray instances, which raises `TypeError: 'NoneType' object is not callable`.

## Change

Replace the `None` assignment with a proper method that wraps void dtypes with the record type before delegating to `ndarray._set_dtype`. This mirrors the existing logic in `__array_finalize__` (lines 414-417) and is consistent with how `MaskedArray` handles the same pattern (`numpy/ma/core.py:3491-3492`).

## Test case (from issue)

```python
import numpy as np
a = np.array([1], dtype="float64").view(np.rec.recarray)
a._set_dtype("float64")  # previously: TypeError
```

Closes #31295