### PR TITLE
DOC: fix dtype.char attribute link

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -442,6 +442,27 @@ phantom_import_file = 'dump.xml'
 # Make numpydoc to generate plots for example sections
 numpydoc_use_plots = True
 
+
+# numpydoc renders class attribute names as object links in the generated
+# attribute list. Qualify the dtype links so ``char`` resolves to
+# ``numpy.dtype.char`` instead of the legacy ``numpy.char`` module.
+from numpydoc.docscrape_sphinx import SphinxClassDoc as _NumpydocSphinxClassDoc
+
+if not getattr(_NumpydocSphinxClassDoc, "_numpy_dtype_link_patch", False):
+    _numpydoc_sphinx_class_doc_init = _NumpydocSphinxClassDoc.__init__
+
+    def _sphinx_class_doc_init_with_dtype_name(
+        self, obj, doc=None, func_doc=None, config=None
+    ):
+        _numpydoc_sphinx_class_doc_init(
+            self, obj, doc=doc, func_doc=func_doc, config=config
+        )
+        if obj is numpy.dtype and not getattr(self, "_name", None):
+            self._name = "numpy.dtype"
+
+    _NumpydocSphinxClassDoc.__init__ = _sphinx_class_doc_init_with_dtype_name
+    _NumpydocSphinxClassDoc._numpy_dtype_link_patch = True
+
 # -----------------------------------------------------------------------------
 # Autosummary
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- qualify numpydoc-generated attribute links for `numpy.dtype`
- ensure the `char` entry on `numpy.dtype` links to `numpy.dtype.char`, not the legacy `numpy.char` module
- leave runtime behavior unchanged

Fixes #28470

## Validation

- `python -m py_compile doc/source/conf.py`
- `git diff --check`
- verified with a minimal Sphinx/numpydoc build that `char` resolves to `#numpy.dtype.char` while `numpy.char` remains documented