### PR TITLE
BUG: Fix signed overflow issue in npy_gcd for INT_MIN on s390x (#31360)

### DIFF
--- a/numpy/_core/src/npymath/npy_math_internal.h.src
+++ b/numpy/_core/src/npymath/npy_math_internal.h.src
@@ -650,12 +650,21 @@ npy_lcm@c@(@type@ a, @type@ b)
  *
  * #type = (npy_int, npy_long, npy_longlong)*2#
  * #c = (,l,ll)*2#
+ * #utype = (npy_uint, npy_ulong, npy_ulonglong)*2#
  * #func=gcd*3,lcm*3#
  */
 NPY_INPLACE @type@
 npy_@func@@c@(@type@ a, @type@ b)
 {
-    return npy_@func@u@c@(a < 0 ? -a : a, b < 0 ? -b : b);
+    /*
+     * Cast to unsigned to avoid overflow when negating minimum signed value.
+     * For negative values, cast to unsigned first, then apply negation in
+     * unsigned arithmetic to avoid undefined behavior.
+     * This ensures correct behavior across all architectures. #31359
+     */
+    @utype@ a_abs = a < 0 ? (@utype@)(0) - (@utype@)a : (@utype@)a;
+    @utype@ b_abs = b < 0 ? (@utype@)(0) - (@utype@)b : (@utype@)b;
+    return (@type@)npy_@func@u@c@(a_abs, b_abs);
 }
 /**end repeat**/
 

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4160,13 +4160,17 @@ class TestRationalFunctions:
         assert_equal(np.lcm(a, b), 10 * big)
 
     def test_gcd_overflow(self):
-        for dtype in (np.int32, np.int64):
-            # verify that we don't overflow when taking abs(x)
-            # not relevant for lcm, where the result is unrepresentable anyway
-            a = dtype(np.iinfo(dtype).min)  # negative power of two
+        # verify that we don't overflow when taking abs(x) for INT_MIN
+        # this was undefined behavior that manifested on s390x with GCC 11.5
+        for dtype in (np.int8, np.int16, np.int32, np.int64):
+            a = dtype(np.iinfo(dtype).min)  # INT_MIN
             q = -(a // 4)
+            # Test with INT_MIN as first argument
             assert_equal(np.gcd(a,  q * 3), q)
             assert_equal(np.gcd(a, -q * 3), q)
+            # Test with INT_MIN as second argument
+            assert_equal(np.gcd(q * 3,  a), q)
+            assert_equal(np.gcd(-q * 3, a), q)
 
     def test_decimal(self):
         from decimal import Decimal


### PR DESCRIPTION
Backport of #31360.

### FIX https://github.com/numpy/numpy/issues/31359

### PR summary

This PR fixes signed overflow issue  in npy_gcd when one of the inputs is the minimum value of a signed integer type (INT_MIN) on s390x architecture.

issue was the expression a < 0 ? -a : a in npy_math_internal.h.src causes undefined behavior when a = INT_MIN because negating INT_MIN overflows a signed integer on s390x. i see it is working fine with other arch so fix only provided to s390x 


#### AI Disclosure
No AI tools were used in identifying, reproducing, or fixing this bug. The bug was identified by running below code after updating the code ..before the code update i see the mismatch in expected and actual result which i informed in issue #31359
```
python3 -c "
import numpy as np
a = np.int32(np.iinfo(np.int32).min)
q = -(a // 4)
result = np.gcd(a, q * 3)
print('Result  :',result)
print('Expected: 536870912')
print('Status  :','PASS' if result == np.int32(536870912) else 'FAIL')
"
Result  : 536870912
Expected: 536870912
Status  : PASS
```

