### PR TITLE
ENH: Add armv7l wheel builds (manylinux)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -39,6 +39,8 @@ jobs:
           - [ubuntu-22.04, musllinux_x86_64, ""]
           - [ubuntu-22.04-arm, manylinux_aarch64, ""]
           - [ubuntu-22.04-arm, musllinux_aarch64, ""]
+          - [ubuntu-22.04-arm, manylinux_armv7l, ""]
+          - [ubuntu-22.04-arm, musllinux_armv7l, ""]
           - [macos-15-intel, macosx_x86_64, openblas]
           - [macos-14, macosx_arm64, openblas]
           - [windows-2022, win_amd64, ""]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -106,6 +106,7 @@ jobs:
         uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          CIBW_ARCHS: ${{ endsWith(matrix.buildplat[1], 'armv7l') && 'armv7l' || 'auto' }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -40,7 +40,6 @@ jobs:
           - [ubuntu-22.04-arm, manylinux_aarch64, ""]
           - [ubuntu-22.04-arm, musllinux_aarch64, ""]
           - [ubuntu-22.04-arm, manylinux_armv7l, ""]
-          - [ubuntu-22.04-arm, musllinux_armv7l, ""]
           - [macos-15-intel, macosx_x86_64, openblas]
           - [macos-14, macosx_arm64, openblas]
           - [windows-2022, win_amd64, ""]

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2437,6 +2437,11 @@ def _selected_real_kind_func(p, r=0, radix=0):
     if machine.startswith(('aarch64', 'alpha', 'arm64', 'loongarch', 'mips', 'power', 'ppc', 'riscv', 's390x', 'sparc')):
         if p <= 33:
             return 16
+    elif machine.startswith(('armv6', 'armv7', 'armv8')):
+        # 32-bit ARM (armv6l, armv7l, armv8l on aarch64 host, etc.) supports
+        # only real*4 and real*8; neither 80-bit extended (real*10) nor
+        # 128-bit quad (real*16) exist
+        pass
     elif p < 19:
         return 10
     elif p <= 33:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,10 @@ select = ["*-win32"]
 config-settings = {setup-args = ["--vsenv", "-Dallow-noblas=true"], build-dir="build"}
 repair-wheel-command = ""
 
+[[tool.cibuildwheel.overrides]]
+select = ["*-manylinux_armv7l", "*-musllinux_armv7l"]
+config-settings = {setup-args = ["-Dallow-noblas=true"], build-dir="build"}
+
 [tool.cibuildwheel.pyodide]
 before-test = "pip install -r {project}/requirements/emscripten_test_requirements.txt"
 # Pyodide ensures that the wheels are already repaired by auditwheel-emscripten


### PR DESCRIPTION
### PR summary

This PR adds support for building armv7l (Raspberry Pi) wheels. 

Addresses the feature request in gh-31351. Please also see my corresponding numpy release PR: https://github.com/numpy/numpy-release/pull/45

<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction

My name is Kristian and currently work at https://candela.com/ where we use numpy for various Python applications. Some of these applications are running on a Raspberry Pi compute module 4. For now we have been building numpy from source in CI by extending the official manylinux Docker images.

I thought it would be nice to build it upstream instead to speed up the CI, but also I think it will benefit a lot of people using Raspberry Pi for various hobby projects.

<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure

I used Claude Sonnet 4.6 to fork and push the commit, but I told it exactly which lines to change.

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
