### PR TITLE
ENH: New-style object sorting with descending support and NaN handling

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -276,8 +276,7 @@ class Sort(Benchmark):
         # used across multiple runs.
         if descending:
             try:
-                with np.errstate(over='raise'):
-                    np.sort(self.arr, stable=stable, descending=True)
+                np.sort(self.arr, stable=stable, descending=True)
             except TypeError:
                 raise SkipNotImplemented(
                     f"Descending sort is not supported for {dtype}"
@@ -289,8 +288,7 @@ class Sort(Benchmark):
     def time_argsort(self, stable, descending, dtype, array_type):
         if descending:
             try:
-                with np.errstate(over='raise'):
-                    np.argsort(self.arr, stable=stable, descending=True)
+                np.argsort(self.arr, stable=stable, descending=True)
             except TypeError:
                 raise SkipNotImplemented(
                     f"Descending argsort is not supported for {dtype}"

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -244,6 +244,7 @@ class Sort(Benchmark):
             'uint8',
             'int8',
             'bool',
+            'object',
         ],
         [
             ('random',),
@@ -274,14 +275,26 @@ class Sort(Benchmark):
         # This is important because the data is prepared once per benchmark, but
         # used across multiple runs.
         if descending:
-            np.sort(self.arr, stable=stable, descending=True)
+            try:
+                with np.errstate(over='raise'):
+                    np.sort(self.arr, stable=stable, descending=True)
+            except TypeError:
+                raise SkipNotImplemented(
+                    f"Descending sort is not supported for {dtype}"
+                )
         else:
             # for backward compatibility to NumPy 2.0
             np.sort(self.arr, stable=stable)
 
     def time_argsort(self, stable, descending, dtype, array_type):
         if descending:
-            np.argsort(self.arr, stable=stable, descending=True)
+            try:
+                with np.errstate(over='raise'):
+                    np.argsort(self.arr, stable=stable, descending=True)
+            except TypeError:
+                    raise SkipNotImplemented(
+                        f"Descending argsort is not supported for {dtype}"
+                    )
         else:
             # for backward compatibility to NumPy 2.0
             np.argsort(self.arr, stable=stable)

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -292,9 +292,9 @@ class Sort(Benchmark):
                 with np.errstate(over='raise'):
                     np.argsort(self.arr, stable=stable, descending=True)
             except TypeError:
-                    raise SkipNotImplemented(
-                        f"Descending argsort is not supported for {dtype}"
-                    )
+                raise SkipNotImplemented(
+                    f"Descending argsort is not supported for {dtype}"
+                )
         else:
             # for backward compatibility to NumPy 2.0
             np.argsort(self.arr, stable=stable)

--- a/doc/release/upcoming_changes/31431.improvement.rst
+++ b/doc/release/upcoming_changes/31431.improvement.rst
@@ -1,6 +1,7 @@
 object array sorting supports `descending=True`
 -----------------------------------------------
-`np.sort` and `np.argsort` with arrays of dtype `object`
+`np.sort` and `np.argsort` with arrays of dtype ``object``
 now support passing `descending=True` to sort in descending order.
-Unordered objects, i.e. `obj` such that `obj != obj`, are sorted
-to the end of the array regardless of the value of `descending`.
+Objects that compare as not equal to themselves, such as NaN-like
+values, are considered unordered and are sorted to the end of the
+array, regardless of the value of `descending`.

--- a/doc/release/upcoming_changes/31431.improvement.rst
+++ b/doc/release/upcoming_changes/31431.improvement.rst
@@ -1,7 +1,7 @@
-object array sorting supports `descending=True`
------------------------------------------------
+object array sorting supports `descending=True` and consistent behavior for NaN-like objects
+--------------------------------------------------------------------------------------------
 `np.sort` and `np.argsort` with arrays of dtype ``object``
-now support passing `descending=True` to sort in descending order.
-Objects that compare as not equal to themselves, such as NaN-like
-values, are considered unordered and are sorted to the end of the
-array, regardless of the value of `descending`.
+now support passing `descending=True` to sort in descending order. Objects that
+compare as not equal to themselves (``obj != obj``), such as NaN-like objects,
+are considered unordered and are sorted to the end of the array, regardless of
+the value of `descending`.

--- a/doc/release/upcoming_changes/31431.improvement.rst
+++ b/doc/release/upcoming_changes/31431.improvement.rst
@@ -1,7 +1,7 @@
-object array sorting supports `descending=True` and consistent behavior for NaN-like objects
---------------------------------------------------------------------------------------------
+Object array sorting supports ``descending=True`` and consistently sorts NaN-like objects
+-----------------------------------------------------------------------------------------
 `np.sort` and `np.argsort` with arrays of dtype ``object``
 now support passing `descending=True` to sort in descending order. Objects that
 compare as not equal to themselves (``obj != obj``), such as NaN-like objects,
 are considered unordered and are sorted to the end of the array, regardless of
-the value of `descending`.
+the value of ``descending``.

--- a/doc/release/upcoming_changes/31431.improvement.rst
+++ b/doc/release/upcoming_changes/31431.improvement.rst
@@ -1,0 +1,6 @@
+object array sorting supports `descending=True`
+-----------------------------------------------
+`np.sort` and `np.argsort` with arrays of dtype `object`
+now support passing `descending=True` to sort in descending order.
+Unordered objects, i.e. `obj` such that `obj != obj`, are sorted
+to the end of the array regardless of the value of `descending`.

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -244,14 +244,6 @@ struct object_tag {
 
     static int _cmp(PyObject *a, PyObject *b, int op)
     {
-        /*
-         * work around gh-3879, we cannot abort an in-progress quicksort
-         * so at least do not raise again
-         */
-        if (PyErr_Occurred()) {
-            return 0;
-        }
-
         if (a == NULL) {
             return 0;
         }
@@ -261,7 +253,7 @@ struct object_tag {
 
         int ret = PyObject_RichCompareBool(a, b, op);
         if (ret < 0) {
-            return 0;
+            return -1;
         }
         if (ret) {
             return 1;
@@ -269,7 +261,7 @@ struct object_tag {
 
         ret = isnan(a);
         if (ret < 0) {
-            return 0;
+            return -1;
         }
         if (ret) {
             return 0;
@@ -277,7 +269,7 @@ struct object_tag {
 
         ret = isnan(b);
         if (ret < 0) {
-            return 0;
+            return -1;
         }
         if (ret) {
             return 1;
@@ -340,6 +332,13 @@ constexpr int cmp(Args... args)
         return Tag::less(args...);
     }
 }
+
+#define NPY_CMP(...)                                         \
+    ({                                                       \
+        npy_intp _r = npy::cmp<Tag, reverse>(__VA_ARGS__);   \
+        if (_r < 0) return _r;                               \
+        _r;                                                  \
+    })
 
 }  // namespace npy
 

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -239,13 +239,10 @@ struct object_tag {
         }
         int ret = PyObject_IsTrue(result);
         Py_DECREF(result);
-        if (ret < 0) {
-            return -1;
-        }
         return ret;
     }
 
-    static int less(PyObject *a, PyObject *b)
+    static int _cmp(PyObject *a, PyObject *b, int op)
     {
         /*
          * work around gh-3879, we cannot abort an in-progress quicksort
@@ -262,7 +259,7 @@ struct object_tag {
             return 1;
         }
 
-        int ret = PyObject_RichCompareBool(a, b, Py_LT);
+        int ret = PyObject_RichCompareBool(a, b, op);
         if (ret < 0) {
             return 0;
         }
@@ -289,51 +286,16 @@ struct object_tag {
         return 0;
     }
 
+    static int less(PyObject *a, PyObject *b) {
+        return _cmp(a, b, Py_LT);
+    }
+
     static int less_equal(PyObject *a, PyObject *b) {
         return !less(b, a);
     }
 
     static int greater(PyObject *a, PyObject *b) {
-        /*
-         * work around gh-3879, we cannot abort an in-progress quicksort
-         * so at least do not raise again
-         */
-        if (PyErr_Occurred()) {
-            return 0;
-        }
-
-        if (a == NULL) {
-            return 0;
-        }
-        if (b == NULL) {
-            return 1;
-        }
-
-        int ret = PyObject_RichCompareBool(a, b, Py_GT);
-        if (ret < 0) {
-            return 0;
-        }
-        if (ret) {
-            return 1;
-        }
-
-        ret = isnan(a);
-        if (ret < 0) {
-            return 0;
-        }
-        if (ret) {
-            return 0;
-        }
-
-        ret = isnan(b);
-        if (ret < 0) {
-            return 0;
-        }
-        if (ret) {
-            return 1;
-        }
-
-        return 0;   
+        return _cmp(a, b, Py_GT);
     }
 };
 

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -244,6 +244,14 @@ struct object_tag {
 
     static int _cmp(PyObject *a, PyObject *b, int op)
     {
+        /*
+         * work around gh-3879, we cannot abort an in-progress quicksort
+         * so at least do not raise again
+         */
+        if (PyErr_Occurred()) {
+            return 0;
+        }
+
         if (a == NULL) {
             return 0;
         }
@@ -253,7 +261,7 @@ struct object_tag {
 
         int ret = PyObject_RichCompareBool(a, b, op);
         if (ret < 0) {
-            return -1;
+            return 0;
         }
         if (ret) {
             return 1;
@@ -261,7 +269,7 @@ struct object_tag {
 
         ret = isnan(a);
         if (ret < 0) {
-            return -1;
+            return 0;
         }
         if (ret) {
             return 0;
@@ -269,7 +277,7 @@ struct object_tag {
 
         ret = isnan(b);
         if (ret < 0) {
-            return -1;
+            return 0;
         }
         if (ret) {
             return 1;
@@ -332,13 +340,6 @@ constexpr int cmp(Args... args)
         return Tag::less(args...);
     }
 }
-
-#define NPY_CMP(...)                                         \
-    ({                                                       \
-        npy_intp _r = npy::cmp<Tag, reverse>(__VA_ARGS__);   \
-        if (_r < 0) return _r;                               \
-        _r;                                                  \
-    })
 
 }  // namespace npy
 

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -243,9 +243,8 @@ struct object_tag {
         }
         int ret = PyObject_IsTrue(result);
         Py_DECREF(result);
-
         if (ret < 0) {
-            return 0;
+            return -1;
         }
         return ret;
     }

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -244,14 +244,6 @@ struct object_tag {
 
     static int _cmp(PyObject *a, PyObject *b, int op)
     {
-        /*
-         * work around gh-3879, we cannot abort an in-progress quicksort
-         * so at least do not raise again
-         */
-        if (PyErr_Occurred()) {
-            return 0;
-        }
-
         if (a == NULL) {
             return 0;
         }
@@ -261,7 +253,7 @@ struct object_tag {
 
         int ret = PyObject_RichCompareBool(a, b, op);
         if (ret < 0) {
-            return 0;
+            return -1;
         }
         if (ret) {
             return 1;
@@ -269,7 +261,7 @@ struct object_tag {
 
         ret = isnan(a);
         if (ret < 0) {
-            return 0;
+            return -1;
         }
         if (ret) {
             return 0;
@@ -277,7 +269,7 @@ struct object_tag {
 
         ret = isnan(b);
         if (ret < 0) {
-            return 0;
+            return -1;
         }
         if (ret) {
             return 1;

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -223,6 +223,95 @@ struct string_like_type {
     }
 };
 
+// This tag is used to register object sorts, which replaces the old generic sort
+// that did not handle NaNs at all. It supposes that any object such that
+// obj != obj is NaN-like and should be sorted to the end as in other dtypes.
+struct object_tag {
+    using type = PyObject *;
+    static constexpr NPY_TYPES type_value = NPY_OBJECT;
+
+    static int isnan(PyObject *a) {
+        if (a == NULL) {
+            return 1;
+        }
+
+        /* PyObject_RichCompareBool is not used here because it takes a shortcut
+         * for identical objects, hence will return false for NaN != NaN. */
+        PyObject *result = PyObject_RichCompare(a, a, Py_NE);
+        if (result == NULL) {
+            return -1;
+        }
+        int ret = PyObject_IsTrue(result);
+        Py_DECREF(result);
+
+        if (ret < 0) {
+            return 0;
+        }
+        return ret;
+    }
+
+    static int less(PyObject *a, PyObject *b)
+    {
+        /*
+         * work around gh-3879, we cannot abort an in-progress quicksort
+         * so at least do not raise again
+         */
+        if (PyErr_Occurred()) {
+            return 0;
+        }
+
+        int isnan_a = isnan(a);
+        int isnan_b = isnan(b); 
+        if (isnan_a < 0 || isnan_b < 0) {
+            return 0;
+        }
+        if (isnan_b) {
+            return 1;
+        }
+        if (isnan_a) {
+            return 0;
+        }
+
+        int ret = PyObject_RichCompareBool(a, b, Py_LT);
+        if (ret < 0) {
+            return 0;
+        }
+        return ret;
+    }
+
+    static int less_equal(PyObject *a, PyObject *b) {
+        return !less(b, a);
+    }
+
+    static int greater(PyObject *a, PyObject *b) {
+        /*
+         * work around gh-3879, we cannot abort an in-progress quicksort
+         * so at least do not raise again
+         */
+        if (PyErr_Occurred()) {
+            return 0;
+        }
+
+        int isnan_a = isnan(a);
+        int isnan_b = isnan(b);
+        if (isnan_a < 0 || isnan_b < 0) {
+            return 0;
+        }
+        if (isnan_b) {
+            return 1;
+        }
+        if (isnan_a) {
+            return 0;
+        }
+
+        int ret = PyObject_RichCompareBool(a, b, Py_GT);
+        if (ret < 0) {
+            return 0;
+        }
+        return ret;
+    }
+};
+
 // Concrete tags consumed by callers.
 using bool_tag        = integral_type<npy_bool,        NPY_BOOL>;
 using byte_tag        = integral_type<npy_byte,        NPY_BYTE>;

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -231,10 +231,6 @@ struct object_tag {
     static constexpr NPY_TYPES type_value = NPY_OBJECT;
 
     static int isnan(PyObject *a) {
-        if (a == NULL) {
-            return 1;
-        }
-
         /* PyObject_RichCompareBool is not used here because it takes a shortcut
          * for identical objects, hence will return false for NaN != NaN. */
         PyObject *result = PyObject_RichCompare(a, a, Py_NE);
@@ -259,23 +255,38 @@ struct object_tag {
             return 0;
         }
 
-        int isnan_a = isnan(a);
-        int isnan_b = isnan(b); 
-        if (isnan_a < 0 || isnan_b < 0) {
+        if (a == NULL) {
             return 0;
         }
-        if (isnan_b) {
+        if (b == NULL) {
             return 1;
-        }
-        if (isnan_a) {
-            return 0;
         }
 
         int ret = PyObject_RichCompareBool(a, b, Py_LT);
         if (ret < 0) {
             return 0;
         }
-        return ret;
+        if (ret) {
+            return 1;
+        }
+
+        ret = isnan(a);
+        if (ret < 0) {
+            return 0;
+        }
+        if (ret) {
+            return 0;
+        }
+
+        ret = isnan(b);
+        if (ret < 0) {
+            return 0;
+        }
+        if (ret) {
+            return 1;
+        }
+
+        return 0;
     }
 
     static int less_equal(PyObject *a, PyObject *b) {
@@ -291,23 +302,38 @@ struct object_tag {
             return 0;
         }
 
-        int isnan_a = isnan(a);
-        int isnan_b = isnan(b);
-        if (isnan_a < 0 || isnan_b < 0) {
+        if (a == NULL) {
             return 0;
         }
-        if (isnan_b) {
+        if (b == NULL) {
             return 1;
-        }
-        if (isnan_a) {
-            return 0;
         }
 
         int ret = PyObject_RichCompareBool(a, b, Py_GT);
         if (ret < 0) {
             return 0;
         }
-        return ret;
+        if (ret) {
+            return 1;
+        }
+
+        ret = isnan(a);
+        if (ret < 0) {
+            return 0;
+        }
+        if (ret) {
+            return 0;
+        }
+
+        ret = isnan(b);
+        if (ret < 0) {
+            return 0;
+        }
+        if (ret) {
+            return 1;
+        }
+
+        return 0;   
     }
 };
 

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -16,13 +16,9 @@
  *
  *   - ``type``        -- the underlying C scalar type
  *   - ``type_value``  -- the corresponding ``NPY_TYPES`` enumerator
- *   - ``less`` / ``greater`` -- the sort-friendly
+ *   - ``less`` / ``less_equal`` / ``greater`` -- the sort-friendly
  *     comparisons that order NaN / NaT to the end (as if largest value
  *     for less and as if smallest for greater).
- *   - ``less_equal`` / ``greater_equal`` -- the corresponding non-strict
- *     comparisons that are consistent with the strict ones, such that
- *     ``less_equal(a, b)`` is equivalent to ``!less(b, a)`` and
- *     similarly for greater.
  *
  * For the four numeric categories that need different NaN/NaT handling,
  * comparisons are implemented once at the ``*_type<T, NPY_TYPES>``
@@ -108,12 +104,7 @@ struct half_tag {
         }
         return !isnan(a) && lt_nonan(a, b);
     }
-    static constexpr int less_equal(npy_half a, npy_half b) {
-        if (isnan(b)) {
-            return 1;
-        }
-        return !lt_nonan(b, a) && !isnan(a);
-    }
+    static constexpr int less_equal(npy_half a, npy_half b) { return !less(b, a); }
 
     // NaN sorts to the end in reverse too.
     static constexpr int greater(npy_half a, npy_half b)
@@ -123,12 +114,7 @@ struct half_tag {
         }
         return !isnan(a) && lt_nonan(b, a);
     }
-    static constexpr int greater_equal(npy_half a, npy_half b) {
-        if (isnan(b)) {
-            return 1;
-        }
-        return !lt_nonan(a, b) && !isnan(a);
-    }
+    static constexpr int greater_equal(npy_half a, npy_half b) { return !greater(b, a); }
 };
 
 template <typename T, NPY_TYPES TypeNum>

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -247,7 +247,8 @@ struct object_tag {
         return ret;
     }
 
-    static int _cmp(PyObject *a, PyObject *b, int op)
+    template <int op>
+    static int _cmp(PyObject *a, PyObject *b)
     {
         if (a == NULL) {
             a = Py_None;
@@ -283,20 +284,57 @@ struct object_tag {
         return 0;
     }
 
+    template <int op>
+    static int _cmp_invert(PyObject *a, PyObject *b)
+    {
+        if (a == NULL) {
+            a = Py_None;
+        }
+        if (b == NULL) {
+            b = Py_None;
+        }
+
+        int ret = isnan(a);
+        if (ret < 0) {
+            return -1;
+        }
+        if (ret) {
+            return 0;
+        }
+
+        ret = PyObject_RichCompareBool(a, b, op);
+        if (ret < 0) {
+            return -1;
+        }
+        if (!ret) {
+            return 1;
+        }
+
+        ret = isnan(b);
+        if (ret < 0) {
+            return -1;
+        }
+        if (ret) {
+            return 0;
+        }
+
+        return 0;
+    }
+
     static int less(PyObject *a, PyObject *b) {
-        return _cmp(a, b, Py_LT);
+        return _cmp<Py_LT>(a, b);
     }
 
     static int less_equal(PyObject *a, PyObject *b) {
-        return _cmp(a, b, Py_LE);
+        return _cmp_invert<Py_GT>(a, b);
     }
 
     static int greater(PyObject *a, PyObject *b) {
-        return _cmp(a, b, Py_GT);
+        return _cmp<Py_GT>(a, b);
     }
 
     static int greater_equal(PyObject *a, PyObject *b) {
-        return _cmp(a, b, Py_GE);
+        return _cmp_invert<Py_LT>(a, b);
     }
 };
 

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -247,8 +247,7 @@ struct object_tag {
         return ret;
     }
 
-    template <int op>
-    static int _cmp(PyObject *a, PyObject *b)
+    static int _cmp(PyObject *a, PyObject *b, int op)
     {
         if (a == NULL) {
             a = Py_None;
@@ -284,57 +283,20 @@ struct object_tag {
         return 0;
     }
 
-    template <int op>
-    static int _cmp_invert(PyObject *a, PyObject *b)
-    {
-        if (a == NULL) {
-            a = Py_None;
-        }
-        if (b == NULL) {
-            b = Py_None;
-        }
-
-        int ret = isnan(a);
-        if (ret < 0) {
-            return -1;
-        }
-        if (ret) {
-            return 0;
-        }
-
-        ret = PyObject_RichCompareBool(a, b, op);
-        if (ret < 0) {
-            return -1;
-        }
-        if (!ret) {
-            return 1;
-        }
-
-        ret = isnan(b);
-        if (ret < 0) {
-            return -1;
-        }
-        if (ret) {
-            return 0;
-        }
-
-        return 0;
-    }
-
     static int less(PyObject *a, PyObject *b) {
-        return _cmp<Py_LT>(a, b);
+        return _cmp(a, b, Py_LT);
     }
 
     static int less_equal(PyObject *a, PyObject *b) {
-        return _cmp_invert<Py_GT>(a, b);
+        return _cmp(a, b, Py_LE);
     }
 
     static int greater(PyObject *a, PyObject *b) {
-        return _cmp<Py_GT>(a, b);
+        return _cmp(a, b, Py_GT);
     }
 
     static int greater_equal(PyObject *a, PyObject *b) {
-        return _cmp_invert<Py_LT>(a, b);
+        return _cmp(a, b, Py_GE);
     }
 };
 

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -245,10 +245,10 @@ struct object_tag {
     static int _cmp(PyObject *a, PyObject *b, int op)
     {
         if (a == NULL) {
-            return 0;
+            a = Py_None;
         }
         if (b == NULL) {
-            return 1;
+            b = Py_None;
         }
 
         int ret = PyObject_RichCompareBool(a, b, op);

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -53,7 +53,6 @@ struct integral_type : integral_tag {
     static constexpr int less(T a, T b) { return a < b; }
     static constexpr int less_equal(T a, T b) { return !(b < a); }
     static constexpr int greater(T a, T b) { return a > b; }
-    static constexpr int greater_equal(T a, T b) { return !(a < b); }
 };
 
 template <typename T, NPY_TYPES TypeNum>
@@ -67,7 +66,6 @@ struct floating_point_type : floating_point_tag {
     // NaN sorts to the end in reverse too: ``a`` is "greater than" ``b``
     // if ``a`` is non-NaN and either ``b < a`` or ``b`` is NaN.
     static constexpr int greater(T a, T b) { return a > b || (b != b && a == a); }
-    static constexpr int greater_equal(T a, T b) { return !greater(b, a); }
 };
 
 // Half is its own per-type tag; no template since there is only one half
@@ -114,7 +112,6 @@ struct half_tag {
         }
         return !isnan(a) && lt_nonan(b, a);
     }
-    static constexpr int greater_equal(npy_half a, npy_half b) { return !greater(b, a); }
 };
 
 template <typename T, NPY_TYPES TypeNum>
@@ -160,7 +157,6 @@ struct complex_type : complex_tag {
         }
         return rb != rb;
     }
-    static constexpr int greater_equal(T a, T b) { return !greater(b, a); }
 };
 
 template <typename T, NPY_TYPES TypeNum>
@@ -182,7 +178,6 @@ struct datetime_type : date_tag {
         if (b == NPY_DATETIME_NAT) return 1;
         return b < a;
     }
-    static constexpr int greater_equal(T a, T b) { return !greater(b, a); }
 };
 
 // String / unicode tags work on runtime-length blocks.  Comparison is
@@ -288,15 +283,11 @@ struct object_tag {
     }
 
     static int less_equal(PyObject *a, PyObject *b) {
-        return _cmp(a, b, Py_LE);
+        return !less(b, a);
     }
 
     static int greater(PyObject *a, PyObject *b) {
         return _cmp(a, b, Py_GT);
-    }
-
-    static int greater_equal(PyObject *a, PyObject *b) {
-        return _cmp(a, b, Py_GE);
     }
 };
 
@@ -339,17 +330,6 @@ constexpr int cmp(Args... args)
     }
     else {
         return Tag::less(args...);
-    }
-}
-
-template <typename Tag, bool reverse, typename T>
-constexpr int cmp_eq(T a, T b)
-{
-    if constexpr (reverse) {
-        return Tag::greater_equal(a, b);
-    }
-    else {
-        return Tag::less_equal(a, b);
     }
 }
 

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -53,6 +53,7 @@ struct integral_type : integral_tag {
     static constexpr int less(T a, T b) { return a < b; }
     static constexpr int less_equal(T a, T b) { return !(b < a); }
     static constexpr int greater(T a, T b) { return a > b; }
+    static constexpr int greater_equal(T a, T b) { return !(a < b); }
 };
 
 template <typename T, NPY_TYPES TypeNum>
@@ -66,6 +67,7 @@ struct floating_point_type : floating_point_tag {
     // NaN sorts to the end in reverse too: ``a`` is "greater than" ``b``
     // if ``a`` is non-NaN and either ``b < a`` or ``b`` is NaN.
     static constexpr int greater(T a, T b) { return a > b || (b != b && a == a); }
+    static constexpr int greater_equal(T a, T b) { return !greater(b, a); }
 };
 
 // Half is its own per-type tag; no template since there is only one half
@@ -112,6 +114,7 @@ struct half_tag {
         }
         return !isnan(a) && lt_nonan(b, a);
     }
+    static constexpr int greater_equal(npy_half a, npy_half b) { return !greater(b, a); }
 };
 
 template <typename T, NPY_TYPES TypeNum>
@@ -157,6 +160,7 @@ struct complex_type : complex_tag {
         }
         return rb != rb;
     }
+    static constexpr int greater_equal(T a, T b) { return !greater(b, a); }
 };
 
 template <typename T, NPY_TYPES TypeNum>
@@ -178,6 +182,7 @@ struct datetime_type : date_tag {
         if (b == NPY_DATETIME_NAT) return 1;
         return b < a;
     }
+    static constexpr int greater_equal(T a, T b) { return !greater(b, a); }
 };
 
 // String / unicode tags work on runtime-length blocks.  Comparison is
@@ -283,11 +288,15 @@ struct object_tag {
     }
 
     static int less_equal(PyObject *a, PyObject *b) {
-        return !less(b, a);
+        return _cmp(a, b, Py_LE);
     }
 
     static int greater(PyObject *a, PyObject *b) {
         return _cmp(a, b, Py_GT);
+    }
+
+    static int greater_equal(PyObject *a, PyObject *b) {
+        return _cmp(a, b, Py_GE);
     }
 };
 
@@ -330,6 +339,17 @@ constexpr int cmp(Args... args)
     }
     else {
         return Tag::less(args...);
+    }
+}
+
+template <typename Tag, bool reverse, typename T>
+constexpr int cmp_eq(T a, T b)
+{
+    if constexpr (reverse) {
+        return Tag::greater_equal(a, b);
+    }
+    else {
+        return Tag::less_equal(a, b);
     }
 }
 

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -16,9 +16,13 @@
  *
  *   - ``type``        -- the underlying C scalar type
  *   - ``type_value``  -- the corresponding ``NPY_TYPES`` enumerator
- *   - ``less`` / ``less_equal`` / ``greater`` -- the sort-friendly
+ *   - ``less`` / ``greater`` -- the sort-friendly
  *     comparisons that order NaN / NaT to the end (as if largest value
  *     for less and as if smallest for greater).
+ *   - ``less_equal`` / ``greater_equal`` -- the corresponding non-strict
+ *     comparisons that are consistent with the strict ones, such that
+ *     ``less_equal(a, b)`` is equivalent to ``!less(b, a)`` and
+ *     similarly for greater.
  *
  * For the four numeric categories that need different NaN/NaT handling,
  * comparisons are implemented once at the ``*_type<T, NPY_TYPES>``
@@ -104,7 +108,12 @@ struct half_tag {
         }
         return !isnan(a) && lt_nonan(a, b);
     }
-    static constexpr int less_equal(npy_half a, npy_half b) { return !less(b, a); }
+    static constexpr int less_equal(npy_half a, npy_half b) {
+        if (isnan(b)) {
+            return 1;
+        }
+        return !lt_nonan(b, a) && !isnan(a);
+    }
 
     // NaN sorts to the end in reverse too.
     static constexpr int greater(npy_half a, npy_half b)
@@ -114,7 +123,12 @@ struct half_tag {
         }
         return !isnan(a) && lt_nonan(b, a);
     }
-    static constexpr int greater_equal(npy_half a, npy_half b) { return !greater(b, a); }
+    static constexpr int greater_equal(npy_half a, npy_half b) {
+        if (isnan(b)) {
+            return 1;
+        }
+        return !lt_nonan(a, b) && !isnan(a);
+    }
 };
 
 template <typename T, NPY_TYPES TypeNum>

--- a/numpy/_core/src/npysort/npysort_heapsort.hpp
+++ b/numpy/_core/src/npysort/npysort_heapsort.hpp
@@ -44,10 +44,10 @@ int heapsort_(type *start, npy_intp n)
     for (l = n >> 1; l > 0; --l) {
         tmp = a[l];
         for (i = l, j = l << 1; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(a[j], a[j + 1])) {
+            if (j < n && NPY_CMP(a[j], a[j + 1])) {
                 j += 1;
             }
-            if (npy::cmp<Tag, reverse>(tmp, a[j])) {
+            if (NPY_CMP(tmp, a[j])) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -64,10 +64,10 @@ int heapsort_(type *start, npy_intp n)
         a[n] = a[1];
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(a[j], a[j + 1])) {
+            if (j < n && NPY_CMP(a[j], a[j + 1])) {
                 j++;
             }
-            if (npy::cmp<Tag, reverse>(tmp, a[j])) {
+            if (NPY_CMP(tmp, a[j])) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -102,10 +102,10 @@ int aheapsort_(type *vv, npy_intp *tosort, npy_intp n)
     for (l = n >> 1; l > 0; --l) {
         tmp = a[l];
         for (i = l, j = l << 1; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]])) {
+            if (j < n && NPY_CMP(v[a[j]], v[a[j + 1]])) {
                 j += 1;
             }
-            if (npy::cmp<Tag, reverse>(v[tmp], v[a[j]])) {
+            if (NPY_CMP(v[tmp], v[a[j]])) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -122,10 +122,10 @@ int aheapsort_(type *vv, npy_intp *tosort, npy_intp n)
         a[n] = a[1];
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]])) {
+            if (j < n && NPY_CMP(v[a[j]], v[a[j + 1]])) {
                 j++;
             }
-            if (npy::cmp<Tag, reverse>(v[tmp], v[a[j]])) {
+            if (NPY_CMP(v[tmp], v[a[j]])) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -175,9 +175,9 @@ int string_heapsort_(type *start, npy_intp n, int elsize)
     for (l = n >> 1; l > 0; --l) {
         Tag::copy(tmp, a + l * len, len);
         for (i = l, j = l << 1; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(a + j * len, a + (j + 1) * len, len))
+            if (j < n && NPY_CMP(a + j * len, a + (j + 1) * len, len))
                 j += 1;
-            if (npy::cmp<Tag, reverse>(tmp, a + j * len, len)) {
+            if (NPY_CMP(tmp, a + j * len, len)) {
                 Tag::copy(a + i * len, a + j * len, len);
                 i = j;
                 j += j;
@@ -194,9 +194,9 @@ int string_heapsort_(type *start, npy_intp n, int elsize)
         Tag::copy(a + n * len, a + len, len);
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(a + j * len, a + (j + 1) * len, len))
+            if (j < n && NPY_CMP(a + j * len, a + (j + 1) * len, len))
                 j++;
-            if (npy::cmp<Tag, reverse>(tmp, a + j * len, len)) {
+            if (NPY_CMP(tmp, a + j * len, len)) {
                 Tag::copy(a + i * len, a + j * len, len);
                 i = j;
                 j += j;
@@ -226,9 +226,9 @@ int string_aheapsort_(type *vv, npy_intp *tosort, npy_intp n, int elsize)
     for (l = n >> 1; l > 0; --l) {
         tmp = a[l];
         for (i = l, j = l << 1; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(v + a[j] * len, v + a[j + 1] * len, len))
+            if (j < n && NPY_CMP(v + a[j] * len, v + a[j + 1] * len, len))
                 j += 1;
-            if (npy::cmp<Tag, reverse>(v + tmp * len, v + a[j] * len, len)) {
+            if (NPY_CMP(v + tmp * len, v + a[j] * len, len)) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -245,9 +245,9 @@ int string_aheapsort_(type *vv, npy_intp *tosort, npy_intp n, int elsize)
         a[n] = a[1];
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(v + a[j] * len, v + a[j + 1] * len, len))
+            if (j < n && NPY_CMP(v + a[j] * len, v + a[j + 1] * len, len))
                 j++;
-            if (npy::cmp<Tag, reverse>(v + tmp * len, v + a[j] * len, len)) {
+            if (NPY_CMP(v + tmp * len, v + a[j] * len, len)) {
                 a[i] = a[j];
                 i = j;
                 j += j;

--- a/numpy/_core/src/npysort/npysort_heapsort.hpp
+++ b/numpy/_core/src/npysort/npysort_heapsort.hpp
@@ -45,10 +45,10 @@ int heapsort_(type *start, npy_intp n)
     for (l = n >> 1; l > 0; --l) {
         tmp = a[l];
         for (i = l, j = l << 1; j <= n;) {
-            ret = npy::cmp<Tag, reverse>(a[j], a[j + 1]);
-            if (ret < 0) return ret;
-            if (j < n && ret) {
-                j += 1;
+            if (j < n) {
+                ret = npy::cmp<Tag, reverse>(a[j], a[j + 1]);
+                if (ret < 0) return ret;
+                if (ret) { j += 1; }
             }
 
             ret = npy::cmp<Tag, reverse>(tmp, a[j]);
@@ -70,10 +70,10 @@ int heapsort_(type *start, npy_intp n)
         a[n] = a[1];
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            ret = npy::cmp<Tag, reverse>(a[j], a[j + 1]);
-            if (ret < 0) return ret;
-            if (j < n && ret) {
-                j++;
+            if (j < n) {
+                ret = npy::cmp<Tag, reverse>(a[j], a[j + 1]);
+                if (ret < 0) return ret;
+                if (ret) { j++; }
             }
 
             ret = npy::cmp<Tag, reverse>(tmp, a[j]);
@@ -114,10 +114,10 @@ int aheapsort_(type *vv, npy_intp *tosort, npy_intp n)
     for (l = n >> 1; l > 0; --l) {
         tmp = a[l];
         for (i = l, j = l << 1; j <= n;) {
-            ret = npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]]);
-            if (ret < 0) return ret;
-            if (j < n && ret) {
-                j += 1;
+            if (j < n) {
+                ret = npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]]);
+                if (ret < 0) return ret;
+                if (ret) { j += 1; }
             }
 
             ret = npy::cmp<Tag, reverse>(v[tmp], v[a[j]]);
@@ -139,10 +139,10 @@ int aheapsort_(type *vv, npy_intp *tosort, npy_intp n)
         a[n] = a[1];
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            ret = npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]]);
-            if (ret < 0) return ret;
-            if (j < n && ret) {
-                j++;
+            if (j < n) {
+                ret = npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]]);
+                if (ret < 0) return ret;
+                if (ret) { j++; }
             }
 
             ret = npy::cmp<Tag, reverse>(v[tmp], v[a[j]]);

--- a/numpy/_core/src/npysort/npysort_heapsort.hpp
+++ b/numpy/_core/src/npysort/npysort_heapsort.hpp
@@ -44,10 +44,10 @@ int heapsort_(type *start, npy_intp n)
     for (l = n >> 1; l > 0; --l) {
         tmp = a[l];
         for (i = l, j = l << 1; j <= n;) {
-            if (j < n && NPY_CMP(a[j], a[j + 1])) {
+            if (j < n && npy::cmp<Tag, reverse>(a[j], a[j + 1])) {
                 j += 1;
             }
-            if (NPY_CMP(tmp, a[j])) {
+            if (npy::cmp<Tag, reverse>(tmp, a[j])) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -64,10 +64,10 @@ int heapsort_(type *start, npy_intp n)
         a[n] = a[1];
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            if (j < n && NPY_CMP(a[j], a[j + 1])) {
+            if (j < n && npy::cmp<Tag, reverse>(a[j], a[j + 1])) {
                 j++;
             }
-            if (NPY_CMP(tmp, a[j])) {
+            if (npy::cmp<Tag, reverse>(tmp, a[j])) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -102,10 +102,10 @@ int aheapsort_(type *vv, npy_intp *tosort, npy_intp n)
     for (l = n >> 1; l > 0; --l) {
         tmp = a[l];
         for (i = l, j = l << 1; j <= n;) {
-            if (j < n && NPY_CMP(v[a[j]], v[a[j + 1]])) {
+            if (j < n && npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]])) {
                 j += 1;
             }
-            if (NPY_CMP(v[tmp], v[a[j]])) {
+            if (npy::cmp<Tag, reverse>(v[tmp], v[a[j]])) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -122,10 +122,10 @@ int aheapsort_(type *vv, npy_intp *tosort, npy_intp n)
         a[n] = a[1];
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            if (j < n && NPY_CMP(v[a[j]], v[a[j + 1]])) {
+            if (j < n && npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]])) {
                 j++;
             }
-            if (NPY_CMP(v[tmp], v[a[j]])) {
+            if (npy::cmp<Tag, reverse>(v[tmp], v[a[j]])) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -175,9 +175,9 @@ int string_heapsort_(type *start, npy_intp n, int elsize)
     for (l = n >> 1; l > 0; --l) {
         Tag::copy(tmp, a + l * len, len);
         for (i = l, j = l << 1; j <= n;) {
-            if (j < n && NPY_CMP(a + j * len, a + (j + 1) * len, len))
+            if (j < n && npy::cmp<Tag, reverse>(a + j * len, a + (j + 1) * len, len))
                 j += 1;
-            if (NPY_CMP(tmp, a + j * len, len)) {
+            if (npy::cmp<Tag, reverse>(tmp, a + j * len, len)) {
                 Tag::copy(a + i * len, a + j * len, len);
                 i = j;
                 j += j;
@@ -194,9 +194,9 @@ int string_heapsort_(type *start, npy_intp n, int elsize)
         Tag::copy(a + n * len, a + len, len);
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            if (j < n && NPY_CMP(a + j * len, a + (j + 1) * len, len))
+            if (j < n && npy::cmp<Tag, reverse>(a + j * len, a + (j + 1) * len, len))
                 j++;
-            if (NPY_CMP(tmp, a + j * len, len)) {
+            if (npy::cmp<Tag, reverse>(tmp, a + j * len, len)) {
                 Tag::copy(a + i * len, a + j * len, len);
                 i = j;
                 j += j;
@@ -226,9 +226,9 @@ int string_aheapsort_(type *vv, npy_intp *tosort, npy_intp n, int elsize)
     for (l = n >> 1; l > 0; --l) {
         tmp = a[l];
         for (i = l, j = l << 1; j <= n;) {
-            if (j < n && NPY_CMP(v + a[j] * len, v + a[j + 1] * len, len))
+            if (j < n && npy::cmp<Tag, reverse>(v + a[j] * len, v + a[j + 1] * len, len))
                 j += 1;
-            if (NPY_CMP(v + tmp * len, v + a[j] * len, len)) {
+            if (npy::cmp<Tag, reverse>(v + tmp * len, v + a[j] * len, len)) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -245,9 +245,9 @@ int string_aheapsort_(type *vv, npy_intp *tosort, npy_intp n, int elsize)
         a[n] = a[1];
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            if (j < n && NPY_CMP(v + a[j] * len, v + a[j + 1] * len, len))
+            if (j < n && npy::cmp<Tag, reverse>(v + a[j] * len, v + a[j + 1] * len, len))
                 j++;
-            if (NPY_CMP(v + tmp * len, v + a[j] * len, len)) {
+            if (npy::cmp<Tag, reverse>(v + tmp * len, v + a[j] * len, len)) {
                 a[i] = a[j];
                 i = j;
                 j += j;

--- a/numpy/_core/src/npysort/npysort_heapsort.hpp
+++ b/numpy/_core/src/npysort/npysort_heapsort.hpp
@@ -37,6 +37,7 @@ int heapsort_(type *start, npy_intp n)
 {
     type tmp, *a;
     npy_intp i, j, l;
+    int ret;
 
     /* The array needs to be offset by one for heapsort indexing */
     a = start - 1;
@@ -44,10 +45,15 @@ int heapsort_(type *start, npy_intp n)
     for (l = n >> 1; l > 0; --l) {
         tmp = a[l];
         for (i = l, j = l << 1; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(a[j], a[j + 1])) {
+            ret = npy::cmp<Tag, reverse>(a[j], a[j + 1]);
+            if (ret < 0) return ret;
+            if (j < n && ret) {
                 j += 1;
             }
-            if (npy::cmp<Tag, reverse>(tmp, a[j])) {
+
+            ret = npy::cmp<Tag, reverse>(tmp, a[j]);
+            if (ret < 0) return ret;
+            if (ret) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -64,10 +70,15 @@ int heapsort_(type *start, npy_intp n)
         a[n] = a[1];
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(a[j], a[j + 1])) {
+            ret = npy::cmp<Tag, reverse>(a[j], a[j + 1]);
+            if (ret < 0) return ret;
+            if (j < n && ret) {
                 j++;
             }
-            if (npy::cmp<Tag, reverse>(tmp, a[j])) {
+
+            ret = npy::cmp<Tag, reverse>(tmp, a[j]);
+            if (ret < 0) return ret;
+            if (ret) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -96,16 +107,22 @@ int aheapsort_(type *vv, npy_intp *tosort, npy_intp n)
 {
     type *v = vv;
     npy_intp *a, i, j, l, tmp;
+    int ret;
     /* The arrays need to be offset by one for heapsort indexing */
     a = tosort - 1;
 
     for (l = n >> 1; l > 0; --l) {
         tmp = a[l];
         for (i = l, j = l << 1; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]])) {
+            ret = npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]]);
+            if (ret < 0) return ret;
+            if (j < n && ret) {
                 j += 1;
             }
-            if (npy::cmp<Tag, reverse>(v[tmp], v[a[j]])) {
+
+            ret = npy::cmp<Tag, reverse>(v[tmp], v[a[j]]);
+            if (ret < 0) return ret;
+            if (ret) {
                 a[i] = a[j];
                 i = j;
                 j += j;
@@ -122,10 +139,15 @@ int aheapsort_(type *vv, npy_intp *tosort, npy_intp n)
         a[n] = a[1];
         n -= 1;
         for (i = 1, j = 2; j <= n;) {
-            if (j < n && npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]])) {
+            ret = npy::cmp<Tag, reverse>(v[a[j]], v[a[j + 1]]);
+            if (ret < 0) return ret;
+            if (j < n && ret) {
                 j++;
             }
-            if (npy::cmp<Tag, reverse>(v[tmp], v[a[j]])) {
+
+            ret = npy::cmp<Tag, reverse>(v[tmp], v[a[j]]);
+            if (ret < 0) return ret;
+            if (ret) {
                 a[i] = a[j];
                 i = j;
                 j += j;

--- a/numpy/_core/src/npysort/npysort_methods.cpp
+++ b/numpy/_core/src/npysort/npysort_methods.cpp
@@ -227,6 +227,12 @@ make_sorts_(PyArray_DTypeMeta *dtypemeta, const char *name)
         NPY_DT_SLOTS(dtypemeta)->f.argsort[2] = atimsort_impl<Tag, type>;
     }
 
+    NPY_ARRAYMETHOD_FLAGS meth_flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
+    if constexpr (std::is_same_v<Tag, npy::object_tag>) {
+        // lock the GIL for object sorts
+        meth_flags = (NPY_ARRAYMETHOD_FLAGS)(meth_flags | NPY_METH_REQUIRES_PYAPI);
+    }
+
     std::string sort_name = std::string(name) + "_sort";
     PyArray_DTypeMeta *sort_dtypes[2] = {dtypemeta, dtypemeta};
     PyType_Slot sort_slots[3] = {
@@ -239,7 +245,7 @@ make_sorts_(PyArray_DTypeMeta *dtypemeta, const char *name)
             1,
             1,
             NPY_NO_CASTING,
-            NPY_METH_NO_FLOATINGPOINT_ERRORS,
+            meth_flags,
             sort_dtypes,
             sort_slots,
     };
@@ -263,7 +269,7 @@ make_sorts_(PyArray_DTypeMeta *dtypemeta, const char *name)
             1,
             1,
             NPY_NO_CASTING,
-            NPY_METH_NO_FLOATINGPOINT_ERRORS,
+            meth_flags,
             argsort_dtypes,
             argsort_slots,
     };
@@ -364,6 +370,7 @@ int register_all_sorts() {
     r += make_string_sorts_<npy::string_tag>(&PyArray_BytesDType, "string");
     r += make_string_sorts_<npy::unicode_tag>(&PyArray_UnicodeDType, "unicode");
     r += make_sorts_<npy::half_tag>(&PyArray_HalfDType, "half");
+    r += make_sorts_<npy::object_tag>(&PyArray_ObjectDType, "object");
 
     return r;
 }

--- a/numpy/_core/src/npysort/quicksort.hpp
+++ b/numpy/_core/src/npysort/quicksort.hpp
@@ -292,12 +292,22 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
             pj = pr - 1;
             std::swap(*pm, *pj);
             for (;;) {
-                do {
-                    ++pi;
-                } while (npy::cmp<Tag, reverse>(v[*pi], vp));
-                do {
-                    --pj;
-                } while (npy::cmp<Tag, reverse>(vp, v[*pj]));
+                if constexpr (std::is_same_v<Tag, npy::object_tag>) {
+                    do {
+                        ++pi;
+                    } while (pi < pj && npy::cmp<Tag, reverse>(v[*pi], vp));
+                    do {
+                        --pj;
+                    } while (pi < pj && npy::cmp<Tag, reverse>(vp, v[*pj]));
+                }
+                else {
+                    do {
+                        ++pi;
+                    } while (npy::cmp<Tag, reverse>(v[*pi], vp));
+                    do {
+                        --pj;
+                    } while (npy::cmp<Tag, reverse>(vp, v[*pj]));
+                }
                 if (pi >= pj) {
                     break;
                 }

--- a/numpy/_core/src/npysort/quicksort.hpp
+++ b/numpy/_core/src/npysort/quicksort.hpp
@@ -162,6 +162,7 @@ quicksort_(type *start, npy_intp num)
     int *psdepth = depth;
     int cdepth = npy_get_msb(num) * 2;
     int ret;
+    constexpr bool is_object = std::is_same_v<Tag, npy::object_tag>;
 
     for (;;) {
         if (NPY_UNLIKELY(cdepth < 0)) {
@@ -194,34 +195,18 @@ quicksort_(type *start, npy_intp num)
             pj = pr - 1;
             std::swap(*pm, *pj);
             for (;;) {
-                if constexpr (std::is_same_v<Tag, npy::object_tag>) {
-                    do {
-                        ++pi;
+                do {
+                    ++pi;
 
-                        ret = npy::cmp<Tag, reverse>(*pi, vp);
-                        if (ret < 0) return ret;
-                    } while (pi < pj && ret);
-                    do {
-                        --pj;
+                    ret = npy::cmp<Tag, reverse>(*pi, vp);
+                    if (ret < 0) return ret;
+                } while ((!is_object || pi < pj) && ret);
+                do {
+                    --pj;
 
-                        ret = npy::cmp<Tag, reverse>(vp, *pj);
-                        if (ret < 0) return ret;
-                    } while (pi < pj && ret);
-                }
-                else {
-                    do {
-                        ++pi;
-
-                        ret = npy::cmp<Tag, reverse>(*pi, vp);
-                        if (ret < 0) return ret;
-                    } while (ret);
-                    do {
-                        --pj;
-
-                        ret = npy::cmp<Tag, reverse>(vp, *pj);
-                        if (ret < 0) return ret;
-                    } while (ret);
-                }
+                    ret = npy::cmp<Tag, reverse>(vp, *pj);
+                    if (ret < 0) return ret;
+                } while ((!is_object || pi < pj) && ret);
                 if (pi >= pj) {
                     break;
                 }
@@ -300,6 +285,7 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
     int *psdepth = depth;
     int cdepth = npy_get_msb(num) * 2;
     int ret;
+    constexpr bool is_object = std::is_same_v<Tag, npy::object_tag>;
 
     for (;;) {
         if (NPY_UNLIKELY(cdepth < 0)) {
@@ -330,30 +316,16 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
             pj = pr - 1;
             std::swap(*pm, *pj);
             for (;;) {
-                if constexpr (std::is_same_v<Tag, npy::object_tag>) {
-                    do {
-                        ++pi;
-                        ret = npy::cmp<Tag, reverse>(v[*pi], vp);
-                        if (ret < 0) return ret;
-                    } while (pi < pj && ret);
-                    do {
-                        --pj;
-                        ret = npy::cmp<Tag, reverse>(vp, v[*pj]);
-                        if (ret < 0) return ret;
-                    } while (pi < pj && ret);
-                }
-                else {
-                    do {
-                        ++pi;
-                        ret = npy::cmp<Tag, reverse>(v[*pi], vp);
-                        if (ret < 0) return ret;
-                    } while (ret);
-                    do {
-                        --pj;
-                        ret = npy::cmp<Tag, reverse>(vp, v[*pj]);
-                        if (ret < 0) return ret;
-                    } while (pi < pj && ret);
-                }
+                do {
+                    ++pi;
+                    ret = npy::cmp<Tag, reverse>(v[*pi], vp);
+                    if (ret < 0) return ret;
+                } while ((!is_object || pi < pj) && ret);
+                do {
+                    --pj;
+                    ret = npy::cmp<Tag, reverse>(vp, v[*pj]);
+                    if (ret < 0) return ret;
+                } while ((!is_object || pi < pj) && ret);
                 if (pi >= pj) {
                     break;
                 }

--- a/numpy/_core/src/npysort/quicksort.hpp
+++ b/numpy/_core/src/npysort/quicksort.hpp
@@ -161,22 +161,32 @@ quicksort_(type *start, npy_intp num)
     int depth[PYA_QS_STACK];
     int *psdepth = depth;
     int cdepth = npy_get_msb(num) * 2;
+    int ret;
 
     for (;;) {
         if (NPY_UNLIKELY(cdepth < 0)) {
-            heapsort_<Tag, type, reverse>(pl, pr - pl + 1);
+            ret = heapsort_<Tag, type, reverse>(pl, pr - pl + 1);
+            if (NPY_UNLIKELY(ret < 0)) {
+                return ret;
+            }
             goto stack_pop;
         }
         while ((pr - pl) > SMALL_QUICKSORT) {
             /* quicksort partition */
             pm = pl + ((pr - pl) >> 1);
-            if (npy::cmp<Tag, reverse>(*pm, *pl)) {
+            ret = npy::cmp<Tag, reverse>(*pm, *pl);
+            if (ret < 0) return ret;
+            if (ret) {
                 std::swap(*pm, *pl);
             }
-            if (npy::cmp<Tag, reverse>(*pr, *pm)) {
+            ret = npy::cmp<Tag, reverse>(*pr, *pm);
+            if (ret < 0) return ret;
+            if (ret) {
                 std::swap(*pr, *pm);
             }
-            if (npy::cmp<Tag, reverse>(*pm, *pl)) {
+            ret = npy::cmp<Tag, reverse>(*pm, *pl);
+            if (ret < 0) return ret;
+            if (ret) {
                 std::swap(*pm, *pl);
             }
             vp = *pm;
@@ -187,18 +197,30 @@ quicksort_(type *start, npy_intp num)
                 if constexpr (std::is_same_v<Tag, npy::object_tag>) {
                     do {
                         ++pi;
-                    } while (pi < pj && npy::cmp<Tag, reverse>(*pi, vp));
+
+                        ret = npy::cmp<Tag, reverse>(*pi, vp);
+                        if (ret < 0) return ret;
+                    } while (pi < pj && ret);
                     do {
                         --pj;
-                    } while (pi < pj && npy::cmp<Tag, reverse>(vp, *pj));
+
+                        ret = npy::cmp<Tag, reverse>(vp, *pj);
+                        if (ret < 0) return ret;
+                    } while (pi < pj && ret);
                 }
                 else {
                     do {
                         ++pi;
-                    } while (npy::cmp<Tag, reverse>(*pi, vp));
+
+                        ret = npy::cmp<Tag, reverse>(*pi, vp);
+                        if (ret < 0) return ret;
+                    } while (ret);
                     do {
                         --pj;
-                    } while (npy::cmp<Tag, reverse>(vp, *pj));
+
+                        ret = npy::cmp<Tag, reverse>(vp, *pj);
+                        if (ret < 0) return ret;
+                    } while (ret);
                 }
                 if (pi >= pj) {
                     break;
@@ -226,8 +248,16 @@ quicksort_(type *start, npy_intp num)
             vp = *pi;
             pj = pi;
             pk = pi - 1;
-            while (pj > pl && npy::cmp<Tag, reverse>(vp, *pk)) {
+
+            ret = npy::cmp<Tag, reverse>(vp, *pk);
+            if (ret < 0) return ret;
+            while (pj > pl && ret) {
                 *pj-- = *pk--;
+
+                if (pj > pl) {
+                    ret = npy::cmp<Tag, reverse>(vp, *pk);
+                    if (ret < 0) return ret;
+                }
             }
             *pj = vp;
         }
@@ -269,22 +299,30 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
     int depth[PYA_QS_STACK];
     int *psdepth = depth;
     int cdepth = npy_get_msb(num) * 2;
+    int ret;
 
     for (;;) {
         if (NPY_UNLIKELY(cdepth < 0)) {
-            aheapsort_<Tag, type, reverse>(vv, pl, pr - pl + 1);
+            ret = aheapsort_<Tag, type, reverse>(vv, pl, pr - pl + 1);
+            if (ret < 0) return ret;
             goto stack_pop;
         }
         while ((pr - pl) > SMALL_QUICKSORT) {
             /* quicksort partition */
             pm = pl + ((pr - pl) >> 1);
-            if (npy::cmp<Tag, reverse>(v[*pm], v[*pl])) {
+            ret = npy::cmp<Tag, reverse>(v[*pm], v[*pl]);
+            if (ret < 0) return ret;
+            if (ret) {
                 std::swap(*pm, *pl);
             }
-            if (npy::cmp<Tag, reverse>(v[*pr], v[*pm])) {
+            ret = npy::cmp<Tag, reverse>(v[*pr], v[*pm]);
+            if (ret < 0) return ret;
+            if (ret) {
                 std::swap(*pr, *pm);
             }
-            if (npy::cmp<Tag, reverse>(v[*pm], v[*pl])) {
+            ret = npy::cmp<Tag, reverse>(v[*pm], v[*pl]);
+            if (ret < 0) return ret;
+            if (ret) {
                 std::swap(*pm, *pl);
             }
             vp = v[*pm];
@@ -295,18 +333,26 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
                 if constexpr (std::is_same_v<Tag, npy::object_tag>) {
                     do {
                         ++pi;
-                    } while (pi < pj && npy::cmp<Tag, reverse>(v[*pi], vp));
+                        ret = npy::cmp<Tag, reverse>(v[*pi], vp);
+                        if (ret < 0) return ret;
+                    } while (pi < pj && ret);
                     do {
                         --pj;
-                    } while (pi < pj && npy::cmp<Tag, reverse>(vp, v[*pj]));
+                        ret = npy::cmp<Tag, reverse>(vp, v[*pj]);
+                        if (ret < 0) return ret;
+                    } while (pi < pj && ret);
                 }
                 else {
                     do {
                         ++pi;
-                    } while (npy::cmp<Tag, reverse>(v[*pi], vp));
+                        ret = npy::cmp<Tag, reverse>(v[*pi], vp);
+                        if (ret < 0) return ret;
+                    } while (ret);
                     do {
                         --pj;
-                    } while (npy::cmp<Tag, reverse>(vp, v[*pj]));
+                        ret = npy::cmp<Tag, reverse>(vp, v[*pj]);
+                        if (ret < 0) return ret;
+                    } while (pi < pj && ret);
                 }
                 if (pi >= pj) {
                     break;
@@ -335,8 +381,16 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
             vp = v[vi];
             pj = pi;
             pk = pi - 1;
-            while (pj > pl && npy::cmp<Tag, reverse>(vp, v[*pk])) {
+
+            ret = npy::cmp<Tag, reverse>(vp, v[*pk]);
+            if (ret < 0) return ret;
+            while (pj > pl && ret) {
                 *pj-- = *pk--;
+
+                if (pj > pl) {
+                    ret = npy::cmp<Tag, reverse>(vp, v[*pk]);
+                if (ret < 0) return ret;
+                }
             }
             *pj = vi;
         }

--- a/numpy/_core/src/npysort/quicksort.hpp
+++ b/numpy/_core/src/npysort/quicksort.hpp
@@ -184,12 +184,22 @@ quicksort_(type *start, npy_intp num)
             pj = pr - 1;
             std::swap(*pm, *pj);
             for (;;) {
-                do {
-                    ++pi;
-                } while (npy::cmp<Tag, reverse>(*pi, vp));
-                do {
-                    --pj;
-                } while (npy::cmp<Tag, reverse>(vp, *pj));
+                if constexpr (std::is_same_v<Tag, npy::object_tag>) {
+                    do {
+                        ++pi;
+                    } while (pi < pj && npy::cmp<Tag, reverse>(*pi, vp));
+                    do {
+                        --pj;
+                    } while (pi < pj && npy::cmp<Tag, reverse>(vp, *pj));
+                }
+                else {
+                    do {
+                        ++pi;
+                    } while (npy::cmp<Tag, reverse>(*pi, vp));
+                    do {
+                        --pj;
+                    } while (npy::cmp<Tag, reverse>(vp, *pj));
+                }
                 if (pi >= pj) {
                     break;
                 }

--- a/numpy/_core/src/npysort/quicksort.hpp
+++ b/numpy/_core/src/npysort/quicksort.hpp
@@ -164,22 +164,19 @@ quicksort_(type *start, npy_intp num)
 
     for (;;) {
         if (NPY_UNLIKELY(cdepth < 0)) {
-            int ret = heapsort_<Tag, type, reverse>(pl, pr - pl + 1);
-            if (NPY_UNLIKELY(ret < 0)) {
-                return ret;
-            }
+            heapsort_<Tag, type, reverse>(pl, pr - pl + 1);
             goto stack_pop;
         }
         while ((pr - pl) > SMALL_QUICKSORT) {
             /* quicksort partition */
             pm = pl + ((pr - pl) >> 1);
-            if (NPY_CMP(*pm, *pl)) {
+            if (npy::cmp<Tag, reverse>(*pm, *pl)) {
                 std::swap(*pm, *pl);
             }
-            if (NPY_CMP(*pr, *pm)) {
+            if (npy::cmp<Tag, reverse>(*pr, *pm)) {
                 std::swap(*pr, *pm);
             }
-            if (NPY_CMP(*pm, *pl)) {
+            if (npy::cmp<Tag, reverse>(*pm, *pl)) {
                 std::swap(*pm, *pl);
             }
             vp = *pm;
@@ -190,18 +187,18 @@ quicksort_(type *start, npy_intp num)
                 if constexpr (std::is_same_v<Tag, npy::object_tag>) {
                     do {
                         ++pi;
-                    } while (pi < pj && NPY_CMP(*pi, vp));
+                    } while (pi < pj && npy::cmp<Tag, reverse>(*pi, vp));
                     do {
                         --pj;
-                    } while (pi < pj && NPY_CMP(vp, *pj));
+                    } while (pi < pj && npy::cmp<Tag, reverse>(vp, *pj));
                 }
                 else {
                     do {
                         ++pi;
-                    } while (NPY_CMP(*pi, vp));
+                    } while (npy::cmp<Tag, reverse>(*pi, vp));
                     do {
                         --pj;
-                    } while (NPY_CMP(vp, *pj));
+                    } while (npy::cmp<Tag, reverse>(vp, *pj));
                 }
                 if (pi >= pj) {
                     break;
@@ -229,7 +226,7 @@ quicksort_(type *start, npy_intp num)
             vp = *pi;
             pj = pi;
             pk = pi - 1;
-            while (pj > pl && NPY_CMP(vp, *pk)) {
+            while (pj > pl && npy::cmp<Tag, reverse>(vp, *pk)) {
                 *pj-- = *pk--;
             }
             *pj = vp;
@@ -275,22 +272,19 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
 
     for (;;) {
         if (NPY_UNLIKELY(cdepth < 0)) {
-            int ret = aheapsort_<Tag, type, reverse>(vv, pl, pr - pl + 1);
-            if (NPY_UNLIKELY(ret < 0)) {
-                return ret;
-            }
+            aheapsort_<Tag, type, reverse>(vv, pl, pr - pl + 1);
             goto stack_pop;
         }
         while ((pr - pl) > SMALL_QUICKSORT) {
             /* quicksort partition */
             pm = pl + ((pr - pl) >> 1);
-            if (NPY_CMP(v[*pm], v[*pl])) {
+            if (npy::cmp<Tag, reverse>(v[*pm], v[*pl])) {
                 std::swap(*pm, *pl);
             }
-            if (NPY_CMP(v[*pr], v[*pm])) {
+            if (npy::cmp<Tag, reverse>(v[*pr], v[*pm])) {
                 std::swap(*pr, *pm);
             }
-            if (NPY_CMP(v[*pm], v[*pl])) {
+            if (npy::cmp<Tag, reverse>(v[*pm], v[*pl])) {
                 std::swap(*pm, *pl);
             }
             vp = v[*pm];
@@ -301,18 +295,18 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
                 if constexpr (std::is_same_v<Tag, npy::object_tag>) {
                     do {
                         ++pi;
-                    } while (pi < pj && NPY_CMP(v[*pi], vp));
+                    } while (pi < pj && npy::cmp<Tag, reverse>(v[*pi], vp));
                     do {
                         --pj;
-                    } while (pi < pj && NPY_CMP(vp, v[*pj]));
+                    } while (pi < pj && npy::cmp<Tag, reverse>(vp, v[*pj]));
                 }
                 else {
                     do {
                         ++pi;
-                    } while (NPY_CMP(v[*pi], vp));
+                    } while (npy::cmp<Tag, reverse>(v[*pi], vp));
                     do {
                         --pj;
-                    } while (NPY_CMP(vp, v[*pj]));
+                    } while (npy::cmp<Tag, reverse>(vp, v[*pj]));
                 }
                 if (pi >= pj) {
                     break;
@@ -341,7 +335,7 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
             vp = v[vi];
             pj = pi;
             pk = pi - 1;
-            while (pj > pl && NPY_CMP(vp, v[*pk])) {
+            while (pj > pl && npy::cmp<Tag, reverse>(vp, v[*pk])) {
                 *pj-- = *pk--;
             }
             *pj = vi;
@@ -404,13 +398,13 @@ string_quicksort_(type *start, npy_intp num, int elsize)
         while ((size_t)(pr - pl) > SMALL_QUICKSORT * len) {
             /* quicksort partition */
             pm = pl + (((pr - pl) / len) >> 1) * len;
-            if (NPY_CMP(pm, pl, len)) {
+            if (npy::cmp<Tag, reverse>(pm, pl, len)) {
                 Tag::swap(pm, pl, len);
             }
-            if (NPY_CMP(pr, pm, len)) {
+            if (npy::cmp<Tag, reverse>(pr, pm, len)) {
                 Tag::swap(pr, pm, len);
             }
-            if (NPY_CMP(pm, pl, len)) {
+            if (npy::cmp<Tag, reverse>(pm, pl, len)) {
                 Tag::swap(pm, pl, len);
             }
             Tag::copy(vp, pm, len);
@@ -420,10 +414,10 @@ string_quicksort_(type *start, npy_intp num, int elsize)
             for (;;) {
                 do {
                     pi += len;
-                } while (NPY_CMP(pi, vp, len));
+                } while (npy::cmp<Tag, reverse>(pi, vp, len));
                 do {
                     pj -= len;
-                } while (NPY_CMP(vp, pj, len));
+                } while (npy::cmp<Tag, reverse>(vp, pj, len));
                 if (pi >= pj) {
                     break;
                 }
@@ -450,7 +444,7 @@ string_quicksort_(type *start, npy_intp num, int elsize)
             Tag::copy(vp, pi, len);
             pj = pi;
             pk = pi - len;
-            while (pj > pl && NPY_CMP(vp, pk, len)) {
+            while (pj > pl && npy::cmp<Tag, reverse>(vp, pk, len)) {
                 Tag::copy(pj, pk, len);
                 pj -= len;
                 pk -= len;
@@ -499,13 +493,13 @@ string_aquicksort_(type *vv, npy_intp *tosort, npy_intp num, int elsize)
         while ((pr - pl) > SMALL_QUICKSORT) {
             /* quicksort partition */
             pm = pl + ((pr - pl) >> 1);
-            if (NPY_CMP(v + (*pm) * len, v + (*pl) * len, len)) {
+            if (npy::cmp<Tag, reverse>(v + (*pm) * len, v + (*pl) * len, len)) {
                 std::swap(*pm, *pl);
             }
-            if (NPY_CMP(v + (*pr) * len, v + (*pm) * len, len)) {
+            if (npy::cmp<Tag, reverse>(v + (*pr) * len, v + (*pm) * len, len)) {
                 std::swap(*pr, *pm);
             }
-            if (NPY_CMP(v + (*pm) * len, v + (*pl) * len, len)) {
+            if (npy::cmp<Tag, reverse>(v + (*pm) * len, v + (*pl) * len, len)) {
                 std::swap(*pm, *pl);
             }
             vp = v + (*pm) * len;
@@ -515,10 +509,10 @@ string_aquicksort_(type *vv, npy_intp *tosort, npy_intp num, int elsize)
             for (;;) {
                 do {
                     ++pi;
-                } while (NPY_CMP(v + (*pi) * len, vp, len));
+                } while (npy::cmp<Tag, reverse>(v + (*pi) * len, vp, len));
                 do {
                     --pj;
-                } while (NPY_CMP(vp, v + (*pj) * len, len));
+                } while (npy::cmp<Tag, reverse>(vp, v + (*pj) * len, len));
                 if (pi >= pj) {
                     break;
                 }
@@ -546,7 +540,7 @@ string_aquicksort_(type *vv, npy_intp *tosort, npy_intp num, int elsize)
             vp = v + vi * len;
             pj = pi;
             pk = pi - 1;
-            while (pj > pl && NPY_CMP(vp, v + (*pk) * len, len)) {
+            while (pj > pl && npy::cmp<Tag, reverse>(vp, v + (*pk) * len, len)) {
                 *pj-- = *pk--;
             }
             *pj = vi;

--- a/numpy/_core/src/npysort/quicksort.hpp
+++ b/numpy/_core/src/npysort/quicksort.hpp
@@ -164,19 +164,22 @@ quicksort_(type *start, npy_intp num)
 
     for (;;) {
         if (NPY_UNLIKELY(cdepth < 0)) {
-            heapsort_<Tag, type, reverse>(pl, pr - pl + 1);
+            int ret = heapsort_<Tag, type, reverse>(pl, pr - pl + 1);
+            if (NPY_UNLIKELY(ret < 0)) {
+                return ret;
+            }
             goto stack_pop;
         }
         while ((pr - pl) > SMALL_QUICKSORT) {
             /* quicksort partition */
             pm = pl + ((pr - pl) >> 1);
-            if (npy::cmp<Tag, reverse>(*pm, *pl)) {
+            if (NPY_CMP(*pm, *pl)) {
                 std::swap(*pm, *pl);
             }
-            if (npy::cmp<Tag, reverse>(*pr, *pm)) {
+            if (NPY_CMP(*pr, *pm)) {
                 std::swap(*pr, *pm);
             }
-            if (npy::cmp<Tag, reverse>(*pm, *pl)) {
+            if (NPY_CMP(*pm, *pl)) {
                 std::swap(*pm, *pl);
             }
             vp = *pm;
@@ -187,18 +190,18 @@ quicksort_(type *start, npy_intp num)
                 if constexpr (std::is_same_v<Tag, npy::object_tag>) {
                     do {
                         ++pi;
-                    } while (pi < pj && npy::cmp<Tag, reverse>(*pi, vp));
+                    } while (pi < pj && NPY_CMP(*pi, vp));
                     do {
                         --pj;
-                    } while (pi < pj && npy::cmp<Tag, reverse>(vp, *pj));
+                    } while (pi < pj && NPY_CMP(vp, *pj));
                 }
                 else {
                     do {
                         ++pi;
-                    } while (npy::cmp<Tag, reverse>(*pi, vp));
+                    } while (NPY_CMP(*pi, vp));
                     do {
                         --pj;
-                    } while (npy::cmp<Tag, reverse>(vp, *pj));
+                    } while (NPY_CMP(vp, *pj));
                 }
                 if (pi >= pj) {
                     break;
@@ -226,7 +229,7 @@ quicksort_(type *start, npy_intp num)
             vp = *pi;
             pj = pi;
             pk = pi - 1;
-            while (pj > pl && npy::cmp<Tag, reverse>(vp, *pk)) {
+            while (pj > pl && NPY_CMP(vp, *pk)) {
                 *pj-- = *pk--;
             }
             *pj = vp;
@@ -272,19 +275,22 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
 
     for (;;) {
         if (NPY_UNLIKELY(cdepth < 0)) {
-            aheapsort_<Tag, type, reverse>(vv, pl, pr - pl + 1);
+            int ret = aheapsort_<Tag, type, reverse>(vv, pl, pr - pl + 1);
+            if (NPY_UNLIKELY(ret < 0)) {
+                return ret;
+            }
             goto stack_pop;
         }
         while ((pr - pl) > SMALL_QUICKSORT) {
             /* quicksort partition */
             pm = pl + ((pr - pl) >> 1);
-            if (npy::cmp<Tag, reverse>(v[*pm], v[*pl])) {
+            if (NPY_CMP(v[*pm], v[*pl])) {
                 std::swap(*pm, *pl);
             }
-            if (npy::cmp<Tag, reverse>(v[*pr], v[*pm])) {
+            if (NPY_CMP(v[*pr], v[*pm])) {
                 std::swap(*pr, *pm);
             }
-            if (npy::cmp<Tag, reverse>(v[*pm], v[*pl])) {
+            if (NPY_CMP(v[*pm], v[*pl])) {
                 std::swap(*pm, *pl);
             }
             vp = v[*pm];
@@ -295,18 +301,18 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
                 if constexpr (std::is_same_v<Tag, npy::object_tag>) {
                     do {
                         ++pi;
-                    } while (pi < pj && npy::cmp<Tag, reverse>(v[*pi], vp));
+                    } while (pi < pj && NPY_CMP(v[*pi], vp));
                     do {
                         --pj;
-                    } while (pi < pj && npy::cmp<Tag, reverse>(vp, v[*pj]));
+                    } while (pi < pj && NPY_CMP(vp, v[*pj]));
                 }
                 else {
                     do {
                         ++pi;
-                    } while (npy::cmp<Tag, reverse>(v[*pi], vp));
+                    } while (NPY_CMP(v[*pi], vp));
                     do {
                         --pj;
-                    } while (npy::cmp<Tag, reverse>(vp, v[*pj]));
+                    } while (NPY_CMP(vp, v[*pj]));
                 }
                 if (pi >= pj) {
                     break;
@@ -335,7 +341,7 @@ aquicksort_(type *vv, npy_intp *tosort, npy_intp num)
             vp = v[vi];
             pj = pi;
             pk = pi - 1;
-            while (pj > pl && npy::cmp<Tag, reverse>(vp, v[*pk])) {
+            while (pj > pl && NPY_CMP(vp, v[*pk])) {
                 *pj-- = *pk--;
             }
             *pj = vi;
@@ -398,13 +404,13 @@ string_quicksort_(type *start, npy_intp num, int elsize)
         while ((size_t)(pr - pl) > SMALL_QUICKSORT * len) {
             /* quicksort partition */
             pm = pl + (((pr - pl) / len) >> 1) * len;
-            if (npy::cmp<Tag, reverse>(pm, pl, len)) {
+            if (NPY_CMP(pm, pl, len)) {
                 Tag::swap(pm, pl, len);
             }
-            if (npy::cmp<Tag, reverse>(pr, pm, len)) {
+            if (NPY_CMP(pr, pm, len)) {
                 Tag::swap(pr, pm, len);
             }
-            if (npy::cmp<Tag, reverse>(pm, pl, len)) {
+            if (NPY_CMP(pm, pl, len)) {
                 Tag::swap(pm, pl, len);
             }
             Tag::copy(vp, pm, len);
@@ -414,10 +420,10 @@ string_quicksort_(type *start, npy_intp num, int elsize)
             for (;;) {
                 do {
                     pi += len;
-                } while (npy::cmp<Tag, reverse>(pi, vp, len));
+                } while (NPY_CMP(pi, vp, len));
                 do {
                     pj -= len;
-                } while (npy::cmp<Tag, reverse>(vp, pj, len));
+                } while (NPY_CMP(vp, pj, len));
                 if (pi >= pj) {
                     break;
                 }
@@ -444,7 +450,7 @@ string_quicksort_(type *start, npy_intp num, int elsize)
             Tag::copy(vp, pi, len);
             pj = pi;
             pk = pi - len;
-            while (pj > pl && npy::cmp<Tag, reverse>(vp, pk, len)) {
+            while (pj > pl && NPY_CMP(vp, pk, len)) {
                 Tag::copy(pj, pk, len);
                 pj -= len;
                 pk -= len;
@@ -493,13 +499,13 @@ string_aquicksort_(type *vv, npy_intp *tosort, npy_intp num, int elsize)
         while ((pr - pl) > SMALL_QUICKSORT) {
             /* quicksort partition */
             pm = pl + ((pr - pl) >> 1);
-            if (npy::cmp<Tag, reverse>(v + (*pm) * len, v + (*pl) * len, len)) {
+            if (NPY_CMP(v + (*pm) * len, v + (*pl) * len, len)) {
                 std::swap(*pm, *pl);
             }
-            if (npy::cmp<Tag, reverse>(v + (*pr) * len, v + (*pm) * len, len)) {
+            if (NPY_CMP(v + (*pr) * len, v + (*pm) * len, len)) {
                 std::swap(*pr, *pm);
             }
-            if (npy::cmp<Tag, reverse>(v + (*pm) * len, v + (*pl) * len, len)) {
+            if (NPY_CMP(v + (*pm) * len, v + (*pl) * len, len)) {
                 std::swap(*pm, *pl);
             }
             vp = v + (*pm) * len;
@@ -509,10 +515,10 @@ string_aquicksort_(type *vv, npy_intp *tosort, npy_intp num, int elsize)
             for (;;) {
                 do {
                     ++pi;
-                } while (npy::cmp<Tag, reverse>(v + (*pi) * len, vp, len));
+                } while (NPY_CMP(v + (*pi) * len, vp, len));
                 do {
                     --pj;
-                } while (npy::cmp<Tag, reverse>(vp, v + (*pj) * len, len));
+                } while (NPY_CMP(vp, v + (*pj) * len, len));
                 if (pi >= pj) {
                     break;
                 }
@@ -540,7 +546,7 @@ string_aquicksort_(type *vv, npy_intp *tosort, npy_intp num, int elsize)
             vp = v + vi * len;
             pj = pi;
             pk = pi - 1;
-            while (pj > pl && npy::cmp<Tag, reverse>(vp, v + (*pk) * len, len)) {
+            while (pj > pl && NPY_CMP(vp, v + (*pk) * len, len)) {
                 *pj-- = *pk--;
             }
             *pj = vi;

--- a/numpy/_core/src/npysort/timsort.hpp
+++ b/numpy/_core/src/npysort/timsort.hpp
@@ -122,14 +122,21 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun)
     pl = arr + l;
 
     /* (not strictly) ascending sequence */
-    if (!npy::cmp<Tag, reverse>(*(pl + 1), *pl)) {
-        for (pi = pl + 1; pi < arr + num - 1 && !npy::cmp<Tag, reverse>(*(pi + 1), *pi);
-             ++pi) {
+    int ret = npy::cmp<Tag, reverse>(*(pl + 1), *pl);
+    if (ret < 0) return ret;
+    
+    if (!ret) {
+        for (pi = pl + 1; pi < arr + num - 1; ++pi) {
+            ret = npy::cmp<Tag, reverse>(*(pi + 1), *pi);
+            if (ret < 0) return ret;
+            if (ret) break;
         }
     }
     else { /* (strictly) descending sequence */
-        for (pi = pl + 1; pi < arr + num - 1 && npy::cmp<Tag, reverse>(*(pi + 1), *pi);
-             ++pi) {
+        for (pi = pl + 1; pi < arr + num - 1; ++pi) {
+            ret = npy::cmp<Tag, reverse>(*(pi + 1), *pi);
+            if (ret < 0) return ret;
+            if (!ret) break;
         }
 
         for (pj = pl, pr = pi; pj < pr; ++pj, --pr) {
@@ -155,7 +162,11 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun)
             vc = *pi;
             pj = pi;
 
-            while (pl < pj && npy::cmp<Tag, reverse>(vc, *(pj - 1))) {
+            while (pl < pj) {
+                ret = npy::cmp<Tag, reverse>(vc, *(pj - 1));
+                if (ret < 0) return ret;
+                if (!ret) break;
+
                 *pj = *(pj - 1);
                 --pj;
             }
@@ -171,7 +182,7 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun)
  * and merge from left to right
  */
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 merge_left_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
 {
     type *end = p2 + l2;
@@ -179,8 +190,11 @@ merge_left_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
     /* first element must be in p2 otherwise skipped in the caller */
     *p1++ = *p2++;
 
+    int ret;
     while (p1 < p2 && p2 < end) {
-        if (npy::cmp<Tag, reverse>(*p2, *p3)) {
+        ret = npy::cmp<Tag, reverse>(*p2, *p3);
+        if (ret < 0) return ret;
+        if (ret) {
             *p1++ = *p2++;
         }
         else {
@@ -191,13 +205,15 @@ merge_left_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
     if (p1 != p2) {
         memcpy(p1, p3, sizeof(type) * (p2 - p1));
     }
+
+    return 0;
 }
 
 /* when the right part of the array (p2) is smaller, copy p2 to buffer
  * and merge from right to left
  */
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
 {
     npy_intp ofs;
@@ -209,8 +225,11 @@ merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
     /* first element must be in p1 otherwise skipped in the caller */
     *p2-- = *p1--;
 
+    int ret;
     while (p1 < p2 && start < p1) {
-        if (npy::cmp<Tag, reverse>(*p3, *p1)) {
+        ret = npy::cmp<Tag, reverse>(*p3, *p1);
+        if (ret < 0) return ret;
+        if (ret) {
             *p2-- = *p1--;
         }
         else {
@@ -222,6 +241,8 @@ merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
         ofs = p2 - start;
         memcpy(start + 1, p3 - ofs + 1, sizeof(type) * ofs);
     }
+
+    return 0;
 }
 
 /* Note: the naming convention of gallop functions are different from that of
@@ -235,9 +256,9 @@ gallop_right_(const type *arr, const npy_intp size, const type key)
 {
     npy_intp last_ofs, ofs, m;
 
-    if (npy::cmp<Tag, reverse>(key, arr[0])) {
-        return 0;
-    }
+    int ret = npy::cmp<Tag, reverse>(key, arr[0]);
+    if (ret < 0) return ret;
+    if (ret) return 0;
 
     last_ofs = 0;
     ofs = 1;
@@ -248,7 +269,9 @@ gallop_right_(const type *arr, const npy_intp size, const type key)
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(key, arr[ofs])) {
+        ret = npy::cmp<Tag, reverse>(key, arr[ofs]);
+        if (ret < 0) return ret;
+        if (ret) {
             break;
         }
         else {
@@ -262,7 +285,9 @@ gallop_right_(const type *arr, const npy_intp size, const type key)
     while (last_ofs + 1 < ofs) {
         m = last_ofs + ((ofs - last_ofs) >> 1);
 
-        if (npy::cmp<Tag, reverse>(key, arr[m])) {
+        ret = npy::cmp<Tag, reverse>(key, arr[m]);
+        if (ret < 0) return ret;
+        if (ret) {
             ofs = m;
         }
         else {
@@ -280,9 +305,9 @@ gallop_left_(const type *arr, const npy_intp size, const type key)
 {
     npy_intp last_ofs, ofs, l, m, r;
 
-    if (npy::cmp<Tag, reverse>(arr[size - 1], key)) {
-        return size;
-    }
+    int ret = npy::cmp<Tag, reverse>(arr[size - 1], key);
+    if (ret < 0) return ret;
+    if (ret) return size;
 
     last_ofs = 0;
     ofs = 1;
@@ -293,7 +318,9 @@ gallop_left_(const type *arr, const npy_intp size, const type key)
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(arr[size - ofs - 1], key)) {
+        int ret = npy::cmp<Tag, reverse>(arr[size - ofs - 1], key);
+        if (ret < 0) return ret;
+        if (ret) {
             break;
         }
         else {
@@ -309,7 +336,9 @@ gallop_left_(const type *arr, const npy_intp size, const type key)
     while (l + 1 < r) {
         m = l + ((r - l) >> 1);
 
-        if (npy::cmp<Tag, reverse>(arr[m], key)) {
+        int ret = npy::cmp<Tag, reverse>(arr[m], key);
+        if (ret < 0) return ret;
+        if (ret) {
             l = m;
         }
         else {
@@ -348,6 +377,7 @@ merge_at_(type *arr, const run *stack, const npy_intp at, buffer_<Tag> *buffer)
     p2 = arr + s2;
     /* arr[s2-1] belongs to arr[s2+l2] */
     l2 = gallop_left_<Tag, type, reverse>(arr + s2, l2, arr[s2 - 1]);
+    if (l2 < 0) return l2;
 
     if (l2 < l1) {
         ret = resize_buffer_<Tag>(buffer, l2);
@@ -356,7 +386,11 @@ merge_at_(type *arr, const run *stack, const npy_intp at, buffer_<Tag> *buffer)
             return ret;
         }
 
-        merge_right_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw);
+        ret = merge_right_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw);
+
+        if (NPY_UNLIKELY(ret < 0)) {
+            return ret;
+        }
     }
     else {
         ret = resize_buffer_<Tag>(buffer, l1);
@@ -365,7 +399,11 @@ merge_at_(type *arr, const run *stack, const npy_intp at, buffer_<Tag> *buffer)
             return ret;
         }
 
-        merge_left_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw);
+        ret = merge_left_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw);
+
+        if (NPY_UNLIKELY(ret < 0)) {
+            return ret;
+        }
     }
 
     return 0;
@@ -477,6 +515,9 @@ timsort_(void *start, npy_intp num)
 
     for (l = 0; l < num;) {
         n = count_run_<Tag, type, reverse>((type *)start, l, num, minrun);
+        if (NPY_UNLIKELY(n < 0))
+            goto cleanup;
+
         ret = found_new_run_<Tag, type, reverse>((type *)start, stack, &stack_ptr, n, num, &buffer);
         if (NPY_UNLIKELY(ret < 0))
             goto cleanup;
@@ -521,16 +562,20 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
     pl = tosort + l;
 
     /* (not strictly) ascending sequence */
-    if (!npy::cmp<Tag, reverse>(arr[*(pl + 1)], arr[*pl])) {
-        for (pi = pl + 1;
-             pi < tosort + num - 1 && !npy::cmp<Tag, reverse>(arr[*(pi + 1)], arr[*pi]);
-             ++pi) {
+    int ret = npy::cmp<Tag, reverse>(arr[*(pl + 1)], arr[*pl]);
+    if (ret < 0) return ret;
+    if (!ret) {
+        for (pi = pl + 1; pi < tosort + num - 1; ++pi) {
+            ret = npy::cmp<Tag, reverse>(arr[*(pi + 1)], arr[*pi]);
+            if (ret < 0) return ret;
+            if (ret) break;
         }
     }
     else { /* (strictly) descending sequence */
-        for (pi = pl + 1;
-             pi < tosort + num - 1 && npy::cmp<Tag, reverse>(arr[*(pi + 1)], arr[*pi]);
-             ++pi) {
+        for (pi = pl + 1; pi < tosort + num - 1; ++pi) {
+            ret = npy::cmp<Tag, reverse>(arr[*(pi + 1)], arr[*pi]);
+            if (ret < 0) return ret;
+            if (!ret) break;
         }
 
         for (pj = pl, pr = pi; pj < pr; ++pj, --pr) {
@@ -557,7 +602,11 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
             vc = arr[*pi];
             pj = pi;
 
-            while (pl < pj && npy::cmp<Tag, reverse>(vc, arr[*(pj - 1)])) {
+            while (pl < pj) {
+                ret = npy::cmp<Tag, reverse>(vc, arr[*(pj - 1)]);
+                if (ret < 0) return ret;
+                if (!ret) break;
+
                 *pj = *(pj - 1);
                 --pj;
             }
@@ -576,9 +625,9 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
 {
     npy_intp last_ofs, ofs, m;
 
-    if (npy::cmp<Tag, reverse>(key, arr[tosort[0]])) {
-        return 0;
-    }
+    int ret = npy::cmp<Tag, reverse>(key, arr[tosort[0]]);
+    if (ret < 0) return ret;
+    if (ret) return 0;
 
     last_ofs = 0;
     ofs = 1;
@@ -589,7 +638,9 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(key, arr[tosort[ofs]])) {
+        ret = npy::cmp<Tag, reverse>(key, arr[tosort[ofs]]);
+        if (ret < 0) return ret;
+        if (ret) {
             break;
         }
         else {
@@ -603,7 +654,9 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
     while (last_ofs + 1 < ofs) {
         m = last_ofs + ((ofs - last_ofs) >> 1);
 
-        if (npy::cmp<Tag, reverse>(key, arr[tosort[m]])) {
+        ret = npy::cmp<Tag, reverse>(key, arr[tosort[m]]);
+        if (ret < 0) return ret;
+        if (ret) {
             ofs = m;
         }
         else {
@@ -622,9 +675,9 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
 {
     npy_intp last_ofs, ofs, l, m, r;
 
-    if (npy::cmp<Tag, reverse>(arr[tosort[size - 1]], key)) {
-        return size;
-    }
+    int ret = npy::cmp<Tag, reverse>(arr[tosort[size - 1]], key);
+    if (ret < 0) return ret;
+    if (ret) return size;
 
     last_ofs = 0;
     ofs = 1;
@@ -635,7 +688,9 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(arr[tosort[size - ofs - 1]], key)) {
+        ret = npy::cmp<Tag, reverse>(arr[tosort[size - ofs - 1]], key);
+        if (ret < 0) return ret;
+        if (ret) {
             break;
         }
         else {
@@ -652,7 +707,9 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
     while (l + 1 < r) {
         m = l + ((r - l) >> 1);
 
-        if (npy::cmp<Tag, reverse>(arr[tosort[m]], key)) {
+        ret = npy::cmp<Tag, reverse>(arr[tosort[m]], key);
+        if (ret < 0) return ret;
+        if (ret) {
             l = m;
         }
         else {
@@ -665,7 +722,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
 }
 
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
              npy_intp *p3)
 {
@@ -674,8 +731,11 @@ amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     /* first element must be in p2 otherwise skipped in the caller */
     *p1++ = *p2++;
 
+    int ret;
     while (p1 < p2 && p2 < end) {
-        if (npy::cmp<Tag, reverse>(arr[*p2], arr[*p3])) {
+        ret = npy::cmp<Tag, reverse>(arr[*p2], arr[*p3]);
+        if (ret < 0) return ret;
+        if (ret) {
             *p1++ = *p2++;
         }
         else {
@@ -686,10 +746,12 @@ amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     if (p1 != p2) {
         memcpy(p1, p3, sizeof(npy_intp) * (p2 - p1));
     }
+
+    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
               npy_intp *p3)
 {
@@ -702,8 +764,11 @@ amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     /* first element must be in p1 otherwise skipped in the caller */
     *p2-- = *p1--;
 
+    int ret;
     while (p1 < p2 && start < p1) {
-        if (npy::cmp<Tag, reverse>(arr[*p3], arr[*p1])) {
+        ret = npy::cmp<Tag, reverse>(arr[*p3], arr[*p1]);
+        if (ret < 0) return ret;
+        if (ret) {
             *p2-- = *p1--;
         }
         else {
@@ -715,6 +780,8 @@ amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
         ofs = p2 - start;
         memcpy(start + 1, p3 - ofs + 1, sizeof(npy_intp) * ofs);
     }
+
+    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
@@ -731,6 +798,7 @@ amerge_at_(type *arr, npy_intp *tosort, const run *stack, const npy_intp at,
     l2 = stack[at + 1].l;
     /* tosort[s2] belongs to tosort[s1+k] */
     k = agallop_right_<Tag, type, reverse>(arr, tosort + s1, l1, arr[tosort[s2]]);
+    if (k < 0) return k;
 
     if (l1 == k) {
         /* already sorted */
@@ -742,24 +810,29 @@ amerge_at_(type *arr, npy_intp *tosort, const run *stack, const npy_intp at,
     p2 = tosort + s2;
     /* tosort[s2-1] belongs to tosort[s2+l2] */
     l2 = agallop_left_<Tag, type, reverse>(arr, tosort + s2, l2, arr[tosort[s2 - 1]]);
+    if (l2 < 0) return l2;
 
     if (l2 < l1) {
         ret = resize_buffer_intp(buffer, l2);
-
         if (NPY_UNLIKELY(ret < 0)) {
             return ret;
         }
 
-        amerge_right_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw);
+        ret = amerge_right_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw);
+        if (NPY_UNLIKELY(ret < 0)) {
+            return ret;
+        }
     }
     else {
         ret = resize_buffer_intp(buffer, l1);
-
         if (NPY_UNLIKELY(ret < 0)) {
             return ret;
         }
 
-        amerge_left_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw);
+        ret = amerge_left_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw);
+        if (NPY_UNLIKELY(ret < 0)) {
+            return ret;
+        }
     }
 
     return 0;
@@ -854,6 +927,9 @@ atimsort_(void *v, npy_intp *tosort, npy_intp num)
 
     for (l = 0; l < num;) {
         n = acount_run_<Tag, type, reverse>((type *)v, tosort, l, num, minrun);
+        if (NPY_UNLIKELY(n < 0)) {
+            goto cleanup;
+        }
         ret = afound_new_run_<Tag, type, reverse>((type*)v, tosort, stack, &stack_ptr, n, num, &buffer);
         if (NPY_UNLIKELY(ret < 0)) {
             goto cleanup;

--- a/numpy/_core/src/npysort/timsort.hpp
+++ b/numpy/_core/src/npysort/timsort.hpp
@@ -122,13 +122,13 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun)
     pl = arr + l;
 
     /* (not strictly) ascending sequence */
-    if (!NPY_CMP(*(pl + 1), *pl)) {
-        for (pi = pl + 1; pi < arr + num - 1 && !NPY_CMP(*(pi + 1), *pi);
+    if (!npy::cmp<Tag, reverse>(*(pl + 1), *pl)) {
+        for (pi = pl + 1; pi < arr + num - 1 && !npy::cmp<Tag, reverse>(*(pi + 1), *pi);
              ++pi) {
         }
     }
     else { /* (strictly) descending sequence */
-        for (pi = pl + 1; pi < arr + num - 1 && NPY_CMP(*(pi + 1), *pi);
+        for (pi = pl + 1; pi < arr + num - 1 && npy::cmp<Tag, reverse>(*(pi + 1), *pi);
              ++pi) {
         }
 
@@ -155,7 +155,7 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun)
             vc = *pi;
             pj = pi;
 
-            while (pl < pj && NPY_CMP(vc, *(pj - 1))) {
+            while (pl < pj && npy::cmp<Tag, reverse>(vc, *(pj - 1))) {
                 *pj = *(pj - 1);
                 --pj;
             }
@@ -171,7 +171,7 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun)
  * and merge from left to right
  */
 template <typename Tag, typename type, bool reverse>
-static int
+static void
 merge_left_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
 {
     type *end = p2 + l2;
@@ -180,7 +180,7 @@ merge_left_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
     *p1++ = *p2++;
 
     while (p1 < p2 && p2 < end) {
-        if (NPY_CMP(*p2, *p3)) {
+        if (npy::cmp<Tag, reverse>(*p2, *p3)) {
             *p1++ = *p2++;
         }
         else {
@@ -191,15 +191,13 @@ merge_left_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
     if (p1 != p2) {
         memcpy(p1, p3, sizeof(type) * (p2 - p1));
     }
-
-    return 0;
 }
 
 /* when the right part of the array (p2) is smaller, copy p2 to buffer
  * and merge from right to left
  */
 template <typename Tag, typename type, bool reverse>
-static int
+static void
 merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
 {
     npy_intp ofs;
@@ -212,7 +210,7 @@ merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
     *p2-- = *p1--;
 
     while (p1 < p2 && start < p1) {
-        if (NPY_CMP(*p3, *p1)) {
+        if (npy::cmp<Tag, reverse>(*p3, *p1)) {
             *p2-- = *p1--;
         }
         else {
@@ -224,8 +222,6 @@ merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
         ofs = p2 - start;
         memcpy(start + 1, p3 - ofs + 1, sizeof(type) * ofs);
     }
-
-    return 0;
 }
 
 /* Note: the naming convention of gallop functions are different from that of
@@ -239,7 +235,7 @@ gallop_right_(const type *arr, const npy_intp size, const type key)
 {
     npy_intp last_ofs, ofs, m;
 
-    if (NPY_CMP(key, arr[0])) {
+    if (npy::cmp<Tag, reverse>(key, arr[0])) {
         return 0;
     }
 
@@ -252,7 +248,7 @@ gallop_right_(const type *arr, const npy_intp size, const type key)
             break;
         }
 
-        if (NPY_CMP(key, arr[ofs])) {
+        if (npy::cmp<Tag, reverse>(key, arr[ofs])) {
             break;
         }
         else {
@@ -266,7 +262,7 @@ gallop_right_(const type *arr, const npy_intp size, const type key)
     while (last_ofs + 1 < ofs) {
         m = last_ofs + ((ofs - last_ofs) >> 1);
 
-        if (NPY_CMP(key, arr[m])) {
+        if (npy::cmp<Tag, reverse>(key, arr[m])) {
             ofs = m;
         }
         else {
@@ -284,7 +280,7 @@ gallop_left_(const type *arr, const npy_intp size, const type key)
 {
     npy_intp last_ofs, ofs, l, m, r;
 
-    if (NPY_CMP(arr[size - 1], key)) {
+    if (npy::cmp<Tag, reverse>(arr[size - 1], key)) {
         return size;
     }
 
@@ -297,7 +293,7 @@ gallop_left_(const type *arr, const npy_intp size, const type key)
             break;
         }
 
-        if (NPY_CMP(arr[size - ofs - 1], key)) {
+        if (npy::cmp<Tag, reverse>(arr[size - ofs - 1], key)) {
             break;
         }
         else {
@@ -313,7 +309,7 @@ gallop_left_(const type *arr, const npy_intp size, const type key)
     while (l + 1 < r) {
         m = l + ((r - l) >> 1);
 
-        if (NPY_CMP(arr[m], key)) {
+        if (npy::cmp<Tag, reverse>(arr[m], key)) {
             l = m;
         }
         else {
@@ -481,10 +477,6 @@ timsort_(void *start, npy_intp num)
 
     for (l = 0; l < num;) {
         n = count_run_<Tag, type, reverse>((type *)start, l, num, minrun);
-        if (NPY_UNLIKELY(n < 0)) {
-            ret = n;
-            goto cleanup;
-        }
         ret = found_new_run_<Tag, type, reverse>((type *)start, stack, &stack_ptr, n, num, &buffer);
         if (NPY_UNLIKELY(ret < 0))
             goto cleanup;
@@ -529,15 +521,15 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
     pl = tosort + l;
 
     /* (not strictly) ascending sequence */
-    if (!NPY_CMP(arr[*(pl + 1)], arr[*pl])) {
+    if (!npy::cmp<Tag, reverse>(arr[*(pl + 1)], arr[*pl])) {
         for (pi = pl + 1;
-             pi < tosort + num - 1 && !NPY_CMP(arr[*(pi + 1)], arr[*pi]);
+             pi < tosort + num - 1 && !npy::cmp<Tag, reverse>(arr[*(pi + 1)], arr[*pi]);
              ++pi) {
         }
     }
     else { /* (strictly) descending sequence */
         for (pi = pl + 1;
-             pi < tosort + num - 1 && NPY_CMP(arr[*(pi + 1)], arr[*pi]);
+             pi < tosort + num - 1 && npy::cmp<Tag, reverse>(arr[*(pi + 1)], arr[*pi]);
              ++pi) {
         }
 
@@ -565,7 +557,7 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
             vc = arr[*pi];
             pj = pi;
 
-            while (pl < pj && NPY_CMP(vc, arr[*(pj - 1)])) {
+            while (pl < pj && npy::cmp<Tag, reverse>(vc, arr[*(pj - 1)])) {
                 *pj = *(pj - 1);
                 --pj;
             }
@@ -584,7 +576,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
 {
     npy_intp last_ofs, ofs, m;
 
-    if (NPY_CMP(key, arr[tosort[0]])) {
+    if (npy::cmp<Tag, reverse>(key, arr[tosort[0]])) {
         return 0;
     }
 
@@ -597,7 +589,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
             break;
         }
 
-        if (NPY_CMP(key, arr[tosort[ofs]])) {
+        if (npy::cmp<Tag, reverse>(key, arr[tosort[ofs]])) {
             break;
         }
         else {
@@ -611,7 +603,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
     while (last_ofs + 1 < ofs) {
         m = last_ofs + ((ofs - last_ofs) >> 1);
 
-        if (NPY_CMP(key, arr[tosort[m]])) {
+        if (npy::cmp<Tag, reverse>(key, arr[tosort[m]])) {
             ofs = m;
         }
         else {
@@ -630,7 +622,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
 {
     npy_intp last_ofs, ofs, l, m, r;
 
-    if (NPY_CMP(arr[tosort[size - 1]], key)) {
+    if (npy::cmp<Tag, reverse>(arr[tosort[size - 1]], key)) {
         return size;
     }
 
@@ -643,7 +635,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
             break;
         }
 
-        if (NPY_CMP(arr[tosort[size - ofs - 1]], key)) {
+        if (npy::cmp<Tag, reverse>(arr[tosort[size - ofs - 1]], key)) {
             break;
         }
         else {
@@ -660,7 +652,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
     while (l + 1 < r) {
         m = l + ((r - l) >> 1);
 
-        if (NPY_CMP(arr[tosort[m]], key)) {
+        if (npy::cmp<Tag, reverse>(arr[tosort[m]], key)) {
             l = m;
         }
         else {
@@ -673,7 +665,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
 }
 
 template <typename Tag, typename type, bool reverse>
-static int
+static void
 amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
              npy_intp *p3)
 {
@@ -683,7 +675,7 @@ amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     *p1++ = *p2++;
 
     while (p1 < p2 && p2 < end) {
-        if (NPY_CMP(arr[*p2], arr[*p3])) {
+        if (npy::cmp<Tag, reverse>(arr[*p2], arr[*p3])) {
             *p1++ = *p2++;
         }
         else {
@@ -694,12 +686,10 @@ amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     if (p1 != p2) {
         memcpy(p1, p3, sizeof(npy_intp) * (p2 - p1));
     }
-
-    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
-static int
+static void
 amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
               npy_intp *p3)
 {
@@ -713,7 +703,7 @@ amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     *p2-- = *p1--;
 
     while (p1 < p2 && start < p1) {
-        if (NPY_CMP(arr[*p3], arr[*p1])) {
+        if (npy::cmp<Tag, reverse>(arr[*p3], arr[*p1])) {
             *p2-- = *p1--;
         }
         else {
@@ -725,8 +715,6 @@ amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
         ofs = p2 - start;
         memcpy(start + 1, p3 - ofs + 1, sizeof(npy_intp) * ofs);
     }
-
-    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
@@ -969,15 +957,15 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun, type *vp,
     pl = arr + l * len;
 
     /* (not strictly) ascending sequence */
-    if (!NPY_CMP(pl + len, pl, len)) {
+    if (!npy::cmp<Tag, reverse>(pl + len, pl, len)) {
         for (pi = pl + len;
-             pi < arr + (num - 1) * len && !NPY_CMP(pi + len, pi, len);
+             pi < arr + (num - 1) * len && !npy::cmp<Tag, reverse>(pi + len, pi, len);
              pi += len) {
         }
     }
     else { /* (strictly) descending sequence */
         for (pi = pl + len;
-             pi < arr + (num - 1) * len && NPY_CMP(pi + len, pi, len);
+             pi < arr + (num - 1) * len && npy::cmp<Tag, reverse>(pi + len, pi, len);
              pi += len) {
         }
 
@@ -1004,7 +992,7 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun, type *vp,
             Tag::copy(vp, pi, len);
             pj = pi;
 
-            while (pl < pj && NPY_CMP(vp, pj - len, len)) {
+            while (pl < pj && npy::cmp<Tag, reverse>(vp, pj - len, len)) {
                 Tag::copy(pj, pj - len, len);
                 pj -= len;
             }
@@ -1023,7 +1011,7 @@ gallop_right_(const typename Tag::type *arr, const npy_intp size,
 {
     npy_intp last_ofs, ofs, m;
 
-    if (NPY_CMP(key, arr, len)) {
+    if (npy::cmp<Tag, reverse>(key, arr, len)) {
         return 0;
     }
 
@@ -1036,7 +1024,7 @@ gallop_right_(const typename Tag::type *arr, const npy_intp size,
             break;
         }
 
-        if (NPY_CMP(key, arr + ofs * len, len)) {
+        if (npy::cmp<Tag, reverse>(key, arr + ofs * len, len)) {
             break;
         }
         else {
@@ -1050,7 +1038,7 @@ gallop_right_(const typename Tag::type *arr, const npy_intp size,
     while (last_ofs + 1 < ofs) {
         m = last_ofs + ((ofs - last_ofs) >> 1);
 
-        if (NPY_CMP(key, arr + m * len, len)) {
+        if (npy::cmp<Tag, reverse>(key, arr + m * len, len)) {
             ofs = m;
         }
         else {
@@ -1069,7 +1057,7 @@ gallop_left_(const typename Tag::type *arr, const npy_intp size,
 {
     npy_intp last_ofs, ofs, l, m, r;
 
-    if (NPY_CMP(arr + (size - 1) * len, key, len)) {
+    if (npy::cmp<Tag, reverse>(arr + (size - 1) * len, key, len)) {
         return size;
     }
 
@@ -1082,7 +1070,7 @@ gallop_left_(const typename Tag::type *arr, const npy_intp size,
             break;
         }
 
-        if (NPY_CMP(arr + (size - ofs - 1) * len, key, len)) {
+        if (npy::cmp<Tag, reverse>(arr + (size - ofs - 1) * len, key, len)) {
             break;
         }
         else {
@@ -1098,7 +1086,7 @@ gallop_left_(const typename Tag::type *arr, const npy_intp size,
     while (l + 1 < r) {
         m = l + ((r - l) >> 1);
 
-        if (NPY_CMP(arr + m * len, key, len)) {
+        if (npy::cmp<Tag, reverse>(arr + m * len, key, len)) {
             l = m;
         }
         else {
@@ -1111,11 +1099,10 @@ gallop_left_(const typename Tag::type *arr, const npy_intp size,
 }
 
 template <typename Tag, typename type, bool reverse>
-static int
+static void
 merge_left_(typename Tag::type *p1, npy_intp l1, typename Tag::type *p2,
             npy_intp l2, typename Tag::type *p3, size_t len)
-{
-    type *end = p2 + l2 * len;
+{    type *end = p2 + l2 * len;
     memcpy(p3, p1, sizeof(type) * l1 * len);
     /* first element must be in p2 otherwise skipped in the caller */
     Tag::copy(p1, p2, len);
@@ -1123,7 +1110,7 @@ merge_left_(typename Tag::type *p1, npy_intp l1, typename Tag::type *p2,
     p2 += len;
 
     while (p1 < p2 && p2 < end) {
-        if (NPY_CMP(p2, p3, len)) {
+        if (npy::cmp<Tag, reverse>(p2, p3, len)) {
             Tag::copy(p1, p2, len);
             p1 += len;
             p2 += len;
@@ -1138,12 +1125,10 @@ merge_left_(typename Tag::type *p1, npy_intp l1, typename Tag::type *p2,
     if (p1 != p2) {
         memcpy(p1, p3, sizeof(type) * (p2 - p1));
     }
-
-    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
-static int
+static void
 merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3,
              size_t len)
 {
@@ -1159,7 +1144,7 @@ merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3,
     p1 -= len;
 
     while (p1 < p2 && start < p1) {
-        if (NPY_CMP(p3, p1, len)) {
+        if (npy::cmp<Tag, reverse>(p3, p1, len)) {
             Tag::copy(p2, p1, len);
             p2 -= len;
             p1 -= len;
@@ -1175,8 +1160,6 @@ merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3,
         ofs = p2 - start;
         memcpy(start + len, p3 - ofs + len, sizeof(type) * ofs);
     }
-
-    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
@@ -1194,9 +1177,6 @@ merge_at_(type *arr, const run *stack, const npy_intp at,
     /* arr[s2] belongs to arr[s1+k] */
     Tag::copy(buffer->pw, arr + s2 * len, len);
     k = gallop_right_<Tag, type, reverse>(arr + s1 * len, l1, buffer->pw, len);
-    if (NPY_UNLIKELY(k < 0)) {
-        return k;
-    }
 
     if (l1 == k) {
         /* already sorted */
@@ -1209,31 +1189,24 @@ merge_at_(type *arr, const run *stack, const npy_intp at,
     /* arr[s2-1] belongs to arr[s2+l2] */
     Tag::copy(buffer->pw, arr + (s2 - 1) * len, len);
     l2 = gallop_left_<Tag, type, reverse>(arr + s2 * len, l2, buffer->pw, len);
-    if (NPY_UNLIKELY(l2 < 0)) {
-        return l2;
-    }
 
     if (l2 < l1) {
         ret = resize_buffer_<Tag>(buffer, l2);
+
         if (NPY_UNLIKELY(ret < 0)) {
             return ret;
         }
 
-        ret = merge_right_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw, len);
-        if (NPY_UNLIKELY(ret < 0)) {
-            return ret;
-        }
+        merge_right_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw, len);
     }
     else {
         ret = resize_buffer_<Tag>(buffer, l1);
+
         if (NPY_UNLIKELY(ret < 0)) {
             return ret;
         }
 
-        ret = merge_left_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw, len);
-        if (NPY_UNLIKELY(ret < 0)) {
-            return ret;
-        }
+        merge_left_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw, len);
     }
 
     return 0;
@@ -1416,17 +1389,17 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
     pl = tosort + l;
 
     /* (not strictly) ascending sequence */
-    if (!NPY_CMP(arr + (*(pl + 1)) * len, arr + (*pl) * len, len)) {
+    if (!npy::cmp<Tag, reverse>(arr + (*(pl + 1)) * len, arr + (*pl) * len, len)) {
         for (pi = pl + 1;
              pi < tosort + num - 1 &&
-             !NPY_CMP(arr + (*(pi + 1)) * len, arr + (*pi) * len, len);
+             !npy::cmp<Tag, reverse>(arr + (*(pi + 1)) * len, arr + (*pi) * len, len);
              ++pi) {
         }
     }
     else { /* (strictly) descending sequence */
         for (pi = pl + 1;
              pi < tosort + num - 1 &&
-             NPY_CMP(arr + (*(pi + 1)) * len, arr + (*pi) * len, len);
+             npy::cmp<Tag, reverse>(arr + (*(pi + 1)) * len, arr + (*pi) * len, len);
              ++pi) {
         }
 
@@ -1454,7 +1427,7 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
             pj = pi;
 
             while (pl < pj &&
-                   NPY_CMP(arr + vi * len, arr + (*(pj - 1)) * len, len)) {
+                   npy::cmp<Tag, reverse>(arr + vi * len, arr + (*(pj - 1)) * len, len)) {
                 *pj = *(pj - 1);
                 --pj;
             }
@@ -1473,7 +1446,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
 {
     npy_intp last_ofs, ofs, l, m, r;
 
-    if (NPY_CMP(arr + tosort[size - 1] * len, key, len)) {
+    if (npy::cmp<Tag, reverse>(arr + tosort[size - 1] * len, key, len)) {
         return size;
     }
 
@@ -1486,7 +1459,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
             break;
         }
 
-        if (NPY_CMP(arr + tosort[size - ofs - 1] * len, key, len)) {
+        if (npy::cmp<Tag, reverse>(arr + tosort[size - ofs - 1] * len, key, len)) {
             break;
         }
         else {
@@ -1503,7 +1476,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
     while (l + 1 < r) {
         m = l + ((r - l) >> 1);
 
-        if (NPY_CMP(arr + tosort[m] * len, key, len)) {
+        if (npy::cmp<Tag, reverse>(arr + tosort[m] * len, key, len)) {
             l = m;
         }
         else {
@@ -1522,7 +1495,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
 {
     npy_intp last_ofs, ofs, m;
 
-    if (NPY_CMP(key, arr + tosort[0] * len, len)) {
+    if (npy::cmp<Tag, reverse>(key, arr + tosort[0] * len, len)) {
         return 0;
     }
 
@@ -1535,7 +1508,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
             break;
         }
 
-        if (NPY_CMP(key, arr + tosort[ofs] * len, len)) {
+        if (npy::cmp<Tag, reverse>(key, arr + tosort[ofs] * len, len)) {
             break;
         }
         else {
@@ -1549,7 +1522,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
     while (last_ofs + 1 < ofs) {
         m = last_ofs + ((ofs - last_ofs) >> 1);
 
-        if (NPY_CMP(key, arr + tosort[m] * len, len)) {
+        if (npy::cmp<Tag, reverse>(key, arr + tosort[m] * len, len)) {
             ofs = m;
         }
         else {
@@ -1562,7 +1535,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
 }
 
 template <typename Tag, typename type, bool reverse>
-static int
+static void
 amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
              npy_intp *p3, size_t len)
 {
@@ -1572,7 +1545,7 @@ amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     *p1++ = *p2++;
 
     while (p1 < p2 && p2 < end) {
-        if (NPY_CMP(arr + (*p2) * len, arr + (*p3) * len, len)) {
+        if (npy::cmp<Tag, reverse>(arr + (*p2) * len, arr + (*p3) * len, len)) {
             *p1++ = *p2++;
         }
         else {
@@ -1583,12 +1556,10 @@ amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     if (p1 != p2) {
         memcpy(p1, p3, sizeof(npy_intp) * (p2 - p1));
     }
-
-    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
-static int
+static void
 amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
               npy_intp *p3, size_t len)
 {
@@ -1602,7 +1573,7 @@ amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     *p2-- = *p1--;
 
     while (p1 < p2 && start < p1) {
-        if (NPY_CMP(arr + (*p3) * len, arr + (*p1) * len, len)) {
+        if (npy::cmp<Tag, reverse>(arr + (*p3) * len, arr + (*p1) * len, len)) {
             *p2-- = *p1--;
         }
         else {
@@ -1614,8 +1585,6 @@ amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
         ofs = p2 - start;
         memcpy(start + 1, p3 - ofs + 1, sizeof(npy_intp) * ofs);
     }
-
-    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
@@ -1632,9 +1601,6 @@ amerge_at_(type *arr, npy_intp *tosort, const run *stack, const npy_intp at,
     l2 = stack[at + 1].l;
     /* tosort[s2] belongs to tosort[s1+k] */
     k = agallop_right_<Tag, type, reverse>(arr, tosort + s1, l1, arr + tosort[s2] * len, len);
-    if (NPY_UNLIKELY(k < 0)) {
-        return k;
-    }
 
     if (l1 == k) {
         /* already sorted */
@@ -1647,31 +1613,24 @@ amerge_at_(type *arr, npy_intp *tosort, const run *stack, const npy_intp at,
     /* tosort[s2-1] belongs to tosort[s2+l2] */
     l2 = agallop_left_<Tag, type, reverse>(arr, tosort + s2, l2, arr + tosort[s2 - 1] * len,
                             len);
-    if (NPY_UNLIKELY(l2 < 0)) {
-        return l2;
-    }
 
     if (l2 < l1) {
         ret = resize_buffer_intp(buffer, l2);
+
         if (NPY_UNLIKELY(ret < 0)) {
             return ret;
         }
 
-        ret = amerge_right_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw, len);
-        if (NPY_UNLIKELY(ret < 0)) {
-            return ret;
-        }
+        amerge_right_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw, len);
     }
     else {
         ret = resize_buffer_intp(buffer, l1);
+
         if (NPY_UNLIKELY(ret < 0)) {
             return ret;
         }
 
-        ret = amerge_left_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw, len);
-        if (NPY_UNLIKELY(ret < 0)) {
-            return ret;
-        }
+        amerge_left_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw, len);
     }
 
     return 0;

--- a/numpy/_core/src/npysort/timsort.hpp
+++ b/numpy/_core/src/npysort/timsort.hpp
@@ -122,13 +122,13 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun)
     pl = arr + l;
 
     /* (not strictly) ascending sequence */
-    if (!npy::cmp<Tag, reverse>(*(pl + 1), *pl)) {
-        for (pi = pl + 1; pi < arr + num - 1 && !npy::cmp<Tag, reverse>(*(pi + 1), *pi);
+    if (!NPY_CMP(*(pl + 1), *pl)) {
+        for (pi = pl + 1; pi < arr + num - 1 && !NPY_CMP(*(pi + 1), *pi);
              ++pi) {
         }
     }
     else { /* (strictly) descending sequence */
-        for (pi = pl + 1; pi < arr + num - 1 && npy::cmp<Tag, reverse>(*(pi + 1), *pi);
+        for (pi = pl + 1; pi < arr + num - 1 && NPY_CMP(*(pi + 1), *pi);
              ++pi) {
         }
 
@@ -155,7 +155,7 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun)
             vc = *pi;
             pj = pi;
 
-            while (pl < pj && npy::cmp<Tag, reverse>(vc, *(pj - 1))) {
+            while (pl < pj && NPY_CMP(vc, *(pj - 1))) {
                 *pj = *(pj - 1);
                 --pj;
             }
@@ -171,7 +171,7 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun)
  * and merge from left to right
  */
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 merge_left_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
 {
     type *end = p2 + l2;
@@ -180,7 +180,7 @@ merge_left_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
     *p1++ = *p2++;
 
     while (p1 < p2 && p2 < end) {
-        if (npy::cmp<Tag, reverse>(*p2, *p3)) {
+        if (NPY_CMP(*p2, *p3)) {
             *p1++ = *p2++;
         }
         else {
@@ -191,13 +191,15 @@ merge_left_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
     if (p1 != p2) {
         memcpy(p1, p3, sizeof(type) * (p2 - p1));
     }
+
+    return 0;
 }
 
 /* when the right part of the array (p2) is smaller, copy p2 to buffer
  * and merge from right to left
  */
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
 {
     npy_intp ofs;
@@ -210,7 +212,7 @@ merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
     *p2-- = *p1--;
 
     while (p1 < p2 && start < p1) {
-        if (npy::cmp<Tag, reverse>(*p3, *p1)) {
+        if (NPY_CMP(*p3, *p1)) {
             *p2-- = *p1--;
         }
         else {
@@ -222,6 +224,8 @@ merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3)
         ofs = p2 - start;
         memcpy(start + 1, p3 - ofs + 1, sizeof(type) * ofs);
     }
+
+    return 0;
 }
 
 /* Note: the naming convention of gallop functions are different from that of
@@ -235,7 +239,7 @@ gallop_right_(const type *arr, const npy_intp size, const type key)
 {
     npy_intp last_ofs, ofs, m;
 
-    if (npy::cmp<Tag, reverse>(key, arr[0])) {
+    if (NPY_CMP(key, arr[0])) {
         return 0;
     }
 
@@ -248,7 +252,7 @@ gallop_right_(const type *arr, const npy_intp size, const type key)
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(key, arr[ofs])) {
+        if (NPY_CMP(key, arr[ofs])) {
             break;
         }
         else {
@@ -262,7 +266,7 @@ gallop_right_(const type *arr, const npy_intp size, const type key)
     while (last_ofs + 1 < ofs) {
         m = last_ofs + ((ofs - last_ofs) >> 1);
 
-        if (npy::cmp<Tag, reverse>(key, arr[m])) {
+        if (NPY_CMP(key, arr[m])) {
             ofs = m;
         }
         else {
@@ -280,7 +284,7 @@ gallop_left_(const type *arr, const npy_intp size, const type key)
 {
     npy_intp last_ofs, ofs, l, m, r;
 
-    if (npy::cmp<Tag, reverse>(arr[size - 1], key)) {
+    if (NPY_CMP(arr[size - 1], key)) {
         return size;
     }
 
@@ -293,7 +297,7 @@ gallop_left_(const type *arr, const npy_intp size, const type key)
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(arr[size - ofs - 1], key)) {
+        if (NPY_CMP(arr[size - ofs - 1], key)) {
             break;
         }
         else {
@@ -309,7 +313,7 @@ gallop_left_(const type *arr, const npy_intp size, const type key)
     while (l + 1 < r) {
         m = l + ((r - l) >> 1);
 
-        if (npy::cmp<Tag, reverse>(arr[m], key)) {
+        if (NPY_CMP(arr[m], key)) {
             l = m;
         }
         else {
@@ -477,6 +481,10 @@ timsort_(void *start, npy_intp num)
 
     for (l = 0; l < num;) {
         n = count_run_<Tag, type, reverse>((type *)start, l, num, minrun);
+        if (NPY_UNLIKELY(n < 0)) {
+            ret = n;
+            goto cleanup;
+        }
         ret = found_new_run_<Tag, type, reverse>((type *)start, stack, &stack_ptr, n, num, &buffer);
         if (NPY_UNLIKELY(ret < 0))
             goto cleanup;
@@ -521,15 +529,15 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
     pl = tosort + l;
 
     /* (not strictly) ascending sequence */
-    if (!npy::cmp<Tag, reverse>(arr[*(pl + 1)], arr[*pl])) {
+    if (!NPY_CMP(arr[*(pl + 1)], arr[*pl])) {
         for (pi = pl + 1;
-             pi < tosort + num - 1 && !npy::cmp<Tag, reverse>(arr[*(pi + 1)], arr[*pi]);
+             pi < tosort + num - 1 && !NPY_CMP(arr[*(pi + 1)], arr[*pi]);
              ++pi) {
         }
     }
     else { /* (strictly) descending sequence */
         for (pi = pl + 1;
-             pi < tosort + num - 1 && npy::cmp<Tag, reverse>(arr[*(pi + 1)], arr[*pi]);
+             pi < tosort + num - 1 && NPY_CMP(arr[*(pi + 1)], arr[*pi]);
              ++pi) {
         }
 
@@ -557,7 +565,7 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
             vc = arr[*pi];
             pj = pi;
 
-            while (pl < pj && npy::cmp<Tag, reverse>(vc, arr[*(pj - 1)])) {
+            while (pl < pj && NPY_CMP(vc, arr[*(pj - 1)])) {
                 *pj = *(pj - 1);
                 --pj;
             }
@@ -576,7 +584,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
 {
     npy_intp last_ofs, ofs, m;
 
-    if (npy::cmp<Tag, reverse>(key, arr[tosort[0]])) {
+    if (NPY_CMP(key, arr[tosort[0]])) {
         return 0;
     }
 
@@ -589,7 +597,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(key, arr[tosort[ofs]])) {
+        if (NPY_CMP(key, arr[tosort[ofs]])) {
             break;
         }
         else {
@@ -603,7 +611,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
     while (last_ofs + 1 < ofs) {
         m = last_ofs + ((ofs - last_ofs) >> 1);
 
-        if (npy::cmp<Tag, reverse>(key, arr[tosort[m]])) {
+        if (NPY_CMP(key, arr[tosort[m]])) {
             ofs = m;
         }
         else {
@@ -622,7 +630,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
 {
     npy_intp last_ofs, ofs, l, m, r;
 
-    if (npy::cmp<Tag, reverse>(arr[tosort[size - 1]], key)) {
+    if (NPY_CMP(arr[tosort[size - 1]], key)) {
         return size;
     }
 
@@ -635,7 +643,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(arr[tosort[size - ofs - 1]], key)) {
+        if (NPY_CMP(arr[tosort[size - ofs - 1]], key)) {
             break;
         }
         else {
@@ -652,7 +660,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
     while (l + 1 < r) {
         m = l + ((r - l) >> 1);
 
-        if (npy::cmp<Tag, reverse>(arr[tosort[m]], key)) {
+        if (NPY_CMP(arr[tosort[m]], key)) {
             l = m;
         }
         else {
@@ -665,7 +673,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
 }
 
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
              npy_intp *p3)
 {
@@ -675,7 +683,7 @@ amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     *p1++ = *p2++;
 
     while (p1 < p2 && p2 < end) {
-        if (npy::cmp<Tag, reverse>(arr[*p2], arr[*p3])) {
+        if (NPY_CMP(arr[*p2], arr[*p3])) {
             *p1++ = *p2++;
         }
         else {
@@ -686,10 +694,12 @@ amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     if (p1 != p2) {
         memcpy(p1, p3, sizeof(npy_intp) * (p2 - p1));
     }
+
+    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
               npy_intp *p3)
 {
@@ -703,7 +713,7 @@ amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     *p2-- = *p1--;
 
     while (p1 < p2 && start < p1) {
-        if (npy::cmp<Tag, reverse>(arr[*p3], arr[*p1])) {
+        if (NPY_CMP(arr[*p3], arr[*p1])) {
             *p2-- = *p1--;
         }
         else {
@@ -715,6 +725,8 @@ amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
         ofs = p2 - start;
         memcpy(start + 1, p3 - ofs + 1, sizeof(npy_intp) * ofs);
     }
+
+    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
@@ -957,15 +969,15 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun, type *vp,
     pl = arr + l * len;
 
     /* (not strictly) ascending sequence */
-    if (!npy::cmp<Tag, reverse>(pl + len, pl, len)) {
+    if (!NPY_CMP(pl + len, pl, len)) {
         for (pi = pl + len;
-             pi < arr + (num - 1) * len && !npy::cmp<Tag, reverse>(pi + len, pi, len);
+             pi < arr + (num - 1) * len && !NPY_CMP(pi + len, pi, len);
              pi += len) {
         }
     }
     else { /* (strictly) descending sequence */
         for (pi = pl + len;
-             pi < arr + (num - 1) * len && npy::cmp<Tag, reverse>(pi + len, pi, len);
+             pi < arr + (num - 1) * len && NPY_CMP(pi + len, pi, len);
              pi += len) {
         }
 
@@ -992,7 +1004,7 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun, type *vp,
             Tag::copy(vp, pi, len);
             pj = pi;
 
-            while (pl < pj && npy::cmp<Tag, reverse>(vp, pj - len, len)) {
+            while (pl < pj && NPY_CMP(vp, pj - len, len)) {
                 Tag::copy(pj, pj - len, len);
                 pj -= len;
             }
@@ -1011,7 +1023,7 @@ gallop_right_(const typename Tag::type *arr, const npy_intp size,
 {
     npy_intp last_ofs, ofs, m;
 
-    if (npy::cmp<Tag, reverse>(key, arr, len)) {
+    if (NPY_CMP(key, arr, len)) {
         return 0;
     }
 
@@ -1024,7 +1036,7 @@ gallop_right_(const typename Tag::type *arr, const npy_intp size,
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(key, arr + ofs * len, len)) {
+        if (NPY_CMP(key, arr + ofs * len, len)) {
             break;
         }
         else {
@@ -1038,7 +1050,7 @@ gallop_right_(const typename Tag::type *arr, const npy_intp size,
     while (last_ofs + 1 < ofs) {
         m = last_ofs + ((ofs - last_ofs) >> 1);
 
-        if (npy::cmp<Tag, reverse>(key, arr + m * len, len)) {
+        if (NPY_CMP(key, arr + m * len, len)) {
             ofs = m;
         }
         else {
@@ -1057,7 +1069,7 @@ gallop_left_(const typename Tag::type *arr, const npy_intp size,
 {
     npy_intp last_ofs, ofs, l, m, r;
 
-    if (npy::cmp<Tag, reverse>(arr + (size - 1) * len, key, len)) {
+    if (NPY_CMP(arr + (size - 1) * len, key, len)) {
         return size;
     }
 
@@ -1070,7 +1082,7 @@ gallop_left_(const typename Tag::type *arr, const npy_intp size,
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(arr + (size - ofs - 1) * len, key, len)) {
+        if (NPY_CMP(arr + (size - ofs - 1) * len, key, len)) {
             break;
         }
         else {
@@ -1086,7 +1098,7 @@ gallop_left_(const typename Tag::type *arr, const npy_intp size,
     while (l + 1 < r) {
         m = l + ((r - l) >> 1);
 
-        if (npy::cmp<Tag, reverse>(arr + m * len, key, len)) {
+        if (NPY_CMP(arr + m * len, key, len)) {
             l = m;
         }
         else {
@@ -1099,10 +1111,11 @@ gallop_left_(const typename Tag::type *arr, const npy_intp size,
 }
 
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 merge_left_(typename Tag::type *p1, npy_intp l1, typename Tag::type *p2,
             npy_intp l2, typename Tag::type *p3, size_t len)
-{    type *end = p2 + l2 * len;
+{
+    type *end = p2 + l2 * len;
     memcpy(p3, p1, sizeof(type) * l1 * len);
     /* first element must be in p2 otherwise skipped in the caller */
     Tag::copy(p1, p2, len);
@@ -1110,7 +1123,7 @@ merge_left_(typename Tag::type *p1, npy_intp l1, typename Tag::type *p2,
     p2 += len;
 
     while (p1 < p2 && p2 < end) {
-        if (npy::cmp<Tag, reverse>(p2, p3, len)) {
+        if (NPY_CMP(p2, p3, len)) {
             Tag::copy(p1, p2, len);
             p1 += len;
             p2 += len;
@@ -1125,10 +1138,12 @@ merge_left_(typename Tag::type *p1, npy_intp l1, typename Tag::type *p2,
     if (p1 != p2) {
         memcpy(p1, p3, sizeof(type) * (p2 - p1));
     }
+
+    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3,
              size_t len)
 {
@@ -1144,7 +1159,7 @@ merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3,
     p1 -= len;
 
     while (p1 < p2 && start < p1) {
-        if (npy::cmp<Tag, reverse>(p3, p1, len)) {
+        if (NPY_CMP(p3, p1, len)) {
             Tag::copy(p2, p1, len);
             p2 -= len;
             p1 -= len;
@@ -1160,6 +1175,8 @@ merge_right_(type *p1, npy_intp l1, type *p2, npy_intp l2, type *p3,
         ofs = p2 - start;
         memcpy(start + len, p3 - ofs + len, sizeof(type) * ofs);
     }
+
+    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
@@ -1177,6 +1194,9 @@ merge_at_(type *arr, const run *stack, const npy_intp at,
     /* arr[s2] belongs to arr[s1+k] */
     Tag::copy(buffer->pw, arr + s2 * len, len);
     k = gallop_right_<Tag, type, reverse>(arr + s1 * len, l1, buffer->pw, len);
+    if (NPY_UNLIKELY(k < 0)) {
+        return k;
+    }
 
     if (l1 == k) {
         /* already sorted */
@@ -1189,24 +1209,31 @@ merge_at_(type *arr, const run *stack, const npy_intp at,
     /* arr[s2-1] belongs to arr[s2+l2] */
     Tag::copy(buffer->pw, arr + (s2 - 1) * len, len);
     l2 = gallop_left_<Tag, type, reverse>(arr + s2 * len, l2, buffer->pw, len);
+    if (NPY_UNLIKELY(l2 < 0)) {
+        return l2;
+    }
 
     if (l2 < l1) {
         ret = resize_buffer_<Tag>(buffer, l2);
-
         if (NPY_UNLIKELY(ret < 0)) {
             return ret;
         }
 
-        merge_right_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw, len);
+        ret = merge_right_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw, len);
+        if (NPY_UNLIKELY(ret < 0)) {
+            return ret;
+        }
     }
     else {
         ret = resize_buffer_<Tag>(buffer, l1);
-
         if (NPY_UNLIKELY(ret < 0)) {
             return ret;
         }
 
-        merge_left_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw, len);
+        ret = merge_left_<Tag, type, reverse>(p1, l1, p2, l2, buffer->pw, len);
+        if (NPY_UNLIKELY(ret < 0)) {
+            return ret;
+        }
     }
 
     return 0;
@@ -1389,17 +1416,17 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
     pl = tosort + l;
 
     /* (not strictly) ascending sequence */
-    if (!npy::cmp<Tag, reverse>(arr + (*(pl + 1)) * len, arr + (*pl) * len, len)) {
+    if (!NPY_CMP(arr + (*(pl + 1)) * len, arr + (*pl) * len, len)) {
         for (pi = pl + 1;
              pi < tosort + num - 1 &&
-             !npy::cmp<Tag, reverse>(arr + (*(pi + 1)) * len, arr + (*pi) * len, len);
+             !NPY_CMP(arr + (*(pi + 1)) * len, arr + (*pi) * len, len);
              ++pi) {
         }
     }
     else { /* (strictly) descending sequence */
         for (pi = pl + 1;
              pi < tosort + num - 1 &&
-             npy::cmp<Tag, reverse>(arr + (*(pi + 1)) * len, arr + (*pi) * len, len);
+             NPY_CMP(arr + (*(pi + 1)) * len, arr + (*pi) * len, len);
              ++pi) {
         }
 
@@ -1427,7 +1454,7 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
             pj = pi;
 
             while (pl < pj &&
-                   npy::cmp<Tag, reverse>(arr + vi * len, arr + (*(pj - 1)) * len, len)) {
+                   NPY_CMP(arr + vi * len, arr + (*(pj - 1)) * len, len)) {
                 *pj = *(pj - 1);
                 --pj;
             }
@@ -1446,7 +1473,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
 {
     npy_intp last_ofs, ofs, l, m, r;
 
-    if (npy::cmp<Tag, reverse>(arr + tosort[size - 1] * len, key, len)) {
+    if (NPY_CMP(arr + tosort[size - 1] * len, key, len)) {
         return size;
     }
 
@@ -1459,7 +1486,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(arr + tosort[size - ofs - 1] * len, key, len)) {
+        if (NPY_CMP(arr + tosort[size - ofs - 1] * len, key, len)) {
             break;
         }
         else {
@@ -1476,7 +1503,7 @@ agallop_left_(const type *arr, const npy_intp *tosort, const npy_intp size,
     while (l + 1 < r) {
         m = l + ((r - l) >> 1);
 
-        if (npy::cmp<Tag, reverse>(arr + tosort[m] * len, key, len)) {
+        if (NPY_CMP(arr + tosort[m] * len, key, len)) {
             l = m;
         }
         else {
@@ -1495,7 +1522,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
 {
     npy_intp last_ofs, ofs, m;
 
-    if (npy::cmp<Tag, reverse>(key, arr + tosort[0] * len, len)) {
+    if (NPY_CMP(key, arr + tosort[0] * len, len)) {
         return 0;
     }
 
@@ -1508,7 +1535,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
             break;
         }
 
-        if (npy::cmp<Tag, reverse>(key, arr + tosort[ofs] * len, len)) {
+        if (NPY_CMP(key, arr + tosort[ofs] * len, len)) {
             break;
         }
         else {
@@ -1522,7 +1549,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
     while (last_ofs + 1 < ofs) {
         m = last_ofs + ((ofs - last_ofs) >> 1);
 
-        if (npy::cmp<Tag, reverse>(key, arr + tosort[m] * len, len)) {
+        if (NPY_CMP(key, arr + tosort[m] * len, len)) {
             ofs = m;
         }
         else {
@@ -1535,7 +1562,7 @@ agallop_right_(const type *arr, const npy_intp *tosort, const npy_intp size,
 }
 
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
              npy_intp *p3, size_t len)
 {
@@ -1545,7 +1572,7 @@ amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     *p1++ = *p2++;
 
     while (p1 < p2 && p2 < end) {
-        if (npy::cmp<Tag, reverse>(arr + (*p2) * len, arr + (*p3) * len, len)) {
+        if (NPY_CMP(arr + (*p2) * len, arr + (*p3) * len, len)) {
             *p1++ = *p2++;
         }
         else {
@@ -1556,10 +1583,12 @@ amerge_left_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     if (p1 != p2) {
         memcpy(p1, p3, sizeof(npy_intp) * (p2 - p1));
     }
+
+    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
-static void
+static int
 amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
               npy_intp *p3, size_t len)
 {
@@ -1573,7 +1602,7 @@ amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
     *p2-- = *p1--;
 
     while (p1 < p2 && start < p1) {
-        if (npy::cmp<Tag, reverse>(arr + (*p3) * len, arr + (*p1) * len, len)) {
+        if (NPY_CMP(arr + (*p3) * len, arr + (*p1) * len, len)) {
             *p2-- = *p1--;
         }
         else {
@@ -1585,6 +1614,8 @@ amerge_right_(type *arr, npy_intp *p1, npy_intp l1, npy_intp *p2, npy_intp l2,
         ofs = p2 - start;
         memcpy(start + 1, p3 - ofs + 1, sizeof(npy_intp) * ofs);
     }
+
+    return 0;
 }
 
 template <typename Tag, typename type, bool reverse>
@@ -1601,6 +1632,9 @@ amerge_at_(type *arr, npy_intp *tosort, const run *stack, const npy_intp at,
     l2 = stack[at + 1].l;
     /* tosort[s2] belongs to tosort[s1+k] */
     k = agallop_right_<Tag, type, reverse>(arr, tosort + s1, l1, arr + tosort[s2] * len, len);
+    if (NPY_UNLIKELY(k < 0)) {
+        return k;
+    }
 
     if (l1 == k) {
         /* already sorted */
@@ -1613,24 +1647,31 @@ amerge_at_(type *arr, npy_intp *tosort, const run *stack, const npy_intp at,
     /* tosort[s2-1] belongs to tosort[s2+l2] */
     l2 = agallop_left_<Tag, type, reverse>(arr, tosort + s2, l2, arr + tosort[s2 - 1] * len,
                             len);
+    if (NPY_UNLIKELY(l2 < 0)) {
+        return l2;
+    }
 
     if (l2 < l1) {
         ret = resize_buffer_intp(buffer, l2);
-
         if (NPY_UNLIKELY(ret < 0)) {
             return ret;
         }
 
-        amerge_right_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw, len);
+        ret = amerge_right_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw, len);
+        if (NPY_UNLIKELY(ret < 0)) {
+            return ret;
+        }
     }
     else {
         ret = resize_buffer_intp(buffer, l1);
-
         if (NPY_UNLIKELY(ret < 0)) {
             return ret;
         }
 
-        amerge_left_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw, len);
+        ret = amerge_left_<Tag, type, reverse>(arr, p1, l1, p2, l2, buffer->pw, len);
+        if (NPY_UNLIKELY(ret < 0)) {
+            return ret;
+        }
     }
 
     return 0;

--- a/numpy/_core/src/npysort/timsort.hpp
+++ b/numpy/_core/src/npysort/timsort.hpp
@@ -122,14 +122,14 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun)
     pl = arr + l;
 
     /* (not strictly) ascending sequence */
-    int ret = npy::cmp<Tag, reverse>(*(pl + 1), *pl);
+    int ret = npy::cmp_eq<Tag, reverse>(*pl, *(pl + 1));
     if (ret < 0) return ret;
     
-    if (!ret) {
+    if (ret) {
         for (pi = pl + 1; pi < arr + num - 1; ++pi) {
-            ret = npy::cmp<Tag, reverse>(*(pi + 1), *pi);
+            ret = npy::cmp_eq<Tag, reverse>(*pi, *(pi + 1));
             if (ret < 0) return ret;
-            if (ret) break;
+            if (!ret) break;
         }
     }
     else { /* (strictly) descending sequence */
@@ -562,13 +562,13 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
     pl = tosort + l;
 
     /* (not strictly) ascending sequence */
-    int ret = npy::cmp<Tag, reverse>(arr[*(pl + 1)], arr[*pl]);
+    int ret = npy::cmp_eq<Tag, reverse>(arr[*pl], arr[*(pl + 1)]);
     if (ret < 0) return ret;
-    if (!ret) {
+    if (ret) {
         for (pi = pl + 1; pi < tosort + num - 1; ++pi) {
-            ret = npy::cmp<Tag, reverse>(arr[*(pi + 1)], arr[*pi]);
+            ret = npy::cmp_eq<Tag, reverse>(arr[*pi], arr[*(pi + 1)]);
             if (ret < 0) return ret;
-            if (ret) break;
+            if (!ret) break;
         }
     }
     else { /* (strictly) descending sequence */

--- a/numpy/_core/src/npysort/timsort.hpp
+++ b/numpy/_core/src/npysort/timsort.hpp
@@ -122,14 +122,14 @@ count_run_(type *arr, npy_intp l, npy_intp num, npy_intp minrun)
     pl = arr + l;
 
     /* (not strictly) ascending sequence */
-    int ret = npy::cmp_eq<Tag, reverse>(*pl, *(pl + 1));
+    int ret = npy::cmp<Tag, reverse>(*(pl + 1), *pl);
     if (ret < 0) return ret;
     
-    if (ret) {
+    if (!ret) {
         for (pi = pl + 1; pi < arr + num - 1; ++pi) {
-            ret = npy::cmp_eq<Tag, reverse>(*pi, *(pi + 1));
+            ret = npy::cmp<Tag, reverse>(*(pi + 1), *pi);
             if (ret < 0) return ret;
-            if (!ret) break;
+            if (ret) break;
         }
     }
     else { /* (strictly) descending sequence */
@@ -562,13 +562,13 @@ acount_run_(type *arr, npy_intp *tosort, npy_intp l, npy_intp num,
     pl = tosort + l;
 
     /* (not strictly) ascending sequence */
-    int ret = npy::cmp_eq<Tag, reverse>(arr[*pl], arr[*(pl + 1)]);
+    int ret = npy::cmp<Tag, reverse>(arr[*(pl + 1)], arr[*pl]);
     if (ret < 0) return ret;
-    if (ret) {
+    if (!ret) {
         for (pi = pl + 1; pi < tosort + num - 1; ++pi) {
-            ret = npy::cmp_eq<Tag, reverse>(arr[*pi], arr[*(pi + 1)]);
+            ret = npy::cmp<Tag, reverse>(arr[*(pi + 1)], arr[*pi]);
             if (ret < 0) return ret;
-            if (!ret) break;
+            if (ret) break;
         }
     }
     else { /* (strictly) descending sequence */

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2811,13 +2811,13 @@ class TestMethods:
         a[nanmask] = nan
 
         b = np.concatenate((a[~nanmask][::-1], a[nanmask]))
-        if np.issubdtype(a.dtype, np.object_):
-            # cast to float for comparison, as object np.nan != np.nan
-            a = a.astype(float)
-            b = b.astype(float)
 
         msg = f"sort, descending={descending}, stable={stable}"
         a_sorted = np.sort(a, stable=stable, descending=descending, axis=-1)
+        if np.issubdtype(a.dtype, np.object_):
+            # cast to float for comparison, as object np.nan != np.nan
+            a_sorted = a_sorted.astype(float)
+            b = b.astype(float)
         assert_equal(a_sorted, b, msg)
 
         # randomized input
@@ -2827,6 +2827,9 @@ class TestMethods:
 
         msg = f"sort, randomized, descending={descending}, stable={stable}"
         a_sorted = np.sort(a_randomized, stable=stable, descending=descending, axis=-1)
+        if np.issubdtype(a.dtype, np.object_):
+            a_sorted = a_sorted.astype(float)
+            
         assert_equal(a_sorted, b, msg)
 
     @pytest.mark.parametrize('dtype', [np.int8, np.int16, np.int32, np.int64])

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2861,6 +2861,7 @@ class TestMethods:
         self._test_sort_descending_nonan(a, stable, descending)
         self._test_sort_descending_nan(a, stable, descending)
 
+    @pytest.mark.parametrize("dtype", [np.complex64, np.complex128, np.clongdouble])
     @pytest.mark.parametrize("stable", [True, False])
     @pytest.mark.parametrize("descending", [True, False])
     @pytest.mark.parametrize("random_seed", [0, 1])
@@ -2915,6 +2916,8 @@ class TestMethods:
             f"descending={descending}",
         )
 
+    @pytest.mark.parametrize("stable", [True, False])
+    @pytest.mark.parametrize("descending", [True, False])
     def test_sort_descending_object(self, stable, descending):
         a = np.arange(101, dtype=float).astype(object)
         self._test_sort_descending_nonan(a, stable, descending)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2983,6 +2983,10 @@ class TestMethods:
 
         idx = np.argsort(a, stable=stable, descending=descending, axis=-1)
         sorted_a = a[idx]
+        if np.issubdtype(a.dtype, np.object_):
+            # cast to float for comparison, as object does not support isnan
+            sorted_a = sorted_a.astype(float)
+
         diff_sorted_a = np.diff(sorted_a[:-11])
         if descending:
             diff_sorted_a = -diff_sorted_a
@@ -3001,6 +3005,10 @@ class TestMethods:
 
         idx = np.argsort(a_randomized, stable=stable, descending=descending, axis=-1)
         sorted_a = a_randomized[idx]
+        if np.issubdtype(a.dtype, np.object_):
+            # cast to float for comparison, as object does not support isnan
+            sorted_a = sorted_a.astype(float)
+
         diff_sorted_a = np.diff(sorted_a[:-11])
         if descending:
             diff_sorted_a = -diff_sorted_a

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2455,6 +2455,9 @@ class TestMethods:
             def __lt__(self, other):
                 return True
 
+            def __le__(self, other):
+                return True
+
         a = np.array([Boom()] * 100, dtype=object)
         for kind in self.sort_kinds:
             msg = f"kind={kind}"

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2829,7 +2829,7 @@ class TestMethods:
         a_sorted = np.sort(a_randomized, stable=stable, descending=descending, axis=-1)
         if np.issubdtype(a.dtype, np.object_):
             a_sorted = a_sorted.astype(float)
-            
+
         assert_equal(a_sorted, b, msg)
 
     @pytest.mark.parametrize('dtype', [np.int8, np.int16, np.int32, np.int64])

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2802,10 +2802,19 @@ class TestMethods:
             nan = np.datetime64('NaT', 'D')
         elif np.issubdtype(a.dtype, np.timedelta64):
             nan = np.timedelta64('NaT', 'D')
-        a[::10] = nan
+        elif np.issubdtype(a.dtype, np.object_):
+            nan = np.nan
+        else:
+            raise ValueError(f"Unsupported dtype for nan testing: {a.dtype}")
 
-        b = a[::-1].copy()
-        b = np.concatenate((b[~np.isnan(b)], b[np.isnan(b)]))
+        nanmask = np.arange(a.size) % 10 == 0
+        a[nanmask] = nan
+
+        b = np.concatenate((a[~nanmask][::-1], a[nanmask]))
+        if np.issubdtype(a.dtype, np.object_):
+            # cast to float for comparison, as object np.nan != np.nan
+            a = a.astype(float)
+            b = b.astype(float)
 
         msg = f"sort, descending={descending}, stable={stable}"
         a_sorted = np.sort(a, stable=stable, descending=descending, axis=-1)
@@ -2852,7 +2861,6 @@ class TestMethods:
         self._test_sort_descending_nonan(a, stable, descending)
         self._test_sort_descending_nan(a, stable, descending)
 
-    @pytest.mark.parametrize("dtype", [np.complex64, np.complex128, np.clongdouble])
     @pytest.mark.parametrize("stable", [True, False])
     @pytest.mark.parametrize("descending", [True, False])
     @pytest.mark.parametrize("random_seed", [0, 1])
@@ -2907,10 +2915,15 @@ class TestMethods:
             f"descending={descending}",
         )
 
+    def test_sort_descending_object(self, stable, descending):
+        a = np.arange(101, dtype=float).astype(object)
+        self._test_sort_descending_nonan(a, stable, descending)
+        self._test_sort_descending_nan(a, stable, descending)
+
     @pytest.mark.parametrize('dtype', ['datetime64[D]', 'timedelta64[D]'])
     @pytest.mark.parametrize('stable', [True, False])
     @pytest.mark.parametrize('descending', [True, False])
-    def test_sort_descending_datetime(self, dtype, stable, descending):
+    def test_sort_descending_dates(self, dtype, stable, descending):
         a = np.arange(0, 101, dtype=dtype)
         self._test_sort_descending_nonan(a, stable, descending)
         self._test_sort_descending_nan(a, stable, descending)
@@ -2954,6 +2967,10 @@ class TestMethods:
             nan = np.datetime64("NaT", "D")
         elif np.issubdtype(a.dtype, np.timedelta64):
             nan = np.timedelta64("NaT", "D")
+        elif np.issubdtype(a.dtype, np.object_):
+            nan = np.nan
+        else:
+            raise ValueError(f"Unsupported dtype for nan testing: {a.dtype}")
         a[::10] = nan
 
         # comparing datetime types directly to numerical zero fails
@@ -3063,6 +3080,13 @@ class TestMethods:
     def test_argsort_descending_string(self, dtype, stable, descending):
         a = np.array([f"{i:03d}" for i in range(101)], dtype=dtype)
         self._test_argsort_descending_nonan(a, stable, descending)
+
+    @pytest.mark.parametrize("stable", [True, False])
+    @pytest.mark.parametrize("descending", [True, False])
+    def test_argsort_descending_object(self, stable, descending):
+        a = np.arange(101, dtype=float).astype(object)
+        self._test_argsort_descending_nonan(a, stable, descending)
+        self._test_argsort_descending_nan(a, stable, descending)
 
     @pytest.mark.parametrize('a', [
         np.array([0, 1, np.nan], dtype=np.float16),

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2455,9 +2455,6 @@ class TestMethods:
             def __lt__(self, other):
                 return True
 
-            def __le__(self, other):
-                return True
-
         a = np.array([Boom()] * 100, dtype=object)
         for kind in self.sort_kinds:
             msg = f"kind={kind}"


### PR DESCRIPTION
Addresses part of #31423. Adds sorting ArrayMethods for `object` that support `descending=True` and new NaN-handling logic using templating. Treats any object such that `obj != obj` as NaN and sorts those to the end. ping @seberg, thanks!

I had to include a sentinel guard for out-of-bounds partitioning in quicksort because object comparisons can be unsafe, hopefully the `constexpr` avoids any performance deficit (probably will). The docs are a bit drafty maybe but should be ready for initial review at least!

#### AI Disclosure
I used LLMs a fair bit for debugging code snippets (much of which went nowhere, but they caught the out-of-bounds issue :))