### PR TITLE
BUG: fix np.interp with empty arrays to return empty array

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1672,6 +1672,10 @@ def interp(x, xp, fp, left=None, right=None, period=None):
         xp = np.concatenate((xp[-1:] - period, xp, xp[0:1] + period))
         fp = np.concatenate((fp[-1:], fp, fp[0:1]))
 
+    # Handle empty inputs: when all arrays are empty, return empty array
+    if (np.asarray(x).size == 0 and np.asarray(xp).size == 0
+            and np.asarray(fp).size == 0):
+        return np.array([], dtype=input_dtype)
     return interp_func(x, xp, fp, left, right)
 
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3295,6 +3295,17 @@ class TestInterp:
         y = np.array(y, order='C').reshape(2, -1)
         assert_almost_equal(np.interp(x, xp, fp, period=360), y)
 
+    def test_empty_arrays(self):
+        # Regression test for gh-30316
+        # np.interp([], [], []) should return an empty array
+        result = np.interp([], [], [])
+        assert_equal(result, np.array([]))
+        assert_equal(result.dtype, np.float64)
+
+        # complex case
+        result_c = np.interp([], [], np.array([], dtype=complex))
+        assert_equal(result_c, np.array([], dtype=complex))
+
 
 quantile_methods = [
     'inverted_cdf', 'averaged_inverted_cdf', 'closest_observation',


### PR DESCRIPTION
Fixes #30316

When `np.interp([], [], [])` is called with all empty inputs, it now returns an empty array of the appropriate dtype instead of raising `ValueError: array of sample points is empty`.

**Changes:**
- Added check in `interp()` that detects when all of `x`, `xp`, and `fp` are empty arrays and returns an empty array
- Added regression test `test_empty_arrays` in `TestInterp`

**Note:** `np.interp(non_empty, [], [])` (where x is non-empty but xp is empty) still raises ValueError as before.