### PR TITLE
MAINT: Refactor subarray handling in _set_dtype, NewFromDescr, and views

### DIFF
--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -18,6 +18,7 @@
 #include "get_attr_string.h"
 #include "mem_overlap.h"
 #include "array_coercion.h"
+#include "alloc.h"  /* for npy_alloc_cache_dim */
 
 /*
  * The casting to use for implicit assignment operations resulting from
@@ -371,49 +372,68 @@ _may_have_objects(PyArray_Descr *dtype)
 }
 
 /*
- * Get a sub-array descriptor base, storing the subarray
- * dimensions and strides, and updating the number of dimensions
- * of the array.
+ * Get the number of dimensions of a subarray.  If added to nd,
+ * it exceeds NPY_MAXDIMS, return -1 with an exception set.
+ */
+static inline int
+_get_subarray_ndim(const PyArray_Descr *descr, const int nd)
+{
+    PyObject *shape = PyDataType_SUBARRAY(descr)->shape;
+    assert(shape);
+    int subnd = PyTuple_Check(shape) ? PyTuple_GET_SIZE(shape) : 1;
+    if (nd + subnd > NPY_MAXDIMS) {
+        PyErr_Format(PyExc_ValueError,
+                "number of dimensions must be within [0, %d]", NPY_MAXDIMS);
+        return -1;
+    }
+    return subnd;
+}
+
+/*
+ * For a sub-array descriptor, return the base descriptor,
+ * set newnd to nd plus the number of subarray dimensions,
+ * and fill newdims by copying nd items from dims and appending
+ * newnd-nd items from the subarray.
+ * If newstrides != NULL, newstrides are similarly filled.
  *
- * Strides are only stored if needed.
+ * Note: caller has to ensure that descr is a subarray, and that
+ * newdims and newstrides are big enough (i.e., NPY_MAXDIMS if
+ * the new size is not yet known).
  */
 NPY_NO_EXPORT PyArray_Descr*
 _get_subarray_base_and_dimensions(
     const PyArray_Descr *descr,
     const int nd, const npy_intp *dims, const npy_intp *strides,
-    int *new_nd, npy_intp *new_dims, npy_intp *new_strides)
+    int *newnd, npy_intp *newdims, npy_intp *newstrides)
 {
-    PyObject *shape = PyDataType_SUBARRAY(descr)->shape;
     PyArray_Descr *base = PyDataType_SUBARRAY(descr)->base;
-    assert(shape && base);
-    npy_bool tuple = PyTuple_Check(shape);
-    int sub_nd = tuple ? PyTuple_GET_SIZE(shape) : 1;
+    PyObject *shape = PyDataType_SUBARRAY(descr)->shape;
+    assert(base && shape);
 
-    if (nd + sub_nd > NPY_MAXDIMS) {
-        PyErr_Format(PyExc_ValueError,
-                "number of dimensions must be within [0, %d]", NPY_MAXDIMS);
+    int subnd = _get_subarray_ndim(descr, nd);
+    if (subnd < 0) {
         return NULL;
     }
 
-    *new_nd = nd + sub_nd;
-    memcpy(new_dims, dims, nd * sizeof(npy_intp));
-    if (tuple) {
-        for (int i = 0; i < sub_nd; i++) {
-            new_dims[i+nd] = (npy_intp)PyLong_AsLong(PyTuple_GET_ITEM(shape, i));
+    *newnd = nd + subnd;
+    memcpy(newdims, dims, nd * sizeof(npy_intp));
+    if (PyTuple_Check(shape)) {
+        for (int i = 0; i < subnd; i++) {
+            newdims[nd+i] = (npy_intp)PyLong_AsLong(PyTuple_GET_ITEM(shape, i));
         }
     }
     else {
-        new_dims[nd] = (npy_intp)PyLong_AsLong(shape);
+        newdims[nd] = (npy_intp)PyLong_AsLong(shape);
     }
-
-    if (strides) {
-        memcpy(new_strides, strides, nd * sizeof(npy_intp));
+    if (newstrides) {
+        assert(strides || nd==0);
+        memcpy(newstrides, strides, nd * sizeof(npy_intp));
         npy_intp tempsize;
         /* Make new strides -- always C-contiguous */
         tempsize = base->elsize;
-        for (int i = nd + sub_nd - 1; i >= nd; i--) {
-            new_strides[i] = tempsize;
-            tempsize *= new_dims[i] ? new_dims[i] : 1;
+        for (int i = nd + subnd - 1; i >= nd; i--) {
+            newstrides[i] = tempsize;
+            tempsize *= newdims[i] ? newdims[i] : 1;
         }
     }
 
@@ -424,16 +444,22 @@ _get_subarray_base_and_dimensions(
 /*
  * Check whether self can be viewed with the given dtype.
  * If so, return a new reference to the dtype (possibly changed).
- * If needed, also determine new dimensions and strides for the last axis.
- * If no change is needed, newlastdim is set to -1.
+ * If needed, also determine new dimensions and strides:
+ * - For views, *newdims and *newstrides hold storage.  If a change is
+ *   required, copy old dims and strides and make the change.
+ *   If no change is needed, set *newdims and *newstrides to self's versions.
+ * - For _set_dtype, *newdims and *newstrides are NULL. Allocate a new
+ *   array if the number of dimensions increases (because type is a
+ *   subarray), and otherwise use self's dims and strides, possibly
+ *   changing the last element in-place.
  */
 NPY_NO_EXPORT PyArray_Descr*
 _check_compatibility_with_new_dtype(
     PyArrayObject *self, PyArray_Descr *type,
-    npy_intp *newlastdim, npy_intp *newlaststride)
+    int *newnd, npy_intp **newdims, npy_intp **newstrides)
 {
     PyArray_Descr *dtype = PyArray_DESCR(self);
-    *newlastdim = -1;  /* By default, no change needed. */
+    int nd = PyArray_NDIM(self);
 
     /* Check that we are not reinterpreting memory containing Objects. */
     if (_may_have_objects(dtype) || _may_have_objects(type)) {
@@ -450,6 +476,31 @@ _check_compatibility_with_new_dtype(
         Py_DECREF(safe);
     }
 
+    if (PyDataType_HASSUBARRAY(type)) {
+        if (type->elsize != dtype->elsize) {
+            PyErr_SetString(PyExc_ValueError,
+                    "Changing the dtype to a subarray type is only supported "
+                    "if the total itemsize is unchanged");
+            return NULL;
+        }
+        int subnd = _get_subarray_ndim(type, nd);
+        if (subnd < 0) {
+            return NULL;
+        }
+        if (*newdims == NULL) {
+            *newdims = npy_alloc_cache_dim(2 * (nd + subnd));
+            if (*newdims == NULL) {
+                return NULL;
+            }
+            *newstrides = *newdims + nd + subnd;
+        }
+        return _get_subarray_base_and_dimensions(
+            type, nd, PyArray_DIMS(self), PyArray_STRIDES(self),
+            newnd, *newdims, *newstrides);  /* cannot fail given check above. */
+    }
+
+    /* Number of dimensions can no longer change. */
+    *newnd = nd;
     if (type->elsize != dtype->elsize) {
         /*
          * Viewing as an unsized void implies a void dtype matching
@@ -461,20 +512,13 @@ _check_compatibility_with_new_dtype(
                 return NULL;
             }
             newtype->elsize = dtype->elsize;
+            *newdims = PyArray_DIMS(self);
+            *newstrides = PyArray_STRIDES(self);
             return newtype;
         }
         /*
-         * Otherwise, changing the size of the dtype results in a shape change,
-         * which we signal by setting newlastdim and newlaststride.
+         * Otherwise, changing the size of the dtype results in a shape change.
          */
-        /* Check forbidden cases. */
-        if (PyDataType_HASSUBARRAY(type)) {
-            PyErr_SetString(PyExc_ValueError,
-                    "Changing the dtype to a subarray type is only supported "
-                    "if the total itemsize is unchanged");
-            return NULL;
-        }
-        int nd = PyArray_NDIM(self);
         if (nd == 0) {
             PyErr_SetString(PyExc_ValueError,
                     "Changing the dtype of a 0d array is only supported "
@@ -482,9 +526,10 @@ _check_compatibility_with_new_dtype(
             return NULL;
         }
         /* Resize on last axis only (we have nd>0 here). */
-        npy_intp lastdim = PyArray_DIMS(self)[nd-1];
+        int lastaxis = nd-1;
+        npy_intp lastdim = PyArray_DIMS(self)[lastaxis];
         if (lastdim != 1 && PyArray_SIZE(self) != 0 &&
-                PyArray_STRIDES(self)[nd-1] != dtype->elsize) {
+                PyArray_STRIDES(self)[lastaxis] != dtype->elsize) {
             PyErr_SetString(PyExc_ValueError,
                     "To change to a dtype of a different size, the last axis "
                     "must be contiguous");
@@ -498,7 +543,7 @@ _check_compatibility_with_new_dtype(
                         "divisor of the size of original dtype");
                 return NULL;
             }
-            *newlastdim = (dtype->elsize / type->elsize) * lastdim;
+            lastdim *= (dtype->elsize / type->elsize);
         }
         else /* type->elsize > dtype->elsize */ {
             /* If it is compatible, decrease the size of the relevant axis. */
@@ -510,9 +555,25 @@ _check_compatibility_with_new_dtype(
                         "of the array.");
                 return NULL;
             }
-            *newlastdim = lastsize / type->elsize;
+            lastdim = lastsize / type->elsize;
         }
-        *newlaststride = type->elsize;
+        if (*newdims != NULL) {
+            /* Have storage for dims & strides (view); copy unchanged ones */
+            memcpy(*newdims, PyArray_DIMS(self), lastaxis * sizeof(npy_intp));
+            memcpy(*newstrides, PyArray_STRIDES(self), lastaxis * sizeof(npy_intp));
+        }
+        else {
+            /* Don't have storage, so update in place (_set_dtype) */
+            *newdims = PyArray_DIMS(self);
+            *newstrides = PyArray_STRIDES(self);
+        }
+        (*newdims)[lastaxis] = lastdim;
+        (*newstrides)[lastaxis] = type->elsize;
+    }
+    else {
+        /* Itemsizes equal, dims and strides unchanged. */
+        *newdims = PyArray_DIMS(self);
+        *newstrides = PyArray_STRIDES(self);
     }
     Py_INCREF(type);
     return type;

--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -371,6 +371,57 @@ _may_have_objects(PyArray_Descr *dtype)
 }
 
 /*
+ * Get a sub-array descriptor base, storing the subarray
+ * dimensions and strides, and updating the number of dimensions
+ * of the array.
+ *
+ * Strides are only stored if needed.
+ */
+NPY_NO_EXPORT PyArray_Descr*
+_get_subarray_base_and_dimensions(
+    const PyArray_Descr *descr,
+    const int nd, const npy_intp *dims, const npy_intp *strides,
+    int *new_nd, npy_intp *new_dims, npy_intp *new_strides)
+{
+    PyObject *shape = PyDataType_SUBARRAY(descr)->shape;
+    PyArray_Descr *base = PyDataType_SUBARRAY(descr)->base;
+    assert(shape && base);
+    npy_bool tuple = PyTuple_Check(shape);
+    int sub_nd = tuple ? PyTuple_GET_SIZE(shape) : 1;
+
+    if (nd + sub_nd > NPY_MAXDIMS) {
+        PyErr_Format(PyExc_ValueError,
+                "number of dimensions must be within [0, %d]", NPY_MAXDIMS);
+        return NULL;
+    }
+
+    *new_nd = nd + sub_nd;
+    memcpy(new_dims, dims, nd * sizeof(npy_intp));
+    if (tuple) {
+        for (int i = 0; i < sub_nd; i++) {
+            new_dims[i+nd] = (npy_intp)PyLong_AsLong(PyTuple_GET_ITEM(shape, i));
+        }
+    }
+    else {
+        new_dims[nd] = (npy_intp)PyLong_AsLong(shape);
+    }
+
+    if (strides) {
+        memcpy(new_strides, strides, nd * sizeof(npy_intp));
+        npy_intp tempsize;
+        /* Make new strides -- always C-contiguous */
+        tempsize = base->elsize;
+        for (int i = nd + sub_nd - 1; i >= nd; i--) {
+            new_strides[i] = tempsize;
+            tempsize *= new_dims[i] ? new_dims[i] : 1;
+        }
+    }
+
+    Py_INCREF(base);
+    return base;
+}
+
+/*
  * Check whether self can be viewed with the given dtype.
  * If so, return a new reference to the dtype (possibly changed).
  * If needed, also determine new dimensions and strides for the last axis.

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -95,23 +95,39 @@ _unpack_field_index(
 NPY_NO_EXPORT int
 _may_have_objects(PyArray_Descr *dtype);
 
-/* For use in viewing as a new descriptor */
+/*
+ * For a sub-array descriptor, return the base descriptor,
+ * set newnd to nd plus the number of subarray dimensions,
+ * and fill newdims by copying nd items from dims and appending
+ * newnd-nd items from the subarray.
+ * If newstrides != NULL, they are similarly filled.
+ *
+ * Note: caller has to ensure that descr is a subarray, and that
+ * newdims and newstrides are big enough (i.e., NPY_MAXDIMS if
+ * the new size is not yet known).
+ */
 NPY_NO_EXPORT PyArray_Descr*
 _get_subarray_base_and_dimensions(
     const PyArray_Descr *descr,
     const int nd, const npy_intp *dims, const npy_intp *strides,
-    int *new_nd, npy_intp *new_dims, npy_intp *new_strides);
+    int *newnd, npy_intp *newdims, npy_intp *newstrides);
 
 /*
  * Check whether self can be viewed with the given dtype.
  * If so, return a new reference to the dtype (possibly changed).
- * If needed, also determine new dimensions and strides for the last axis.
- * If no change is needed, newlastdim is set to -1.
+ * If needed, also determine new dimensions and strides:
+ * - For views, *newdims and *newstrides hold storage.  If a change is
+ *   required, copy old dims and strides and make the change.
+ *   If no change is needed, set *dims and *strides to self's versions.
+ * - For _set_dtype, *newdims and *newstrides are NULL. Allocate a new
+ *   array if the number of dimensions increases (because type is a
+ *   subarray), and otherwise use self's dims and strides, possibly
+ *   changing the last element in-place.
  */
 NPY_NO_EXPORT PyArray_Descr*
 _check_compatibility_with_new_dtype(
     PyArrayObject *self, PyArray_Descr *type,
-    npy_intp *newlastdim, npy_intp *newlaststride);
+    int *newnd, npy_intp **newdims, npy_intp **newstrides);
 
 /*
  * Returns -1 and sets an exception if *index is an invalid index for

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -95,6 +95,13 @@ _unpack_field_index(
 NPY_NO_EXPORT int
 _may_have_objects(PyArray_Descr *dtype);
 
+/* For use in viewing as a new descriptor */
+NPY_NO_EXPORT PyArray_Descr*
+_get_subarray_base_and_dimensions(
+    const PyArray_Descr *descr,
+    const int nd, const npy_intp *dims, const npy_intp *strides,
+    int *new_nd, npy_intp *new_dims, npy_intp *new_strides);
+
 /*
  * Check whether self can be viewed with the given dtype.
  * If so, return a new reference to the dtype (possibly changed).

--- a/numpy/_core/src/multiarray/convert.c
+++ b/numpy/_core/src/multiarray/convert.c
@@ -611,35 +611,21 @@ PyArray_View(PyArrayObject *self, PyArray_Descr *type, PyTypeObject *pytype)
          * Path 1: subclass lives in the future and its __array_finalize__
          * can handle getting the correct dtype+shape.
          */
-        npy_intp newlastdim, newlaststride;
-        /* Check whether the type is compatible. */
+        npy_intp storage[2 * NPY_MAXDIMS];
+        int newnd;
+        npy_intp *newdims = storage;
+        npy_intp *newstrides = storage + NPY_MAXDIMS;
+        /* Check whether the type is compatible. dims and strides pointers
+           will be set to input ones if no change needed, otherwise filled. */
         Py_SETREF(type, _check_compatibility_with_new_dtype(
-                      self, type, &newlastdim, &newlaststride));
+                      self, type, &newnd, &newdims, &newstrides));
         if (type == NULL) {
             return NULL;
         }
         /* Take view with old or adjusted dims (steals reference to type) */
-        if (newlastdim < 0) {
-            return PyArray_NewFromDescr_int(subtype, type,
-                    nd, dims, strides, PyArray_DATA(self),
-                    flags, (PyObject *)self, (PyObject *)self, 0);
-        }
-        else {
-            NPY_ALLOC_WORKSPACE(newdims, npy_intp, 2 * 4, 2 * nd);
-            if (newdims == NULL) {
-                goto finish;
-            }
-            npy_intp *newstrides = newdims + nd;
-            memcpy(newdims, dims, (nd-1)*sizeof(npy_intp));
-            memcpy(newstrides, strides, (nd-1)*sizeof(npy_intp));
-            newdims[nd-1] = newlastdim;
-            newstrides[nd-1] = newlaststride;
-            ret = PyArray_NewFromDescr_int(subtype, type,
-                    nd, newdims, newstrides, PyArray_DATA(self),
-                    flags, (PyObject *)self, (PyObject *)self, 0);
-            npy_free_workspace(newdims);
-            return ret;
-        }
+        return PyArray_NewFromDescr_int(
+            subtype, type, newnd, newdims, newstrides, PyArray_DATA(self),
+            flags, (PyObject *)self, (PyObject *)self, 0);
     }
     /*
      * Other paths: first create a view with the old dtype.

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -641,8 +641,7 @@ PyArray_NewFromDescr_int(
                input ones (for strides, if the input strides are known). */
             int newnd;
             npy_intp newdims[2*NPY_MAXDIMS];
-            npy_intp *newstrides = (
-                (strides != NULL || nd == 0) ? newdims + NPY_MAXDIMS : NULL);
+            npy_intp *newstrides = strides ? newdims + NPY_MAXDIMS : NULL;
             Py_SETREF(descr, _get_subarray_base_and_dimensions(
                           descr, nd, dims, strides,
                           &newnd, newdims, newstrides));

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -276,72 +276,6 @@ fromfile_skip_separator(FILE **fp, const char *sep, void *NPY_UNUSED(stream_data
     return result;
 }
 
-/*
- * Change a sub-array field to the base descriptor
- * and update the dimensions and strides
- * appropriately.  Dimensions and strides are added
- * to the end.
- *
- * Strides are only added if given (because data is given).
- */
-static int
-_update_descr_and_dimensions(PyArray_Descr **des, npy_intp *newdims,
-                             npy_intp *newstrides, int oldnd)
-{
-    _PyArray_LegacyDescr *old;
-    int newnd;
-    int numnew;
-    npy_intp *mydim;
-    int i;
-    int tuple;
-
-    old = (_PyArray_LegacyDescr *)*des;  /* guaranteed as it has subarray */
-    *des = old->subarray->base;
-
-
-    mydim = newdims + oldnd;
-    tuple = PyTuple_Check(old->subarray->shape);
-    if (tuple) {
-        numnew = PyTuple_GET_SIZE(old->subarray->shape);
-    }
-    else {
-        numnew = 1;
-    }
-
-
-    newnd = oldnd + numnew;
-    if (newnd > NPY_MAXDIMS) {
-        goto finish;
-    }
-    if (tuple) {
-        for (i = 0; i < numnew; i++) {
-            mydim[i] = (npy_intp) PyLong_AsLong(
-                    PyTuple_GET_ITEM(old->subarray->shape, i));
-        }
-    }
-    else {
-        mydim[0] = (npy_intp) PyLong_AsLong(old->subarray->shape);
-    }
-
-    if (newstrides) {
-        npy_intp tempsize;
-        npy_intp *mystrides;
-
-        mystrides = newstrides + oldnd;
-        /* Make new strides -- always C-contiguous */
-        tempsize = (*des)->elsize;
-        for (i = numnew - 1; i >= 0; i--) {
-            mystrides[i] = tempsize;
-            tempsize *= mydim[i] ? mydim[i] : 1;
-        }
-    }
-
- finish:
-    Py_INCREF(*des);
-    Py_DECREF(old);
-    return newnd;
-}
-
 NPY_NO_EXPORT void
 _unaligned_strided_byte_copy(char *dst, npy_intp outstrides, char *src,
                              npy_intp instrides, npy_intp N, int elsize)
@@ -703,18 +637,18 @@ PyArray_NewFromDescr_int(
     if (!(cflags & _NPY_ARRAY_ENSURE_DTYPE_IDENTITY)) {
         if (PyDataType_SUBARRAY(descr)) {
             PyObject *ret;
+            int newnd;
             npy_intp newdims[2*NPY_MAXDIMS];
-            npy_intp *newstrides = NULL;
-            memcpy(newdims, dims, nd*sizeof(npy_intp));
-            if (strides) {
-                newstrides = newdims + NPY_MAXDIMS;
-                memcpy(newstrides, strides, nd*sizeof(npy_intp));
+            npy_intp *newstrides = strides ? newdims + NPY_MAXDIMS : NULL;
+            Py_SETREF(descr, _get_subarray_base_and_dimensions(
+                          descr, nd, dims, strides,
+                          &newnd, newdims, newstrides));
+            if (descr == NULL) {
+                return NULL;
             }
-            nd =_update_descr_and_dimensions(&descr, newdims,
-                                            newstrides, nd);
             ret = PyArray_NewFromDescr_int(
                     subtype, descr,
-                    nd, newdims, newstrides, data,
+                    newnd, newdims, newstrides, data,
                     flags, obj, base, cflags);
             return ret;
         }

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -636,21 +636,22 @@ PyArray_NewFromDescr_int(
      */
     if (!(cflags & _NPY_ARRAY_ENSURE_DTYPE_IDENTITY)) {
         if (PyDataType_SUBARRAY(descr)) {
-            PyObject *ret;
+            /* For a subarray, get the base dtype and use that in a retry
+               with the subarray dimensions and strides appended to the
+               input ones (for strides, if the input strides are known). */
             int newnd;
             npy_intp newdims[2*NPY_MAXDIMS];
-            npy_intp *newstrides = strides ? newdims + NPY_MAXDIMS : NULL;
+            npy_intp *newstrides = (
+                (strides != NULL || nd == 0) ? newdims + NPY_MAXDIMS : NULL);
             Py_SETREF(descr, _get_subarray_base_and_dimensions(
                           descr, nd, dims, strides,
                           &newnd, newdims, newstrides));
             if (descr == NULL) {
                 return NULL;
             }
-            ret = PyArray_NewFromDescr_int(
-                    subtype, descr,
-                    newnd, newdims, newstrides, data,
+            return PyArray_NewFromDescr_int(
+                    subtype, descr, newnd, newdims, newstrides, data,
                     flags, obj, base, cflags);
-            return ret;
         }
 
         /* Check datatype element size */

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -364,40 +364,31 @@ array_descr_set_internal(PyArrayObject *self, PyObject *arg)
     /* Viewing as a subarray increases the number of dimensions */
     if (PyDataType_HASSUBARRAY(newtype)) {
         assert(newlastdim < 0);  /* not allowed for subarrays */
-        /*
-         * create new array object from data and update
-         * dimensions, strides and descr from it
-         */
-        PyArrayObject *temp;
-        /*
-         * We would decref newtype here.
-         * temp will steal a reference to it
-         */
-        temp = (PyArrayObject *)
-            PyArray_NewFromDescr(&PyArray_Type, newtype, PyArray_NDIM(self),
-                                 PyArray_DIMS(self), PyArray_STRIDES(self),
-                                 PyArray_DATA(self), PyArray_FLAGS(self), NULL);
-        if (temp == NULL) {
-            return -1;
-        }
+        PyObject *shape = PyDataType_SUBARRAY(newtype)->shape;
+        /* Just assert(PyTuple_Check(shape))?? */
+        int nd = PyArray_NDIM(self);
+        int new_nd = nd + (PyTuple_Check(shape) ? PyTuple_GET_SIZE(shape) : 1);
         /* create new dimensions cache and fill it */
-        npy_intp new_nd = PyArray_NDIM(temp);
         npy_intp *new_dims = npy_alloc_cache_dim(2 * new_nd);
         if (new_dims == NULL) {
-            Py_DECREF(temp);
             PyErr_NoMemory();
+            Py_DECREF(newtype);
             return -1;
         }
-        memcpy(new_dims, PyArray_DIMS(temp), new_nd * sizeof(npy_intp));
-        memcpy(new_dims + new_nd, PyArray_STRIDES(temp), new_nd * sizeof(npy_intp));
+        npy_intp *new_strides = new_dims + new_nd;
+        int chk_nd;
+        Py_SETREF(newtype, _get_subarray_base_and_dimensions(
+                      newtype, nd, PyArray_DIMS(self), PyArray_STRIDES(self),
+                      &chk_nd, new_dims, new_strides));
+        if (newtype == NULL) {
+            return -1;
+        }
+        assert(chk_nd == new_nd);
         /* Update self with new cache */
         npy_free_cache_dim_array(self);
         ((PyArrayObject_fields *)self)->nd = new_nd;
         ((PyArrayObject_fields *)self)->dimensions = new_dims;
-        ((PyArrayObject_fields *)self)->strides = new_dims + new_nd;
-        newtype = PyArray_DESCR(temp);
-        Py_INCREF(newtype);
-        Py_DECREF(temp);
+        ((PyArrayObject_fields *)self)->strides = new_strides;
     }
     else if (newlastdim >= 0) {
         int lastaxis = PyArray_NDIM(self) - 1;

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -354,46 +354,26 @@ array_descr_set_internal(PyArrayObject *self, PyObject *arg)
         return -1;
     }
     /* Check dtype and possibly give new dim & stride for last axis */
-    npy_intp newlastdim, newlaststride;
+    int newnd;
+    npy_intp *newdims = NULL;
+    npy_intp *newstrides = NULL;
+    /* Check whether the type is compatible, get pointers to dimensions and
+       strides (can be from input or to newly allocated dim_array). */
     Py_SETREF(newtype, _check_compatibility_with_new_dtype(
-                  self, newtype, &newlastdim, &newlaststride));
+                  self, newtype, &newnd, &newdims, &newstrides));
     if (newtype == NULL) {
         return -1;
     }
-
-    /* Viewing as a subarray increases the number of dimensions */
-    if (PyDataType_HASSUBARRAY(newtype)) {
-        assert(newlastdim < 0);  /* not allowed for subarrays */
-        PyObject *shape = PyDataType_SUBARRAY(newtype)->shape;
-        /* Just assert(PyTuple_Check(shape))?? */
-        int nd = PyArray_NDIM(self);
-        int new_nd = nd + (PyTuple_Check(shape) ? PyTuple_GET_SIZE(shape) : 1);
-        /* create new dimensions cache and fill it */
-        npy_intp *new_dims = npy_alloc_cache_dim(2 * new_nd);
-        if (new_dims == NULL) {
-            PyErr_NoMemory();
-            Py_DECREF(newtype);
-            return -1;
-        }
-        npy_intp *new_strides = new_dims + new_nd;
-        int chk_nd;
-        Py_SETREF(newtype, _get_subarray_base_and_dimensions(
-                      newtype, nd, PyArray_DIMS(self), PyArray_STRIDES(self),
-                      &chk_nd, new_dims, new_strides));
-        if (newtype == NULL) {
-            return -1;
-        }
-        assert(chk_nd == new_nd);
-        /* Update self with new cache */
+    if (newnd != PyArray_NDIM(self)) {
+        /* Update self with new dim array created above (subarray dtype). */
+        assert(newdims != PyArray_DIMS(self));
         npy_free_cache_dim_array(self);
-        ((PyArrayObject_fields *)self)->nd = new_nd;
-        ((PyArrayObject_fields *)self)->dimensions = new_dims;
-        ((PyArrayObject_fields *)self)->strides = new_strides;
+        ((PyArrayObject_fields *)self)->nd = newnd;
+        ((PyArrayObject_fields *)self)->dimensions = newdims;
+        ((PyArrayObject_fields *)self)->strides = newstrides;
     }
-    else if (newlastdim >= 0) {
-        int lastaxis = PyArray_NDIM(self) - 1;
-        PyArray_DIMS(self)[lastaxis] = newlastdim;
-        PyArray_STRIDES(self)[lastaxis] = newlaststride;
+    else { /* We keep our old dims (possibly changed inplace) */
+        assert(newdims == PyArray_DIMS(self));
     }
     Py_DECREF(PyArray_DESCR(self));
     ((PyArrayObject_fields *)self)->descr = newtype;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -475,6 +475,17 @@ class TestAttributes:
 
         assert_equal(arr, np.array(data, dtype=dtype))
 
+    def test_subarray_order_f(self):
+        # Subarrays are always C contiguous, but if we request Fortran,
+        # we should get it if the subarray is resolved away.
+        data = ([[1, 2, 3], [4, 5, 6]])
+        arr = np.full((), data, dtype=("f8", (2, 3)), order="F")
+        assert not arr.flags.c_contiguous
+        assert arr.flags.f_contiguous
+        arr2 = np.full((4, 5), data, dtype=("f8", (2, 3)), order="F")
+        assert not arr2.flags.c_contiguous
+        assert arr2.flags.f_contiguous
+
 
 class TestArrayConstruction:
     def test_array(self):


### PR DESCRIPTION
A further follow-up of the way views are done and dtypes are set, specifically targeting dtypes with subarrays.

Subarrays were handled very similarly in `_set_dtype` and `NewFromDescr_int`, so the first commit factors out the common code. The second commit then calls that from the new dtype checking routine, so it also gets used in `.view()`.

@seberg - this probably wasn't worth the nearly a day I spent on it, but it does seem to make things cleaner, and hopefully it makes sense to you too...

No AI used.