### PR TITLE
BUG: Fix np.nextafter(-0.0, +0.0) to return +0.0 for float16

### DIFF
--- a/numpy/_core/src/npymath/halffloat.cpp
+++ b/numpy/_core/src/npymath/halffloat.cpp
@@ -108,7 +108,7 @@ npy_half npy_half_nextafter(npy_half x, npy_half y)
     if (npy_half_isnan(x) || npy_half_isnan(y)) {
         ret = NPY_HALF_NAN;
     } else if (npy_half_eq_nonan(x, y)) {
-        ret = x;
+        ret = y;
     } else if (npy_half_iszero(x)) {
         ret = (y&0x8000u) + 1; /* Smallest subnormal half */
     } else if (!(x&0x8000u)) { /* x > 0 */

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4834,8 +4834,8 @@ def test_nextafter_signed_zero(sctype):
     def _equal_signed_zero(a, b):
         return (a == b) and (np.signbit(a) == np.signbit(b))
 
-    pos_zero = dtype(+0.0)
-    neg_zero = dtype(-0.0)
+    pos_zero = sctype(+0.0)
+    neg_zero = sctype(-0.0)
 
     assert _equal_signed_zero(np.nextafter(pos_zero, neg_zero), neg_zero), \
         f"nextafter(+0.0, -0.0) != -0.0 for {dtype.__name__}"

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4828,11 +4828,12 @@ def test_nextafter_0():
 
 
 @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64, np.longdouble])
-def test_nextafter_signed_zero(dtype):
-    def _equal_signed_zero(a, b):
-        return (a == b) & (np.signbit(a) == np.signbit(b))
+def test_nextafter_signed_zero(sctype):
+    """`nextafter(-0.0, +0.0)` must return the sign of the second parameter"""
 
-    """#31472 nextafter(-0.0, +0.0) changes the zero sign correctly."""
+    def _equal_signed_zero(a, b):
+        return (a == b) and (np.signbit(a) == np.signbit(b))
+
     pos_zero = dtype(+0.0)
     neg_zero = dtype(-0.0)
 

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4827,7 +4827,7 @@ def test_nextafter_0():
         assert_equal(np.nextafter(t(0), t(direction)) / t(2.1), direction * 0.0)
 
 
-@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64, np.longdouble])
+@pytest.mark.parametrize("sctype", [np.float16, np.float32, np.float64, np.longdouble])
 def test_nextafter_signed_zero(sctype):
     """`nextafter(-0.0, +0.0)` must return the sign of the second parameter"""
 
@@ -4838,14 +4838,14 @@ def test_nextafter_signed_zero(sctype):
     neg_zero = sctype(-0.0)
 
     assert _equal_signed_zero(np.nextafter(pos_zero, neg_zero), neg_zero), \
-        f"nextafter(+0.0, -0.0) != -0.0 for {dtype.__name__}"
+        f"nextafter(+0.0, -0.0) != -0.0 for {sctype.__name__}"
     assert _equal_signed_zero(np.nextafter(neg_zero, pos_zero), pos_zero), \
-        f"nextafter(-0.0, +0.0) != +0.0 for {dtype.__name__}"
+        f"nextafter(-0.0, +0.0) != +0.0 for {sctype.__name__}"
 
     assert _equal_signed_zero(np.nextafter(pos_zero, pos_zero), pos_zero), \
-        f"nextafter(+0.0, +0.0) != +0.0 for {dtype.__name__}"
+        f"nextafter(+0.0, +0.0) != +0.0 for {sctype.__name__}"
     assert _equal_signed_zero(np.nextafter(neg_zero, neg_zero), neg_zero), \
-        f"nextafter(-0.0, -0.0) != -0.0 for {dtype.__name__}"
+        f"nextafter(-0.0, -0.0) != -0.0 for {sctype.__name__}"
 
 
 def _test_spacing(t):

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -4826,6 +4826,27 @@ def test_nextafter_0():
                     0. < direction * np.nextafter(t(0), t(direction)) < tiny)
         assert_equal(np.nextafter(t(0), t(direction)) / t(2.1), direction * 0.0)
 
+
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64, np.longdouble])
+def test_nextafter_signed_zero(dtype):
+    def _equal_signed_zero(a, b):
+        return (a == b) & (np.signbit(a) == np.signbit(b))
+
+    """#31472 nextafter(-0.0, +0.0) changes the zero sign correctly."""
+    pos_zero = dtype(+0.0)
+    neg_zero = dtype(-0.0)
+
+    assert _equal_signed_zero(np.nextafter(pos_zero, neg_zero), neg_zero), \
+        f"nextafter(+0.0, -0.0) != -0.0 for {dtype.__name__}"
+    assert _equal_signed_zero(np.nextafter(neg_zero, pos_zero), pos_zero), \
+        f"nextafter(-0.0, +0.0) != +0.0 for {dtype.__name__}"
+
+    assert _equal_signed_zero(np.nextafter(pos_zero, pos_zero), pos_zero), \
+        f"nextafter(+0.0, +0.0) != +0.0 for {dtype.__name__}"
+    assert _equal_signed_zero(np.nextafter(neg_zero, neg_zero), neg_zero), \
+        f"nextafter(-0.0, -0.0) != -0.0 for {dtype.__name__}"
+
+
 def _test_spacing(t):
     one = t(1)
     eps = np.finfo(t).eps


### PR DESCRIPTION
### PR summary

Fixes #31472 to ensure that `np.nextafter(-0.0, +0.0) = +0.0` and `np.nextafter(+0.0, -0.0) = -0.0` for `float16`.

Thanks to @seberg for the suggested fix!

### First time committer introduction

Hi, I'm Juniper, a doctoral student at the University of Helsinki. I've contributed to https://github.com/numpy/numpy-quaddtype before. I use numpy for portable scientific computing and have a research project that inadvertently fuzzes edge cases in numpy, including negative zero, which is how I came across this issue.

#### AI Disclosure

No AI was used in the preparation of this PR.
