### PR TITLE
BUG: pass sorted=False in unique_all, unique_counts, and unique_inverse

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -493,6 +493,7 @@ def unique_all(x):
         return_inverse=True,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueAllResult(*result)
 
@@ -549,6 +550,7 @@ def unique_counts(x):
         return_inverse=False,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueCountsResult(*result)
 
@@ -606,6 +608,7 @@ def unique_inverse(x):
         return_inverse=True,
         return_counts=False,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueInverseResult(*result)
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -1,6 +1,8 @@
 """Test functions for 1D array set operations.
 
 """
+from unittest import mock
+
 import pytest
 
 import numpy as np
@@ -1217,15 +1219,19 @@ class TestUnique:
         for res_unique_array_api, res_unique in [
             (
                 np.unique_values(arr),
-                np.unique(arr, equal_nan=False)
+                np.unique(arr, equal_nan=False, sorted=False)
             ),
             (
                 np.unique_counts(arr),
-                np.unique(arr, return_counts=True, equal_nan=False)
+                np.unique(
+                    arr, return_counts=True, equal_nan=False, sorted=False
+                )
             ),
             (
                 np.unique_inverse(arr),
-                np.unique(arr, return_inverse=True, equal_nan=False)
+                np.unique(
+                    arr, return_inverse=True, equal_nan=False, sorted=False
+                )
             ),
             (
                 np.unique_all(arr),
@@ -1234,7 +1240,8 @@ class TestUnique:
                     return_index=True,
                     return_inverse=True,
                     return_counts=True,
-                    equal_nan=False
+                    equal_nan=False,
+                    sorted=False,
                 )
             )
         ]:
@@ -1247,6 +1254,27 @@ class TestUnique:
             for actual, expected in zip(res_unique_array_api, res_unique):
                 # Order of output is not guaranteed
                 assert_equal(np.sort(actual), np.sort(expected))
+
+    @pytest.mark.thread_unsafe(
+        reason="patches numpy.lib._arraysetops_impl.unique in-process"
+    )
+    @mock.patch("numpy.lib._arraysetops_impl.unique", wraps=np.unique)
+    def test_array_api_unique_forwards_sorted_false(self, m_unique):
+        # Array API helpers must call ``unique(..., sorted=False)`` as documented
+        # (avoids the default unique(sorted=True) and locks in the contract).
+        x = np.array([3, 1, 2, 1])
+        for helper in (
+            np.unique_values,
+            np.unique_counts,
+            np.unique_inverse,
+            np.unique_all,
+        ):
+            m_unique.reset_mock()
+            helper(x)
+            m_unique.assert_called_once()
+            assert m_unique.call_args.kwargs.get("sorted") is False, (
+                helper.__name__
+            )
 
     def test_unique_inverse_shape(self):
         # Regression test for https://github.com/numpy/numpy/issues/25552


### PR DESCRIPTION
## Summary

- Pass `sorted=False` into `np.unique` from `unique_all`, `unique_counts`, and `unique_inverse`, matching the documented Array API contract and the existing `unique_values` implementation (see #31241).
- Add the test coverage that was [requested in #31244](https://github.com/numpy/numpy/pull/31244#issuecomment-4244681030):
  - `test_unique_array_api_functions` now uses `np.unique(..., sorted=False, ...)` as the reference, consistent with the docstrings.
  - `test_array_api_unique_forwards_sorted_false` patches `unique` and asserts the four `unique_*` helpers forward `sorted=False`, so a missing keyword would fail the test.

## Note

Follow-up to #31244, with the tests maintainers asked for there.

A quick bit of context: a [comment on a CPython PR](https://github.com/python/cpython/pull/148939#issuecomment-4308615641) is why my account was restricted on that project—I had a clumsy first try at a workflow that didn’t match what they want, and it read the wrong way. I’m not running automation against upstreams; these are one-off, small fixes on my own time, and I’m trying to be easy to review. I kept this change strictly to the `sorted` plumbing and tests. If anything still feels off, I’m happy to follow whatever process you prefer.

Closes #31241
