### PR TITLE
BUG: pass DType class (not instance) to ufunc in `_unsigned_subtract`

### DIFF
--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -195,6 +195,26 @@ class TestSFloat:
         with pytest.raises(TypeError):
             np.add(a, a, out=c, casting="safe")
 
+    def test_sfloat_histogram_passes_dtype_class(self):
+        # Regression test for gh-31447: ``_unsigned_subtract`` used to
+        # forward a DType instance (from ``np.result_type``) to
+        # ``np.subtract``, which the ufunc dispatcher rejects for
+        # non-legacy user DTypes with "Cannot pass a new user DType
+        # instance ...". SF has no registered subtract loop, so the
+        # call still raises after the fix, but with the expected
+        # missing-loop error instead of the instance-rejection error.
+        # ``_unsigned_subtract`` is exercised directly because SF also
+        # lacks ``minimum``/``maximum`` loops, so a full
+        # ``np.histogram(arr)`` call fails earlier without ever
+        # reaching the fixed code path.
+        from numpy.lib._histograms_impl import _unsigned_subtract
+        a = np.array([3.]).view(SF(1.))
+        b = np.array([1.]).view(SF(1.))
+        try:
+            _unsigned_subtract(a, b)
+        except TypeError as e:
+            assert "Cannot pass a new user DType instance" not in str(e)
+
     @pytest.mark.parametrize("ufunc",
             [np.logical_and, np.logical_or, np.logical_xor])
     def test_logical_ufuncs_casts_to_bool(self, ufunc):

--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -196,24 +196,24 @@ class TestSFloat:
             np.add(a, a, out=c, casting="safe")
 
     def test_sfloat_histogram_passes_dtype_class(self):
-        # Regression test for gh-31447: ``_unsigned_subtract`` used to
-        # forward a DType instance (from ``np.result_type``) to
-        # ``np.subtract``, which the ufunc dispatcher rejects for
-        # non-legacy user DTypes with "Cannot pass a new user DType
-        # instance ...". SF has no registered subtract loop, so the
-        # call still raises after the fix, but with the expected
-        # missing-loop error instead of the instance-rejection error.
-        # ``_unsigned_subtract`` is exercised directly because SF also
-        # lacks ``minimum``/``maximum`` loops, so a full
-        # ``np.histogram(arr)`` call fails earlier without ever
-        # reaching the fixed code path.
+        # Regression test for gh-31447.
+        #
+        # ``_unsigned_subtract`` used to forward a DType instance (from
+        # ``np.result_type``) to ``np.subtract``; the ufunc dispatcher
+        # rejects instances of non-legacy user DTypes.
+        #
+        # Expected behaviour:
+        #   pre-fix:  TypeError "Cannot pass a new user DType instance ..."
+        #   post-fix: TypeError "ufunc 'subtract' did not contain a loop"
+        #             (SF has no subtract loop; once the dispatcher
+        #             accepts the DType class, the missing-loop error
+        #             surfaces.)
         from numpy.lib._histograms_impl import _unsigned_subtract
         a = np.array([3.]).view(SF(1.))
         b = np.array([1.]).view(SF(1.))
-        try:
+        with pytest.raises(TypeError,
+                match="ufunc 'subtract' did not contain a loop"):
             _unsigned_subtract(a, b)
-        except TypeError as e:
-            assert "Cannot pass a new user DType instance" not in str(e)
 
     @pytest.mark.parametrize("ufunc",
             [np.logical_and, np.logical_or, np.logical_xor])

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -344,7 +344,7 @@ def _unsigned_subtract(a, b):
     try:
         unsigned_dt = signed_to_unsigned[dt.type]
     except KeyError:
-        return np.subtract(a, b, dtype=dt)
+        return np.subtract(a, b, dtype=type(dt))
     else:
         # we know the inputs are integers, and we are deliberately casting
         # signed to unsigned.  The input may be negative python integers so


### PR DESCRIPTION
## Summary

`np.histogram` raises `TypeError: Cannot pass a new user DType instance to the dtype or signature arguments of ufuncs. Pass the DType class instead.` for any non-legacy user DType e.g. `numpy-quaddtype`

Root cause: `_unsigned_subtract` in `numpy/lib/_histograms_impl.py` passes `dtype=dt` (a DType **instance** from `np.result_type`) to `np.subtract`. For legacy/built-in DTypes the dispatcher silently converts instance to class, but for new user DTypes the dispatcher rejects instances by design (see`ufunc_object.c::_get_dtype`, comment at `ufunc_object.c:3954-3958`).

This is the same anti-pattern that #25201 (commit 04444cdff3, "MAINT: Use new converter to fix promotions and avoid manual wrapping") cleaned up across `function_base.py`, `fromnumeric.py`, `_function_base_impl.py`, etc. but `_histograms_impl.py` was missed. `linspace`, for example, already does `dtype=type(dt)`  with an explicit comment.

## AI Disclosure:
None

cc: @seberg 
