### PR TITLE
BLD: use batched C99 function detection to speed up configure stage of build

### DIFF
--- a/numpy/_core/feature_detection_cmath.h
+++ b/numpy/_core/feature_detection_cmath.h
@@ -1,0 +1,95 @@
+/*
+ * Prototypes for C99 complex-math functions probed as a batch by meson.build.
+ *
+ * For MSVC we must include <complex.h> to pick up the non-standard
+ * _Fcomplex/_Dcomplex/_Lcomplex typedefs, since MSVC doesn't support the C99 `_Complex`
+ * keyword directly. For every other compiler we avoid including <complex.h> so that
+ * macro-based declarations (notably musl's `#define crealf(x) ((float)(x))`) don't
+ * conflict with the plain prototypes below.
+ */
+
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#include <complex.h>
+typedef _Fcomplex cfloat;
+typedef _Dcomplex cdouble;
+typedef _Lcomplex cldouble;
+#else
+typedef float  _Complex cfloat;
+typedef double _Complex cdouble;
+typedef long double _Complex cldouble;
+#endif
+
+/* Mandatory complex math (double) */
+cdouble csin(cdouble);
+cdouble csinh(cdouble);
+cdouble ccos(cdouble);
+cdouble ccosh(cdouble);
+cdouble ctan(cdouble);
+cdouble ctanh(cdouble);
+double         creal(cdouble);
+double         cimag(cdouble);
+cdouble conj(cdouble);
+
+/* float variants */
+cfloat  csinf(cfloat);
+cfloat  csinhf(cfloat);
+cfloat  ccosf(cfloat);
+cfloat  ccoshf(cfloat);
+cfloat  ctanf(cfloat);
+cfloat  ctanhf(cfloat);
+float          crealf(cfloat);
+float          cimagf(cfloat);
+cfloat  conjf(cfloat);
+
+/* long double variants */
+cldouble csinl(cldouble);
+cldouble csinhl(cldouble);
+cldouble ccosl(cldouble);
+cldouble ccoshl(cldouble);
+cldouble ctanl(cldouble);
+cldouble ctanhl(cldouble);
+long double     creall(cldouble);
+long double     cimagl(cldouble);
+cldouble conjl(cldouble);
+
+/* C99 complex (double) */
+double         cabs(cdouble);
+cdouble cacos(cdouble);
+cdouble cacosh(cdouble);
+double         carg(cdouble);
+cdouble casin(cdouble);
+cdouble casinh(cdouble);
+cdouble catan(cdouble);
+cdouble catanh(cdouble);
+cdouble cexp(cdouble);
+cdouble clog(cdouble);
+cdouble cpow(cdouble, cdouble);
+cdouble csqrt(cdouble);
+
+/* C99 complex (float) */
+float          cabsf(cfloat);
+cfloat  cacosf(cfloat);
+cfloat  cacoshf(cfloat);
+float          cargf(cfloat);
+cfloat  casinf(cfloat);
+cfloat  casinhf(cfloat);
+cfloat  catanf(cfloat);
+cfloat  catanhf(cfloat);
+cfloat  cexpf(cfloat);
+cfloat  clogf(cfloat);
+cfloat  cpowf(cfloat, cfloat);
+cfloat  csqrtf(cfloat);
+
+/* C99 complex (long double) */
+long double     cabsl(cldouble);
+cldouble cacosl(cldouble);
+cldouble cacoshl(cldouble);
+long double     cargl(cldouble);
+cldouble casinl(cldouble);
+cldouble casinhl(cldouble);
+cldouble catanl(cldouble);
+cldouble catanhl(cldouble);
+cldouble cexpl(cldouble);
+cldouble clogl(cldouble);
+cldouble cpowl(cldouble, cldouble);
+cldouble csqrtl(cldouble);

