### PR TITLE
BUG: `np.ones` does not raise ValueError for generic datetime64

### DIFF
--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1982,10 +1982,12 @@ array_copyto(PyObject *NPY_UNUSED(ignored),
         PyArray_Descr *descr;
         PyArray_DTypeMeta *dst_DType = NPY_DTYPE(PyArray_DESCR(dst));
         bool is_npy_nan = PyFloat_Check(src_obj) && npy_isnan(PyFloat_AsDouble(src_obj));
-        if (!is_npy_nan && dst_DType->type_num == NPY_TIMEDELTA) {
+        if (!is_npy_nan && (dst_DType->type_num == NPY_TIMEDELTA ||
+                            dst_DType->type_num == NPY_DATETIME)) {
             descr = PyArray_DESCR(dst);
             Py_INCREF(descr);
-        } else {
+        }
+        else {
             descr = npy_find_descr_for_scalar(src_obj, PyArray_DESCR(src), DType,
                                               dst_DType);
         }

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -589,6 +589,21 @@ def test_copy_order():
     res = np.copy(c, order='K')
     check_copy_result(res, c, ccontig=False, fcontig=False, strides=True)
 
+
+def test_forbid_to_copyto_generic_datetime():
+    # See gh-30903
+    with pytest.warns(
+        DeprecationWarning,
+        match="The 'generic' unit for NumPy timedelta is deprecated",
+    ):
+        a = np.array(["NaT"], dtype='M8')
+
+    with pytest.raises(
+        ValueError,
+        match="Converting an integer to a NumPy datetime requires a specified unit",
+    ):
+        np.copyto(a, 1, casting="unsafe")
+
 def test_contiguous_flags():
     a = np.ones((4, 4, 1))[::2, :, :]
     a = stride_tricks.as_strided(a, strides=a.strides[:2] + (-123,))

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -3167,6 +3167,14 @@ class TestDateTime:
         with pytest.raises(AssertionError):
             np.testing.assert_allclose(a, b, atol=atol)
 
+    def test_forbid_ones_for_generic_datetime(self):
+        # gh-30903
+        with pytest.raises(
+            ValueError,
+            match="Converting an integer to a NumPy datetime requires a specified unit",
+        ):
+            np.ones(3, dtype="M8")
+
 class TestDateTimeData:
 
     def test_basic(self):

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -1531,10 +1531,12 @@ def test_iter_copy():
 @pytest.mark.parametrize("loop_dtype", np.typecodes["All"])
 @pytest.mark.filterwarnings(
     "ignore::numpy.exceptions.ComplexWarning",
-    "ignore::DeprecationWarning",
 )
 def test_iter_copy_casts(dtype, loop_dtype):
     # Ensure the dtype is never flexible:
+    if dtype.lower() == "m":
+        dtype = dtype + "8[D]"
+
     if loop_dtype.lower() == "m":
         loop_dtype = loop_dtype + "[ms]"
     elif np.dtype(loop_dtype).itemsize == 0:

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -1533,12 +1533,15 @@ def test_iter_copy():
     "ignore::numpy.exceptions.ComplexWarning",
 )
 def test_iter_copy_casts(dtype, loop_dtype):
-    # Ensure the dtype is never flexible:
     if dtype.lower() == "m":
         dtype = dtype + "8[D]"
 
+    is_datetimelike = False
     if loop_dtype.lower() == "m":
-        loop_dtype = loop_dtype + "[ms]"
+        loop_dtype = loop_dtype + "8[ms]"
+        is_datetimelike = True
+
+    # Ensure the dtype is never flexible:
     elif np.dtype(loop_dtype).itemsize == 0:
         loop_dtype = loop_dtype + "50"
 
@@ -1547,13 +1550,13 @@ def test_iter_copy_casts(dtype, loop_dtype):
     try:
         expected = arr.astype(loop_dtype)
     except Exception:
-        # Some casts are not possible, do not worry about them
+        pytest.xfail(reason=f"{dtype} -> {loop_dtype} cast intentionally skipped")
         return
 
     it = np.nditer((arr,), ["buffered", "external_loop", "refs_ok"],
                    op_dtypes=[loop_dtype], casting="unsafe")
 
-    if np.issubdtype(np.dtype(loop_dtype), np.number):
+    if np.issubdtype(np.dtype(loop_dtype), np.number) and not is_datetimelike:
         # Casting to strings may be strange, but for simple dtypes do not rely
         # on the cast being correct:
         assert_array_equal(expected, np.ones(1000, dtype=loop_dtype))

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2870,14 +2870,8 @@ def test_ufunc_types(ufunc):
         if 'O' in typ or '?' in typ:
             continue
         inp, out = typ.split('->')
-        if 'm' in inp:
-            with pytest.warns(
-                DeprecationWarning,
-                match="The 'generic' unit for NumPy timedelta is deprecated",
-            ):
-                args = [np.ones((3, 3), t) for t in inp]
-        else:
-            args = [np.ones((3, 3), t) for t in inp]
+        _inp_dtypes = [t if t.lower() != 'm' else t + "8[D]" for t in inp]
+        args = [np.ones((3, 3), t) for t in _inp_dtypes]
         with warnings.catch_warnings(record=True):
             warnings.filterwarnings("always")
             res = ufunc(*args)
@@ -2885,9 +2879,9 @@ def test_ufunc_types(ufunc):
             outs = tuple(out)
             assert len(res) == len(outs)
             for r, t in zip(res, outs):
-                assert r.dtype == np.dtype(t)
+                assert r.dtype.char == t
         else:
-            assert res.dtype == np.dtype(out)
+            assert res.dtype.char == out
 
 @pytest.mark.parametrize('ufunc', [getattr(np, x) for x in dir(np)
                                 if isinstance(getattr(np, x), np.ufunc)])


### PR DESCRIPTION
Closes gh-30903
(Follow up attempt to #31319)


### PR summary


This PR sets the descriptor for the Python scalar `1` in `array_copyto` when the destination dtype is `datetime64`.

With this change, `np.ones(..., dtype="M8")` raises an error immediately, because the fill value `1` is cast to a `datetime64` scalar with a generic unit.


#### Root cause

When `np.ones` is called with `dtype="M8"`, the Python integer `1` is eventually passed to the C cast function below. Since the C representation of `npy_datetime` is the same as `npy_int64`, this cast currently succeeds without checking whether the datetime unit is valid.

As a result, the invalid value is only detected later, for example when the array is passed to another function that checks the validity of the datetime unit, such as when the array is printed.

https://github.com/numpy/numpy/blob/c36307a4241a3cee9a806044787e6ebd3e7b2c03/numpy/_core/src/multiarray/arraytypes.c.src#L1300-L1345


#### Alternative

Another alternative is to create new casting rule for `datetime64`. (see below). But, this seems a bit too much for this issue, so I chose the current one. If preferred, I can implement the alternative one.


https://github.com/numpy/numpy/blob/0adb7ef2609525f0c3ab91fe2914cc700d4311cc/numpy/_core/src/multiarray/datetime.c#L4304-L4324

#### AI Disclosure

ChatGPT is used to polish the description of this PR, but I have not used AI to write the code for this PR.

