### PR TITLE
ENH: use PyMem_RawMalloc instead of system allocator for better performance on free-threading

### DIFF
--- a/doc/release/upcoming_changes/31503.change.rst
+++ b/doc/release/upcoming_changes/31503.change.rst
@@ -1,4 +1,4 @@
 NumPy's internal memory allocations now use ``PyMem_RawMalloc``
 ---------------------------------------------------------------
 NumPy's internal memory allocations now use ``PyMem_RawMalloc`` instead of
-``malloc``and can be tracked by ``tracemalloc``.
+``malloc`` and can be tracked by ``tracemalloc``.

--- a/doc/release/upcoming_changes/31503.change.rst
+++ b/doc/release/upcoming_changes/31503.change.rst
@@ -1,0 +1,4 @@
+NumPy's internal memory allocations now use ``PyMem_RawMalloc``
+---------------------------------------------------------------
+NumPy's internal memory allocations now use ``PyMem_RawMalloc`` instead of
+``malloc``and can be tracked by ``tracemalloc``.

--- a/numpy/_core/src/_simd/_simd_convert.inc
+++ b/numpy/_core/src/_simd/_simd_convert.inc
@@ -60,7 +60,7 @@ simd_sequence_new(Py_ssize_t len, simd_data_type dtype)
     const simd_data_info *info = simd_data_getinfo(dtype);
     assert(len > 0 && info->is_sequence && info->lane_size > 0);
     size_t size = sizeof(simd__alloc_data) + len * info->lane_size + NPY_SIMD_WIDTH;
-    void *ptr = malloc(size);
+    void *ptr = PyMem_RawMalloc(size);
     if (ptr == NULL) {
         return PyErr_NoMemory();
     }
@@ -82,7 +82,7 @@ simd_sequence_len(void const *ptr)
 static void
 simd_sequence_free(void *ptr)
 {
-    free(((simd__alloc_data *)ptr)[-1].ptr);
+    PyMem_RawFree(((simd__alloc_data *)ptr)[-1].ptr);
 }
 
 static void *

--- a/numpy/_core/src/common/mem_overlap.c
+++ b/numpy/_core/src/common/mem_overlap.c
@@ -544,9 +544,9 @@ solve_diophantine(unsigned int n, diophantine_term_t *E, npy_int64 b,
         diophantine_term_t *Ep = NULL;
         npy_int64 *Epsilon = NULL, *Gamma = NULL;
 
-        Ep = malloc(n * sizeof(diophantine_term_t));
-        Epsilon = malloc(n * sizeof(npy_int64));
-        Gamma = malloc(n * sizeof(npy_int64));
+        Ep = PyMem_RawMalloc(n * sizeof(diophantine_term_t));
+        Epsilon = PyMem_RawMalloc(n * sizeof(npy_int64));
+        Gamma = PyMem_RawMalloc(n * sizeof(npy_int64));
         if (Ep == NULL || Epsilon == NULL || Gamma == NULL) {
             res = MEM_OVERLAP_ERROR;
         }
@@ -557,9 +557,9 @@ solve_diophantine(unsigned int n, diophantine_term_t *E, npy_int64 b,
             res = diophantine_dfs(n, n-1, E, Ep, Gamma, Epsilon, b, max_work,
                                   require_ub_nontrivial, x, &count);
         }
-        free(Ep);
-        free(Gamma);
-        free(Epsilon);
+        PyMem_RawFree(Ep);
+        PyMem_RawFree(Gamma);
+        PyMem_RawFree(Epsilon);
         return res;
     }
 }

--- a/numpy/_core/src/common/npy_cpuinfo_parser.h
+++ b/numpy/_core/src/common/npy_cpuinfo_parser.h
@@ -188,7 +188,7 @@ extract_cpuinfo_field(const char* buffer, int buflen, const char* field)
 
     /* Copy the line into a heap-allocated buffer */
     len = q - p;
-    result = malloc(len + 1);
+    result = PyMem_RawMalloc(len + 1);
     if (result == NULL) {
         goto EXIT;
     }
@@ -247,7 +247,7 @@ get_feature_from_proc_cpuinfo(unsigned long *hwcap, unsigned long *hwcap2) {
     if (cpuinfo_len < 0) {
         return 0;
     }
-    char *cpuinfo = malloc(cpuinfo_len);
+    char *cpuinfo = PyMem_RawMalloc(cpuinfo_len);
     if (cpuinfo == NULL) {
         return 0;
     }
@@ -255,7 +255,7 @@ get_feature_from_proc_cpuinfo(unsigned long *hwcap, unsigned long *hwcap2) {
     cpuinfo_len = read_file("/proc/cpuinfo", cpuinfo, cpuinfo_len);
     char *cpuFeatures = extract_cpuinfo_field(cpuinfo, cpuinfo_len, "Features");
     if (cpuFeatures == NULL) {
-        free(cpuinfo);
+        PyMem_RawFree(cpuinfo);
         return 0;
     }
     *hwcap |= has_list_item(cpuFeatures, "fphp") ? NPY__HWCAP_FPHP : 0;
@@ -281,8 +281,8 @@ get_feature_from_proc_cpuinfo(unsigned long *hwcap, unsigned long *hwcap2) {
     *hwcap |= has_list_item(cpuFeatures, "sha2") ? NPY__HWCAP_SHA2 : 0;
     *hwcap |= has_list_item(cpuFeatures, "crc32") ? NPY__HWCAP_CRC32 : 0;
 #endif
-    free(cpuinfo);
-    free(cpuFeatures);
+    PyMem_RawFree(cpuinfo);
+    PyMem_RawFree(cpuFeatures);
     return 1;
 }
 #endif  /* NUMPY_CORE_SRC_COMMON_NPY_CPUINFO_PARSER_H_ */

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -652,7 +652,7 @@ UNICODE_getitem(void *ip, void *vap)
 
     /* swap and align if needed */
     if (swap || align) {
-        buf = (npy_ucs4 *)malloc(size);
+        buf = (npy_ucs4 *)PyMem_RawMalloc(size);
         if (buf == NULL) {
             PyErr_NoMemory();
             return NULL;
@@ -669,7 +669,7 @@ UNICODE_getitem(void *ip, void *vap)
         ucs4len--;
     }
     PyObject *ret = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, src, ucs4len);
-    free(buf);
+    PyMem_RawFree(buf);
     return ret;
 }
 

--- a/numpy/_core/src/multiarray/buffer.c
+++ b/numpy/_core/src/multiarray/buffer.c
@@ -934,7 +934,7 @@ _descriptor_from_pep3118_format(char const *s)
     }
 
     /* Strip whitespace, except from field names */
