### PR TITLE
BUG: searchsorted rejects incompatible dtype pairs (gh-24032)

### DIFF
--- a/benchmarks/benchmarks/bench_searchsorted.py
+++ b/benchmarks/benchmarks/bench_searchsorted.py
@@ -33,3 +33,17 @@ class SearchSorted(Benchmark):
 
     def time_searchsorted(self, array_size, n_queries, query_order, use_sorter, seed):
         np.searchsorted(self.arr, self.queries, sorter=self.sorter)
+
+
+class SearchSortedListNeedle(Benchmark):
+    # gh-31495: the needle is a python list, so the runtime is dominated by
+    # dtype discovery/conversion of `v`, which must only happen once.
+    params = [[1_000, 1_000_000]]
+    param_names = ['n_queries']
+
+    def setup(self, n_queries):
+        self.arr = np.arange(100)
+        self.queries = list(range(n_queries))
+
+    def time_searchsorted_list(self, n_queries):
+        self.arr.searchsorted(self.queries)

--- a/benchmarks/benchmarks/bench_searchsorted.py
+++ b/benchmarks/benchmarks/bench_searchsorted.py
@@ -33,17 +33,3 @@ class SearchSorted(Benchmark):
 
     def time_searchsorted(self, array_size, n_queries, query_order, use_sorter, seed):
         np.searchsorted(self.arr, self.queries, sorter=self.sorter)
-
-
-class SearchSortedListNeedle(Benchmark):
-    # gh-31495: the needle is a python list, so the runtime is dominated by
-    # dtype discovery/conversion of `v`, which must only happen once.
-    params = [[1_000, 1_000_000]]
-    param_names = ['n_queries']
-
-    def setup(self, n_queries):
-        self.arr = np.arange(100)
-        self.queries = list(range(n_queries))
-
-    def time_searchsorted_list(self, n_queries):
-        self.arr.searchsorted(self.queries)

--- a/doc/release/upcoming_changes/31495.change.rst
+++ b/doc/release/upcoming_changes/31495.change.rst
@@ -1,0 +1,9 @@
+``searchsorted`` rejects mixed string/non-string inputs
+-------------------------------------------------------
+`numpy.searchsorted` (and `numpy.ndarray.searchsorted`) now raises a
+``TypeError`` when one input is a string array and the other a non-string
+array, for example ``np.searchsorted([1, 2, 3], ["1"])``.  Previously both
+inputs were silently promoted to a string dtype, so the values were compared
+as strings and incorrect indices were returned.  Pairings that promote to a
+non-legacy-string dtype (such as ``StringDType`` or ``object``) are
+unaffected.

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2105,27 +2105,34 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
     PyArray_ArgBinSearchFunc *argbinsearch = NULL;
     NPY_BEGIN_THREADS_DEF;
 
-    /* Discover op2's natural dtype, then promote.  Reject the specific
-     * string-vs-non-string mixture that would otherwise silently promote
-     * to a string dtype and return wrong indices (gh-24032). */
+    /* Reject the string-vs-non-string mixture that would otherwise silently
+     * promote to a string dtype and return wrong indices (gh-24032).  The
+     * check is on the dtypes, so it is applied independently of `v`'s size:
+     * an explicitly-typed but empty `v` (e.g. an empty integer array searched
+     * in a string `a`) is rejected just like a non-empty one, matching how
+     * comparison ufuncs such as ``np.less`` reject the same dtype pairing.
+     *
+     * The only exemption is when no dtype can be inferred from `v` at all
+     * (dtype_v == NULL, e.g. an empty list): such a `v` carries no type intent
+     * and always yields an empty result, so it must keep working. */
     PyArray_Descr *dtype_a = PyArray_DESCR(op1);
     PyArray_Descr *dtype_v = NULL;
     if (PyArray_DTypeFromObject(op2, NPY_MAXDIMS, &dtype_v) < 0) {
         return NULL;
     }
