### PR TITLE
BUG: np.einsum() fails with a 0-dimensional out argument and optimize='optimal' (#31354)

### DIFF
--- a/numpy/_core/einsumfunc.py
+++ b/numpy/_core/einsumfunc.py
@@ -1225,7 +1225,7 @@ def bmm_einsum(eq, a, b, out=None, **kwargs):
     if (out is not None) and (not matmul_out_compatible):
         # handle case where out is specified, but we also needed
         # to reshape / transpose ``ab`` after the matmul
-        out[:] = ab
+        out[...] = ab
         ab = out
     elif output_order is not None:
         ab = asanyarray(ab, order=output_order)

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -762,6 +762,14 @@ class TestEinsum:
         # see issue gh-15776 and issue gh-15256
         assert_equal(np.einsum('i,j', [1], [2], out=None), [[2]])
 
+    def test_einsum_0d_out(self):
+        # Issue gh-31350, a zero-dimensional out must not cause an error
+        # with optimize='optimal'
+        a = np.ones(7)
+        out = np.array(0)
+        np.einsum('i,i->', a, a, out=out, optimize='optimal')
+        assert_equal(out, 7)
+
     def test_object_loop(self):
 
         class Mult:


### PR DESCRIPTION
Backport of #31354.

### PR summary

This PR fixes #31350.

It replaces the expression `out[:]` found in `bmm_einsum()` with the more universal `out[...]`, which is also valid for a 0-dimensional `out`.

`TestEinsum.test_einsum_misc()` in `numpy/_core/tests/test_einsum.py` has been extended to cover #31350.

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

I am a researcher who uses NumPy in a multitude of scientific computing projects, mostly simulation codes for computational condensed matter theory. I discovered the issue #31350 while working on one of such (private) projects.

#### AI Disclosure

No AI has been used in preparation of this PR.