-    buf = malloc(strlen(s) + 1);
+    buf = PyMem_RawMalloc(strlen(s) + 1);
     if (buf == NULL) {
         PyErr_NoMemory();
         return NULL;
@@ -956,7 +956,7 @@ _descriptor_from_pep3118_format(char const *s)
 
     str = PyUnicode_FromStringAndSize(buf, strlen(buf));
     if (str == NULL) {
-        free(buf);
+        PyMem_RawFree(buf);
         return NULL;
     }
 
@@ -964,7 +964,7 @@ _descriptor_from_pep3118_format(char const *s)
     _numpy_internal = PyImport_ImportModule("numpy._core._internal");
     if (_numpy_internal == NULL) {
         Py_DECREF(str);
-        free(buf);
+        PyMem_RawFree(buf);
         return NULL;
     }
     descr = PyObject_CallMethod(
@@ -977,7 +977,7 @@ _descriptor_from_pep3118_format(char const *s)
         PyErr_Format(PyExc_ValueError,
                      "'%s' is not a valid PEP 3118 buffer format string", buf);
         npy_PyErr_ChainExceptionsCause(exc, val, tb);
-        free(buf);
+        PyMem_RawFree(buf);
         return NULL;
     }
     if (!PyArray_DescrCheck(descr)) {
@@ -985,10 +985,10 @@ _descriptor_from_pep3118_format(char const *s)
                      "internal error: numpy._core._internal._dtype_from_pep3118 "
                      "did not return a valid dtype, got %s", buf);
         Py_DECREF(descr);
-        free(buf);
+        PyMem_RawFree(buf);
         return NULL;
     }
-    free(buf);
+    PyMem_RawFree(buf);
     return (PyArray_Descr*)descr;
 }
 

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -135,7 +135,7 @@ swab_separator(const char *sep)
     int skip_space = 0;
     char *s, *start;
 
