### PR TITLE
TST: add a lot of missing `slow` markers

### DIFF
--- a/numpy/_core/tests/test_mem_policy.py
+++ b/numpy/_core/tests/test_mem_policy.py
@@ -231,6 +231,7 @@ def get_module(tmp_path):
                                                more_init=more_init)
 
 
+@pytest.mark.slow
 def test_set_policy(get_module):
 
     get_handler_name = np._core.multiarray.get_handler_name

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -10030,6 +10030,7 @@ class TestCTypes:
         'empty-2d',
         'readonly'
     ])
+    @pytest.mark.slow
     def test_ctypes_data_as_holds_reference(self, arr):
         # gh-9647
         # create a copy to ensure that pytest does not mess with the refcounts

--- a/numpy/_core/tests/test_multiprocessing.py
+++ b/numpy/_core/tests/test_multiprocessing.py
@@ -28,6 +28,7 @@ def bool_array_reader(shm_name, n):
 
 @pytest.mark.skipif(IS_WASM,
                     reason="WASM does not support _posixshmem")
+@pytest.mark.slow
 def test_read_write_bool_array():
     # See: gh-30389
     #

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -10,6 +10,8 @@ from numpy._core._type_aliases import c_names_dict as _c_names_dict
 
 from . import util
 
+pytestmark = pytest.mark.slow
+
 wrap = None
 
 # Extend core typeinfo with CHARACTER to test dtype('c')

--- a/numpy/f2py/tests/test_assumed_shape.py
+++ b/numpy/f2py/tests/test_assumed_shape.py
@@ -6,6 +6,8 @@ import pytest
 from . import util
 
 
+# Note: do not mark as slow! This is one of a small set of f2py compile tests retained
+# in the default suite invocation for compile-path coverage.
 class TestAssumedShapeSumExample(util.F2PyTest):
     sources = [
         util.getpath("tests", "src", "assumed_shape", "foo_free.f90"),
@@ -15,7 +17,6 @@ class TestAssumedShapeSumExample(util.F2PyTest):
         util.getpath("tests", "src", "assumed_shape", ".f2py_f2cmap"),
     ]
 
-    @pytest.mark.slow
     def test_all(self):
         r = self.module.fsum([1, 2])
         assert r == 3
@@ -30,6 +31,7 @@ class TestAssumedShapeSumExample(util.F2PyTest):
         assert r == 3
 
 
+@pytest.mark.slow
 class TestF2cmapOption(TestAssumedShapeSumExample):
     def setup_method(self):
         # Use a custom file name for .f2py_f2cmap

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -13,11 +13,11 @@ import numpy as np
 from . import util
 
 
+@pytest.mark.slow
 class TestF77Callback(util.F2PyTest):
     sources = [util.getpath("tests", "src", "callback", "foo.f")]
 
     @pytest.mark.parametrize("name", ["t", "t2"])
-    @pytest.mark.slow
     def test_all(self, name):
         self.check_function(name)
 
@@ -194,6 +194,7 @@ class TestF77Callback(util.F2PyTest):
         assert r == 3
 
 
+@pytest.mark.slow
 class TestF77CallbackPythonTLS(TestF77Callback):
     """
     Callback tests using Python thread-local storage instead of
@@ -203,10 +204,10 @@ class TestF77CallbackPythonTLS(TestF77Callback):
     options = ["-DF2PY_USE_PYTHON_TLS"]
 
 
+@pytest.mark.slow
 class TestF90Callback(util.F2PyTest):
     sources = [util.getpath("tests", "src", "callback", "gh17797.f90")]
 
-    @pytest.mark.slow
     def test_gh17797(self):
         def incr(x):
             return x + 123
@@ -216,6 +217,7 @@ class TestF90Callback(util.F2PyTest):
         assert r == 123 + 1 + 2 + 3
 
 
+@pytest.mark.slow
 class TestGH18335(util.F2PyTest):
     """The reproduction of the reported issue requires specific input that
     extensions may break the issue conditions, so the reproducer is
