### PR TITLE
BUG: Fix regression in ``arr.conj()``

### DIFF
--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -829,7 +829,7 @@ NPY_NO_EXPORT PyObject *
 PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
 {
     if (PyArray_ISCOMPLEX(self) || PyArray_ISOBJECT(self) ||
-            PyArray_ISUSERDEF(self) || !NPY_DT_is_legacy(PyArray_DESCR(self))) {
+            PyArray_ISUSERDEF(self) || !NPY_DT_is_legacy(NPY_DTYPE(PyArray_DESCR(self)))) {
         if (out == NULL) {
             return PyArray_GenericUnaryFunction(self,
                                                 n_ops.conjugate);

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3918,6 +3918,17 @@ class TestMethods:
         assert_raises(TypeError, a.conj)
         assert_raises(TypeError, a.conjugate)
 
+    @pytest.mark.parametrize("dtype", ["?", "b", "h", "I"])
+    def test_conjugate_view(self, dtype):
+        a = np.ones(10, dtype=dtype)
+        assert a.conj() is a
+
+    @pytest.mark.parametrize("dtype", ["S", "U", "M8[ns]"])
+    def test_conjugate_error(self, dtype):
+        a = np.ones(10, dtype=dtype)
+        with pytest.raises(TypeError, match="cannot conjugate non-numeric dtype"):
+            a.conj()
+
     def test_conjugate_out(self):
         # Minimal test for the out argument being passed on correctly
         # NOTE: The ability to pass `out` is currently undocumented!


### PR DESCRIPTION
I'll make these helpers static-inline functions on main. Unfortunately, this doesn't just cause wrong promotion for bool->uint8 in `arr.conj()`, but it also leads to all other non-complex types returning unnecessary copies which seems like a pretty unfortunate regression, even if it might not be very visible in practice.

I am suspecting we may need a 2.4.6 for this :(

(No AI)