-    s = start = malloc(strlen(sep)+3);
+    s = start = PyMem_RawMalloc(strlen(sep)+3);
     if (s == NULL) {
         PyErr_NoMemory();
         return NULL;
@@ -3602,7 +3602,7 @@ array_from_text(PyArray_Descr *dtype, npy_intp num, char const *sep, size_t *nre
     }
     NPY_END_ALLOW_THREADS;
 
-    free(clean_sep);
+    PyMem_RawFree(clean_sep);
 
     if (stop_reading_flag == -2) {
         if (PyErr_Occurred()) {

--- a/numpy/_core/src/multiarray/dtypemeta.c
+++ b/numpy/_core/src/multiarray/dtypemeta.c
@@ -417,7 +417,7 @@ dtypemeta_initialize_struct_from_spec(
          * Like PyArray_RegisterDataType, this mutates global userdescrs state
          * and is expected to run during module import while single-threaded.
          */
-        _PyArray_LegacyDescr **tmp = realloc(userdescrs,
+        _PyArray_LegacyDescr **tmp = PyMem_RawRealloc(userdescrs,
                 (NPY_NUMUSERTYPES + 1) * sizeof(void *));
         if (tmp == NULL) {
             PyErr_NoMemory();

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1960,7 +1960,7 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
             PyDataMem_FREE(valbuffer);
             goto fail;
         }
-        swaps = malloc(NPY_LIKELY(n > 0) ? n * sizeof(int) : 1);
+        swaps = PyMem_RawMalloc(NPY_LIKELY(n > 0) ? n * sizeof(int) : 1);
         if (swaps == NULL) {
             PyDataMem_FREE(valbuffer);
             PyDataMem_FREE(indbuffer);
@@ -1993,7 +1993,7 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
                             && PyErr_Occurred())) {
                     PyDataMem_FREE(valbuffer);
                     PyDataMem_FREE(indbuffer);
-                    free(swaps);
+                    PyMem_RawFree(swaps);
                     goto fail;
                 }
                 PyArray_ITER_NEXT(its[j]);
@@ -2004,7 +2004,7 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
         }
         PyDataMem_FREE(valbuffer);
         PyDataMem_FREE(indbuffer);
-        free(swaps);
+        PyMem_RawFree(swaps);
     }
     else {
         while (size--) {

--- a/numpy/_core/src/multiarray/usertypes.c
+++ b/numpy/_core/src/multiarray/usertypes.c
@@ -57,7 +57,7 @@ _append_new(int **p_types, int insert)
     while (types[n] != NPY_NOTYPE) {
         n++;
     }
-    newtypes = (int *)realloc(types, (n + 2)*sizeof(int));
+    newtypes = (int *)PyMem_RawRealloc(types, (n + 2)*sizeof(int));
     if (newtypes == NULL) {
         PyErr_NoMemory();
         return -1;
@@ -281,7 +281,7 @@ PyArray_RegisterDataType(PyArray_DescrProto *descr_proto)
         }
     }
 
-    userdescrs = realloc(userdescrs,
+    userdescrs = PyMem_RawRealloc(userdescrs,
                          (NPY_NUMUSERTYPES+1)*sizeof(void *));
     if (userdescrs == NULL) {
         PyErr_SetString(PyExc_MemoryError, "RegisterDataType");
@@ -484,7 +484,7 @@ PyArray_RegisterCanCast(PyArray_Descr *descr, int totype,
          * -- they become part of the data-type
          */
         if (PyDataType_GetArrFuncs(descr)->cancastto == NULL) {
-            PyDataType_GetArrFuncs(descr)->cancastto = (int *)malloc(1*sizeof(int));
+            PyDataType_GetArrFuncs(descr)->cancastto = (int *)PyMem_RawMalloc(1*sizeof(int));
             if (PyDataType_GetArrFuncs(descr)->cancastto == NULL) {
                 PyErr_NoMemory();
                 return -1;
@@ -498,7 +498,7 @@ PyArray_RegisterCanCast(PyArray_Descr *descr, int totype,
         if (PyDataType_GetArrFuncs(descr)->cancastscalarkindto == NULL) {
             int i;
             PyDataType_GetArrFuncs(descr)->cancastscalarkindto =
-                (int **)malloc(NPY_NSCALARKINDS* sizeof(int*));
+                (int **)PyMem_RawMalloc(NPY_NSCALARKINDS* sizeof(int*));
             if (PyDataType_GetArrFuncs(descr)->cancastscalarkindto == NULL) {
                 PyErr_NoMemory();
                 return -1;
@@ -509,7 +509,7 @@ PyArray_RegisterCanCast(PyArray_Descr *descr, int totype,
         }
         if (PyDataType_GetArrFuncs(descr)->cancastscalarkindto[scalar] == NULL) {
             PyDataType_GetArrFuncs(descr)->cancastscalarkindto[scalar] =
-                (int *)malloc(1*sizeof(int));
+                (int *)PyMem_RawMalloc(1*sizeof(int));
             if (PyDataType_GetArrFuncs(descr)->cancastscalarkindto[scalar] == NULL) {
                 PyErr_NoMemory();
                 return -1;

--- a/numpy/_core/src/npysort/heapsort.cpp
+++ b/numpy/_core/src/npysort/heapsort.cpp
@@ -58,7 +58,7 @@ npy_heapsort(void *start, npy_intp num, void *varr)
     if (elsize == 0) {
         return 0;  /* no need for sorting elements of no size */
     }
-    char *tmp = (char *)malloc(elsize);
+    char *tmp = (char *)PyMem_RawMalloc(elsize);
     char *a = (char *)start - elsize;
     npy_intp i, j, l;
 
@@ -106,7 +106,7 @@ npy_heapsort(void *start, npy_intp num, void *varr)
         GENERIC_COPY(a + i * elsize, tmp, elsize);
     }
 
-    free(tmp);
+    PyMem_RawFree(tmp);
     return 0;
 }
 

--- a/numpy/_core/src/npysort/mergesort.cpp
+++ b/numpy/_core/src/npysort/mergesort.cpp
@@ -97,13 +97,13 @@ mergesort_(type *start, npy_intp num)
 
     pl = start;
     pr = pl + num;
-    pw = (type *)malloc((num / 2) * sizeof(type));
+    pw = (type *)PyMem_RawMalloc((num / 2) * sizeof(type));
     if (pw == NULL) {
         return -NPY_ENOMEM;
     }
     mergesort0_<Tag, type, reverse>(pl, pr, pw);
 
-    free(pw);
+    PyMem_RawFree(pw);
     return 0;
 }
 
@@ -160,18 +160,18 @@ amergesort_(type *v, npy_intp *tosort, npy_intp num)
 
     pl = tosort;
     pr = pl + num;
-    pw = (npy_intp *)malloc((num / 2) * sizeof(npy_intp));
+    pw = (npy_intp *)PyMem_RawMalloc((num / 2) * sizeof(npy_intp));
     if (pw == NULL) {
         return -NPY_ENOMEM;
     }
     amergesort0_<Tag, type, reverse>(pl, pr, v, pw);
-    free(pw);
+    PyMem_RawFree(pw);
 
     return 0;
 }
 
 /*
- 
+
  *****************************************************************************
  **                             STRING SORTS                                **
  *****************************************************************************
@@ -237,21 +237,21 @@ string_mergesort_(type *start, npy_intp num, int elsize)
 
     pl = start;
     pr = pl + num * len;
-    pw = (type *)malloc((num / 2) * elsize);
+    pw = (type *)PyMem_RawMalloc((num / 2) * elsize);
     if (pw == NULL) {
         err = -NPY_ENOMEM;
         goto fail_0;
     }
-    vp = (type *)malloc(elsize);
+    vp = (type *)PyMem_RawMalloc(elsize);
     if (vp == NULL) {
         err = -NPY_ENOMEM;
         goto fail_1;
     }
     mergesort0_<Tag, type, reverse>(pl, pr, pw, vp, len);
 
-    free(vp);
+    PyMem_RawFree(vp);
 fail_1:
-    free(pw);
+    PyMem_RawFree(pw);
 fail_0:
     return err;
 }
@@ -317,12 +317,12 @@ string_amergesort_(type *v, npy_intp *tosort, npy_intp num, void *varr)
 
     pl = tosort;
     pr = pl + num;
-    pw = (npy_intp *)malloc((num / 2) * sizeof(npy_intp));
+    pw = (npy_intp *)PyMem_RawMalloc((num / 2) * sizeof(npy_intp));
     if (pw == NULL) {
         return -NPY_ENOMEM;
     }
     amergesort0_<Tag, type, reverse>(pl, pr, v, pw, len);
-    free(pw);
+    PyMem_RawFree(pw);
 
     return 0;
 }
@@ -405,16 +405,16 @@ npy_mergesort_impl(void *start, npy_intp num, void *varr,
         return 0;
     }
 
-    pw = (char *)malloc((num >> 1) * elsize);
-    vp = (char *)malloc(elsize);
+    pw = (char *)PyMem_RawMalloc((num >> 1) * elsize);
+    vp = (char *)PyMem_RawMalloc(elsize);
 
     if (pw != NULL && vp != NULL) {
         npy_mergesort0(pl, pr, pw, vp, elsize, cmp, arr);
         err = 0;
     }
 
-    free(vp);
-    free(pw);
+    PyMem_RawFree(vp);
+    PyMem_RawFree(pw);
 
     return err;
 }
@@ -489,12 +489,12 @@ npy_amergesort_impl(void *v, npy_intp *tosort, npy_intp num, void *varr,
 
     pl = tosort;
     pr = pl + num;
-    pw = (npy_intp *)malloc((num >> 1) * sizeof(npy_intp));
+    pw = (npy_intp *)PyMem_RawMalloc((num >> 1) * sizeof(npy_intp));
     if (pw == NULL) {
         return -NPY_ENOMEM;
     }
     npy_amergesort0(pl, pr, (char *)v, pw, elsize, cmp, arr);
-    free(pw);
+    PyMem_RawFree(pw);
 
     return 0;
 }

--- a/numpy/_core/src/npysort/npysort_heapsort.h
+++ b/numpy/_core/src/npysort/npysort_heapsort.h
@@ -148,7 +148,7 @@ int string_heapsort_(type *start, npy_intp n, int elsize)
         return 0;  /* no need for sorting if strings are empty */
     }
 
-    type *tmp = (type *)malloc(elsize);
+    type *tmp = (type *)PyMem_RawMalloc(elsize);
     type *a = (type *)start - len;
     npy_intp i, j, l;
 
@@ -192,7 +192,7 @@ int string_heapsort_(type *start, npy_intp n, int elsize)
         Tag::copy(a + i * len, tmp, len);
     }
 
-    free(tmp);
+    PyMem_RawFree(tmp);
     return 0;
 }
 

--- a/numpy/_core/src/npysort/quicksort.hpp
+++ b/numpy/_core/src/npysort/quicksort.hpp
@@ -322,7 +322,7 @@ string_quicksort_(type *start, npy_intp num, int elsize)
         return 0;
     }
 
-    vp = (type *)malloc(elsize);
+    vp = (type *)PyMem_RawMalloc(elsize);
     if (vp == NULL) {
         return -NPY_ENOMEM;
     }
@@ -397,7 +397,7 @@ string_quicksort_(type *start, npy_intp num, int elsize)
         cdepth = *(--psdepth);
     }
 
-    free(vp);
+    PyMem_RawFree(vp);
     return 0;
 }
 

--- a/numpy/_core/src/npysort/quicksort_generic.cpp
+++ b/numpy/_core/src/npysort/quicksort_generic.cpp
@@ -107,7 +107,7 @@ npy_quicksort_impl(void *start, npy_intp num, void *varr,
         return 0;
     }
 
-    vp = (char *)malloc(elsize);
+    vp = (char *)PyMem_RawMalloc(elsize);
     if (vp == NULL) {
         return -NPY_ENOMEM;
     }
@@ -186,7 +186,7 @@ npy_quicksort_impl(void *start, npy_intp num, void *varr,
         cdepth = *(--psdepth);
     }
 
-    free(vp);
+    PyMem_RawFree(vp);
     return 0;
 }
 

--- a/numpy/_core/src/npysort/radixsort.hpp
+++ b/numpy/_core/src/npysort/radixsort.hpp
@@ -115,7 +115,7 @@ radixsort_(UT *start, npy_intp num)
         return 0;
     }
 
-    UT *aux = (UT *)malloc(num * sizeof(UT));
+    UT *aux = (UT *)PyMem_RawMalloc(num * sizeof(UT));
     if (aux == nullptr) {
         return -NPY_ENOMEM;
     }
@@ -125,7 +125,7 @@ radixsort_(UT *start, npy_intp num)
         memcpy(start, sorted, num * sizeof(UT));
     }
 
