### PR TITLE
BUG: Fix segfault in nditer.multi_index when __getitem__ raises

### DIFF
--- a/numpy/_core/src/multiarray/nditer_pywrap.c
+++ b/numpy/_core/src/multiarray/nditer_pywrap.c
@@ -1676,6 +1676,9 @@ npyiter_multi_index_set(
         }
         for (idim = 0; idim < ndim; ++idim) {
             PyObject *v = PySequence_GetItem(value, idim);
+            if (v == NULL) {
+                return -1;
+            }
             multi_index[idim] = PyLong_AsLong(v);
             Py_DECREF(v);
             if (error_converting(multi_index[idim])) {

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -3660,3 +3660,19 @@ def test_signature_methods(method):
 
     assert "self" in sig.parameters
     assert sig.parameters["self"].kind is inspect.Parameter.POSITIONAL_ONLY
+
+
+def test_nditer_multi_index_no_segfault():
+    class BadSequence:
+        def __len__(self):
+            return 2
+
+        def __getitem__(self, i):
+            if i == 1:
+                raise RuntimeError("intentional error")
+            return 0
+
+    arr = np.zeros((3, 4))
+    it = np.nditer(arr, flags=["multi_index"])
+    with pytest.raises(RuntimeError, match="intentional error"):
+        it.multi_index = BadSequence()


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.


  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

Add a NULL check for PySequence_GetItem in the multi_index setter to prevent
segmentation faults when __getitem__ raises an exception.

As reported in:
https://gist.github.com/devdanzin/ccc2d9553ca1c90ab1835362ee21a40a#reproducer-3-nditermulti_index-segfault-with-raising-sequence
(discussed in https://github.com/numpy/numpy/issues/31046)

#### Reproduce error:
```py
import numpy as np

class BadSequence:
    def __len__(self):
        return 2

    def __getitem__(self, i):
        if i == 1:
            raise RuntimeError("intentional error")
        return 0



arr = np.zeros((3, 4))
it = np.nditer(arr, flags=["multi_index"])

it.multi_index = BadSequence()
```
#### Actual behavior:
```raw
Segmentation fault         (core dumped)
```

#### Expected behavior:
```py
RuntimeError: intentional error
```
### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->AI tools were used to assist with English writing and phrasing in this PR.
The technical analysis, debugging, and code changes were performed and verified manually.