@@ -224,7 +226,6 @@ class TestGH18335(util.F2PyTest):
     """
     sources = [util.getpath("tests", "src", "callback", "gh18335.f90")]
 
-    @pytest.mark.slow
     def test_gh18335(self):
         def foo(x):
             x[0] += 1
@@ -233,6 +234,7 @@ class TestGH18335(util.F2PyTest):
         assert r == 123 + 1
 
 
+@pytest.mark.slow
 class TestGH25211(util.F2PyTest):
     sources = [util.getpath("tests", "src", "callback", "gh25211.f"),
                util.getpath("tests", "src", "callback", "gh25211.pyf")]

--- a/numpy/f2py/tests/test_character.py
+++ b/numpy/f2py/tests/test_character.py
@@ -134,6 +134,7 @@ class TestCharacterString(util.F2PyTest):
         assert_array_equal(f(a), expected)
 
 
+@pytest.mark.slow
 class TestCharacter(util.F2PyTest):
     # options = ['--debug-capi', '--build-dir', '/tmp/test-build-f2py']
     suffix = '.f90'
@@ -432,6 +433,7 @@ class TestCharacter(util.F2PyTest):
         assert_equal(f(b'B'), b"B")
 
 
+@pytest.mark.slow
 class TestMiscCharacter(util.F2PyTest):
     # options = ['--debug-capi', '--build-dir', '/tmp/test-build-f2py']
     suffix = '.f90'
@@ -515,7 +517,6 @@ class TestMiscCharacter(util.F2PyTest):
        end subroutine {fprefix}_character_bc_old
     """)
 
-    @pytest.mark.slow
     def test_gh18684(self):
         # Test character(len=5) and character*5 usages
         f = getattr(self.module, self.fprefix + '_gh18684')
@@ -575,6 +576,7 @@ class TestMiscCharacter(util.F2PyTest):
         assert_raises(Exception, lambda: f(b'c'))
 
 
+@pytest.mark.slow
 class TestStringScalarArr(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "scalar_string.f90")]
 
@@ -594,6 +596,7 @@ class TestStringScalarArr(util.F2PyTest):
             expected = '|S12'
             assert out.dtype == expected
 
+@pytest.mark.slow
 class TestStringAssumedLength(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "gh24008.f")]
 

--- a/numpy/f2py/tests/test_common.py
+++ b/numpy/f2py/tests/test_common.py
@@ -16,6 +16,7 @@ class TestCommonBlock(util.F2PyTest):
         assert self.module.block.ok == np.array(3, dtype=np.int32)
 
 
+@pytest.mark.slow
 class TestCommonWithUse(util.F2PyTest):
     sources = [util.getpath("tests", "src", "common", "gh19161.f90")]
 

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -13,6 +13,7 @@ from numpy.f2py.crackfortran import markinnerspaces, nameargspattern
 from . import util
 
 
+@pytest.mark.slow
 class TestNoSpace(util.F2PyTest):
     # issue gh-15035: add handling for endsubroutine, endfunction with no space
     # between "end" and the block name
@@ -96,6 +97,7 @@ class TestModuleProcedure:
         assert mod['vars']['seta']['attrspec'] == ['public', ]
 
 
+@pytest.mark.slow
 class TestExternal(util.F2PyTest):
     # issue gh-17859: add external attribute support
     sources = [util.getpath("tests", "src", "crackfortran", "gh17859.f")]
@@ -115,6 +117,7 @@ class TestExternal(util.F2PyTest):
         assert r == 123
 
 
