### PR TITLE
DOC: fix nitpicky Sphinx warnings in NEP 13

### DIFF
--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -632,28 +632,28 @@ Ufuncs used by :class:`ndarray` and
 ====== ============ =========================================
 Symbol Operator     NumPy Ufunc(s)
 ====== ============ =========================================
-``<``  ``lt``       ``less``
-``<=`` ``le``       ``less_equal``
-``==`` ``eq``       ``equal``
-``!=`` ``ne``       ``not_equal``
-``>``  ``gt``       ``greater``
-``>=`` ``ge``       ``greater_equal``
-``+``  ``add``      ``add``
-``-``  ``sub``      ``subtract``
-``*``  ``mul``      ``multiply``
-``/``  ``truediv``  ``true_divide``
+``<``  ``lt``       :func:`~numpy.less`
+``<=`` ``le``       :func:`~numpy.less_equal`
+``==`` ``eq``       :func:`~numpy.equal`
+``!=`` ``ne``       :func:`~numpy.not_equal`
+``>``  ``gt``       :func:`~numpy.greater`
+``>=`` ``ge``       :func:`~numpy.greater_equal`
+``+``  ``add``      :func:`~numpy.add`
+``-``  ``sub``      :func:`~numpy.subtract`
+``*``  ``mul``      :func:`~numpy.multiply`
+``/``  ``truediv``  :func:`~numpy.true_divide`
        (Python 3)
-``/``  ``div``      ``divide``
+``/``  ``div``      :func:`~numpy.divide`
        (Python 2)
-``//`` ``floordiv`` ``floor_divide``
-``%``  ``mod``      ``remainder``
-NA     ``divmod``   ``divmod``
-``**`` ``pow``      ``power`` [10]_
-``<<`` ``lshift``   ``left_shift``
-``>>`` ``rshift``   ``right_shift``
-``&``  ``and_``     ``bitwise_and``
-``^``  ``xor_``     ``bitwise_xor``
-``|``  ``or_``      ``bitwise_or``
+``//`` ``floordiv`` :func:`~numpy.floor_divide`
+``%``  ``mod``      :func:`~numpy.remainder`
+NA     ``divmod``   :func:`~numpy.divmod`
+``**`` ``pow``      :func:`~numpy.power` [10]_
+``<<`` ``lshift``   :func:`~numpy.left_shift`
+``>>`` ``rshift``   :func:`~numpy.right_shift`
+``&``  ``and_``     :func:`~numpy.bitwise_and`
+``^``  ``xor_``     :func:`~numpy.bitwise_xor`
+``|``  ``or_``      :func:`~numpy.bitwise_or`
 ``@``  ``matmul``   Not yet implemented as a ufunc [11]_
 ====== ============ =========================================
 
@@ -662,20 +662,21 @@ And here is the list of unary operators:
 ====== ============ =========================================
 Symbol Operator     NumPy Ufunc(s)
 ====== ============ =========================================
-``-``  ``neg``      ``negative``
-``+``  ``pos``      ``positive`` [12]_
-NA     ``abs``      ``absolute``
-``~``  ``invert``   ``invert``
+``-``  ``neg``      :func:`~numpy.negative`
+``+``  ``pos``      :func:`~numpy.positive` [12]_
+NA     ``abs``      :func:`~numpy.absolute`
+``~``  ``invert``   :func:`~numpy.invert`
 ====== ============ =========================================
 
 .. [10] class :class:`ndarray` takes short cuts for ``__pow__`` for the
