### PR TITLE
TST: Validate warning message content in _DeprecationTestCase

### DIFF
--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -4,6 +4,7 @@ to document how deprecations should eventually be turned into errors.
 
 """
 import contextlib
+import re
 import warnings
 from collections.abc import Callable
 
@@ -86,6 +87,12 @@ class _DeprecationTestCase:
         for warning in w_context:
             if warning.category is self.warning_cls:
                 num_found += 1
+                if self.message:
+                    if not re.match(self.message, str(warning.message)):
+                        raise AssertionError(
+                            f"Warning message '{warning.message}' did not match "
+                            f"expected pattern '{self.message}'"
+                        )
             elif not ignore_others:
                 name = self.warning_cls.__name__
                 raise AssertionError(f"expected {name} but got: {warning.category}")


### PR DESCRIPTION
### PR summary
This PR fixes a bug in the `_DeprecationTestCase` utility where the `message` attribute was ignored during validation. The utility now uses `re.match` to ensure that emitted warnings strictly match the expected pattern.

* **Related Issue:** Fixes #31361
* **Verification:** Confirmed that sabotaging a message string now correctly triggers an `AssertionError`. All 75 tests in `numpy/_core/tests/test_deprecations.py` pass with strict validation enabled.

#### AI Disclosure
The PR description was formatted and refined using AI. The code changes and the validation/testing were done manually.