### PR TITLE
ENH: Use radixsort also for descending sorts

### DIFF
--- a/numpy/_core/src/npysort/npysort_methods.cpp
+++ b/numpy/_core/src/npysort/npysort_methods.cpp
@@ -78,7 +78,12 @@ sort_loop_(PyArrayMethod_Context *context, char *const data[],
         case NPY_SORT_DEFAULT | NPY_SORT_DESCENDING:
             return quicksort_<Tag, type, true>((type *)data[0], dimensions[0]);
         case NPY_SORT_STABLE | NPY_SORT_DESCENDING:
+        if constexpr (use_radixsort) {
+            return radixsort<type, true>(data[0], dimensions[0]);
+        }
+        else {
             return timsort_<Tag, type, true>((type *)data[0], dimensions[0]);
+        }
         default:
             npy_gil_error(PyExc_RuntimeError, "unknown sort kind %d",
                           (int)params->flags);
@@ -118,8 +123,14 @@ argsort_loop_(PyArrayMethod_Context *context, char *const data[],
             return aquicksort_<Tag, type, true>((type *)data[0], (npy_intp *)data[1],
                                                 dimensions[0]);
         case NPY_SORT_STABLE | NPY_SORT_DESCENDING:
+        if constexpr (use_radixsort) {
+            return aradixsort<type, true>(
+                    data[0], (npy_intp *)data[1], dimensions[0]);
+        }
+        else {
             return atimsort_<Tag, type, true>((type *)data[0], (npy_intp *)data[1],
                                               dimensions[0]);
+        }
         default:
             npy_gil_error(PyExc_RuntimeError, "unknown sort kind %d",
                           (int)params->flags);

--- a/numpy/_core/src/npysort/radixsort.hpp
+++ b/numpy/_core/src/npysort/radixsort.hpp
@@ -14,28 +14,26 @@
  */
 
 // Reference: https://github.com/eloj/radix-sorting#-key-derivation
-template <class T, class UT>
+template <bool reverse, class T, class UT>
 UT
 KEY_OF(UT x)
 {
-    // Floating-point is currently disabled.
-    // Floating-point tests succeed for double and float on macOS but not on
-    // Windows/Linux. Basic sorting tests succeed but others relying on sort
-    // fail. Possibly related to floating-point normalisation or multiple NaN
-    // reprs? Not sure.
-    if (std::is_floating_point<T>::value) {
-        // For floats, we invert the key if the sign bit is set, else we invert
-        // the sign bit.
-        return ((x) ^ (-((x) >> (sizeof(T) * 8 - 1)) |
-                       ((UT)1 << (sizeof(T) * 8 - 1))));
-    }
-    else if (std::is_signed<T>::value) {
+    UT key;
+
+    if constexpr (std::is_signed_v<T>) {
         // For signed ints, we flip the sign bit so the negatives are below the
         // positives.
-        return ((x) ^ ((UT)1 << (sizeof(UT) * 8 - 1)));
+        key = x ^ (UT(1) << (sizeof(UT) * 8 - 1));
     }
     else {
-        return x;
+        key = x;
+    }
+
+    if constexpr (reverse) {
+        return ~key;
+    }
+    else {
+        return key;
     }
 }
 
@@ -46,15 +44,15 @@ nth_byte(T key, npy_intp l)
     return (key >> (l << 3)) & 0xFF;
 }
 
-template <class T, class UT>
+template <class T, class UT, bool reverse>
 static UT *
 radixsort0(UT *start, UT *aux, npy_intp num)
 {
     npy_intp cnt[sizeof(UT)][1 << 8] = {{0}};
-    UT key0 = KEY_OF<T>(start[0]);
+    UT key0 = KEY_OF<reverse, T>(start[0]);
 
     for (npy_intp i = 0; i < num; i++) {
-        UT k = KEY_OF<T>(start[i]);
+        UT k = KEY_OF<reverse, T>(start[i]);
 
         for (size_t l = 0; l < sizeof(UT); l++) {
             cnt[l][nth_byte(k, l)]++;
@@ -81,7 +79,7 @@ radixsort0(UT *start, UT *aux, npy_intp num)
     for (size_t l = 0; l < ncols; l++) {
         UT *temp;
         for (npy_intp i = 0; i < num; i++) {
-            UT k = KEY_OF<T>(start[i]);
+            UT k = KEY_OF<reverse, T>(start[i]);
             npy_intp dst = cnt[cols[l]][nth_byte(k, cols[l])]++;
             aux[dst] = start[i];
         }
@@ -94,7 +92,7 @@ radixsort0(UT *start, UT *aux, npy_intp num)
     return start;
 }
 
-template <class T, class UT>
+template <class T, class UT, bool reverse>
 static int
 radixsort_(UT *start, npy_intp num)
 {
@@ -103,9 +101,9 @@ radixsort_(UT *start, npy_intp num)
     }
 
     npy_bool all_sorted = 1;
-    UT k1 = KEY_OF<T>(start[0]);
+    UT k1 = KEY_OF<reverse, T>(start[0]);
     for (npy_intp i = 1; i < num; i++) {
-        UT k2 = KEY_OF<T>(start[i]);
+        UT k2 = KEY_OF<reverse, T>(start[i]);
         if (k1 > k2) {
             all_sorted = 0;
             break;
@@ -122,7 +120,7 @@ radixsort_(UT *start, npy_intp num)
         return -NPY_ENOMEM;
     }
 
-    UT *sorted = radixsort0<T>(start, aux, num);
+    UT *sorted = radixsort0<T, UT, reverse>(start, aux, num);
     if (sorted != start) {
         memcpy(start, sorted, num * sizeof(UT));
     }
@@ -131,31 +129,31 @@ radixsort_(UT *start, npy_intp num)
     return 0;
 }
 
-template <class T>
+template <class T, bool reverse = false>
 static int
 radixsort(void *start, npy_intp num)
 {
     using UT = typename std::make_unsigned<T>::type;
-    return radixsort_<T>((UT *)start, num);
+    return radixsort_<T, UT, reverse>((UT *)start, num);
 }
 
 // ``PyArray_SortFunc``-shaped trampoline.
-template <typename Tag, typename type>
+template <typename Tag, typename type, bool reverse = false>
 static int
 radixsort_impl(void *start, npy_intp num, void *NPY_UNUSED(varr))
 {
-    return radixsort<type>(start, num);
+    return radixsort<type, reverse>(start, num);
 }
 
-template <class T, class UT>
+template <class T, class UT, bool reverse>
 static npy_intp *
 aradixsort0(UT *start, npy_intp *aux, npy_intp *tosort, npy_intp num)
 {
     npy_intp cnt[sizeof(UT)][1 << 8] = {{0}};
-    UT key0 = KEY_OF<T>(start[0]);
+    UT key0 = KEY_OF<reverse, T>(start[0]);
 
     for (npy_intp i = 0; i < num; i++) {
-        UT k = KEY_OF<T>(start[i]);
+        UT k = KEY_OF<reverse, T>(start[i]);
 
         for (size_t l = 0; l < sizeof(UT); l++) {
             cnt[l][nth_byte(k, l)]++;
@@ -182,7 +180,7 @@ aradixsort0(UT *start, npy_intp *aux, npy_intp *tosort, npy_intp num)
     for (size_t l = 0; l < ncols; l++) {
         npy_intp *temp;
         for (npy_intp i = 0; i < num; i++) {
-            UT k = KEY_OF<T>(start[tosort[i]]);
+            UT k = KEY_OF<reverse, T>(start[tosort[i]]);
             npy_intp dst = cnt[cols[l]][nth_byte(k, cols[l])]++;
             aux[dst] = tosort[i];
         }
@@ -195,7 +193,7 @@ aradixsort0(UT *start, npy_intp *aux, npy_intp *tosort, npy_intp num)
     return tosort;
 }
 
-template <class T, class UT>
+template <class T, class UT, bool reverse>
 static int
 aradixsort_(UT *start, npy_intp *tosort, npy_intp num)
 {
@@ -208,9 +206,9 @@ aradixsort_(UT *start, npy_intp *tosort, npy_intp num)
         return 0;
     }
 
-    k1 = KEY_OF<T>(start[tosort[0]]);
+    k1 = KEY_OF<reverse, T>(start[tosort[0]]);
     for (npy_intp i = 1; i < num; i++) {
-        k2 = KEY_OF<T>(start[tosort[i]]);
+        k2 = KEY_OF<reverse, T>(start[tosort[i]]);
         if (k1 > k2) {
             all_sorted = 0;
             break;
@@ -227,7 +225,7 @@ aradixsort_(UT *start, npy_intp *tosort, npy_intp num)
         return -NPY_ENOMEM;
     }
 
-    sorted = aradixsort0<T>(start, aux, tosort, num);
+    sorted = aradixsort0<T, UT, reverse>(start, aux, tosort, num);
     if (sorted != tosort) {
         memcpy(tosort, sorted, num * sizeof(npy_intp));
     }
@@ -236,18 +234,18 @@ aradixsort_(UT *start, npy_intp *tosort, npy_intp num)
     return 0;
 }
 
-template <class T>
+template <class T, bool reverse = false>
 static int
 aradixsort(void *start, npy_intp *tosort, npy_intp num)
 {
     using UT = typename std::make_unsigned<T>::type;
-    return aradixsort_<T>((UT *)start, tosort, num);
+    return aradixsort_<T, UT, reverse>((UT *)start, tosort, num);
 }
 
 // ``PyArray_ArgSortFunc``-shaped trampoline.
-template <typename Tag, typename type>
+template <typename Tag, typename type, bool reverse = false>
 static int
 aradixsort_impl(void *start, npy_intp *tosort, npy_intp num, void *NPY_UNUSED(varr))
 {
-    return aradixsort<type>(start, tosort, num);
+    return aradixsort<type, reverse>(start, tosort, num);
 }

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2991,6 +2991,28 @@ class TestMethods:
         self._test_argsort_descending_nonan(a, stable, descending)
 
     @pytest.mark.parametrize(
+        "dtype", [
+            np.bool, np.int8, np.uint8, np.int16, np.uint16,
+            np.int32, np.uint32, np.int64, np.uint64]
+    )
+    @pytest.mark.parametrize("descending", [False, True])
+    def test_argsort_stable_bool_int_duplicates(self, dtype, descending):
+        if dtype is np.bool:
+            values = [False, True]
+        else:
+            info = np.iinfo(dtype)
+            values = [info.min, 1, info.max]
+
+        a = np.array(values * 2, dtype=dtype)
+        expected = np.array(
+            sorted(range(a.size), key=lambda i: a[i], reverse=descending)
+        )
+
+        idx = np.argsort(a, stable=True, descending=descending)
+        assert_equal(idx, expected)
+        assert_equal(np.sort(a, stable=True, descending=descending), a[expected])
+
+    @pytest.mark.parametrize(
         "dtype", [np.float16, np.float32, np.float64, np.longdouble]
     )
     @pytest.mark.parametrize("stable", [True, False])


### PR DESCRIPTION
This was skipped in the original PR to keep it a bit more minimal. I opted for just changing the bin discovery as I couldn't measure a difference for sorting a large int16 array.
(One could also reverse the bins later, but this gives the smaller code diff.)

The unused float path is deleted. I doubt we'll have appetite to re-add it soon, so I just deleted it.

The bot thought there was no test with duplicate values, so this adds one for bool+integers.

Used an agent a bit, but the change is so simple...