-    free(aux);
+    PyMem_RawFree(aux);
     return 0;
 }
 
@@ -220,7 +220,7 @@ aradixsort_(UT *start, npy_intp *tosort, npy_intp num)
         return 0;
     }
 
-    aux = (npy_intp *)malloc(num * sizeof(npy_intp));
+    aux = (npy_intp *)PyMem_RawMalloc(num * sizeof(npy_intp));
     if (aux == NULL) {
         return -NPY_ENOMEM;
     }
@@ -230,7 +230,7 @@ aradixsort_(UT *start, npy_intp *tosort, npy_intp num)
         memcpy(tosort, sorted, num * sizeof(npy_intp));
     }
 
-    free(aux);
+    PyMem_RawFree(aux);
     return 0;
 }
 

--- a/numpy/_core/src/npysort/timsort.hpp
+++ b/numpy/_core/src/npysort/timsort.hpp
@@ -44,7 +44,7 @@ resize_buffer_intp(buffer_intp *buffer, npy_intp new_size)
         return 0;
     }
 
-    npy_intp *new_pw = (npy_intp *)realloc(buffer->pw, new_size * sizeof(npy_intp));
+    npy_intp *new_pw = (npy_intp *)PyMem_RawRealloc(buffer->pw, new_size * sizeof(npy_intp));
 
     buffer->size = new_size;
 
@@ -78,7 +78,7 @@ resize_buffer_(buffer_<Tag> *buffer, npy_intp new_size)
         return 0;
     }
 
-    type *new_pw = (type *)realloc(buffer->pw, new_size * sizeof(type));
+    type *new_pw = (type *)PyMem_RawRealloc(buffer->pw, new_size * sizeof(type));
     buffer->size = new_size;
 
     if (NPY_UNLIKELY(new_pw == NULL)) {
@@ -479,7 +479,7 @@ timsort_(void *start, npy_intp num)
     ret = 0;
 cleanup:
 
-    free(buffer.pw);
+    PyMem_RawFree(buffer.pw);
 
     return ret;
 }
@@ -856,7 +856,7 @@ atimsort_(void *v, npy_intp *tosort, npy_intp num)
 cleanup:
 
     if (buffer.pw != NULL) {
-        free(buffer.pw);
+        PyMem_RawFree(buffer.pw);
     }
 
     return ret;
@@ -912,7 +912,7 @@ resize_buffer_(string_buffer_<Tag> *buffer, npy_intp new_size)
         return 0;
     }
 
-    type *new_pw = (type *)realloc(buffer->pw, sizeof(type) * new_size * buffer->len);
+    type *new_pw = (type *)PyMem_RawRealloc(buffer->pw, sizeof(type) * new_size * buffer->len);
     buffer->size = new_size;
 
     if (NPY_UNLIKELY(new_pw == NULL)) {
@@ -1348,7 +1348,7 @@ string_timsort_(void *start, npy_intp num, int elsize)
 
 cleanup:
     if (buffer.pw != NULL) {
-        free(buffer.pw);
+        PyMem_RawFree(buffer.pw);
     }
     return ret;
 }
@@ -1768,7 +1768,7 @@ string_atimsort_(void *start, npy_intp *tosort, npy_intp num, int elsize)
 
 cleanup:
     if (buffer.pw != NULL) {
-        free(buffer.pw);
+        PyMem_RawFree(buffer.pw);
     }
     return ret;
 }