-    if (dtype_v == NULL) {
-        dtype_v = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
-    }
-    if (PyTypeNum_ISSTRING(dtype_a->type_num)
-            != PyTypeNum_ISSTRING(dtype_v->type_num)) {
+    if (dtype_v != NULL
+            && PyTypeNum_ISSTRING(dtype_a->type_num)
+                != PyTypeNum_ISSTRING(dtype_v->type_num)) {
         PyErr_Format(PyExc_TypeError,
                 "Incompatible types for searching: a (%S) and v (%S)",
                 dtype_a, dtype_v);
         Py_DECREF(dtype_v);
         return NULL;
     }
-    dtype = PyArray_PromoteTypes(dtype_a, dtype_v);
-    Py_DECREF(dtype_v);
+    Py_XDECREF(dtype_v);
+
+    /* Find common type (unchanged historical behavior for the accepted cases) */
+    dtype = PyArray_DescrFromObject((PyObject *)op2, dtype_a);
     if (dtype == NULL) {
         return NULL;
     }

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1,4 +1,5 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define _UMATHMODULE
 #define _MULTIARRAYMODULE
 
 #define PY_SSIZE_T_CLEAN
@@ -8,6 +9,7 @@
 
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"
+#include "numpy/ufuncobject.h"
 
 #include "numpy/npy_math.h"
 #include "numpy/npy_cpu.h"
@@ -17,6 +19,7 @@
 
 
 #include "npy_static_data.h"
+#include "npy_import.h"
 #include "common.h"
 #include "dtype_transfer.h"
 #include "dtypemeta.h"
@@ -33,6 +36,7 @@
 #include "alloc.h"
 #include "arraytypes.h"
 #include "array_coercion.h"
+#include "dispatching.h"
 #include "simd/simd.h"
 
 static NPY_GCC_OPT_3 inline int
@@ -2061,6 +2065,68 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
 }
 
 
