### PR TITLE
BENCH: Update sort benchmarks to use new-style args and smaller dtypes

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -280,12 +280,17 @@ class Sort(Benchmark):
         # Using np.sort(...) instead of arr.sort(...) because it makes a copy.
         # This is important because the data is prepared once per benchmark, but
         # used across multiple runs.
-        np.sort(self.arr, stable=stable, descending=descending)
+        if descending:
+            np.sort(self.arr, stable=stable, descending=True)
+        else:
+            # for backward compatibility to NumPy 2.0
+            np.sort(self.arr, stable=stable)
 
     def time_argsort(self, stable, descending, dtype, array_type):
         if descending:
             np.argsort(self.arr, stable=stable, descending=True)
         else:
+            # for backward compatibility to NumPy 2.0
             np.argsort(self.arr, stable=stable)
 
 

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -181,7 +181,6 @@ class SortGenerator:
         """
         arr = SortGenerator.ordered_range(size, dtype=dtype)
         rnd = np.random.RandomState(1792364059)
-        np.random.shuffle(arr)
         rnd.shuffle(arr)
         return arr
 

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -212,6 +212,83 @@ class SortGenerator:
         return np.array(b)
 
 
+class SortGeneratorSmall:
+    # This is a separate class as for certain small dtypes we
+    # need to repeat elements to get the desired array size.
+
+    # The size of the unsorted area in the "random unsorted area"
+    # benchmarks
+    AREA_SIZE = 100
+    # The size of the "partially ordered" sub-arrays
+    BUBBLE_SIZE = 100
+
+    limits = {
+        'bool': (0, 2),
+        'uint8': (0, 256),
+        'int8': (-128, 128),
+        'int16': (-32768, 32768),
+        'float16': (-1000, 1000),
+    }
+
+    @staticmethod
+    @memoize
+    def arange(dtype):
+        return np.arange(*SortGeneratorSmall.limits[dtype], dtype=dtype)
+
+    @staticmethod
+    @memoize
+    def random(size, dtype, rnd):
+        """
+        Returns a randomly-shuffled array.
+        """
+        arange = SortGeneratorSmall.arange(dtype)
+        rnd = np.random.RandomState(1792364059)
+        arr = rnd.choice(arange, size=size, replace=True)
+        return arr
+
+    @staticmethod
+    @memoize
+    def ordered(size, dtype, rnd):
+        """
+        Returns an ordered array.
+        """
+        arange = SortGeneratorSmall.arange(dtype)
+        return np.repeat(arange, size // arange.size + 1)[:size]
+
+    @staticmethod
+    @memoize
+    def reversed(size, dtype, rnd):
+        """
+        Returns an array that's in descending order.
+        """
+        arange = SortGeneratorSmall.arange(dtype)
+        return np.repeat(arange[::-1], size // arange.size + 1)[:size]
+
+    @staticmethod
+    @memoize
+    def uniform(size, dtype, rnd):
+        """
+        Returns an array that has the same value everywhere.
+        """
+        return np.ones(size, dtype=dtype)
+
+    @staticmethod
+    @memoize
+    def sorted_block(size, dtype, block_size, rnd):
+        """
+        Returns an array with blocks that are all sorted.
+        """
+        a = SortGeneratorSmall.arange(dtype=dtype)
+        a = np.repeat(a, size // a.size + 1)[:size]
+        b = []
+        if size < block_size:
+            return a
+        block_num = size // block_size
+        for i in range(block_num):
+            b.extend(a[i::block_num])
+        return np.array(b)
+
+
 class Sort(Benchmark):
     """
     This benchmark tests sorting performance with several
