### PR TITLE
ENH: allow larger than C int sized structured dtypes

### DIFF
--- a/doc/release/upcoming_changes/31332.improvement.rst
+++ b/doc/release/upcoming_changes/31332.improvement.rst
@@ -1,0 +1,6 @@
+Structured dtypes now support larger field sizes
+------------------------------------------------
+It is now possible to construct structured data types with
+field sizes and offsets that exceed the size of a standard C
+integer. Arrays using these structured data types are now
+also possible to construct.

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -610,8 +610,8 @@ cdef extern from "numpy/arrayobject.h":
     #object PyArray_FromBuffer (object, dtype, npy_intp, npy_intp)
     #object PyArray_FromIter (object, dtype, npy_intp)
     object PyArray_Return (ndarray)
-    #object PyArray_GetField (ndarray, dtype, npy_intp)
-    #int PyArray_SetField (ndarray, dtype, npy_intp, object) except -1
+    #object PyArray_GetField (ndarray, dtype, int)
+    #int PyArray_SetField (ndarray, dtype, int, object) except -1
     object PyArray_Byteswap (ndarray, npy_bool)
     object PyArray_Resize (ndarray, PyArray_Dims *, int, NPY_ORDER)
     int PyArray_CopyInto (ndarray, ndarray) except -1

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -611,7 +611,7 @@ cdef extern from "numpy/arrayobject.h":
     #object PyArray_FromIter (object, dtype, npy_intp)
     object PyArray_Return (ndarray)
     #object PyArray_GetField (ndarray, dtype, npy_intp)
-    #int PyArray_SetField (ndarray, dtype, int, object) except -1
+    #int PyArray_SetField (ndarray, dtype, npy_intp, object) except -1
     object PyArray_Byteswap (ndarray, npy_bool)
     object PyArray_Resize (ndarray, PyArray_Dims *, int, NPY_ORDER)
     int PyArray_CopyInto (ndarray, ndarray) except -1

--- a/numpy/__init__.cython-30.pxd
+++ b/numpy/__init__.cython-30.pxd
@@ -610,7 +610,7 @@ cdef extern from "numpy/arrayobject.h":
     #object PyArray_FromBuffer (object, dtype, npy_intp, npy_intp)
     #object PyArray_FromIter (object, dtype, npy_intp)
     object PyArray_Return (ndarray)
-    #object PyArray_GetField (ndarray, dtype, int)
+    #object PyArray_GetField (ndarray, dtype, npy_intp)
     #int PyArray_SetField (ndarray, dtype, int, object) except -1
     object PyArray_Byteswap (ndarray, npy_bool)
     object PyArray_Resize (ndarray, PyArray_Dims *, int, NPY_ORDER)

