### PR TITLE
BUG: fix memory leak in np.zeros when fill-zero loop raises (#31320)

### DIFF
--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -442,9 +442,9 @@ array_dealloc(PyArrayObject *self)
                 nbytes = 1;
             }
             PyDataMem_UserFREE(fa->data, nbytes, fa->mem_handler);
-            Py_DECREF(fa->mem_handler);
         }
     }
+    Py_CLEAR(fa->mem_handler);
 
     /* must match allocation in PyArray_NewFromDescr */
     npy_free_cache_dim(fa->dimensions, 2 * fa->nd);

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -906,6 +906,13 @@ PyArray_NewFromDescr_int(
             raise_memory_error(fa->nd, fa->dimensions, descr);
             goto fail;
         }
+        /*
+         * Set fa->data and NPY_ARRAY_OWNDATA immediately after allocation so
+         * that the fail path (Py_DECREF(fa) -> dealloc) frees the buffer if
+         * the fill-zero loop below raises an error.
+         */
+        fa->data = data;
+        fa->flags |= NPY_ARRAY_OWNDATA;
 
         /*
          * If the array needs special dtype-specific zero-filling logic, do that
@@ -919,8 +926,6 @@ PyArray_NewFromDescr_int(
                 goto fail;
             }
         }
-
-        fa->flags |= NPY_ARRAY_OWNDATA;
     }
     else {
         /* The handlers should never be called in this case */
@@ -929,8 +934,8 @@ PyArray_NewFromDescr_int(
          * If data is passed in, this object won't own it.
          */
         fa->flags &= ~NPY_ARRAY_OWNDATA;
+        fa->data = data;
     }
-    fa->data = data;
 
     /*
      * Always update the aligned flag.  Not owned data or input strides may
@@ -998,7 +1003,6 @@ PyArray_NewFromDescr_int(
 
  fail:
     NPY_traverse_info_xfree(&fill_zero_info);
-    Py_XDECREF(fa->mem_handler);
     Py_DECREF(fa);
     return NULL;
 }


### PR DESCRIPTION
Backport of #31320.

BUG: fix memory leak in np.zeros when fill-zero loop raises

### PR summary

This PR fixes a memory leak in np.zeros that occurs when the fill-zero loop raises an exception (which can happen for custom user-defined dtypes). It does this by setting NPY_ARRAY_OWNDATA earlier to ensure the data will be deallocated, combined with changes to mem_handler cleanup to avoid a double-decref.

I'm not entirely sure whether this is the most appropriate way to fix the leak, but it does seem to work correctly based on testing with `tracemalloc`.

#### AI Disclosure

The bug was detected through testing with `tracemalloc`, then located and fixed by Claude Opus 4.7.
Full AI-generated description: https://gist.github.com/MaartenBaert/f3eadd280f84ef6896586025f59788ec
