### PR TITLE
DOC: Add forgotten ``register_dlpack_dtype`` to docs

### DIFF
--- a/doc/source/reference/routines.dtypes.rst
+++ b/doc/source/reference/routines.dtypes.rst
@@ -71,3 +71,11 @@ Others
 .. attribute:: ObjectDType
                VoidDType
 
+
+Routines for DType authors
+--------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   register_dlpack_dtype


### PR DESCRIPTION
Forgot to add this, and I think there was a brief universal CI failure so missed it (although... maybe I just _thought_ that also affected circle CI and it didn't, don't recall)

[skip azp] [skip cirrus] [skip actions]