### PR TITLE
BUG: exclude __pycache__ directories from wheels

### DIFF
--- a/numpy/meson.build
+++ b/numpy/meson.build
@@ -363,13 +363,28 @@ else
 endif
 
 foreach subdir: pure_subdirs
-  install_subdir(subdir, install_dir: np_dir, install_tag: 'python-runtime', exclude_directories: ['tests'])
+  install_subdir(
+    subdir,
+    install_dir: np_dir,
+    install_tag: 'python-runtime',
+    exclude_directories: ['tests', '__pycache__']
+  )
   if fs.is_dir(subdir/'tests')
-    install_subdir(subdir/'tests', install_dir: np_dir/subdir, install_tag: 'tests')
+    install_subdir(
+      subdir/'tests',
+      install_dir: np_dir/subdir,
+      install_tag: 'tests',
+      exclude_directories: ['__pycache__']
+    )
   endif
 endforeach
 
-install_subdir('tests', install_dir: np_dir, install_tag: 'tests')
+install_subdir(
+  'tests',
+  install_dir: np_dir,
+  install_tag: 'tests',
+  exclude_directories: ['__pycache__']
+)
 
 compilers = {
   'C': cc,


### PR DESCRIPTION
## Summary

Closes #31392

This updates the Meson install rules to exclude `__pycache__` directories from wheel contents
Issue was reported for wheels containing bytecode cache files such as:

```text
numpy/distutils/__pycache__/conv_template.cpython-311.pyc
```

`__pycache__` directories are generated locally during Python execution/compilation and should not be copied into built wheels.

## Validation

Created a local `__pycache__` directory under an installed pure Python subdirectory:

```bash
python -c "import py_compile; py_compile.compile('numpy/f2py/__init__.py')"
find numpy/f2py -name "__pycache__" -o -name "*.pyc"
```

Built the wheel:

```bash
python -m build -w
```

Confirmed no `__pycache__` entries were included:

```bash
unzip -l dist/*.whl | grep __pycache__
unzip -l dist/*.whl | grep "numpy/f2py/__pycache__"
```

Both grep commands returned no output

AI was used to help draft the PR description and to sanity check local verification steps. The code change was made and tested locally by me.