### PR TITLE
Add Geometric Mean

### DIFF
--- a/doc/source/reference/routines.statistics.rst
+++ b/doc/source/reference/routines.statistics.rst
@@ -22,6 +22,7 @@ Averages and variances
 .. autosummary::
    :toctree: generated/
 
+   gmean
    median
    average
    mean

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -491,6 +491,7 @@ else:
         interp,
         iterable,
         kaiser,
+        gmean,
         median,
         meshgrid,
         percentile,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -438,6 +438,7 @@ from numpy.lib._function_base_impl import (
     digitize,
     cov,
     corrcoef,
+    gmean,
     median,
     sinc,
     hamming,
@@ -668,7 +669,7 @@ __all__ = [
     "nanpercentile", "nanvar", "nanstd", "nanprod", "nancumsum", "nancumprod",
     "nanquantile",
     # lib._function_base_impl.__all__
-    "select", "piecewise", "trim_zeros", "copy", "iterable", "percentile", "diff",
+    "select", "piecewise", "trim_zeros", "copy", "iterable", "percentile", "diff","gmean",
     "gradient", "angle", "unwrap", "sort_complex", "flip", "rot90", "extract", "place",
     "vectorize", "asarray_chkfinite", "average", "bincount", "digitize", "cov",
     "corrcoef", "median", "sinc", "hamming", "hanning", "bartlett", "blackman",

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -45,6 +45,7 @@ from numpy._core.umath import (
     floor,
     frompyfunc,
     less_equal,
+    log,
     minimum,
     mod,
     not_equal,
@@ -3904,6 +3905,90 @@ def _ureduce(a, func, keepdims=False, **kwargs):
         r = r[(Ellipsis, ) + index_r]
 
     return r
+
+def _gmean_dispatcher(
+        a, axis=None, dtype=None, out=None, keepdims=None):
+    return (a, out)
+
+
+@array_function_dispatch(_gmean_dispatcher)
+def gmean(a, axis=None, dtype=None, out=None, keepdims=False):
+    """
+    Compute the geometric mean along the specified axis.
+
+    Returns the geometric mean of the array elements.
+
+    Parameters
+    ----------
+    a : array_like
+        Input array or object that can be converted to an array.
+    axis : {int, sequence of int, None}, optional
+        Axis or axes along which the geometric means are computed. The default,
+        axis=None, will compute the geometric mean along a flattened version of
+        the array.
+    dtype : dtype, optional
+        Type to use in computing the geometric mean. For arrays of integer
+        type the default is float64; for arrays of float types it is the same
+        as the array type.
+    out : ndarray, optional
+        Alternative output array in which to place the result. It must have the
+        same shape and buffer length as the expected output, but the type (of
+        the output) will be cast if necessary.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left in the result
+        as dimensions with size one. With this option, the result will broadcast
+        correctly against the original `arr`.
+
+    Returns
+    -------
+    gmean : ndarray
+        A new array holding the result. If `out` is specified, that array is returned instead.
+
+    See Also
+    --------
+    mean
+
+    Notes
+    -----
+    Given a vector ``V`` of length ``N``, the geometric mean of ``V`` is
+
+    .. math:: \\left(\\prod_{i=1}^N V_i\\right)^{1/N}
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> a = np.array([[1, 2], [3, 4]])
+    >>> np.gmean(a)
+    2.2133638394006434
+    >>> np.gmean(a, axis=0)
+    array([1.73205081, 2.82842712])
+    >>> np.gmean(a, axis=1)
+    array([1.41421356, 3.46410162])
+    >>> np.gmean(a, axis=(0, 1))
+    2.2133638394006434
+
+    """
+    return _ureduce(a, func=_gmean, keepdims=keepdims, axis=axis,
+                    dtype=dtype, out=out)
+
+
+def _gmean(a, axis=None, dtype=None, out=None):
+    a = np.asanyarray(a)
+
+    if dtype is None:
+        if issubclass(a.dtype.type, np.integer):
+            dtype = np.float64
+        else:
+            dtype = a.dtype
+
+    a = a.astype(dtype, copy=False)
+
+    # We have to check for NaNs (as of writing 'M' doesn't actually work).
+    supports_nans = np.issubdtype(a.dtype, np.inexact) or a.dtype.kind in 'Mm'
+    if supports_nans:
+        a = np.where(np.isnan(a), np.nan, a)
+
+    return exp(np.mean(log(a), axis=axis, out=out))
 
 
 def _median_dispatcher(

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -68,7 +68,7 @@ __all__ = [
     'select', 'piecewise', 'trim_zeros', 'copy', 'iterable', 'percentile',
     'diff', 'gradient', 'angle', 'unwrap', 'sort_complex', 'flip',
     'rot90', 'extract', 'place', 'vectorize', 'asarray_chkfinite', 'average',
-    'bincount', 'digitize', 'cov', 'corrcoef',
+    'bincount', 'digitize', 'cov', 'corrcoef','gmean',
     'median', 'sinc', 'hamming', 'hanning', 'bartlett',
     'blackman', 'kaiser', 'trapezoid', 'i0',
     'meshgrid', 'delete', 'insert', 'append', 'interp',
@@ -3959,13 +3959,13 @@ def gmean(a, axis=None, dtype=None, out=None, keepdims=False):
     >>> import numpy as np
     >>> a = np.array([[1, 2], [3, 4]])
     >>> np.gmean(a)
-    2.2133638394006434
+    2.213363839400643
     >>> np.gmean(a, axis=0)
     array([1.73205081, 2.82842712])
     >>> np.gmean(a, axis=1)
     array([1.41421356, 3.46410162])
     >>> np.gmean(a, axis=(0, 1))
-    2.2133638394006434
+    2.213363839400643
 
     """
     return _ureduce(a, func=_gmean, keepdims=keepdims, axis=axis,
@@ -3983,7 +3983,7 @@ def _gmean(a, axis=None, dtype=None, out=None):
 
     a = a.astype(dtype, copy=False)
 
-    # We have to check for NaNs (as of writing 'M' doesn't actually work).
+    # Check for NaNs
     supports_nans = np.issubdtype(a.dtype, np.inexact) or a.dtype.kind in 'Mm'
     if supports_nans:
         a = np.where(np.isnan(a), np.nan, a)

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -62,6 +62,7 @@ __all__ = [
     "digitize",
     "cov",
     "corrcoef",
+    "gmean",
     "median",
     "sinc",
     "hamming",
@@ -1352,6 +1353,123 @@ def sinc(x: _ArrayLikeComplex_co) -> np.ndarray | Any: ...
 
 # NOTE: We assume that `axis` is only provided for >=1-D arrays because for <1-D arrays
 # it has no effect, and would complicate the overloads significantly.
+@overload  # known scalar-type, keepdims=False (default)
+def gmean[ScalarT: np.inexact | np.timedelta64](
+    a: _ArrayLike[ScalarT],
+    axis: None = None,
+    out: None = None,
+    overwrite_input: bool = False,
+    keepdims: L[False] = False,
+) -> ScalarT: ...
+@overload  # float array-like, keepdims=False (default)
+def gmean(
+    a: _ArrayLikeInt_co | _SeqND[float] | float,
+    axis: None = None,
+    out: None = None,
+    overwrite_input: bool = False,
+    keepdims: L[False] = False,
+) -> np.float64: ...
+@overload  # complex array-like, keepdims=False (default)
+def gmean(
+    a: _ListSeqND[complex],
+    axis: None = None,
+    out: None = None,
+    overwrite_input: bool = False,
+    keepdims: L[False] = False,
+) -> np.complex128: ...
+@overload  # complex scalar, keepdims=False (default)
+def gmean(
+    a: complex,
+    axis: None = None,
+    out: None = None,
+    overwrite_input: bool = False,
+    keepdims: L[False] = False,
+) -> np.complex128 | Any: ...
+@overload  # known array-type, keepdims=True
+def gmean[ArrayT: NDArray[_ScalarNumeric]](
+    a: ArrayT,
+    axis: _ShapeLike | None = None,
+    out: None = None,
+    overwrite_input: bool = False,
+    *,
+    keepdims: L[True],
+) -> ArrayT: ...
+@overload  # known scalar-type, keepdims=True
+def gmean[ScalarT: _ScalarNumeric](
+    a: _ArrayLike[ScalarT],
+    axis: _ShapeLike | None = None,
+    out: None = None,
+    overwrite_input: bool = False,
+    *,
+    keepdims: L[True],
+) -> NDArray[ScalarT]: ...
+@overload  # known scalar-type, axis=<given>
+def gmean[ScalarT: _ScalarNumeric](
+    a: _ArrayLike[ScalarT],
+    axis: _ShapeLike,
+    out: None = None,
+    overwrite_input: bool = False,
+    keepdims: bool = False,
+) -> NDArray[ScalarT]: ...
+@overload  # float array-like, keepdims=True
+def gmean(
+    a: _SeqND[float],
+    axis: _ShapeLike | None = None,
+    out: None = None,
+    overwrite_input: bool = False,
+    *,
+    keepdims: L[True],
+) -> NDArray[np.float64]: ...
+@overload  # float array-like, axis=<given>
+def gmean(
+    a: _SeqND[float],
+    axis: _ShapeLike,
+    out: None = None,
+    overwrite_input: bool = False,
+    keepdims: bool = False,
+) -> NDArray[np.float64]: ...
+@overload  # complex array-like, keepdims=True
+def gmean(
+    a: _ListSeqND[complex],
+    axis: _ShapeLike | None = None,
+    out: None = None,
+    overwrite_input: bool = False,
+    *,
+    keepdims: L[True],
+) -> NDArray[np.complex128]: ...
+@overload  # complex array-like, axis=<given>
+def gmean(
+    a: _ListSeqND[complex],
+    axis: _ShapeLike,
+    out: None = None,
+    overwrite_input: bool = False,
+    keepdims: bool = False,
+) -> NDArray[np.complex128]: ...
+@overload  # out=<given> (keyword)
+def gmean[ArrayT: np.ndarray](
+    a: _ArrayLikeComplex_co | _ArrayLike[np.timedelta64 | np.object_],
+    axis: _ShapeLike | None = None,
+    *,
+    out: ArrayT,
+    overwrite_input: bool = False,
+    keepdims: bool = False,
+) -> ArrayT: ...
+@overload  # out=<given> (positional)
+def gmean[ArrayT: np.ndarray](
+    a: _ArrayLikeComplex_co | _ArrayLike[np.timedelta64 | np.object_],
+    axis: _ShapeLike | None,
+    out: ArrayT,
+    overwrite_input: bool = False,
+    keepdims: bool = False,
+) -> ArrayT: ...
+@overload  # fallback
+def gmean(
+    a: _ArrayLikeComplex_co | _ArrayLike[np.timedelta64 | np.object_],
+    axis: _ShapeLike | None = None,
+    out: None = None,
+    overwrite_input: bool = False,
+    keepdims: bool = False,
+) -> Incomplete: ...
 @overload  # known scalar-type, keepdims=False (default)
 def median[ScalarT: np.inexact | np.timedelta64](
     a: _ArrayLike[ScalarT],

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -4456,6 +4456,38 @@ class TestLerp:
         assert nfb._lerp(a, b, t) == 2.6
 
 
+class TestGMean:
+
+    def test_basic(self):
+        a0 = np.array(1)
+        a1 = np.arange(1, 3)
+        a2 = np.arange(1, 7).reshape(2, 3)
+        assert_equal(np.gmean(a0), 1)
+        assert_allclose(np.gmean(a1), np.sqrt(2))
+        assert_allclose(np.gmean(a2), 2.605171084697352)
+        assert_allclose(np.gmean(a2, axis=0), [1.73205081, 2.44948974, 3.16227766])
+        assert_allclose(np.gmean(a2, axis=1), [1.81712059, 4.16016765])
+        assert_allclose(np.gmean(a2, axis=None), 2.605171084697352)
+
+    def test_axis_keyword(self):
+        a3 = np.array([[2, 3],
+                       [0, 1],
+                       [6, 7],
+                       [4, 5]])
+        for a in [a3, np.random.randint(1, 100, size=(2, 3, 4))]:
+            orig = a.copy()
+            np.gmean(a, axis=None)
+            for ax in range(a.ndim):
+                np.gmean(a, axis=ax)
+            assert_array_equal(a, orig)
+
+        assert_allclose(np.gmean(a3, axis=0), [2.88449914, 3.91486764])
+        assert_allclose(np.gmean(a3.T, axis=1), [2.88449914, 3.91486764])
+        assert_allclose(np.gmean(a3), 2.60517108)
+        assert_allclose(np.gmean(a3, axis=None), 2.60517108)
+        assert_allclose(np.gmean(a3.T), 2.60517108)
+
+
 class TestMedian:
 
     def test_basic(self):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -4464,10 +4464,10 @@ class TestGMean:
         a2 = np.arange(1, 7).reshape(2, 3)
         assert_equal(np.gmean(a0), 1)
         assert_allclose(np.gmean(a1), np.sqrt(2))
-        assert_allclose(np.gmean(a2), 2.605171084697352)
-        assert_allclose(np.gmean(a2, axis=0), [1.73205081, 2.44948974, 3.16227766])
-        assert_allclose(np.gmean(a2, axis=1), [1.81712059, 4.16016765])
-        assert_allclose(np.gmean(a2, axis=None), 2.605171084697352)
+        assert_allclose(np.gmean(a2), 2.993795165523909)
+        assert_allclose(np.gmean(a2, axis=0), [2.        , 3.16227766, 4.24264069])
+        assert_allclose(np.gmean(a2, axis=1), [1.81712059, 4.93242415])
+        assert_allclose(np.gmean(a2, axis=None), 2.993795165523909)
 
     def test_axis_keyword(self):
         a3 = np.array([[2, 3],
@@ -4481,11 +4481,11 @@ class TestGMean:
                 np.gmean(a, axis=ax)
             assert_array_equal(a, orig)
 
-        assert_allclose(np.gmean(a3, axis=0), [2.88449914, 3.91486764])
-        assert_allclose(np.gmean(a3.T, axis=1), [2.88449914, 3.91486764])
-        assert_allclose(np.gmean(a3), 2.60517108)
-        assert_allclose(np.gmean(a3, axis=None), 2.60517108)
-        assert_allclose(np.gmean(a3.T), 2.60517108)
+        assert_allclose(np.gmean(a3, axis=0), [0, 3.20108587])
+        assert_allclose(np.gmean(a3.T, axis=1), [0, 3.20108587])
+        assert_allclose(np.gmean(a3), 0)
+        assert_allclose(np.gmean(a3, axis=None), 0)
+        assert_allclose(np.gmean(a3.T), 0)
 
 
 class TestMedian:

--- a/numpy/matlib.pyi
+++ b/numpy/matlib.pyi
@@ -207,6 +207,7 @@ from numpy import (  # noqa: F401
     getbufsize,
     geterr,
     geterrcall,
+    gmean,
     gradient,
     greater,
     greater_equal,


### PR DESCRIPTION
### PR summary
This PR implements the [geometric mean](https://en.wikipedia.org/wiki/Geometric_mean). The function is so far only added as plain function. If interest exists, I can add `numpy.nangmean`.

The method is added to `numpy.__all__`, documented in the API-reference and covered by tests.


### First time committer introduction
Hi, I am Siemen Aulich. Currently finishing my master's in physics with a focus of machine-learning for high-energy physics. During an analysis of a machine-learning model, I wanted to use a geometric mean. I realised, that this function does not exist in `numpy`. 



#### AI Disclosure
AI-tools (GitHub copilot) was used to create the outline for the test. The numerics for the test, however, where computed using `scipy`