### PR TITLE
DOC: use base min and max rather than aliases amin and amax in see-also

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -3058,7 +3058,7 @@ def max(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
 
     See Also
     --------
-    amin :
+    min :
         The minimum value of an array along a given axis, propagating any NaNs.
     nanmax :
         The maximum value of an array along a given axis, ignoring any NaNs.
@@ -3196,7 +3196,7 @@ def min(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
 
     See Also
     --------
-    amax :
+    max :
         The maximum value of an array along a given axis, propagating any NaNs.
     nanmin :
         The minimum value of an array along a given axis, ignoring any NaNs.


### PR DESCRIPTION
### PR summary

Currently, the documentation for `numpy.max` has a see-also to `numpy.amin`, which only states that it's an alias of `numpy.min`, so you have to click through a second time to see the actual detail. Similarly in reverse from `numpy.min` to `numpy.amax` to `numpy.max`.

This seems to be left over from when `numpy.amax` and `numpy.amin` were the standard, documented forms. This PR changes these so that the intermediary page on the alias is skipped, and you go straight from the `numpy.max` documentation to the `numpy.min` documentation, similarly to before #23302 was merged.

### First time committer introduction

I am a research software engineer using Numpy heavily both directly and indirectly in my work in lattice quantum field theory. In this instance however I was teaching a [Software Carpentry lesson](https://swcarpentry.github.io/python-novice-inflammation) that makes use of both `amax` and `max`, and was looking up the reasoning behind the aliases, when I found the circuitous cross-references that this PR addresses.

#### AI Disclosure

No AI tools used.