### PR TITLE
BUG: prevent float16 quantile overflow for large arrays (gh-31487)

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4755,6 +4755,12 @@ def _quantile(
         np.issubdtype(arr.dtype, np.inexact) or arr.dtype.kind in 'Mm'
     )
 
+    # float16 can only represent up to 65504, which overflows for large arrays.
+    # Cast quantiles to a dtype that can represent all possible virtual indexes.
+    if (np.issubdtype(quantiles.dtype, np.floating)
+            and np.finfo(quantiles.dtype).max < values_count):
+        quantiles = quantiles.astype(np.result_type(quantiles, np.float64))
+
     if weights is None:
         # --- Computation of indexes
         # Index where to find the value in the sorted array.

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -4398,6 +4398,19 @@ class TestQuantile:
         assert value == q * 50_000
         assert value.dtype == np.float16
 
+    def test_float16_quantiles_large_array_gh_31487(self):
+        # Regression test for gh-31487: float16 quantiles overflow
+        # for arrays larger than float16 max (65504).
+        a = np.zeros(65521, dtype=np.float16)
+        a[:10] = 1
+        q = np.array([0.5, 1.0], dtype=np.float16)
+        # quantile with float16 quantiles
+        result = np.quantile(a, q)
+        assert not np.isnan(result).any()
+        # nanquantile with float16 quantiles
+        result = np.nanquantile(a, q)
+        assert not np.isnan(result).any()
+
     @pytest.mark.parametrize("method", interpolating_quantile_methods)
     @pytest.mark.parametrize("q", [0.5, 1])
     def test_q_weak_promotion(self, method, q):


### PR DESCRIPTION
## PR summary

For large arrays (> 65504 elements), passing quantiles as ``float16`` caused an overflow in the virtual-index computation inside ``_quantile`` because ``(n - 1) * quantiles`` exceeds the maximum finite ``float16`` value and overflows to ``inf``.  The overflow propagates and ultimately produces ``nan`` results instead of valid quantiles.

This PR adds a dtype-safety check: when the floating-point quantile type cannot represent the array size, the quantiles are up-cast to ``float64`` before computing virtual indexes.  This is a minimal, targeted fix that only affects the internal computation and preserves the existing output-dtype rules.

Fixes #31487

## AI Disclosure

No AI tools used
