### PR TITLE
MAINT: Add tests for conj and make NPY_DT_is_ helpers static inline

### DIFF
--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -111,11 +111,22 @@ typedef struct {
 
 #define NPY_DT_SLOTS(dtype) ((NPY_DType_Slots *)(dtype)->dt_slots)
 
-#define NPY_DT_is_legacy(dtype) (((dtype)->flags & NPY_DT_LEGACY) != 0)
-#define NPY_DT_is_abstract(dtype) (((dtype)->flags & NPY_DT_ABSTRACT) != 0)
-#define NPY_DT_is_parametric(dtype) (((dtype)->flags & NPY_DT_PARAMETRIC) != 0)
-#define NPY_DT_is_numeric(dtype) (((dtype)->flags & NPY_DT_NUMERIC) != 0)
-#define NPY_DT_is_user_defined(dtype) (((dtype)->type_num == -1))
+static inline int NPY_DT_is_legacy(PyArray_DTypeMeta *dtype) {
+    return (dtype->flags & NPY_DT_LEGACY) != 0;
+}
+static inline int NPY_DT_is_abstract(PyArray_DTypeMeta *dtype) {
+    return (dtype->flags & NPY_DT_ABSTRACT) != 0;
+}
+static inline int NPY_DT_is_parametric(PyArray_DTypeMeta *dtype) {
+    return (dtype->flags & NPY_DT_PARAMETRIC) != 0;
+}
+static inline int NPY_DT_is_numeric(PyArray_DTypeMeta *dtype) {
+    return (dtype->flags & NPY_DT_NUMERIC) != 0;
+}
+static inline int NPY_DT_is_user_defined(PyArray_DTypeMeta *dtype) {
+    // New-style user defined dtypes have a type_num of -1 also on DType
+    return dtype->type_num == -1;
+}
 
 /*
  * Macros for convenient classmethod calls, since these require

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3851,7 +3851,7 @@ format_longfloat(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds)
  */
 static int _is_user_defined_string_array(PyArrayObject* array)
 {
-    if (NPY_DT_is_user_defined(PyArray_DESCR(array))) {
+    if (NPY_DT_is_user_defined(NPY_DTYPE(PyArray_DESCR(array)))) {
         PyTypeObject* scalar_type = NPY_DTYPE(PyArray_DESCR(array))->scalar_type;
         if (PyType_IsSubtype(scalar_type, &PyBytes_Type) ||
             PyType_IsSubtype(scalar_type, &PyUnicode_Type)) {

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -4230,6 +4230,17 @@ class TestMethods:
         assert_raises(TypeError, a.conj)
         assert_raises(TypeError, a.conjugate)
 
+    @pytest.mark.parametrize("dtype", ["?", "b", "h", "I"])
+    def test_conjugate_view(self, dtype):
+        a = np.ones(10, dtype=dtype)
+        assert a.conj() is a
+
+    @pytest.mark.parametrize("dtype", ["S", "U", "M8[ns]"])
+    def test_conjugate_error(self, dtype):
+        a = np.ones(10, dtype=dtype)
+        with pytest.raises(TypeError, match="cannot conjugate non-numeric dtype"):
+            a.conj()
+
     def test_conjugate_out(self):
         # Minimal test for the out argument being passed on correctly
         # NOTE: The ability to pass `out` is currently undocumented!


### PR DESCRIPTION
Most of these used the flags, but that can go wrong because descrs also have flags :(.
This makes them static inline, for the `NPY_DT_is_user_defined` that is irrelevant, but just change it anyway (both structs have the identical type number).

(No AI)