### PR TITLE
TYP: datetime.{[date]time,timedelta} also ArrayLike

### DIFF
--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -1,3 +1,4 @@
+import datetime
 from collections.abc import Buffer, Callable, Collection
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -52,7 +53,11 @@ type _DualArrayLike[DTypeT: np.dtype, BuiltinT] = (
     | _NestedSequence[BuiltinT]
 )
 
-type ArrayLike = Buffer | _DualArrayLike[np.dtype, complex | bytes | str]
+type ArrayLike = Buffer | _DualArrayLike[np.dtype, complex | bytes |
+                                         datetime.datetime |
+                                         datetime.timedelta |
+                                         datetime.date |
+                                         str]
 
 # `ArrayLike<X>_co`: array-like objects that can be coerced into `X`
 # given the casting rules `same_kind`

--- a/numpy/typing/tests/data/pass/array_like.py
+++ b/numpy/typing/tests/data/pass/array_like.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime, timedelta
+
 import numpy as np
 from numpy._typing import ArrayLike, NDArray, _SupportsArray
 
@@ -13,6 +15,9 @@ x9: ArrayLike = [1, 2, 3]
 x10: ArrayLike = (1, 2, 3)
 x11: ArrayLike = "foo"
 x12: ArrayLike = memoryview(b'foo')
+x13: ArrayLike = datetime.now()
+x14: ArrayLike = timedelta(seconds=1)
+x15: ArrayLike = date.today()
 
 
 class A:
@@ -20,7 +25,7 @@ class A:
         return np.array([1.0, 2.0, 3.0])
 
 
-x13: ArrayLike = A()
+x16: ArrayLike = A()
 
 scalar: _SupportsArray[np.dtype[np.int64]] = np.int64(1)
 scalar.__array__()


### PR DESCRIPTION
### PR summary

The Python types for time and duration:
```
      datetime.datetime
      datetime.date
      datetime.timedelta
```
have long been usable as an input to several Numpy NDarray
initializers including ndarray, asarray, atleast_1d, and similar.
However, numpy.typing didn't recognize them as ArraryLike till this PR.

#### AI Disclosure
No AI tools used
