### PR TITLE
BUG: Handle nan values on histogram's slow path.

### DIFF
--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -876,13 +876,23 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
         cum_n = np.zeros(bin_edges.shape, ntype)
         if weights is None:
             for i in _range(0, len(a), BLOCK):
-                sa = np.sort(a[i:i + BLOCK])
+                tmp_a = a[i:i + BLOCK]
+                # nan != nan
+                not_nan = tmp_a == tmp_a
+                if not all(not_nan):
+                    tmp_a = tmp_a[not_nan]
+                sa = np.sort(tmp_a)
                 cum_n += _search_sorted_inclusive(sa, bin_edges)
         else:
             zero = np.zeros(1, dtype=ntype)
             for i in _range(0, len(a), BLOCK):
                 tmp_a = a[i:i + BLOCK]
                 tmp_w = weights[i:i + BLOCK]
+                # nan != nan
+                not_nan = tmp_a == tmp_a
+                if not all(not_nan):
+                    tmp_a = tmp_a[not_nan]
+                    tmp_w = tmp_w[not_nan]
                 sorting_index = np.argsort(tmp_a)
                 sa = tmp_a[sorting_index]
                 sw = tmp_w[sorting_index]

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -429,6 +429,23 @@ class TestHistogram:
         assert edges[0] == Z[0]
         assert edges[-1] == Z[-1]
 
+    def test_nan_values(self):
+        # gh 28730
+        # This is regression test to make sure nan values
+        # are handed properly in histogram's slow path.
+        non_uniform = np.arange(0,5)
+        w = np.array([1., 2., 99999.])
+        x1 = np.histogram(np.asarray([0., 1., np.nan], dtype=object), bins = non_uniform)
+        x2 = np.histogram(np.asarray([0., 1., np.nan], dtype=float), bins = non_uniform)
+        assert_equal(x1[0], x2[0])
+        x3 = histogram(np.asarray([np.nan, np.nan], dtype=object), bins = non_uniform)
+        assert x3[0].sum() == 0
+        x4 = np.histogram(np.asarray([0., 1., np.nan], dtype=object), bins =
+                          non_uniform, weights = w)
+        x5 = np.histogram(np.asarray([0., 1., np.nan], dtype=float), bins =
+                               non_uniform, weights = w)
+        assert_equal(x4[0], x5[0])
+
 class TestHistogramOptimBinNums:
     """
     Provide test coverage when using provided estimators for optimal number of

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -433,17 +433,17 @@ class TestHistogram:
         # gh 28730
         # This is regression test to make sure nan values
         # are handed properly in histogram's slow path.
-        non_uniform = np.arange(0,5)
+        non_uniform = np.arange(0, 5)
         w = np.array([1., 2., 99999.])
-        x1 = np.histogram(np.asarray([0., 1., np.nan], dtype=object), bins = non_uniform)
-        x2 = np.histogram(np.asarray([0., 1., np.nan], dtype=float), bins = non_uniform)
+        x1 = np.histogram(np.asarray([0., 1., np.nan], dtype=object), bins=non_uniform)
+        x2 = np.histogram(np.asarray([0., 1., np.nan], dtype=float), bins=non_uniform)
         assert_equal(x1[0], x2[0])
-        x3 = histogram(np.asarray([np.nan, np.nan], dtype=object), bins = non_uniform)
+        x3 = histogram(np.asarray([np.nan, np.nan], dtype=object), bins=non_uniform)
         assert x3[0].sum() == 0
-        x4 = np.histogram(np.asarray([0., 1., np.nan], dtype=object), bins =
-                          non_uniform, weights = w)
-        x5 = np.histogram(np.asarray([0., 1., np.nan], dtype=float), bins =
-                               non_uniform, weights = w)
+        x4 = np.histogram(np.asarray([0., 1., np.nan], dtype=object),
+                          bins=non_uniform, weights=w)
+        x5 = np.histogram(np.asarray([0., 1., np.nan], dtype=float),
+                          bins=non_uniform, weights=w)
         assert_equal(x4[0], x5[0])
 
 class TestHistogramOptimBinNums:


### PR DESCRIPTION
### PR summary
Fixes https://github.com/numpy/numpy/issues/28730
Contrary to histogramdd (which is another problem I think), histogram uses a different algorithm that uses `_search_sorted_inclusive` on its slow path where nan values work ambigiously depending on the dtype. This is a small workaround to fix it basically.

~I am still not sure if this fix is proper, I will play around the PR until its ready~

<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
I have used claude to review the code. The changes are not AI written.