--- a/numpy/_core/feature_detection_math.h
+++ b/numpy/_core/feature_detection_math.h
@@ -1,0 +1,46 @@
+/*
+ * Prototypes for math functions probed as a batch by meson.build.
+ *
+ * Intentionally omits <math.h> and <stdlib.h> to avoid conflicting with
+ * calling-convention-modified declarations (e.g. MSVC's __cdecl) or
+ * macro-based declarations in system headers.
+ */
+
+double sin(double);
+double cos(double);
+double tan(double);
+double sinh(double);
+double cosh(double);
+double tanh(double);
+double fabs(double);
+double floor(double);
+double ceil(double);
+double sqrt(double);
+double log10(double);
+double log(double);
+double exp(double);
+double asin(double);
+double acos(double);
+double atan(double);
+double fmod(double, double);
+double modf(double, double*);
+double frexp(double, int*);
+double ldexp(double, int);
+double expm1(double);
+double log1p(double);
+double acosh(double);
+double asinh(double);
+double atanh(double);
+double rint(double);
+double trunc(double);
+double exp2(double);
+double copysign(double, double);
+double nextafter(double, double);
+double cbrt(double);
+double log2(double);
+double pow(double, double);
+double hypot(double, double);
+double atan2(double, double);
+
+long long strtoll(const char*, char**, int);
+unsigned long long strtoull(const char*, char**, int);

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -200,9 +200,43 @@ foreach symbol_type: complex_types_to_check
   cdata.set(symbol_type[0], cc.sizeof(symbol_type[1], prefix: '#include <complex.h>'))
 endforeach
 
