### PR TITLE
BUG: Fix pinv crash with rtol=None on integer dtype arrays

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2238,7 +2238,8 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
         if rtol is _NoValue:
             rcond = 1e-15
         elif rtol is None:
-            rcond = max(a.shape[-2:]) * finfo(a.dtype).eps
+            _, rt = _commonType(a)
+            rcond = max(a.shape[-2:]) * finfo(rt).eps
         else:
             rcond = rtol
     elif rtol is not _NoValue:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -917,6 +917,25 @@ def test_pinv_rtol_arg():
         np.linalg.pinv(a, rcond=0.5, rtol=0.5)
 
 
+def test_pinv_rtol_none_integer():
+    # gh-30917: pinv with rtol=None should not crash on integer dtypes
+    a = np.array([[1, 2], [3, 4]], dtype=np.int32)
+    result = np.linalg.pinv(a, rtol=None)
+    # Result should be float64
+    assert result.dtype == np.float64
+    # Result should be approximately correct
+    expected = np.linalg.pinv(a.astype(np.float64))
+    assert_allclose(result, expected, atol=1e-14)
+
+    # Also test with int64, uint8
+    for dt in [np.int64, np.uint8, np.int16]:
+        a = np.array([[1, 2], [3, 4]], dtype=dt)
+        result = np.linalg.pinv(a, rtol=None)
+        assert result.dtype == np.float64
+        expected = np.linalg.pinv(a.astype(np.float64))
+        assert_allclose(result, expected, atol=1e-14)
+
+
 class DetCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
 
     def do(self, a, b, tags):


### PR DESCRIPTION
### PR summary
Fixes gh-30917: `np.linalg.pinv(a, rtol=None)` crashes with ValueError on integer dtype arrays (int32, int64, uint8, int16) because `finfo()` is called directly on the integer dtype. Use `_commonType(a)` to obtain the appropriate float type first, consistent with other linalg functions.

### First time committer introduction
I am a Signal Processing / ML engineer interested in contributing to numerical Python libraries.

#### AI Disclosure
AI tools assisted with code generation. The bug was manually reproduced on a test server, and all changes were reviewed and verified before submission.