### PR TITLE
Setup compilation cache and use it for building the wheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -101,10 +101,36 @@ jobs:
             echo "CIBW_ENVIRONMENT_MACOS=$CIBW PKG_CONFIG_PATH=$PKG_CONFIG_PATH DYLD_LIBRARY_PATH=$DYLD" >> "$GITHUB_ENV"
           fi
 
+      - name: Setup compilation cache
+        if: startsWith(matrix.buildplat[1], 'musllinux_') || startsWith(matrix.buildplat[1], 'manylinux_')
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+        with:
+          key: build-wheels-${{ matrix.buildplat[1] }}-${{ matrix.python }}
+          save: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+          max-size: 500MB
+          evict-old-files: 1d
+          install: 'no' # we only care for the CCACHE_DIR to be restored/saved
+
       - name: Build wheels
         uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          CIBW_BEFORE_ALL_LINUX: |
+            set -eux
+            if   command -v apk     >/dev/null 2>&1; then apk add --no-cache ccache
+            elif command -v dnf     >/dev/null 2>&1; then dnf install -y ccache || (dnf install -y epel-release && dnf install -y ccache)
+            elif command -v yum     >/dev/null 2>&1; then yum install -y ccache || (yum install -y epel-release && yum install -y ccache)
+            elif command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y --no-install-recommends ccache
+            else echo "no known package manager"; exit 1
+            fi
+            ccache --version
+            ccache --zero-stats
+          CIBW_AFTER_ALL_LINUX: |
+            ccache --show-stats
+          CIBW_ENVIRONMENT_LINUX: >-
+            CCACHE_DIR=/host/${{ github.workspace }}/.ccache
+            CCACHE_BASEDIR=/project
+            CCACHE_COMPILERCHECK=content
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
### PR summary

On slower platforms like linux-riscv64, it's very beneficial to use ccache to speed up the build. It also benefits other platforms as well.

