### PR TITLE
ENH: faster days→year/month/day in datetime.c (Joffe fast-date-64)

### DIFF
--- a/benchmarks/benchmarks/bench_datetime.py
+++ b/benchmarks/benchmarks/bench_datetime.py
@@ -1,0 +1,82 @@
+import numpy as np
+
+from .common import Benchmark
+
+
+class DatetimeAsString(Benchmark):
+    """ISO string formatting from datetime64 — exercises set_datetimestruct_days
+    on every element for every output unit.
+    """
+    params = [
+        [10_000, 1_000_000],
+        ['datetime64[D]', 'datetime64[s]', 'datetime64[ms]',
+         'datetime64[us]', 'datetime64[ns]'],
+    ]
+    param_names = ['size', 'dtype']
+
+    def setup(self, size, dtype):
+        rng = np.random.default_rng(0xD47E)
+        # Span +-50 years around 1970, generate at day resolution then cast.
+        days = rng.integers(-18262, 18262, size=size).astype('datetime64[D]')
+        self.arr = days.astype(dtype)
+
+    def time_datetime_as_string(self, size, dtype):
+        np.datetime_as_string(self.arr)
+
+
+class DatetimeAstypeCoarser(Benchmark):
+    """Cast datetime64 to a coarser calendar unit (Y/M/W).
+    Y and M require year/month extraction, which is the days->ymd hot path.
+    W requires only day-floor arithmetic and is included as a control.
+    """
+    params = [
+        [1_000_000],
+        ['datetime64[D]', 'datetime64[s]', 'datetime64[us]', 'datetime64[ns]'],
+        ['datetime64[Y]', 'datetime64[M]', 'datetime64[W]'],
+    ]
+    param_names = ['size', 'src', 'dst']
+
+    def setup(self, size, src, dst):
+        rng = np.random.default_rng(0xD47E)
+        days = rng.integers(-18262, 18262, size=size).astype('datetime64[D]')
+        self.arr = days.astype(src)
+
+    def time_astype(self, size, src, dst):
+        self.arr.astype(dst)
+
+
+class DatetimeToObject(Benchmark):
+    """Convert datetime64 to a Python datetime.date / datetime.datetime array.
+    Each element goes through set_datetimestruct_days; Python object creation
+    is a fixed overhead on top.
+    """
+    params = [
+        [100_000],
+        ['datetime64[D]', 'datetime64[s]', 'datetime64[us]', 'datetime64[ns]'],
+    ]
+    param_names = ['size', 'dtype']
+
+    def setup(self, size, dtype):
+        rng = np.random.default_rng(0xD47E)
+        days = rng.integers(-18262, 18262, size=size).astype('datetime64[D]')
+        self.arr = days.astype(dtype)
+
+    def time_astype_object(self, size, dtype):
+        self.arr.astype(object)
+
+
+class DatetimeWideRange(Benchmark):
+    """Same as DatetimeAsString but spanning a wider date range
+    (~+-2700 years from epoch) to stress the leap-cycle code paths.
+    """
+    params = [[1_000_000], ['datetime64[D]', 'datetime64[us]']]
+    param_names = ['size', 'dtype']
+
+    def setup(self, size, dtype):
+        rng = np.random.default_rng(0xD47E)
+        days = rng.integers(-1_000_000, 1_000_000,
+                            size=size).astype('datetime64[D]')
+        self.arr = days.astype(dtype)
+
+    def time_datetime_as_string(self, size, dtype):
+        np.datetime_as_string(self.arr)

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -191,7 +191,7 @@ get_datetimestruct_minutes(const npy_datetimestruct *dts)
 
 /*
  * Modifies '*days_' to be the day offset within the year,
- * and returns the year.
+ * and returns the year.  Slow-path / fallback algorithm.
  */
 static npy_int64
 days_to_yearsdays(npy_int64 *days_)
@@ -222,12 +222,127 @@ days_to_yearsdays(npy_int64 *days_)
     return year + 2000;
 }
 
