### PR TITLE
MAINT: simplify view implementations in MaskedArray and recarray.

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3256,28 +3256,12 @@ class MaskedArray(ndarray):
         results.
         """
 
-        if dtype is None:
-            if type is None:
-                output = ndarray.view(self)
-            else:
-                output = ndarray.view(self, type)
-        elif type is None:
-            try:
-                if issubclass(dtype, ndarray):
-                    output = ndarray.view(self, dtype)
-                    dtype = None
-                else:
-                    output = ndarray.view(self, dtype)
-            except TypeError:
-                output = ndarray.view(self, dtype)
-        else:
-            output = ndarray.view(self, dtype, type)
+        if type is None and (isinstance(dtype, builtins.type)
+                             and issubclass(dtype, ndarray)):
+            type = dtype
+            dtype = None
 
-        # also make the mask be a view (so attr changes to the view's
-        # mask do no affect original object's mask)
-        # (especially important to avoid affecting np.masked singleton)
-        if getmask(output) is not nomask:
-            output._mask = output._mask.view()
+        output = super().view(*[a for a in (dtype, type) if a is not None])
 
         # Make sure to reset the _fill_value if needed
         if getattr(output, '_fill_value', None) is not None:

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -12,7 +12,7 @@ and the masking of individual fields.
 #  or whatever restricted keywords.  An idea would be to no bother in the
 #  first place, and then rename the invalid fields with a trailing
 #  underscore. Maybe we could just overload the parser function ?
-
+import builtins
 import warnings
 
 import numpy as np
@@ -353,40 +353,17 @@ class MaskedRecords(ma.MaskedArray):
         Returns a view of the mrecarray.
 
         """
-        # OK, basic copy-paste from MaskedArray.view.
-        if dtype is None:
-            if type is None:
-                output = np.ndarray.view(self)
-            else:
-                output = np.ndarray.view(self, type)
-        # Here again.
-        elif type is None:
-            try:
-                if issubclass(dtype, np.ndarray):
-                    output = np.ndarray.view(self, dtype)
-                else:
-                    output = np.ndarray.view(self, dtype)
-            # OK, there's the change
-            except TypeError:
-                dtype = np.dtype(dtype)
-                # we need to revert to MaskedArray, but keeping the possibility
-                # of subclasses (eg, TimeSeriesRecords), so we'll force a type
-                # set to the first parent
-                if dtype.fields is None:
-                    basetype = self.__class__.__bases__[0]
-                    output = self.__array__().view(dtype, basetype)
-                    output._update_from(self)
-                else:
-                    output = np.ndarray.view(self, dtype)
-                output._fill_value = None
-        else:
-            output = np.ndarray.view(self, dtype, type)
-        # Update the mask, just like in MaskedArray.view
-        if (getattr(output, '_mask', ma.nomask) is not ma.nomask):
-            mdtype = ma.make_mask_descr(output.dtype)
-            output._mask = self._mask.view(mdtype, np.ndarray)
-            output._mask = output._mask.reshape(output.shape)
-        return output
+        # If the new dtype has no fields, we need to revert to MaskedArray,
+        # but keep the possibility of subclasses (eg, TimeSeriesRecords).
+        # So we'll force a type set to the first parent.
+        if (type is None
+                and dtype is not None
+                and not (isinstance(dtype, builtins.type)
+                         and issubclass(dtype, np.ndarray))
+                and (dtype := np.dtype(dtype)).fields is None):
+            type = self.__class__.__bases__[0]
+
+        return super().view(*[a for a in (dtype, type) if a is not None])
 
     def harden_mask(self):
         """


### PR DESCRIPTION
These are possible after the changes in `ndarray.view()` in #31234 (and taken from the initial version of #31271). Also used the occasion to do `super().view` rather than calling `ndarray.view` (which predates the introduction of `super` in python...).

No AI used.