### PR TITLE
DOC: clarify ambiguous bins parameter in histogram2d

### DIFF
--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -1,4 +1,4 @@
-"""
+X"""
 Histogram-related functions
 """
 import contextlib
@@ -936,6 +936,13 @@ def histogramdd(sample, bins=10, range=None, density=None, weights=None):
           edges along each dimension.
         * The number of bins for each dimension (nx, ny, ... =bins)
         * The number of bins for all dimensions (nx=ny=...=bins).
+
+    .. note::
+        When ``bins`` is a sequence of integers, e.g. ``bins=[3, 5, 4]``,
+        each value is interpreted as the **number of bins** for that
+        dimension, not bin edge positions. This can be easy to miss
+        with many dimensions. To specify bin edges explicitly, pass
+        a sequence of arrays instead.
 
     range : sequence, optional
         A sequence of length D, each an optional (lower, upper) tuple giving

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -1,4 +1,4 @@
-X"""
+"""
 Histogram-related functions
 """
 import contextlib

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -718,6 +718,16 @@ def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
         * A combination [int, array] or [array, int], where int
           is the number of bins and array is the bin edges.
 
+        .. note::
+            When ``bins=[m, n]`` where both values are integers,
+            they are interpreted as the **number of bins** per
+            dimension, not bin edge positions. For example,
+            ``bins=[3, 5]`` creates 3 bins along x and 5 bins
+            along y. This distinction can be easy to miss,
+            especially when using `histogramdd` with many
+            dimensions. To specify edges explicitly, pass arrays:
+            ``bins=[array1, array2]``.
+
     range : array_like, shape(2,2), optional
         The leftmost and rightmost edges of the bins along each dimension
         (if not specified explicitly in the `bins` parameters):


### PR DESCRIPTION
### PR summary
This PR adds a `.. note::` to the `bins` parameter docstring 
in both `histogram2d` and `histogramdd` clarifying that when 
`bins` is passed as integers e.g. `bins=[3, 5]`, each value 
means number of bins per dimension, not bin edge positions. 
This addresses the ambiguity reported in #31296.

### First time committer introduction
Hi! I am Shrimon, a first year CS student interested in ML 
and open source. I found this issue while exploring NumPy's 
documentation and thought it would be a good first 
contribution. I have experience with Python and data science 
projects including competition work.

#### AI Disclosure
I used Claude (Anthropic) as a learning guide to help me 
navigate the contribution process, find the correct files, 
and understand the codebase structure. The documentation 
content and actual changes are my own work.
