### PR TITLE
TST: fix duplicated word in nditer test comment

### DIFF
--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -2183,7 +2183,7 @@ def test_iter_buffered_cast_structured_type_failure_with_cleanup():
 
     for intent in ["readwrite", "readonly", "writeonly"]:
         # This test was initially designed to test an error at a different
-        # place, but will now raise earlier to to the cast not being possible:
+        # place, but will now raise earlier due to the cast not being possible:
         # `assert np.can_cast(a.dtype, sdt2, casting="unsafe")` fails.
         # Without a faulty DType, there is probably no reliable
         # way to get the initial tested behaviour.


### PR DESCRIPTION
Fix a duplicated word in a test comment in `numpy/_core/tests/test_nditer.py`.

The comment on line 2186 read:
`# place, but will now raise earlier to to the cast not being possible:`

The phrase "to to" is a typo for "due to". This corrects it.