### PR TITLE
BUG: avoid quantile index overflow for float16 array q

### DIFF
--- a/doc/release/upcoming_changes/31487.change.rst
+++ b/doc/release/upcoming_changes/31487.change.rst
@@ -1,0 +1,3 @@
+``quantile``, ``percentile``, ``nanquantile``, and ``nanpercentile`` now
+avoid overflow in internal index calculations when a large input array is
+combined with a low-precision floating-point array for ``q``.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4567,7 +4567,7 @@ def _compute_virtual_index(n, quantiles, alpha: float, beta: float):
     ) - 1
 
 
-def _get_gamma(virtual_indexes, previous_indexes, method):
+def _get_gamma(virtual_indexes, previous_indexes, method, dtype):
     """
     Compute gamma (a.k.a 'm' or 'weight') for the linear interpolation
     of quantiles.
@@ -4588,7 +4588,7 @@ def _get_gamma(virtual_indexes, previous_indexes, method):
     gamma = method["fix_gamma"](gamma, virtual_indexes)
     # Ensure both that we have an array, and that we keep the dtype
     # (which may have been matched to the input array).
-    return np.asanyarray(gamma, dtype=virtual_indexes.dtype)
+    return np.asanyarray(gamma, dtype=dtype)
 
 
 def _lerp(a, b, t, out=None):
@@ -4766,8 +4766,11 @@ def _quantile(
             raise ValueError(
                 f"{method!r} is not a valid method. Use one of: "
                 f"{_QuantileMethods.keys()}") from None
-        virtual_indexes = method_props["get_virtual_index"](values_count,
-                                                            quantiles)
+        gamma_dtype = np.asanyarray(
+            method_props["get_virtual_index"](1, quantiles)
+        ).dtype
+        virtual_indexes = method_props["get_virtual_index"](
+            np.intp(values_count), quantiles)
         virtual_indexes = np.asanyarray(virtual_indexes)
 
         if method_props["fix_gamma"] is None:
@@ -4810,7 +4813,7 @@ def _quantile(
             next = arr[next_indexes]
             # --- Linear interpolation
             gamma = _get_gamma(virtual_indexes, previous_indexes,
-                               method_props)
+                               method_props, gamma_dtype)
             if weak_q:
                 gamma = float(gamma)
             else:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3938,6 +3938,20 @@ class TestPercentile:
         assert z == one
         assert z.dtype == a.dtype
 
+    @pytest.mark.parametrize(["function", "quantile"], [
+        (np.quantile, np.array([0.5], dtype=np.float16)),
+        (np.percentile, np.array([50], dtype=np.float16)),
+    ])
+    @pytest.mark.parametrize("method", quantile_methods)
+    def test_float16_array_quantile_gh_31487(self, function, quantile, method):
+        a = np.zeros(65521, dtype=np.float16)
+        a[:20_000] = 1
+
+        result = function(a, quantile, method=method)
+
+        assert_equal(result, np.array([0], dtype=np.float16))
+        assert result.dtype == a.dtype
+
     @pytest.mark.slow
     def test_percentile_gh_29003_Fraction(self):
         zero = Fraction(0)

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1343,6 +1343,21 @@ class TestNanFunctions_Quantile:
         assert_equal(np.nanquantile(x, 1), 3.5)
         assert_equal(np.nanquantile(x, 0.5), 1.75)
 
+    @pytest.mark.parametrize(["function", "quantile"], [
+        (np.nanquantile, np.array([0.5], dtype=np.float16)),
+        (np.nanpercentile, np.array([0.5], dtype=np.float16)),
+        (np.nanpercentile, np.array([50], dtype=np.float16)),
+    ])
+    def test_float16_array_quantile_gh_31487(self, function, quantile):
+        x = np.zeros(65521, dtype=np.float16)
+        x[:10] = 1
+        x[20] = np.nan
+
+        result = function(x, quantile)
+
+        assert_equal(result, np.array([0], dtype=np.float16))
+        assert result.dtype == x.dtype
+
     def test_complex(self):
         arr_c = np.array([0.5 + 3.0j, 2.1 + 0.5j, 1.6 + 2.3j], dtype='G')
         assert_raises(TypeError, np.nanquantile, arr_c, 0.5)


### PR DESCRIPTION
Fixes #31487.

## Summary
- Compute quantile virtual indexes with a strong `np.intp` sample-size scalar so low-precision floating-point `q` arrays do not overflow during index calculation.
- Keep the interpolation gamma dtype derived from the existing `q` promotion behavior, so float16/float32 result dtype behavior stays unchanged.
- Add regression coverage for `quantile`, `percentile`, `nanquantile`, and `nanpercentile` with large float16 inputs and float16 array `q`.

## Reproducer
Before this change, large float16 inputs with float16 array `q` produced `nan` and overflow warnings, for example:

```python
arr = np.zeros(65521, dtype=np.float16)
arr[:10] = 1
np.nanquantile(arr, np.array([0.5], dtype=np.float16))
```

## Tests
- `python -m pytest numpy/lib/tests/test_function_base.py`
- `python -m pytest numpy/lib/tests/test_nanfunctions.py`
- `python -W error -m pytest numpy/lib/tests/test_function_base.py::TestPercentile::test_float16_array_quantile_gh_31487 numpy/lib/tests/test_nanfunctions.py::TestNanFunctions_Quantile::test_float16_array_quantile_gh_31487`