@@ -221,8 +298,20 @@ class Sort(Benchmark):
     params = [
         # In NumPy 1.17 and newer, 'merge' can be one of several
         # stable sorts, it isn't necessarily merge sort.
-        ['quick', 'merge', 'heap'],
-        ['float64', 'int64', 'float32', 'uint32', 'int32', 'int16', 'float16'],
+        [True, False],
+        [True, False],
+        [
+            'float64',
+            'int64',
+            'float32',
+            'uint32',
+            'int32',
+            'int16',
+            'float16',
+            'uint8',
+            'int8',
+            'bool',
+        ],
         [
             ('random',),
             ('ordered',),
@@ -233,25 +322,29 @@ class Sort(Benchmark):
             ('sorted_block', 1000),
         ],
     ]
-    param_names = ['kind', 'dtype', 'array_type']
+    param_names = ['stable', 'descending', 'dtype', 'array_type']
 
     # The size of the benchmarked arrays.
     ARRAY_SIZE = 1000000
+    
+    small_dtypes = ['bool', 'uint8', 'int8', 'int16', 'float16']
 
-    def setup(self, kind, dtype, array_type):
+    def setup(self, stable, descending, dtype, array_type):
         rnd = np.random.RandomState(507582308)
         array_class = array_type[0]
-        generate_array_method = getattr(SortGenerator, array_class)
+
+        cls = SortGeneratorSmall if dtype in self.small_dtypes else SortGenerator
+        generate_array_method = getattr(cls, array_class)
         self.arr = generate_array_method(self.ARRAY_SIZE, dtype, *array_type[1:], rnd)
 
-    def time_sort(self, kind, dtype, array_type):
+    def time_sort(self, stable, descending, dtype, array_type):
         # Using np.sort(...) instead of arr.sort(...) because it makes a copy.
         # This is important because the data is prepared once per benchmark, but
         # used across multiple runs.
-        np.sort(self.arr, kind=kind)
+        np.sort(self.arr, stable=stable, descending=descending)
 
-    def time_argsort(self, kind, dtype, array_type):
-        np.argsort(self.arr, kind=kind)
+    def time_argsort(self, stable, descending, dtype, array_type):
+        np.argsort(self.arr, stable=stable, descending=descending)
 
 
 class Partition(Benchmark):

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -206,7 +206,7 @@ class SortGenerator:
             except (OverflowError, FloatingPointError):
                 raise SkipNotImplemented("Cannot construct arange for this size.")
 
-        return SortGenerator.ordered_range(size, dtype=dtype)[::-1].copy()
+        return SortGenerator.ordered_range(size, dtype=dtype)[::-1]
 
     @staticmethod
     @memoize
@@ -275,6 +275,7 @@ class Sort(Benchmark):
         self.arr = generate_array_method(self.ARRAY_SIZE, dtype, *array_type[1:], rnd)
         if descending:
             self.arr = self.arr[::-1]
+        self.arr = self.arr.copy()
 
     def time_sort(self, stable, descending, dtype, array_type):
         # Using np.sort(...) instead of arr.sort(...) because it makes a copy.

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -206,7 +206,7 @@ class SortGenerator:
             except (OverflowError, FloatingPointError):
                 raise SkipNotImplemented("Cannot construct arange for this size.")
 
-        return SortGenerator.ordered_range(size, dtype=dtype)[::-1]
+        return SortGenerator.ordered_range(size, dtype=dtype)[::-1].copy()
 
     @staticmethod
     @memoize

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -153,13 +153,33 @@ class SortGenerator:
     # The size of the "partially ordered" sub-arrays
     BUBBLE_SIZE = 100
 
