### PR TITLE
BUG: interp returns empty array for empty x input

### DIFF
--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -574,12 +574,10 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t len_arg
     }
     lenxp = PyArray_SIZE(axp);
     lenx = PyArray_SIZE(ax);
-    if (lenxp == 0) {
-        if (lenx != 0) {
-            PyErr_SetString(PyExc_ValueError,
-                    "array of sample points is empty");
-            goto fail;
-        }
+    if (lenxp == 0 && lenx != 0) {
+        PyErr_SetString(PyExc_ValueError,
+                "array of sample points is empty");
+        goto fail;
     }
     if (PyArray_SIZE(afp) != lenxp) {
         PyErr_SetString(PyExc_ValueError,
@@ -593,10 +591,7 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t len_arg
         goto fail;
     }
     if (lenx == 0) {
-        Py_DECREF(afp);
-        Py_DECREF(axp);
-        Py_DECREF(ax);
-        return PyArray_Return(af);
+        goto finish;
     }
 
     dy = (const npy_double *)PyArray_DATA(afp);
@@ -703,6 +698,12 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t len_arg
     Py_DECREF(ax);
     return PyArray_Return(af);
 
+finish:
+    Py_DECREF(afp);
+    Py_DECREF(axp);
+    Py_DECREF(ax);
+    return PyArray_Return(af);
+
 fail:
     Py_XDECREF(afp);
     Py_XDECREF(axp);
@@ -755,12 +756,10 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t
     }
     lenxp = PyArray_SIZE(axp);
     lenx = PyArray_SIZE(ax);
-    if (lenxp == 0) {
-        if (lenx != 0) {
-            PyErr_SetString(PyExc_ValueError,
-                    "array of sample points is empty");
-            goto fail;
-        }
+    if (lenxp == 0 && lenx != 0) {
+        PyErr_SetString(PyExc_ValueError,
+                "array of sample points is empty");
+        goto fail;
     }
     if (PyArray_SIZE(afp) != lenxp) {
         PyErr_SetString(PyExc_ValueError,
@@ -777,10 +776,7 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t
         goto fail;
     }
     if (lenx == 0) {
-        Py_DECREF(afp);
-        Py_DECREF(axp);
-        Py_DECREF(ax);
-        return PyArray_Return(af);
+        goto finish;
     }
 
     dy = (const npy_cdouble *)PyArray_DATA(afp);
@@ -907,6 +903,12 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t
     }
     PyArray_free(slopes);
 
+    Py_DECREF(afp);
+    Py_DECREF(axp);
+    Py_DECREF(ax);
+    return PyArray_Return(af);
+
+finish:
     Py_DECREF(afp);
     Py_DECREF(axp);
     Py_DECREF(ax);

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -693,10 +693,6 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t len_arg
     }
 
     PyArray_free(slopes);
-    Py_DECREF(afp);
-    Py_DECREF(axp);
-    Py_DECREF(ax);
-    return PyArray_Return(af);
 
 finish:
     Py_DECREF(afp);
@@ -902,11 +898,6 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t
         NPY_END_THREADS;
     }
     PyArray_free(slopes);
-
-    Py_DECREF(afp);
-    Py_DECREF(axp);
-    Py_DECREF(ax);
-    return PyArray_Return(af);
 
 finish:
     Py_DECREF(afp);

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -573,10 +573,13 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t len_arg
         goto fail;
     }
     lenxp = PyArray_SIZE(axp);
