### PR TITLE
REL: Prepare for the NumPy 2.4.5 release.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -80,6 +80,7 @@ Abraham Medina <abhram_medina@yahoo.com>
 Adrin Jalali <adrin.jalali@gmail.com>
 Akhil Kannan <akhilkannan10a@gmail.com>
 Akhil Kannan <akhilkannan10a@gmail.com> <143798318+Alverok@users.noreply.github.com>
+Anarion Zuo <anarionzuo@outlook.com>
 Arun Kota <arunkumarkota@gmail.com>
 Arun Kota <arunkumarkota@gmail.com> Arun Kota <arunkota@Aruns-iMac.local>
 Aarthi Agurusa <agurusa@gmail.com>

--- a/doc/changelog/2.4.5-changelog.rst
+++ b/doc/changelog/2.4.5-changelog.rst
@@ -1,14 +1,3 @@
-.. currentmodule:: numpy
-
-=========================
-NumPy 2.4.5 Release Notes
-=========================
-
-The NumPy 2.4.5 is a patch release that fixes bugs discovered after the 2.4.4
-release, has some typing improvements, and maintains infrastructure.
-
-This release supports Python versions 3.11-3.14
-
 
 Contributors
 ============
@@ -17,7 +6,6 @@ A total of 17 people contributed to this release.  People with a "+" by their
 names contributed a patch for the first time.
 
 * Aleksei Nikiforov
-* Anarion Zuo +
 * Ankit Ahlawat
 * Breno Favaretto +
 * Charles Harris
@@ -32,8 +20,8 @@ names contributed a patch for the first time.
 * RoomWithOutRoof +
 * Sebastian Berg
 * Warren Weckesser
+* Anarion Zuo +
 * div +
-
 
 Pull requests merged
 ====================


### PR DESCRIPTION
- Create 2.4.5-changelog.rst
- Update 2.4.5-notes.rst
- Update .mailmap

#### AI Disclosure

No AI was used.