+@pytest.mark.slow
 class TestCrackFortran(util.F2PyTest):
     # gh-2848: commented lines between parameters in subroutine parameter lists
     sources = [util.getpath("tests", "src", "crackfortran", "gh2848.f90"),
@@ -149,6 +152,7 @@ class TestMarkinnerspaces:
         assert markinnerspaces(r'a "b c" "d e"') == r'a "b@_@c" "d@_@e"'
 
 
+@pytest.mark.slow
 class TestDimSpec(util.F2PyTest):
     """This test suite tests various expressions that are used as dimension
     specifications.
@@ -218,7 +222,6 @@ class TestDimSpec(util.F2PyTest):
         )
 
     @pytest.mark.parametrize("dimspec", all_dimspecs)
-    @pytest.mark.slow
     def test_array_size(self, dimspec):
 
         count = self.all_dimspecs.index(dimspec)
@@ -260,6 +263,7 @@ class TestModuleDeclaration:
         assert mod[0]["vars"]["abar"]["="] == "bar('abar')"
 
 
+@pytest.mark.slow
 class TestEval(util.F2PyTest):
     def test_eval_scalar(self):
         eval_scalar = crackfortran._eval_scalar
@@ -270,6 +274,7 @@ class TestEval(util.F2PyTest):
         assert eval_scalar('"123"', {}) == "'123'"
 
 
+@pytest.mark.slow
 class TestFortranReader(util.F2PyTest):
     @pytest.mark.parametrize("encoding",
                              ['ascii', 'utf-8', 'utf-16', 'utf-32'])
@@ -333,15 +338,16 @@ class TestNameArgsPatternBacktracking:
             good_version_of_adversary = repeated_adversary + '@)@'
             assert nameargspattern.search(good_version_of_adversary)
 
+@pytest.mark.slow
 class TestFunctionReturn(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "gh23598.f90")]
 
-    @pytest.mark.slow
     def test_function_rettype(self):
         # gh-23598
         assert self.module.intproduct(3, 4) == 12
 
 
+@pytest.mark.slow
 class TestFortranGroupCounters(util.F2PyTest):
     def test_end_if_comment(self):
         # gh-23533

--- a/numpy/f2py/tests/test_data.py
+++ b/numpy/f2py/tests/test_data.py
@@ -6,11 +6,11 @@ from numpy.f2py.crackfortran import crackfortran
 from . import util
 
 
+@pytest.mark.slow
 class TestData(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "data_stmts.f90")]
 
     # For gh-23276
-    @pytest.mark.slow
     def test_data_stmts(self):
         assert self.module.cmplxdat.i == 2
         assert self.module.cmplxdat.j == 3
@@ -35,6 +35,7 @@ class TestData(util.F2PyTest):
         assert mod[0]['vars']['my_array']['='] == '(/(1.0d0, 2.0d0), (-3.0d0, 4.0d0)/)'
         assert mod[0]['vars']['z']['='] == '(/3.5,  7.0/)'
 
+@pytest.mark.slow
 class TestDataF77(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "data_common.f")]
 
@@ -48,6 +49,7 @@ class TestDataF77(util.F2PyTest):
         assert mod[0]['vars']['mydata']['='] == '0'
 
 
+@pytest.mark.slow
 class TestDataMultiplierF77(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "data_multiplier.f")]
 
@@ -60,6 +62,7 @@ class TestDataMultiplierF77(util.F2PyTest):
         assert self.module.mycom.evar5 == 0
 
 
+@pytest.mark.slow
 class TestDataWithCommentsF77(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "data_with_comments.f")]
 

--- a/numpy/f2py/tests/test_f2cmap.py
+++ b/numpy/f2py/tests/test_f2cmap.py
@@ -1,8 +1,11 @@
+import pytest
+
 import numpy as np
 
 from . import util
 
 
+@pytest.mark.slow
 class TestF2Cmap(util.F2PyTest):
     sources = [
         util.getpath("tests", "src", "f2cmap", "isoFortranEnvMap.f90"),

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -221,6 +221,7 @@ def test_gen_pyf_no_overwrite(capfd, hello_world_f90, monkeypatch):
 
 
 @pytest.mark.skipif(sys.version_info <= (3, 12), reason="Python 3.12 required")
+@pytest.mark.slow
 def test_untitled_cli(capfd, hello_world_f90, monkeypatch):
     """Check that modules are named correctly
 
@@ -233,6 +234,7 @@ def test_untitled_cli(capfd, hello_world_f90, monkeypatch):
         out, _ = capfd.readouterr()
         assert "untitledmodule.c" in out
 
+@pytest.mark.slow
 def test_no_distutils_backend(capfd, hello_world_f90, monkeypatch):
     """Check that distutils backend and related options fail
     CLI :: --fcompiler --help-link --backend distutils
@@ -507,6 +509,7 @@ def test_nolatexdoc(capfd, hello_world_f90, monkeypatch):
         out, _ = capfd.readouterr()
         assert "Documentation is saved to file" not in out
 
+@pytest.mark.slow
 def test_latex_doc_gh30268(tmp_path):
 
     if not util.has_fortran_compiler():
@@ -691,6 +694,7 @@ def test_inclheader(capfd, hello_world_f90, monkeypatch):
             assert "#include <stdio.h>" in ocmr
 
 @pytest.mark.skipif((platform.system() != 'Linux'), reason='Compiler required')
+@pytest.mark.slow
 def test_cli_obj(capfd, hello_world_f90, monkeypatch):
     """Ensures that the extra object can be specified when using meson backend
     """
@@ -806,6 +810,7 @@ def test_npdistop(hello_world_f90, monkeypatch):
 
 @pytest.mark.skipif((platform.system() != 'Linux') or sys.version_info <= (3, 12),
                     reason='Compiler and Python 3.12 or newer required')
+@pytest.mark.slow
 def test_no_freethreading_compatible(hello_world_f90, monkeypatch):
     """
     CLI :: --no-freethreading-compatible

--- a/numpy/f2py/tests/test_isoc.py
+++ b/numpy/f2py/tests/test_isoc.py
@@ -6,13 +6,13 @@ from numpy.testing import assert_allclose
 from . import util
 
 
+@pytest.mark.slow
 class TestISOC(util.F2PyTest):
     sources = [
         util.getpath("tests", "src", "isocintrin", "isoCtests.f90"),
     ]
 
     # gh-24553
-    @pytest.mark.slow
     def test_c_double(self):
         out = self.module.coddity.c_add(1, 2)
         exp_out = 3

--- a/numpy/f2py/tests/test_kind.py
+++ b/numpy/f2py/tests/test_kind.py
@@ -12,6 +12,7 @@ from . import util
 
 IS_PPC_OR_AIX = platform.machine().lower().startswith("ppc") or platform.system() == 'AIX'
 
+@pytest.mark.slow
 class TestKind(util.F2PyTest):
     sources = [util.getpath("tests", "src", "kind", "foo.f90")]
 

--- a/numpy/f2py/tests/test_mixed.py
+++ b/numpy/f2py/tests/test_mixed.py
@@ -5,6 +5,7 @@ import pytest
 from . import util
 
 
+@pytest.mark.slow
 class TestMixed(util.F2PyTest):
     sources = [
         util.getpath("tests", "src", "mixed", "foo.f"),
@@ -12,7 +13,6 @@ class TestMixed(util.F2PyTest):
         util.getpath("tests", "src", "mixed", "foo_free.f90"),
     ]
 
-    @pytest.mark.slow
     def test_all(self):
         assert self.module.bar11() == 11
         assert self.module.foo_fixed.bar12() == 12

--- a/numpy/f2py/tests/test_parameter.py
+++ b/numpy/f2py/tests/test_parameter.py
@@ -5,6 +5,7 @@ import numpy as np
 from . import util
 
 
+@pytest.mark.slow
 class TestParameters(util.F2PyTest):
     # Check that intent(in out) translates as intent(inout)
     sources = [
@@ -16,7 +17,6 @@ class TestParameters(util.F2PyTest):
         util.getpath("tests", "src", "parameter", "constant_array.f90"),
     ]
 
-    @pytest.mark.slow
     def test_constant_real_single(self):
         # non-contiguous should raise error
         x = np.arange(6, dtype=np.float32)[::2]
@@ -27,7 +27,6 @@ class TestParameters(util.F2PyTest):
         self.module.foo_single(x)
         assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
 
-    @pytest.mark.slow
     def test_constant_real_double(self):
         # non-contiguous should raise error
         x = np.arange(6, dtype=np.float64)[::2]
@@ -38,7 +37,6 @@ class TestParameters(util.F2PyTest):
         self.module.foo_double(x)
         assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
 
-    @pytest.mark.slow
     def test_constant_compound_int(self):
         # non-contiguous should raise error
         x = np.arange(6, dtype=np.int32)[::2]
@@ -49,14 +47,12 @@ class TestParameters(util.F2PyTest):
         self.module.foo_compound_int(x)
         assert np.allclose(x, [0 + 1 + 2 * 6, 1, 2])
 
-    @pytest.mark.slow
     def test_constant_non_compound_int(self):
         # check values
         x = np.arange(4, dtype=np.int32)
         self.module.foo_non_compound_int(x)
         assert np.allclose(x, [0 + 1 + 2 + 3 * 4, 1, 2, 3])
 
-    @pytest.mark.slow
     def test_constant_integer_int(self):
         # non-contiguous should raise error
         x = np.arange(6, dtype=np.int32)[::2]
@@ -67,7 +63,6 @@ class TestParameters(util.F2PyTest):
         self.module.foo_int(x)
         assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
 
-    @pytest.mark.slow
     def test_constant_integer_long(self):
         # non-contiguous should raise error
         x = np.arange(6, dtype=np.int64)[::2]
@@ -78,7 +73,6 @@ class TestParameters(util.F2PyTest):
         self.module.foo_long(x)
         assert np.allclose(x, [0 + 1 + 2 * 3, 1, 2])
 
-    @pytest.mark.slow
     def test_constant_both(self):
         # non-contiguous should raise error
         x = np.arange(6, dtype=np.float64)[::2]
@@ -89,7 +83,6 @@ class TestParameters(util.F2PyTest):
         self.module.foo(x)
         assert np.allclose(x, [0 + 1 * 3 * 3 + 2 * 3 * 3, 1 * 3, 2 * 3])
 
-    @pytest.mark.slow
     def test_constant_no(self):
         # non-contiguous should raise error
         x = np.arange(6, dtype=np.float64)[::2]
@@ -100,7 +93,6 @@ class TestParameters(util.F2PyTest):
         self.module.foo_no(x)
         assert np.allclose(x, [0 + 1 * 3 * 3 + 2 * 3 * 3, 1 * 3, 2 * 3])
 
-    @pytest.mark.slow
     def test_constant_sum(self):
         # non-contiguous should raise error
         x = np.arange(6, dtype=np.float64)[::2]

--- a/numpy/f2py/tests/test_quoted_character.py
+++ b/numpy/f2py/tests/test_quoted_character.py
@@ -8,11 +8,12 @@ import pytest
 from . import util
 
 
+# Note: do not mark as slow! This is one of a small set of f2py compile tests retained
+# in the default suite invocation for compile-path coverage.
 class TestQuotedCharacter(util.F2PyTest):
     sources = [util.getpath("tests", "src", "quoted_character", "foo.f")]
 
     @pytest.mark.skipif(sys.platform == "win32",
                         reason="Fails with MinGW64 Gfortran (Issue #9673)")
-    @pytest.mark.slow
     def test_quoted_character(self):
         assert self.module.foo() == (b"'", b'"', b";", b"!", b"(", b")")

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -9,11 +9,11 @@ import numpy.testing as npt
 from . import util
 
 
+@pytest.mark.slow
 class TestIntentInOut(util.F2PyTest):
     # Check that intent(in out) translates as intent(inout)
     sources = [util.getpath("tests", "src", "regression", "inout.f90")]
 
-    @pytest.mark.slow
     def test_inout(self):
         # non-contiguous should raise error
         x = np.arange(6, dtype=np.float32)[::2]
@@ -25,11 +25,11 @@ class TestIntentInOut(util.F2PyTest):
         assert np.allclose(x, [3, 1, 2])
 
 
+@pytest.mark.slow
 class TestDataOnlyMultiModule(util.F2PyTest):
     # Check that modules without subroutines work
     sources = [util.getpath("tests", "src", "regression", "datonly.f90")]
 
-    @pytest.mark.slow
     def test_mdat(self):
         assert self.module.datonly.max_value == 100
         assert self.module.dat.max_ == 1009
@@ -37,21 +37,21 @@ class TestDataOnlyMultiModule(util.F2PyTest):
         assert self.module.simple_subroutine(5) == 1014
 
 
+@pytest.mark.slow
 class TestModuleWithDerivedType(util.F2PyTest):
     # Check that modules with derived types work
     sources = [util.getpath("tests", "src", "regression", "mod_derived_types.f90")]
 
-    @pytest.mark.slow
     def test_mtypes(self):
         assert self.module.no_type_subroutine(10) == 110
         assert self.module.type_subroutine(10) == 210
 
 
+@pytest.mark.slow
 class TestNegativeBounds(util.F2PyTest):
     # Check that negative bounds work correctly
     sources = [util.getpath("tests", "src", "negative_bounds", "issue_20853.f90")]
 
-    @pytest.mark.slow
     def test_negbound(self):
         xvec = np.arange(12)
         xlow = -6
@@ -68,12 +68,12 @@ class TestNegativeBounds(util.F2PyTest):
         assert np.allclose(rval, expval)
 
 
+@pytest.mark.slow
 class TestNumpyVersionAttribute(util.F2PyTest):
     # Check that th attribute __f2py_numpy_version__ is present
     # in the compiled module and that has the value np.__version__.
     sources = [util.getpath("tests", "src", "regression", "inout.f90")]
 
-    @pytest.mark.slow
     def test_numpy_version_attribute(self):
 
         # Check that self.module has an attribute named "__f2py_numpy_version__"
@@ -93,22 +93,22 @@ def test_include_path():
         assert fname in fnames_in_dir
 
 
+@pytest.mark.slow
 class TestIncludeFiles(util.F2PyTest):
     sources = [util.getpath("tests", "src", "regression", "incfile.f90")]
     options = [f"-I{util.getpath('tests', 'src', 'regression')}",
                f"--include-paths {util.getpath('tests', 'src', 'regression')}"]
 
-    @pytest.mark.slow
     def test_gh25344(self):
         exp = 7.0
         res = self.module.add(3.0, 4.0)
         assert exp == res
 
+@pytest.mark.slow
 class TestF77Comments(util.F2PyTest):
     # Check that comments are stripped from F77 continuation lines
     sources = [util.getpath("tests", "src", "regression", "f77comments.f")]
 
-    @pytest.mark.slow
     def test_gh26148(self):
         x1 = np.array(3, dtype=np.int32)
         x2 = np.array(5, dtype=np.int32)
@@ -116,18 +116,17 @@ class TestF77Comments(util.F2PyTest):
         assert res[0] == 8
         assert res[1] == 15
 
-    @pytest.mark.slow
     def test_gh26466(self):
         # Check that comments after PARAMETER directions are stripped
         expected = np.arange(1, 11, dtype=np.float32) * 2
         res = self.module.testsub2()
         npt.assert_allclose(expected, res)
 
+@pytest.mark.slow
 class TestF90Continuation(util.F2PyTest):
     # Check that comments are stripped from F90 continuation lines
     sources = [util.getpath("tests", "src", "regression", "f90continuation.f90")]
 
-    @pytest.mark.slow
     def test_gh26148b(self):
         x1 = np.array(3, dtype=np.int32)
         x2 = np.array(5, dtype=np.int32)
@@ -135,11 +134,11 @@ class TestF90Continuation(util.F2PyTest):
         assert res[0] == 8
         assert res[1] == 15
 
+@pytest.mark.slow
 class TestLowerF2PYDirectives(util.F2PyTest):
     # Check variables are cased correctly
     sources = [util.getpath("tests", "src", "regression", "lower_f2py_fortran.f90")]
 
-    @pytest.mark.slow
     def test_gh28014(self):
         self.module.inquire_next(3)
         assert True
@@ -197,7 +196,6 @@ class TestAssignmentOnlyModules(util.F2PyTest):
     # Ensure that variables are exposed without functions or subroutines in a module
     sources = [util.getpath("tests", "src", "regression", "assignOnlyModule.f90")]
 
-    @pytest.mark.slow
     def test_gh27167(self):
         assert (self.module.f_globals.n_max == 16)
         assert (self.module.f_globals.i_max == 18)

--- a/numpy/f2py/tests/test_return_logical.py
+++ b/numpy/f2py/tests/test_return_logical.py
@@ -5,6 +5,7 @@ from numpy import array
 from . import util
 
 
+@pytest.mark.slow
 class TestReturnLogical(util.F2PyTest):
     def check_function(self, t):
         assert t(True) == 1

--- a/numpy/f2py/tests/test_semicolon_split.py
+++ b/numpy/f2py/tests/test_semicolon_split.py
@@ -15,6 +15,7 @@ from . import util
 @pytest.mark.skipif(
     not IS_64BIT, reason="32-bit builds are buggy"
 )
+@pytest.mark.slow
 class TestMultiline(util.F2PyTest):
     suffix = ".pyf"
     module_name = "multiline"

--- a/numpy/f2py/tests/test_size.py
+++ b/numpy/f2py/tests/test_size.py
@@ -5,10 +5,11 @@ import numpy as np
 from . import util
 
 
+# Note: do not mark as slow! This is one of a small set of f2py compile tests retained
+# in the default suite invocation for compile-path coverage.
 class TestSizeSumExample(util.F2PyTest):
     sources = [util.getpath("tests", "src", "size", "foo.f90")]
 
-    @pytest.mark.slow
     def test_all(self):
         r = self.module.foo([[]])
         assert r == [0]
@@ -22,7 +23,6 @@ class TestSizeSumExample(util.F2PyTest):
         r = self.module.foo([[1, 2], [3, 4], [5, 6]])
         assert np.allclose(r, [3, 7, 11])
 
-    @pytest.mark.slow
     def test_transpose(self):
         r = self.module.trans([[]])
         assert np.allclose(r.T, np.array([[]]))
@@ -33,7 +33,6 @@ class TestSizeSumExample(util.F2PyTest):
         r = self.module.trans([[1, 2, 3], [4, 5, 6]])
         assert np.allclose(r, [[1, 4], [2, 5], [3, 6]])
 
-    @pytest.mark.slow
     def test_flatten(self):
         r = self.module.flatten([[]])
         assert np.allclose(r, [])

--- a/numpy/f2py/tests/test_string.py
+++ b/numpy/f2py/tests/test_string.py
@@ -5,10 +5,10 @@ import numpy as np
 from . import util
 
 
+@pytest.mark.slow
 class TestString(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "char.f90")]
 
