### PR TITLE
BUG: Fix np.abs(nan) returning negative NaN on wasm32/Pyodide

### DIFF
--- a/numpy/_core/src/umath/loops.c.src
+++ b/numpy/_core/src/umath/loops.c.src
@@ -1508,9 +1508,7 @@ LONGDOUBLE_absolute(char **args, npy_intp const *dimensions, npy_intp const *ste
 {
     UNARY_LOOP {
         const npy_longdouble in1 = *(npy_longdouble *)ip1;
-        const npy_longdouble tmp = in1 > 0 ? in1 : -in1;
-        /* add 0 to clear -0.0 */
-        *((npy_longdouble *)op1) = tmp + 0;
+        *((npy_longdouble *)op1) = npy_fabsl(in1);
     }
     npy_clear_floatstatus_barrier((char*)dimensions);
 }

--- a/numpy/_core/src/umath/loops_unary_fp.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_unary_fp.dispatch.c.src
@@ -17,9 +17,7 @@ NPY_FINLINE float c_recip_f32(float a)
 { return 1.0f / a; }
 NPY_FINLINE float c_abs_f32(float a)
 {
-    const float tmp = a > 0 ? a : -a;
-    /* add 0 to clear -0.0 */
-    return tmp + 0;
+    return npy_fabsf(a);
 }
 NPY_FINLINE float c_square_f32(float a)
 { return a * a; }
@@ -30,9 +28,7 @@ NPY_FINLINE double c_recip_f64(double a)
 { return 1.0 / a; }
 NPY_FINLINE double c_abs_f64(double a)
 {
-    const double tmp = a > 0 ? a : -a;
-    /* add 0 to clear -0.0 */
-    return tmp + 0;
+    return npy_fabs(a);
 }
 NPY_FINLINE double c_square_f64(double a)
 { return a * a; }

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4890,16 +4890,18 @@ def test_pos_nan():
     """Check np.nan is a positive nan."""
     assert_(np.signbit(np.nan) == 0)
 def test_abs_nan_signbit():
-    """#31421 abs(nan) preserves positive sign bit correctly for longdouble."""
-    pos_nan = np.longdouble(np.nan)
-    assert_(np.signbit(np.abs(pos_nan)) == 0,
-            "abs(+nan) should have positive sign for longdouble")
+    """#31421 abs(nan) preserves positive sign bit correctly."""
+    for dtype in [np.float32, np.float64, np.longdouble]:
+        pos_nan = dtype(np.nan)
+        assert_(np.signbit(np.abs(pos_nan)) == 0,
+                f"abs(+nan) should have positive sign for {dtype.__name__}")
 
-    neg_nan = np.longdouble(-np.nan)
-    assert_(np.signbit(np.abs(neg_nan)) == 0,
-            "abs(-nan) should have positive sign for longdouble")
+        neg_nan = dtype(-np.nan)
+        assert_(np.signbit(np.abs(neg_nan)) == 0,
+                f"abs(-nan) should have positive sign for {dtype.__name__}")
 
-    arr = np.array([np.nan, -np.nan], dtype=np.longdouble)
+    # Test with array
+    arr = np.array([np.nan, -np.nan])
     result = np.signbit(np.abs(arr))
     assert_array_equal(result, [False, False],
                       "abs of NaN array should have all positive signs")

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4889,6 +4889,21 @@ def test_nextafter_vs_spacing():
 def test_pos_nan():
     """Check np.nan is a positive nan."""
     assert_(np.signbit(np.nan) == 0)
+def test_abs_nan_signbit():
+    """#31421 abs(nan) preserves positive sign bit correctly."""
+    for dtype in [np.float16, np.float32, np.float64, np.longdouble]:
+        pos_nan = dtype(np.nan)
+        assert_(np.signbit(np.abs(pos_nan)) == 0,
+                f"abs(+nan) should have positive sign for {dtype.__name__}")
+
+        neg_nan = dtype(-np.nan)
+        assert_(np.signbit(np.abs(neg_nan)) == 0,
+                f"abs(-nan) should have positive sign for {dtype.__name__}")
+    arr = np.array([np.nan, -np.nan])
+    result = np.signbit(np.abs(arr))
+    assert_array_equal(result, [False, False],
+                      "abs of NaN array should have all positive signs")
+
 
 def test_reduceat():
     """Test bug in reduceat when structured arrays are not copied."""

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4890,16 +4890,16 @@ def test_pos_nan():
     """Check np.nan is a positive nan."""
     assert_(np.signbit(np.nan) == 0)
 def test_abs_nan_signbit():
-    """#31421 abs(nan) preserves positive sign bit correctly."""
-    for dtype in [np.float16, np.float32, np.float64, np.longdouble]:
-        pos_nan = dtype(np.nan)
-        assert_(np.signbit(np.abs(pos_nan)) == 0,
-                f"abs(+nan) should have positive sign for {dtype.__name__}")
+    """#31421 abs(nan) preserves positive sign bit correctly for longdouble."""
+    pos_nan = np.longdouble(np.nan)
+    assert_(np.signbit(np.abs(pos_nan)) == 0,
+            "abs(+nan) should have positive sign for longdouble")
 
-        neg_nan = dtype(-np.nan)
-        assert_(np.signbit(np.abs(neg_nan)) == 0,
-                f"abs(-nan) should have positive sign for {dtype.__name__}")
-    arr = np.array([np.nan, -np.nan])
+    neg_nan = np.longdouble(-np.nan)
+    assert_(np.signbit(np.abs(neg_nan)) == 0,
+            "abs(-nan) should have positive sign for longdouble")
+
+    arr = np.array([np.nan, -np.nan], dtype=np.longdouble)
     result = np.signbit(np.abs(arr))
     assert_array_equal(result, [False, False],
                       "abs of NaN array should have all positive signs")

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4889,18 +4889,21 @@ def test_nextafter_vs_spacing():
 def test_pos_nan():
     """Check np.nan is a positive nan."""
     assert_(np.signbit(np.nan) == 0)
-def test_abs_nan_signbit():
+
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64, np.longdouble])
+def test_abs_nan_signbit(dtype):
     """#31421 abs(nan) preserves positive sign bit correctly."""