+/*
+ * Mirror `np.less.resolve_dtypes((dtype_a, dtype_v, None))` in C — reject
+ * pairings like int+str that would otherwise be silently promoted to string
+ * and yield wrong searchsorted results (gh-24032).
+ *
+ * Returns 0 if compatible, -1 with a TypeError set otherwise.
+ */
+static int
+searchsorted_check_dtypes(PyArray_Descr *dtype_a, PyArray_Descr *dtype_v)
+{
+    static PyObject *less_ufunc = NULL;
+    if (npy_cache_import_runtime("numpy", "less", &less_ufunc) < 0) {
+        return -1;
+    }
+
+    /* The legacy type resolver dereferences PyArray_DESCR(ops[i]), so we
+     * need real PyArrayObjects (0-d, no data). The third slot is for the
+     * output and is cleared by promote_and_get_ufuncimpl. */
+    PyArrayObject *ops[3] = {NULL, NULL, NULL};
+    PyArray_DTypeMeta *op_DTypes[3] = {NPY_DTYPE(dtype_a), NPY_DTYPE(dtype_v), NULL};
+    PyArray_DTypeMeta *signature[3] = {NULL, NULL, NULL};
+    PyArray_Descr *dtypes[2] = {dtype_a, dtype_v};
+    int rv = -1;
+
+    Py_INCREF(op_DTypes[0]);
+    Py_INCREF(op_DTypes[1]);
+    for (int i = 0; i < 2; i++) {
+        Py_INCREF(dtypes[i]);
+        ops[i] = (PyArrayObject *)PyArray_NewFromDescr_int(
+                &PyArray_Type, dtypes[i], 0, NULL, NULL, NULL, 0, NULL, NULL,
+                _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
+        if (ops[i] == NULL) {
+            goto cleanup;
+        }
+    }
+
+    PyArrayMethodObject *impl = promote_and_get_ufuncimpl(
+            (PyUFuncObject *)less_ufunc, ops, signature, op_DTypes,
+            NPY_FALSE, NPY_FALSE, NPY_FALSE);
+    if (impl == NULL) {
+        PyErr_Clear();
+        PyErr_Format(PyExc_TypeError,
+                "Incompatible types for searching: a (%S) and v (%S)",
+                dtype_a, dtype_v);
+    }
+    else {
+        rv = 0;
+    }
+
+cleanup:
+    Py_XDECREF(ops[0]);
+    Py_XDECREF(ops[1]);
+    Py_XDECREF(op_DTypes[0]);
+    Py_XDECREF(op_DTypes[1]);
+    Py_XDECREF(op_DTypes[2]);
+    Py_XDECREF(signature[0]);
+    Py_XDECREF(signature[1]);
+    Py_XDECREF(signature[2]);
+    return rv;
+}
+
+
 /*NUMPY_API
  *
  * Search the sorted array op1 for the location of the items in op2. The
@@ -2105,8 +2171,26 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
     PyArray_ArgBinSearchFunc *argbinsearch = NULL;
     NPY_BEGIN_THREADS_DEF;
 
-    /* Find common type */
-    dtype = PyArray_DescrFromObject((PyObject *)op2, PyArray_DESCR(op1));
+    /* Discover op2's natural dtype, reject incompatible pairs (gh-24032),
+     * then promote. Same-DType and number/number pairs always have a less
+     * loop, so they skip the heavy check. */
+    PyArray_Descr *dtype_a = PyArray_DESCR(op1);
+    PyArray_Descr *dtype_v = NULL;
+    if (PyArray_DTypeFromObject(op2, NPY_MAXDIMS, &dtype_v) < 0) {
+        return NULL;
+    }
+    if (dtype_v == NULL) {
+        dtype_v = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
+    }
+    if (NPY_DTYPE(dtype_a) != NPY_DTYPE(dtype_v)
+            && !(PyTypeNum_ISNUMBER(dtype_a->type_num)
+                 && PyTypeNum_ISNUMBER(dtype_v->type_num))
+            && searchsorted_check_dtypes(dtype_a, dtype_v) < 0) {
+        Py_DECREF(dtype_v);
+        return NULL;
+    }
+    dtype = PyArray_PromoteTypes(dtype_a, dtype_v);
+    Py_DECREF(dtype_v);
     if (dtype == NULL) {
         return NULL;
     }

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1,5 +1,4 @@
 #define NPY_NO_DEPRECATED_API NPY_API_VERSION
-#define _UMATHMODULE
 #define _MULTIARRAYMODULE
 
 #define PY_SSIZE_T_CLEAN
@@ -9,7 +8,6 @@
 
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"
-#include "numpy/ufuncobject.h"
 
 #include "numpy/npy_math.h"
 #include "numpy/npy_cpu.h"
@@ -19,7 +17,6 @@
 
 
 #include "npy_static_data.h"
-#include "npy_import.h"
 #include "common.h"
 #include "dtype_transfer.h"
 #include "dtypemeta.h"
@@ -36,7 +33,6 @@
 #include "alloc.h"
 #include "arraytypes.h"
 #include "array_coercion.h"
-#include "dispatching.h"
 #include "simd/simd.h"
 
 static NPY_GCC_OPT_3 inline int
@@ -2065,68 +2061,6 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
 }
 
 
