### PR TITLE
TYP: `_NestedSequence` type parameter default to work around a mypy issue (#31399)

### DIFF
--- a/numpy/_typing/_nested_sequence.py
+++ b/numpy/_typing/_nested_sequence.py
@@ -1,13 +1,19 @@
 """A module containing the `_NestedSequence` protocol."""
 
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from typing_extensions import TypeVar
+
+    _T_co = TypeVar("_T_co", covariant=True, default=Any)
+else:
+    from typing import TypeVar
+
+    _T_co = TypeVar("_T_co", covariant=True)
+
 
 __all__ = ["_NestedSequence"]
-
-_T_co = TypeVar("_T_co", covariant=True)
 
 
 @runtime_checkable


### PR DESCRIPTION
Backport of #31399.

### PR summary

This works around false positive `var-annotated`  mypy errors in certain situations, that's currently blocking a fix for the typeshed stdlib stubs.

x-ref: https://github.com/python/typeshed/pull/15472#issuecomment-4406093095

#### AI Disclosure
N/A