+    small_limits = {
+        'bool': (0, 2),
+        'uint8': (0, 256),
+        'int8': (-128, 128),
+        'int16': (-32768, 32768),
+        'float16': (-1000, 1000),
+    }
+
+    @staticmethod
+    @memoize
+    def ordered_range(size, dtype):
+        """
+        Returns an ordered array of the given size and dtype.
+        """
+        if dtype in SortGenerator.small_limits:
+            arange = np.arange(*SortGenerator.small_limits[dtype], dtype=dtype)
+            return np.repeat(arange, size // arange.size + 1)[:size]
+        else:
+            return np.arange(size, dtype=dtype)
+
     @staticmethod
     @memoize
     def random(size, dtype, rnd):
         """
         Returns a randomly-shuffled array.
         """
-        arr = np.arange(size, dtype=dtype)
+        arr = SortGenerator.ordered_range(size, dtype=dtype)
         rnd = np.random.RandomState(1792364059)
         np.random.shuffle(arr)
         rnd.shuffle(arr)
@@ -171,7 +191,7 @@ class SortGenerator:
         """
         Returns an ordered array.
         """
-        return np.arange(size, dtype=dtype)
+        return SortGenerator.ordered_range(size, dtype=dtype)
 
     @staticmethod
     @memoize
@@ -179,14 +199,14 @@ class SortGenerator:
         """
         Returns an array that's in descending order.
         """
-        dtype = np.dtype(dtype)
-        try:
-            with np.errstate(over="raise"):
-                res = dtype.type(size - 1)
-        except (OverflowError, FloatingPointError):
-            raise SkipNotImplemented("Cannot construct arange for this size.")
+        if dtype not in SortGenerator.small_limits:
+            try:
+                with np.errstate(over="raise"):
+                    res = np.dtype(dtype).type(size - 1)
+            except (OverflowError, FloatingPointError):
+                raise SkipNotImplemented("Cannot construct arange for this size.")
 
-        return np.arange(size - 1, -1, -1, dtype=dtype)
+        return SortGenerator.ordered_range(size, dtype=dtype)[::-1]
 
     @staticmethod
     @memoize
@@ -202,84 +222,7 @@ class SortGenerator:
         """
         Returns an array with blocks that are all sorted.
         """
-        a = np.arange(size, dtype=dtype)
-        b = []
-        if size < block_size:
-            return a
-        block_num = size // block_size
-        for i in range(block_num):
-            b.extend(a[i::block_num])
-        return np.array(b)
-
-
-class SortGeneratorSmall:
-    # This is a separate class as for certain small dtypes we
-    # need to repeat elements to get the desired array size.
-
-    # The size of the unsorted area in the "random unsorted area"
-    # benchmarks
-    AREA_SIZE = 100
-    # The size of the "partially ordered" sub-arrays
-    BUBBLE_SIZE = 100
-
-    limits = {
-        'bool': (0, 2),
-        'uint8': (0, 256),
-        'int8': (-128, 128),
-        'int16': (-32768, 32768),
-        'float16': (-1000, 1000),
-    }
-
-    @staticmethod
-    @memoize
-    def arange(dtype):
-        return np.arange(*SortGeneratorSmall.limits[dtype], dtype=dtype)
-
-    @staticmethod
-    @memoize
-    def random(size, dtype, rnd):
-        """
-        Returns a randomly-shuffled array.
-        """
-        arange = SortGeneratorSmall.arange(dtype)
-        rnd = np.random.RandomState(1792364059)
-        arr = rnd.choice(arange, size=size, replace=True)
-        return arr
-
-    @staticmethod
-    @memoize
-    def ordered(size, dtype, rnd):
-        """
-        Returns an ordered array.
-        """
-        arange = SortGeneratorSmall.arange(dtype)
-        return np.repeat(arange, size // arange.size + 1)[:size]
-
-    @staticmethod
-    @memoize
-    def reversed(size, dtype, rnd):
-        """
-        Returns an array that's in descending order.
-        """
-        arange = SortGeneratorSmall.arange(dtype)
-        return np.repeat(arange[::-1], size // arange.size + 1)[:size]
-
-    @staticmethod
-    @memoize
-    def uniform(size, dtype, rnd):
-        """
-        Returns an array that has the same value everywhere.
-        """
-        return np.ones(size, dtype=dtype)
-
-    @staticmethod
-    @memoize
-    def sorted_block(size, dtype, block_size, rnd):
-        """
-        Returns an array with blocks that are all sorted.
-        """
-        a = SortGeneratorSmall.arange(dtype=dtype)
-        a = np.repeat(a, size // a.size + 1)[:size]
+        a = SortGenerator.ordered_range(size, dtype=dtype)
         b = []
         if size < block_size:
             return a
@@ -327,14 +270,10 @@ class Sort(Benchmark):
     # The size of the benchmarked arrays.
     ARRAY_SIZE = 1000000
 
-    small_dtypes = ['bool', 'uint8', 'int8', 'int16', 'float16']
-
     def setup(self, stable, descending, dtype, array_type):
         rnd = np.random.RandomState(507582308)
         array_class = array_type[0]
-
-        cls = SortGeneratorSmall if dtype in self.small_dtypes else SortGenerator
-        generate_array_method = getattr(cls, array_class)
+        generate_array_method = getattr(SortGenerator, array_class)
         self.arr = generate_array_method(self.ARRAY_SIZE, dtype, *array_type[1:], rnd)
 
     def time_sort(self, stable, descending, dtype, array_type):

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -283,7 +283,10 @@ class Sort(Benchmark):
         np.sort(self.arr, stable=stable, descending=descending)
 
     def time_argsort(self, stable, descending, dtype, array_type):
-        np.argsort(self.arr, stable=stable, descending=descending)
+        if descending:
+            np.argsort(self.arr, stable=stable, descending=True)
+        else:
+            np.argsort(self.arr, stable=stable)
 
 
 class Partition(Benchmark):

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -239,8 +239,6 @@ class Sort(Benchmark):
     real-world applications.
     """
     params = [
-        # In NumPy 1.17 and newer, 'merge' can be one of several
-        # stable sorts, it isn't necessarily merge sort.
         [True, False],
         [True, False],
         [

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -326,7 +326,7 @@ class Sort(Benchmark):
 
     # The size of the benchmarked arrays.
     ARRAY_SIZE = 1000000
-    
+
     small_dtypes = ['bool', 'uint8', 'int8', 'int16', 'float16']
 
     def setup(self, stable, descending, dtype, array_type):

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -199,13 +199,6 @@ class SortGenerator:
         """
         Returns an array that's in descending order.
         """
-        if dtype not in SortGenerator.small_limits:
-            try:
-                with np.errstate(over="raise"):
-                    res = np.dtype(dtype).type(size - 1)
-            except (OverflowError, FloatingPointError):
-                raise SkipNotImplemented("Cannot construct arange for this size.")
-
         return SortGenerator.ordered_range(size, dtype=dtype)[::-1]
 
     @staticmethod

--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -273,6 +273,8 @@ class Sort(Benchmark):
         array_class = array_type[0]
         generate_array_method = getattr(SortGenerator, array_class)
         self.arr = generate_array_method(self.ARRAY_SIZE, dtype, *array_type[1:], rnd)
+        if descending:
+            self.arr = self.arr[::-1]
 
     def time_sort(self, stable, descending, dtype, array_type):
         # Using np.sort(...) instead of arr.sort(...) because it makes a copy.


### PR DESCRIPTION
Updates the benchmarks to use the new-style sort kwargs, `stable` and `descending`, instead of the older `kind`, aligned with a [comment](https://github.com/numpy/numpy/pull/31345#issuecomment-4435933886) from @charris. This adds support for descending benchmarks and could be useful as we add dtypes such as `object`. cc @seberg

I also added a small class to allow for benchmarking smaller sized arrays. I'm not sure if I went too far with that or whether it is actually necessary, but mainly was curious as I noticed several benchmarks (even for `int16` and `float16`) were being skipped for certain array types, and I remember for `radixsort` I was curious about short/bool performance but they weren't included. Completely open to remove/adjust this to reduce complexity.

I can also post a benchmarks run if needed and this seems to be a good direction.

#### AI Disclosure
No AI tools used.