### PR TITLE
REV: "MAINT: Use Python 3.12 for dependabot pip updates."

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,6 @@ updates:
     directory: /requirements
     schedule:
       interval: daily
-    python-version: "3.12"  # Dependencies are requiring newer python
     cooldown:
       default-days: 7     # optional
     groups:


### PR DESCRIPTION
Reverts numpy/numpy#31307. Dependabot does not support the added line.