### PR TITLE
ENH: wire Highway VQSelect for np.partition on aarch64/ppc64

### DIFF
--- a/doc/release/upcoming_changes/31504.performance.rst
+++ b/doc/release/upcoming_changes/31504.performance.rst
@@ -1,0 +1,26 @@
+``np.partition`` is now faster on aarch64 and ppc64
+----------------------------------------------------
+`numpy.partition` on non-x86 platforms (aarch64, ppc64) now uses
+Highway's ``VQSelectStatic`` instead of the scalar quickselect.
+Applies to arrays with 16 384 or more elements of ``int16``,
+``uint16``, ``int32``, ``uint32``, ``int64``, ``uint64``, ``float32``,
+or ``float64`` dtype.
+
+Measured speedups vs scalar introselect on Apple M1 Pro (NEON, aarch64),
+arrays of 100k–1M elements, kth = N/2:
+
+* ``float32``: 2.2–5.0×
+* ``float64``: 1.8–2.7×
+* ``int32``: 6.4×
+* ``uint32``: 4.2–7.0×
+* ``int64``: 2.4–2.9×
+* ``uint64``: 2.5–2.9×
+* ``int16``: 9.1–11.6×
+* ``uint16``: 8.1–12.3×
+
+Speedup varies with array size and kth position; the lower end of each
+range is for N=1M and the upper for N=100k (or vice versa for float32).
+ppc64 (VSX2) benchmarks have not yet been measured.
+
+`numpy.argpartition` is not affected; Highway VQSelect operates on a
+keys-only array and cannot maintain a parallel index array.

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -924,6 +924,15 @@ foreach gen_mtargets : [
       ASIMDHP, VSX2,  # VXE FIXME: disable VXE due to runtime segfault
     ] : []
   ],
+  [
+    'highway_qselect.dispatch.h',
+    'src/npysort/highway_qselect.dispatch.cpp',
+    use_highway ? [
+      # VQSelect for non-x86, all widths: aarch64 (NEON) and ppc64.
+      # 16-bit ints need only base ASIMD (no ASIMDHP); float16 is excluded.
+      ASIMD, VSX2,
+    ] : []
+  ],
 ]
 
 

--- a/numpy/_core/src/npysort/highway_qselect.dispatch.cpp
+++ b/numpy/_core/src/npysort/highway_qselect.dispatch.cpp
@@ -1,0 +1,41 @@
+#define VQSORT_ONLY_STATIC 1
+#include "hwy/highway.h"
+#include "hwy/contrib/sort/vqsort-inl.h"
+
+#include "highway_qsort.hpp"
+#include "quicksort_generic.hpp"
+
+namespace np::highway::qsort_simd {
+template <typename T>
+void NPY_CPU_DISPATCH_CURFX(QSelect)(T *arr, npy_intp num, npy_intp kth)
+{
+#if VQSORT_ENABLED
+    // Guard the npy_intp (signed) → size_t (unsigned) casts below.
+    assert(num > 0 && kth >= 0 && kth < num);
+    hwy::HWY_NAMESPACE::VQSelectStatic(arr,
+                                       static_cast<size_t>(num),
+                                       static_cast<size_t>(kth),
+                                       hwy::SortAscending());
+#else
+    // VQSORT_ENABLED can be 0 on a registered target (e.g. aarch64 ASAN, or a
+    // HWY_DISABLE_VQSORT build).  Match the sibling sort dispatch and degrade
+    // to a scalar sort rather than fail to compile: a fully sorted array
+    // satisfies partition's postcondition at any kth.  (void)kth: unused here.
+    (void)kth;
+    sort::Quick<false>(arr, num);
+#endif
+}
+
+// 16-bit integers (int16_t/uint16_t) are plain integers covered by base ASIMD,
+// so they share this dispatch.  Half (float16) is omitted: selection.cpp
+// excludes it (scalar introselect handles float16 partition).
+template void NPY_CPU_DISPATCH_CURFX(QSelect)<int16_t>(int16_t*, npy_intp, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSelect)<uint16_t>(uint16_t*, npy_intp, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSelect)<int32_t>(int32_t*, npy_intp, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSelect)<uint32_t>(uint32_t*, npy_intp, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSelect)<int64_t>(int64_t*, npy_intp, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSelect)<uint64_t>(uint64_t*, npy_intp, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSelect)<float>(float*, npy_intp, npy_intp);
+template void NPY_CPU_DISPATCH_CURFX(QSelect)<double>(double*, npy_intp, npy_intp);
+
+} // np::highway::qsort_simd

