### PR TITLE
BUG: Don't call INCREF/DECREF on descr in NpyStringAcquireAllocator (#31456)

### DIFF
--- a/numpy/_core/src/common/raii_utils.hpp
+++ b/numpy/_core/src/common/raii_utils.hpp
@@ -126,11 +126,9 @@ public:
 //
 // Instead of
 //
-//   Py_INCREF(descr);
 //   npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
 //   [code that uses allocator]
 //   NpyString_release_allocator(allocator);
-//   Py_DECREF(descr);
 //
 // use
 //
@@ -141,19 +139,16 @@ public:
 //
 class NpyStringAcquireAllocator
 {
-    PyArray_StringDTypeObject *_descr;
     npy_string_allocator *_allocator;
 
 public:
 
-    NpyStringAcquireAllocator(PyArray_StringDTypeObject *descr) : _descr(descr) {
-        Py_INCREF(_descr);
-        _allocator = NpyString_acquire_allocator(_descr);
+    NpyStringAcquireAllocator(PyArray_StringDTypeObject *descr) {
+        _allocator = NpyString_acquire_allocator(descr);
     }
 
     ~NpyStringAcquireAllocator() {
         NpyString_release_allocator(_allocator);
-        Py_DECREF(_descr);
     }
 
     NpyStringAcquireAllocator(const NpyStringAcquireAllocator&) = delete;

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -260,6 +260,7 @@ def test_self_casts(dtype, dtype2, strings):
         ["this", "is", "an", "array"],
         ["€", "", "😊"],
         ["A¢☃€ 😊", " A☃€¢😊", "☃€😊 A¢", "😊☃A¢ €"],
+        ["short", "12345678"] * 1000,
     ],
 )
 class TestStringLikeCasts:


### PR DESCRIPTION
Backport of #31456.

Remove incorrect calls of Py_INCREF(descr) and Py_DECREF(descr) in the RAII object NpyStringAcquireAllocator.

Closes gh-31415.

#### AI Disclosure
No AI tools used.