### PR TITLE
CI: Add wheel building and testing on Linux-riscv64

### DIFF
--- a/.github/workflows/linux_riscv64.yml
+++ b/.github/workflows/linux_riscv64.yml
@@ -1,0 +1,83 @@
+# Workflow to build and test wheels, similarly to numpy/numpy-release.
+# To work on these jobs in a fork, comment out:
+#
+#     if: github.repository == 'numpy/numpy'
+name: Linux-riscv64 Wheel builder
+
+on:
+  pull_request:
+    branches:
+      - main
+      - maintenance/**
+    paths-ignore:
+      - '**.pyi'
+      - '**.md'
+      - '**.rst'
+      - 'tools/stubtest/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  build_wheels:
+    name: Build wheel ${{ matrix.python }}-manylinux_riscv64-
+    # To enable this job on a fork, comment out:
+    if: github.repository == 'numpy/numpy'
+    runs-on: ubuntu-24.04-riscv
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["cp312"]
+
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_BASEDIR: "/project"
+      CCACHE_COMPILERCHECK: "content"
+    steps:
+      - name: Checkout numpy
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Restore compilation cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: ccache-restore
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-wheels-manylinux_riscv64-${{ matrix.python }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-wheels-manylinux_riscv64-${{ matrix.python }}-
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-manylinux_riscv64
+          CIBW_BEFORE_ALL_LINUX: |
+            set -eux
+            CCACHE_VERSION=4.13.6
+            curl -fsSL https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-linux-$(uname -m)-musl-static.tar.gz | \
+              tar -xvzf - --strip-components 1 -C /usr/local/bin ccache-${CCACHE_VERSION}-linux-$(uname -m)-musl-static/ccache
+            ccache --version
+            ccache --zero-stats
+          CIBW_ENVIRONMENT_PASS_LINUX: >-
+            CCACHE_BASEDIR
+            CCACHE_COMPILERCHECK
+          CIBW_CONTAINER_ENGINE: "docker; create_args: --volume ${{ env.CCACHE_DIR }}:/root/.ccache"
+
+      - name: Save compilation cache
+        if: always() && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-wheels-manylinux_riscv64-${{ matrix.python }}-${{ github.run_id }}
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.python }}-manylinux_riscv64-
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/linux_riscv64.yml
+++ b/.github/workflows/linux_riscv64.yml
@@ -5,6 +5,14 @@
 name: Linux-riscv64 Wheel builder
 
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.pyi'
+      - '**.md'
+      - '**.rst'
+      - 'tools/stubtest/**'
   pull_request:
     branches:
       - main
@@ -71,7 +79,7 @@ jobs:
           CIBW_CONTAINER_ENGINE: "docker; create_args: --volume ${{ env.CCACHE_DIR }}:/root/.ccache"
 
       - name: Save compilation cache
-        if: always() && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: always() && github.ref == 'refs/heads/main'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.CCACHE_DIR }}

--- a/.github/workflows/linux_riscv64.yml
+++ b/.github/workflows/linux_riscv64.yml
@@ -17,11 +17,6 @@ on:
     branches:
       - main
       - maintenance/**
-    paths-ignore:
-      - '**.pyi'
-      - '**.md'
-      - '**.rst'
-      - 'tools/stubtest/**'
   workflow_dispatch:
 
 concurrency:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ build-dir = "build"
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
+manylinux-riscv64-image = "manylinux_2_39"
 musllinux-x86_64-image = "musllinux_1_2"
 musllinux-aarch64-image = "musllinux_1_2"
 

--- a/tools/wheels/cibw_test_command.sh
+++ b/tools/wheels/cibw_test_command.sh
@@ -27,5 +27,11 @@ fi
 
 # Run full tests with -n=auto. This makes pytest-xdist distribute tests across
 # the available N CPU cores. Also print the durations for the 10 slowest tests
-# to help with debugging slow or hanging tests
-python -c "import sys; import numpy; sys.exit(not numpy.test(label='full', extra_argv=['-n=auto', '--durations=10']))"
+# to help with debugging slow or hanging tests.
+# On riscv64 use 'fast' to stay within the CI time budget (the slowest 'full'
+# tests alone add ~15 min on native hardware).
+if [[ "$(uname -m)" == "riscv64" ]]; then
+    python -c "import sys; import numpy; sys.exit(not numpy.test(label='fast', extra_argv=['-n=auto', '--durations=10']))"
+else
+    python -c "import sys; import numpy; sys.exit(not numpy.test(label='full', extra_argv=['-n=auto', '--durations=10']))"
+fi


### PR DESCRIPTION
### PR summary

Follow up to https://github.com/numpy/numpy/pull/30995 with ccache and in a separate `linux_riscv64.yml`.

#### AI Disclosure

AI tools used for research and understanding of the problem. Artisanal coding by (human) hands

cc @rgommers @andyfaff @gounthar 