-    @pytest.mark.slow
     def test_char(self):
         strings = np.array(["ab", "cd", "ef"], dtype="c").T
         inp, out = self.module.char_test.change_strings(
@@ -19,6 +19,7 @@ class TestString(util.F2PyTest):
         assert out == pytest.approx(expected)
 
 
+@pytest.mark.slow
 class TestDocStringArguments(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "string.f")]
 
@@ -36,6 +37,7 @@ class TestDocStringArguments(util.F2PyTest):
         assert d.tobytes() == b"D23"
 
 
+@pytest.mark.slow
 class TestFixedString(util.F2PyTest):
     sources = [util.getpath("tests", "src", "string", "fixed_string.f90")]
 

--- a/numpy/f2py/tests/test_symbolic.py
+++ b/numpy/f2py/tests/test_symbolic.py
@@ -33,6 +33,7 @@ from numpy.f2py.symbolic import (
 from . import util
 
 
+@pytest.mark.slow
 class TestSymbolic(util.F2PyTest):
     def test_eliminate_quotes(self):
         def worker(s):

--- a/numpy/f2py/tests/test_value_attrspec.py
+++ b/numpy/f2py/tests/test_value_attrspec.py
@@ -3,11 +3,11 @@ import pytest
 from . import util
 
 
+@pytest.mark.slow
 class TestValueAttr(util.F2PyTest):
     sources = [util.getpath("tests", "src", "value_attrspec", "gh21665.f90")]
 
     # gh-21665
-    @pytest.mark.slow
     def test_gh21665(self):
         inp = 2
         out = self.module.fortfuncs.square(inp)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2124,6 +2124,7 @@ class TestLeaks:
     @pytest.mark.thread_unsafe(
         reason="test result depends on the reference count of a global object"
     )
+    @pytest.mark.slow
     def test_frompyfunc_leaks(self, name, incr):
         # exposed in gh-11867 as np.vectorized, but the problem stems from
         # frompyfunc.
@@ -3927,6 +3928,7 @@ class TestPercentile:
         assert z == one
         assert z.dtype == a.dtype
 
+    @pytest.mark.slow
     def test_percentile_gh_29003_Fraction(self):
         zero = Fraction(0)
         one = Fraction(1)

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2684,6 +2684,7 @@ def test_npzfile_dict():
 
 @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
 @pytest.mark.thread_unsafe(reason="garbage collector is global state")
+@pytest.mark.slow
 def test_load_refcount():
     # Check that objects returned by np.load are directly freed based on
     # their refcount, rather than needing the gc to collect them.

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1273,6 +1273,7 @@ class TestNanFunctions_Percentile:
         assert_equal(q_weighted, result)
 
     @pytest.mark.parametrize("axis", [0, 1, 2])
+    @pytest.mark.slow
     def test_nan_value_with_weight_ndim(self, axis):
         # Create a multi-dimensional array to test
         np.random.seed(1)

--- a/numpy/linalg/tests/test_regression.py
+++ b/numpy/linalg/tests/test_regression.py
@@ -167,6 +167,7 @@ class TestRegression:
         assert res.shape == (4,)
 
     @pytest.mark.thread_unsafe(reason="test is already testing threads with openblas")
+    @pytest.mark.slow
     def test_openblas_threading(self):
         # gh-27036
         # Test whether matrix multiplication involving a large matrix always

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -98,6 +98,7 @@ class TestRegression:
             assert_(c in a)
             assert_raises(ValueError, random.choice, a, p=probs * 0.9)
 
+    @pytest.mark.slow
     def test_shuffle_of_array_of_different_length_strings(self):
         # Test that permuting an array of different length strings
         # will not cause a segfault on garbage collection
@@ -113,6 +114,7 @@ class TestRegression:
         import gc
         gc.collect()
 
+    @pytest.mark.slow
     def test_shuffle_of_array_of_objects(self):
         # Test that permuting an array of objects will not cause
         # a segfault on garbage collection.

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -2060,6 +2060,7 @@ def test_clear_and_catch_warnings_inherit():
 
 @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
 @pytest.mark.thread_unsafe(reason="garbage collector is global state")
+@pytest.mark.slow
 class TestAssertNoGcCycles:
     """ Test assert_no_gc_cycles """
 
@@ -2088,7 +2089,6 @@ class TestAssertNoGcCycles:
         with assert_raises(AssertionError):
             assert_no_gc_cycles(make_cycle)
 
-    @pytest.mark.slow
     def test_fails(self):
         """
         Test that in cases where the garbage cannot be collected, we raise an

--- a/numpy/tests/test_ctypeslib.py
+++ b/numpy/tests/test_ctypeslib.py
@@ -255,6 +255,7 @@ class TestAsArray:
         check(as_array(pointer(c_array[0][0]), shape=(2, 3)))
 
     @pytest.mark.thread_unsafe(reason="garbage collector is global state")
+    @pytest.mark.slow
     def test_reference_cycles(self):
         # related to gh-6511
         import ctypes

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -239,6 +239,7 @@ SKIP_LIST_2 = [
 ]
 
 
+@pytest.mark.slow
 def test_all_modules_are_expected_2():
     """
     Method checking all objects. The pkgutil-based method in


### PR DESCRIPTION
As discussed in gh-31419, the goal is to mark tests with a duration above 0.5-1 sec. on commonly used CPUs (say x86-64 CPU of a few years old) as `slow` unless there's a good reason to keep it in the default set that gets executed by `numpy.test()` rather than `numpy.test('full')`.

Slowest tests are compile tests for `cython` and `f2py`, tests for reference cycles and the like, multi-threaded tests, custom memory allocators, and highly parametrized tests that are relatively slow (often dealing with object arrays or other inherently slower features).

Most of the changes are for `f2py`; almost all compile tests were in the default set - which doesn't really make sense.

With this change, we move about 700 out of 47,000 tests to the 'full' mode, resulting in a speedup of the default test() invocation of roughly 50%. Remaining slowest tests recorded in [31419#comment](https://github.com/numpy/numpy/issues/31419#issuecomment-4439959086).

Closes gh-31419


#### AI Disclosure

I did the first several iterations by hand, then asked Claude Code to apply the rest of the markers based on the output of `spin test . -- --durations=50`.