-/*
- * Mirror `np.less.resolve_dtypes((dtype_a, dtype_v, None))` in C — reject
- * pairings like int+str that would otherwise be silently promoted to string
- * and yield wrong searchsorted results (gh-24032).
- *
- * Returns 0 if compatible, -1 with a TypeError set otherwise.
- */
-static int
-searchsorted_check_dtypes(PyArray_Descr *dtype_a, PyArray_Descr *dtype_v)
-{
-    static PyObject *less_ufunc = NULL;
-    if (npy_cache_import_runtime("numpy", "less", &less_ufunc) < 0) {
-        return -1;
-    }
-
-    /* The legacy type resolver dereferences PyArray_DESCR(ops[i]), so we
-     * need real PyArrayObjects (0-d, no data). The third slot is for the
-     * output and is cleared by promote_and_get_ufuncimpl. */
-    PyArrayObject *ops[3] = {NULL, NULL, NULL};
-    PyArray_DTypeMeta *op_DTypes[3] = {NPY_DTYPE(dtype_a), NPY_DTYPE(dtype_v), NULL};
-    PyArray_DTypeMeta *signature[3] = {NULL, NULL, NULL};
-    PyArray_Descr *dtypes[2] = {dtype_a, dtype_v};
-    int rv = -1;
-
-    Py_INCREF(op_DTypes[0]);
-    Py_INCREF(op_DTypes[1]);
-    for (int i = 0; i < 2; i++) {
-        Py_INCREF(dtypes[i]);
-        ops[i] = (PyArrayObject *)PyArray_NewFromDescr_int(
-                &PyArray_Type, dtypes[i], 0, NULL, NULL, NULL, 0, NULL, NULL,
-                _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
-        if (ops[i] == NULL) {
-            goto cleanup;
-        }
-    }
-
-    PyArrayMethodObject *impl = promote_and_get_ufuncimpl(
-            (PyUFuncObject *)less_ufunc, ops, signature, op_DTypes,
-            NPY_FALSE, NPY_FALSE, NPY_FALSE);
-    if (impl == NULL) {
-        PyErr_Clear();
-        PyErr_Format(PyExc_TypeError,
-                "Incompatible types for searching: a (%S) and v (%S)",
-                dtype_a, dtype_v);
-    }
-    else {
-        rv = 0;
-    }
-
-cleanup:
-    Py_XDECREF(ops[0]);
-    Py_XDECREF(ops[1]);
-    Py_XDECREF(op_DTypes[0]);
-    Py_XDECREF(op_DTypes[1]);
-    Py_XDECREF(op_DTypes[2]);
-    Py_XDECREF(signature[0]);
-    Py_XDECREF(signature[1]);
-    Py_XDECREF(signature[2]);
-    return rv;
-}
-
-
 /*NUMPY_API
  *
  * Search the sorted array op1 for the location of the items in op2. The
@@ -2171,9 +2105,9 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
     PyArray_ArgBinSearchFunc *argbinsearch = NULL;
     NPY_BEGIN_THREADS_DEF;
 
-    /* Discover op2's natural dtype, reject incompatible pairs (gh-24032),
-     * then promote. Same-DType and number/number pairs always have a less
-     * loop, so they skip the heavy check. */
+    /* Discover op2's natural dtype, then promote.  Reject the specific
+     * string-vs-non-string mixture that would otherwise silently promote
+     * to a string dtype and return wrong indices (gh-24032). */
     PyArray_Descr *dtype_a = PyArray_DESCR(op1);
     PyArray_Descr *dtype_v = NULL;
     if (PyArray_DTypeFromObject(op2, NPY_MAXDIMS, &dtype_v) < 0) {
@@ -2182,10 +2116,11 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
     if (dtype_v == NULL) {
         dtype_v = PyArray_DescrFromType(NPY_DEFAULT_TYPE);
     }
-    if (NPY_DTYPE(dtype_a) != NPY_DTYPE(dtype_v)
-            && !(PyTypeNum_ISNUMBER(dtype_a->type_num)
-                 && PyTypeNum_ISNUMBER(dtype_v->type_num))
-            && searchsorted_check_dtypes(dtype_a, dtype_v) < 0) {
+    if (PyTypeNum_ISSTRING(dtype_a->type_num)
+            != PyTypeNum_ISSTRING(dtype_v->type_num)) {
+        PyErr_Format(PyExc_TypeError,
+                "Incompatible types for searching: a (%S) and v (%S)",
+                dtype_a, dtype_v);
         Py_DECREF(dtype_v);
         return NULL;
     }

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -2105,36 +2105,65 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
     PyArray_ArgBinSearchFunc *argbinsearch = NULL;
     NPY_BEGIN_THREADS_DEF;
 
-    /* Reject the string-vs-non-string mixture that would otherwise silently
-     * promote to a string dtype and return wrong indices (gh-24032).  The
-     * check is on the dtypes, so it is applied independently of `v`'s size:
-     * an explicitly-typed but empty `v` (e.g. an empty integer array searched
-     * in a string `a`) is rejected just like a non-empty one, matching how
-     * comparison ufuncs such as ``np.less`` reject the same dtype pairing.
-     *
-     * The only exemption is when no dtype can be inferred from `v` at all
-     * (dtype_v == NULL, e.g. an empty list): such a `v` carries no type intent
-     * and always yields an empty result, so it must keep working. */
+    /*
+     * Find the common search type: discover `v`'s dtype once, then promote
+     * with `a`'s dtype.  This gives the same result as the historical
+     * ``PyArray_DescrFromObject(op2, dtype_a)`` without scanning a possibly
+     * large sequence `v` a second time.
+     */
     PyArray_Descr *dtype_a = PyArray_DESCR(op1);
     PyArray_Descr *dtype_v = NULL;
     if (PyArray_DTypeFromObject(op2, NPY_MAXDIMS, &dtype_v) < 0) {
         return NULL;
     }
-    if (dtype_v != NULL
-            && PyTypeNum_ISSTRING(dtype_a->type_num)
-                != PyTypeNum_ISSTRING(dtype_v->type_num)) {
-        PyErr_Format(PyExc_TypeError,
-                "Incompatible types for searching: a (%S) and v (%S)",
-                dtype_a, dtype_v);
-        Py_DECREF(dtype_v);
-        return NULL;
+    if (dtype_v == NULL) {
+        /*
+         * No dtype could be inferred from `v` (e.g. an empty list): such a
+         * `v` carries no type intent (and always yields an empty result), so
+         * keep the historical behavior.
+         */
+        dtype = PyArray_DescrFromObject((PyObject *)op2, dtype_a);
+        if (dtype == NULL) {
+            return NULL;
+        }
     }
-    Py_XDECREF(dtype_v);
-
-    /* Find common type (unchanged historical behavior for the accepted cases) */
-    dtype = PyArray_DescrFromObject((PyObject *)op2, dtype_a);
-    if (dtype == NULL) {
-        return NULL;
+    else {
+        dtype = PyArray_PromoteTypes(dtype_a, dtype_v);
+        if (dtype == NULL) {
+            /*
+             * The dtype discovery machinery falls back to object on
+             * promotion failure (e.g. datetime64 vs. string); mirror that
+             * so these pairings behave exactly as before.
+             */
+            if (PyErr_ExceptionMatches(npy_static_pydata.DTypePromotionError)) {
+                PyErr_Clear();
+                dtype = PyArray_DescrFromType(NPY_OBJECT);
+            }
+            if (dtype == NULL) {
+                Py_DECREF(dtype_v);
+                return NULL;
+            }
+        }
+        /*
+         * Reject mixtures that only "work" by promoting to a legacy string
+         * dtype (e.g. int vs. str): the values would compare as strings and
+         * give wrong indices (gh-24032).  The check runs after promotion so
+         * that pairings promoting to StringDType or object keep working, and
+         * it only involves the dtypes, so an explicitly-typed but empty `v`
+         * is rejected just like a non-empty one, matching how comparison
+         * ufuncs such as ``np.less`` reject the same dtype pairing.
+         */
+        if (PyTypeNum_ISSTRING(dtype->type_num)
+                && !(PyTypeNum_ISSTRING(dtype_a->type_num)
+                     && PyTypeNum_ISSTRING(dtype_v->type_num))) {
+            PyErr_Format(PyExc_TypeError,
+                    "Incompatible types for searching: a (%S) and v (%S)",
+                    dtype_a, dtype_v);
+            Py_DECREF(dtype_v);
+            Py_DECREF(dtype);
+            return NULL;
+        }
+        Py_DECREF(dtype_v);
     }
 
     /* Look for binary search function */

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3314,6 +3314,13 @@ class TestMethods:
         assert_(not isinstance(a.searchsorted(b, 'left', s), A))
         assert_(not isinstance(a.searchsorted(b, 'right', s), A))
 
+    def test_searchsorted_incompatible_inputs(self):
+        # gh-24032: incompatible types must raise rather than silently
+        # promote to a string dtype and return wrong indices.
+        assert_raises(TypeError, np.searchsorted, [1, 2, 3], ["1"])
+        assert_raises(TypeError, np.searchsorted, ["1", "2", "3"], [2])
+        assert_raises(TypeError, np.searchsorted, [b"1", b"2", b"3"], 1)
+
     @pytest.mark.parametrize("dtype", np.typecodes["All"])
     def test_argpartition_out_of_range(self, dtype):
         # Test out of range values in kth raise an error, gh-5469

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3321,6 +3321,29 @@ class TestMethods:
         assert_raises(TypeError, np.searchsorted, ["1", "2", "3"], [2])
         assert_raises(TypeError, np.searchsorted, [b"1", b"2", b"3"], 1)
 
+    def test_searchsorted_empty_v(self):
+        # gh-24032 regression: an empty python list carries no type intent, so
+        # its dtype cannot be inferred and the incompatible-type check must be
+        # skipped -- it always yields an empty result regardless of `a`.
+        for a in (["a", "b"], [b"a", b"b"], [1, 2, 3]):
+            res = np.searchsorted(a, [])
+            assert_equal(res, np.array([], dtype=np.intp))
+            # an empty array with a *compatible* dtype also works
+            res = np.searchsorted(a, np.array([], dtype=np.asarray(a).dtype))
+            assert_equal(res, np.array([], dtype=np.intp))
+
+    def test_searchsorted_incompatible_empty_v(self):
+        # gh-24032: the string-vs-non-string check is on the dtypes, so an
+        # explicitly-typed but empty `v` is rejected just like a non-empty one
+        # (the contract must not depend on len(v)). This mirrors how comparison
+        # ufuncs such as np.less reject the same dtype pairing.
+        assert_raises(TypeError, np.searchsorted, ["a", "b"],
+                      np.array([], dtype=np.int64))
+        assert_raises(TypeError, np.searchsorted, [b"a", b"b"],
+                      np.array([], dtype=np.int64))
+        assert_raises(TypeError, np.searchsorted, [1, 2, 3],
+                      np.array([], dtype="U1"))
+
     @pytest.mark.parametrize("dtype", np.typecodes["All"])
     def test_argpartition_out_of_range(self, dtype):
         # Test out of range values in kth raise an error, gh-5469

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3317,9 +3317,25 @@ class TestMethods:
     def test_searchsorted_incompatible_inputs(self):
         # gh-24032: incompatible types must raise rather than silently
         # promote to a string dtype and return wrong indices.
-        assert_raises(TypeError, np.searchsorted, [1, 2, 3], ["1"])
-        assert_raises(TypeError, np.searchsorted, ["1", "2", "3"], [2])
-        assert_raises(TypeError, np.searchsorted, [b"1", b"2", b"3"], 1)
+        with pytest.raises(TypeError, match="Incompatible types for searching"):
+            np.searchsorted([1, 2, 3], ["1"])
+        with pytest.raises(TypeError, match="Incompatible types for searching"):
+            np.searchsorted(["1", "2", "3"], [2])
+        with pytest.raises(TypeError, match="Incompatible types for searching"):
+            np.searchsorted([b"1", b"2", b"3"], 1)
+
+    def test_searchsorted_string_promotions_still_work(self):
+        # gh-24032 review: only pairings whose *promoted* dtype is a legacy
+        # string (while an input is not) are rejected.  Pairings that promote
+        # to StringDType or object must keep working.
+        # StringDType haystack, python str needles (promotes to StringDType)
+        a = np.array(["a", "b"], dtype="T")
+        assert_equal(a.searchsorted(["b"]), [1])
+        assert_equal(a.searchsorted("b"), 1)
+        # object haystack, string needles (promotes to object)
+        a = np.array(["a", "b"], dtype=object)
+        assert_equal(a.searchsorted(["b"]), [1])
+        assert_equal(a.searchsorted(np.array(["b"])), [1])
 
     def test_searchsorted_empty_v(self):
         # gh-24032 regression: an empty python list carries no type intent, so
@@ -3337,12 +3353,12 @@ class TestMethods:
         # explicitly-typed but empty `v` is rejected just like a non-empty one
         # (the contract must not depend on len(v)). This mirrors how comparison
         # ufuncs such as np.less reject the same dtype pairing.
-        assert_raises(TypeError, np.searchsorted, ["a", "b"],
-                      np.array([], dtype=np.int64))
-        assert_raises(TypeError, np.searchsorted, [b"a", b"b"],
-                      np.array([], dtype=np.int64))
-        assert_raises(TypeError, np.searchsorted, [1, 2, 3],
-                      np.array([], dtype="U1"))
+        with pytest.raises(TypeError, match="Incompatible types for searching"):
+            np.searchsorted(["a", "b"], np.array([], dtype=np.int64))
+        with pytest.raises(TypeError, match="Incompatible types for searching"):
+            np.searchsorted([b"a", b"b"], np.array([], dtype=np.int64))
+        with pytest.raises(TypeError, match="Incompatible types for searching"):
+            np.searchsorted([1, 2, 3], np.array([], dtype="U1"))
 
     @pytest.mark.parametrize("dtype", np.typecodes["All"])
     def test_argpartition_out_of_range(self, dtype):


### PR DESCRIPTION

### PR summary
Without an explicit check, ``np.searchsorted([1, 2, 3], ['1'])`` and similar mismatched-type calls were silently promoted to a string dtype and returned wrong indices. Mirror ``np.less.resolve_dtypes`` in C inside ``PyArray_SearchSorted`` to raise ``TypeError`` for unsupported pairings, with a fast-path skip for same-DType and number/number pairs.

This is an alternative to #26650.

Benchmarks:
```
=== main  (bf8007a59e (parent of fix branch)) ===
numpy 2.5.0.dev0+git20260524.06eb78b
np.searchsorted (Python wrapper):
  small int+int ndarrays (3+2)          :  1004.8 ns
  medium int+int (1000+3)               :  1036.0 ns
  array+list (10+2)                     :  1396.0 ns
  list+list (3+2)                       :  2434.7 ns
  float+int (3+2)                       :  1238.1 ns
  str+str                               :  1244.9 ns
  int+scalar                            :  1153.5 ns
arr.searchsorted (no wrapper):
  small int+int (3+2)                   :   356.7 ns
  medium int+int (1000+3)               :   374.6 ns

=== branch  (06eb78babc fix/searchsorted-incompatible-types-c) ===
numpy 2.5.0.dev0+git20260524.06eb78b
np.searchsorted (Python wrapper):
  small int+int ndarrays (3+2)          :   998.1 ns
  medium int+int (1000+3)               :  1029.7 ns
  array+list (10+2)                     :  1394.2 ns
  list+list (3+2)                       :  2438.4 ns
  float+int (3+2)                       :  1234.5 ns
  str+str                               :  1229.0 ns
  int+scalar                            :  1158.8 ns
arr.searchsorted (no wrapper):
  small int+int (3+2)                   :   355.5 ns
  medium int+int (1000+3)               :   372.9 ns
```
So performance neutral.

#### AI Disclosure

Claude was used to implement for first C version. Additional prompts have been used to add the fast path and reduce the diff vs main.

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