-    for dtype in [np.float16, np.float32, np.float64, np.longdouble]:
-        pos_nan = dtype(np.nan)
-        assert_(np.signbit(np.abs(pos_nan)) == 0,
-                f"abs(+nan) should have positive sign for {dtype.__name__}")
+    pos_nan = dtype(np.nan)
+    assert not np.signbit(np.abs(pos_nan)), \
+        f"abs(+nan) should have positive sign for {dtype.__name__}"
 
-        neg_nan = dtype(-np.nan)
-        assert_(np.signbit(np.abs(neg_nan)) == 0,
-                f"abs(-nan) should have positive sign for {dtype.__name__}")
+    neg_nan = dtype(-np.nan)
+    assert not np.signbit(np.abs(neg_nan)), \
+        f"abs(-nan) should have positive sign for {dtype.__name__}"
 
-    # Test with array
+
+def test_abs_nan_signbit_array():
+    """#31421 abs(nan) array preserves positive sign bit correctly."""
     arr = np.array([np.nan, -np.nan])
     result = np.signbit(np.abs(arr))
     assert_array_equal(result, [False, False],

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4891,7 +4891,7 @@ def test_pos_nan():
     assert_(np.signbit(np.nan) == 0)
 def test_abs_nan_signbit():
     """#31421 abs(nan) preserves positive sign bit correctly."""
-    for dtype in [np.float32, np.float64, np.longdouble]:
+    for dtype in [np.float16, np.float32, np.float64, np.longdouble]:
         pos_nan = dtype(np.nan)
         assert_(np.signbit(np.abs(pos_nan)) == 0,
                 f"abs(+nan) should have positive sign for {dtype.__name__}")


### PR DESCRIPTION
Fix: #31421


### PR summary
This PR fixes a bug where np.signbit(np.abs(np.nan)) incorrectly returns True instead of False.

 ### problem 
 
 The `LONGDOUBLE_absolute` function in `numpy/_core/src/umath/loops.c.src` used `tmp + 0 to clear -0.0,` but this operation corrupted the sign bit of `NaN` values, causing np.signbit(np.abs(np.nan)) to return True.

### Testing 

Manually run the new test case and run all the `numpy/_core/tests/test_umath.py ` file test cases.