-# Mandatory functions: if not found, fail the build
-# Some of these can still be blocklisted if the C99 implementation
-# is buggy, see numpy/_core/src/common/npy_config.h
+# Mandatory and optional math functions are detected via batched cc.links()
+# probes that take each function's address through a static array, forcing the
+# linker to resolve the symbol. On failure we fall back to per-function probes
+# so a missing mandatory symbol is reported by name, and so optional functions
+# that are partially available on an unusual libm are still detected
+# individually.
+#
+# Platform-specific libm bugs are handled via `#undef HAVE_*` in
+# numpy/_core/src/common/npy_config.h.
+
+inc_curdir = include_directories('.')
+
+# Shared C-source boilerplate. '@INCLUDES@' and '@REFS@' are substituted
+# per-batch via .replace() below.
+_batch_probe_template = '''
+#include <stdint.h>
+#include <stddef.h>
+@INCLUDES@
+
+typedef void (*funcptr)(void);
+
+static const funcptr funcs[] = {
+@REFS@};
+
+int main(int argc, char **argv) {
+    volatile uintptr_t s = 0;
+    unsigned i;
+    (void)argc; (void)argv;
+    for (i = 0; i < sizeof(funcs)/sizeof(funcs[0]); i++) {
+        s ^= (uintptr_t)funcs[i];
+    }
+    return (int)(s & 1);
+}
+'''
+
+# Mandatory functions: if the batched link fails, fall back to per-function
+# checks to identify which symbol is actually missing.
 mandatory_math_funcs = [
   'sin', 'cos', 'tan', 'sinh', 'cosh', 'tanh', 'fabs',
   'floor', 'ceil', 'sqrt', 'log10', 'log', 'exp', 'asin',
@@ -211,26 +245,41 @@ mandatory_math_funcs = [
   'rint', 'trunc', 'exp2', 'copysign', 'nextafter', 'cbrt',
   'log2', 'pow', 'hypot', 'atan2',
 ]
-foreach func: mandatory_math_funcs
-  if not cc.has_function(func, prefix: '#include <math.h>', dependencies: m_dep)
-    error(f'Function `@func@` not found')
-  endif
-endforeach
-
 mandatory_complex_math_funcs = [
   'csin', 'csinh', 'ccos', 'ccosh', 'ctan', 'ctanh', 'creal', 'cimag', 'conj'
 ]
-foreach func: mandatory_complex_math_funcs
-  if not cc.has_function(func, prefix: '#include <complex.h>', dependencies: m_dep)
-    error(f'Function `@func@` not found')
-  endif
-endforeach
+mandatory_strto_funcs = ['strtoll', 'strtoull']
 
-foreach func: ['strtoll', 'strtoull']
-  if not cc.has_function(func, prefix: '#include <stdlib.h>')
-    error(f'Function `@func@` not found')
-  endif
+_mandatory_refs = ''
+foreach _f : mandatory_math_funcs + mandatory_complex_math_funcs + mandatory_strto_funcs
+  _mandatory_refs += '    (funcptr)' + _f + ',\n'
 endforeach
+_mandatory_src = _batch_probe_template.replace(
+  '@INCLUDES@',
+  '#include "feature_detection_math.h"\n#include "feature_detection_cmath.h"'
+).replace('@REFS@', _mandatory_refs)
+
+if not cc.links(_mandatory_src,
+    include_directories: inc_curdir,
+    dependencies: m_dep,
+    name: 'mandatory libm functions (batched)')
+  # Re-run per-function to name the missing symbol for the user.
+  foreach func: mandatory_math_funcs
+    if not cc.has_function(func, prefix: '#include <math.h>', dependencies: m_dep)
+      error(f'Function `@func@` not found')
+    endif
+  endforeach
+  foreach func: mandatory_complex_math_funcs
+    if not cc.has_function(func, prefix: '#include <complex.h>', dependencies: m_dep)
+      error(f'Function `@func@` not found')
+    endif
+  endforeach
+  foreach func: mandatory_strto_funcs
+    if not cc.has_function(func, prefix: '#include <stdlib.h>')
+      error(f'Function `@func@` not found')
+    endif
+  endforeach
+endif
 
 c99_complex_funcs = [
   'cabs', 'cacos', 'cacosh', 'carg', 'casin', 'casinh', 'catan',
@@ -239,19 +288,33 @@ c99_complex_funcs = [
   # but are missing in FreeBSD. Issue gh-22850
   'csin', 'csinh', 'ccos', 'ccosh', 'ctan', 'ctanh',
 ]
-foreach func: c99_complex_funcs
-  func_single = func + 'f'
-  func_longdouble = func + 'l'
-  if cc.has_function(func, prefix: '#include <complex.h>', dependencies: m_dep)
-    cdata.set10('HAVE_' + func.to_upper(), true)
-  endif
-  if cc.has_function(func_single, prefix: '#include <complex.h>', dependencies: m_dep)
-    cdata.set10('HAVE_' + func_single.to_upper(), true)
-  endif
-  if cc.has_function(func_longdouble, prefix: '#include <complex.h>', dependencies: m_dep)
-    cdata.set10('HAVE_' + func_longdouble.to_upper(), true)
-  endif
+c99_complex_funcs_all = []
+foreach _f : c99_complex_funcs
+  c99_complex_funcs_all += [_f, _f + 'f', _f + 'l']
 endforeach
+
+_c99cplx_refs = ''
+foreach _f : c99_complex_funcs_all
+  _c99cplx_refs += '    (funcptr)' + _f + ',\n'
+endforeach
+_c99cplx_src = _batch_probe_template.replace(
+  '@INCLUDES@', '#include "feature_detection_cmath.h"'
+).replace('@REFS@', _c99cplx_refs)
+
+if cc.links(_c99cplx_src,
+    include_directories: inc_curdir,
+    dependencies: m_dep,
+    name: 'C99 complex funcs (batched)')
+  foreach func: c99_complex_funcs_all
+    cdata.set10('HAVE_' + func.to_upper(), true)
+  endforeach
+else
+  foreach func: c99_complex_funcs_all
+    if cc.has_function(func, prefix: '#include <complex.h>', dependencies: m_dep)
+      cdata.set10('HAVE_' + func.to_upper(), true)
+    endif
+  endforeach
+endif
 
 # We require C99 so these should always be found at build time. But for
 # libnpymath as a C99 compat layer, these may still be relevant.
@@ -293,7 +356,6 @@ foreach optional_attr: optional_variable_attributes
   endif
 endforeach
 
-inc_curdir = include_directories('.')
 optional_file_funcs = ['fallocate', 'ftello', 'fseeko']
 foreach filefunc_maybe: optional_file_funcs
   config_value = 'HAVE_' + filefunc_maybe.to_upper()


### PR DESCRIPTION
This reintroduces the `feature_detection_math.h` and `feature_detection_cmath.h` that we had in the distutils build (files reworked but adapted the idea from the 1.25.x branch - improved to avoid undefs and pragmas). It speeds up the configure stage significantly, especially on Windows where these checks are quite slow. On macOS the relative speedup is ~30%.

The other benefit is to significantly reduce the length of the build log printed to stdout, so it's easier to find things in it.

Note that the `_math.h` header in 1.25.x had `float` and `long double` signatures, but those were never used, so they're left out here.

The most significant change from 1.25.x is to use:
```C
static const funcptr funcs[] = { (funcptr)sin, ... };
```
to take a static address of each function, which forces the linker to resolve each function in the batch check with `cc.links`.

I also tried using batch checks for other groups of functions (e.g., `optional_file_funcs`) like in 1.25.x, but decided that the extra complexity in `_core/meson.build` wasn't worth it, so ended up reverting those changes. 

#### AI Disclosure

I used Claude Opus 4.7 to implement most of these changes, starting by adapting the headers from the 1.25.x branch, then getting rid of the `undef`'s and `pragma`s, and then implementing the batched checks. I then manually cleaned up some of the code and comments in the process of reviewing the code.