--- a/numpy/_core/src/npysort/timsort_generic.cpp
+++ b/numpy/_core/src/npysort/timsort_generic.cpp
@@ -81,7 +81,7 @@ resize_buffer_intp(buffer_intp *buffer, npy_intp new_size)
         return 0;
     }
 
-    npy_intp *new_pw = (npy_intp *)realloc(buffer->pw, new_size * sizeof(npy_intp));
+    npy_intp *new_pw = (npy_intp *)PyMem_RawRealloc(buffer->pw, new_size * sizeof(npy_intp));
 
     buffer->size = new_size;
 
@@ -113,7 +113,7 @@ resize_buffer_char(buffer_char *buffer, npy_intp new_size)
         return 0;
     }
 
-    char *new_pw = (char *)realloc(buffer->pw, sizeof(char) * new_size * buffer->len);
+    char *new_pw = (char *)PyMem_RawRealloc(buffer->pw, sizeof(char) * new_size * buffer->len);
     buffer->size = new_size;
 
     if (NPY_UNLIKELY(new_pw == NULL)) {
@@ -552,7 +552,7 @@ npy_timsort(void *start, npy_intp num, void *varr)
 
 cleanup:
     if (buffer.pw != NULL) {
-        free(buffer.pw);
+        PyMem_RawFree(buffer.pw);
     }
     return ret;
 }
@@ -979,7 +979,7 @@ npy_atimsort(void *start, npy_intp *tosort, npy_intp num, void *varr)
 
 cleanup:
     if (buffer.pw != NULL) {
-        free(buffer.pw);
+        PyMem_RawFree(buffer.pw);
     }
     return ret;
 }

--- a/numpy/_core/src/umath/matmul.c.src
+++ b/numpy/_core/src/umath/matmul.c.src
@@ -493,7 +493,7 @@ NPY_NO_EXPORT void
                  op_size = oblasable ? 0 : sz * dm * dp,
                  total_size = ip1_size + ip2_size + op_size;
 
-        tmp_ip12op = (uint8_t*)malloc(total_size);
+        tmp_ip12op = (uint8_t*)PyMem_RawMalloc(total_size);
 
         if (tmp_ip12op == NULL) {
             PyGILState_STATE gil_state = PyGILState_Ensure();
@@ -637,7 +637,7 @@ NPY_NO_EXPORT void
         npy_clear_floatstatus_barrier((char*)args);
     }
 #endif
-    if (allocate_buffer) free(tmp_ip12op);
+    if (allocate_buffer) PyMem_RawFree(tmp_ip12op);
 #endif
 }
 

