### PR TITLE
DOC: clarify np.correlate definition and add proper docstring

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1846,7 +1846,56 @@ add_newdoc('numpy._core.multiarray', 'from_dlpack',
     """)
 
 add_newdoc('numpy._core.multiarray', 'correlate',
-    """cross_correlate(a,v, mode=0)""")
+    """
+    correlate(a, v, mode='valid')
+
+    Cross-correlation of two 1-dimensional sequences.
+
+    This function computes the correlation as commonly defined in signal
+    processing contexts::
+
+        c[k] = sum_n a[n+k] * conj(v[n])
+
+    Note that this definition is not universal. Another common definition
+    swaps the roles of the two sequences::
+
+        c[k] = sum_n a[n] * conj(v[n+k])
+
+    which is related to the first by ``c[k] = c[-k]`` (i.e., the result is
+    reversed). NumPy uses the first definition above.
+
+    Parameters
+    ----------
+    a : array_like
+        First input sequence.
+    v : array_like
+        Second input sequence.
+    mode : {'valid', 'full', 'same'}, optional
+        Refer to the `convolve` docstring for full descriptions of the modes.
+        Default is 'valid'.
+
+    Returns
+    -------
+    out : ndarray
+        Discrete cross-correlation of `a` and `v`.
+
+    See Also
+    --------
+    convolve : Discrete, linear convolution of two sequences.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> np.correlate([1, 2, 3], [0, 1, 0.5])
+    array([3.5])
+
+    >>> np.correlate([1, 2, 3], [0, 1, 0.5], 'full')
+    array([0.5,  2. ,  3.5,  3. ,  0. ])
+
+    >>> np.correlate([1, 2], [1, 2, 3])
+    array([8, 5])
+
+    """)
 
 add_newdoc('numpy._core.multiarray', 'arange',
     """

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -1846,56 +1846,7 @@ add_newdoc('numpy._core.multiarray', 'from_dlpack',
     """)
 
 add_newdoc('numpy._core.multiarray', 'correlate',
-    """
-    correlate(a, v, mode='valid')
-
-    Cross-correlation of two 1-dimensional sequences.
-
-    This function computes the correlation as commonly defined in signal
-    processing contexts::
-
-        c[k] = sum_n a[n+k] * conj(v[n])
-
-    Note that this definition is not universal. Another common definition
-    swaps the roles of the two sequences::
-
-        c[k] = sum_n a[n] * conj(v[n+k])
-
-    which is related to the first by ``c[k] = c[-k]`` (i.e., the result is
-    reversed). NumPy uses the first definition above.
-
-    Parameters
-    ----------
-    a : array_like
-        First input sequence.
-    v : array_like
-        Second input sequence.
-    mode : {'valid', 'full', 'same'}, optional
-        Refer to the `convolve` docstring for full descriptions of the modes.
-        Default is 'valid'.
-
-    Returns
-    -------
-    out : ndarray
-        Discrete cross-correlation of `a` and `v`.
-
-    See Also
-    --------
-    convolve : Discrete, linear convolution of two sequences.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> np.correlate([1, 2, 3], [0, 1, 0.5])
-    array([3.5])
-
-    >>> np.correlate([1, 2, 3], [0, 1, 0.5], 'full')
-    array([0.5,  2. ,  3.5,  3. ,  0. ])
-
-    >>> np.correlate([1, 2], [1, 2, 3])
-    array([8, 5])
-
-    """)
+    """cross_correlate(a,v, mode=0)""")
 
 add_newdoc('numpy._core.multiarray', 'arange',
     """

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -758,7 +758,7 @@ def correlate(a, v, mode='valid'):
 
     which is related to :math:`c_k` by :math:`c'_k = c_{-k}`.
     
-    NumPy uses the first definition above, where `a` is shifted by `k`.
+    NumPy uses the first definition above, where ``a`` is shifted by ``k``.
 
     `numpy.correlate` may perform slowly in large arrays (i.e. n = 1e5)
     because it does not use the FFT to compute the convolution; in that case,

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -757,7 +757,7 @@ def correlate(a, v, mode='valid'):
     .. math:: c'_k = \sum_n a_{n} \cdot \overline{v_{n+k}}
 
     which is related to :math:`c_k` by :math:`c'_k = c_{-k}`.
-    
+
     NumPy uses the first definition above, where ``a`` is shifted by ``k``.
 
     `numpy.correlate` may perform slowly in large arrays (i.e. n = 1e5)

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -757,6 +757,8 @@ def correlate(a, v, mode='valid'):
     .. math:: c'_k = \sum_n a_{n} \cdot \overline{v_{n+k}}
 
     which is related to :math:`c_k` by :math:`c'_k = c_{-k}`.
+    
+    NumPy uses the first definition above, where `a` is shifted by `k`.
 
     `numpy.correlate` may perform slowly in large arrays (i.e. n = 1e5)
     because it does not use the FFT to compute the convolution; in that case,


### PR DESCRIPTION
### PR summary
Closes #20090. The existing docstring for np.correlate was a single line that didn't explain which definition of cross-correlation NumPy implements. This PR adds a proper docstring with the formula, a note about the alternate definition, parameters, return value, and examples.

### First time committer introduction
Hi, I'm Lalitha, a computer science student. I use NumPy regularly and came across this issue while studying signal processing concepts. I wanted to make my first open source contribution and this seemed like a good place to start.

### AI Disclosure
Used an AI assistant for minor help with formatting and verifying example outputs. The fix and understanding of the issue is my own.