### PR TITLE
added __complex__ to scalars

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2080,6 +2080,7 @@ gentype_getarray(PyObject *scalar, PyObject *args)
 }
 
 static char doc_sc_wraparray[] = "__array_wrap__ implementation for scalar types";
+static char doc_scalar_complex[] = "__complex__($self, /)\n--\n\ncomplex(self)";
 
 /*
  * __array_wrap__ for scalars, returning a scalar if possible.
@@ -2517,13 +2518,28 @@ numbertype_class_getitem(PyObject *cls, PyObject *args)
  * #n = f, l#
  */
 static PyObject *
-@name@_complex(PyObject *self, PyObject *NPY_UNUSED(args),
-               PyObject *NPY_UNUSED(kwds))
+@name@_complex(PyObject *self, PyObject *NPY_UNUSED(args))
 {
     return PyComplex_FromDoubles(npy_creal@n@(PyArrayScalar_VAL(self, @Name@)),
                                  npy_cimag@n@(PyArrayScalar_VAL(self, @Name@)));
 }
 /**end repeat**/
+
+static PyObject *
+scalar_complex(PyObject *self, PyObject *NPY_UNUSED(args))
+{
+    PyObject *real_obj = PyNumber_Float(self);
+    if (real_obj == NULL) {
+        return NULL;
+    }
+    double real = PyFloat_AsDouble(real_obj);
+    Py_DECREF(real_obj);
+    if (real == -1.0 && PyErr_Occurred()) {
+        return NULL;
+    }
+
+    return PyComplex_FromDoubles(real, 0.0);
+}
 
 /**begin repeat
  *  #name = half, float, double, longdouble#
@@ -2895,7 +2911,20 @@ static PyMethodDef numbertype_methods[] = {
 };
 
 /**begin repeat
- * #name = boolean,datetime#
+ * #name = boolean#
+ */
+static PyMethodDef @name@type_methods[] = {
+    {"__complex__",
+        (PyCFunction)scalar_complex,
+        METH_NOARGS, doc_scalar_complex},
+    /* for typing */
+    {"__class_getitem__", Py_GenericAlias, METH_CLASS | METH_O, NULL},
+    {NULL, NULL, 0, NULL} /* sentinel */
+};
+/**end repeat**/
+
+/**begin repeat
+ * #name = datetime#
  */
 static PyMethodDef @name@type_methods[] = {
     /* for typing */
@@ -2910,7 +2939,7 @@ static PyMethodDef @name@type_methods[] = {
 static PyMethodDef @name@type_methods[] = {
     {"__complex__",
         (PyCFunction)@name@_complex,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_NOARGS, doc_scalar_complex},
     /* for typing */
     {"__class_getitem__",
         (PyCFunction)numbertype_class_getitem,
@@ -2942,6 +2971,9 @@ static PyMethodDef integertype_methods[] = {
  * #name = half,float,double,longdouble#
  */
 static PyMethodDef @name@type_methods[] = {
+    {"__complex__",
+        (PyCFunction)scalar_complex,
+        METH_NOARGS, doc_scalar_complex},
     {"as_integer_ratio",
         (PyCFunction)@name@_as_integer_ratio,
         METH_NOARGS, NULL},
@@ -2973,6 +3005,9 @@ static PyMethodDef @name@type_methods[] = {
  *         long, ulong, longlong, ulonglong#
  */
 static PyMethodDef @name@type_methods[] = {
+    {"__complex__",
+        (PyCFunction)scalar_complex,
+        METH_NOARGS, doc_scalar_complex},
     /* for typing */
     {"__class_getitem__",
         (PyCFunction)numbertype_class_getitem,

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -1164,3 +1164,29 @@ def test_scalar_matches_array_op_with_pyscalar(op, sctype, other_type, rop):
         assert np.array(res).dtype == expected.dtype
     else:
         assert res.dtype == expected.dtype
+
+@pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
+def test_complex_scalar_dunder_complex(dtype):
+    x = np.mean(np.asarray(4 + 2j, dtype=dtype))
+
+    y = x.__complex__()
+
+    assert isinstance(y, complex)
+    assert y == complex(x)
+    assert y == complex(4 + 2j)
+
+
+@pytest.mark.parametrize("dtype", [np.bool_, np.int32, np.int64, np.float32, np.float64])
+def test_real_scalar_dunder_complex(dtype):
+    if dtype is np.bool_:
+        x = np.all(np.asarray(True, dtype=dtype))
+    elif np.issubdtype(dtype, np.integer):
+        x = np.sum(np.asarray(4, dtype=dtype))
+    else:
+        x = np.mean(np.asarray(4, dtype=dtype))
+
+    y = x.__complex__()
+
+    assert isinstance(y, complex)
+    assert y == complex(x)
+    assert y.imag == 0.0


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.


-->
  
NumPy scalars now implement `__complex__()` consistently across real and complex dtypes, aligning them with Python’s numeric protocol. Real scalars share a new helper that converts the value via float(self) and returns a Python complex with zero imaginary part, complex scalars return a Python complex with matching real and imaginary parts. 

This fixes #27305 

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
Copilot was used to help orient me to scalartypes.c.src. No AI code was used.