### PR TITLE
BUG:  `dtype.metadata` lost for zero-sized void dtypes in array creation functions

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1420,6 +1420,16 @@ descr_is_legacy_parametric_instance(PyArray_Descr *descr,
         return 0;
     }
 
+    /*
+     * A descriptor with user-attached metadata is not a bare prototype:
+     * the metadata is explicit state that must round-trip through array
+     * creation, so keep it rather than collapsing to the DType singleton
+     * (gh-31436).
+     */
+    if (((_PyArray_LegacyDescr *)descr)->metadata != NULL) {
+        return 0;
+    }
+
     if (PyDataType_ISUNSIZED(descr)) {
         return 1;
     }

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -927,6 +927,20 @@ class TestMetadata:
         d = np.dtype((np.void, np.dtype('i4,i4', metadata={'datum': 1})))
         assert_(d.metadata == {'datum': 1})
 
+    def test_metadata_preserved_zero_sized_void(self):
+        # gh-31436: array creation functions dropped metadata for unsized
+        # legacy dtypes (notably zero-sized void) because the descriptor was
+        # treated as a bare prototype and rebuilt from the DType singleton.
+        dt = np.dtype('V0', metadata={'type': 'struct_marker'})
+        assert dt.metadata == {'type': 'struct_marker'}
+        for arr in (np.zeros(5, dtype=dt),
+                    np.empty(5, dtype=dt),
+                    np.ones(5, dtype=dt),
+                    np.full(5, b'', dtype=dt)):
+            assert arr.dtype == dt
+            assert arr.dtype.metadata == {'type': 'struct_marker'}
+
+
 class TestString:
     def test_complex_dtype_str(self):
         dt = np.dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)),


### PR DESCRIPTION
### PR summary

`descr_is_legacy_parametric_instance` in `numpy/_core/src/multiarray/descriptor.c` treated any unsized legacy dtype (e.g. `|V0`) as a bare prototype, so `PyArray_ExtractDTypeAndDescriptor` dropped the caller's descriptor and `PyArray_Zeros_int` / `PyArray_Empty_int` rebuilt one from the DType singleton, discarding the original `metadata` dict. The fix treats a descriptor with a non-null `metadata` field as already-concrete, so the user-supplied descriptor (and its metadata) survives `np.zeros`, `np.empty`, `np.ones`, and `np.full`.

### First time committer introduction

Long-time NumPy user interested in the dtype system; happy to contribute a small fix to descriptor handling.

#### AI Disclosure

Used Claude to draft the patch and the regression test. All changes reviewed by hand before commit.

Closes #31436