### PR TITLE
DOC: Update reshape docstring to clarify it returns a new array

### DIFF
--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -406,7 +406,7 @@ Can you reshape an array?
 
 **Yes!**
 
-Using ``arr.reshape()`` will give a new shape to an array without changing the
+Using ``arr.reshape()`` will return a reshaped array without changing the
 data. Just remember that when you use the reshape method, the array you want to
 produce needs to have the same number of elements as the original array. If you
 start with an array with 12 elements, you'll need to make sure that your new

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -4749,7 +4749,7 @@ _array_method_doc('transpose', "*axes",
     --------
     transpose : Equivalent function.
     ndarray.T : Array property returning the array transposed.
-    ndarray.reshape : Give a new shape to an array without changing its data.
+    ndarray.reshape : Return a reshaped ndarray without changing data.
 
     Examples
     --------

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -207,7 +207,7 @@ def _reshape_dispatcher(a, /, shape, order=None, *, copy=None):
 @array_function_dispatch(_reshape_dispatcher)
 def reshape(a, /, shape, order='C', *, copy=None):
     """
-    Gives a new shape to an array without changing its data.
+    Returns a reshaped ndarray without changing data.
 
     Parameters
     ----------

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -4751,7 +4751,7 @@ class MaskedArray(ndarray):
 
     def reshape(self, *s, **kwargs):
         """
-        Give a new shape to the array without changing its data.
+        Returns a reshaped masked array without changing its data.
 
         Returns a masked array containing the same data, but with a new shape.
         The result is a view on the original array; if this is not possible, a


### PR DESCRIPTION
### PR summary

This PR updates the docstrings and documentation for `reshape` to clarify that it returns a reshaped array, preventing confusion about whether it modifies the array in-place.
It changes the summary from "Gives a new shape to an array without changing its data." to "Returns a reshaped ndarray without changing data."

### First time committer introduction
Hi, I'm Shubham! I use NumPy regularly for data tasks and wanted to contribute by clarifying this documentation detail that previously confused me.

#### AI Disclosure
I used an AI coding assistant (Gemini and Claude sonnet ) to help me. The actual documentation suggestion was my own idea.
