### PR TITLE
BUG/DEPR: Disallow noninteger types for the k parameter in rot90().

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1,6 +1,7 @@
 import builtins
 import collections.abc
 import functools
+import operator
 import re
 import warnings
 
@@ -246,6 +247,16 @@ def rot90(m, k=1, axes=(0, 1)):
     if (axes[0] >= m.ndim or axes[0] < -m.ndim
         or axes[1] >= m.ndim or axes[1] < -m.ndim):
         raise ValueError(f"Axes={axes} out of range for array of ndim={m.ndim}.")
+
+    try:
+        k = operator.index(k)
+    except TypeError:
+        # DEPRECATED 2026-04-27, NumPy 2.5
+        msg = (f"Passing a value for k ({k!r}) that is not an integer type has been "
+               "deprecated in NumPy 2.5. The value will be cast to an integer.  In "
+               "the future this will be an error.")
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        k = int(k)
 
     k %= 4
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -149,6 +149,14 @@ class TestRot90:
             assert_equal(rot90(a, k=k, axes=(2, 0)),
                          rot90(a_rot90_20, k=k - 1, axes=(2, 0)))
 
+    @pytest.mark.parametrize('k', [2.0, 2.25])
+    def test_noninteger_k_deprecation_warning(self, k):
+        a = np.array([[1, 2], [3, 4]])
+        with pytest.warns(DeprecationWarning,
+                          match="not an integer type has been deprecated"):
+            b = rot90(a, k=k)
+        assert_array_equal(b, np.rot90(a, k=2), strict=True)
+
 
 class TestFlip:
 


### PR DESCRIPTION
Closes gh-31342.

With this PR, passing a float for `k` generates a `DeprecationWarning`:

```
In [1]: x = np.arange(9).reshape((3, 3))

In [2]: np.rot90(x, k=2.25)
<ipython-input-2-245e772700e1>:1: DeprecationWarning: Passing a value for k (2.25) that is not an integer type has been deprecated in NumPy 2.5. The value will be cast to an integer.  In the future this will be an error.
  np.rot90(x, k=2.25)
Out[2]: 
array([[8, 7, 6],
       [5, 4, 3],
       [2, 1, 0]])

```

Passing something that can't be cast to an int generates the same warning, and then raises an exception when `k = int(k)` fails:

```
In [3]: np.rot90(x, k="foo")
<ipython-input-3-bc2435488499>:1: DeprecationWarning: Passing a value for k ('foo') that is not an integer type has been deprecated in NumPy 2.5. The value will be cast to an integer.  In the future this will be an error.
  np.rot90(x, k="foo")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
File ~/repos/git/forks/numpy/build-install/usr/lib/python3.14/site-packages/numpy/lib/_function_base_impl.py:252, in rot90(m, k, axes)
    251 try:
--> 252     k = operator.index(k)
    253 except TypeError:
    254     # DEPRECATED 2026-04-27, NumPy 2.5

TypeError: 'str' object cannot be interpreted as an integer

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
Cell In[3], line 1
----> 1 np.rot90(x, k="foo")

File ~/repos/git/forks/numpy/build-install/usr/lib/python3.14/site-packages/numpy/lib/_function_base_impl.py:259, in rot90(m, k, axes)
    255     msg = (f"Passing a value for k ({k!r}) that is not an integer type has been "
    256            "deprecated in NumPy 2.5. The value will be cast to an integer.  In "
    257            "the future this will be an error.")
    258     warnings.warn(msg, DeprecationWarning, stacklevel=2)
--> 259     k = int(k)
    261 k %= 4
    263 if k == 0:

ValueError: invalid literal for int() with base 10: 'foo'
```

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

No AI tools used.