+/*
+ * Portable 64x64 -> 128 unsigned multiplication helpers used by the fast
+ * days->y/m/d path below.  npy_mul_hi_u64 returns the high 64 bits;
+ * npy_mul_full_u64 returns the low 64 bits and writes the high 64 to *hi.
+ *
+ * GCC/Clang: native __uint128_t.
+ * MSVC x64/ARM64: __umulh / _umul128 intrinsics from <intrin.h>.
+ * Other compilers: no fast path defined; the existing slow code is used.
+ */
+#if defined(__SIZEOF_INT128__)
+#  define NPY_HAVE_FAST_DAYS_TO_YMD 1
+static inline uint64_t
+npy_mul_hi_u64(uint64_t a, uint64_t b)
+{
+    return (uint64_t)(((__uint128_t)a * b) >> 64);
+}
+static inline uint64_t
+npy_mul_full_u64(uint64_t a, uint64_t b, uint64_t *hi)
+{
+    __uint128_t p = (__uint128_t)a * b;
+    *hi = (uint64_t)(p >> 64);
+    return (uint64_t)p;
+}
+#elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
+#  define NPY_HAVE_FAST_DAYS_TO_YMD 1
+#  include <intrin.h>
+#  if defined(_M_X64)
+#    pragma intrinsic(__umulh, _umul128)
+#  else  /* _M_ARM64: _umul128 is x64-only; use __umulh + native multiply */
+#    pragma intrinsic(__umulh)
+#  endif
+static inline uint64_t
+npy_mul_hi_u64(uint64_t a, uint64_t b)
+{
+    return __umulh(a, b);
+}
+static inline uint64_t
+npy_mul_full_u64(uint64_t a, uint64_t b, uint64_t *hi)
+{
+#  if defined(_M_X64)
+    return _umul128(a, b, hi);
+#  else  /* _M_ARM64 */
+    *hi = __umulh(a, b);
+    return a * b;
+#  endif
+}
+#endif
+
+#ifdef NPY_HAVE_FAST_DAYS_TO_YMD
+/*
+ * Joffe's fast-date-64 algorithm — converts epoch days (since 1970-01-01)
+ * directly to (year, month, day) using four 64x64->128 multiplications.
+ * Branch-free; correct for the full numpy datetime64[D] usable range
+ * (well beyond +/-1e12 years).  Reference:
+ * https://www.benjoffe.com/fast-date-64
+ *
+ * Valid for any signed days such that (D_SHIFT - (uint64_t)days) does not
+ * cross the wrap point that would invalidate the unsigned arithmetic; the
+ * caller bounds inputs via days_in_joffe_range() before calling.
+ */
+static inline void
+days_to_ymd_fast(npy_int64 days_in,
+                 npy_int64 *out_year, int *out_month, int *out_day)
+{
+    const uint64_t ERAS    = 4726498270ULL;
+    const uint64_t D_SHIFT = 146097ULL * ERAS - 719469ULL;
+    const uint64_t Y_SHIFT = 400ULL * ERAS - 1ULL;
+    const uint64_t C1 = 505054698555331ULL;     /* floor(2^64 * 4 / 146097) */
+    const uint64_t C2 = 50504432782230121ULL;   /* ceil(2^64 * 4 / 1461)    */
+    const uint64_t C3 = 8619973866219416ULL;    /* floor(2^64 / 2140)       */
+
+    uint64_t rev = D_SHIFT - (uint64_t)days_in;
+    uint64_t cen = npy_mul_hi_u64(rev, C1);
+    uint64_t jul = rev + cen - cen / 4;
+
+    uint64_t num_hi;
+    uint64_t low = npy_mul_full_u64(jul, C2, &num_hi);
+    uint64_t yrs = Y_SHIFT - num_hi;
+
+    uint64_t ypt = npy_mul_hi_u64(782432ULL, low);
+
+    int      bump  = (ypt < 126464);
+    uint64_t shift = bump ? 191360ULL : 977792ULL;
+
+    uint64_t N = (yrs % 4) * 512 + shift - ypt;
+    uint64_t D = npy_mul_hi_u64(N % 65536, C3);
+
+    *out_day   = (int)(D + 1);
+    *out_month = (int)(N / 65536);
+    *out_year  = (npy_int64)(yrs + (uint64_t)bump);
+}
+
+/*
+ * Joffe's algorithm covers approximately +/-1.89e12 years from 1970.
+ * NumPy's documented datetime64[D] range exceeds this (+/-2.5e16 years), so
+ * gate the fast path with a conservative bound and fall through to the
+ * existing slow code outside that range.  +/-5e14 days ~ +/-1.37e12 years,
+ * comfortably inside Joffe's safe domain.
+ */
+#  define NPY_FAST_YMD_BOUND 500000000000000LL
+static inline int
+days_in_joffe_range(npy_int64 days)
+{
+    return days >= -NPY_FAST_YMD_BOUND && days <= NPY_FAST_YMD_BOUND;
+}
+#endif  /* NPY_HAVE_FAST_DAYS_TO_YMD */
+
 /* Extracts the month number from a 'datetime64[D]' value */
 NPY_NO_EXPORT int
 days_to_month_number(npy_datetime days)
 {
     npy_int64 year;
     int *month_lengths, i;
+
+#ifdef NPY_HAVE_FAST_DAYS_TO_YMD
+    if (days_in_joffe_range(days)) {
+        npy_int64 y; int m, d;
+        days_to_ymd_fast(days, &y, &m, &d);
+        return m;
+    }
+#endif
 
     year = days_to_yearsdays(&days);
     month_lengths = _days_per_month_table[is_leapyear(year)];
@@ -253,6 +368,17 @@ static void
 set_datetimestruct_days(npy_int64 days, npy_datetimestruct *dts)
 {
     int *month_lengths, i;
+
+#ifdef NPY_HAVE_FAST_DAYS_TO_YMD
+    if (days_in_joffe_range(days)) {
+        npy_int64 y; int m, d;
+        days_to_ymd_fast(days, &y, &m, &d);
+        dts->year = y;
+        dts->month = m;
+        dts->day = d;
+        return;
+    }
+#endif
 
     dts->year = days_to_yearsdays(&days);
     month_lengths = _days_per_month_table[is_leapyear(dts->year)];

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -732,6 +732,54 @@ class TestDateTime:
         assert_equal(np.array('2001-03-22', dtype='M8[D]').astype('O'),
                     datetime.date(2001, 3, 22))
 
+    @pytest.mark.parametrize("days_offset", [
+        -719162,    # 0001-01-01 (earliest date Python's datetime.date supports)
+        -25567,     # 1900-01-01 (non-leap century)
+        -1,         # 1969-12-31
+        0,          # epoch
+        1,          # 1970-01-02
+        59, 60,     # 1970-03-01 / 1970-03-02 (1970 is non-leap)
+        11017,      # 2000-02-29 (leap-year corner case)
+        11018,      # 2000-03-01
+        19815,      # 2024-04-28
+        2932896,    # 9999-12-31 (latest Python datetime.date supports)
+    ])
+    def test_days_to_ymd_anchor_dates(self, days_offset):
+        # Cross-check the days->y/m/d kernel against Python's stdlib at
+        # values that exercise the leap-year and century rules.
+        arr = np.array([days_offset], dtype='i8').view('M8[D]')
+        expected = datetime.date(1970, 1, 1) + datetime.timedelta(days=days_offset)
+        assert_equal(arr.astype(object)[0], expected)
+
+    def test_days_to_ymd_dense_sample(self):
+        # Strided cross-check against Python's stdlib over the full range
+        # supported by datetime.date.  Stride 1009 is prime to avoid
+        # aliasing with weekly / monthly / yearly cycles.
+        epoch = datetime.date(1970, 1, 1)
+        start = (datetime.date(1, 1, 1) - epoch).days
+        stop = (datetime.date(9999, 12, 31) - epoch).days
+        days = np.arange(start, stop, 1009, dtype='i8')
+        arr = days.view('M8[D]')
+        actual = arr.astype(object)
+        expected = np.array(
+            [epoch + datetime.timedelta(days=int(d)) for d in days],
+            dtype=object,
+        )
+        assert_array_equal(actual, expected)
+
+    @pytest.mark.parametrize("days_offset", [
+        6 * 10**14,    # ~1.6e12 years AD
+        -6 * 10**14,   # ~1.6e12 years BC
+    ])
+    def test_days_to_ymd_extreme_roundtrip(self, days_offset):
+        # Days beyond the fast-path bound exercise the slow-path fallback.
+        # Verify the result is internally consistent by round-tripping
+        # through datetime_as_string and the parser.
+        arr = np.array([days_offset], dtype='i8').view('M8[D]')
+        s = np.datetime_as_string(arr)
+        parsed = np.array([str(s[0])], dtype='M8[D]')
+        assert_array_equal(arr, parsed)
+
     def test_dtype_comparison(self):
         assert_(not (np.dtype('M8[us]') == np.dtype('M8[ms]')))
         assert_(np.dtype('M8[us]') != np.dtype('M8[ms]'))


### PR DESCRIPTION
### PR summary

Closes #31349.

Replaces `days_to_yearsdays` plus the 12-iteration month-length loop in `set_datetimestruct_days` and `days_to_month_number` with Ben Joffe's 2025 branch-free algorithm ([benjoffe.com/fast-date-64](https://www.benjoffe.com/fast-date-64), BSL-1.0). Joffe computes (year, month, day) directly from epoch days using four 64×64→128 unsigned multiplications, no month loop.

The fast path is gated on availability of a 64×64→128 unsigned multiply: `__uint128_t` for GCC/Clang and `__umulh` / `_umul128` intrinsics for MSVC x64/ARM64. Other compilers/architectures continue to use the existing slow path. A conservative bounds check (±1.37×10¹² years) keeps inputs well inside Joffe's documented ±1.89×10¹² safe range; out-of-range inputs transparently fall back.

#### Benchmarks

x86-64 (gcc 11.4), 1M-element arrays, min of 5 runs, in-tree build:

| Operation                                 | baseline  | this PR   | speedup |
|-------------------------------------------|----------:|----------:|--------:|
| `astype('M8[Y]')` from `M8[D]`            | 25.71 ms  |  4.79 ms  | **5.37×** |
| `astype('M8[M]')` from `M8[D]`            | 26.30 ms  |  5.04 ms  | **5.22×** |
| `astype('M8[Y]')` from `M8[s]`            | 27.73 ms  |  6.60 ms  | **4.20×** |
| `astype('M8[Y]')` from `M8[us]`           | 27.72 ms  |  7.14 ms  | **3.88×** |
| `astype('M8[Y]')` from `M8[ns]`           | 28.83 ms  |  8.00 ms  | **3.60×** |
| `astype(object)` from `M8[D]` (100k)      |  4.42 ms  |  2.09 ms  | **2.11×** |
| `astype(object)` from `M8[s]` (100k)      |  5.23 ms  |  2.85 ms  | **1.84×** |
| `datetime_as_string` `M8[ns]` (1M)        |225.75 ms  |199.15 ms  | 1.13×   |
| `datetime_as_string` wide-range `M8[D]`   |181.70 ms  |154.49 ms  | 1.18×   |
| _control_: `M8[D]→M8[W]` (unchanged path) |  6.64 ms  |  6.62 ms  | 1.00×   |
| _control_: `M8[s]→M8[W]`                  |  6.49 ms  |  6.58 ms  | 0.98×   |
| _control_: `M8[us]→M8[W]`                 |  6.58 ms  |  6.53 ms  | 1.01×   |
| _control_: `M8[ns]→M8[W]`                 |  6.60 ms  |  6.62 ms  | 1.00×   |

#### Test plan

- [x] New tests in `numpy/_core/tests/test_datetime.py` (third commit) cross-check the days→y/m/d kernel against Python's stdlib `datetime`.
- [x] `pytest numpy/_core/tests/test_datetime.py` - 485 passed (471 prior + 14 new), 4 pre-existing xfails (`gh-13197`, unrelated).
- [x] `pytest -k "datetime or busday"` across `test_datetime.py` and `test_multiarray.py`.
- [ ] MSVC fast path: not validated locally - relies on upstream Windows CI runners. The `_umul128` / `__umulh` intrinsics match the `__uint128_t` semantics of the GCC/Clang path.

#### AI Disclosure

This PR was prepared with assistance from Claude Code:

- Rfined the implementation in `numpy/_core/src/multiarray/datetime.c` which is initally based on my draft, specifically gating macros, Windows support and the bounds check.
- Created `benchmarks/benchmarks/bench_datetime.py` in full and collected the results.
- Created test cases in `pytest numpy/_core/tests/test_datetime.py`.