### PR TITLE
MAINT: ensure `_core.sctypes` lists are deterministically ordered

### DIFF
--- a/numpy/_core/_type_aliases.py
+++ b/numpy/_core/_type_aliases.py
@@ -121,10 +121,10 @@ for type_info in typeinfo.values():
 
     del type_info, concrete_type
 
-# sort sctype groups by bitsize
+# sort sctype groups by bitsize, then by name (sort needs to be deterministic)
 for sctype_key in sctypes.keys():
     sctype_list = list(sctypes[sctype_key])
-    sctype_list.sort(key=lambda x: dtype(x).itemsize)
+    sctype_list.sort(key=lambda x: (dtype(x).itemsize, x.__name__))
     sctypes[sctype_key] = sctype_list
 
     del sctype_key, sctype_list


### PR DESCRIPTION
The incomplete sorting before turning sets into lists caused issues with `pytest-xdist` not seeing the same test splits and therefore erroring out immediately (see gh-31414).

While this seems to happen only on RISC-V, the problem isn't actually RISC-V specific beyond it materializing there, possibly due to different implementation of sorting behavior when tie-breaking on the first sort key. That shouldn't be relied on though, this should be considered a (minor) bug in NumPy.

Closes gh-31414

#### AI Disclosure

Claude Opus 4.7 used to double-check the diagnosis. Fix implemented by hand.