### PR TITLE
BUG: Avoid optimization causing astropy regression

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1315,6 +1315,13 @@ _convert_from_dict(PyObject *obj, int align)
             Py_DECREF(new);
             goto fail;
         }
+        if (itemsize != new->elsize) {
+            /*
+             * astropy relied on "holes" at the end not being used until this
+             * is fixed we cannot optimize the path as a full dtype copy.
+             */
+            new->flags |= NPY_NOT_TRIVIALLY_COPYABLE;
+        }
         /* Set the itemsize */
         new->elsize = itemsize;
     }

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -628,6 +628,21 @@ class TestRecord:
         assert arr.dtype.hasobject  # but claims to contain objects
         del arr  # the deletion failed previously.
 
+    def test_structured_out_of_range(self):
+        # This test should be able to fail as an optimization, but astropy
+        # relied on the non-optimized behavior.
+        # A future version could force astropy to either fix the code or
+        # introduce a kwarg to disable the optimization default. But for now
+        # we avoid the astropy regression.
+        # The following dtype cannot be assumed to just include padding
+        dtype = np.dtype(dict(names=["a"], formats=["i4"], itemsize=8))
+        raw_arr = np.zeros(10, dtype="i8")
+        arr1 = raw_arr.view(dtype)
+        arr2 = np.full(10, -1, dtype="i8").view(dtype)
+        # This should only fill in the i4 field of `dtype`:
+        arr1[...] = arr2
+        assert (raw_arr.view("i4")[1::2] == 0).all()
+
 
 class TestSubarray:
     def test_single_subarray(self):


### PR DESCRIPTION
Arguably, I think astropy is relying on things it shouldn't rely on, but let's not break them.
I am considering adding a dict option here to enable the optimization on this path (i.e. allow setting the flag explicitly unless a subfield disables it).

But if astropy wants this in quickly to unblock CI, this should be fine.

Closes gh-31363