### PR TITLE
MAINT: clarify why a structured dtype might not be trivially copyable

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1315,24 +1315,19 @@ _convert_from_dict(PyObject *obj, int align)
             Py_DECREF(new);
             goto fail;
         }
-        if (itemsize != new->elsize) {
-            /*
-             * astropy relied on "holes" at the end not being used until this
-             * is fixed we cannot optimize the path as a full dtype copy.
-             */
-            new->flags |= NPY_NOT_TRIVIALLY_COPYABLE;
-        }
         /* Set the itemsize */
         new->elsize = itemsize;
     }
 
     /*
-     * Mark as not trivially copyable only if explicit offsets were provided
-     * and the layout has holes. Alignment padding (without explicit offsets)
-     * is safe to overwrite with memcpy.
+     * Check if anything prevents using memcpy for whole items for this dtype,
+     * i.e., whether there are any holes unrelated to alignment padding
+     * (since those holes might be used to avoid accessing/overwriting stuff).
+     * Such holes can be introduced due to choices of itemsize or offsets.
      */
-    if (offsets != NULL &&
-            !is_dtype_struct_simple_unaligned_layout((PyArray_Descr *)new)) {
+    if (new->elsize != totalsize
+        || (offsets != NULL && !is_dtype_struct_simple_unaligned_layout(
+                (PyArray_Descr *)new))) {
         new->flags |= NPY_NOT_TRIVIALLY_COPYABLE;
     }
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -629,12 +629,9 @@ class TestRecord:
         del arr  # the deletion failed previously.
 
     def test_structured_out_of_range(self):
-        # This test should be able to fail as an optimization, but astropy
-        # relied on the non-optimized behavior.
-        # A future version could force astropy to either fix the code or
-        # introduce a kwarg to disable the optimization default. But for now
-        # we avoid the astropy regression.
-        # The following dtype cannot be assumed to just include padding
+        # Regression test for gh-29270 against over-eager optimization of
+        # copying of structured dtype: do not copy when dtype has holes
+        # because the itemsize was explicitly given.
         dtype = np.dtype(dict(names=["a"], formats=["i4"], itemsize=8))
         raw_arr = np.zeros(10, dtype="i8")
         arr1 = raw_arr.view(dtype)


### PR DESCRIPTION
A follow-up on gh-31371, partially to have a place to discuss that is not a closed issue or PR: after thinking a bit more, I think the solution in gh-31371 is actually the right one: if you pass in `itemsize` and that leads to holes, then just like for `offsets`, one should assume those holes are on purpose and thus  the whole item cannot be safely copied. 

This PR is in partially to discuss; all it really does is change comments to make the logic explicit, and bring the tests for non-trivially-copyable to one place--there is no functional change.

EDIT: Note that even with this limitation, we have solved the original issue, which was about slowdowns for a regular structured array with no offsets or itemsize provided.

No AI used.