+    lenx = PyArray_SIZE(ax);
     if (lenxp == 0) {
-        PyErr_SetString(PyExc_ValueError,
-                "array of sample points is empty");
-        goto fail;
+        if (lenx != 0) {
+            PyErr_SetString(PyExc_ValueError,
+                    "array of sample points is empty");
+            goto fail;
+        }
     }
     if (PyArray_SIZE(afp) != lenxp) {
         PyErr_SetString(PyExc_ValueError,
@@ -589,7 +592,12 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t len_arg
     if (af == NULL) {
         goto fail;
     }
-    lenx = PyArray_SIZE(ax);
+    if (lenx == 0) {
+        Py_DECREF(afp);
+        Py_DECREF(axp);
+        Py_DECREF(ax);
+        return PyArray_Return(af);
+    }
 
     dy = (const npy_double *)PyArray_DATA(afp);
     dx = (const npy_double *)PyArray_DATA(axp);
@@ -746,10 +754,13 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t
         goto fail;
     }
     lenxp = PyArray_SIZE(axp);
+    lenx = PyArray_SIZE(ax);
     if (lenxp == 0) {
-        PyErr_SetString(PyExc_ValueError,
-                "array of sample points is empty");
-        goto fail;
+        if (lenx != 0) {
+            PyErr_SetString(PyExc_ValueError,
+                    "array of sample points is empty");
+            goto fail;
+        }
     }
     if (PyArray_SIZE(afp) != lenxp) {
         PyErr_SetString(PyExc_ValueError,
@@ -757,7 +768,6 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t
         goto fail;
     }
 
-    lenx = PyArray_SIZE(ax);
     dx = (const npy_double *)PyArray_DATA(axp);
     dz = (const npy_double *)PyArray_DATA(ax);
 
@@ -765,6 +775,12 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t
                                             PyArray_DIMS(ax), NPY_CDOUBLE);
     if (af == NULL) {
         goto fail;
+    }
+    if (lenx == 0) {
+        Py_DECREF(afp);
+        Py_DECREF(axp);
+        Py_DECREF(ax);
+        return PyArray_Return(af);
     }
 
     dy = (const npy_cdouble *)PyArray_DATA(afp);

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1648,6 +1648,10 @@ def interp(x, xp, fp, left=None, right=None, period=None):
         interp_func = compiled_interp
         input_dtype = np.float64
 
+    x = np.asarray(x)
+    if x.size == 0:
+        return np.empty(x.shape, dtype=input_dtype)
+
     if period is not None:
         if period == 0:
             raise ValueError("period must be a non-zero value")

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1649,7 +1649,8 @@ def interp(x, xp, fp, left=None, right=None, period=None):
         input_dtype = np.float64
 
     x = np.asarray(x)
-    if x.size == 0:
+    xp = np.asarray(xp)
+    if x.size == 0 and xp.size == 0:
         return np.empty(x.shape, dtype=input_dtype)
 
     if period is not None:

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1648,11 +1648,6 @@ def interp(x, xp, fp, left=None, right=None, period=None):
         interp_func = compiled_interp
         input_dtype = np.float64
 
-    x = np.asarray(x)
-    xp = np.asarray(xp)
-    if x.size == 0 and xp.size == 0:
-        return np.empty(x.shape, dtype=input_dtype)
-
     if period is not None:
         if period == 0:
             raise ValueError("period must be a non-zero value")

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3107,6 +3107,13 @@ class TestInterp:
         assert_raises(ValueError, interp, 0, [], [], period=360)
         assert_raises(ValueError, interp, 0, [0], [1, 2], period=360)
 
+    def test_empty_x(self):
+        # gh-30316
+        assert_array_equal(interp([], [], []), np.array([], dtype=np.float64))
+        assert_array_equal(interp([], [1, 2], [3, 4]), np.array([], dtype=np.float64))
+        assert_array_equal(interp([], [], [], period=360), np.array([], dtype=np.float64))
+        assert_array_equal(interp([], [1, 2], [3+4j, 5+6j]), np.array([], dtype=np.complex128))
+
     def test_basic(self):
         x = np.linspace(0, 1, 5)
         y = np.linspace(0, 1, 5)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3106,6 +3106,7 @@ class TestInterp:
         assert_raises(ValueError, interp, 0, [0, 1], [1, 2], period=0)
         assert_raises(ValueError, interp, 0, [], [], period=360)
         assert_raises(ValueError, interp, 0, [0], [1, 2], period=360)
+        assert_raises(ValueError, interp, [], [], [3, 4, 5])
 
     def test_empty_x(self):
         # gh-30316

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3112,8 +3112,10 @@ class TestInterp:
         # gh-30316
         assert_array_equal(interp([], [], []), np.array([], dtype=np.float64))
         assert_array_equal(interp([], [1, 2], [3, 4]), np.array([], dtype=np.float64))
-        assert_array_equal(interp([], [], [], period=360), np.array([], dtype=np.float64))
-        assert_array_equal(interp([], [1, 2], [3+4j, 5+6j]), np.array([], dtype=np.complex128))
+        assert_array_equal(
+            interp([], [], [], period=360), np.array([], dtype=np.float64))
+        assert_array_equal(
+            interp([], [1, 2], [3 + 4j, 5 + 6j]), np.array([], dtype=np.complex128))
 
     def test_basic(self):
         x = np.linspace(0, 1, 5)


### PR DESCRIPTION
### PR summary

Return an empty array with the correct dtype when the `x` argument to `np.interp` is empty, instead of raising `ValueError` about empty sample points.

Closes #30316

### First time committer introduction

Hi, I'm NIK-TIGER-BILL. I use NumPy daily for data processing and scientific computing. This bug was affecting my workflows where I sometimes need to interpolate over empty arrays.

#### AI Disclosure

No AI tools used