### PR TITLE
PERF: avoid temporary allocation in np.gradient for strided axes

### DIFF
--- a/benchmarks/benchmarks/bench_gradient.py
+++ b/benchmarks/benchmarks/bench_gradient.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+
+class GradientStridedAxis:
+    params = [
+        [np.float32, np.float64],
+        ["C", "F"],
+        [
+            ((1000, 1000), 0),
+            ((1000, 1000), 1),
+            ((100, 100, 100), 0),
+            ((100, 100, 100), 1),
+            ((100, 100, 100), 2),
+        ],
+    ]
+    param_names = ["dtype", "order", "case"]
+
+    def setup(self, dtype, order, case):
+        shape, axis = case
+        rng = np.random.default_rng(42)
+        arr = rng.random(shape).astype(dtype)
+
+        if order == "C":
+            self.arr = np.ascontiguousarray(arr)
+        elif order == "F":
+            self.arr = np.asfortranarray(arr)
+
+        self.dx = 0.01
+        self.axis = axis
+
+    def time_gradient_scalar_spacing_axis(self, dtype, order, case):
+        np.gradient(self.arr, self.dx, axis=self.axis)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1321,7 +1321,15 @@ def gradient(f, *varargs, axis=None, edge_order=1):
         slice4[axis] = slice(2, None)
 
         if uniform_spacing:
-            out[tuple(slice1)] = (f[tuple(slice4)] - f[tuple(slice2)]) / (2. * ax_dx)
+            slice1_t = tuple(slice1)
+            slice2_t = tuple(slice2)
+            slice4_t = tuple(slice4)
+
+            if f.strides[axis] != f.itemsize:
+                np.subtract(f[slice4_t], f[slice2_t], out=out[slice1_t])
+                out[slice1_t] /= (2. * ax_dx)
+            else:
+                out[slice1_t] = (f[slice4_t] - f[slice2_t]) / (2. * ax_dx)
         else:
             dx1 = ax_dx[0:-1]
             dx2 = ax_dx[1:]


### PR DESCRIPTION
### PR summary

I investigated np.gradient and found out the central difference quotient was calculated in one line in _function_base_impl.py 

```python
out[slice1_t] = (f[slice4_t] - f[slice2_t]) / (2. * ax_dx) 
```

So first it calculates the difference f[slice4_t] - f[slice2_t], creates a temporary array for that result, then does the division by 2 * dx and saves the final result in out. This costs unnecessary memory and memory bandwidth, especially for large arrays. For some cases it is faster to calculate the difference, directly save the result in out and then scale out further.

## Explanation

For normal numpy arrays (C-order arrays), the last axis is contiguous in memory. For Fortran-order arrays (F-order arrays), the first axis is contiguous in memory. My tests showed that the existing method is good or sometimes even better for contiguous axes. But for non-contiguous, strided axes, the new proposed method is faster.
Therefore, I kept the existing method for contiguous axes and uses the new method as a case only for strided axes.

## Results
float32, C-order, (1000, 1000), axis=0:
196 µs -> 137 µs

float64, C-order, (1000, 1000), axis=0:
377 µs -> 273 µs

float32, F-order, (1000, 1000), axis=1:
196 µs -> 137 µs

float64, F-order, (1000, 1000), axis=1:
379 µs -> 270 µs

The added ASV benchmarks showed an increase of roughly 25-40% for the new method on strided-axis cases (tested on MacOS/arm64 , Apple M4 Max).

ASV
"SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED."

Tests
python -m pytest numpy/lib/tests/test_function_base.py -k gradient
"28 passed, 1468 deselected"

### First time committer introduction
I used numpy for over a decade in physics. My main focus in corporate research is in NLP and Riemannian Optimization. I wanted to contribute to the numpy community for a long time as I benefited from it long enough.

#### AI Disclosure
ChatGPT reviewed the benchmark script and help me rewriting the PR title. 

