### PR TITLE
BLD/MAINT: improve support for Intel LLVM compilers

### DIFF
--- a/numpy/_core/include/numpy/npy_common.h
+++ b/numpy/_core/include/numpy/npy_common.h
@@ -392,11 +392,11 @@ typedef struct
 #include <complex.h>
 
 
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__INTEL_LLVM_COMPILER)
 typedef _Dcomplex npy_cdouble;
 typedef _Fcomplex npy_cfloat;
 typedef _Lcomplex npy_clongdouble;
-#else /* !defined(_MSC_VER) || defined(__INTEL_COMPILER) */
+#else /* !defined(_MSC_VER) || defined(__INTEL_COMPILER) && !defined(__INTEL_LLVM_COMPILER) */
 typedef double _Complex npy_cdouble;
 typedef float _Complex npy_cfloat;
 typedef longdouble_t _Complex npy_clongdouble;

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -179,7 +179,7 @@ if not cc.has_header('complex.h')
   error('"complex.h" header not found')
 endif
 
-if cc.get_argument_syntax() == 'msvc'
+if cc.get_id() == 'msvc' or cc.get_id() == 'clang-cl'
   complex_types_to_check = [
     ['NPY_SIZEOF_COMPLEX_FLOAT', '_Fcomplex'],
     ['NPY_SIZEOF_COMPLEX_DOUBLE', '_Dcomplex'],


### PR DESCRIPTION
With these changes, downstream users wanting to use the Intel compilers can do so when linking against NumPy headers.

Also include a build change for NumPy itself that is clearly correct: Intel compilers do not use `_Fcomplex` & co for complex types, but the regular C99 complex.h types.

Taken over from PR gh-25044

Closes gh-25044
Closes gh-31337 (reports the same `_Fcomplex` issue)

Note: I decided to start fresh because gh-25044 accumulated a conflict, and while most of that PR should no longer be relevant, I didn't want to just push a commit to remove that code. This is the most important and the clearly correct part of that PR, and there's no reason that wasn't merged already.

#### AI Disclosure

No AI usage