### PR TITLE
TYP: Fix `DTypeLike` runtime type-checker support

### DIFF
--- a/numpy/_typing/_dtype_like.py
+++ b/numpy/_typing/_dtype_like.py
@@ -39,6 +39,7 @@ class _HasDType[DTypeT: np.dtype](Protocol):
     def dtype(self) -> DTypeT: ...
 
 
+@runtime_checkable
 class _HasNumPyDType[DTypeT: np.dtype](Protocol):
     @property
     def __numpy_dtype__(self, /) -> DTypeT: ...


### PR DESCRIPTION
Runtime type-checkers like [beartype](https://github.com/beartype/beartype) currently aren't able to check if something is an instance of `numpy.typing.DTypeLike` because not all protocols in the union type aren't runtime checkable (see https://github.com/mikedh/trimesh/actions/runs/25796361932/job/75774562690?pr=2541 for example). The fix is to to add a `@runtime_checkable` to the `_HasNumPyDType` protocol.

---

On the 2.4 branch the `_HasDType` protocol is *also* missing a `@runtime_checkable` (https://github.com/numpy/numpy/blob/be93fe2960dbf49b4647f5783c66d967fb2c65b5/numpy/_typing/_dtype_like.py#L44-L51). So it should also be added there when backporting this, as well as importing `runtime_checkable` from `typing`.

---

No AI