### PR TITLE
MAINT: Update some requirements.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - pytest-xdist
   - hypothesis
   # For type annotations
-  - mypy=1.20.0
+  - mypy==1.20.2
   - orjson # makes mypy faster
   # For building docs
   - sphinx>=4.5.0

--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -5,10 +5,10 @@ pydata-sphinx-theme>=0.16.1
 sphinx-copybutton
 sphinx-design
 scipy
-matplotlib!=3.10.6
+matplotlib>=3.10.8
 pandas
 breathe>=4.36.0
-ipython!=8.1.0
+ipython>=9.12.0
 # Needed for ipython>=8.17
 # https://github.com/ipython/ipython/issues/14237
 pickleshare

--- a/requirements/emscripten_test_requirements.txt
+++ b/requirements/emscripten_test_requirements.txt
@@ -1,4 +1,4 @@
-hypothesis==6.151.9
-pytest==9.0.2
+hypothesis==6.152.1
+pytest==9.0.3
 tzdata
 pytest-xdist

--- a/requirements/pkgconf_requirements.txt
+++ b/requirements/pkgconf_requirements.txt
@@ -1,1 +1,1 @@
-pkgconf==2.5.1.post1
+pkgconf==2.5.1.post1  # post2 has problems.

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,6 +1,6 @@
 Cython
-hypothesis==6.151.9
-pytest==9.0.2
+hypothesis==6.152.1
+pytest==9.0.3
 pytest-cov==7.1.0
 meson
 ninja; sys_platform != "emscripten"

--- a/requirements/typing_requirements.txt
+++ b/requirements/typing_requirements.txt
@@ -2,5 +2,5 @@
 
 -r test_requirements.txt
 
-mypy==1.20.0
+mypy==1.20.2
 pyrefly==0.61.0


### PR DESCRIPTION
Dependabot was not able to update these because it runs Python 3.9 and these packages have dropped support for that version. Dependabot might work if it read the pyproject.toml file to get the Python version, but then it would scan everything, and I am not ready for that experiment.

This might be a bit aggressive, we will see.


#### AI Disclosure

I used Grok to find the latest releases of a list of dependencies.