### PR TITLE
TST: fix two issues in the test suite with `fork` deprecation warning

### DIFF
--- a/numpy/_core/tests/test_multiprocessing.py
+++ b/numpy/_core/tests/test_multiprocessing.py
@@ -1,4 +1,5 @@
 import multiprocessing
+
 import pytest
 
 import numpy as np

--- a/numpy/_core/tests/test_multiprocessing.py
+++ b/numpy/_core/tests/test_multiprocessing.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import pytest
 
 import numpy as np
@@ -43,7 +44,8 @@ def test_read_write_bool_array():
     from multiprocessing import shared_memory
     n = 10000
     shm = shared_memory.SharedMemory(create=True, size=n)
-    with ProcessPoolExecutor(max_workers=2) as executor:
+    ctx = multiprocessing.get_context("spawn")
+    with ProcessPoolExecutor(max_workers=2, mp_context=ctx) as executor:
         f_writer = executor.submit(bool_array_writer, shm.name, n)
         f_reader = executor.submit(bool_array_reader, shm.name, n)
     shm.unlink()

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -2004,6 +2004,9 @@ def test_generalized_raise_multiloop():
     assert_raises(np.linalg.LinAlgError, np.linalg.inv, x)
 
 
+@pytest.mark.filterwarnings(
+    r"ignore:.*fork\(\) may lead to deadlocks.*:DeprecationWarning"
+)
 @pytest.mark.skipif(
     threading.active_count() > 1,
     reason="skipping test that uses fork because there are multiple threads")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ skip = ["*_i686", "*_ppc64le", "*_s390x", "*_universal2"]
 before-build = "bash {project}/tools/wheels/cibw_before_build.sh {project}"
 before-test = "pip install -r {project}/requirements/test_requirements.txt"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
-enable = ["cpython-freethreading", "cpython-prerelease"]
+enable = ["cpython-prerelease"]
 
 # The build will use openblas64 everywhere, except on arm64 macOS >=14.0 (uses Accelerate)
 [tool.cibuildwheel.config-settings]

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,8 +18,6 @@ filterwarnings =
     ignore:Importing from numpy.matlib is
 # pytest warning when using PYTHONOPTIMIZE
     ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning
-# TODO: remove below when array_api user warning is removed
-    ignore:The numpy.array_api submodule is still experimental. See NEP 47.
 # ignore matplotlib headless warning for pyplot
     ignore:Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.:UserWarning
 # Ignore DeprecationWarning from typing.mypy_plugin


### PR DESCRIPTION
(1) suppress warning for `os.fork()` usage in xerbla test
    
This seems harmless to leave as is, this won't deadlock and has been running like this for years. If needed, it could be rewritten in the future (probably using `subprocess.run`).
    
Addresses this warning showing up in the full test suite for wheel builds:
```
  linalg/tests/test_linalg.py::test_xerbla_override
    /private/var/folders/x7/_nsk_h4s1kng41z5pgfbx7sh0000gn/T/cibw-run-pxirkora/cp312-macosx_x86_64/venv-test-x86_64/lib/python3.12/site-packages/numpy/linalg/tests/test_linalg.py:2021: DeprecationWarning: This process (pid=25651) is multi-threaded, use of fork() may lead to deadlocks in the child.
      pid = os.fork()
```
    
Also remove an outdated warning filter in `pytest.ini`.
    
(2) fix a recently added multiprocessing test to avoid `fork` deprecation
   
Test was introduced in PR gh-30418.
    
Addresses this warning:
```
  _core/tests/test_multiprocessing.py::test_read_write_bool_array
  _core/tests/test_multiprocessing.py::test_read_write_bool_array
    /opt/python/cp312-cp312/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=1748) is multi-threaded, use of fork() may lead to deadlocks in the child.
      self.pid = os.fork()
```

Also clean up a warning from `cibuildwheel` due to an outdated entry in `pyproject.toml` while we're at it.

#### AI Disclosure

claude.ai used to sanity check the `os.fork` issues.