### PR TITLE
BUG: `np.linalg.svd(..., hermitian=True)` returns non-unitary `vh` (#31347)

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -61,7 +61,6 @@ from numpy._core import (
     overrides,
     prod,
     reciprocal,
-    sign,
     single,
     sort,
     sqrt,
@@ -1810,7 +1809,8 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
         # and related arrays to have the correct order
         if compute_uv:
             s, u = eigh(a)
-            sgn = sign(s)
+            # avoid zero sign
+            sgn = np.copysign(1.0, s)
             s = abs(s)
             sidx = argsort(s)[..., ::-1]
             sgn = np.take_along_axis(sgn, sidx, axis=-1)

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -745,6 +745,12 @@ class SVDHermitianCases(HermitianTestCase, HermitianGeneralizedTestCase):
 class TestSVDHermitian(SVDHermitianCases, SVDBaseTests):
     hermitian = True
 
+    def test_singular(self):
+        x = np.array([[1, 0], [0, 0]])
+        u, _, vh = linalg.svd(x, hermitian=self.hermitian)
+        assert_allclose(u @ u.T.conj(), np.eye(2), rtol=1e-14)
+        assert_allclose(vh @ vh.T.conj(), np.eye(2), rtol=1e-14)
+
 
 class CondCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
     # cond(x, p) for p in (None, 2, -2)


### PR DESCRIPTION
Backport of #31347.

* Explicitly remove 0 from eigenvalue signs to ensure that vh is unitary.
* Add Hermitian SVD test that has 0 as a singular value.

### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

Currently `np.linalg.svd` can return non-unitary `vh` due to sign 0 appearing when input array is singular.
This PR fixes the issue.

```python
>>> import numpy as np
>>> res = np.linalg.svd(np.array([[1, 0], [0, 0]]), hermitian=True)
>>> res.Vh
array([[1., 0.],
       [0., 0.]])
```

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

I've used ChatGPT to ensure that my PR is following the guideline. No codes are generated by AI.
