### PR TITLE
ENH: handle masked arrays on histogram.

### DIFF
--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -277,7 +277,7 @@ _hist_bin_selectors = {'stone': _hist_bin_stone,
 
 def _ravel_and_check_weights(a, weights):
     """ Check a and weights have matching shapes, and ravel both """
-    a = np.asarray(a)
+    a = np.asanyarray(a)
 
     # Ensure that the array is a "subtractable" dtype
     if a.dtype == np.bool:
@@ -286,12 +286,25 @@ def _ravel_and_check_weights(a, weights):
         a = a.astype(np.uint8)
 
     if weights is not None:
-        weights = np.asarray(weights)
+        weights = np.asanyarray(weights)
         if weights.shape != a.shape:
             raise ValueError(
                 'weights should have the same shape as a.')
-        weights = weights.ravel()
-    a = a.ravel()
+
+    # Handle masked input. Weights or the data may be masked (possible both)
+    if isinstance(a, np.ma.MaskedArray) or isinstance(weights, np.ma.MaskedArray):
+        mask = np.ma.getmaskarray(a)
+        if isinstance(weights, np.ma.MaskedArray):
+            mask = mask | np.ma.getmaskarray(weights)
+        mask = mask.ravel()
+        a = np.asarray(a).ravel()[~mask]
+        if weights is not None:
+            weights = np.asarray(weights).ravel()[~mask]
+    else:
+        a = a.ravel()
+        if weights is not None:
+            weights = weights.ravel()
+
     return a, weights
 
 

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -429,6 +429,66 @@ class TestHistogram:
         assert edges[0] == Z[0]
         assert edges[-1] == Z[-1]
 
+    def test_masks(self):
+        # gh-10019: histogram ignores masked elements.
+        a = np.ma.array([1, 2, 3, 4, 5], mask=[False, False, True, False, False])
+        hist, _ = histogram(a, bins=[1, 2, 3, 4, 5, 6])
+        assert_array_equal(hist, [1, 1, 0, 1, 1])
+
+        n = 100
+        mask = np.zeros(n, dtype=bool)
+        mask[12:15] = True
+        y = np.ma.array(np.arange(n) + 0.5, mask=mask)
+        hist, _ = histogram(y)
+        assert_array_equal(hist, [10, 7, 10, 10, 10, 10, 10, 10, 10, 10])
+
+        a_plain = np.array([1.0, 2.0, 3.0, 4.0])
+        a_masked = np.ma.array([1.0, 2.0, 3.0, 4.0])
+        assert_array_equal(histogram(a_masked)[0], histogram(a_plain)[0])
+
+        a = np.ma.array([1.0, 2.0, 3.0], mask=[True, True, True])
+        hist, _ = histogram(a, bins=3, range=(0.0, 3.0))
+        assert_array_equal(hist, [0, 0, 0])
+
+        a = np.ma.array([[1, 2], [3, 4]], mask=[[False, True], [False, False]])
+        hist, _ = histogram(a, bins=[1, 2, 3, 4, 5])
+        assert_array_equal(hist, [1, 0, 1, 1])  # value 2 is masked
+
+        data = np.array([1.0, 2.0, 100.0, 4.0, 5.0])
+        mask = np.array([False, False, True, False, False])
+        h_masked, e_masked = histogram(np.ma.array(data, mask=mask), bins=4)
+        h_filtered, e_filtered = histogram(data[~mask], bins=4)
+        assert_array_equal(h_masked, h_filtered)
+        assert_array_equal(e_masked, e_filtered)
+
+        # Masked outlier doesn't affect auto bin selection or range
+        data = np.concatenate([np.linspace(0.0, 1.0, 50), [1000.0]])
+        mask = np.zeros(51, dtype=bool)
+        mask[-1] = True
+        h_masked, e_masked = histogram(np.ma.array(data, mask=mask), bins='auto')
+        h_ref, e_ref = histogram(data[:-1], bins='auto')
+        assert_array_equal(h_masked, h_ref)
+        assert_array_equal(e_masked, e_ref)
+
+        a = np.ma.array([1.0, 2.0, 3.0, 4.0, 5.0], mask=[False, True, False, False,
+                                                         False])
+        hist, edges = histogram(a, bins=4, density=True)
+        assert_almost_equal((hist * np.diff(edges)).sum(), 1.0)
+
+        # masked weights
+        a = np.array([1, 2, 3, 4, 5])
+        w = np.ma.array([1.0, 1.0, 99.0, 1.0, 1.0], mask=[False, False, True, False,
+                                                          False])
+        hist, _ = histogram(a, bins=[1, 2, 3, 4, 5, 6], weights=w)
+        assert_array_equal(hist, [1.0, 1.0, 0.0, 1.0, 1.0])
+
+        # Both masked data and weights
+        a = np.ma.array([1, 2, 3, 4, 5], mask=[False, True, False, False, False])
+        w = np.ma.array([1.0, 1.0, 99.0, 1.0, 1.0], mask=[False, False, True, False,
+                                                          False])
+        hist, _ = histogram(a, bins=[1, 2, 3, 4, 5, 6], weights=w)
+        assert_array_equal(hist, [1.0, 0.0, 0.0, 1.0, 1.0])
+
 class TestHistogramOptimBinNums:
     """
     Provide test coverage when using provided estimators for optimal number of


### PR DESCRIPTION
Add logic to handle masked data and masked weights on histogram.
fixes https://github.com/numpy/numpy/issues/10019
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
This PR makes weights and the input data to be possibly passed with masked arrays. 
If both the weights and input are masked, it will combine the masked data as I feel like this is more natural. It will not raise errors if masks are not matched.
### Other comments
note that this PR does not add masked support for histogramdd. I will open other PRs for it (hopefully).
#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
the lines 297-302 was generated by Claude (because of lazyness)
tests were partially written by claude
Claude was also used to review the code
