### PR TITLE
BUG: Handle large numbers and edge creations on histogram.

### DIFF
--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -295,7 +295,7 @@ def _ravel_and_check_weights(a, weights):
     return a, weights
 
 
-def _get_outer_edges(a, range):
+def _get_outer_edges(a, range, n_bins=1):
     """
     Determine the outer bin edges to use, from either the data or the range
     argument
@@ -319,8 +319,9 @@ def _get_outer_edges(a, range):
 
     # expand empty range to avoid divide by zero
     if first_edge == last_edge:
-        first_edge = first_edge - 0.5
-        last_edge = last_edge + 0.5
+        half = max(0.5, n_bins * np.spacing(abs(first_edge)))
+        first_edge = first_edge - half
+        last_edge = last_edge + half
 
     return first_edge, last_edge
 
@@ -422,7 +423,7 @@ def _get_bin_edges(a, bins, range, weights):
         if n_equal_bins < 1:
             raise ValueError('`bins` must be positive, when an integer')
 
-        first_edge, last_edge = _get_outer_edges(a, range)
+        first_edge, last_edge = _get_outer_edges(a, range, n_equal_bins)
 
     elif np.ndim(bins) == 1:
         bin_edges = np.asarray(bins)

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -432,11 +432,11 @@ class TestHistogram:
     def test_low_spread_big_data(self):
         # issue 8627
         for x in [2**53, 2**60, 2**61, 2**62, 2**63]:
-            for bins in [1,10,100,1000]:
+            for bins in [1, 10, 100, 1000]:
                 hist, _ = np.histogram([x], bins)
                 result = np.zeros(bins)
-                result[bins//2] = 1
-                assert_array_equal(hist,result)
+                result[bins // 2] = 1
+                assert_array_equal(hist, result)
         double_numbers = np.array([1e20] * 20)
         hist, _ = np.histogram(double_numbers, bins=100)
         result = np.zeros(100)

--- a/numpy/lib/tests/test_histograms.py
+++ b/numpy/lib/tests/test_histograms.py
@@ -429,6 +429,20 @@ class TestHistogram:
         assert edges[0] == Z[0]
         assert edges[-1] == Z[-1]
 
+    def test_low_spread_big_data(self):
+        # issue 8627
+        for x in [2**53, 2**60, 2**61, 2**62, 2**63]:
+            for bins in [1,10,100,1000]:
+                hist, _ = np.histogram([x], bins)
+                result = np.zeros(bins)
+                result[bins//2] = 1
+                assert_array_equal(hist,result)
+        double_numbers = np.array([1e20] * 20)
+        hist, _ = np.histogram(double_numbers, bins=100)
+        result = np.zeros(100)
+        result[50] = 20
+        assert_array_equal(hist, result)
+
 class TestHistogramOptimBinNums:
     """
     Provide test coverage when using provided estimators for optimal number of


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
Fixes https://github.com/numpy/numpy/issues/8627 (wrongly tagged another issue)
If I am understanding correctly, prior to this PR, `np.linspace` would give equal edges because of the distances between float64 types i.e `2**52+0.5` couldn't be represented as a proper float and as a result edges would be equal and monotonic check would fail. To make sure this never happens, the `_outer_bin_edge` should use the number of bins and the spacing of the type of the edge.

this PR handles all 3 histogram functions.
### Other comments
This is the first time I have worked on an issue about large floats/numbers, so be warned.

There are specific cases like `np.histogram([2**53,2**53+2])` which is not quite possible to fix, ~unless bin numbers are  changed undirectly. There is a issue about better default bin number selection which will fix this.~
In some cases with big data values with very low spread, the similar issue I think will occur and linspace may generate equal sized edges. The first workaround would be to chose smaller bin sizes or somewhere in logic we could add spacing like this PR's case. But this is somewhat unrelated to the main issue so I might open another PR for that
#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
Claude used to review the code.