### PR TITLE
TST: suppress shape deprecation warning in test_recarray_conflict_fields

### DIFF
--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -271,7 +271,9 @@ class TestFromrecords:
         assert_(type(ra.mean) is type(ra.var))
         ra = ra.reshape((1, 3))
         assert_(ra.shape == (1, 3))
-        ra.shape = ['A', 'B', 'C']
+        # gh-29536: setting .shape on an ndarray is deprecated
+        with pytest.warns(DeprecationWarning, match="Setting the shape"):
+            ra.shape = ['A', 'B', 'C']
         assert_array_equal(ra['shape'], [['A', 'B', 'C']])
         ra.field = 5
         assert_array_equal(ra['field'], [[5, 5, 5]])


### PR DESCRIPTION
### PR summary

The recarray field-conflict fallback exercises `arr.shape = ...` to trigger the field setter; the shape deprecation (#29536) made this emit a DeprecationWarning that surfaced in wheel build logs.

Noted in https://github.com/numpy/numpy/pull/29575#issuecomment-4433151108

#### AI Disclosure

AI was used to search through commit history and draft a fix.