--- a/numpy/_core/src/npysort/highway_qsort.hpp
+++ b/numpy/_core/src/npysort/highway_qsort.hpp
@@ -11,6 +11,9 @@ NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, npy_intp siz
 #include "highway_qsort_16bit.dispatch.h"
 NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSort, (T *arr, npy_intp size, bool reverse))
 
+#include "highway_qselect.dispatch.h"
+NPY_CPU_DISPATCH_DECLARE(template <typename T> void QSelect, (T *arr, npy_intp num, npy_intp kth))
+
 } // np::highway::qsort_simd
 
 #endif // NUMPY_SRC_COMMON_NPYSORT_HWY_SIMD_QSORT_HPP

--- a/numpy/_core/src/npysort/selection.cpp
+++ b/numpy/_core/src/npysort/selection.cpp
@@ -26,9 +26,9 @@
 #include <cstdlib>
 #include <utility>
 #include "x86_simd_qsort.hpp"
+#include "highway_qsort.hpp"
 
 #define NOT_USED NPY_UNUSED(unused)
-#define DISABLE_HIGHWAY_OPTIMIZATION (defined(__arm__) || defined(__aarch64__))
 
 template<typename T>
 inline bool quickselect_dispatch(T* v, npy_intp num, npy_intp kth)
@@ -43,6 +43,7 @@ inline bool quickselect_dispatch(T* v, npy_intp num, npy_intp kth)
         (sizeof(T) == sizeof(uint16_t) || sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t))) {
         using TF = typename np::meta::FixedWidth<T>::Type;
         void (*dispfunc)(TF*, npy_intp, npy_intp) = nullptr;
+#if defined(NPY_CPU_AMD64) || defined(NPY_CPU_X86)
         if constexpr (sizeof(T) == sizeof(uint16_t)) {
             #include "x86_simd_qsort_16bit.dispatch.h"
             NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSelect, <TF>);
@@ -51,6 +52,26 @@ inline bool quickselect_dispatch(T* v, npy_intp num, npy_intp kth)
             #include "x86_simd_qsort.dispatch.h"
             NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::qsort_simd::template QSelect, <TF>);
         }