-        cases where the power equals ``1`` (``positive``),
-        ``-1`` (``reciprocal``), ``2`` (``square``), ``0`` (an
-        otherwise private ``_ones_like`` ufunc), and ``0.5``
-        (``sqrt``), and the array is float or complex (or integer
+        cases where the power equals ``1`` (:func:`~numpy.positive`),
+        ``-1`` (:func:`~numpy.reciprocal`), ``2`` (:func:`~numpy.square`),
+        ``0`` (an otherwise private ``_ones_like`` ufunc), and ``0.5``
+        (:func:`~numpy.sqrt`), and the array is float or complex (or integer
         for square).
 
-.. [11] Because NumPy's ``matmul`` is not a ufunc, it is
+
+.. [11] Because NumPy's :func:`~numpy.matmul` is not a ufunc, it is
         `currently not possible <https://github.com/numpy/numpy/issues/9028>`_
         to override ``numpy_array @ other`` with ``other`` taking precedence
         if ``other`` implements ``__array_func__``.
@@ -687,7 +688,7 @@ Future extensions to other functions
 
 Some NumPy functions could be implemented as (generalized) Ufunc, in
 which case it would be possible for them to be overridden by the
-``__array_ufunc__`` method. A prime candidate is ``numpy.matmul``,
+``__array_ufunc__`` method.  A prime candidate is :func:`~numpy.matmul`,
 which currently is not a Ufunc, but could be relatively easily be
 rewritten as a (set of) generalized Ufuncs. The same may happen with
 functions such as :func:`~numpy.median`, :func:`~numpy.min`, and

--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -321,7 +321,7 @@ implicit type casting hierarchy.
    explicitly specified.
 
 Subclasses can be easily constructed if methods consistently use
-:func:``super`` to pass through the class hierarchy [7]_.  To support
+:py:class:`super` to pass through the class hierarchy [7]_.  To support
 this, :class:`ndarray` has its own ``__array_ufunc__`` method,
 equivalent to::
 
@@ -352,11 +352,11 @@ if they have not overridden the default `ndarray` implementation. As a
 consequence, calling `ndarray.__array_ufunc__` will not result to a
 nested ufunc dispatch cycle.
 
-The use of :func:``super`` should be particularly useful for subclasses of
+The use of :py:class:`super` should be particularly useful for subclasses of
 :class:`ndarray` that only add an attribute like a unit.  In their
 `__array_ufunc__` implementation, such classes can do possible
 adjustment of the arguments relevant to their own class, and pass on to
-the superclass implementation using :func:``super`` until the ufunc is
+the superclass implementation using :py:class:`super` until the ufunc is
 actually done, and then do possible adjustments of the outputs.
 
 In general, custom implementations of `__array_ufunc__` should avoid
@@ -392,7 +392,7 @@ which both override ``__array_ufunc__``, with specific instances ``q``
 and ``ma``, where the latter contains a regular array. Executing
 ``np.multiply(q, ma)``, the ufunc will first dispatch to
 ``q.__array_ufunc__``, which returns :obj:`NotImplemented` (since the
-quantity class turns itself into an array and calls :func:``super``, which
+quantity class turns itself into an array and calls :py:class:`super`, which
 passes on to ``ndarray.__array_ufunc__``, which sees the override on
 ``ma``). Next, ``ma.__array_ufunc__`` gets a chance. It does not know
 quantity, and if it were to just return :obj:`NotImplemented` as well,
@@ -668,7 +668,7 @@ NA     ``abs``      ``absolute``
 ``~``  ``invert``   ``invert``
 ====== ============ =========================================
 
-.. [10] class :`ndarray` takes short cuts for ``__pow__`` for the
+.. [10] class :class:`ndarray` takes short cuts for ``__pow__`` for the
         cases where the power equals ``1`` (``positive``),
         ``-1`` (``reciprocal``), ``2`` (``square``), ``0`` (an
         otherwise private ``_ones_like`` ufunc), and ``0.5``
@@ -690,7 +690,8 @@ which case it would be possible for them to be overridden by the
 ``__array_ufunc__`` method. A prime candidate is ``numpy.matmul``,
 which currently is not a Ufunc, but could be relatively easily be
 rewritten as a (set of) generalized Ufuncs. The same may happen with
-functions such as ``numpy.median``, ``numpy.min``, and ``numpy.argsort``.
+functions such as :func:`~numpy.median`, :func:`~numpy.min`, and
+:func:`~numpy.argsort`.
 
 
 .. Local Variables:

--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -249,7 +249,7 @@ three groups:
   (indirect) upcasting is possible.
 
 Note that the legacy behaviour of NumPy ufuncs is to try to convert
-unknown objects to :class:`ndarray` via :func:`np.asarray`.  This is
+unknown objects to :class:`ndarray` via :func:`numpy.asarray`.  This is
 equivalent to placing :class:`ndarray` above these objects in the graph.
 Since we above defined :class:`ndarray` to return `NotImplemented` for
 classes with custom ``__array_ufunc__``, this puts :class:`ndarray`
@@ -321,7 +321,7 @@ implicit type casting hierarchy.
    explicitly specified.
 
 Subclasses can be easily constructed if methods consistently use
-:func:`super` to pass through the class hierarchy [7]_.  To support
+:func:``super`` to pass through the class hierarchy [7]_.  To support
 this, :class:`ndarray` has its own ``__array_ufunc__`` method,
 equivalent to::
 
@@ -352,18 +352,18 @@ if they have not overridden the default `ndarray` implementation. As a
 consequence, calling `ndarray.__array_ufunc__` will not result to a
 nested ufunc dispatch cycle.
 
-The use of :func:`super` should be particularly useful for subclasses of
+The use of :func:``super`` should be particularly useful for subclasses of
 :class:`ndarray` that only add an attribute like a unit.  In their
 `__array_ufunc__` implementation, such classes can do possible
 adjustment of the arguments relevant to their own class, and pass on to
-the superclass implementation using :func:`super` until the ufunc is
+the superclass implementation using :func:``super`` until the ufunc is
 actually done, and then do possible adjustments of the outputs.
 
 In general, custom implementations of `__array_ufunc__` should avoid
 nested dispatch cycles, where one not just calls the ufunc via
 ``getattr(ufunc, method)(*items, **kwargs)``, but catches possible
 exceptions, etc.  As always, there may be exceptions. For instance, for a
-class like :class:`MaskedArray`, which only cares that whatever
+class like :class:`numpy.ma.MaskedArray`, which only cares that whatever
 it contains is an :class:`ndarray` subclass, a reimplementation with
 ``__array_ufunc__`` may well be more easily done by directly applying
 the ufunc to its data, and then adjusting the mask.  Indeed, one can
@@ -392,7 +392,7 @@ which both override ``__array_ufunc__``, with specific instances ``q``
 and ``ma``, where the latter contains a regular array. Executing
 ``np.multiply(q, ma)``, the ufunc will first dispatch to
 ``q.__array_ufunc__``, which returns :obj:`NotImplemented` (since the
-quantity class turns itself into an array and calls :func:`super`, which
+quantity class turns itself into an array and calls :func:``super``, which
 passes on to ``ndarray.__array_ufunc__``, which sees the override on
 ``ma``). Next, ``ma.__array_ufunc__`` gets a chance. It does not know
 quantity, and if it were to just return :obj:`NotImplemented` as well,
@@ -406,7 +406,7 @@ a masked array and thus return a result (obviously, if it was not a
 array subclass, it could still return :obj:`NotImplemented`).
 
 Note that in the context of the type hierarchy discussed above this is a
-somewhat tricky example, since :class:`MaskedArray` has a strange
+somewhat tricky example, since :class:`numpy.ma.MaskedArray` has a strange
 position: it is above all subclasses of :class:`ndarray`, in that it can
 cast them to its own type, but it does not itself know how to interact
 with them in ufuncs.
@@ -632,28 +632,28 @@ Ufuncs used by :class:`ndarray` and
 ====== ============ =========================================
 Symbol Operator     NumPy Ufunc(s)
 ====== ============ =========================================
-``<``  ``lt``       :func:`less`
-``<=`` ``le``       :func:`less_equal`
-``==`` ``eq``       :func:`equal`
-``!=`` ``ne``       :func:`not_equal`
-``>``  ``gt``       :func:`greater`
-``>=`` ``ge``       :func:`greater_equal`
-``+``  ``add``      :func:`add`
-``-``  ``sub``      :func:`subtract`
-``*``  ``mul``      :func:`multiply`
-``/``  ``truediv``  :func:`true_divide`
+``<``  ``lt``       ``less``
+``<=`` ``le``       ``less_equal``
+``==`` ``eq``       ``equal``
+``!=`` ``ne``       ``not_equal``
+``>``  ``gt``       ``greater``
+``>=`` ``ge``       ``greater_equal``
+``+``  ``add``      ``add``
+``-``  ``sub``      ``subtract``
+``*``  ``mul``      ``multiply``
+``/``  ``truediv``  ``true_divide``
        (Python 3)
-``/``  ``div``      :func:`divide`
+``/``  ``div``      ``divide``
        (Python 2)
-``//`` ``floordiv`` :func:`floor_divide`
-``%``  ``mod``      :func:`remainder`
-NA     ``divmod``   :func:`divmod`
-``**`` ``pow``      :func:`power` [10]_
-``<<`` ``lshift``   :func:`left_shift`
-``>>`` ``rshift``   :func:`right_shift`
-``&``  ``and_``     :func:`bitwise_and`
-``^``  ``xor_``     :func:`bitwise_xor`
-``|``  ``or_``      :func:`bitwise_or`
+``//`` ``floordiv`` ``floor_divide``
+``%``  ``mod``      ``remainder``
+NA     ``divmod``   ``divmod``
+``**`` ``pow``      ``power`` [10]_
+``<<`` ``lshift``   ``left_shift``
+``>>`` ``rshift``   ``right_shift``
+``&``  ``and_``     ``bitwise_and``
+``^``  ``xor_``     ``bitwise_xor``
+``|``  ``or_``      ``bitwise_or``
 ``@``  ``matmul``   Not yet implemented as a ufunc [11]_
 ====== ============ =========================================
 
@@ -662,22 +662,24 @@ And here is the list of unary operators:
 ====== ============ =========================================
 Symbol Operator     NumPy Ufunc(s)
 ====== ============ =========================================
-``-``  ``neg``      :func:`negative`
-``+``  ``pos``      :func:`positive` [12]_
-NA     ``abs``      :func:`absolute`
-``~``  ``invert``   :func:`invert`
+``-``  ``neg``      ``negative``
+``+``  ``pos``      ``positive`` [12]_
+NA     ``abs``      ``absolute``
+``~``  ``invert``   ``invert``
 ====== ============ =========================================
 
 .. [10] class :`ndarray` takes short cuts for ``__pow__`` for the
-        cases where the power equals ``1`` (:func:`positive`),
-        ``-1`` (:func:`reciprocal`), ``2`` (:func:`square`), ``0`` (an
+        cases where the power equals ``1`` (``positive``),
+        ``-1`` (``reciprocal``), ``2`` (``square``), ``0`` (an
         otherwise private ``_ones_like`` ufunc), and ``0.5``
-        (:func:`sqrt`), and the array is float or complex (or integer
+        (``sqrt``), and the array is float or complex (or integer
         for square).
-.. [11] Because NumPy's :func:`matmul` is not a ufunc, it is
+
+.. [11] Because NumPy's ``matmul`` is not a ufunc, it is
         `currently not possible <https://github.com/numpy/numpy/issues/9028>`_
         to override ``numpy_array @ other`` with ``other`` taking precedence
         if ``other`` implements ``__array_func__``.
+
 .. [12] :class:`ndarray` currently does a copy instead of using this ufunc.
 
 Future extensions to other functions
@@ -685,11 +687,10 @@ Future extensions to other functions
 
 Some NumPy functions could be implemented as (generalized) Ufunc, in
 which case it would be possible for them to be overridden by the
-``__array_ufunc__`` method.  A prime candidate is :func:`~numpy.matmul`,
+``__array_ufunc__`` method. A prime candidate is ``numpy.matmul``,
 which currently is not a Ufunc, but could be relatively easily be
 rewritten as a (set of) generalized Ufuncs. The same may happen with
-functions such as :func:`~numpy.median`, :func:`~numpy.min`, and
-:func:`~numpy.argsort`.
+functions such as ``numpy.median``, ``numpy.min``, and ``numpy.argsort``.
 
 
 .. Local Variables:

--- a/doc/neps/nep-0013-ufunc-overrides.rst
+++ b/doc/neps/nep-0013-ufunc-overrides.rst
@@ -632,28 +632,28 @@ Ufuncs used by :class:`ndarray` and
 ====== ============ =========================================
 Symbol Operator     NumPy Ufunc(s)
 ====== ============ =========================================
-``<``  ``lt``       :func:`~numpy.less`
-``<=`` ``le``       :func:`~numpy.less_equal`
-``==`` ``eq``       :func:`~numpy.equal`
-``!=`` ``ne``       :func:`~numpy.not_equal`
-``>``  ``gt``       :func:`~numpy.greater`
-``>=`` ``ge``       :func:`~numpy.greater_equal`
-``+``  ``add``      :func:`~numpy.add`
-``-``  ``sub``      :func:`~numpy.subtract`
-``*``  ``mul``      :func:`~numpy.multiply`
-``/``  ``truediv``  :func:`~numpy.true_divide`
+``<``  ``lt``       :obj:`numpy.less`
+``<=`` ``le``       :obj:`numpy.less_equal`
+``==`` ``eq``       :obj:`numpy.equal`
+``!=`` ``ne``       :obj:`numpy.not_equal`
+``>``  ``gt``       :obj:`numpy.greater`
+``>=`` ``ge``       :obj:`numpy.greater_equal`
+``+``  ``add``      :obj:`numpy.add`
+``-``  ``sub``      :obj:`numpy.subtract`
+``*``  ``mul``      :obj:`numpy.multiply`
+``/``  ``truediv``  :obj:`numpy.true_divide`
        (Python 3)
-``/``  ``div``      :func:`~numpy.divide`
+``/``  ``div``      :obj:`numpy.divide`
        (Python 2)
-``//`` ``floordiv`` :func:`~numpy.floor_divide`
-``%``  ``mod``      :func:`~numpy.remainder`
-NA     ``divmod``   :func:`~numpy.divmod`
-``**`` ``pow``      :func:`~numpy.power` [10]_
-``<<`` ``lshift``   :func:`~numpy.left_shift`
-``>>`` ``rshift``   :func:`~numpy.right_shift`
-``&``  ``and_``     :func:`~numpy.bitwise_and`
-``^``  ``xor_``     :func:`~numpy.bitwise_xor`
-``|``  ``or_``      :func:`~numpy.bitwise_or`
+``//`` ``floordiv`` :obj:`numpy.floor_divide`
+``%``  ``mod``      :obj:`numpy.remainder`
+NA     ``divmod``   :obj:`numpy.divmod`
+``**`` ``pow``      :obj:`numpy.power` [10]_
+``<<`` ``lshift``   :obj:`numpy.left_shift`
+``>>`` ``rshift``   :obj:`numpy.right_shift`
+``&``  ``and_``     :obj:`numpy.bitwise_and`
+``^``  ``xor_``     :obj:`numpy.bitwise_xor`
+``|``  ``or_``      :obj:`numpy.bitwise_or`
 ``@``  ``matmul``   Not yet implemented as a ufunc [11]_
 ====== ============ =========================================
 
@@ -662,21 +662,21 @@ And here is the list of unary operators:
 ====== ============ =========================================
 Symbol Operator     NumPy Ufunc(s)
 ====== ============ =========================================
-``-``  ``neg``      :func:`~numpy.negative`
-``+``  ``pos``      :func:`~numpy.positive` [12]_
-NA     ``abs``      :func:`~numpy.absolute`
-``~``  ``invert``   :func:`~numpy.invert`
+``-``  ``neg``      :obj:`numpy.negative`
+``+``  ``pos``      :obj:`numpy.positive` [12]_
+NA     ``abs``      :obj:`numpy.absolute`
+``~``  ``invert``   :obj:`numpy.invert`
 ====== ============ =========================================
 
 .. [10] class :class:`ndarray` takes short cuts for ``__pow__`` for the
-        cases where the power equals ``1`` (:func:`~numpy.positive`),
-        ``-1`` (:func:`~numpy.reciprocal`), ``2`` (:func:`~numpy.square`),
+        cases where the power equals ``1`` (:obj:`numpy.positive`),
+        ``-1`` (:obj:`numpy.reciprocal`), ``2`` (:obj:`numpy.square`),
         ``0`` (an otherwise private ``_ones_like`` ufunc), and ``0.5``
-        (:func:`~numpy.sqrt`), and the array is float or complex (or integer
+        (:obj:`numpy.sqrt`), and the array is float or complex (or integer
         for square).
 
 
-.. [11] Because NumPy's :func:`~numpy.matmul` is not a ufunc, it is
+.. [11] Because NumPy's :obj:`numpy.matmul` is not a ufunc, it is
         `currently not possible <https://github.com/numpy/numpy/issues/9028>`_
         to override ``numpy_array @ other`` with ``other`` taking precedence
         if ``other`` implements ``__array_func__``.
@@ -688,11 +688,11 @@ Future extensions to other functions
 
 Some NumPy functions could be implemented as (generalized) Ufunc, in
 which case it would be possible for them to be overridden by the
-``__array_ufunc__`` method.  A prime candidate is :func:`~numpy.matmul`,
+``__array_ufunc__`` method.  A prime candidate is :obj:`numpy.matmul`,
 which currently is not a Ufunc, but could be relatively easily be
 rewritten as a (set of) generalized Ufuncs. The same may happen with
-functions such as :func:`~numpy.median`, :func:`~numpy.min`, and
-:func:`~numpy.argsort`.
+functions such as :obj:`numpy.median`, :obj:`numpy.min`, and
+:obj:`numpy.argsort`.
 
 
 .. Local Variables:

--- a/doc/neps/nep-0040-legacy-datatype-impl.rst
+++ b/doc/neps/nep-0040-legacy-datatype-impl.rst
@@ -339,7 +339,7 @@ Each of these signatures is associated with a single inner-loop function defined
 in C, which does the actual calculation, and may be called multiple times.
 
 The main step in finding the correct inner-loop function is to call a
-:c:type:`PyUFunc_TypeResolutionFunc` which retrieves the input dtypes from
+:c:type:`PyUFuncObject.type_resolver.PyUFunc_TypeResolutionFunc` which retrieves the input dtypes from
 the provided input arrays
 and will determine the full type signature (including output dtype) to be executed.
 

--- a/doc/neps/nep-0051-scalar-representation.rst
+++ b/doc/neps/nep-0051-scalar-representation.rst
@@ -224,10 +224,10 @@ Related work
 ============
 
 A PR to only change the representation of booleans was previously
-made `here <https://github.com/numpy/numpy/pull/17592>`_.
+made `here <https://github.com/numpy/numpy/pull/17592>`__.
 
 The implementation is (at the time of writing) largely finished and can be
-found `here <https://github.com/numpy/numpy/pull/22449>`_
+found `here <https://github.com/numpy/numpy/pull/22449>`__
 
 Implementation
 ==============


### PR DESCRIPTION
### PR summary

Fix unresolved Sphinx references in NEP 13. Closes #25998

This PR replaces `:func:` roles that cannot be resolved in the NEP
documentation build with inline literals (``func``), preventing warnings
when building NEPs with nitpicky mode (-n -W).

This reduces warnings in NEP 13 without changing content or meaning.

Remaining warnings in the NEP build are related to toctree structure and
are outside the scope of this PR.

### First time committer introduction

Hi, I’m a first-time contributor to NumPy.
I’m a computer science student and have been using NumPy in my academic work and projects. While exploring the repository and documentation, I wanted to contribute by improving documentation quality.
This issue stood out as a good opportunity to understand the documentation build system and Sphinx behavior, so I worked on fixing the unresolved references in NEP 13.


#### AI Disclosure
AI was only used for guidance in understanding Sphinx warnings and debugging reference resolution issues.
The final code changes (replacement of unresolved `:func:` roles with inline literals) were reviewed and applied manually, and no AI-generated code was directly used.