### PR TITLE
BUILD: newer MKL uses so.3

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -312,6 +312,7 @@ jobs:
         # add the expected .so -> .so.2 symlinks to fix linking
         cd ..
         for i in $( ls libmkl*.so.2 ); do ln -s $i ${i%.*}; done
+        for i in $( ls libmkl*.so.3 ); do ln -s $i ${i%.*}; done
 
     - name: Build with defaults (LP64)
       run: |


### PR DESCRIPTION
Backport of #31388.

Fixes #31386

Newer MKL package uses so.3 suffix, symlink still required.

Tested locally. No AI was used.