--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -1190,7 +1190,7 @@ slogdet(char **args,
     safe_m = m != 0 ? m : 1;
     matrix_size = safe_m * safe_m * sizeof(typ);
     pivot_size = safe_m * sizeof(fortran_int);
-    tmp_buff = (char *)malloc(matrix_size + pivot_size);
+    tmp_buff = (char *)PyMem_RawMalloc(matrix_size + pivot_size);
 
     if (tmp_buff) {
         /* swapped steps to get matrix in FORTRAN order */
@@ -1204,7 +1204,7 @@ slogdet(char **args,
                                           (basetyp*)args[2]);
         END_OUTER_LOOP
 
-        free(tmp_buff);
+        PyMem_RawFree(tmp_buff);
     }
     else {
         /* TODO: Requires use of new ufunc API to indicate error return */
@@ -1238,7 +1238,7 @@ det(char **args,
     safe_m = m != 0 ? m : 1;
     matrix_size = safe_m * safe_m * sizeof(typ);
     pivot_size = safe_m * sizeof(fortran_int);
-    tmp_buff = (char *)malloc(matrix_size + pivot_size);
+    tmp_buff = (char *)PyMem_RawMalloc(matrix_size + pivot_size);
 
     if (tmp_buff) {
         /* swapped steps to get matrix in FORTRAN order */
@@ -1257,7 +1257,7 @@ det(char **args,
             *(typ *)args[1] = det_from_slogdet(sign, logdet);
         END_OUTER_LOOP
 
-        free(tmp_buff);
+        PyMem_RawFree(tmp_buff);
     }
     else {
         /* TODO: Requires use of new ufunc API to indicate error return */
@@ -1331,7 +1331,7 @@ init_evd(EIGH_PARAMS_t<typ>* params, char JOBZ, char UPLO,
     size_t alloc_size = safe_N * (safe_N + 1) * sizeof(typ);
     fortran_int lda = fortran_int_max(N, 1);
 
-    mem_buff = (npy_uint8 *)malloc(alloc_size);
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(alloc_size);
 
     if (!mem_buff) {
         goto no_memory;
@@ -1366,7 +1366,7 @@ init_evd(EIGH_PARAMS_t<typ>* params, char JOBZ, char UPLO,
         liwork = query_iwork_size;
     }
 
-    mem_buff2 = (npy_uint8 *)malloc(lwork*sizeof(typ) + liwork*sizeof(fortran_int));
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(lwork*sizeof(typ) + liwork*sizeof(fortran_int));
     if (!mem_buff2) {
         goto no_memory;
     }
@@ -1387,8 +1387,8 @@ init_evd(EIGH_PARAMS_t<typ>* params, char JOBZ, char UPLO,
  error:
     /* something failed */
     memset(params, 0, sizeof(*params));
-    free(mem_buff2);
-    free(mem_buff);
+    PyMem_RawFree(mem_buff2);
+    PyMem_RawFree(mem_buff);
 
     return 0;
 }
@@ -1443,7 +1443,7 @@ using fbasetyp = fortran_type_t<basetyp>;
     size_t safe_N = N;
     fortran_int lda = fortran_int_max(N, 1);
 
-    mem_buff = (npy_uint8 *)malloc(safe_N * safe_N * sizeof(typ) +
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(safe_N * safe_N * sizeof(typ) +
                       safe_N * sizeof(basetyp));
     if (!mem_buff) {
         goto no_memory;
@@ -1480,7 +1480,7 @@ using fbasetyp = fortran_type_t<basetyp>;
         liwork = query_iwork_size;
     }
 
-    mem_buff2 = (npy_uint8 *)malloc(lwork*sizeof(typ) +
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(lwork*sizeof(typ) +
                        lrwork*sizeof(basetyp) +
                        liwork*sizeof(fortran_int));
     if (!mem_buff2) {
@@ -1505,8 +1505,8 @@ no_memory:
     report_no_memory();
 error:
     memset(params, 0, sizeof(*params));
-    free(mem_buff2);
-    free(mem_buff);
+    PyMem_RawFree(mem_buff2);
+    PyMem_RawFree(mem_buff);
 
     return 0;
 }
@@ -1524,8 +1524,8 @@ static inline void
 release_evd(EIGH_PARAMS_t<typ> *params)
 {
     /* allocated memory in A and WORK */
-    free(params->A);
-    free(params->WORK);
+    PyMem_RawFree(params->A);
+    PyMem_RawFree(params->WORK);
     memset(params, 0, sizeof(*params));
 }
 
@@ -1722,7 +1722,7 @@ init_gesv(GESV_PARAMS_t<ftyp> *params, fortran_int N, fortran_int NRHS)
     size_t safe_N = N;
     size_t safe_NRHS = NRHS;
     fortran_int ld = fortran_int_max(N, 1);
-    mem_buff = (npy_uint8 *)malloc(safe_N * safe_N * sizeof(ftyp) +
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(safe_N * safe_N * sizeof(ftyp) +
                       safe_N * safe_NRHS*sizeof(ftyp) +
                       safe_N * sizeof(fortran_int));
     if (!mem_buff) {
@@ -1745,7 +1745,7 @@ init_gesv(GESV_PARAMS_t<ftyp> *params, fortran_int N, fortran_int NRHS)
  error:
     report_no_memory();
 
-    free(mem_buff);
+    PyMem_RawFree(mem_buff);
     memset(params, 0, sizeof(*params));
 
     return 0;
@@ -1756,7 +1756,7 @@ static inline void
 release_gesv(GESV_PARAMS_t<ftyp> *params)
 {
     /* memory block base is in A */
-    free(params->A);
+    PyMem_RawFree(params->A);
     memset(params, 0, sizeof(*params));
 }
 
@@ -1974,7 +1974,7 @@ init_potrf(POTR_PARAMS_t<ftyp> *params, char UPLO, fortran_int N)
     size_t safe_N = N;
     fortran_int lda = fortran_int_max(N, 1);
 
-    mem_buff = (npy_uint8 *)malloc(safe_N * safe_N * sizeof(ftyp));
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(safe_N * safe_N * sizeof(ftyp));
     if (!mem_buff) {
         goto error;
     }
@@ -1990,7 +1990,7 @@ init_potrf(POTR_PARAMS_t<ftyp> *params, char UPLO, fortran_int N)
  error:
     report_no_memory();
 
-    free(mem_buff);
+    PyMem_RawFree(mem_buff);
     memset(params, 0, sizeof(*params));
 
     return 0;
@@ -2001,7 +2001,7 @@ static inline void
 release_potrf(POTR_PARAMS_t<ftyp> *params)
 {
     /* memory block base in A */
-    free(params->A);
+    PyMem_RawFree(params->A);
     memset(params, 0, sizeof(*params));
 }
 
@@ -2184,7 +2184,7 @@ scalar_trait)
     fortran_int ld = fortran_int_max(n, 1);
 
     /* allocate data for known sizes (all but work) */
-    mem_buff = (npy_uint8 *)malloc(a_size + wr_size + wi_size +
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(a_size + wr_size + wi_size +
                       vlr_size + vrr_size +
                       w_size + vl_size + vr_size);
     if (!mem_buff) {
@@ -2229,7 +2229,7 @@ scalar_trait)
         work_count = (size_t)work_size_query;
     }
 
-    mem_buff2 = (npy_uint8 *)malloc(work_count*sizeof(typ));
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(work_count*sizeof(typ));
     if (!mem_buff2) {
         goto no_memory;
     }
@@ -2244,8 +2244,8 @@ scalar_trait)
     report_no_memory();
 
  error:
-    free(mem_buff2);
-    free(mem_buff);
+    PyMem_RawFree(mem_buff2);
+    PyMem_RawFree(mem_buff);
     memset(params, 0, sizeof(*params));
 
     return 0;
@@ -2407,7 +2407,7 @@ using realtyp = basetype_t<ftyp>;
     size_t total_size = a_size + w_size + vl_size + vr_size + rwork_size;
     fortran_int ld = fortran_int_max(n, 1);
 
-    mem_buff = (npy_uint8 *)malloc(total_size);
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(total_size);
     if (!mem_buff) {
         goto no_memory;
     }
@@ -2449,7 +2449,7 @@ using realtyp = basetype_t<ftyp>;
         if(work_count == 0) work_count = 1;
     }
 
-    mem_buff2 = (npy_uint8 *)malloc(work_count*sizeof(ftyp));
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(work_count*sizeof(ftyp));
     if (!mem_buff2) {
         goto no_memory;
     }
@@ -2464,8 +2464,8 @@ using realtyp = basetype_t<ftyp>;
  no_memory:
     report_no_memory();
  error:
-    free(mem_buff2);
-    free(mem_buff);
+    PyMem_RawFree(mem_buff2);
+    PyMem_RawFree(mem_buff);
     memset(params, 0, sizeof(*params));
 
     return 0;
@@ -2484,8 +2484,8 @@ template<typename typ>
 static inline void
 release_geev(GEEV_PARAMS_t<typ> *params)
 {
-    free(params->WORK);
-    free(params->A);
+    PyMem_RawFree(params->WORK);
+    PyMem_RawFree(params->A);
     memset(params, 0, sizeof(*params));
 }
 
@@ -2771,7 +2771,7 @@ init_gesdd(GESDD_PARAMS_t<ftyp> *params,
     u_size = safe_u_row_count * safe_m * sizeof(ftyp);
     vt_size = safe_n * safe_vt_column_count * sizeof(ftyp);
 
-    mem_buff = (npy_uint8 *)malloc(a_size + s_size + u_size + vt_size + iwork_size);
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(a_size + s_size + u_size + vt_size + iwork_size);
 
     if (!mem_buff) {
         goto no_memory;
@@ -2816,7 +2816,7 @@ init_gesdd(GESDD_PARAMS_t<ftyp> *params,
         work_size = (size_t)work_count * sizeof(ftyp);
     }
 
-    mem_buff2 = (npy_uint8 *)malloc(work_size);
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(work_size);
     if (!mem_buff2) {
         goto no_memory;
     }
@@ -2832,8 +2832,8 @@ init_gesdd(GESDD_PARAMS_t<ftyp> *params,
     report_no_memory();
  error:
     TRACE_TXT("%s failed init\n", __FUNCTION__);
-    free(mem_buff);
-    free(mem_buff2);
+    PyMem_RawFree(mem_buff);
+    PyMem_RawFree(mem_buff2);
     memset(params, 0, sizeof(*params));
 
     return 0;
@@ -2910,7 +2910,7 @@ using frealtyp = basetype_t<ftyp>;
     rwork_size *= sizeof(ftyp);
     iwork_size = 8 * safe_min_m_n* sizeof(fortran_int);
 
-    mem_buff = (npy_uint8 *)malloc(a_size +
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(a_size +
                       s_size +
                       u_size +
                       vt_size +
@@ -2960,7 +2960,7 @@ using frealtyp = basetype_t<ftyp>;
         work_size = (size_t)work_count * sizeof(ftyp);
     }
 
-    mem_buff2 = (npy_uint8 *)malloc(work_size);
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(work_size);
     if (!mem_buff2) {
         goto no_memory;
     }
@@ -2977,8 +2977,8 @@ using frealtyp = basetype_t<ftyp>;
 
  error:
     TRACE_TXT("%s failed init\n", __FUNCTION__);
-    free(mem_buff2);
-    free(mem_buff);
+    PyMem_RawFree(mem_buff2);
+    PyMem_RawFree(mem_buff);
     memset(params, 0, sizeof(*params));
 
     return 0;
@@ -2989,8 +2989,8 @@ static inline void
 release_gesdd(GESDD_PARAMS_t<typ>* params)
 {
     /* A and WORK contain allocated blocks */
-    free(params->A);
-    free(params->WORK);
+    PyMem_RawFree(params->A);
+    PyMem_RawFree(params->WORK);
     memset(params, 0, sizeof(*params));
 }
 
@@ -3210,7 +3210,7 @@ using ftyp = fortran_doublereal;
     size_t work_size;
     fortran_int lda = fortran_int_max(1, m);
 
-    mem_buff = (npy_uint8 *)malloc(a_size + tau_size);
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(a_size + tau_size);
 
     if (!mem_buff)
         goto no_memory;
@@ -3244,7 +3244,7 @@ using ftyp = fortran_doublereal;
     params->LWORK = fortran_int_max(fortran_int_max(1, n), work_count);
 
     work_size = (size_t) params->LWORK * sizeof(ftyp);
-    mem_buff2 = (npy_uint8 *)malloc(work_size);
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(work_size);
     if (!mem_buff2)
         goto no_memory;
 
@@ -3259,8 +3259,8 @@ using ftyp = fortran_doublereal;
 
  error:
     TRACE_TXT("%s failed init\n", __FUNCTION__);
-    free(mem_buff);
-    free(mem_buff2);
+    PyMem_RawFree(mem_buff);
+    PyMem_RawFree(mem_buff2);
     memset(params, 0, sizeof(*params));
 
     return 0;
@@ -3288,7 +3288,7 @@ using ftyp = fortran_doublecomplex;
     size_t work_size;
     fortran_int lda = fortran_int_max(1, m);
 
-    mem_buff = (npy_uint8 *)malloc(a_size + tau_size);
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(a_size + tau_size);
 
     if (!mem_buff)
         goto no_memory;
@@ -3324,7 +3324,7 @@ using ftyp = fortran_doublecomplex;
 
     work_size = (size_t) params->LWORK * sizeof(ftyp);
 
-    mem_buff2 = (npy_uint8 *)malloc(work_size);
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(work_size);
     if (!mem_buff2)
         goto no_memory;
 
@@ -3339,8 +3339,8 @@ using ftyp = fortran_doublecomplex;
 
  error:
     TRACE_TXT("%s failed init\n", __FUNCTION__);
-    free(mem_buff);
-    free(mem_buff2);
+    PyMem_RawFree(mem_buff);
+    PyMem_RawFree(mem_buff2);
     memset(params, 0, sizeof(*params));
 
     return 0;
@@ -3352,8 +3352,8 @@ static inline void
 release_geqrf(GEQRF_PARAMS_t<ftyp>* params)
 {
     /* A and WORK contain allocated blocks */
-    free(params->A);
-    free(params->WORK);
+    PyMem_RawFree(params->A);
+    PyMem_RawFree(params->WORK);
     memset(params, 0, sizeof(*params));
 }
 
@@ -3465,7 +3465,7 @@ using ftyp = fortran_doublereal;
     size_t work_size;
     fortran_int lda = fortran_int_max(1, m);
 
-    mem_buff = (npy_uint8 *)malloc(q_size + tau_size + a_size);
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(q_size + tau_size + a_size);
 
     if (!mem_buff)
         goto no_memory;
@@ -3501,7 +3501,7 @@ using ftyp = fortran_doublereal;
 
     work_size = (size_t) params->LWORK * sizeof(ftyp);
 
-    mem_buff2 = (npy_uint8 *)malloc(work_size);
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(work_size);
     if (!mem_buff2)
         goto no_memory;
 
@@ -3516,8 +3516,8 @@ using ftyp = fortran_doublereal;
 
  error:
     TRACE_TXT("%s failed init\n", __FUNCTION__);
-    free(mem_buff);
-    free(mem_buff2);
+    PyMem_RawFree(mem_buff);
+    PyMem_RawFree(mem_buff2);
     memset(params, 0, sizeof(*params));
 
     return 0;
@@ -3548,7 +3548,7 @@ using ftyp=fortran_doublecomplex;
     size_t work_size;
     fortran_int lda = fortran_int_max(1, m);
 
-    mem_buff = (npy_uint8 *)malloc(q_size + tau_size + a_size);
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(q_size + tau_size + a_size);
 
     if (!mem_buff)
         goto no_memory;
@@ -3585,7 +3585,7 @@ using ftyp=fortran_doublecomplex;
 
     work_size = (size_t) params->LWORK * sizeof(ftyp);
 
-    mem_buff2 = (npy_uint8 *)malloc(work_size);
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(work_size);
     if (!mem_buff2)
         goto no_memory;
 
@@ -3601,8 +3601,8 @@ using ftyp=fortran_doublecomplex;
 
  error:
     TRACE_TXT("%s failed init\n", __FUNCTION__);
-    free(mem_buff);
-    free(mem_buff2);
+    PyMem_RawFree(mem_buff);
+    PyMem_RawFree(mem_buff2);
     memset(params, 0, sizeof(*params));
 
     return 0;
@@ -3658,8 +3658,8 @@ static inline void
 release_gqr(GQR_PARAMS_t<typ>* params)
 {
     /* A and WORK contain allocated blocks */
-    free(params->Q);
-    free(params->WORK);
+    PyMem_RawFree(params->Q);
+    PyMem_RawFree(params->WORK);
     memset(params, 0, sizeof(*params));
 }
 
@@ -3889,7 +3889,7 @@ scalar_trait)
     fortran_int ldb = fortran_int_max(1, fortran_int_max(m,n));
 
     size_t msize = a_size + b_size + s_size;
-    mem_buff = (npy_uint8 *)malloc(msize != 0 ? msize : 1);
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(msize != 0 ? msize : 1);
 
     if (!mem_buff) {
         goto no_memory;
@@ -3926,7 +3926,7 @@ scalar_trait)
         iwork_size = (size_t)iwork_size_query * sizeof(fortran_int);
     }
 
-    mem_buff2 = (npy_uint8 *)malloc(work_size + iwork_size);
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(work_size + iwork_size);
     if (!mem_buff2) {
         goto no_memory;
     }
@@ -3945,8 +3945,8 @@ scalar_trait)
 
  error:
     TRACE_TXT("%s failed init\n", __FUNCTION__);
-    free(mem_buff);
-    free(mem_buff2);
+    PyMem_RawFree(mem_buff);
+    PyMem_RawFree(mem_buff2);
     memset(params, 0, sizeof(*params));
     return 0;
 }
@@ -4016,7 +4016,7 @@ using frealtyp = basetype_t<ftyp>;
     fortran_int ldb = fortran_int_max(1, fortran_int_max(m,n));
 
     size_t msize = a_size + b_size + s_size;
-    mem_buff = (npy_uint8 *)malloc(msize != 0 ? msize : 1);
+    mem_buff = (npy_uint8 *)PyMem_RawMalloc(msize != 0 ? msize : 1);
 
     if (!mem_buff) {
         goto no_memory;
@@ -4057,7 +4057,7 @@ using frealtyp = basetype_t<ftyp>;
         iwork_size = (size_t)iwork_size_query * sizeof(fortran_int);
     }
 
-    mem_buff2 = (npy_uint8 *)malloc(work_size + rwork_size + iwork_size);
+    mem_buff2 = (npy_uint8 *)PyMem_RawMalloc(work_size + rwork_size + iwork_size);
     if (!mem_buff2) {
         goto no_memory;
     }
@@ -4078,8 +4078,8 @@ using frealtyp = basetype_t<ftyp>;
 
  error:
     TRACE_TXT("%s failed init\n", __FUNCTION__);
-    free(mem_buff);
-    free(mem_buff2);
+    PyMem_RawFree(mem_buff);
+    PyMem_RawFree(mem_buff2);
     memset(params, 0, sizeof(*params));
 
     return 0;
@@ -4090,8 +4090,8 @@ static inline void
 release_gelsd(GELSD_PARAMS_t<ftyp>* params)
 {
     /* A and WORK contain allocated blocks */
-    free(params->A);
-    free(params->WORK);
+    PyMem_RawFree(params->A);
+    PyMem_RawFree(params->WORK);
     memset(params, 0, sizeof(*params));
 }
 

--- a/numpy/random/src/distributions/random_mvhg_count.c
+++ b/numpy/random/src/distributions/random_mvhg_count.c
@@ -71,7 +71,7 @@ int random_multivariate_hypergeometric_count(bitgen_t *bitgen_state,
         return 0;
     }
 
-    choices = malloc(total * (sizeof *choices));
+    choices = PyMem_RawMalloc(total * (sizeof *choices));
     if (choices == NULL) {
         return -1;
     }
@@ -125,7 +125,7 @@ int random_multivariate_hypergeometric_count(bitgen_t *bitgen_state,
         }
     }
 
-    free(choices);
+    PyMem_RawFree(choices);
 
     return 0;
 }

--- a/numpy/random/src/mt19937/mt19937-jump.c
+++ b/numpy/random/src/mt19937/mt19937-jump.c
@@ -1,3 +1,4 @@
+#include <Python.h>
 #include "mt19937-jump.h"
 #include "mt19937.h"
 
@@ -66,7 +67,7 @@ void horner1(unsigned long *pf, mt19937_state *state) {
   int i = MEXP - 1;
   mt19937_state *temp;
 
-  temp = (mt19937_state *)calloc(1, sizeof(mt19937_state));
+  temp = (mt19937_state *)PyMem_RawCalloc(1, sizeof(mt19937_state));
 
   while (get_coef(pf, i) == 0)
     i--;
@@ -92,14 +93,14 @@ void horner1(unsigned long *pf, mt19937_state *state) {
     ;
 
   copy_state(state, temp);
-  free(temp);
+  PyMem_RawFree(temp);
 }
 
 void mt19937_jump_state(mt19937_state *state) {
   unsigned long *pf;
   int i;
 
-  pf = (unsigned long *)calloc(P_SIZE, sizeof(unsigned long));
+  pf = (unsigned long *)PyMem_RawCalloc(P_SIZE, sizeof(unsigned long));
   for (i = 0; i<P_SIZE; i++) {
     pf[i] = poly_coef[i];
   }
@@ -110,5 +111,5 @@ void mt19937_jump_state(mt19937_state *state) {
 
   horner1(pf, state);
 
-  free(pf);
+  PyMem_RawFree(pf);
 }


### PR DESCRIPTION


### PR summary

Fixes #28454

<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

This PR replaces usage of system allocator `malloc` with `PyMem_RawMalloc` and friends for better performance on free-threading where mimalloc is used as the underlying allocator.


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

I used Claude to find all the places where the replacement makes sense. 