--- a/numpy/_core/src/multiarray/array_assign_array.c
+++ b/numpy/_core/src/multiarray/array_assign_array.c
@@ -42,7 +42,10 @@ copycast_isaligned(int ndim, npy_intp const *shape,
     int aligned;
     int big_aln, small_aln;
 
-    int uint_aln = npy_uint_alignment(dtype->elsize);
+    int uint_aln = 0;
+    if (dtype->elsize <= NPY_MAX_INT) {
+        uint_aln = npy_uint_alignment((int)dtype->elsize);
+    }
     int true_aln = dtype->alignment;
 
     /* uint alignment can be 0, meaning not uint alignable */

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1032,7 +1032,7 @@ static int
 VOID_setitem(PyArray_Descr *descr_, PyObject *op, char *ip)
 {
     _PyArray_LegacyDescr *descr = (_PyArray_LegacyDescr *)descr_;
-    int itemsize = descr->elsize;
+    npy_intp itemsize = descr->elsize;
     int res;
 
     if (PyDataType_HASFIELDS(descr)) {
@@ -1150,9 +1150,9 @@ VOID_setitem(PyArray_Descr *descr_, PyObject *op, char *ip)
         if (PyObject_GetBuffer(op, &view, PyBUF_SIMPLE) < 0) {
             return -1;
         }
-        memcpy(ip, view.buf, PyArray_MIN(view.len, itemsize));
+        memcpy(ip, view.buf, (size_t)PyArray_MIN(view.len, itemsize));
         if (itemsize > view.len) {
-            memset(ip + view.len, 0, itemsize - view.len);
+            memset(ip + view.len, 0, (size_t)(itemsize - view.len));
         }
         PyBuffer_Release(&view);
     }
@@ -1914,7 +1914,7 @@ static int
 
 static inline void
 _basic_copyn(void *dst, npy_intp dstride, void *src, npy_intp sstride,
-             npy_intp n, int elsize) {
+             npy_intp n, npy_intp elsize) {
     if (src == NULL) {
         return;
     }
@@ -1928,7 +1928,7 @@ _basic_copyn(void *dst, npy_intp dstride, void *src, npy_intp sstride,
 }
 
 static inline void
-_basic_copy(void *dst, void *src, int elsize) {
+_basic_copy(void *dst, void *src, npy_intp elsize) {
     if (src == NULL) {
         return;
     }
@@ -2383,7 +2383,7 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
     if (descr->subarray != NULL) {
         PyArray_Descr *new;
         npy_intp num;
-        int subitemsize;
+        npy_intp subitemsize;
         /*
          * In certain cases subarray copy can be optimized. This is when
          * swapping is unnecessary and the subarrays data type can certainly
@@ -2558,7 +2558,7 @@ count_nonzero_trivial_@name@(npy_intp count, const char *data, npy_int stride)
 /**end repeat**/
 
 NPY_NO_EXPORT npy_intp
-count_nonzero_trivial_dispatcher(npy_intp count, const char* data, npy_intp stride, int dtype_num) { 
+count_nonzero_trivial_dispatcher(npy_intp count, const char* data, npy_intp stride, int dtype_num) {
     switch(dtype_num) {
         /**begin repeat
          *
@@ -4378,8 +4378,8 @@ static int
 }
 /**end repeat**/
 
-/* 
-Keeping Half macros consistent with standard C 
+/*
+Keeping Half macros consistent with standard C
 Reference: https://en.cppreference.com/w/c/types/limits.html
 */
 #define HALF_MAX 31743       /* Bit pattern for 65504.0 */

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1050,7 +1050,7 @@ static int
 VOID_setitem(PyArray_Descr *descr_, PyObject *op, char *ip)
 {
     _PyArray_LegacyDescr *descr = (_PyArray_LegacyDescr *)descr_;
-    int itemsize = descr->elsize;
+    npy_intp itemsize = descr->elsize;
     int res;
 
     if (PyDataType_HASFIELDS(descr)) {
@@ -1168,9 +1168,9 @@ VOID_setitem(PyArray_Descr *descr_, PyObject *op, char *ip)
         if (PyObject_GetBuffer(op, &view, PyBUF_SIMPLE) < 0) {
             return -1;
         }
-        memcpy(ip, view.buf, PyArray_MIN(view.len, itemsize));
+        memcpy(ip, view.buf, (size_t)PyArray_MIN(view.len, itemsize));
         if (itemsize > view.len) {
-            memset(ip + view.len, 0, itemsize - view.len);
+            memset(ip + view.len, 0, (size_t)(itemsize - view.len));
         }
         PyBuffer_Release(&view);
     }
@@ -1932,7 +1932,7 @@ static int
 
 static inline void
 _basic_copyn(void *dst, npy_intp dstride, void *src, npy_intp sstride,
-             npy_intp n, int elsize) {
+             npy_intp n, npy_intp elsize) {
     if (src == NULL) {
         return;
     }
@@ -1946,7 +1946,7 @@ _basic_copyn(void *dst, npy_intp dstride, void *src, npy_intp sstride,
 }
 
 static inline void
-_basic_copy(void *dst, void *src, int elsize) {
+_basic_copy(void *dst, void *src, npy_intp elsize) {
     if (src == NULL) {
         return;
     }
@@ -2471,7 +2471,7 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
     if (descr->subarray != NULL) {
         PyArray_Descr *new;
         npy_intp num;
-        int subitemsize;
+        npy_intp subitemsize;
         /*
          * In certain cases subarray copy can be optimized. This is when
          * swapping is unnecessary and the subarrays data type can certainly
@@ -2656,7 +2656,7 @@ count_nonzero_trivial_@name@(npy_intp count, const char *data, npy_int stride)
 /**end repeat**/
 
 NPY_NO_EXPORT npy_intp
-count_nonzero_trivial_dispatcher(npy_intp count, const char* data, npy_intp stride, int dtype_num) { 
+count_nonzero_trivial_dispatcher(npy_intp count, const char* data, npy_intp stride, int dtype_num) {
     switch(dtype_num) {
         /**begin repeat
          *
@@ -4454,8 +4454,8 @@ static int
 }
 /**end repeat**/
 
-/* 
-Keeping Half macros consistent with standard C 
+/*
+Keeping Half macros consistent with standard C
 Reference: https://en.cppreference.com/w/c/types/limits.html
 */
 #define HALF_MAX 31743       /* Bit pattern for 65504.0 */

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2220,7 +2220,14 @@ get_byteswap_loop(
     PyArray_Descr *const *descrs = context->descriptors;
     assert(descrs[0]->kind == descrs[1]->kind);
     assert(descrs[0]->elsize == descrs[1]->elsize);
-    int itemsize = descrs[0]->elsize;
+    if (descrs[0]->elsize > NPY_MAX_INT) {
+        // TODO: add a regression test for >INT_MAX byte-swap itemsize support.
+        PyErr_SetString(PyExc_TypeError,
+                "byte-swapping with itemsize larger than INT_MAX "
+                "is not supported");
+        return -1;
+    }
+    int itemsize = (int)descrs[0]->elsize;
     *flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
     *out_transferdata = NULL;
     if (descrs[0]->kind == 'c') {
@@ -2958,20 +2965,16 @@ structured_to_nonstructured_resolve_descriptors(
 
     /* Void dtypes always do the full cast. */
     if (given_descrs[1] == NULL) {
+        /*
+         * Reject string casts, historically these worked only for empty arrays.
+         * (One could go via object and hex printing, but...)
+         */
+        if (dtypes[1]->type_num == NPY_STRING || dtypes[1]->type_num == NPY_UNICODE) {
+            return -1;
+        }
         loop_descrs[1] = NPY_DT_CALL_default_descr(dtypes[1]);
         if (loop_descrs[1] == NULL) {
             return -1;
-        }
-        /*
-         * Special case strings here, it should be useless (and only actually
-         * work for empty arrays).  Possibly this should simply raise for
-         * all parametric DTypes.
-         */
-        if (dtypes[1]->type_num == NPY_STRING) {
-            loop_descrs[1]->elsize = given_descrs[0]->elsize;
-        }
-        else if (dtypes[1]->type_num == NPY_UNICODE) {
-            loop_descrs[1]->elsize = given_descrs[0]->elsize * 4;
         }
     }
     else {

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2331,7 +2331,14 @@ get_byteswap_loop(
     PyArray_Descr *const *descrs = context->descriptors;
     assert(descrs[0]->kind == descrs[1]->kind);
     assert(descrs[0]->elsize == descrs[1]->elsize);
-    int itemsize = descrs[0]->elsize;
+    if (descrs[0]->elsize > NPY_MAX_INT) {
+        // TODO: add a regression test for >INT_MAX byte-swap itemsize support.
+        PyErr_SetString(PyExc_TypeError,
+                "byte-swapping with itemsize larger than INT_MAX "
+                "is not supported");
+        return -1;
+    }
+    int itemsize = (int)descrs[0]->elsize;
     *flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
     *out_transferdata = NULL;
     if (descrs[0]->kind == 'c') {
@@ -3070,20 +3077,16 @@ structured_to_nonstructured_resolve_descriptors(
 
     /* Void dtypes always do the full cast. */
     if (given_descrs[1] == NULL) {
+        /*
+         * Reject string casts, historically these worked only for empty arrays.
+         * (One could go via object and hex printing, but...)
+         */
+        if (dtypes[1]->type_num == NPY_STRING || dtypes[1]->type_num == NPY_UNICODE) {
+            return -1;
+        }
         loop_descrs[1] = NPY_DT_CALL_default_descr(dtypes[1]);
         if (loop_descrs[1] == NULL) {
             return -1;
-        }
-        /*
-         * Special case strings here, it should be useless (and only actually
-         * work for empty arrays).  Possibly this should simply raise for
-         * all parametric DTypes.
-         */
-        if (dtypes[1]->type_num == NPY_STRING) {
-            loop_descrs[1]->elsize = given_descrs[0]->elsize;
-        }
-        else if (dtypes[1]->type_num == NPY_UNICODE) {
-            loop_descrs[1]->elsize = given_descrs[0]->elsize * 4;
         }
     }
     else {

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -3460,7 +3460,7 @@ array_fromfile_binary(FILE *fp, PyArray_Descr *dtype, npy_intp num, size_t *nrea
 {
     PyArrayObject *r;
     npy_off_t start, numbytes;
-    int elsize;
+    npy_intp elsize;
 
     if (num < 0) {
         int fail = 0;

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1204,6 +1204,11 @@ _dtype_from_buffer_3118(PyObject *memoryview)
          * TODO: void would make more sense here, as it wouldn't null
          *       terminate.
          */
+        if (view->itemsize > NPY_MAX_INT) {
+            PyErr_SetString(PyExc_ValueError,
+                    "buffer itemsize is too large for a string dtype");
+            return NULL;
+        }
         descr = PyArray_DescrNewFromType(NPY_STRING);
         if (descr == NULL) {
             return NULL;
@@ -3719,7 +3724,7 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
     Py_buffer view;
     Py_ssize_t ts;
     npy_intp s, n;
-    int itemsize;
+    npy_intp itemsize;
     int writeable = 1;
 
     if (type == NULL) {
@@ -3806,7 +3811,7 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
         n = s/itemsize;
     }
     else {
-        if (s < n*itemsize) {
+        if (itemsize != 0 && n > s / itemsize) {
             PyErr_SetString(PyExc_ValueError,
                             "buffer is smaller than requested"\
                             " size");
@@ -3856,7 +3861,7 @@ NPY_NO_EXPORT PyObject *
 PyArray_FromString(char *data, npy_intp slen, PyArray_Descr *dtype,
                    npy_intp num, char *sep)
 {
-    int itemsize;
+    npy_intp itemsize;
     PyArrayObject *ret;
     npy_bool binary;
 
@@ -3894,7 +3899,7 @@ PyArray_FromString(char *data, npy_intp slen, PyArray_Descr *dtype,
             num = slen/itemsize;
         }
         else {
-            if (slen < num*itemsize) {
+            if (num > slen / itemsize) {
                 PyErr_SetString(PyExc_ValueError,
                                 "string is smaller than " \
                                 "requested size");

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1207,6 +1207,11 @@ _dtype_from_buffer_3118(PyObject *memoryview)
          * TODO: void would make more sense here, as it wouldn't null
          *       terminate.
          */
+        if (view->itemsize > NPY_MAX_INT) {
+            PyErr_SetString(PyExc_ValueError,
+                    "buffer itemsize is too large for a string dtype");
+            return NULL;
+        }
         descr = PyArray_DescrNewFromType(NPY_STRING);
         if (descr == NULL) {
             return NULL;
@@ -3728,7 +3733,7 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
     Py_buffer view;
     Py_ssize_t ts;
     npy_intp s, n;
-    int itemsize;
+    npy_intp itemsize;
     int writeable = 1;
 
     if (type == NULL) {
@@ -3815,7 +3820,7 @@ PyArray_FromBuffer(PyObject *buf, PyArray_Descr *type,
         n = s/itemsize;
     }
     else {
-        if (s < n*itemsize) {
+        if (itemsize != 0 && n > s / itemsize) {
             PyErr_SetString(PyExc_ValueError,
                             "buffer is smaller than requested"\
                             " size");
@@ -3865,7 +3870,7 @@ NPY_NO_EXPORT PyObject *
 PyArray_FromString(char *data, npy_intp slen, PyArray_Descr *dtype,
                    npy_intp num, char *sep)
 {
-    int itemsize;
+    npy_intp itemsize;
     PyArrayObject *ret;
     npy_bool binary;
 
@@ -3903,7 +3908,7 @@ PyArray_FromString(char *data, npy_intp slen, PyArray_Descr *dtype,
             num = slen/itemsize;
         }
         else {
-            if (slen < num*itemsize) {
+            if (num > slen / itemsize) {
                 PyErr_SetString(PyExc_ValueError,
                                 "string is smaller than " \
                                 "requested size");

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -3469,7 +3469,7 @@ array_fromfile_binary(FILE *fp, PyArray_Descr *dtype, npy_intp num, size_t *nrea
 {
     PyArrayObject *r;
     npy_off_t start, numbytes;
-    int elsize;
+    npy_intp elsize;
 
     if (num < 0) {
         int fail = 0;

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -324,8 +324,8 @@ _convert_from_tuple(PyObject *obj, int align)
             overflowed = 1;
         }
         else {
-            overflowed = npy_mul_with_overflow_longlong(
-                &nbytes, type->elsize, (npy_intp) items);
+            overflowed = npy_mul_sizes_with_overflow(
+                &nbytes, type->elsize, items);
         }
         if (overflowed) {
             PyErr_SetString(PyExc_ValueError,

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2723,7 +2723,8 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
     PyObject *ret, *mod, *obj;
     PyObject *state;
     char endian;
-    int elsize, alignment;
+    npy_intp elsize;
+    int alignment;
 
     ret = PyTuple_New(3);
     if (ret == NULL) {

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1140,7 +1140,7 @@ _convert_from_dict(PyObject *obj, int align)
                 Py_DECREF(ind);
                 goto fail;
             }
-            long offset = PyArray_PyIntAsInt(off);
+            npy_intp offset = PyArray_PyIntAsIntp(off);
             if (error_converting(offset)) {
                 Py_DECREF(off);
                 Py_DECREF(tup);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -316,12 +316,6 @@ _convert_from_tuple(PyObject *obj, int align)
                                 "dimension smaller then zero.");
                 goto fail;
             }
-            if (shape.ptr[i] > NPY_MAX_INTP) {
-                PyErr_SetString(PyExc_ValueError,
-                                "invalid shape in fixed-type tuple: "
-                                "dimension does not fit into a C int.");
-                goto fail;
-            }
         }
         npy_intp items = PyArray_OverflowMultiplyList(shape.ptr, shape.len);
         int overflowed;

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -337,7 +337,7 @@ _convert_from_tuple(PyObject *obj, int align)
         if (newdescr == NULL) {
             goto fail;
         }
-        newdescr->elsize = (long long)nbytes;
+        newdescr->elsize = nbytes;
         newdescr->subarray = PyArray_malloc(sizeof(PyArray_ArrayDescr));
         if (newdescr->subarray == NULL) {
             Py_DECREF(newdescr);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -316,7 +316,7 @@ _convert_from_tuple(PyObject *obj, int align)
                                 "dimension smaller then zero.");
                 goto fail;
             }
-            if (shape.ptr[i] > NPY_MAX_INT) {
+            if (shape.ptr[i] > NPY_MAX_INTP) {
                 PyErr_SetString(PyExc_ValueError,
                                 "invalid shape in fixed-type tuple: "
                                 "dimension does not fit into a C int.");
@@ -325,13 +325,13 @@ _convert_from_tuple(PyObject *obj, int align)
         }
         npy_intp items = PyArray_OverflowMultiplyList(shape.ptr, shape.len);
         int overflowed;
-        int nbytes;
-        if (items < 0 || items > NPY_MAX_INT) {
+        long long nbytes;
+        if (items < 0 || items > NPY_MAX_INTP) {
             overflowed = 1;
         }
         else {
-            overflowed = npy_mul_with_overflow_int(
-                &nbytes, type->elsize, (int) items);
+            overflowed = npy_mul_with_overflow_longlong(
+                &nbytes, type->elsize, (npy_intp) items);
         }
         if (overflowed) {
             PyErr_SetString(PyExc_ValueError,
@@ -343,7 +343,7 @@ _convert_from_tuple(PyObject *obj, int align)
         if (newdescr == NULL) {
             goto fail;
         }
-        newdescr->elsize = nbytes;
+        newdescr->elsize = (int)nbytes;
         newdescr->subarray = PyArray_malloc(sizeof(PyArray_ArrayDescr));
         if (newdescr->subarray == NULL) {
             Py_DECREF(newdescr);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -364,7 +364,7 @@ _convert_from_tuple(PyObject *obj, int align)
         }
         for (int i=0; i < shape.len; i++) {
             PyTuple_SET_ITEM(newdescr->subarray->shape, i,
-                             PyLong_FromLong((long)shape.ptr[i]));
+                             PyLong_FromSsize_t(shape.ptr[i]));
 
             if (PyTuple_GET_ITEM(newdescr->subarray->shape, i) == NULL) {
                 Py_DECREF(newdescr);
@@ -521,7 +521,7 @@ _convert_from_array_descr(PyObject *obj, int align)
             goto fail;
         }
         PyTuple_SET_ITEM(tup, 0, (PyObject *)conv);
-        PyTuple_SET_ITEM(tup, 1, PyLong_FromLong((long) totalsize));
+        PyTuple_SET_ITEM(tup, 1, PyLong_FromSsize_t(totalsize));
 
         /*
          * Title can be "meta-data".  Only insert it
@@ -642,7 +642,7 @@ _convert_from_list(PyObject *obj, int align)
             }
             maxalign = PyArray_MAX(maxalign, _align);
         }
-        PyObject *size_obj = PyLong_FromLong((long) totalsize);
+        PyObject *size_obj = PyLong_FromSsize_t(totalsize);
         if (!size_obj) {
             Py_DECREF(conv);
             goto fail;
@@ -1156,7 +1156,7 @@ _convert_from_dict(PyObject *obj, int align)
                 goto fail;
             }
 
-            PyTuple_SET_ITEM(tup, 1, PyLong_FromLong(offset));
+            PyTuple_SET_ITEM(tup, 1, PyLong_FromSsize_t(offset));
             /* Flag whether the fields are specified out of order */
             if (offset < totalsize) {
                 has_out_of_order_fields = 1;
@@ -1180,7 +1180,7 @@ _convert_from_dict(PyObject *obj, int align)
             if (align && _align > 1) {
                 totalsize = NPY_NEXT_ALIGNED_OFFSET(totalsize, _align);
             }
-            PyTuple_SET_ITEM(tup, 1, PyLong_FromLong(totalsize));
+            PyTuple_SET_ITEM(tup, 1, PyLong_FromSsize_t(totalsize));
             totalsize += newdescr->elsize;
         }
         if (len == 3) {
@@ -1797,7 +1797,7 @@ _convert_from_str(PyObject *obj, int align)
     }
 
     int check_num = NPY_NOTYPE + 10;
-    int elsize = 0;
+    npy_intp elsize = 0;
     /* A typecode like 'd' */
     if (len == 1) {
         /* Python byte string characters are unsigned */
@@ -1810,7 +1810,7 @@ _convert_from_str(PyObject *obj, int align)
 
         /* Attempt to parse the integer, make sure it's the rest of the string */
         errno = 0;
-        long result = strtol(type + 1, &typeend, 10);
+        npy_intp result = strtol(type + 1, &typeend, 10);
         npy_bool some_parsing_happened = !(type == typeend);
         npy_bool entire_string_consumed = *typeend == '\0';
         npy_bool parsing_succeeded =
@@ -1820,7 +1820,7 @@ _convert_from_str(PyObject *obj, int align)
             goto fail;
         }
 
-        elsize = (int)result;
+        elsize = result;
 
 
         if (parsing_succeeded && typeend - type == len) {
@@ -2820,7 +2820,7 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
         elsize = -1;
         alignment = -1;
     }
-    PyTuple_SET_ITEM(state, 5, PyLong_FromLong(elsize));
+    PyTuple_SET_ITEM(state, 5, PyLong_FromSsize_t(elsize));
     PyTuple_SET_ITEM(state, 6, PyLong_FromLong(alignment));
     PyTuple_SET_ITEM(state, 7, PyLong_FromUnsignedLongLong(
             self->flags & ~NPY_NOT_TRIVIALLY_COPYABLE));

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -343,7 +343,7 @@ _convert_from_tuple(PyObject *obj, int align)
         if (newdescr == NULL) {
             goto fail;
         }
-        newdescr->elsize = (int)nbytes;
+        newdescr->elsize = (long long)nbytes;
         newdescr->subarray = PyArray_malloc(sizeof(PyArray_ArrayDescr));
         if (newdescr->subarray == NULL) {
             Py_DECREF(newdescr);
@@ -410,7 +410,7 @@ _convert_from_array_descr(PyObject *obj, int align)
     /* Types with fields need the Python C API for field access */
     npy_uint64 dtypeflags = NPY_NEEDS_PYAPI;
     int maxalign = 1;
-    int totalsize = 0;
+    npy_intp totalsize = 0;
     PyObject *fields = PyDict_New();
     if (!fields) {
         Py_DECREF(nameslist);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1095,7 +1095,7 @@ _convert_from_dict(PyObject *obj, int align)
 
     /* Types with fields need the Python C API for field access */
     npy_uint64 dtypeflags = NPY_NEEDS_PYAPI;
-    int totalsize = 0;
+    npy_intp totalsize = 0;
     int maxalign = 1;
     int has_out_of_order_fields = 0;
     for (int i = 0; i < n; i++) {

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -627,7 +627,7 @@ _convert_from_list(PyObject *obj, int align)
     /* Types with fields need the Python C API for field access */
     npy_uint64 dtypeflags = NPY_NEEDS_PYAPI;
     int maxalign = 1;
-    int totalsize = 0;
+    npy_intp totalsize = 0;
     for (int i = 0; i < n; i++) {
         PyArray_Descr *conv = _convert_from_any(
                 PyList_GET_ITEM(obj, i), align); // noqa: borrowed-ref OK

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -319,8 +319,8 @@ _convert_from_tuple(PyObject *obj, int align)
         }
         npy_intp items = PyArray_OverflowMultiplyList(shape.ptr, shape.len);
         int overflowed;
-        long long nbytes;
-        if (items < 0 || items > NPY_MAX_INTP) {
+        npy_intp nbytes;
+        if (items < 0) {
             overflowed = 1;
         }
         else {

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -258,7 +258,7 @@ _convert_from_tuple(PyObject *obj, int align)
      */
     if (PyDataType_ISUNSIZED(type)) {
         /* interpret next item as a typesize */
-        int itemsize = PyArray_PyIntAsInt(PyTuple_GET_ITEM(obj,1));
+        npy_intp itemsize = PyArray_PyIntAsIntp(PyTuple_GET_ITEM(obj,1));
         if (type->type_num == NPY_UNICODE) {
             if (itemsize > NPY_MAX_INT / 4) {
                 itemsize = -1;
@@ -266,6 +266,9 @@ _convert_from_tuple(PyObject *obj, int align)
             else {
                 itemsize *= 4;
             }
+        }
+        else if (type->type_num == NPY_STRING && itemsize > NPY_MAX_INT) {
+            itemsize = -1;
         }
         if (itemsize < 0) {
             /* Error may or may not be set by PyIntAsInt. */
@@ -915,7 +918,7 @@ _validate_object_field_overlap(_PyArray_LegacyDescr *dtype)
     PyObject *names, *fields, *key, *tup, *title;
     Py_ssize_t i, j, names_size;
     PyArray_Descr *fld_dtype, *fld2_dtype;
-    int fld_offset, fld2_offset;
+    npy_intp fld_offset, fld2_offset;
 
     /* Get some properties from the dtype */
     names = dtype->names;
@@ -935,7 +938,7 @@ _validate_object_field_overlap(_PyArray_LegacyDescr *dtype)
             }
             return -1;
         }
-        if (!PyArg_ParseTuple(tup, "Oi|O", &fld_dtype, &fld_offset, &title)) {
+        if (!PyArg_ParseTuple(tup, "On|O", &fld_dtype, &fld_offset, &title)) {
             return -1;
         }
 
@@ -955,7 +958,7 @@ _validate_object_field_overlap(_PyArray_LegacyDescr *dtype)
                         }
                         return -1;
                     }
-                    if (!PyArg_ParseTuple(tup, "Oi|O", &fld2_dtype,
+                    if (!PyArg_ParseTuple(tup, "On|O", &fld2_dtype,
                                                 &fld2_offset, &title)) {
                         return -1;
                     }
@@ -1149,8 +1152,9 @@ _convert_from_dict(PyObject *obj, int align)
             }
             Py_DECREF(off);
             if (offset < 0) {
-                PyErr_Format(PyExc_ValueError, "offset %ld cannot be negative",
-                             offset);
+                PyErr_Format(PyExc_ValueError,
+                             "offset %zd cannot be negative",
+                             (Py_ssize_t)offset);
                 Py_DECREF(tup);
                 Py_DECREF(ind);
                 goto fail;
@@ -1164,10 +1168,10 @@ _convert_from_dict(PyObject *obj, int align)
             /* If align=True, enforce field alignment */
             if (align && offset % newdescr->alignment != 0) {
                 PyErr_Format(PyExc_ValueError,
-                        "offset %ld for NumPy dtype with fields is "
+                        "offset %zd for NumPy dtype with fields is "
                         "not divisible by the field alignment %d "
                         "with align=True",
-                        offset, newdescr->alignment);
+                        (Py_ssize_t)offset, newdescr->alignment);
                 Py_DECREF(ind);
                 Py_DECREF(tup);
                 goto fail;
@@ -1285,7 +1289,7 @@ _convert_from_dict(PyObject *obj, int align)
     if (tmp == NULL) {
         PyErr_Clear();
     } else {
-        int itemsize = (int)PyArray_PyIntAsInt(tmp);
+        npy_intp itemsize = PyArray_PyIntAsIntp(tmp);
         Py_DECREF(tmp);
         if (error_converting(itemsize)) {
             Py_DECREF(new);
@@ -1294,9 +1298,9 @@ _convert_from_dict(PyObject *obj, int align)
         /* Make sure the itemsize isn't made too small */
         if (itemsize < new->elsize) {
             PyErr_Format(PyExc_ValueError,
-                    "NumPy dtype descriptor requires %d bytes, "
-                    "cannot override to smaller itemsize of %d",
-                    new->elsize, itemsize);
+                    "NumPy dtype descriptor requires %zd bytes, "
+                    "cannot override to smaller itemsize of %zd",
+                    (Py_ssize_t)new->elsize, (Py_ssize_t)itemsize);
             Py_DECREF(new);
             goto fail;
         }
@@ -1304,8 +1308,8 @@ _convert_from_dict(PyObject *obj, int align)
         if (align && new->alignment > 0 && itemsize % new->alignment != 0) {
             PyErr_Format(PyExc_ValueError,
                     "NumPy dtype descriptor requires alignment of %d bytes, "
-                    "which is not divisible into the specified itemsize %d",
-                    new->alignment, itemsize);
+                    "which is not divisible into the specified itemsize %zd",
+                    new->alignment, (Py_ssize_t)itemsize);
             Py_DECREF(new);
             goto fail;
         }
@@ -1810,13 +1814,13 @@ _convert_from_str(PyObject *obj, int align)
 
         /* Attempt to parse the integer, make sure it's the rest of the string */
         errno = 0;
-        npy_intp result = strtol(type + 1, &typeend, 10);
+        long long result = strtoll(type + 1, &typeend, 10);
         npy_bool some_parsing_happened = !(type == typeend);
         npy_bool entire_string_consumed = *typeend == '\0';
         npy_bool parsing_succeeded =
                 (errno == 0) && some_parsing_happened && entire_string_consumed;
         // make sure it doesn't overflow or go negative
-        if (result > INT_MAX || result < 0) {
+        if (result > NPY_MAX_INTP || result < 0) {
             goto fail;
         }
 
@@ -1827,7 +1831,11 @@ _convert_from_str(PyObject *obj, int align)
 
             kind = type[0];
             switch (kind) {
+                // TODO(seberg): This currently limits strings to int size.
                 case NPY_STRINGLTR:
+                    if (elsize > NPY_MAX_INT) {
+                        goto fail;
+                    }
                     check_num = NPY_STRING;
                     break;
 
@@ -2097,7 +2105,7 @@ arraydescr_protocol_typestr_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 
     char basic_ = self->kind;
     char endian = self->byteorder;
-    int size = self->elsize;
+    npy_intp size = self->elsize;
     PyObject *ret;
 
     if (endian == '=') {
@@ -2113,7 +2121,7 @@ arraydescr_protocol_typestr_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
         ret = PyUnicode_FromFormat("%c%c", endian, basic_);
     }
     else {
-        ret = PyUnicode_FromFormat("%c%c%d", endian, basic_, size);
+        ret = PyUnicode_FromFormat("%c%c%zd", endian, basic_, (Py_ssize_t)size);
     }
     if (ret == NULL) {
         return NULL;
@@ -2754,7 +2762,7 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
         if (self->type_num == NPY_UNICODE) {
             elsize >>= 2;
         }
-        obj = PyUnicode_FromFormat("%c%d",self->kind, elsize);
+        obj = PyUnicode_FromFormat("%c%zd", self->kind, (Py_ssize_t)elsize);
     }
     PyTuple_SET_ITEM(ret, 1, Py_BuildValue("(NOO)", obj, Py_False, Py_True));
 
@@ -2844,14 +2852,14 @@ _descr_find_object(PyArray_Descr *self)
     if (PyDataType_HASFIELDS(self)) {
         PyObject *key, *value, *title = NULL;
         PyArray_Descr *new;
-        int offset;
+        npy_intp offset;
         Py_ssize_t pos = 0;
 
         while (PyDict_Next(PyDataType_FIELDS(self), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset, &title)) {
+            if (!PyArg_ParseTuple(value, "On|O", &new, &offset, &title)) {
                 PyErr_Clear();
                 return 0;
             }
@@ -3457,7 +3465,7 @@ is_dtype_struct_simple_unaligned_layout(PyArray_Descr *dtype)
     PyObject *names, *fields, *key, *tup, *title;
     Py_ssize_t i, names_size;
     PyArray_Descr *fld_dtype;
-    int fld_offset;
+    npy_intp fld_offset;
     npy_intp total_offset;
 
     /* Get some properties from the dtype */
@@ -3477,7 +3485,7 @@ is_dtype_struct_simple_unaligned_layout(PyArray_Descr *dtype)
         if (tup == NULL) {
             return 0;
         }
-        if (!PyArg_ParseTuple(tup, "Oi|O", &fld_dtype, &fld_offset, &title)) {
+        if (!PyArg_ParseTuple(tup, "On|O", &fld_dtype, &fld_offset, &title)) {
             PyErr_Clear();
             return 0;
         }

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2253,13 +2253,13 @@ _arraydescr_isnative(PyArray_Descr *self)
     else {
         PyObject *key, *value, *title = NULL;
         PyArray_Descr *new;
-        int offset;
+        npy_intp offset;
         Py_ssize_t pos = 0;
         while (PyDict_Next(PyDataType_FIELDS(self), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset, &title)) {
+            if (!PyArg_ParseTuple(value, "On|O", &new, &offset, &title)) {
                 return -1;
             }
             if (!_arraydescr_isnative(new)) {

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -352,7 +352,7 @@ _convert_from_tuple(PyObject *obj, int align)
         if (newdescr == NULL) {
             goto fail;
         }
-        newdescr->elsize = nbytes;
+        newdescr->elsize = (long long)nbytes;
         newdescr->subarray = PyArray_malloc(sizeof(PyArray_ArrayDescr));
         if (newdescr->subarray == NULL) {
             Py_DECREF(newdescr);
@@ -438,7 +438,7 @@ _convert_from_array_descr(PyObject *obj, int align)
     /* Types with fields need the Python C API for field access */
     npy_uint64 dtypeflags = NPY_NEEDS_PYAPI;
     int maxalign = 1;
-    int totalsize = 0;
+    npy_intp totalsize = 0;
     PyObject *fields = PyDict_New();
     if (!fields) {
         Py_DECREF(nameslist);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -255,7 +255,7 @@ _convert_from_tuple(PyObject *obj, int align)
      */
     if (PyDataType_ISUNSIZED(type)) {
         /* interpret next item as a typesize */
-        int itemsize = PyArray_PyIntAsInt(PyTuple_GET_ITEM(obj,1));
+        npy_intp itemsize = PyArray_PyIntAsIntp(PyTuple_GET_ITEM(obj,1));
         if (type->type_num == NPY_UNICODE) {
             if (itemsize > NPY_MAX_INT / 4) {
                 itemsize = -1;
@@ -263,6 +263,9 @@ _convert_from_tuple(PyObject *obj, int align)
             else {
                 itemsize *= 4;
             }
+        }
+        else if (type->type_num == NPY_STRING && itemsize > NPY_MAX_INT) {
+            itemsize = -1;
         }
         if (itemsize < 0) {
             /* Error may or may not be set by PyIntAsInt. */
@@ -947,7 +950,7 @@ _validate_object_field_overlap(_PyArray_LegacyDescr *dtype)
     PyObject *names, *fields, *key, *tup, *title;
     Py_ssize_t i, j, names_size;
     PyArray_Descr *fld_dtype, *fld2_dtype;
-    int fld_offset, fld2_offset;
+    npy_intp fld_offset, fld2_offset;
 
     /* Get some properties from the dtype */
     names = dtype->names;
@@ -967,7 +970,7 @@ _validate_object_field_overlap(_PyArray_LegacyDescr *dtype)
             }
             return -1;
         }
-        if (!PyArg_ParseTuple(tup, "Oi|O", &fld_dtype, &fld_offset, &title)) {
+        if (!PyArg_ParseTuple(tup, "On|O", &fld_dtype, &fld_offset, &title)) {
             return -1;
         }
 
@@ -987,7 +990,7 @@ _validate_object_field_overlap(_PyArray_LegacyDescr *dtype)
                         }
                         return -1;
                     }
-                    if (!PyArg_ParseTuple(tup, "Oi|O", &fld2_dtype,
+                    if (!PyArg_ParseTuple(tup, "On|O", &fld2_dtype,
                                                 &fld2_offset, &title)) {
                         return -1;
                     }
@@ -1190,8 +1193,9 @@ _convert_from_dict(PyObject *obj, int align)
             }
             Py_DECREF(off);
             if (offset < 0) {
-                PyErr_Format(PyExc_ValueError, "offset %ld cannot be negative",
-                             offset);
+                PyErr_Format(PyExc_ValueError,
+                             "offset %zd cannot be negative",
+                             (Py_ssize_t)offset);
                 Py_DECREF(tup);
                 Py_DECREF(ind);
                 goto fail;
@@ -1205,10 +1209,10 @@ _convert_from_dict(PyObject *obj, int align)
             /* If align=True, enforce field alignment */
             if (align && offset % newdescr->alignment != 0) {
                 PyErr_Format(PyExc_ValueError,
-                        "offset %ld for NumPy dtype with fields is "
+                        "offset %zd for NumPy dtype with fields is "
                         "not divisible by the field alignment %d "
                         "with align=True",
-                        offset, newdescr->alignment);
+                        (Py_ssize_t)offset, newdescr->alignment);
                 Py_DECREF(ind);
                 Py_DECREF(tup);
                 goto fail;
@@ -1326,7 +1330,7 @@ _convert_from_dict(PyObject *obj, int align)
     if (tmp == NULL) {
         PyErr_Clear();
     } else {
-        int itemsize = (int)PyArray_PyIntAsInt(tmp);
+        npy_intp itemsize = PyArray_PyIntAsIntp(tmp);
         Py_DECREF(tmp);
         if (error_converting(itemsize)) {
             Py_DECREF(new);
@@ -1335,9 +1339,9 @@ _convert_from_dict(PyObject *obj, int align)
         /* Make sure the itemsize isn't made too small */
         if (itemsize < new->elsize) {
             PyErr_Format(PyExc_ValueError,
-                    "NumPy dtype descriptor requires %d bytes, "
-                    "cannot override to smaller itemsize of %d",
-                    new->elsize, itemsize);
+                    "NumPy dtype descriptor requires %zd bytes, "
+                    "cannot override to smaller itemsize of %zd",
+                    (Py_ssize_t)new->elsize, (Py_ssize_t)itemsize);
             Py_DECREF(new);
             goto fail;
         }
@@ -1345,8 +1349,8 @@ _convert_from_dict(PyObject *obj, int align)
         if (align && new->alignment > 0 && itemsize % new->alignment != 0) {
             PyErr_Format(PyExc_ValueError,
                     "NumPy dtype descriptor requires alignment of %d bytes, "
-                    "which is not divisible into the specified itemsize %d",
-                    new->alignment, itemsize);
+                    "which is not divisible into the specified itemsize %zd",
+                    new->alignment, (Py_ssize_t)itemsize);
             Py_DECREF(new);
             goto fail;
         }
@@ -1855,13 +1859,13 @@ _convert_from_str(PyObject *obj, int align)
 
         /* Attempt to parse the integer, make sure it's the rest of the string */
         errno = 0;
-        npy_intp result = strtol(type + 1, &typeend, 10);
+        long long result = strtoll(type + 1, &typeend, 10);
         npy_bool some_parsing_happened = !(type == typeend);
         npy_bool entire_string_consumed = *typeend == '\0';
         npy_bool parsing_succeeded =
                 (errno == 0) && some_parsing_happened && entire_string_consumed;
         // make sure it doesn't overflow or go negative
-        if (result > INT_MAX || result < 0) {
+        if (result > NPY_MAX_INTP || result < 0) {
             goto fail;
         }
 
@@ -1872,7 +1876,11 @@ _convert_from_str(PyObject *obj, int align)
 
             kind = type[0];
             switch (kind) {
+                // TODO(seberg): This currently limits strings to int size.
                 case NPY_STRINGLTR:
+                    if (elsize > NPY_MAX_INT) {
+                        goto fail;
+                    }
                     check_num = NPY_STRING;
                     break;
 
@@ -2175,7 +2183,7 @@ arraydescr_protocol_typestr_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
 
     char basic_ = self->kind;
     char endian = self->byteorder;
-    int size = self->elsize;
+    npy_intp size = self->elsize;
     PyObject *ret;
 
     if (endian == '=') {
@@ -2191,7 +2199,7 @@ arraydescr_protocol_typestr_get(PyArray_Descr *self, void *NPY_UNUSED(ignored))
         ret = PyUnicode_FromFormat("%c%c", endian, basic_);
     }
     else {
-        ret = PyUnicode_FromFormat("%c%c%d", endian, basic_, size);
+        ret = PyUnicode_FromFormat("%c%c%zd", endian, basic_, (Py_ssize_t)size);
     }
     if (ret == NULL) {
         return NULL;
@@ -2832,7 +2840,7 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
         if (self->type_num == NPY_UNICODE) {
             elsize >>= 2;
         }
-        obj = PyUnicode_FromFormat("%c%d",self->kind, elsize);
+        obj = PyUnicode_FromFormat("%c%zd", self->kind, (Py_ssize_t)elsize);
     }
     PyTuple_SET_ITEM(ret, 1, Py_BuildValue("(NOO)", obj, Py_False, Py_True));
 
@@ -2922,14 +2930,14 @@ _descr_find_object(PyArray_Descr *self)
     if (PyDataType_HASFIELDS(self)) {
         PyObject *key, *value, *title = NULL;
         PyArray_Descr *new;
-        int offset;
+        npy_intp offset;
         Py_ssize_t pos = 0;
 
         while (PyDict_Next(PyDataType_FIELDS(self), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset, &title)) {
+            if (!PyArg_ParseTuple(value, "On|O", &new, &offset, &title)) {
                 PyErr_Clear();
                 return 0;
             }
@@ -3536,7 +3544,7 @@ is_dtype_struct_simple_unaligned_layout(PyArray_Descr *dtype)
     PyObject *names, *fields, *key, *tup, *title;
     Py_ssize_t i, names_size;
     PyArray_Descr *fld_dtype;
-    int fld_offset;
+    npy_intp fld_offset;
     npy_intp total_offset;
 
     /* Get some properties from the dtype */
@@ -3556,7 +3564,7 @@ is_dtype_struct_simple_unaligned_layout(PyArray_Descr *dtype)
         if (tup == NULL) {
             return 0;
         }
-        if (!PyArg_ParseTuple(tup, "Oi|O", &fld_dtype, &fld_offset, &title)) {
+        if (!PyArg_ParseTuple(tup, "On|O", &fld_dtype, &fld_offset, &title)) {
             PyErr_Clear();
             return 0;
         }

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -325,12 +325,6 @@ _convert_from_tuple(PyObject *obj, int align)
                                 "dimension smaller then zero.");
                 goto fail;
             }
-            if (shape.ptr[i] > NPY_MAX_INTP) {
-                PyErr_SetString(PyExc_ValueError,
-                                "invalid shape in fixed-type tuple: "
-                                "dimension does not fit into a C int.");
-                goto fail;
-            }
         }
         npy_intp items = PyArray_OverflowMultiplyList(shape.ptr, shape.len);
         int overflowed;

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2331,13 +2331,13 @@ _arraydescr_isnative(PyArray_Descr *self)
     else {
         PyObject *key, *value, *title = NULL;
         PyArray_Descr *new;
-        int offset;
+        npy_intp offset;
         Py_ssize_t pos = 0;
         while (PyDict_Next(PyDataType_FIELDS(self), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset, &title)) {
+            if (!PyArg_ParseTuple(value, "On|O", &new, &offset, &title)) {
                 return -1;
             }
             if (!_arraydescr_isnative(new)) {

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -333,8 +333,8 @@ _convert_from_tuple(PyObject *obj, int align)
             overflowed = 1;
         }
         else {
-            overflowed = npy_mul_with_overflow_longlong(
-                &nbytes, type->elsize, (npy_intp) items);
+            overflowed = npy_mul_sizes_with_overflow(
+                &nbytes, type->elsize, items);
         }
         if (overflowed) {
             PyErr_SetString(PyExc_ValueError,

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1130,7 +1130,7 @@ _convert_from_dict(PyObject *obj, int align)
 
     /* Types with fields need the Python C API for field access */
     npy_uint64 dtypeflags = NPY_NEEDS_PYAPI;
-    int totalsize = 0;
+    npy_intp totalsize = 0;
     int maxalign = 1;
     int has_out_of_order_fields = 0;
     for (int i = 0; i < n; i++) {

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -325,7 +325,7 @@ _convert_from_tuple(PyObject *obj, int align)
                                 "dimension smaller then zero.");
                 goto fail;
             }
-            if (shape.ptr[i] > NPY_MAX_INT) {
+            if (shape.ptr[i] > NPY_MAX_INTP) {
                 PyErr_SetString(PyExc_ValueError,
                                 "invalid shape in fixed-type tuple: "
                                 "dimension does not fit into a C int.");
@@ -334,13 +334,13 @@ _convert_from_tuple(PyObject *obj, int align)
         }
         npy_intp items = PyArray_OverflowMultiplyList(shape.ptr, shape.len);
         int overflowed;
-        int nbytes;
-        if (items < 0 || items > NPY_MAX_INT) {
+        long long nbytes;
+        if (items < 0 || items > NPY_MAX_INTP) {
             overflowed = 1;
         }
         else {
-            overflowed = npy_mul_with_overflow_int(
-                &nbytes, type->elsize, (int) items);
+            overflowed = npy_mul_with_overflow_longlong(
+                &nbytes, type->elsize, (npy_intp) items);
         }
         if (overflowed) {
             PyErr_SetString(PyExc_ValueError,
@@ -353,7 +353,7 @@ _convert_from_tuple(PyObject *obj, int align)
             goto fail;
         }
         newdescr->elsize = nbytes;
-        newdescr->subarray = PyMem_RawMalloc(sizeof(PyArray_ArrayDescr));
+        newdescr->subarray = PyArray_malloc(sizeof(PyArray_ArrayDescr));
         if (newdescr->subarray == NULL) {
             Py_DECREF(newdescr);
             PyErr_NoMemory();

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -373,7 +373,7 @@ _convert_from_tuple(PyObject *obj, int align)
         }
         for (int i=0; i < shape.len; i++) {
             PyTuple_SET_ITEM(newdescr->subarray->shape, i,
-                             PyLong_FromLong((long)shape.ptr[i]));
+                             PyLong_FromSsize_t(shape.ptr[i]));
 
             if (PyTuple_GET_ITEM(newdescr->subarray->shape, i) == NULL) {
                 Py_DECREF(newdescr);
@@ -548,7 +548,7 @@ _convert_from_array_descr(PyObject *obj, int align)
             goto fail;
         }
         PyTuple_SET_ITEM(tup, 0, (PyObject *)conv);
-        PyTuple_SET_ITEM(tup, 1, PyLong_FromLong((long) totalsize));
+        PyTuple_SET_ITEM(tup, 1, PyLong_FromSsize_t(totalsize));
 
         /*
          * Title can be "meta-data".  Only insert it
@@ -673,7 +673,7 @@ _convert_from_list(PyObject *obj, int align)
             }
             maxalign = PyArray_MAX(maxalign, _align);
         }
-        PyObject *size_obj = PyLong_FromLong((long) totalsize);
+        PyObject *size_obj = PyLong_FromSsize_t(totalsize);
         if (!size_obj) {
             Py_DECREF(conv);
             goto fail;
@@ -1197,7 +1197,7 @@ _convert_from_dict(PyObject *obj, int align)
                 goto fail;
             }
 
-            PyTuple_SET_ITEM(tup, 1, PyLong_FromLong(offset));
+            PyTuple_SET_ITEM(tup, 1, PyLong_FromSsize_t(offset));
             /* Flag whether the fields are specified out of order */
             if (offset < totalsize) {
                 has_out_of_order_fields = 1;
@@ -1221,7 +1221,7 @@ _convert_from_dict(PyObject *obj, int align)
             if (align && _align > 1) {
                 totalsize = NPY_NEXT_ALIGNED_OFFSET(totalsize, _align);
             }
-            PyTuple_SET_ITEM(tup, 1, PyLong_FromLong(totalsize));
+            PyTuple_SET_ITEM(tup, 1, PyLong_FromSsize_t(totalsize));
             totalsize += newdescr->elsize;
         }
         if (len == 3) {
@@ -1842,7 +1842,7 @@ _convert_from_str(PyObject *obj, int align)
     }
 
     int check_num = NPY_NOTYPE + 10;
-    int elsize = 0;
+    npy_intp elsize = 0;
     /* A typecode like 'd' */
     if (len == 1) {
         /* Python byte string characters are unsigned */
@@ -1855,7 +1855,7 @@ _convert_from_str(PyObject *obj, int align)
 
         /* Attempt to parse the integer, make sure it's the rest of the string */
         errno = 0;
-        long result = strtol(type + 1, &typeend, 10);
+        npy_intp result = strtol(type + 1, &typeend, 10);
         npy_bool some_parsing_happened = !(type == typeend);
         npy_bool entire_string_consumed = *typeend == '\0';
         npy_bool parsing_succeeded =
@@ -1865,7 +1865,7 @@ _convert_from_str(PyObject *obj, int align)
             goto fail;
         }
 
-        elsize = (int)result;
+        elsize = result;
 
 
         if (parsing_succeeded && typeend - type == len) {
@@ -2898,7 +2898,7 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
         elsize = -1;
         alignment = -1;
     }
-    PyTuple_SET_ITEM(state, 5, PyLong_FromLong(elsize));
+    PyTuple_SET_ITEM(state, 5, PyLong_FromSsize_t(elsize));
     PyTuple_SET_ITEM(state, 6, PyLong_FromLong(alignment));
     PyTuple_SET_ITEM(state, 7, PyLong_FromUnsignedLongLong(
             self->flags & ~NPY_NOT_TRIVIALLY_COPYABLE));

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2801,7 +2801,8 @@ arraydescr_reduce(PyArray_Descr *self, PyObject *NPY_UNUSED(args))
     PyObject *ret, *mod, *obj;
     PyObject *state;
     char endian;
-    int elsize, alignment;
+    npy_intp elsize;
+    int alignment;
 
     ret = PyTuple_New(3);
     if (ret == NULL) {

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -346,7 +346,7 @@ _convert_from_tuple(PyObject *obj, int align)
         if (newdescr == NULL) {
             goto fail;
         }
-        newdescr->elsize = (long long)nbytes;
+        newdescr->elsize = nbytes;
         newdescr->subarray = PyArray_malloc(sizeof(PyArray_ArrayDescr));
         if (newdescr->subarray == NULL) {
             Py_DECREF(newdescr);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -654,7 +654,7 @@ _convert_from_list(PyObject *obj, int align)
     /* Types with fields need the Python C API for field access */
     npy_uint64 dtypeflags = NPY_NEEDS_PYAPI;
     int maxalign = 1;
-    int totalsize = 0;
+    npy_intp totalsize = 0;
     for (int i = 0; i < n; i++) {
         PyArray_Descr *conv = _convert_from_any(
                 PyList_GET_ITEM(obj, i), align); // noqa: borrowed-ref OK

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1181,7 +1181,7 @@ _convert_from_dict(PyObject *obj, int align)
                 Py_DECREF(ind);
                 goto fail;
             }
-            long offset = PyArray_PyIntAsInt(off);
+            npy_intp offset = PyArray_PyIntAsIntp(off);
             if (error_converting(offset)) {
                 Py_DECREF(off);
                 Py_DECREF(tup);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -328,8 +328,8 @@ _convert_from_tuple(PyObject *obj, int align)
         }
         npy_intp items = PyArray_OverflowMultiplyList(shape.ptr, shape.len);
         int overflowed;
-        long long nbytes;
-        if (items < 0 || items > NPY_MAX_INTP) {
+        npy_intp nbytes;
+        if (items < 0) {
             overflowed = 1;
         }
         else {

--- a/numpy/_core/src/multiarray/dtype_transfer.c
+++ b/numpy/_core/src/multiarray/dtype_transfer.c
@@ -2284,7 +2284,7 @@ get_fields_transfer_function(int NPY_UNUSED(aligned),
     npy_int i;
     size_t structsize;
     Py_ssize_t field_count;
-    int src_offset, dst_offset;
+    npy_intp src_offset, dst_offset;
     _field_transfer_data *data;
 
     /*
@@ -2313,7 +2313,7 @@ get_fields_transfer_function(int NPY_UNUSED(aligned),
         for (i = 0; i < field_count; ++i) {
             key = PyTuple_GET_ITEM(PyDataType_NAMES(dst_dtype), i);
             tup = PyDict_GetItem(PyDataType_FIELDS(dst_dtype), key); // noqa: borrowed-ref OK
-            if (!PyArg_ParseTuple(tup, "Oi|O", &dst_fld_dtype,
+            if (!PyArg_ParseTuple(tup, "On|O", &dst_fld_dtype,
                                                     &dst_offset, &title)) {
                 PyMem_Free(data);
                 return NPY_FAIL;
@@ -2377,7 +2377,7 @@ get_fields_transfer_function(int NPY_UNUSED(aligned),
 
         key = PyTuple_GET_ITEM(PyDataType_NAMES(src_dtype), 0);
         tup = PyDict_GetItem(PyDataType_FIELDS(src_dtype), key); // noqa: borrowed-ref OK
-        if (!PyArg_ParseTuple(tup, "Oi|O",
+        if (!PyArg_ParseTuple(tup, "On|O",
                               &src_fld_dtype, &src_offset, &title)) {
             PyMem_Free(data);
             return NPY_FAIL;
@@ -2429,14 +2429,14 @@ get_fields_transfer_function(int NPY_UNUSED(aligned),
     for (i = 0; i < field_count; ++i) {
         key = PyTuple_GET_ITEM(PyDataType_NAMES(dst_dtype), i);
         tup = PyDict_GetItem(PyDataType_FIELDS(dst_dtype), key); // noqa: borrowed-ref OK
-        if (!PyArg_ParseTuple(tup, "Oi|O", &dst_fld_dtype,
+        if (!PyArg_ParseTuple(tup, "On|O", &dst_fld_dtype,
                                                 &dst_offset, &title)) {
             NPY_AUXDATA_FREE((NpyAuxData *)data);
             return NPY_FAIL;
         }
         key = PyTuple_GET_ITEM(PyDataType_NAMES(src_dtype), i);
         tup = PyDict_GetItem(PyDataType_FIELDS(src_dtype), key); // noqa: borrowed-ref OK
-        if (!PyArg_ParseTuple(tup, "Oi|O", &src_fld_dtype,
+        if (!PyArg_ParseTuple(tup, "On|O", &src_fld_dtype,
                                                 &src_offset, &title)) {
             NPY_AUXDATA_FREE((NpyAuxData *)data);
             return NPY_FAIL;

--- a/numpy/_core/src/multiarray/dtype_traversal.c
+++ b/numpy/_core/src/multiarray/dtype_traversal.c
@@ -343,11 +343,11 @@ get_fields_traverse_function(
 
     single_field_traverse_data *field = data->fields;
     for (i = 0; i < field_count; ++i) {
-        int offset;
+        npy_intp offset;
 
         key = PyTuple_GET_ITEM(names, i);
         tup = PyDict_GetItem(dtype->fields, key); // noqa: borrowed-ref OK
-        if (!PyArg_ParseTuple(tup, "Oi|O", &fld_dtype, &offset, &title)) {
+        if (!PyArg_ParseTuple(tup, "On|O", &fld_dtype, &offset, &title)) {
             NPY_AUXDATA_FREE((NpyAuxData *)data);
             return -1;
         }

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -730,7 +730,7 @@ void_ensure_canonical(_PyArray_LegacyDescr *self)
                         totalsize, field_descr->alignment);
                 maxalign = PyArray_MAX(maxalign, field_descr->alignment);
             }
-            PyObject *offset_obj = PyLong_FromLong(totalsize);
+            PyObject *offset_obj = PyLong_FromSsize_t(totalsize);
             if (offset_obj == NULL) {
                 Py_DECREF(new_tuple);
                 Py_DECREF(new);

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -709,7 +709,7 @@ void_ensure_canonical(_PyArray_LegacyDescr *self)
         int aligned = PyDataType_FLAGCHK((PyArray_Descr *)new, NPY_ALIGNED_STRUCT);
         new->flags = new->flags & ~NPY_FROM_FIELDS;
         new->flags |= NPY_NEEDS_PYAPI;  /* always needed for field access */
-        int totalsize = 0;
+        npy_intp totalsize = 0;
         int maxalign = 1;
         for (Py_ssize_t i = 0; i < field_num; i++) {
             PyObject *name = PyTuple_GET_ITEM(self->names, i);

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -799,7 +799,7 @@ void_ensure_canonical(_PyArray_LegacyDescr *self)
         int aligned = PyDataType_FLAGCHK((PyArray_Descr *)new, NPY_ALIGNED_STRUCT);
         new->flags = new->flags & ~NPY_FROM_FIELDS;
         new->flags |= NPY_NEEDS_PYAPI;  /* always needed for field access */
-        int totalsize = 0;
+        npy_intp totalsize = 0;
         int maxalign = 1;
         for (Py_ssize_t i = 0; i < field_num; i++) {
             PyObject *name = PyTuple_GET_ITEM(self->names, i);

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -820,7 +820,7 @@ void_ensure_canonical(_PyArray_LegacyDescr *self)
                         totalsize, field_descr->alignment);
                 maxalign = PyArray_MAX(maxalign, field_descr->alignment);
             }
-            PyObject *offset_obj = PyLong_FromLong(totalsize);
+            PyObject *offset_obj = PyLong_FromSsize_t(totalsize);
             if (offset_obj == NULL) {
                 Py_DECREF(new_tuple);
                 Py_DECREF(new);

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -317,7 +317,7 @@ array_data_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 static PyObject *
 array_itemsize_get(PyArrayObject *self, void* NPY_UNUSED(ignored))
 {
-    return PyLong_FromLong((long) PyArray_ITEMSIZE(self));
+    return PyArray_PyIntFromIntp(PyArray_ITEMSIZE(self));
 }
 
 static PyObject *

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -321,7 +321,7 @@ array_data_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 static PyObject *
 array_itemsize_get(PyArrayObject *self, void* NPY_UNUSED(ignored))
 {
-    return PyLong_FromLong((long) PyArray_ITEMSIZE(self));
+    return PyArray_PyIntFromIntp(PyArray_ITEMSIZE(self));
 }
 
 static PyObject *

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -667,7 +667,7 @@ iter_ass_sub_Bool(PyArrayIterObject *self, PyArrayObject *ind,
     /* Loop over Boolean array */
     npy_intp one = 1;
     PyArray_Descr *dtype = PyArray_DESCR(self->ao);
-    int itemsize = dtype->elsize;
+    npy_intp itemsize = dtype->elsize;
     npy_intp transfer_strides[2] = {itemsize, itemsize};
     while (counter--) {
         if (*((npy_bool *)dptr) != 0) {
@@ -698,7 +698,7 @@ iter_ass_sub_int(PyArrayIterObject *self, PyArrayObject *ind,
 
     npy_intp one = 1;
     PyArray_Descr *dtype = PyArray_DESCR(self->ao);
-    int itemsize = dtype->elsize;
+    npy_intp itemsize = dtype->elsize;
     npy_intp transfer_strides[2] = {itemsize, itemsize};
 
     if (PyArray_NDIM(ind) == 0) {

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -693,7 +693,7 @@ iter_ass_sub_Bool(PyArrayIterObject *self, PyArrayObject *ind,
     /* Loop over Boolean array */
     npy_intp one = 1;
     PyArray_Descr *dtype = PyArray_DESCR(self->ao);
-    int itemsize = dtype->elsize;
+    npy_intp itemsize = dtype->elsize;
     npy_intp transfer_strides[2] = {itemsize, itemsize};
     while (counter--) {
         if (*((npy_bool *)dptr) != 0) {
@@ -724,7 +724,7 @@ iter_ass_sub_int(PyArrayIterObject *self, PyArrayObject *ind,
 
     npy_intp one = 1;
     PyArray_Descr *dtype = PyArray_DESCR(self->ao);
-    int itemsize = dtype->elsize;
+    npy_intp itemsize = dtype->elsize;
     npy_intp transfer_strides[2] = {itemsize, itemsize};
 
     if (PyArray_NDIM(ind) == 0) {

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -373,11 +373,11 @@ array_swapaxes(PyArrayObject *self, PyObject *args)
   steals reference to typed, must not be NULL
 */
 NPY_NO_EXPORT PyObject *
-PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, int offset)
+PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, npy_intp offset)
 {
     PyObject *ret = NULL;
     PyObject *safe;
-    int self_elsize, typed_elsize;
+    npy_intp self_elsize, typed_elsize;
 
     if (self == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -402,7 +402,7 @@ PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, int offset)
 
         /* only returns True or raises */
         safe = PyObject_CallFunction(npy_runtime_imports._getfield_is_safe,
-                                     "OOi", PyArray_DESCR(self),
+                                     "OOn", PyArray_DESCR(self),
                                      typed, offset);
         if (safe == NULL) {
             Py_DECREF(typed);
@@ -445,10 +445,10 @@ array_getfield(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
 
     PyArray_Descr *dtype = NULL;
-    int offset = 0;
+    npy_intp offset = 0;
     static char *kwlist[] = {"dtype", "offset", 0};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|i:getfield", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|n:getfield", kwlist,
                                      PyArray_DescrConverter, &dtype,
                                      &offset)) {
         Py_XDECREF(dtype);

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1593,13 +1593,14 @@ _deepcopy_call(char *iptr, char *optr, PyArray_Descr *dtype,
     else if (PyDataType_HASFIELDS(dtype)) {
         PyObject *key, *value, *title = NULL;
         PyArray_Descr *new;
-        int offset, res;
+        npy_intp offset;
+        int res;
         Py_ssize_t pos = 0;
         while (PyDict_Next(PyDataType_FIELDS(dtype), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,
+            if (!PyArg_ParseTuple(value, "On|O", &new, &offset,
                                   &title)) {
                 return -1;
             }

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -465,7 +465,7 @@ array_getfield(PyArrayObject *self, PyObject *args, PyObject *kwds)
 */
 NPY_NO_EXPORT int
 PyArray_SetField(PyArrayObject *self, PyArray_Descr *dtype,
-                 int offset, PyObject *val)
+                 npy_intp offset, PyObject *val)
 {
     PyObject *ret = NULL;
     int retval = 0;
@@ -502,11 +502,11 @@ static PyObject *
 array_setfield(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
     PyArray_Descr *dtype = NULL;
-    int offset = 0;
+    npy_intp offset = 0;
     PyObject *value;
     static char *kwlist[] = {"value", "dtype", "offset", 0};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&|i:setfield", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&|n:setfield", kwlist,
                                      &value,
                                      PyArray_DescrConverter, &dtype,
                                      &offset)) {

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -374,12 +374,12 @@ array_swapaxes(PyArrayObject *self, PyObject *args)
   steals reference to typed, must not be NULL
 */
 NPY_NO_EXPORT PyObject *
-PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, int offset)
+PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, npy_intp offset)
 {
     multiarray_umath_state *state = _npy_module_state;
     PyObject *ret = NULL;
     PyObject *safe;
-    int self_elsize, typed_elsize;
+    npy_intp self_elsize, typed_elsize;
 
     if (self == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -403,8 +403,8 @@ PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, int offset)
         }
 
         /* only returns True or raises */
-        safe = PyObject_CallFunction(state->runtime_imports._getfield_is_safe,
-                                     "OOi", PyArray_DESCR(self),
+        safe = PyObject_CallFunction(npy_runtime_imports._getfield_is_safe,
+                                     "OOn", PyArray_DESCR(self),
                                      typed, offset);
         if (safe == NULL) {
             Py_DECREF(typed);
@@ -447,10 +447,10 @@ array_getfield(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
 
     PyArray_Descr *dtype = NULL;
-    int offset = 0;
+    npy_intp offset = 0;
     static char *kwlist[] = {"dtype", "offset", 0};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|i:getfield", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|n:getfield", kwlist,
                                      PyArray_DescrConverter, &dtype,
                                      &offset)) {
         Py_XDECREF(dtype);

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -403,7 +403,7 @@ PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, npy_intp offset)
         }
 
         /* only returns True or raises */
-        safe = PyObject_CallFunction(npy_runtime_imports._getfield_is_safe,
+        safe = PyObject_CallFunction(state->runtime_imports._getfield_is_safe,
                                      "OOn", PyArray_DESCR(self),
                                      typed, offset);
         if (safe == NULL) {

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1651,13 +1651,14 @@ _deepcopy_call(char *iptr, char *optr, PyArray_Descr *dtype,
     else if (PyDataType_HASFIELDS(dtype)) {
         PyObject *key, *value, *title = NULL;
         PyArray_Descr *new;
-        int offset, res;
+        npy_intp offset;
+        int res;
         Py_ssize_t pos = 0;
         while (PyDict_Next(PyDataType_FIELDS(dtype), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,
+            if (!PyArg_ParseTuple(value, "On|O", &new, &offset,
                                   &title)) {
                 return -1;
             }

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -467,7 +467,7 @@ array_getfield(PyArrayObject *self, PyObject *args, PyObject *kwds)
 */
 NPY_NO_EXPORT int
 PyArray_SetField(PyArrayObject *self, PyArray_Descr *dtype,
-                 int offset, PyObject *val)
+                 npy_intp offset, PyObject *val)
 {
     PyObject *ret = NULL;
     int retval = 0;
@@ -504,11 +504,11 @@ static PyObject *
 array_setfield(PyArrayObject *self, PyObject *args, PyObject *kwds)
 {
     PyArray_Descr *dtype = NULL;
-    int offset = 0;
+    npy_intp offset = 0;
     PyObject *value;
     static char *kwlist[] = {"value", "dtype", "offset", 0};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&|i:setfield", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO&|n:setfield", kwlist,
                                      &value,
                                      PyArray_DescrConverter, &dtype,
                                      &offset)) {

--- a/numpy/_core/src/multiarray/nditer_api.c
+++ b/numpy/_core/src/multiarray/nditer_api.c
@@ -2296,7 +2296,7 @@ npyiter_clear_buffers(NpyIter *iter)
         /* Buffer cannot be re-used (not that we should ever try!) */
         op_itflags[iop] &= ~NPY_OP_ITFLAG_BUF_REUSABLE;
 
-        int itemsize = dtypes[iop]->elsize;
+        npy_intp itemsize = dtypes[iop]->elsize;
         if (transferinfo[iop].clear.func(NULL,
                 dtypes[iop], *buffers, NBF_SIZE(bufferdata), itemsize,
                 transferinfo[iop].clear.auxdata) < 0) {

--- a/numpy/_core/src/multiarray/refcount.c
+++ b/numpy/_core/src/multiarray/refcount.c
@@ -183,14 +183,14 @@ PyArray_Item_INCREF(char *data, PyArray_Descr *descr)
     else if (PyDataType_HASFIELDS(descr)) {
         PyObject *key, *value, *title = NULL;
         PyArray_Descr *new;
-        int offset;
+        npy_intp offset;
         Py_ssize_t pos = 0;
 
         while (PyDict_Next(PyDataType_FIELDS(descr), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,
+            if (!PyArg_ParseTuple(value, "On|O", &new, &offset,
                                   &title)) {
                 return;
             }
@@ -245,14 +245,14 @@ PyArray_Item_XDECREF(char *data, PyArray_Descr *descr)
     else if (PyDataType_HASFIELDS(descr)) {
             PyObject *key, *value, *title = NULL;
             PyArray_Descr *new;
-            int offset;
+            npy_intp offset;
             Py_ssize_t pos = 0;
 
             while (PyDict_Next(PyDataType_FIELDS(descr), &pos, &key, &value)) { // noqa: borrowed-ref OK
                 if (NPY_TITLE_KEY(key, value)) {
                     continue;
                 }
-                if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset,
+                if (!PyArg_ParseTuple(value, "On|O", &new, &offset,
                                       &title)) {
                     return;
                 }
@@ -479,14 +479,14 @@ _fill_with_none(char *optr, PyArray_Descr *dtype)
     else if (PyDataType_HASFIELDS(dtype)) {
         PyObject *key, *value, *title = NULL;
         PyArray_Descr *new;
-        int offset;
+        npy_intp offset;
         Py_ssize_t pos = 0;
 
         while (PyDict_Next(PyDataType_FIELDS(dtype), &pos, &key, &value)) { // noqa: borrowed-ref OK
             if (NPY_TITLE_KEY(key, value)) {
                 continue;
             }
-            if (!PyArg_ParseTuple(value, "Oi|O", &new, &offset, &title)) {
+            if (!PyArg_ParseTuple(value, "On|O", &new, &offset, &title)) {
                 return -1;
             }
             if (_fill_with_none(optr + offset, new) < 0) {

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -468,7 +468,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
     void *destptr;
     PyArray_CopySwapFunc *copyswap;
     int type_num;
-    int itemsize;
+    npy_intp itemsize;
     int swap;
 
     type_num = descr->type_num;

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -469,7 +469,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
     void *destptr;
     PyArray_CopySwapFunc *copyswap;
     int type_num;
-    int itemsize;
+    npy_intp itemsize;
     int swap;
 
     type_num = descr->type_num;

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -20,7 +20,7 @@
 #include "mapping.h"
 #include "ctors.h"
 #include "dtypemeta.h"
-#include "descriptor.h" 
+#include "descriptor.h"
 #include "usertypes.h"
 #include "number.h"
 #include "numpyos.h"
@@ -233,7 +233,7 @@ find_binary_operation_path(
     }
 
     if (!was_scalar || PyArray_DESCR(arr)->type_num != NPY_OBJECT) {
-        /* 
+        /*
          * The array is OK for usage and we can simply forward it.  There
          * is a theoretical subtlety here:  If the other object implements
          * `__array_wrap__`, we may ignore that.  However, this only matters
@@ -823,9 +823,8 @@ _void_to_hex(const char* argbuf, const Py_ssize_t arglen,
              const char *schars, const char *bprefix, const char *echars)
 {
     PyObject *retval;
-    int extrachars, slen;
+    Py_ssize_t i, j, extrachars, slen;
     char *retbuf;
-    Py_ssize_t i, j;
     char const *hexdigits = "0123456789ABCDEF";
 
     extrachars = strlen(schars) + strlen(echars);
@@ -1703,11 +1702,11 @@ gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArray_Descr *typecode;
     PyObject *ret;
-    int elsize;
+    npy_intp elsize;
 
     typecode = PyArray_DescrFromScalar(self);
     elsize = typecode->elsize;
-    ret = PyLong_FromLong((long) elsize);
+    ret = PyArray_PyIntFromIntp(elsize);
     Py_DECREF(typecode);
     return ret;
 }
@@ -1827,7 +1826,7 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
     if (strides == NULL) {
         goto finish;
     }
-    
+
     /* descr */
     descr = array_protocol_descr_get(array_descr);
     if (descr == NULL) {

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1958,7 +1958,7 @@ gentype_imag_get(PyObject *self, void *NPY_UNUSED(ignored))
     }
     else {
         char *temp;
-        int elsize;
+        npy_intp elsize;
         typecode = PyArray_DescrFromScalar(self);
         elsize = typecode->elsize;
         temp = npy_alloc_cache_zero(1, elsize);

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1964,7 +1964,7 @@ gentype_imag_get(PyObject *self, void *NPY_UNUSED(ignored))
     }
     else {
         char *temp;
-        int elsize;
+        npy_intp elsize;
         typecode = PyArray_DescrFromScalar(self);
         elsize = typecode->elsize;
         temp = npy_alloc_cache_zero(1, elsize);

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -828,9 +828,8 @@ _void_to_hex(const char* argbuf, const Py_ssize_t arglen,
              const char *schars, const char *bprefix, const char *echars)
 {
     PyObject *retval;
-    int extrachars, slen;
+    Py_ssize_t i, j, extrachars, slen;
     char *retbuf;
-    Py_ssize_t i, j;
     char const *hexdigits = "0123456789ABCDEF";
 
     extrachars = strlen(schars) + strlen(echars);
@@ -1709,11 +1708,11 @@ gentype_itemsize_get(PyObject *self, void *NPY_UNUSED(ignored))
 {
     PyArray_Descr *typecode;
     PyObject *ret;
-    int elsize;
+    npy_intp elsize;
 
     typecode = PyArray_DescrFromScalar(self);
     elsize = typecode->elsize;
-    ret = PyLong_FromLong((long) elsize);
+    ret = PyArray_PyIntFromIntp(elsize);
     Py_DECREF(typecode);
     return ret;
 }

--- a/numpy/_core/src/multiarray/textreading/field_types.c
+++ b/numpy/_core/src/multiarray/textreading/field_types.c
@@ -11,7 +11,7 @@
 
 
 NPY_NO_EXPORT void
-field_types_xclear(int num_field_types, field_type *ft) {
+field_types_xclear(npy_intp num_field_types, field_type *ft) {
     assert(num_field_types >= 0);
     if (ft == NULL) {
         return;
@@ -131,8 +131,8 @@ field_type_grow_recursive(PyArray_Descr *descr,
             }
             PyArray_Descr *field_descr;
             PyObject *title;
-            int offset;
-            if (!PyArg_ParseTuple(tup, "Oi|O", &field_descr, &offset, &title)) {
+            npy_intp offset;
+            if (!PyArg_ParseTuple(tup, "On|O", &field_descr, &offset, &title)) {
                 Py_DECREF(tup);
                 field_types_xclear(num_field_types, *ft);
                 return -1;

--- a/numpy/_core/src/multiarray/textreading/field_types.h
+++ b/numpy/_core/src/multiarray/textreading/field_types.h
@@ -62,7 +62,7 @@ typedef struct _field_type {
 
 
 NPY_NO_EXPORT void
-field_types_xclear(int num_field_types, field_type *ft);
+field_types_xclear(npy_intp num_field_types, field_type *ft);
 
 NPY_NO_EXPORT npy_intp
 field_types_create(PyArray_Descr *descr, field_type **ft);

--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -73,9 +73,9 @@ _append_new(int **p_types, int insert)
 static npy_bool
 _default_nonzero(void *ip, void *arr)
 {
-    int elsize = PyArray_ITEMSIZE(arr);
+    npy_intp elsize = PyArray_ITEMSIZE(arr);
     char *ptr = ip;
-    while (elsize--) {
+    while (elsize-- > 0) {
         if (*ptr++ != 0) {
             return NPY_TRUE;
         }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2921,7 +2921,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         NpyIter_IterNextFunc *iternext;
         char **dataptr;
 
-        int itemsize = descrs[0]->elsize;
+        npy_intp itemsize = descrs[0]->elsize;
 
         /* Get the variables needed for the loop */
         iternext = NpyIter_GetIterNext(iter, NULL);
@@ -2967,7 +2967,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
                 }
             }
             else {
-                memmove(dataptr_copy[2], dataptr_copy[1], itemsize);
+                memmove(dataptr_copy[2], dataptr_copy[1], (size_t)itemsize);
             }
 
             if (count_m1 > 0) {
@@ -2986,7 +2986,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     else if (iter == NULL) {
         char *dataptr_copy[3];
 
-        int itemsize = descrs[0]->elsize;
+        npy_intp itemsize = descrs[0]->elsize;
 
         /* Execute the loop with no iterators */
         npy_intp count = PyArray_DIM(op[1], axis);
@@ -3026,7 +3026,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             }
         }
         else {
-            memmove(dataptr_copy[2], dataptr_copy[1], itemsize);
+            memmove(dataptr_copy[2], dataptr_copy[1], (size_t)itemsize);
         }
 
         if (count > 1) {
@@ -3340,7 +3340,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
         npy_intp stride0, stride1;
         npy_intp stride0_ind = PyArray_STRIDE(op[0], axis);
 
-        int itemsize = descrs[0]->elsize;
+        npy_intp itemsize = descrs[0]->elsize;
 
         /* Get the variables needed for the loop */
         iternext = NpyIter_GetIterNext(iter, NULL);
@@ -3393,7 +3393,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
                                         *(PyObject **)dataptr_copy[1];
                 }
                 else {
-                    memmove(dataptr_copy[0], dataptr_copy[1], itemsize);
+                    memmove(dataptr_copy[0], dataptr_copy[1], (size_t)itemsize);
                 }
 
                 if (count > 1) {
@@ -3413,7 +3413,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
     else if (iter == NULL) {
         char *dataptr_copy[3];
 
-        int itemsize = descrs[0]->elsize;
+        npy_intp itemsize = descrs[0]->elsize;
 
         npy_intp stride0_ind = PyArray_STRIDE(op[0], axis);
         npy_intp stride1 = PyArray_STRIDE(op[1], axis);
@@ -3452,7 +3452,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
                                     *(PyObject **)dataptr_copy[1];
             }
             else {
-                memmove(dataptr_copy[0], dataptr_copy[1], itemsize);
+                memmove(dataptr_copy[0], dataptr_copy[1], (size_t)itemsize);
             }
 
             if (count > 1) {

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3169,7 +3169,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         NpyIter_IterNextFunc *iternext;
         char **dataptr;
 
-        int itemsize = loop_descrs[0]->elsize;
+        npy_intp itemsize = loop_descrs[0]->elsize;
 
         /* Get the variables needed for the loop */
         iternext = NpyIter_GetIterNext(iter, NULL);
@@ -3215,7 +3215,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
                 }
             }
             else {
-                memmove(dataptr_copy[2], dataptr_copy[1], itemsize);
+                memmove(dataptr_copy[2], dataptr_copy[1], (size_t)itemsize);
             }
 
             if (count_m1 > 0) {
@@ -3234,7 +3234,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     else if (iter == NULL) {
         char *dataptr_copy[3];
 
-        int itemsize = loop_descrs[0]->elsize;
+        npy_intp itemsize = loop_descrs[0]->elsize;
 
         /* Execute the loop with no iterators */
         npy_intp count = PyArray_DIM(op[1], axis);
@@ -3274,7 +3274,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             }
         }
         else {
-            memmove(dataptr_copy[2], dataptr_copy[1], itemsize);
+            memmove(dataptr_copy[2], dataptr_copy[1], (size_t)itemsize);
         }
 
         if (count > 1) {
@@ -3589,7 +3589,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
         npy_intp stride0, stride1;
         npy_intp stride0_ind = PyArray_STRIDE(op[0], axis);
 
-        int itemsize = descrs[0]->elsize;
+        npy_intp itemsize = descrs[0]->elsize;
 
         /* Get the variables needed for the loop */
         iternext = NpyIter_GetIterNext(iter, NULL);
@@ -3642,7 +3642,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
                                         *(PyObject **)dataptr_copy[1];
                 }
                 else {
-                    memmove(dataptr_copy[0], dataptr_copy[1], itemsize);
+                    memmove(dataptr_copy[0], dataptr_copy[1], (size_t)itemsize);
                 }
 
                 if (count > 1) {
@@ -3662,7 +3662,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
     else if (iter == NULL) {
         char *dataptr_copy[3];
 
-        int itemsize = descrs[0]->elsize;
+        npy_intp itemsize = descrs[0]->elsize;
 
         npy_intp stride0_ind = PyArray_STRIDE(op[0], axis);
         npy_intp stride1 = PyArray_STRIDE(op[1], axis);
@@ -3701,7 +3701,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
                                     *(PyObject **)dataptr_copy[1];
             }
             else {
-                memmove(dataptr_copy[0], dataptr_copy[1], itemsize);
+                memmove(dataptr_copy[0], dataptr_copy[1], (size_t)itemsize);
             }
 
             if (count > 1) {

--- a/numpy/_core/tests/test_casting_unittests.py
+++ b/numpy/_core/tests/test_casting_unittests.py
@@ -687,11 +687,11 @@ class TestCasting:
             assert data2.copy()[()] == element
 
     def test_void_to_string_special_case(self):
-        # Cover a small special case in void to string casting that could
-        # probably just as well be turned into an error (compare
-        # `test_object_to_parametric_internal_error` below).
-        assert np.array([], dtype="V5").astype("S").dtype.itemsize == 5
-        assert np.array([], dtype="V5").astype("U").dtype.itemsize == 4 * 5
+        # These used to succeed for empty arrays, but now we reject them:
+        with pytest.raises(TypeError, match="cannot cast"):
+            np.array([], dtype="V5").astype("S")  # was S5
+        with pytest.raises(TypeError, match="cannot cast"):
+            np.array([], dtype="V5").astype("U")  # was U5
 
     def test_object_to_parametric_internal_error(self):
         # We reject casting from object to a parametric type, without

--- a/numpy/_core/tests/test_casting_unittests.py
+++ b/numpy/_core/tests/test_casting_unittests.py
@@ -693,11 +693,11 @@ class TestCasting:
             assert data2.copy()[()] == element
 
     def test_void_to_string_special_case(self):
-        # Cover a small special case in void to string casting that could
-        # probably just as well be turned into an error (compare
-        # `test_object_to_parametric_internal_error` below).
-        assert np.array([], dtype="V5").astype("S").dtype.itemsize == 5
-        assert np.array([], dtype="V5").astype("U").dtype.itemsize == 4 * 5
+        # These used to succeed for empty arrays, but now we reject them:
+        with pytest.raises(TypeError, match="cannot cast"):
+            np.array([], dtype="V5").astype("S")  # was S5
+        with pytest.raises(TypeError, match="cannot cast"):
+            np.array([], dtype="V5").astype("U")  # was U5
 
     def test_object_to_parametric_internal_error(self):
         # We reject casting from object to a parametric type, without

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2052,6 +2052,9 @@ class TestDTypeSignatures:
     ([("x", np.float64, 2 ** 28)], (2 ** 28 * 8)),
     ("2147483648i,2147483648i", 17179869184),
     (dict(names=["a"], formats=["2147483648i"]), 8589934592),
+    (dict(names=["a"], formats=["2147483648i"], offsets=[1]), 8589934593),
+    (dict(names=["a"], formats=["2147483648i"], offsets=[2 ** 31 - 100]), 10737418140),
+    (dict(names=["a"], formats=["2147483648i"], offsets=[2 ** 31]), 10737418240),
 ])
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2050,11 +2050,19 @@ class TestDTypeSignatures:
 
 @pytest.mark.parametrize("kind, exp", [
     ([("x", np.float64, 2 ** 28)], (2 ** 28 * 8)),
+    ([("x", np.float64, 2 ** 27), ("y", np.float64, 2 ** 27)], (2 ** 28 * 8)),
+    ([("x", np.float32, 2 ** 28), ("y", np.float64, 2 ** 27)], (2 ** 28 * 8)),
+    ([("x", np.float16, 2 ** 29), ("y", np.float64, 2 ** 27)], (2 ** 28 * 8)),
     ("2147483648i,2147483648i", 17179869184),
+    ("2147483648f,2147483648f", 17179869184),
+    ("2147483648d,2147483648d", 34359738368),
+    ("2b,2147483648b,2f,4i", 2147483674),
     (dict(names=["a"], formats=["2147483648i"]), 8589934592),
     (dict(names=["a"], formats=["2147483648i"], offsets=[1]), 8589934593),
     (dict(names=["a"], formats=["2147483648i"], offsets=[2 ** 31 - 100]), 10737418140),
     (dict(names=["a"], formats=["2147483648i"], offsets=[2 ** 31]), 10737418240),
+    (dict(names=["a", "b", "c"], formats=["2147483648b", "16i", "12f"],
+     offsets=[2 ** 31, 2 ** 32, 2 ** 32 + 69]), 4294967413),
 ])
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1265,6 +1265,7 @@ class TestPickling:
             assert_equal(x, y)
             assert_equal(x[0], y[0])
 
+    @pytest.mark.slow()
     @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
     def test_pickling_large(self):
         # The actual itemsize is larger than a c-integer here.

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1249,7 +1249,7 @@ class TestDTypeMakeCanonical:
 
 class TestPickling:
 
-    def check_pickling(self, dtype):
+    def check_pickling(self, dtype, arr_assert=True):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             buf = pickle.dumps(dtype, proto)
             # The dtype pickling itself pickles `np.dtype` if it is pickled
@@ -1259,22 +1259,25 @@ class TestPickling:
             pickled = pickle.loads(buf)
             assert_equal(pickled, dtype)
             assert_equal(pickled.descr, dtype.descr)
+            assert_equal(pickled.itemsize, dtype.itemsize)
             if dtype.metadata is not None:
                 assert_equal(pickled.metadata, dtype.metadata)
             # Check the reconstructed dtype is functional
             x = np.zeros(3, dtype=dtype)
             y = np.zeros(3, dtype=pickled)
-            assert_equal(x, y)
-            assert_equal(x[0], y[0])
+            # some large structured dtypes are too large to
+            # reasonably compare across all elements
+            if arr_assert:
+                assert_equal(x, y)
+                assert_equal(x[0], y[0])
 
-    @pytest.mark.slow()
     @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
     def test_pickling_large(self):
         # The actual itemsize is larger than a c-integer here.
         dtype = np.dtype(f"({2**31},)i")
-        self.check_pickling(dtype)
+        self.check_pickling(dtype, False)
         dtype = np.dtype(f"({2**31},)i", metadata={"a": "b"})
-        self.check_pickling(dtype)
+        self.check_pickling(dtype, False)
 
     @pytest.mark.parametrize('t', [int, float, complex, np.int32, str, object,
                                    bool])

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2051,6 +2051,7 @@ class TestDTypeSignatures:
 @pytest.mark.parametrize("kind, exp", [
     ([("x", np.float64, 2 ** 28)], (2 ** 28 * 8)),
     ("2147483648i,2147483648i", 17179869184),
+    (dict(names=["a"], formats=["2147483648i"]), 8589934592),
 ])
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2071,6 +2071,8 @@ class TestDTypeSignatures:
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)
     assert kind_dtype.itemsize == exp
+    for name in kind_dtype.names:
+        assert kind_dtype[name].shape[0] > 0
 
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2077,8 +2077,11 @@ def test_gh_31308(kind, exp):
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
 @requires_memory(free_bytes=2e9)
-def test_gh_31308_materialized():
-    kind = [("x", np.float64, 2 ** 28)]
+@pytest.mark.parametrize("val, kind, exp", [
+    ((1,), [("x", np.float64, 2 ** 28)], 2 ** 28),
+    ((1, 1), [("x", np.float64, 2 ** 28), ("y", np.float64, 1)], 2 ** 28),
+])
+def test_gh_31308_materialized(val, kind, exp):
     kind_dtype = np.dtype(kind)
-    rec_arr = np.array((1,), dtype=kind_dtype)
-    assert rec_arr["x"].size == 2 ** 28
+    rec_arr = np.array(val, dtype=kind_dtype)
+    assert rec_arr["x"].size == exp

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2054,6 +2054,7 @@ def test_gh_31308():
     assert kind_dtype.itemsize == (2 ** 28) * 8
 
 
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
 @requires_memory(free_bytes=2e9)
 def test_gh_31308_materialized():
     kind = [("x", np.float64, 2 ** 28)]

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -26,7 +26,7 @@ from numpy.testing import (
     assert_equal,
     assert_raises,
 )
-from numpy.testing._private.utils import requires_deep_recursion
+from numpy.testing._private.utils import requires_deep_recursion, requires_memory
 
 
 def assert_dtype_equal(a, b):
@@ -2051,8 +2051,9 @@ def test_gh_31308():
     assert kind_dtype.itemsize == (2 ** 28) * 8
 
 
-@pytest.mark.xfail(run=False)
+@requires_memory(free_bytes=2e9)
 def test_gh_31308_materialized():
     kind = [("x", np.float64, 2 ** 28)]
     kind_dtype = np.dtype(kind)
     rec_arr = np.array((1,), dtype=kind_dtype)
+    assert rec_arr["x"].size == 2 ** 28

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2048,10 +2048,13 @@ class TestDTypeSignatures:
         assert params_actual == params_expect
 
 
-def test_gh_31308():
-    kind = [("x", np.float64, 2 ** 28)]
+@pytest.mark.parametrize("kind, exp", [
+    ([("x", np.float64, 2 ** 28)], (2 ** 28 * 8)),
+    ("2147483648i,2147483648i", 17179869184),
+])
+def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)
-    assert kind_dtype.itemsize == (2 ** 28) * 8
+    assert kind_dtype.itemsize == exp
 
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -739,6 +739,8 @@ class TestSubarray:
         # Check that the shape is valid.
         max_intp = np.iinfo(np.intp).max
         # Too large values (the datatype is part of this)
+        assert_raises(ValueError, np.dtype, [('a', 'f8', max_intp // 8 + 1)])
+        assert_raises(ValueError, np.dtype, [('a', 'f4', max_intp // 4 + 1)])
         assert_raises(ValueError, np.dtype, [('a', 'f4', max_intp + 1)])
         # Negative values
         assert_raises(ValueError, np.dtype, [('a', 'f4', -1)])

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1262,12 +1262,12 @@ class TestPickling:
             assert_equal(pickled.itemsize, dtype.itemsize)
             if dtype.metadata is not None:
                 assert_equal(pickled.metadata, dtype.metadata)
-            # Check the reconstructed dtype is functional
-            x = np.zeros(3, dtype=dtype)
-            y = np.zeros(3, dtype=pickled)
             # some large structured dtypes are too large to
             # reasonably compare across all elements
             if arr_assert:
+                # Check the reconstructed dtype is functional
+                x = np.zeros(3, dtype=dtype)
+                y = np.zeros(3, dtype=pickled)
                 assert_equal(x, y)
                 assert_equal(x[0], y[0])
 
@@ -2067,6 +2067,7 @@ class TestDTypeSignatures:
     (dict(names=["a", "b", "c"], formats=["2147483648b", "16i", "12f"],
      offsets=[2 ** 31, 2 ** 32, 2 ** 32 + 69]), 4294967413),
 ])
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)
     assert kind_dtype.itemsize == exp

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2048,6 +2048,7 @@ class TestDTypeSignatures:
 def test_gh_31308():
     kind = [("x", np.float64, 2 ** 28)]
     kind_dtype = np.dtype(kind)
+    assert kind_dtype.itemsize == (2 ** 28) * 8
 
 
 @pytest.mark.xfail(run=False)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -737,13 +737,8 @@ class TestSubarray:
 
     def test_shape_invalid(self):
         # Check that the shape is valid.
-        max_int = np.iinfo(np.intc).max
         max_intp = np.iinfo(np.intp).max
         # Too large values (the datatype is part of this)
-        assert_raises(ValueError, np.dtype, [('a', 'f4', max_int // 4 + 1)])
-        assert_raises(ValueError, np.dtype, [('a', 'f4', max_int + 1)])
-        assert_raises(ValueError, np.dtype, [('a', 'f4', (max_int, 2))])
-        # Takes a different code path (fails earlier:
         assert_raises(ValueError, np.dtype, [('a', 'f4', max_intp + 1)])
         # Negative values
         assert_raises(ValueError, np.dtype, [('a', 'f4', -1)])
@@ -1271,7 +1266,6 @@ class TestPickling:
             assert_equal(x[0], y[0])
 
     @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
-    @pytest.mark.xfail(reason="dtype conversion doesn't allow this yet.")
     def test_pickling_large(self):
         # The actual itemsize is larger than a c-integer here.
         dtype = np.dtype(f"({2**31},)i")
@@ -2049,3 +2043,15 @@ class TestDTypeSignatures:
 
         params_actual = set(sig.parameters)
         assert params_actual == params_expect
+
+
+def test_gh_31308():
+    kind = [("x", np.float64, 2 ** 28)]
+    kind_dtype = np.dtype(kind)
+
+
+@pytest.mark.xfail(run=False)
+def test_gh_31308_materialized():
+    kind = [("x", np.float64, 2 ** 28)]
+    kind_dtype = np.dtype(kind)
+    rec_arr = np.array((1,), dtype=kind_dtype)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -3,11 +3,11 @@ import ctypes
 import inspect
 import operator
 import os
-from io import StringIO
 import pickle
 import sys
 import types
 import warnings
+from io import StringIO
 from itertools import permutations
 from typing import Any
 
@@ -23,10 +23,10 @@ from numpy.testing import (
     HAS_REFCOUNT,
     IS_64BIT,
     assert_,
+    assert_allclose,
     assert_array_equal,
     assert_equal,
     assert_raises,
-    assert_allclose,
 )
 from numpy.testing._private.utils import requires_deep_recursion, requires_memory
 
@@ -2213,9 +2213,9 @@ def test_gh_31308_deepcopy_and_scalar_object_large_offsets():
 @requires_memory(free_bytes=2e10)
 def test_gh_31308_huge_void_scalars():
     __tracebackhide__ = True  # locals too large to print nicely
-    dt = np.dtype(f"V{2**31+1}")
+    dt = np.dtype(f"V{2**31 + 1}")
     arr = np.zeros(1, dtype=dt)
-    assert arr.itemsize == 2**31+1
+    assert arr.itemsize == 2**31 + 1
     item = arr[0]
     assert item.dtype == dt
     # The following string conversion is just too slow to run in CI:

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -25,6 +25,7 @@ from numpy.testing import (
     assert_array_equal,
     assert_equal,
     assert_raises,
+    assert_allclose,
 )
 from numpy.testing._private.utils import requires_deep_recursion, requires_memory
 
@@ -2108,3 +2109,15 @@ def test_gh_31308_getfield():
     # dtype should still error out
     with pytest.raises(ValueError, match="is larger"):
         field = rec_arr.getfield(np.float64, offset=2**31 + 1)
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+@requires_memory(free_bytes=2e9)
+def test_gh_31308_setfield():
+    # avoid overflow when using ndarray.setfield
+    # with large structured dtypes
+    kind = [("x", np.float64, 2**28 + 1)]
+    kind_dtype = np.dtype(kind)
+    rec_arr = np.array((1,), dtype=kind_dtype)
+    rec_arr.setfield(7, np.float64, offset=2**31)
+    actual = rec_arr.getfield(np.float64, offset=2**31)
+    assert_allclose(actual, 7)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2103,6 +2103,14 @@ def test_gh_31308_array_itemsize_getter_large_dtype():
 
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_binary_imports_reject_too_small_large_itemsize():
+    kind_dtype = np.dtype(dict(
+        names=["a"], formats=["i1"], itemsize=2 ** 31 + 1))
+    with pytest.raises(ValueError, match="buffer is smaller than requested size"):
+        np.frombuffer(b"\0", dtype=kind_dtype, count=1)
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
 def test_gh_31308_out_of_order_object_fields_large_offsets():
     kind_dtype = np.dtype(dict(
         names=["b", "a"],

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2073,9 +2073,99 @@ class TestDTypeSignatures:
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)
     assert kind_dtype.itemsize == exp
+    assert kind_dtype.str == f"|V{exp}"
     assert kind_dtype.isnative
     for name in kind_dtype.names:
         assert kind_dtype[name].shape[0] > 0
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_result_type_keeps_large_offsets():
+    kind_dtype = np.dtype([("x", np.float64, 2 ** 28), ("y", np.float64, 1)])
+    canonical = np.result_type(kind_dtype)
+    assert canonical.itemsize == kind_dtype.itemsize
+    assert canonical.str == kind_dtype.str
+    assert canonical.fields["y"][1] == kind_dtype.fields["y"][1]
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_dict_itemsize_override_large():
+    kind_dtype = np.dtype(dict(names=["a"], formats=["i1"], itemsize=2 ** 31))
+    assert kind_dtype.itemsize == 2 ** 31
+    assert kind_dtype.str == f"|V{2 ** 31}"
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_array_itemsize_getter_large_dtype():
+    kind_dtype = np.dtype([("x", np.float64, 2 ** 28)])
+    arr = np.empty(0, dtype=kind_dtype)
+    assert arr.itemsize == kind_dtype.itemsize
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_out_of_order_object_fields_large_offsets():
+    kind_dtype = np.dtype(dict(
+        names=["b", "a"],
+        formats=["O", "O"],
+        offsets=[2 ** 31 + 16, 2 ** 31],
+        itemsize=2 ** 31 + 24,
+    ))
+    assert kind_dtype.fields["a"][1] == 2 ** 31
+    assert kind_dtype.fields["b"][1] == 2 ** 31 + 16
+    with pytest.raises(TypeError, match="overlapping object fields"):
+        np.dtype(dict(
+            names=["b", "a"],
+            formats=["O", "O"],
+            offsets=[2 ** 31 + 4, 2 ** 31],
+            itemsize=2 ** 31 + 16,
+        ))
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+@requires_memory(free_bytes=2.2e9)
+def test_gh_31308_copyto_large_offsets():
+    src_scalar = np.array([37], dtype=np.int8)
+    struct_dtype = np.dtype(
+        dict(names=["a"], formats=["i1"], offsets=[2 ** 31], itemsize=2 ** 31 + 1)
+    )
+    dst_struct = np.zeros(1, dtype=struct_dtype)
+    dst_scalar = np.array([0], dtype=np.int8)
+
+    np.copyto(dst_struct, src_scalar, casting="unsafe")
+    np.copyto(dst_scalar, dst_struct, casting="unsafe")
+    assert dst_struct["a"][0] == 37
+    assert dst_scalar[0] == 37
+
+    # Also hit structured->structured setup on large offsets.
+    src_struct_0 = np.zeros(0, dtype=struct_dtype)
+    dst_struct_0 = np.zeros(0, dtype=np.dtype(
+        dict(names=["a"], formats=["i1"], offsets=[2 ** 31 + 4], itemsize=2 ** 31 + 5)
+    ))
+    np.copyto(dst_struct_0, src_struct_0, casting="unsafe")
+    assert dst_struct_0.dtype.fields["a"][1] == 2 ** 31 + 4
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_negative_offset_error_message():
+    bad_offset = -(2 ** 31) - 1
+    with pytest.raises(
+            ValueError,
+            match=rf"offset {bad_offset} cannot be negative"):
+        np.dtype(dict(names=["a"], formats=["i1"], offsets=[bad_offset]))
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_legacy_setstate_keeps_object_flag():
+    kind_dtype = np.dtype(dict(names=["a"], formats=["O"], offsets=[2 ** 31]))
+    reconstruct, args, state = kind_dtype.__reduce__()
+    assert state[0] >= 3
+
+    reparsed = reconstruct(*args)
+    # Exercise the compatibility path that recomputes flags using
+    # _descr_find_object() for older pickle versions.
+    reparsed.__setstate__((2, *state[1:]))
+    assert reparsed.hasobject
+    assert reparsed.fields["a"][1] == 2 ** 31
 
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
@@ -2092,6 +2182,38 @@ def test_gh_31308_materialized(val, kind, exp):
     # of large structured dtypes:
     with pytest.raises(TypeError, match="not ordered"):
         np.argmax(rec_arr)
+
+
+@requires_memory(free_bytes=2e10)
+def test_gh_31308_deepcopy_and_scalar_object_large_offsets():
+    dt = np.dtype([("x", np.int8, 2 ** 31), ("y", object)])
+    arr = np.zeros(1, dtype=dt)
+    arr["y"] = object()
+    # See that deepcopying the object field works:
+    copy = arr.__deepcopy__({})
+    assert copy["y"] is not arr["y"]
+    # Also check that getting the scalar is fine:
+    scalar = arr[()]
+    # and go back to array (needs to increment the object)
+    arr2 = np.array(scalar)
+    arr2.flat[...] = arr
+    # Currently tests a very niche path (that might be otherwise unused):
+    arr.flat = arr
+
+
+@pytest.mark.slow
+@requires_memory(free_bytes=2e10)
+def test_gh_31308_huge_void_scalars():
+    __tracebackhide__ = True  # locals too large to print nicely
+    dt = np.dtype(f"V{2**31+1}")
+    arr = np.zeros(1, dtype=dt)
+    assert arr.itemsize == 2**31+1
+    item = arr[0]
+    assert item.dtype == dt
+    # The following string conversion is just too slow to run in CI:
+    # _ = str(item)
+    # assert len(_) == (2**31 + 1) * 4 + 3
+    # assert _[:6] == r"b'\x00"
 
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2090,3 +2090,21 @@ def test_gh_31308_materialized(val, kind, exp):
     # of large structured dtypes:
     with pytest.raises(TypeError, match="not ordered"):
         np.argmax(rec_arr)
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+@requires_memory(free_bytes=2e9)
+def test_gh_31308_getfield():
+    # for large structured dtypes, getfield
+    # needs to properly handle offsets that
+    # exceed the size of a C int
+    kind = [("x", np.float64, 2**28 + 1)]
+    kind_dtype = np.dtype(kind)
+    rec_arr = np.array((1,), dtype=kind_dtype)
+    # previously, this overflowed:
+    field = rec_arr.getfield(np.float64, offset=2**31)
+    assert field.size == 1
+    # exceeding the size of the large structured
+    # dtype should still error out
+    with pytest.raises(ValueError, match="is larger"):
+        field = rec_arr.getfield(np.float64, offset=2**31 + 1)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2086,3 +2086,7 @@ def test_gh_31308_materialized(val, kind, exp):
     kind_dtype = np.dtype(kind)
     rec_arr = np.array(val, dtype=kind_dtype)
     assert rec_arr["x"].size == exp
+    # avoid _ArrayMemoryError with proper handling
+    # of large structured dtypes:
+    with pytest.raises(TypeError, match="not ordered"):
+        np.argmax(rec_arr)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2071,6 +2071,7 @@ class TestDTypeSignatures:
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)
     assert kind_dtype.itemsize == exp
+    assert kind_dtype.isnative
     for name in kind_dtype.names:
         assert kind_dtype[name].shape[0] > 0
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -3,6 +3,7 @@ import ctypes
 import inspect
 import operator
 import os
+from io import StringIO
 import pickle
 import sys
 import types
@@ -2121,3 +2122,14 @@ def test_gh_31308_setfield():
     rec_arr.setfield(7, np.float64, offset=2**31)
     actual = rec_arr.getfield(np.float64, offset=2**31)
     assert_allclose(actual, 7)
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+@requires_memory(free_bytes=2e9)
+def test_gh_31308_loadtxt():
+    c = StringIO("1 2")
+    kind = {"names": ["x", "y"],
+            "formats": ["f8", "f8"],
+            "offsets": [0, 2 ** 28 * 8]}
+    kind_dtype = np.dtype(kind)
+    arr = np.loadtxt(c, dtype=kind_dtype)
+    assert arr.itemsize == 2 ** 28 * 8 + 8

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2198,3 +2198,7 @@ def test_gh_31308_materialized(val, kind, exp):
     kind_dtype = np.dtype(kind)
     rec_arr = np.array(val, dtype=kind_dtype)
     assert rec_arr["x"].size == exp
+    # avoid _ArrayMemoryError with proper handling
+    # of large structured dtypes:
+    with pytest.raises(TypeError, match="not ordered"):
+        np.argmax(rec_arr)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -26,7 +26,7 @@ from numpy.testing import (
     assert_raises,
 )
 from numpy.testing._private.hypothesis_helpers import HAS_HYPOTHESIS, hynp, hypothesis
-from numpy.testing._private.utils import requires_deep_recursion
+from numpy.testing._private.utils import requires_deep_recursion, requires_memory
 
 
 def assert_dtype_equal(a, b):
@@ -2163,8 +2163,9 @@ def test_gh_31308():
     assert kind_dtype.itemsize == (2 ** 28) * 8
 
 
-@pytest.mark.xfail(run=False)
+@requires_memory(free_bytes=2e9)
 def test_gh_31308_materialized():
     kind = [("x", np.float64, 2 ** 28)]
     kind_dtype = np.dtype(kind)
     rec_arr = np.array((1,), dtype=kind_dtype)
+    assert rec_arr["x"].size == 2 ** 28

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2160,10 +2160,13 @@ class TestDTypeSignatures:
         assert params_actual == params_expect
 
 
-def test_gh_31308():
-    kind = [("x", np.float64, 2 ** 28)]
+@pytest.mark.parametrize("kind, exp", [
+    ([("x", np.float64, 2 ** 28)], (2 ** 28 * 8)),
+    ("2147483648i,2147483648i", 17179869184),
+])
+def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)
-    assert kind_dtype.itemsize == (2 ** 28) * 8
+    assert kind_dtype.itemsize == exp
 
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -24,6 +24,7 @@ from numpy.testing import (
     assert_array_equal,
     assert_equal,
     assert_raises,
+    assert_allclose,
 )
 from numpy.testing._private.hypothesis_helpers import HAS_HYPOTHESIS, hynp, hypothesis
 from numpy.testing._private.utils import requires_deep_recursion, requires_memory
@@ -2220,3 +2221,15 @@ def test_gh_31308_getfield():
     # dtype should still error out
     with pytest.raises(ValueError, match="is larger"):
         field = rec_arr.getfield(np.float64, offset=2**31 + 1)
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+@requires_memory(free_bytes=2e9)
+def test_gh_31308_setfield():
+    # avoid overflow when using ndarray.setfield
+    # with large structured dtypes
+    kind = [("x", np.float64, 2**28 + 1)]
+    kind_dtype = np.dtype(kind)
+    rec_arr = np.array((1,), dtype=kind_dtype)
+    rec_arr.setfield(7, np.float64, offset=2**31)
+    actual = rec_arr.getfield(np.float64, offset=2**31)
+    assert_allclose(actual, 7)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -3,11 +3,11 @@ import ctypes
 import inspect
 import operator
 import os
-from io import StringIO
 import pickle
 import sys
 import types
 import warnings
+from io import StringIO
 from itertools import permutations
 from typing import Any
 
@@ -22,10 +22,10 @@ from numpy.testing import (
     IS_64BIT,
     IS_WASM,
     assert_,
+    assert_allclose,
     assert_array_equal,
     assert_equal,
     assert_raises,
-    assert_allclose,
 )
 from numpy.testing._private.hypothesis_helpers import HAS_HYPOTHESIS, hynp, hypothesis
 from numpy.testing._private.utils import requires_deep_recursion, requires_memory
@@ -2325,9 +2325,9 @@ def test_gh_31308_deepcopy_and_scalar_object_large_offsets():
 @requires_memory(free_bytes=2e10)
 def test_gh_31308_huge_void_scalars():
     __tracebackhide__ = True  # locals too large to print nicely
-    dt = np.dtype(f"V{2**31+1}")
+    dt = np.dtype(f"V{2**31 + 1}")
     arr = np.zeros(1, dtype=dt)
-    assert arr.itemsize == 2**31+1
+    assert arr.itemsize == 2**31 + 1
     item = arr[0]
     assert item.dtype == dt
     # The following string conversion is just too slow to run in CI:

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1325,12 +1325,12 @@ class TestPickling:
             assert_equal(pickled.itemsize, dtype.itemsize)
             if dtype.metadata is not None:
                 assert_equal(pickled.metadata, dtype.metadata)
-            # Check the reconstructed dtype is functional
-            x = np.zeros(3, dtype=dtype)
-            y = np.zeros(3, dtype=pickled)
             # some large structured dtypes are too large to
             # reasonably compare across all elements
             if arr_assert:
+                # Check the reconstructed dtype is functional
+                x = np.zeros(3, dtype=dtype)
+                y = np.zeros(3, dtype=pickled)
                 assert_equal(x, y)
                 assert_equal(x[0], y[0])
 
@@ -2179,6 +2179,7 @@ class TestDTypeSignatures:
     (dict(names=["a", "b", "c"], formats=["2147483648b", "16i", "12f"],
      offsets=[2 ** 31, 2 ** 32, 2 ** 32 + 69]), 4294967413),
 ])
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)
     assert kind_dtype.itemsize == exp

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2183,6 +2183,7 @@ class TestDTypeSignatures:
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)
     assert kind_dtype.itemsize == exp
+    assert kind_dtype.isnative
     for name in kind_dtype.names:
         assert kind_dtype[name].shape[0] > 0
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2215,6 +2215,14 @@ def test_gh_31308_array_itemsize_getter_large_dtype():
 
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_binary_imports_reject_too_small_large_itemsize():
+    kind_dtype = np.dtype(dict(
+        names=["a"], formats=["i1"], itemsize=2 ** 31 + 1))
+    with pytest.raises(ValueError, match="buffer is smaller than requested size"):
+        np.frombuffer(b"\0", dtype=kind_dtype, count=1)
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
 def test_gh_31308_out_of_order_object_fields_large_offsets():
     kind_dtype = np.dtype(dict(
         names=["b", "a"],

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1312,7 +1312,7 @@ class TestDTypeMakeCanonical:
 
 class TestPickling:
 
-    def check_pickling(self, dtype):
+    def check_pickling(self, dtype, arr_assert=True):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             buf = pickle.dumps(dtype, proto)
             # The dtype pickling itself pickles `np.dtype` if it is pickled
@@ -1322,22 +1322,25 @@ class TestPickling:
             pickled = pickle.loads(buf)
             assert_equal(pickled, dtype)
             assert_equal(pickled.descr, dtype.descr)
+            assert_equal(pickled.itemsize, dtype.itemsize)
             if dtype.metadata is not None:
                 assert_equal(pickled.metadata, dtype.metadata)
             # Check the reconstructed dtype is functional
             x = np.zeros(3, dtype=dtype)
             y = np.zeros(3, dtype=pickled)
-            assert_equal(x, y)
-            assert_equal(x[0], y[0])
+            # some large structured dtypes are too large to
+            # reasonably compare across all elements
+            if arr_assert:
+                assert_equal(x, y)
+                assert_equal(x[0], y[0])
 
-    @pytest.mark.slow()
     @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
     def test_pickling_large(self):
         # The actual itemsize is larger than a c-integer here.
         dtype = np.dtype(f"({2**31},)i")
-        self.check_pickling(dtype)
+        self.check_pickling(dtype, False)
         dtype = np.dtype(f"({2**31},)i", metadata={"a": "b"})
-        self.check_pickling(dtype)
+        self.check_pickling(dtype, False)
 
     @pytest.mark.parametrize('t', [int, float, complex, np.int32, str, object,
                                    bool])

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2166,6 +2166,7 @@ def test_gh_31308():
     assert kind_dtype.itemsize == (2 ** 28) * 8
 
 
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
 @requires_memory(free_bytes=2e9)
 def test_gh_31308_materialized():
     kind = [("x", np.float64, 2 ** 28)]

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2189,8 +2189,11 @@ def test_gh_31308(kind, exp):
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
 @requires_memory(free_bytes=2e9)
-def test_gh_31308_materialized():
-    kind = [("x", np.float64, 2 ** 28)]
+@pytest.mark.parametrize("val, kind, exp", [
+    ((1,), [("x", np.float64, 2 ** 28)], 2 ** 28),
+    ((1, 1), [("x", np.float64, 2 ** 28), ("y", np.float64, 1)], 2 ** 28),
+])
+def test_gh_31308_materialized(val, kind, exp):
     kind_dtype = np.dtype(kind)
-    rec_arr = np.array((1,), dtype=kind_dtype)
-    assert rec_arr["x"].size == 2 ** 28
+    rec_arr = np.array(val, dtype=kind_dtype)
+    assert rec_arr["x"].size == exp

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2163,6 +2163,7 @@ class TestDTypeSignatures:
 @pytest.mark.parametrize("kind, exp", [
     ([("x", np.float64, 2 ** 28)], (2 ** 28 * 8)),
     ("2147483648i,2147483648i", 17179869184),
+    (dict(names=["a"], formats=["2147483648i"]), 8589934592),
 ])
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2162,11 +2162,19 @@ class TestDTypeSignatures:
 
 @pytest.mark.parametrize("kind, exp", [
     ([("x", np.float64, 2 ** 28)], (2 ** 28 * 8)),
+    ([("x", np.float64, 2 ** 27), ("y", np.float64, 2 ** 27)], (2 ** 28 * 8)),
+    ([("x", np.float32, 2 ** 28), ("y", np.float64, 2 ** 27)], (2 ** 28 * 8)),
+    ([("x", np.float16, 2 ** 29), ("y", np.float64, 2 ** 27)], (2 ** 28 * 8)),
     ("2147483648i,2147483648i", 17179869184),
+    ("2147483648f,2147483648f", 17179869184),
+    ("2147483648d,2147483648d", 34359738368),
+    ("2b,2147483648b,2f,4i", 2147483674),
     (dict(names=["a"], formats=["2147483648i"]), 8589934592),
     (dict(names=["a"], formats=["2147483648i"], offsets=[1]), 8589934593),
     (dict(names=["a"], formats=["2147483648i"], offsets=[2 ** 31 - 100]), 10737418140),
     (dict(names=["a"], formats=["2147483648i"], offsets=[2 ** 31]), 10737418240),
+    (dict(names=["a", "b", "c"], formats=["2147483648b", "16i", "12f"],
+     offsets=[2 ** 31, 2 ** 32, 2 ** 32 + 69]), 4294967413),
 ])
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2183,6 +2183,8 @@ class TestDTypeSignatures:
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)
     assert kind_dtype.itemsize == exp
+    for name in kind_dtype.names:
+        assert kind_dtype[name].shape[0] > 0
 
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -774,6 +774,8 @@ class TestSubarray:
         # Check that the shape is valid.
         max_intp = np.iinfo(np.intp).max
         # Too large values (the datatype is part of this)
+        assert_raises(ValueError, np.dtype, [('a', 'f8', max_intp // 8 + 1)])
+        assert_raises(ValueError, np.dtype, [('a', 'f4', max_intp // 4 + 1)])
         assert_raises(ValueError, np.dtype, [('a', 'f4', max_intp + 1)])
         # Negative values
         assert_raises(ValueError, np.dtype, [('a', 'f4', -1)])

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -3,6 +3,7 @@ import ctypes
 import inspect
 import operator
 import os
+from io import StringIO
 import pickle
 import sys
 import types
@@ -2233,3 +2234,14 @@ def test_gh_31308_setfield():
     rec_arr.setfield(7, np.float64, offset=2**31)
     actual = rec_arr.getfield(np.float64, offset=2**31)
     assert_allclose(actual, 7)
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+@requires_memory(free_bytes=2e9)
+def test_gh_31308_loadtxt():
+    c = StringIO("1 2")
+    kind = {"names": ["x", "y"],
+            "formats": ["f8", "f8"],
+            "offsets": [0, 2 ** 28 * 8]}
+    kind_dtype = np.dtype(kind)
+    arr = np.loadtxt(c, dtype=kind_dtype)
+    assert arr.itemsize == 2 ** 28 * 8 + 8

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2202,3 +2202,21 @@ def test_gh_31308_materialized(val, kind, exp):
     # of large structured dtypes:
     with pytest.raises(TypeError, match="not ordered"):
         np.argmax(rec_arr)
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+@requires_memory(free_bytes=2e9)
+def test_gh_31308_getfield():
+    # for large structured dtypes, getfield
+    # needs to properly handle offsets that
+    # exceed the size of a C int
+    kind = [("x", np.float64, 2**28 + 1)]
+    kind_dtype = np.dtype(kind)
+    rec_arr = np.array((1,), dtype=kind_dtype)
+    # previously, this overflowed:
+    field = rec_arr.getfield(np.float64, offset=2**31)
+    assert field.size == 1
+    # exceeding the size of the large structured
+    # dtype should still error out
+    with pytest.raises(ValueError, match="is larger"):
+        field = rec_arr.getfield(np.float64, offset=2**31 + 1)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2160,6 +2160,7 @@ class TestDTypeSignatures:
 def test_gh_31308():
     kind = [("x", np.float64, 2 ** 28)]
     kind_dtype = np.dtype(kind)
+    assert kind_dtype.itemsize == (2 ** 28) * 8
 
 
 @pytest.mark.xfail(run=False)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1328,6 +1328,7 @@ class TestPickling:
             assert_equal(x, y)
             assert_equal(x[0], y[0])
 
+    @pytest.mark.slow()
     @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
     def test_pickling_large(self):
         # The actual itemsize is larger than a c-integer here.

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2185,9 +2185,99 @@ class TestDTypeSignatures:
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)
     assert kind_dtype.itemsize == exp
+    assert kind_dtype.str == f"|V{exp}"
     assert kind_dtype.isnative
     for name in kind_dtype.names:
         assert kind_dtype[name].shape[0] > 0
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_result_type_keeps_large_offsets():
+    kind_dtype = np.dtype([("x", np.float64, 2 ** 28), ("y", np.float64, 1)])
+    canonical = np.result_type(kind_dtype)
+    assert canonical.itemsize == kind_dtype.itemsize
+    assert canonical.str == kind_dtype.str
+    assert canonical.fields["y"][1] == kind_dtype.fields["y"][1]
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_dict_itemsize_override_large():
+    kind_dtype = np.dtype(dict(names=["a"], formats=["i1"], itemsize=2 ** 31))
+    assert kind_dtype.itemsize == 2 ** 31
+    assert kind_dtype.str == f"|V{2 ** 31}"
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_array_itemsize_getter_large_dtype():
+    kind_dtype = np.dtype([("x", np.float64, 2 ** 28)])
+    arr = np.empty(0, dtype=kind_dtype)
+    assert arr.itemsize == kind_dtype.itemsize
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_out_of_order_object_fields_large_offsets():
+    kind_dtype = np.dtype(dict(
+        names=["b", "a"],
+        formats=["O", "O"],
+        offsets=[2 ** 31 + 16, 2 ** 31],
+        itemsize=2 ** 31 + 24,
+    ))
+    assert kind_dtype.fields["a"][1] == 2 ** 31
+    assert kind_dtype.fields["b"][1] == 2 ** 31 + 16
+    with pytest.raises(TypeError, match="overlapping object fields"):
+        np.dtype(dict(
+            names=["b", "a"],
+            formats=["O", "O"],
+            offsets=[2 ** 31 + 4, 2 ** 31],
+            itemsize=2 ** 31 + 16,
+        ))
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+@requires_memory(free_bytes=2.2e9)
+def test_gh_31308_copyto_large_offsets():
+    src_scalar = np.array([37], dtype=np.int8)
+    struct_dtype = np.dtype(
+        dict(names=["a"], formats=["i1"], offsets=[2 ** 31], itemsize=2 ** 31 + 1)
+    )
+    dst_struct = np.zeros(1, dtype=struct_dtype)
+    dst_scalar = np.array([0], dtype=np.int8)
+
+    np.copyto(dst_struct, src_scalar, casting="unsafe")
+    np.copyto(dst_scalar, dst_struct, casting="unsafe")
+    assert dst_struct["a"][0] == 37
+    assert dst_scalar[0] == 37
+
+    # Also hit structured->structured setup on large offsets.
+    src_struct_0 = np.zeros(0, dtype=struct_dtype)
+    dst_struct_0 = np.zeros(0, dtype=np.dtype(
+        dict(names=["a"], formats=["i1"], offsets=[2 ** 31 + 4], itemsize=2 ** 31 + 5)
+    ))
+    np.copyto(dst_struct_0, src_struct_0, casting="unsafe")
+    assert dst_struct_0.dtype.fields["a"][1] == 2 ** 31 + 4
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_negative_offset_error_message():
+    bad_offset = -(2 ** 31) - 1
+    with pytest.raises(
+            ValueError,
+            match=rf"offset {bad_offset} cannot be negative"):
+        np.dtype(dict(names=["a"], formats=["i1"], offsets=[bad_offset]))
+
+
+@pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+def test_gh_31308_legacy_setstate_keeps_object_flag():
+    kind_dtype = np.dtype(dict(names=["a"], formats=["O"], offsets=[2 ** 31]))
+    reconstruct, args, state = kind_dtype.__reduce__()
+    assert state[0] >= 3
+
+    reparsed = reconstruct(*args)
+    # Exercise the compatibility path that recomputes flags using
+    # _descr_find_object() for older pickle versions.
+    reparsed.__setstate__((2, *state[1:]))
+    assert reparsed.hasobject
+    assert reparsed.fields["a"][1] == 2 ** 31
 
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
@@ -2204,6 +2294,38 @@ def test_gh_31308_materialized(val, kind, exp):
     # of large structured dtypes:
     with pytest.raises(TypeError, match="not ordered"):
         np.argmax(rec_arr)
+
+
+@requires_memory(free_bytes=2e10)
+def test_gh_31308_deepcopy_and_scalar_object_large_offsets():
+    dt = np.dtype([("x", np.int8, 2 ** 31), ("y", object)])
+    arr = np.zeros(1, dtype=dt)
+    arr["y"] = object()
+    # See that deepcopying the object field works:
+    copy = arr.__deepcopy__({})
+    assert copy["y"] is not arr["y"]
+    # Also check that getting the scalar is fine:
+    scalar = arr[()]
+    # and go back to array (needs to increment the object)
+    arr2 = np.array(scalar)
+    arr2.flat[...] = arr
+    # Currently tests a very niche path (that might be otherwise unused):
+    arr.flat = arr
+
+
+@pytest.mark.slow
+@requires_memory(free_bytes=2e10)
+def test_gh_31308_huge_void_scalars():
+    __tracebackhide__ = True  # locals too large to print nicely
+    dt = np.dtype(f"V{2**31+1}")
+    arr = np.zeros(1, dtype=dt)
+    assert arr.itemsize == 2**31+1
+    item = arr[0]
+    assert item.dtype == dt
+    # The following string conversion is just too slow to run in CI:
+    # _ = str(item)
+    # assert len(_) == (2**31 + 1) * 4 + 3
+    # assert _[:6] == r"b'\x00"
 
 
 @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -772,13 +772,8 @@ class TestSubarray:
 
     def test_shape_invalid(self):
         # Check that the shape is valid.
-        max_int = np.iinfo(np.intc).max
         max_intp = np.iinfo(np.intp).max
         # Too large values (the datatype is part of this)
-        assert_raises(ValueError, np.dtype, [('a', 'f4', max_int // 4 + 1)])
-        assert_raises(ValueError, np.dtype, [('a', 'f4', max_int + 1)])
-        assert_raises(ValueError, np.dtype, [('a', 'f4', (max_int, 2))])
-        # Takes a different code path (fails earlier:
         assert_raises(ValueError, np.dtype, [('a', 'f4', max_intp + 1)])
         # Negative values
         assert_raises(ValueError, np.dtype, [('a', 'f4', -1)])
@@ -1334,7 +1329,6 @@ class TestPickling:
             assert_equal(x[0], y[0])
 
     @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
-    @pytest.mark.xfail(reason="dtype conversion doesn't allow this yet.")
     def test_pickling_large(self):
         # The actual itemsize is larger than a c-integer here.
         dtype = np.dtype(f"({2**31},)i")
@@ -2161,3 +2155,15 @@ class TestDTypeSignatures:
 
         params_actual = set(sig.parameters)
         assert params_actual == params_expect
+
+
+def test_gh_31308():
+    kind = [("x", np.float64, 2 ** 28)]
+    kind_dtype = np.dtype(kind)
+
+
+@pytest.mark.xfail(run=False)
+def test_gh_31308_materialized():
+    kind = [("x", np.float64, 2 ** 28)]
+    kind_dtype = np.dtype(kind)
+    rec_arr = np.array((1,), dtype=kind_dtype)

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -2164,6 +2164,9 @@ class TestDTypeSignatures:
     ([("x", np.float64, 2 ** 28)], (2 ** 28 * 8)),
     ("2147483648i,2147483648i", 17179869184),
     (dict(names=["a"], formats=["2147483648i"]), 8589934592),
+    (dict(names=["a"], formats=["2147483648i"], offsets=[1]), 8589934593),
+    (dict(names=["a"], formats=["2147483648i"], offsets=[2 ** 31 - 100]), 10737418140),
+    (dict(names=["a"], formats=["2147483648i"], offsets=[2 ** 31]), 10737418240),
 ])
 def test_gh_31308(kind, exp):
     kind_dtype = np.dtype(kind)

--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -9,6 +9,7 @@ import pytest
 
 import numpy as np
 from numpy.testing import (
+    IS_64BIT,
     assert_,
     assert_array_almost_equal,
     assert_array_equal,
@@ -16,6 +17,7 @@ from numpy.testing import (
     assert_raises,
     temppath,
 )
+from numpy.testing._private.utils import requires_memory
 
 
 class TestFromrecords:
@@ -107,6 +109,17 @@ class TestFromrecords:
         fd.close()
         assert_equal(r1, r2)
         assert_equal(r2, r3)
+
+    @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+    @requires_memory(free_bytes=2e9)
+    def test_recarray_fromfile_massive(self, tmpdir):
+        kind = [("x", np.float64, 2 ** 28)]
+        kind_dtype = np.dtype(kind)
+        rec_arr = np.array((1,), dtype=kind_dtype)
+        with tmpdir.as_cwd():
+            rec_arr.tofile("f.data")
+            actual = np.fromfile("f.data", dtype=kind_dtype)
+            assert actual.itemsize == 2 ** 28 * 8
 
     def test_recarray_from_obj(self):
         count = 10

--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -14,6 +14,7 @@ from numpy.testing import (
     assert_array_almost_equal,
     assert_array_equal,
     assert_equal,
+    assert_allclose,
     assert_raises,
     temppath,
 )
@@ -111,15 +112,17 @@ class TestFromrecords:
         assert_equal(r2, r3)
 
     @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
-    @requires_memory(free_bytes=2e9)
+    @requires_memory(free_bytes=4.3e9)
     def test_recarray_fromfile_massive(self, tmpdir):
-        kind = [("x", np.float64, 2 ** 28)]
+        kind = [("x", np.float64, 2 ** 29)]
         kind_dtype = np.dtype(kind)
         rec_arr = np.array((1,), dtype=kind_dtype)
         with tmpdir.as_cwd():
             rec_arr.tofile("f.data")
             actual = np.fromfile("f.data", dtype=kind_dtype)
-            assert actual.itemsize == 2 ** 28 * 8
+            assert actual.itemsize == 2 ** 29 * 8
+            item = actual["x"][0][1]
+            assert_allclose(item, 1)
 
     def test_recarray_from_obj(self):
         count = 10

--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -11,10 +11,10 @@ import numpy as np
 from numpy.testing import (
     IS_64BIT,
     assert_,
+    assert_allclose,
     assert_array_almost_equal,
     assert_array_equal,
     assert_equal,
-    assert_allclose,
     assert_raises,
     temppath,
 )

--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -9,6 +9,7 @@ import pytest
 
 import numpy as np
 from numpy.testing import (
+    IS_64BIT,
     assert_,
     assert_array_almost_equal,
     assert_array_equal,
@@ -16,6 +17,7 @@ from numpy.testing import (
     assert_raises,
     temppath,
 )
+from numpy.testing._private.utils import requires_memory
 
 
 class TestFromrecords:
@@ -121,6 +123,17 @@ class TestFromrecords:
             ValueError, match="Arrays containing references are not supported"
         ):
             np.rec.fromstring(b"dummy data", formats="O", shape=1)
+
+    @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
+    @requires_memory(free_bytes=2e9)
+    def test_recarray_fromfile_massive(self, tmpdir):
+        kind = [("x", np.float64, 2 ** 28)]
+        kind_dtype = np.dtype(kind)
+        rec_arr = np.array((1,), dtype=kind_dtype)
+        with tmpdir.as_cwd():
+            rec_arr.tofile("f.data")
+            actual = np.fromfile("f.data", dtype=kind_dtype)
+            assert actual.itemsize == 2 ** 28 * 8
 
     def test_recarray_from_obj(self):
         count = 10

--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -14,6 +14,7 @@ from numpy.testing import (
     assert_array_almost_equal,
     assert_array_equal,
     assert_equal,
+    assert_allclose,
     assert_raises,
     temppath,
 )
@@ -125,15 +126,17 @@ class TestFromrecords:
             np.rec.fromstring(b"dummy data", formats="O", shape=1)
 
     @pytest.mark.skipif(not IS_64BIT, reason="test requires 64-bit system")
-    @requires_memory(free_bytes=2e9)
+    @requires_memory(free_bytes=4.3e9)
     def test_recarray_fromfile_massive(self, tmpdir):
-        kind = [("x", np.float64, 2 ** 28)]
+        kind = [("x", np.float64, 2 ** 29)]
         kind_dtype = np.dtype(kind)
         rec_arr = np.array((1,), dtype=kind_dtype)
         with tmpdir.as_cwd():
             rec_arr.tofile("f.data")
             actual = np.fromfile("f.data", dtype=kind_dtype)
-            assert actual.itemsize == 2 ** 28 * 8
+            assert actual.itemsize == 2 ** 29 * 8
+            item = actual["x"][0][1]
+            assert_allclose(item, 1)
 
     def test_recarray_from_obj(self):
         count = 10


### PR DESCRIPTION
* Fixes gh-30315 
* Fixes gh-31308

* ~Although the original failing regression test does pass here, it is not even close to safe to do this yet even though the full testsuite passes locally with `test_pickling_large` re-enabled.~

~I spent a few hours debugging on this one--I'll add a few initial inline self-review comments to start...~

[skip azp] [skip cirrus] [skip actions]


#### AI Disclosure
~No AI tools used~ Sebastian did use AI support to review/improve the reach of the work in the code base, since many places use i.e,. `elsize` and so on. Tyler used Claude Opus 5 to select its top two concerns after carefully reviewing the PR and Sebastian's comments.
