### PR TITLE
Improve error messages for invalid norm orders in linalg.norm

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2805,7 +2805,10 @@ def norm(x, ord=None, axis=None, keepdims=False):
         # None of the str-type keywords for ord ('fro', 'nuc')
         # are valid for vectors
         elif isinstance(ord, str):
-            raise ValueError(f"Invalid norm order '{ord}' for vectors")
+            raise ValueError(
+                f"Invalid norm order '{ord}' for vectors. "
+                f"Valid string values for vectors are: None, 'fro', 'f', 'nuc'."
+            )
         else:
             absx = abs(x)
             absx **= ord
@@ -2843,7 +2846,10 @@ def norm(x, ord=None, axis=None, keepdims=False):
         elif ord == 'nuc':
             ret = _multi_svd_norm(x, row_axis, col_axis, sum, 0)
         else:
-            raise ValueError("Invalid norm order for matrices.")
+            raise ValueError(
+                f"Invalid norm order '{ord}' for matrices. "
+                f"Valid string values for matrices are: None, 'fro', 'f', 'nuc'."
+            )
         if keepdims:
             ret_shape = list(x.shape)
             ret_shape[axis[0]] = 1


### PR DESCRIPTION
Improve error messages for invalid norm orders in linalg.norm

Add valid options to error messages when users pass invalid string values for the ord parameter in numpy.linalg.norm for both vectors and matrices.

Before:
- Invalid norm order 'invalid' for vectors
- Invalid norm order for matrices.

After:
- Invalid norm order 'invalid' for vectors. Valid string values for vectors are: None, 'fro', 'f', 'nuc'.
- Invalid norm order 'invalid' for matrices. Valid string values for matrices are: None, 'fro', 'f', 'nuc'.

This helps users understand what values are accepted without needing to consult the documentation.