+#else
+        // Attempt Highway VQSelect on non-x86 platforms.  One dispatch handles
+        // all widths (16/32/64-bit ints and float/double); 16-bit integers are
+        // plain integers covered by base ASIMD, so no separate ASIMDHP target
+        // is needed.  Registered for ASIMD (aarch64 NEON) and VSX2 (ppc64); on
+        // other architectures dispfunc stays null and we fall through to scalar
+        // introselect below.
+        //
+        // Half (float16) is excluded: HWY_HAVE_FLOAT16 gating adds complexity
+        // and float16 partition is uncommon; scalar introselect is correct.
+        //
+        // Single threshold for all types; below it scalar introselect wins.
+        static constexpr npy_intp HWY_QSELECT_MIN_N = 16384;
+        if constexpr (!std::is_same_v<TF, np::Half>) {
+            if (num >= HWY_QSELECT_MIN_N) {
+                #include "highway_qselect.dispatch.h"
+                NPY_CPU_DISPATCH_CALL_XB(dispfunc = np::highway::qsort_simd::template QSelect, <TF>);
+            }
+        }
+#endif
         if (dispfunc) {
             (*dispfunc)(reinterpret_cast<TF*>(v), num, kth);
             return true;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -26,6 +26,8 @@ from contextlib import ExitStack, contextmanager
 from datetime import datetime, timedelta
 from decimal import Decimal
 
+import platform
+
 import pytest
 
 import numpy as np
@@ -11227,6 +11229,125 @@ def test_argsort_largearrays(dtype):
     rnd = np.random.RandomState(1100710816)
     arr = -0.5 + rnd.random(N).astype(dtype)
     assert_arg_sorted(arr, np.argsort(arr, kind='quick'))
+
+
+def _is_highway_qselect_platform():
+    """True on platforms where the Highway VQSelect dispatch is active."""
+    m = platform.machine()
+    # Linux reports "aarch64"; macOS Apple Silicon reports "arm64".
+    return m in ("aarch64", "arm64") or m.startswith("ppc64")
+
+
+@pytest.mark.parametrize("dtype", [
+    np.int32, np.uint32, np.int64, np.uint64, np.float32, np.float64,
+])
+@pytest.mark.parametrize("N,kth", [
+    (16384, 0),          # threshold boundary, minimum
+    (16384, 16383),      # threshold boundary, maximum
+    (100_000, 10),       # small k (ORDER BY … LIMIT pattern)
+    (100_000, 99_999),   # large k
+    (100_000, 50_000),   # median
+    (1_000_000, 100),    # large array
+])
+def test_partition_highway(dtype, N, kth):
+    rng = np.random.default_rng(1100710816)
+    if np.issubdtype(dtype, np.floating):
+        arr = rng.random(N).astype(dtype)
+    else:
+        info = np.iinfo(dtype)
+        arr = rng.integers(info.min, info.max, size=N, dtype=dtype)
+    result = np.partition(arr, kth)
+    assert_equal(result[kth], np.sort(arr)[kth])
+    assert np.all(result[:kth] <= result[kth]), (
+        f"Elements before kth={kth} not all <= result[kth]"
+    )
+    assert np.all(result[kth:] >= result[kth]), (
+        f"Elements after kth={kth} not all >= result[kth]"
+    )
+
+
+@pytest.mark.skipif(
+    not _is_highway_qselect_platform(),
+    reason="Highway VQSelect dispatch only active on aarch64/ppc64"
+)
+@pytest.mark.parametrize("dtype", [
+    np.int32, np.uint32, np.int64, np.uint64, np.float32, np.float64,
+])
+@pytest.mark.parametrize("N,kth", [
+    (16384, 0),
+    (100_000, 50_000),
+    (1_000_000, 100),
+])
+def test_partition_highway_native(dtype, N, kth):
+    """Skipped on x86 so on-target CI shows an explicit pass for the new path."""
+    rng = np.random.default_rng(42)
+    if np.issubdtype(dtype, np.floating):
+        arr = rng.random(N).astype(dtype)
+    else:
+        info = np.iinfo(dtype)
+        arr = rng.integers(info.min, info.max, size=N, dtype=dtype)
+    result = np.partition(arr, kth)
+    assert_equal(result[kth], np.sort(arr)[kth])
+    assert np.all(result[:kth] <= result[kth])
+    assert np.all(result[kth:] >= result[kth])
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_partition_highway_nan(dtype):
+    # NaNs must be partitioned to the end, matching NumPy's contract.
+    N = 100_000
+    rng = np.random.default_rng(42)
+    arr = rng.random(N).astype(dtype)
+    arr[rng.choice(N, 500, replace=False)] = np.nan
+    result = np.partition(arr, N - 501)
+    # The last 500 elements should all be NaN (Highway/NumPy contract: NaNs
+    # are treated as greater than all finite values and sort to the end).
+    assert np.all(np.isnan(result[-500:])), "NaN not at end of partitioned array"
+    # No NaNs should appear before the NaN region.
+    assert np.all(~np.isnan(result[:-500])), "NaN found before expected range"
+
+
+# float16 (Half) is excluded from the Highway path; it falls back to scalar
+# introselect.  int16/uint16 ride the same ASIMD/VSX2 dispatch as wider types.
+@pytest.mark.parametrize("dtype", [np.int16, np.uint16])
+@pytest.mark.parametrize("N,kth", [
+    (16384, 0),          # threshold boundary, minimum
+    (16384, 16383),      # threshold boundary, maximum
+    (100_000, 10),       # small k (ORDER BY … LIMIT pattern)
+    (100_000, 99_999),   # large k
+    (100_000, 50_000),   # median
+])
+def test_partition_highway_16bit(dtype, N, kth):
+    rng = np.random.default_rng(42)
+    info = np.iinfo(dtype)
+    arr = rng.integers(info.min, info.max, size=N, dtype=dtype)
+    result = np.partition(arr, kth)
+    assert_equal(result[kth], np.sort(arr)[kth])
+    assert np.all(result[:kth] <= result[kth]), (
+        f"Elements before kth={kth} not all <= result[kth]"
+    )
+    assert np.all(result[kth:] >= result[kth]), (
+        f"Elements after kth={kth} not all >= result[kth]"
+    )
+
+
+@pytest.mark.skipif(
+    not _is_highway_qselect_platform(),
+    reason="Highway 16-bit VQSelect dispatch only active on aarch64/ppc64"
+)
+@pytest.mark.parametrize("dtype", [np.int16, np.uint16])
+def test_partition_highway_16bit_native(dtype):
+    """Skipped on x86 so on-target CI shows an explicit pass for the 16-bit path."""
+    N = 100_000
+    kth = N // 2
+    rng = np.random.default_rng(42)
+    info = np.iinfo(dtype)
+    arr = rng.integers(info.min, info.max, size=N, dtype=dtype)
+    result = np.partition(arr, kth)
+    assert_equal(result[kth], np.sort(arr)[kth])
+    assert np.all(result[:kth] <= result[kth])
+    assert np.all(result[kth:] >= result[kth])
+
 
 @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
 @pytest.mark.thread_unsafe(


### PR DESCRIPTION
## Summary

  `np.partition` on non-x86 platforms (aarch64, ppc64) has always fallen back to
  scalar introselect. `np.sort` already uses Highway's VQSort on these targets
  (gh-24018); this wires the matching `VQSelectStatic` into `np.partition`.

  x86/x86-64 already has partition acceleration via Intel's `x86-simd-sort`; this
  is purely the non-x86 counterpart.

  ## What changed

  - `quickselect_dispatch` now tries Highway VQSelect on non-x86 before falling
    back to scalar introselect, mirroring the existing x86/non-x86 split in
    `quicksort.hpp`.
  - One dispatch file (`highway_qselect.dispatch.cpp`) covers all widths
    (int16/uint16/int32/uint32/int64/uint64/float32/float64), registered for
    `ASIMD` (aarch64 NEON) and `VSX2` (ppc64). 16-bit ints need only base ASIMD,
    so no separate ASIMDHP target.
  - float16 is excluded — `HWY_HAVE_FLOAT16` gating adds complexity and float16
    partition is uncommon; scalar introselect remains correct there.
  - A minimum-size threshold (`HWY_QSELECT_MIN_N = 16384`) keeps scalar
    introselect for L1-resident arrays where dispatch overhead dominates.
  - Removes the dead `DISABLE_HIGHWAY_OPTIMIZATION` macro.

  `np.argpartition` is **not** covered: VQSelect is keys-only and can't maintain a
  parallel index array.

  ## Threshold rationale

  A size sweep on M1 Pro (N=64–65536, kth=N/2) showed scalar introselect's
  random-pivot variance dominates below 16384 — at N=8192 int64 regresses to
  0.28× and float32 to 0.70×. At N=16384 every type reliably wins (1.2× for
  int64, up to 11× for 16-bit), so a single threshold is used for all widths.

  ## Benchmarks

  M1 Pro NEON, numpy 2.4.4 scalar vs this branch (ns/elem):
  
  | dtype   | n    | k   | scalar | vqselect | speedup |
  |---------|------|-----|--------|----------|---------|
  | float32 | 100K | 10  | 5.0    | 2.3      | 2.2×    |
  | float32 | 1M   | 100 | 6.8    | 2.6      | 2.6×    |
  | float32 | 10M  | 100 | 8.9    | 2.7      | 3.3×    |
  | float64 | 100K | 10  | 8.0    | 3.6      | 2.2×    |
  | float64 | 1M   | 100 | 9.2    | 4.5      | 2.0×    |
  | int32   | 100K | 10  | 6.3    | 1.3      | 4.9×    |
  | int32   | 1M   | 100 | 5.8    | 1.5      | 3.8×    |
  | int64   | 1M   | 100 | 5.9    | 2.9      | 2.0×    |

  16-bit types reach 8–12×. Below the 16384 threshold, parity (falls back to
  scalar). ppc64/VSX2 is wired but unmeasured.

  ## Testing

  New `np.partition` correctness tests across all dispatched dtypes, kth
  positions (min/median/max), threshold boundaries, and NaN ordering, plus
  on-target (`_native`) tests that run on aarch64/ppc64. Verified locally on
  Apple Silicon (aarch64): full build clean, new tests + the existing
  partition/sort suite pass (12707 passed).