### PR TITLE
BUG: support () indexing for string scalars

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -4240,6 +4240,40 @@ gen_arrtype_subscript(PyObject *self, PyObject *key)
 }
 
 
+/*
+ * String-like scalars support empty-tuple indexing like other NumPy scalars.
+ * This returns the scalar itself for scalar[()], while all other indexing
+ * is delegated to the underlying Python bytes/str mapping implementation.
+ */
+static PyObject *
+string_arrtype_subscript(PyObject *self, PyObject *key)
+{
+    if (PyTuple_CheckExact(key) && PyTuple_GET_SIZE(key) == 0) {
+        Py_INCREF(self);
+        return self;
+    }
+    return PyBytes_Type.tp_as_mapping->mp_subscript(self, key);
+}
+
+static PyObject *
+unicode_arrtype_subscript(PyObject *self, PyObject *key)
+{
+    if (PyTuple_CheckExact(key) && PyTuple_GET_SIZE(key) == 0) {
+        Py_INCREF(self);
+        return self;
+    }
+    return PyUnicode_Type.tp_as_mapping->mp_subscript(self, key);
+}
+
+static PyMappingMethods string_arrtype_as_mapping = {
+    .mp_subscript = (binaryfunc)string_arrtype_subscript,
+};
+
+static PyMappingMethods unicode_arrtype_as_mapping = {
+    .mp_subscript = (binaryfunc)unicode_arrtype_subscript,
+};
+
+
 /**begin repeat
  * #Name = Bool,
  *         Byte, Short, Int, Long, LongLong,
@@ -4490,9 +4524,11 @@ initialize_numeric_types(void)
     PyStringArrType_Type.tp_alloc = NULL;
     PyStringArrType_Type.tp_free = NULL;
 
+    PyStringArrType_Type.tp_as_mapping = &string_arrtype_as_mapping;
     PyStringArrType_Type.tp_repr = stringtype_repr;
     PyStringArrType_Type.tp_str = stringtype_str;
 
+    PyUnicodeArrType_Type.tp_as_mapping = &unicode_arrtype_as_mapping;
     PyUnicodeArrType_Type.tp_repr = unicodetype_repr;
     PyUnicodeArrType_Type.tp_str = unicodetype_str;
 

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -1164,3 +1164,17 @@ def test_scalar_matches_array_op_with_pyscalar(op, sctype, other_type, rop):
         assert np.array(res).dtype == expected.dtype
     else:
         assert res.dtype == expected.dtype
+
+class TestStringLikeScalars:
+    # Zero-dimensional NumPy scalars should support the empty-tuple
+    # scalar index and return themselves, like other NumPy scalars.
+    @pytest.mark.parametrize(
+        ("scalar", "expected"),
+        [
+            (np.str_("abc"), np.str_("abc")),
+            (np.bytes_(b"abc"), np.bytes_(b"abc")),
+        ],
+    )
+    def test_empty_tuple_index_returns_scalar(self, scalar, expected):
+        assert scalar.shape == ()
+        assert scalar[()] == expected


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->


Zero-dimensional arrays and NumPy scalar types are documented to support the empty-tuple index `x[()]` as a scalar index that returns the scalar value. However, `np.str_` and `np.bytes_` scalars currently raise `TypeError` when indexed with `scalar[()]`, because the index is handled by the underlying Python `str`/`bytes` mapping implementation instead of NumPy’s scalar indexing behavior.

This change makes `np.str_` and `np.bytes_` scalars treat `scalar[()]` as a scalar index and return the scalar value, consistent with other 0‑d NumPy scalars. All other indices are still delegated to the Python `str`/`bytes` mapping implementation to preserve existing behavior.

In addition, it adds regression tests in
`numpy/_core/tests/test_scalarmath.py` that assert:

- `np.str_("abc").shape == ()` and `np.str_("abc")[()]` returns the same
  scalar value.
- `np.bytes_(b"abc").shape == ()` and `np.bytes_(b"abc")[()]` returns
  the same scalar value.

Fixes gh-31435.

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

Hi, this is my first contribution to NumPy. I use NumPy a lot in my own projects, so I wanted to help improve a library I use a lot and start getting involved in open source development.
#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
ChatGPT was used to help make sure this PR is following guidelines. No AI code was used.