### PR TITLE
Handle Python scalars consistently in np.astype

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2673,7 +2673,10 @@ def astype(x, dtype, /, *, copy=True, device=None):
             'Device not understood. Only "cpu" is allowed, but received:'
             f' {device}'
         )
+    if isscalar(x):
+        return np.asarray(x).astype(dtype, copy=copy)
     return x.astype(dtype, copy=copy)
+
 
 
 inf = PINF

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2674,7 +2674,7 @@ def astype(x, dtype, /, *, copy=True, device=None):
             f' {device}'
         )
     if isscalar(x):
-        return np.asarray(x).astype(dtype, copy=copy)
+        return np.asarray(x).astype(dtype, copy=copy)[()]
     return x.astype(dtype, copy=copy)
 
 

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2678,7 +2678,6 @@ def astype(x, dtype, /, *, copy=True, device=None):
     return x.astype(dtype, copy=copy)
 
 
-
 inf = PINF
 nan = NAN
 False_ = nt.bool(False)


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->
I use numpy as a machine learner, and data-analytic. I also use it for a lot of other tasks, but primarily for ML. 
I was interested in reviewing the code of numpy, and how it works, and i saw a bug in astype.

So, the issue i found was in the astype function. This PR update 'np.astype':, so python scalar inputs are also handled, instead of ending with error 'AttributeError'
>>> import numpy as np
>>> np.astype(np.int64(1), np.float64)
np.float64(1.0)
>>> np.astype(1, np.float64)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\vov\anaconda3\Lib\site-packages\numpy\_core\numeric.py", line 2730, in astype
    return x.astype(dtype, copy=copy)
           ^^^^^^^^
AttributeError: 'int' object has no attribute 'astype'
>>>

So, as python integers do not have a .astype attribute, in my edits, if the integer is scalar, it is converted by the np.asarray , which does not raise an issue, and makes the python-native scalars work fine

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
No AI tools used