### PR TITLE
ENH: Descending partitioning

### DIFF
--- a/doc/release/upcoming_changes/31511.new_feature.rst
+++ b/doc/release/upcoming_changes/31511.new_feature.rst
@@ -1,5 +1,5 @@
 New `descending` keyword argument for ``numpy.partition`` and ``numpy.argpartition``
---------------------------------------------------------------------------
+------------------------------------------------------------------------------------
 Users can now pass the `descending=True` keyword argument to ``numpy.partition`` and
 ``numpy.argpartition`` to partition and argpartition arrays in descending order.
 NaN values, if present, are partitioned to the end of the array in both ascending and

--- a/doc/release/upcoming_changes/31511.new_feature.rst
+++ b/doc/release/upcoming_changes/31511.new_feature.rst
@@ -1,0 +1,9 @@
+New `descending` keyword argument for ``numpy.partition`` and ``numpy.argpartition``
+--------------------------------------------------------------------------
+Users can now pass the `descending=True` keyword argument to ``numpy.partition`` and
+``numpy.argpartition`` to partition and argpartition arrays in descending order.
+NaN values, if present, are partitioned to the end of the array in both ascending and
+descending sorts. This feature is available for all built-in dtypes except
+`string`, `unicode`, `void`, `object`, and `generic`. Note that SIMD optimizations
+for partitioning are currently not available for descending order, so performance
+may be slower.

--- a/doc/release/upcoming_changes/31511.new_feature.rst
+++ b/doc/release/upcoming_changes/31511.new_feature.rst
@@ -1,9 +1,9 @@
-New `descending` keyword argument for ``numpy.partition`` and ``numpy.argpartition``
-------------------------------------------------------------------------------------
-Users can now pass the `descending=True` keyword argument to ``numpy.partition`` and
-``numpy.argpartition`` to partition and argpartition arrays in descending order.
+New ``descending`` keyword argument for `numpy.partition` and `numpy.argpartition`
+----------------------------------------------------------------------------------
+Users can now pass the ``descending=True`` keyword argument to `numpy.partition` and
+`numpy.argpartition` to partition and argpartition arrays in descending order.
 NaN values, if present, are partitioned to the end of the array in both ascending and
 descending sorts. This feature is available for all built-in dtypes except
-`string`, `unicode`, `void`, `object`, and `generic`. Note that SIMD optimizations
-for partitioning are currently not available for descending order, so performance
-may be slower.
+``string``, ``unicode``, ``void``, ``object``, and ``generic``. Note that SIMD
+optimizations for partitioning are currently not available for descending order,
+so performance may be slower.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -4677,8 +4677,6 @@ Enumerated Types
     .. c:enumerator:: NPY_SORT_DESCENDING
 
         (Requirement) Specifies that the sort must be in descending order.
-        This functionality is not yet implemented for any of the NumPy types
-        and cannot yet be set from the Python interface.
 
 .. c:enum:: NPY_SCALARKIND
 
@@ -4759,9 +4757,21 @@ Enumerated Types
 
 .. c:enum:: NPY_SELECTKIND
 
-    A variable type indicating the selection algorithm being used.
+    A variable type indicating the selection algorithm options for
+    the partitioning functions, see also :c:type:`NPY_SORTKIND`.
+
+    .. c:enumerator:: NPY_SELECT_DEFAULT
+
+        The default selection algorithm.
+
+    .. c:enumerator:: NPY_SELECT_DESCENDING
+
+        (Requirement) Flag that changes the partition/sort order to descending.
 
     .. c:enumerator:: NPY_INTROSELECT
+
+        Identical to ``NPY_SELECT_DEFAULT`` but defined prior to NumPy 2.5.
+        Prefer ``NPY_SELECT_DEFAULT`` if compiling with NumPy 2.5 or later.
 
 .. c:enum:: NPY_CASTING
 

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3614,8 +3614,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: None = None,
+        descending: py_bool | None = None,
     ) -> None: ...
     @overload
     def partition(
@@ -3623,8 +3624,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: str | Sequence[str] | None = None,
+        descending: py_bool | None = None,
     ) -> None: ...
 
     # keep in sync with `ma.core.MaskedArray.argpartition`
@@ -3635,8 +3637,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: None,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: None = None,
+        descending: py_bool | None = None,
     ) -> ndarray[tuple[int], _dtype[intp]]: ...
     @overload  # axis: index (default)
     def argpartition(
@@ -3644,8 +3647,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: None = None,
+        descending: py_bool | None = None,
     ) -> ndarray[_ShapeT_co, _dtype[intp]]: ...
     @overload  # void, axis: None
     def argpartition(
@@ -3653,8 +3657,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: None,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: str | Sequence[str] | None = None,
+        descending: py_bool | None = None,
     ) -> ndarray[tuple[int], _dtype[intp]]: ...
     @overload  # void, axis: index (default)
     def argpartition(
@@ -3662,8 +3667,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: str | Sequence[str] | None = None,
+        descending: py_bool | None = None,
     ) -> ndarray[_ShapeT_co, _dtype[intp]]: ...
 
     # keep in sync with `ma.MaskedArray.diagonal`

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3318,14 +3318,13 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
     ----------
     kth : int or sequence of ints
         Element index to partition by. The k-th value of the array will
-        be in the position it would be in a sorted array, all elements that
-        sorted array, all elements that are less than this element (or
-        greater if `descending` is True) will be moved before it, and
-        all elements that are greater than or equal to this element
-        (or less than or equal if `descending` is True) will be moved after it.
-        The order of all elements within each partition is undefined. If
-        provided with a sequence of k-th it will partition all elements
-        indexed by k-th of them into their sorted position at once.
+        be in the position it would be in a sorted array, all elements
+        that are less than this element (or greater if `descending` is True)
+        will be moved before it, and all elements that are greater than or
+        equal to this element (or less than or equal if `descending` is True)
+        will be moved after it. The order of all elements within each partition
+        is undefined. If provided with a sequence of k-th it will partition all
+        elements indexed by k-th of them into their sorted position at once.
 
         .. deprecated:: 1.22.0
             Passing booleans as index is deprecated.

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3341,14 +3341,14 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
         but unspecified fields will still be used, in the order in which
         they come up in the dtype, to break ties.
     descending : bool, optional
-        Partition order. If ``True``, the left partition would contain
-        values less than or equal to the k-th element and the right partition
-        will contain values greater than or equal to the k-th element.
+        Partition order. If ``True``, the left partition will contain
+        values greater than the k-th element and the right partition
+        will contain values less than or equal to the k-th element.
         If ``False`` or ``None``, the left partition will contain values
-        less than or equal to the k-th element and the right partition
-        will contain values greater than or equal to the k-th element. Values
-        that are NaN are partitioned towards the end of the array regardless of
-        order. Default: ``None``.
+        less than the k-th element and the right partition will contain values
+        greater than or equal to the k-th element. Values that are NaN
+        are partitioned towards the end of the array regardless of order.
+        Default: ``None``.
 
         .. versionadded:: 2.6.0
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3316,8 +3316,6 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
 
     Parameters
     ----------
-    a : array_like
-        Array to be sorted.
     kth : int or sequence of ints
         Element index to partition by. The k-th value of the array will
         be in the position it would be in a sorted array, all elements that

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3307,7 +3307,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
 
     a.partition(kth, axis=-1, kind='introselect', order=None, descending=None)
 
-    Partially sorts the array in such a way that the value of the element in k-th
+    Partially sorts the array in such a way that the value of the element in the k-th
     position is in the position it would be in a sorted array. In the output array,
     all elements that would be to the left of the k-th element in a sorted array are
     located to the left of this element and all that would be to the right are located

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3284,10 +3284,10 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('dot',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('argpartition',
     """
-    argpartition($self, kth, /, axis=-1, kind='introselect', order=None)
+    argpartition($self, kth, /, axis=-1, kind='introselect', order=None, descending=None)
     --
 
-    a.argpartition(kth, axis=-1, kind='introselect', order=None)
+    a.argpartition(kth, axis=-1, kind='introselect', order=None, descending=None)
 
     Returns the indices that would partition this array.
 
@@ -3302,27 +3302,30 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('argpartition',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
     """
-    partition($self, kth, /, axis=-1, kind='introselect', order=None)
+    partition($self, kth, /, axis=-1, kind='introselect', order=None, descending=None)
     --
 
-    a.partition(kth, axis=-1, kind='introselect', order=None)
+    a.partition(kth, axis=-1, kind='introselect', order=None, descending=None)
 
-    Partially sorts the elements in the array in such a way that the value of
-    the element in k-th position is in the position it would be in a sorted
-    array. In the output array, all elements smaller than the k-th element
-    are located to the left of this element and all equal or greater are
-    located to its right. The ordering of the elements in the two partitions
-    on the either side of the k-th element in the output array is undefined.
+    Partially sorts the array in such a way that the value of the element in k-th
+    position is in the position it would be in a sorted array. In the output array,
+    all elements that would be to the left of the k-th element in a sorted array are
+    located to the left of this element and all that would be to the right are located
+    to its right. The ordering of the elements in the two partitions on the either side
+    of the k-th element in the output array is undefined.
 
     Parameters
     ----------
+    a : array_like
+        Array to be sorted.
     kth : int or sequence of ints
-        Element index to partition by. The kth element value will be in its
-        final sorted position and all smaller elements will be moved before it
-        and all equal or greater elements behind it.
-        The order of all elements in the partitions is undefined.
-        If provided with a sequence of kth it will partition all elements
-        indexed by kth of them into their sorted position at once.
+        Element index to partition by. The k-th value of the array will
+        be in the position it would be in a sorted array, all elements that
+        would be sorted before it will be moved before it, and all elements
+        that would be sorted after it will be moved after it. The order of
+        all elements within the partitions is undefined. If provided with a
+        sequence of k-th it will partition all elements indexed by k-th of
+        them into their sorted position at once.
 
         .. deprecated:: 1.22.0
             Passing booleans as index is deprecated.
@@ -3337,6 +3340,17 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
         be specified as a string, and not all fields need to be specified,
         but unspecified fields will still be used, in the order in which
         they come up in the dtype, to break ties.
+    descending : bool, optional
+        Partition order. If ``True``, the left partition would contain
+        values less than or equal to the k-th element and the right partition
+        will contain values greater than or equal to the k-th element.
+        If ``False`` or ``None``, the left partition will contain values
+        less than or equal to the k-th element and the right partition
+        will contain values greater than or equal to the k-th element. Values
+        that are NaN are partitioned towards the end of the array regardless of
+        order. Default: ``None``.
+
+        .. versionadded:: 2.6.0
 
     See Also
     --------

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3319,11 +3319,13 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
     kth : int or sequence of ints
         Element index to partition by. The k-th value of the array will
         be in the position it would be in a sorted array, all elements that
-        would be sorted before it will be moved before it, and all elements
-        that would be sorted after it will be moved after it. The order of
-        all elements within the partitions is undefined. If provided with a
-        sequence of k-th it will partition all elements indexed by k-th of
-        them into their sorted position at once.
+        sorted array, all elements that are less than this element (or
+        greater if `descending` is True) will be moved before it, and
+        all elements that are greater than or equal to this element
+        (or less than or equal if `descending` is True) will be moved after it.
+        The order of all elements within each partition is undefined. If
+        provided with a sequence of k-th it will partition all elements
+        indexed by k-th of them into their sorted position at once.
 
         .. deprecated:: 1.22.0
             Passing booleans as index is deprecated.
@@ -3331,7 +3333,9 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
         Axis along which to sort. Default is -1, which means sort along the
         last axis.
     kind : {'introselect'}, optional
-        Selection algorithm. Default is 'introselect'.
+        NumPy currently offers only one selection algorithm, 'introselect',
+        and this parameter provides no additional functionality. Default
+        is ``None``.
     order : str or list of str, optional
         When `a` is an array with fields defined, this argument specifies
         which fields to compare first, second, etc. A single field can
@@ -3339,14 +3343,10 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
         but unspecified fields will still be used, in the order in which
         they come up in the dtype, to break ties.
     descending : bool, optional
-        Sort order. If ``True``, the left partition will contain
-        values greater than the k-th element and the right partition
-        will contain values less than or equal to the k-th element.
-        If ``False`` or ``None``, the left partition will contain values
-        less than the k-th element and the right partition will contain values
-        greater than or equal to the k-th element. Values that are NaN
-        are partitioned towards the end of the array regardless of order.
-        Default: ``None``.
+        Sort order. If ``True``, the array will be partitioned in
+        descending order. If ``False`` or ``None``, the array will be
+        partitioned in ascending order. Values that are NaN are partitioned
+        towards the end of the array regardless of order. Default: ``None``.
 
         .. versionadded:: 2.6.0
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3339,7 +3339,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('partition',
         but unspecified fields will still be used, in the order in which
         they come up in the dtype, to break ties.
     descending : bool, optional
-        Partition order. If ``True``, the left partition will contain
+        Sort order. If ``True``, the left partition will contain
         values greater than the k-th element and the right partition
         will contain values less than or equal to the k-th element.
         If ``False`` or ``None``, the left partition will contain values

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -854,13 +854,13 @@ def partition(a, kth, axis=-1, kind=np._NoValue, order=None, descending=np._NoVa
         a = asanyarray(a).copy(order="K")
 
     # Sanitize for backward compatibility
-    extra_kwargs = {}
+    kwargs = {}
     if descending is not np._NoValue:
-        extra_kwargs['descending'] = descending
+        kwargs['descending'] = descending
     if kind is not np._NoValue:
-        extra_kwargs['kind'] = kind
+        kwargs['kind'] = kind
 
-    a.partition(kth, axis=axis, order=order, **extra_kwargs)
+    a.partition(kth, axis=axis, order=order, **kwargs)
     return a
 
 

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -738,23 +738,25 @@ def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
 
     Creates a copy of the array and partially sorts it in such a way that
     the value of the element in k-th position is in the position it would be
-    in a sorted array. In the output array, all elements smaller than the k-th
-    element are located to the left of this element and all equal or greater
-    are located to its right. The ordering of the elements in the two
-    partitions on the either side of the k-th element in the output array is
-    undefined.
+    in a sorted array. In the output array, all elements that would be to the left
+    of the k-th element in a sorted array are located to the left of this element and
+    all that would be to the right are located to its right. The ordering of the
+    elements in the two partitions on the either side of the k-th element in the
+    output array is undefined.
 
     Parameters
     ----------
     a : array_like
         Array to be sorted.
     kth : int or sequence of ints
-        Element index to partition by. The k-th value of the element
-        will be in its final sorted position and all smaller elements
-        will be moved before it and all equal or greater elements behind
-        it. The order of all elements in the partitions is undefined. If
-        provided with a sequence of k-th it will partition all elements
-        indexed by k-th  of them into their sorted position at once.
+        Element index to partition by. In the returned array, the k-th
+        value of the array will be in the position it would be in a
+        sorted array, all elements that would be sorted before it will
+        be moved before it, and all elements that would be sorted after
+        it will be moved after it. The order of all elements within the
+        partitions is undefined. If provided with a sequence of k-th it
+        will partition all elements indexed by k-th of them into their
+        sorted position at once.
 
     axis : int or None, optional
         Axis along which to sort. If None, the array is flattened before
@@ -767,6 +769,17 @@ def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
         field can be specified as a string.  Not all fields need be
         specified, but unspecified fields will still be used, in the
         order in which they come up in the dtype, to break ties.
+    descending : bool, optional
+        Partition order. If ``True``, the left partition would contain
+        values less than or equal to the k-th element and the right partition
+        will contain values greater than or equal to the k-th element.
+        If ``False`` or ``None``, the left partition will contain values
+        less than or equal to the k-th element and the right partition
+        will contain values greater than or equal to the k-th element. Values
+        that are NaN are partitioned towards the end of the array regardless of
+        order. Default: ``None``.
+
+        .. versionadded:: 2.6.0
 
     Returns
     -------
@@ -803,7 +816,8 @@ def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
     the real parts except when they are equal, in which case the order
     is determined by the imaginary parts.
 
-    The sort order of ``np.nan`` is bigger than ``np.inf``.
+    Regardless of sort order, `np.nan` is partitioned to the right of
+    any other value.
 
     Examples
     --------
@@ -864,12 +878,14 @@ def argpartition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue)
     a : array_like
         Array to sort.
     kth : int or sequence of ints
-        Element index to partition by. The k-th element will be in its
-        final sorted position and all smaller elements will be moved
-        before it and all larger elements behind it. The order of all
-        elements in the partitions is undefined. If provided with a
-        sequence of k-th it will partition all of them into their sorted
-        position at once.
+        Element index to partition by. In the returned array, the k-th
+        value of the array will be in the position it would be in a
+        sorted array, all elements that would be sorted before it will
+        be moved before it, and all elements that would be sorted after
+        it will be moved after it. The order of all elements within the
+        partitions is undefined. If provided with a sequence of k-th it
+        will partition all elements indexed by k-th of them into their
+        sorted position at once.
 
     axis : int or None, optional
         Axis along which to sort. The default is -1 (the last axis). If
@@ -882,6 +898,17 @@ def argpartition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue)
         field can be specified as a string, and not all fields need be
         specified, but unspecified fields will still be used, in the
         order in which they come up in the dtype, to break ties.
+    descending : bool, optional
+        Partition order. If ``True``, the left partition would contain
+        indices of elements less than or equal to the k-th element and the
+        right partition will contain indices of elements greater than or
+        equal to the k-th element. If ``False`` or ``None``, the left partition
+        will contain indices of elements less than or equal to the k-th element
+        and the right partition will contain indices of elements greater than or
+        equal to the k-th element. Indices of values that are NaN are partitioned
+        towards the end of the array regardless of order. Default: ``None``.
+
+        .. versionadded:: 2.6.0
 
     Returns
     -------

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -770,14 +770,14 @@ def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
         specified, but unspecified fields will still be used, in the
         order in which they come up in the dtype, to break ties.
     descending : bool, optional
-        Partition order. If ``True``, the left partition would contain
-        values less than or equal to the k-th element and the right partition
-        will contain values greater than or equal to the k-th element.
+        Partition order. If ``True``, the left partition will contain
+        values greater than the k-th element and the right partition
+        will contain values less than or equal to the k-th element.
         If ``False`` or ``None``, the left partition will contain values
-        less than or equal to the k-th element and the right partition
-        will contain values greater than or equal to the k-th element. Values
-        that are NaN are partitioned towards the end of the array regardless of
-        order. Default: ``None``.
+        less than the k-th element and the right partition will contain values
+        greater than or equal to the k-th element. Values that are NaN
+        are partitioned towards the end of the array regardless of order.
+        Default: ``None``.
 
         .. versionadded:: 2.6.0
 
@@ -899,14 +899,14 @@ def argpartition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue)
         specified, but unspecified fields will still be used, in the
         order in which they come up in the dtype, to break ties.
     descending : bool, optional
-        Partition order. If ``True``, the left partition would contain
-        indices of elements less than or equal to the k-th element and the
-        right partition will contain indices of elements greater than or
-        equal to the k-th element. If ``False`` or ``None``, the left partition
-        will contain indices of elements less than or equal to the k-th element
-        and the right partition will contain indices of elements greater than or
-        equal to the k-th element. Indices of values that are NaN are partitioned
-        towards the end of the array regardless of order. Default: ``None``.
+        Partition order. If ``True``, the left partition will contain
+        values greater than the k-th element and the right partition
+        will contain values less than or equal to the k-th element.
+        If ``False`` or ``None``, the left partition will contain values
+        less than the k-th element and the right partition will contain values
+        greater than or equal to the k-th element. Values that are NaN
+        are partitioned towards the end of the array regardless of order.
+        Default: ``None``.
 
         .. versionadded:: 2.6.0
 

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -939,7 +939,7 @@ def argpartition(a, kth, axis=-1, kind=np._NoValue, order=None, descending=np._N
     see `partition` for notes on the enhanced sort order and
     different selection algorithms.
 
-    ExamplesNone
+    Examples
     --------
     One dimensional array:
 

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -727,12 +727,12 @@ def matrix_transpose(x, /):
     return swapaxes(x, -1, -2)
 
 
-def _partition_dispatcher(a, kth, axis=None, kind=None, order=None):
+def _partition_dispatcher(a, kth, axis=None, kind=None, order=None, descending=None):
     return (a,)
 
 
 @array_function_dispatch(_partition_dispatcher)
-def partition(a, kth, axis=-1, kind='introselect', order=None):
+def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
     """
     Return a partitioned copy of an array.
 
@@ -839,16 +839,20 @@ def partition(a, kth, axis=-1, kind='introselect', order=None):
         axis = -1
     else:
         a = asanyarray(a).copy(order="K")
-    a.partition(kth, axis=axis, kind=kind, order=order)
+    # Sanitize for backward compatibility
+    if descending is not np._NoValue:
+        a.partition(kth, axis=axis, kind=kind, order=order, descending=descending)
+    else:
+        a.partition(kth, axis=axis, kind=kind, order=order)
     return a
 
 
-def _argpartition_dispatcher(a, kth, axis=None, kind=None, order=None):
+def _argpartition_dispatcher(a, kth, axis=None, kind=None, order=None, descending=None):
     return (a,)
 
 
 @array_function_dispatch(_argpartition_dispatcher)
-def argpartition(a, kth, axis=-1, kind='introselect', order=None):
+def argpartition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
     """
     Perform an indirect partition along the given axis using the
     algorithm specified by the `kind` keyword. It returns an array of
@@ -931,7 +935,23 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
            [1, 1, 3]])
 
     """
-    return _wrapfunc(a, 'argpartition', kth, axis=axis, kind=kind, order=order)
+    if descending is not np._NoValue:
+        return _wrapfunc(
+            a,
+            'argpartition',
+            kth, axis=axis,
+            kind=kind,
+            order=order,
+            descending=descending
+        )
+    return _wrapfunc(
+        a,
+        'argpartition',
+        kth,
+        axis=axis,
+        kind=kind,
+        order=order
+    )
 
 
 def _sort_dispatcher(

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -770,7 +770,7 @@ def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
         specified, but unspecified fields will still be used, in the
         order in which they come up in the dtype, to break ties.
     descending : bool, optional
-        Partition order. If ``True``, the left partition will contain
+        Sort order. If ``True``, the left partition will contain
         values greater than the k-th element and the right partition
         will contain values less than or equal to the k-th element.
         If ``False`` or ``None``, the left partition will contain values
@@ -899,7 +899,7 @@ def argpartition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue)
         specified, but unspecified fields will still be used, in the
         order in which they come up in the dtype, to break ties.
     descending : bool, optional
-        Partition order. If ``True``, the left partition will contain
+        Sort order. If ``True``, the left partition will contain
         values greater than the k-th element and the right partition
         will contain values less than or equal to the k-th element.
         If ``False`` or ``None``, the left partition will contain values

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -737,7 +737,7 @@ def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
     Return a partitioned copy of an array.
 
     Creates a copy of the array and partially sorts it in such a way that
-    the value of the element in k-th position is in the position it would be
+    the value of the element in the k-th position is in the position it would be
     in a sorted array. In the output array, all elements that would be to the left
     of the k-th element in a sorted array are located to the left of this element and
     all that would be to the right are located to its right. The ordering of the

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -732,7 +732,7 @@ def _partition_dispatcher(a, kth, axis=None, kind=None, order=None, descending=N
 
 
 @array_function_dispatch(_partition_dispatcher)
-def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
+def partition(a, kth, axis=-1, kind=np._NoValue, order=None, descending=np._NoValue):
     """
     Return a partitioned copy of an array.
 
@@ -852,11 +852,15 @@ def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
         axis = -1
     else:
         a = asanyarray(a).copy(order="K")
+
     # Sanitize for backward compatibility
+    extra_kwargs = {}
     if descending is not np._NoValue:
-        a.partition(kth, axis=axis, kind=kind, order=order, descending=descending)
-    else:
-        a.partition(kth, axis=axis, kind=kind, order=order)
+        extra_kwargs['descending'] = descending
+    if kind is not np._NoValue:
+        extra_kwargs['kind'] = kind
+
+    a.partition(kth, axis=axis, order=order, **extra_kwargs)
     return a
 
 
@@ -865,7 +869,7 @@ def _argpartition_dispatcher(a, kth, axis=None, kind=None, order=None, descendin
 
 
 @array_function_dispatch(_argpartition_dispatcher)
-def argpartition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
+def argpartition(a, kth, axis=-1, kind=np._NoValue, order=None, descending=np._NoValue):
     """
     Perform an indirect partition along the given axis using the
     algorithm specified by the `kind` keyword. It returns an array of
@@ -935,7 +939,7 @@ def argpartition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue)
     see `partition` for notes on the enhanced sort order and
     different selection algorithms.
 
-    Examples
+    ExamplesNone
     --------
     One dimensional array:
 
@@ -960,23 +964,14 @@ def argpartition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue)
            [1, 1, 3]])
 
     """
+    # Sanitize for backward compatibility
+    kwargs = {}
     if descending is not np._NoValue:
-        return _wrapfunc(
-            a,
-            'argpartition',
-            kth, axis=axis,
-            kind=kind,
-            order=order,
-            descending=descending
-        )
-    return _wrapfunc(
-        a,
-        'argpartition',
-        kth,
-        axis=axis,
-        kind=kind,
-        order=order
-    )
+        kwargs['descending'] = descending
+    if kind is not np._NoValue:
+        kwargs['kind'] = kind
+
+    return _wrapfunc(a, "argpartition", kth, axis=axis, order=order, **kwargs)
 
 
 def _sort_dispatcher(

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -751,18 +751,21 @@ def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
     kth : int or sequence of ints
         Element index to partition by. In the returned array, the k-th
         value of the array will be in the position it would be in a
-        sorted array, all elements that would be sorted before it will
-        be moved before it, and all elements that would be sorted after
-        it will be moved after it. The order of all elements within the
-        partitions is undefined. If provided with a sequence of k-th it
-        will partition all elements indexed by k-th of them into their
-        sorted position at once.
+        sorted array, all elements that are less than this element (or
+        greater if `descending` is True) will be moved before it, and
+        all elements that are greater than or equal to this element
+        (or less than or equal if `descending` is True) will be moved after it.
+        The order of all elements within each partition is undefined. If
+        provided with a sequence of k-th it will partition all elements
+        indexed by k-th of them into their sorted position at once.
 
     axis : int or None, optional
         Axis along which to sort. If None, the array is flattened before
         sorting. The default is -1, which sorts along the last axis.
     kind : {'introselect'}, optional
-        Selection algorithm. Default is 'introselect'.
+        NumPy currently offers only one selection algorithm, 'introselect',
+        and this parameter provides no additional functionality. Default
+        is ``None``.
     order : str or list of str, optional
         When `a` is an array with fields defined, this argument
         specifies which fields to compare first, second, etc.  A single
@@ -770,14 +773,10 @@ def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
         specified, but unspecified fields will still be used, in the
         order in which they come up in the dtype, to break ties.
     descending : bool, optional
-        Sort order. If ``True``, the left partition will contain
-        values greater than the k-th element and the right partition
-        will contain values less than or equal to the k-th element.
-        If ``False`` or ``None``, the left partition will contain values
-        less than the k-th element and the right partition will contain values
-        greater than or equal to the k-th element. Values that are NaN
-        are partitioned towards the end of the array regardless of order.
-        Default: ``None``.
+        Sort order. If ``True``, the array will be partitioned in
+        descending order. If ``False`` or ``None``, the array will be
+        partitioned in ascending order. Values that are NaN are partitioned
+        towards the end of the array regardless of order. Default: ``None``.
 
         .. versionadded:: 2.6.0
 
@@ -880,18 +879,21 @@ def argpartition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue)
     kth : int or sequence of ints
         Element index to partition by. In the returned array, the k-th
         value of the array will be in the position it would be in a
-        sorted array, all elements that would be sorted before it will
-        be moved before it, and all elements that would be sorted after
-        it will be moved after it. The order of all elements within the
-        partitions is undefined. If provided with a sequence of k-th it
-        will partition all elements indexed by k-th of them into their
-        sorted position at once.
+        sorted array, all elements that are less than this element (or
+        greater if `descending` is True) will be moved before it, and
+        all elements that are greater than or equal to this element
+        (or less than or equal if `descending` is True) will be moved after it.
+        The order of all elements within each partition is undefined. If
+        provided with a sequence of k-th it will partition all elements
+        indexed by k-th of them into their sorted position at once.
 
     axis : int or None, optional
         Axis along which to sort. The default is -1 (the last axis). If
         None, the flattened array is used.
     kind : {'introselect'}, optional
-        Selection algorithm. Default is 'introselect'
+        NumPy currently offers only one selection algorithm, 'introselect',
+        and this parameter provides no additional functionality. Default
+        is ``None``.
     order : str or list of str, optional
         When `a` is an array with fields defined, this argument
         specifies which fields to compare first, second, etc. A single
@@ -899,14 +901,10 @@ def argpartition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue)
         specified, but unspecified fields will still be used, in the
         order in which they come up in the dtype, to break ties.
     descending : bool, optional
-        Sort order. If ``True``, the left partition will contain
-        values greater than the k-th element and the right partition
-        will contain values less than or equal to the k-th element.
-        If ``False`` or ``None``, the left partition will contain values
-        less than the k-th element and the right partition will contain values
-        greater than or equal to the k-th element. Values that are NaN
-        are partitioned towards the end of the array regardless of order.
-        Default: ``None``.
+        Sort order. If ``True``, the array will be partitioned in
+        descending order. If ``False`` or ``None``, the array will be
+        partitioned in ascending order. Values that are NaN are partitioned
+        towards the end of the array regardless of order. Default: ``None``.
 
         .. versionadded:: 2.6.0
 

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -350,40 +350,45 @@ def partition[ArrayT: np.ndarray](
     a: ArrayT,
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> ArrayT: ...
 @overload  # ?d
 def partition[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> NDArray[ScalarT]: ...
 @overload  # axis: None
 def partition[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> _Array1D[ScalarT]: ...
 @overload  # fallback
 def partition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> NDArray[Any]: ...
 @overload  # fallback, axis: None
 def partition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> _Array1D[Any]: ...
 
 # keep roughly in sync with `ndarray.argpartition`
@@ -392,56 +397,63 @@ def argpartition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int], np.dtype[np.intp]]: ...
 @overload  # known shape, axis: index (default)
 def argpartition[ShapeT: _Shape](
     a: np.ndarray[ShapeT],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...
 @overload  # 1d array-like, axis: index (default)
 def argpartition(
     a: Sequence[np.generic | complex],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int], np.dtype[np.intp]]: ...
 @overload  # 2d array-like, axis: index (default)
 def argpartition(
     a: Sequence[Sequence[np.generic | complex]],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int, int], np.dtype[np.intp]]: ...
 @overload  # ?d array-like, axis: index (default)
 def argpartition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: None = None,
+    descending: bool | _NoValueType = ...,
 ) -> NDArray[np.intp]: ...
 @overload  # void, axis: None
 def argpartition(
     a: _SupportsArray[np.dtype[np.void]],
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int], np.dtype[intp]]: ...
 @overload  # void, axis: index (default)
 def argpartition[ShapeT: _Shape](
     a: np.ndarray[ShapeT, np.dtype[np.void]],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...
 
 #

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -350,7 +350,7 @@ def partition[ArrayT: np.ndarray](
     a: ArrayT,
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: str | Sequence[str] | None = None,
     descending: bool | _NoValueType = ...,
 ) -> ArrayT: ...
@@ -359,7 +359,7 @@ def partition[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: str | Sequence[str] | None = None,
     descending: bool | _NoValueType = ...,
 ) -> NDArray[ScalarT]: ...
@@ -368,7 +368,7 @@ def partition[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: str | Sequence[str] | None = None,
     descending: bool | _NoValueType = ...,
 ) -> _Array1D[ScalarT]: ...
@@ -377,7 +377,7 @@ def partition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: str | Sequence[str] | None = None,
     descending: bool | _NoValueType = ...,
 ) -> NDArray[Any]: ...
@@ -386,7 +386,7 @@ def partition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: str | Sequence[str] | None = None,
     descending: bool | _NoValueType = ...,
 ) -> _Array1D[Any]: ...
@@ -397,7 +397,7 @@ def argpartition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: None = None,
     descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int], np.dtype[np.intp]]: ...
@@ -406,7 +406,7 @@ def argpartition[ShapeT: _Shape](
     a: np.ndarray[ShapeT],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: None = None,
     descending: bool | _NoValueType = ...,
 ) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...
@@ -415,7 +415,7 @@ def argpartition(
     a: Sequence[np.generic | complex],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: None = None,
     descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int], np.dtype[np.intp]]: ...
@@ -424,7 +424,7 @@ def argpartition(
     a: Sequence[Sequence[np.generic | complex]],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: None = None,
     descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int, int], np.dtype[np.intp]]: ...
@@ -433,7 +433,7 @@ def argpartition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: None = None,
     descending: bool | _NoValueType = ...,
 ) -> NDArray[np.intp]: ...
@@ -442,7 +442,7 @@ def argpartition(
     a: _SupportsArray[np.dtype[np.void]],
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: str | Sequence[str] | None = None,
     descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int], np.dtype[intp]]: ...
@@ -451,7 +451,7 @@ def argpartition[ShapeT: _Shape](
     a: np.ndarray[ShapeT, np.dtype[np.void]],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind | None = None,
+    kind: _PartitionKind | _NoValueType = ...,
     order: str | Sequence[str] | None = None,
     descending: bool | _NoValueType = ...,
 ) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -201,7 +201,8 @@ typedef enum {
         NPY_INTROSELECT = 0,
         // new style names
         NPY_SELECT_DEFAULT = 0,
-        NPY_SELECT_DESCENDING = 1,
+        NPY_SELECT_STABLE = 2,
+        NPY_SELECT_DESCENDING = 4,
 } NPY_SELECTKIND;
 #define NPY_NSELECTS (NPY_SELECT_DESCENDING + 1)
 

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -197,9 +197,13 @@ typedef enum {
 
 
 typedef enum {
-        NPY_INTROSELECT=0
+        _NPY_SELECT_UNDEFINED = -1,
+        NPY_INTROSELECT = 0,
+        // new style names
+        NPY_SELECT_DEFAULT = 0,
+        NPY_SELECT_DESCENDING = 1,
 } NPY_SELECTKIND;
-#define NPY_NSELECTS (NPY_INTROSELECT + 1)
+#define NPY_NSELECTS (NPY_SELECT_DESCENDING + 1)
 
 
 typedef enum {

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -2139,7 +2139,12 @@ run_selectkind_converter(PyObject* NPY_UNUSED(self), PyObject *args)
         return NULL;
     }
     switch (kind) {
+        case _NPY_SELECT_UNDEFINED: return PyUnicode_FromString("_NPY_SELECT_UNDEFINED");
         case NPY_INTROSELECT: return PyUnicode_FromString("NPY_INTROSELECT");
+        default:
+            // the other possible values in NPY_SELECTKIND can only
+            // be set with keywords.
+            break;
     }
     return PyLong_FromLong(kind);
 }

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -634,6 +634,10 @@ static int selectkind_parser(char const *str, Py_ssize_t length, void *data)
 NPY_NO_EXPORT int
 PyArray_SelectkindConverter(PyObject *obj, NPY_SELECTKIND *selectkind)
 {
+    /* Leave the desired default from the caller for Py_None */
+    if (obj == Py_None) {
+        return NPY_SUCCEED;
+    }
     return string_converter_helper(
         obj, (void *)selectkind, selectkind_parser, "select kind",
         "must be 'introselect'");

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1723,7 +1723,7 @@ PyArray_Partition(PyArrayObject *op, PyArrayObject * ktharray, int axis,
         }
         else if (which & NPY_SELECT_DESCENDING) {
             PyErr_SetString(PyExc_TypeError,
-                            "type does not have descending partition");
+                            "type does not support descending partition");
             return -1;
         }
         else {
@@ -1779,7 +1779,7 @@ PyArray_ArgPartition(PyArrayObject *op, PyArrayObject *ktharray, int axis,
         }
         else if (which & NPY_SELECT_DESCENDING) {
             PyErr_SetString(PyExc_TypeError,
-                            "type does not have descending partition");
+                            "type does not support descending partition");
             return NULL;
         }
         else {

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1717,8 +1717,14 @@ PyArray_Partition(PyArrayObject *op, PyArrayObject * ktharray, int axis,
     part = get_partition_func(PyArray_TYPE(op), which);
     if (part == NULL) {
         /* Use sorting, slower but equivalent */
-        if (PyDataType_GetArrFuncs(PyArray_DESCR(op))->compare) {
+        if ((PyDataType_GetArrFuncs(PyArray_DESCR(op))->compare)
+            && !(which & NPY_SELECT_DESCENDING)) { // TODO: descending sorts for partition
             sort = npy_quicksort;
+        }
+        else if (which & NPY_SELECT_DESCENDING) {
+            PyErr_SetString(PyExc_TypeError,
+                            "type does not have descending partition");
+            return -1;
         }
         else {
             PyErr_SetString(PyExc_TypeError,
@@ -1767,8 +1773,14 @@ PyArray_ArgPartition(PyArrayObject *op, PyArrayObject *ktharray, int axis,
     argpart = get_argpartition_func(PyArray_TYPE(op), which);
     if (argpart == NULL) {
         /* Use sorting, slower but equivalent */
-        if (PyDataType_GetArrFuncs(PyArray_DESCR(op))->compare) {
+        if ((PyDataType_GetArrFuncs(PyArray_DESCR(op))->compare) &&
+            !(which & NPY_SELECT_DESCENDING)) { // TODO: descending sorts for partition
             argsort = npy_aquicksort;
+        }
+        else if (which & NPY_SELECT_DESCENDING) {
+            PyErr_SetString(PyExc_TypeError,
+                            "type does not have descending partition");
+            return NULL;
         }
         else {
             PyErr_SetString(PyExc_TypeError,

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1529,7 +1529,7 @@ array_argpartition(PyArrayObject *self,
             {"|axis", &PyArray_AxisConverter, &axis},
             {"|kind", &PyArray_SelectkindConverter, &sortkind},
             {"|order", NULL, &order},
-            {"|descending", &PyArray_OptionalBoolConverter, &descending}) < 0) {
+            {"$descending", &PyArray_OptionalBoolConverter, &descending}) < 0) {
         return NULL;
     }
 

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1343,20 +1343,37 @@ array_partition(PyArrayObject *self,
 {
     int axis=-1;
     int val;
-    NPY_SELECTKIND sortkind = NPY_INTROSELECT;
+    NPY_SELECTKIND sortkind = _NPY_SELECT_UNDEFINED;
     PyObject *order = NULL;
     PyArray_Descr *saved = NULL;
     PyArray_Descr *newd;
     PyArrayObject * ktharray;
     PyObject * kthobj;
+    int descending = -1;
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("partition", args, len_args, kwnames,
             {"kth", NULL, &kthobj},
             {"|axis", &PyArray_PythonPyIntFromInt, &axis},
             {"|kind", &PyArray_SelectkindConverter, &sortkind},
-            {"|order", NULL, &order}) < 0) {
+            {"|order", NULL, &order},
+            {"$descending", &PyArray_OptionalBoolConverter, &descending}
+            ) < 0) {
         return NULL;
+    }
+
+    if (sortkind == _NPY_SELECT_UNDEFINED) {
+        // keywords only if sortkind not passed
+        sortkind = descending > 0? NPY_SELECT_DESCENDING: NPY_SELECT_DEFAULT;
+    }
+    else {
+        // Check that no keywords are used
+        if (descending != -1) {
+            PyErr_SetString(PyExc_ValueError,
+                    "`kind` and keyword parameters can't be provided at "
+                    "the same time. Use only one of them.");
+            return NULL;
+        }
     }
 
     if (order == Py_None) {
@@ -1499,20 +1516,37 @@ array_argpartition(PyArrayObject *self,
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     int axis = -1;
-    NPY_SELECTKIND sortkind = NPY_INTROSELECT;
+    NPY_SELECTKIND sortkind = _NPY_SELECT_UNDEFINED;
     PyObject *order = NULL, *res;
     PyArray_Descr *newd, *saved=NULL;
     PyObject * kthobj;
     PyArrayObject * ktharray;
+    int descending = -1;
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("argpartition", args, len_args, kwnames,
             {"kth", NULL, &kthobj},
             {"|axis", &PyArray_AxisConverter, &axis},
             {"|kind", &PyArray_SelectkindConverter, &sortkind},
-            {"|order", NULL, &order}) < 0) {
+            {"|order", NULL, &order},
+            {"|descending", &PyArray_OptionalBoolConverter, &descending}) < 0) {
         return NULL;
     }
+
+    if (sortkind == _NPY_SELECT_UNDEFINED) {
+        // keywords only if sortkind not passed
+        sortkind = descending > 0? NPY_SELECT_DESCENDING: NPY_SELECT_DEFAULT;
+    }
+    else {
+        // Check that no keywords are used
+        if (descending != -1) {
+            PyErr_SetString(PyExc_ValueError,
+                    "`kind` and keyword parameters can't be provided at "
+                    "the same time. Use only one of them.");
+            return NULL;
+        }
+    }
+
     if (order == Py_None) {
         order = NULL;
     }

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1364,7 +1364,7 @@ array_partition(PyArrayObject *self,
 
     if (sortkind == _NPY_SELECT_UNDEFINED) {
         // keywords only if sortkind not passed
-        sortkind = descending > 0? NPY_SELECT_DESCENDING: NPY_SELECT_DEFAULT;
+        sortkind = descending > 0 ? NPY_SELECT_DESCENDING : NPY_SELECT_DEFAULT;
     }
     else {
         // Check that no keywords are used
@@ -1535,7 +1535,7 @@ array_argpartition(PyArrayObject *self,
 
     if (sortkind == _NPY_SELECT_UNDEFINED) {
         // keywords only if sortkind not passed
-        sortkind = descending > 0? NPY_SELECT_DESCENDING: NPY_SELECT_DEFAULT;
+        sortkind = descending > 0 ? NPY_SELECT_DESCENDING : NPY_SELECT_DEFAULT;
     }
     else {
         // Check that no keywords are used

--- a/numpy/_core/src/npysort/selection.cpp
+++ b/numpy/_core/src/npysort/selection.cpp
@@ -518,10 +518,17 @@ _get_partition_func(int type, NPY_SELECTKIND which)
 {
     npy_intp i;
     npy_intp ntypes = partition_t::map.size();
-    int idx = which & NPY_SELECT_DESCENDING ? 1 : 0;
+    int idx;
 
-    if ((int)which < 0 || (int)which >= NPY_NSELECTS) {
-        return NULL;
+    switch (which) {
+        case NPY_SELECT_DEFAULT:
+            idx = 0;
+            break;
+        case NPY_SELECT_DESCENDING:
+            idx = 1;
+            break;
+        default:
+            return NULL;
     }
 
     for (i = 0; i < ntypes; i++) {

--- a/numpy/_core/src/npysort/selection.cpp
+++ b/numpy/_core/src/npysort/selection.cpp
@@ -82,7 +82,7 @@ inline bool argquickselect_dispatch(T* v, npy_intp* arg, npy_intp num, npy_intp 
     return false;
 }
 
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 NPY_NO_EXPORT int
 introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth, npy_intp *pivots, npy_intp *npiv);
 
@@ -156,7 +156,7 @@ inexact()
  * gets min and median and moves median to low and min to low + 1
  * for efficient partitioning, see unguarded_partition
  */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 static inline void
 median3_swap_(type *v, npy_intp *tosort, npy_intp low, npy_intp mid,
               npy_intp high)
@@ -164,14 +164,14 @@ median3_swap_(type *v, npy_intp *tosort, npy_intp low, npy_intp mid,
     Idx<arg> idx(tosort);
     Sortee<type, arg> sortee(v, tosort);
 
-    if (Tag::less(v[idx(high)], v[idx(mid)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(high)], v[idx(mid)])) {
         std::swap(sortee(high), sortee(mid));
     }
-    if (Tag::less(v[idx(high)], v[idx(low)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(high)], v[idx(low)])) {
         std::swap(sortee(high), sortee(low));
     }
     /* move pivot to low */
-    if (Tag::less(v[idx(low)], v[idx(mid)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(low)], v[idx(mid)])) {
         std::swap(sortee(low), sortee(mid));
     }
     /* move 3-lowest element to low + 1 */
@@ -179,7 +179,7 @@ median3_swap_(type *v, npy_intp *tosort, npy_intp low, npy_intp mid,
 }
 
 /* select index of median of five elements */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 static npy_intp
 median5_(type *v, npy_intp *tosort)
 {
@@ -187,23 +187,23 @@ median5_(type *v, npy_intp *tosort)
     Sortee<type, arg> sortee(v, tosort);
 
     /* could be optimized as we only need the index (no swaps) */
-    if (Tag::less(v[idx(1)], v[idx(0)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(1)], v[idx(0)])) {
         std::swap(sortee(1), sortee(0));
     }
-    if (Tag::less(v[idx(4)], v[idx(3)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(4)], v[idx(3)])) {
         std::swap(sortee(4), sortee(3));
     }
-    if (Tag::less(v[idx(3)], v[idx(0)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(3)], v[idx(0)])) {
         std::swap(sortee(3), sortee(0));
     }
-    if (Tag::less(v[idx(4)], v[idx(1)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(4)], v[idx(1)])) {
         std::swap(sortee(4), sortee(1));
     }
-    if (Tag::less(v[idx(2)], v[idx(1)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(2)], v[idx(1)])) {
         std::swap(sortee(2), sortee(1));
     }
-    if (Tag::less(v[idx(3)], v[idx(2)])) {
-        if (Tag::less(v[idx(3)], v[idx(1)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(3)], v[idx(2)])) {
+        if (npy::cmp<Tag, reverse>(v[idx(3)], v[idx(1)])) {
             return 1;
         }
         else {
@@ -222,7 +222,7 @@ median5_(type *v, npy_intp *tosort)
  *                  ll ... hh
  * lower-than-pivot [x x x x] larger-than-pivot
  */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 static inline void
 unguarded_partition_(type *v, npy_intp *tosort, const type pivot, npy_intp *ll,
                      npy_intp *hh)
@@ -233,10 +233,10 @@ unguarded_partition_(type *v, npy_intp *tosort, const type pivot, npy_intp *ll,
     for (;;) {
         do {
             (*ll)++;
-        } while (Tag::less(v[idx(*ll)], pivot));
+        } while (npy::cmp<Tag, reverse>(v[idx(*ll)], pivot));
         do {
             (*hh)--;
-        } while (Tag::less(pivot, v[idx(*hh)]));
+        } while (npy::cmp<Tag, reverse>(pivot, v[idx(*hh)]));
 
         if (*hh < *ll) {
             break;
@@ -251,7 +251,7 @@ unguarded_partition_(type *v, npy_intp *tosort, const type pivot, npy_intp *ll,
  * if used as partition pivot it splits the range into at least 30%/70%
  * allowing linear time worst-case quickselect
  */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 static npy_intp
 median_of_median5_(type *v, npy_intp *tosort, const npy_intp num,
                    npy_intp *pivots, npy_intp *npiv)
@@ -263,13 +263,13 @@ median_of_median5_(type *v, npy_intp *tosort, const npy_intp num,
     npy_intp right = num - 1;
     npy_intp nmed = (right + 1) / 5;
     for (i = 0, subleft = 0; i < nmed; i++, subleft += 5) {
-        npy_intp m = median5_<Tag, arg>(v + (arg ? 0 : subleft),
+        npy_intp m = median5_<Tag, arg, reverse>(v + (arg ? 0 : subleft),
                                         tosort + (arg ? subleft : 0));
         std::swap(sortee(subleft + m), sortee(i));
     }
 
     if (nmed > 2) {
-        introselect_<Tag, arg>(v, tosort, nmed, nmed / 2, pivots, npiv);
+        introselect_<Tag, arg, reverse>(v, tosort, nmed, nmed / 2, pivots, npiv);
     }
     return nmed / 2;
 }
@@ -279,7 +279,7 @@ median_of_median5_(type *v, npy_intp *tosort, const npy_intp num,
  * useful for close multiple partitions
  * (e.g. even element median, interpolating percentile)
  */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 static int
 dumb_select_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth)
 {
@@ -292,7 +292,7 @@ dumb_select_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth)
         type minval = v[idx(i)];
         npy_intp k;
         for (k = i + 1; k < num; k++) {
-            if (Tag::less(v[idx(k)], minval)) {
+            if (npy::cmp<Tag, reverse>(v[idx(k)], minval)) {
                 minidx = k;
                 minval = v[idx(k)];
             }
@@ -316,7 +316,7 @@ dumb_select_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth)
  * kth 8:   0  1  2  3  4  5  6 [8  7] -> stack []
  *
  */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 NPY_NO_EXPORT int
 introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
              npy_intp *pivots, npy_intp *npiv)
@@ -354,7 +354,7 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
      * e.g. for interpolating percentile
      */
     if (kth - low < 3) {
-        dumb_select_<Tag, arg>(v + (arg ? 0 : low), tosort + (arg ? low : 0),
+        dumb_select_<Tag, arg, reverse>(v + (arg ? 0 : low), tosort + (arg ? low : 0),
                                high - low + 1, kth - low);
         store_pivot(kth, kth, pivots, npiv);
         return 0;
@@ -366,7 +366,7 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
         npy_intp maxidx = low;
         type maxval = v[idx(low)];
         for (k = low + 1; k < num; k++) {
-            if (!Tag::less(v[idx(k)], maxval)) {
+            if (!npy::cmp<Tag, reverse>(v[idx(k)], maxval)) {
                 maxidx = k;
                 maxval = v[idx(k)];
             }
@@ -391,12 +391,12 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
             const npy_intp mid = low + (high - low) / 2;
             /* median of 3 pivot strategy,
              * swapping for efficient partition */
-            median3_swap_<Tag, arg>(v, tosort, low, mid, high);
+            median3_swap_<Tag, arg, reverse>(v, tosort, low, mid, high);
         }
         else {
             npy_intp mid;
             /* FIXME: always use pivots to optimize this iterative partition */
-            mid = ll + median_of_median5_<Tag, arg>(v + (arg ? 0 : ll),
+            mid = ll + median_of_median5_<Tag, arg, reverse>(v + (arg ? 0 : ll),
                                                     tosort + (arg ? ll : 0),
                                                     hh - ll, NULL, NULL);
             std::swap(sortee(mid), sortee(low));
@@ -412,7 +412,7 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
          * previous swapping removes need for bound checks
          * pivot 3-lowest [x x x] 3-highest
          */
-        unguarded_partition_<Tag, arg>(v, tosort, v[idx(low)], &ll, &hh);
+        unguarded_partition_<Tag, arg, reverse>(v, tosort, v[idx(low)], &ll, &hh);
 
         /* move pivot into position */
         std::swap(sortee(low), sortee(hh));
@@ -432,7 +432,7 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
 
     /* two elements */
     if (high == low + 1) {
-        if (Tag::less(v[idx(high)], v[idx(low)])) {
+        if (npy::cmp<Tag, reverse>(v[idx(high)], v[idx(low)])) {
             std::swap(sortee(high), sortee(low));
         }
     }
@@ -447,30 +447,34 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
  *****************************************************************************
  */
 
-template <typename Tag>
+template <typename Tag, bool reverse>
 static int
 introselect_noarg(void *v, npy_intp num, npy_intp kth, npy_intp *pivots,
                   npy_intp *npiv, npy_intp nkth, void *)
 {
     using T = typename std::conditional<std::is_same_v<Tag, npy::half_tag>, np::Half, typename Tag::type>::type;
-    if ((nkth == 1) && (quickselect_dispatch((T *)v, num, kth))) {
-        return 0;
+    if constexpr (!reverse) {
+        if ((nkth == 1) && (quickselect_dispatch((T *)v, num, kth))) {
+            return 0;
+        }
     }
-    return introselect_<Tag, false>((typename Tag::type *)v, nullptr, num, kth,
-                                    pivots, npiv);
+    return introselect_<Tag, false, reverse>((typename Tag::type *)v, nullptr, num, kth,
+                                             pivots, npiv);
 }
 
-template <typename Tag>
+template <typename Tag, bool reverse>
 static int
 introselect_arg(void *v, npy_intp *tosort, npy_intp num, npy_intp kth,
                 npy_intp *pivots, npy_intp *npiv, npy_intp nkth, void *)
 {
     using T = typename Tag::type;
-    if ((nkth == 1) && (argquickselect_dispatch((T *)v, tosort, num, kth))) {
-        return 0;
+    if constexpr (!reverse) {
+        if ((nkth == 1) && (argquickselect_dispatch((T *)v, tosort, num, kth))) {
+            return 0;
+        }
     }
-    return introselect_<Tag, true>((typename Tag::type *)v, tosort, num, kth,
-                                   pivots, npiv);
+    return introselect_<Tag, true, reverse>((typename Tag::type *)v, tosort, num, kth,
+                                            pivots, npiv);
 }
 
 struct arg_map {
@@ -484,8 +488,9 @@ static constexpr std::array<arg_map, sizeof...(Tags)>
 make_partition_map(npy::taglist<Tags...>)
 {
     return std::array<arg_map, sizeof...(Tags)>{
-            arg_map{Tags::type_value, {&introselect_noarg<Tags>},
-                {&introselect_arg<Tags>}}...};
+            arg_map{Tags::type_value,
+                {&introselect_noarg<Tags, false>, &introselect_noarg<Tags, true>},
+                {&introselect_arg<Tags, false>, &introselect_arg<Tags, true>}}...};
 }
 
 struct partition_t {

--- a/numpy/_core/src/npysort/selection.cpp
+++ b/numpy/_core/src/npysort/selection.cpp
@@ -27,7 +27,7 @@
 #include <utility>
 #include "x86_simd_qsort.hpp"
 
-template<typename T>
+template<typename Tag, typename T>
 inline bool quickselect_dispatch(T* v, npy_intp num, npy_intp kth)
 {
 #ifndef __CYGWIN__
@@ -36,8 +36,12 @@ inline bool quickselect_dispatch(T* v, npy_intp num, npy_intp kth)
      * int64_t, uint64_t, double
      */
     if constexpr (
-        (std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, np::Half>) &&
-        (sizeof(T) == sizeof(uint16_t) || sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t))) {
+        (std::is_base_of_v<npy::floating_point_tag, Tag>
+            || std::is_base_of_v<npy::integral_tag, Tag>
+            || std::is_base_of_v<npy::half_tag, Tag>) &&
+        (sizeof(T) == sizeof(uint16_t)
+            || sizeof(T) == sizeof(uint32_t)
+            || sizeof(T) == sizeof(uint64_t))) {
         using TF = typename np::meta::FixedWidth<T>::Type;
         void (*dispfunc)(TF*, npy_intp, npy_intp) = nullptr;
         if constexpr (sizeof(T) == sizeof(uint16_t)) {
@@ -58,7 +62,7 @@ inline bool quickselect_dispatch(T* v, npy_intp num, npy_intp kth)
     return false;
 }
 
-template<typename T>
+template<typename Tag, typename T>
 inline bool argquickselect_dispatch(T* v, npy_intp* arg, npy_intp num, npy_intp kth)
 {
 #ifndef __CYGWIN__
@@ -66,7 +70,8 @@ inline bool argquickselect_dispatch(T* v, npy_intp* arg, npy_intp num, npy_intp 
      * Only defined for int32_t, uint32_t, float32, int64_t, uint64_t, double
      */
     if constexpr (
-        (std::is_integral_v<T> || std::is_floating_point_v<T>) &&
+        (std::is_base_of_v<npy::floating_point_tag, Tag>
+        || std::is_base_of_v<npy::integral_tag, Tag>) &&
         (sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint64_t))) {
         using TF = typename np::meta::FixedWidth<T>::Type;
         #include "x86_simd_argsort.dispatch.h"
@@ -454,7 +459,7 @@ introselect_noarg(void *v, npy_intp num, npy_intp kth, npy_intp *pivots,
 {
     using T = typename std::conditional<std::is_same_v<Tag, npy::half_tag>, np::Half, typename Tag::type>::type;
     if constexpr (!reverse) {
-        if ((nkth == 1) && (quickselect_dispatch((T *)v, num, kth))) {
+        if ((nkth == 1) && (quickselect_dispatch<Tag>((T *)v, num, kth))) {
             return 0;
         }
     }
@@ -469,7 +474,7 @@ introselect_arg(void *v, npy_intp *tosort, npy_intp num, npy_intp kth,
 {
     using T = typename Tag::type;
     if constexpr (!reverse) {
-        if ((nkth == 1) && (argquickselect_dispatch((T *)v, tosort, num, kth))) {
+        if ((nkth == 1) && (argquickselect_dispatch<Tag>((T *)v, tosort, num, kth))) {
             return 0;
         }
     }
@@ -500,8 +505,8 @@ struct partition_t {
                          npy::uint_tag, npy::long_tag, npy::ulong_tag,
                          npy::longlong_tag, npy::ulonglong_tag, npy::half_tag,
                          npy::float_tag, npy::double_tag, npy::longdouble_tag,
-                         npy::cfloat_tag, npy::cdouble_tag,
-                         npy::clongdouble_tag>;
+                         npy::cfloat_tag, npy::cdouble_tag, npy::clongdouble_tag,
+                         npy::datetime_tag, npy::timedelta_tag>;
 
     static constexpr std::array<arg_map, taglist::size> map =
             make_partition_map(taglist());

--- a/numpy/_core/src/npysort/selection.cpp
+++ b/numpy/_core/src/npysort/selection.cpp
@@ -484,8 +484,8 @@ introselect_arg(void *v, npy_intp *tosort, npy_intp num, npy_intp kth,
 
 struct arg_map {
     int typenum;
-    PyArray_PartitionFunc *part[NPY_NSELECTS];
-    PyArray_ArgPartitionFunc *argpart[NPY_NSELECTS];
+    PyArray_PartitionFunc *part[2];
+    PyArray_ArgPartitionFunc *argpart[2];
 };
 
 template <class... Tags>
@@ -518,13 +518,15 @@ _get_partition_func(int type, NPY_SELECTKIND which)
 {
     npy_intp i;
     npy_intp ntypes = partition_t::map.size();
+    int idx = which & NPY_SELECT_DESCENDING ? 1 : 0;
 
     if ((int)which < 0 || (int)which >= NPY_NSELECTS) {
         return NULL;
     }
+
     for (i = 0; i < ntypes; i++) {
         if (type == partition_t::map[i].typenum) {
-            return partition_t::map[i].part[which];
+            return partition_t::map[i].part[idx];
         }
     }
     return NULL;
@@ -535,10 +537,11 @@ _get_argpartition_func(int type, NPY_SELECTKIND which)
 {
     npy_intp i;
     npy_intp ntypes = partition_t::map.size();
+    int idx = which & NPY_SELECT_DESCENDING ? 1 : 0;
 
     for (i = 0; i < ntypes; i++) {
         if (type == partition_t::map[i].typenum) {
-            return partition_t::map[i].argpart[which];
+            return partition_t::map[i].argpart[idx];
         }
     }
     return NULL;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3270,6 +3270,16 @@ class TestMethods:
         self._test_argpartition_descending(a, k, None, descending)
         self._test_argpartition_descending(a, k, nan, descending)
 
+    @pytest.mark.parametrize('dtype', ['datetime64[D]', 'timedelta64[D]',
+                                       np.str_, np.bytes_, np.object_])
+    def test_partition_and_argpartition_raise_on_descending(self, dtype):
+        a = np.arange(10, dtype=np.float64).astype(dtype)
+
+        with assert_raises(TypeError, msg="type does not have descending partition"):
+            np.partition(a, 5, descending=True)
+        with assert_raises(TypeError, msg="type does not have descending partition"):
+            np.argpartition(a, 5, descending=True)
+
     @pytest.mark.parametrize('a', [
         np.array([0, 1, np.nan], dtype=np.float16),
         np.array([0, 1, np.nan], dtype=np.float32),

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3162,12 +3162,11 @@ class TestMethods:
         self, dtype, k, descending, random_seed
     ):
         arange = np.tile(np.arange(25, dtype=dtype), 4)
-        nans = np.full(100, np.nan + 1j * np.nan, dtype=dtype)
 
         no_nans = arange + 1j * arange
-        im_nans = arange + 1j * nans
-        re_nans = nans + 1j * arange
-        all_nans = nans + 1j * nans
+        im_nans = arange + complex(0, np.nan)
+        re_nans = complex(np.nan, 0) + 1j * arange
+        all_nans = np.full(100, complex(np.nan, np.nan), dtype=dtype)
 
         a = np.concatenate((no_nans, im_nans, re_nans, all_nans))
         rng = np.random.default_rng(random_seed)

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2851,7 +2851,7 @@ class TestMethods:
     def test_sort_descending_complex(self, dtype, stable, descending):
         a = np.arange(-50, 51, dtype=dtype) + 1j * np.arange(-50, 51, dtype=dtype)
         self._test_sort_descending_nonan(a, stable, descending)
-        self._test_sort_descending_nan(a, np.nan + 1j * np.nan, stable, descending)
+        self._test_sort_descending_nan(a, complex(np.nan, np.nan), stable, descending)
 
     @pytest.mark.parametrize("dtype", [np.complex64, np.complex128, np.clongdouble])
     @pytest.mark.parametrize("stable", [True, False])

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3162,7 +3162,6 @@ class TestMethods:
         a = np.array([f"{i:03d}" for i in range(101)], dtype=dtype)
         self._test_partition_descending(a, k, None, descending)
 
-    @pytest.mark.skip(reason="descending partitions not supported for date types yet")
     @pytest.mark.parametrize('dtype', ['datetime64[D]', 'timedelta64[D]'])
     @pytest.mark.parametrize('k', [2, 15, 50, 95])
     @pytest.mark.parametrize('descending', [True, False])
@@ -3257,7 +3256,6 @@ class TestMethods:
         a = np.array([f"{i:03d}" for i in range(101)], dtype=dtype)
         self._test_argpartition_descending(a, k, None, descending)
 
-    @pytest.mark.skip(reason="descending partitions not supported for date types yet")
     @pytest.mark.parametrize('dtype', ['datetime64[D]', 'timedelta64[D]'])
     @pytest.mark.parametrize('k', [2, 15, 50, 80])
     @pytest.mark.parametrize('descending', [True, False])
@@ -3270,8 +3268,7 @@ class TestMethods:
         self._test_argpartition_descending(a, k, None, descending)
         self._test_argpartition_descending(a, k, nan, descending)
 
-    @pytest.mark.parametrize('dtype', ['datetime64[D]', 'timedelta64[D]',
-                                       np.str_, np.bytes_, np.object_])
+    @pytest.mark.parametrize('dtype', [np.str_, np.bytes_, np.object_])
     def test_partition_and_argpartition_raise_on_descending(self, dtype):
         a = np.arange(10, dtype=np.float64).astype(dtype)
 

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -9470,7 +9470,7 @@ class TestNewBufferProtocol:
         _multiarray_tests.corrupt_or_fix_bufferinfo(obj)
 
     def test_no_suboffsets(self):
-        _testbuffer = pytest.importskip("_testbuffer")
+        _testbuffer = pytest.importorskip("_testbuffer")
 
         for shape in [(2, 3), (2, 3, 4)]:
             data = list(range(np.prod(shape)))

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -4072,7 +4072,7 @@ class TestMethods:
         # Some dtypes use BLAS for 'dot' operation and
         # not all BLAS support floating-point errors.
         if not BLAS_SUPPORTS_FPE and dtype == np.double:
-            pytest.mark.skip("BLAS does not support FPE")
+            pytest.skip("BLAS does not support FPE")
 
         a = np.array([1, 1], dtype=dtype)
         b = np.array([-np.inf, np.inf], dtype=dtype)
@@ -9470,10 +9470,7 @@ class TestNewBufferProtocol:
         _multiarray_tests.corrupt_or_fix_bufferinfo(obj)
 
     def test_no_suboffsets(self):
-        try:
-            import _testbuffer
-        except ImportError:
-            raise pytest.mark.skip("_testbuffer is not available")
+        _testbuffer = pytest.importskip("_testbuffer")
 
         for shape in [(2, 3), (2, 3, 4)]:
             data = list(range(np.prod(shape)))

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2790,22 +2790,11 @@ class TestMethods:
         a_sorted = np.sort(a_randomized, stable=stable, descending=descending, axis=-1)
         assert_equal(a_sorted, b, msg)
 
-    def _test_sort_descending_nan(self, a, stable, descending):
+    def _test_sort_descending_nan(self, a, nan, stable, descending):
         if not descending:
             a = a[::-1]
         # add nans to check that they are sorted to the end
-        if np.issubdtype(a.dtype, np.complexfloating):
-            nan = np.nan + 1j * np.nan
-        elif np.issubdtype(a.dtype, np.floating):
-            nan = np.nan
-        elif np.issubdtype(a.dtype, np.datetime64):
-            nan = np.datetime64('NaT', 'D')
-        elif np.issubdtype(a.dtype, np.timedelta64):
-            nan = np.timedelta64('NaT', 'D')
-        elif np.issubdtype(a.dtype, np.object_):
-            nan = np.nan
-        else:
-            raise ValueError(f"Unsupported dtype for nan testing: {a.dtype}")
+        a[::10] = nan
 
         nanmask = np.arange(a.size) % 10 == 0
         a[nanmask] = nan
@@ -2854,7 +2843,7 @@ class TestMethods:
     def test_sort_descending_floats(self, dtype, stable, descending):
         a = np.linspace(-50, 50, 101, dtype=dtype)
         self._test_sort_descending_nonan(a, stable, descending)
-        self._test_sort_descending_nan(a, stable, descending)
+        self._test_sort_descending_nan(a, np.nan, stable, descending)
 
     @pytest.mark.parametrize("dtype", [np.complex64, np.complex128, np.clongdouble])
     @pytest.mark.parametrize("stable", [True, False])
@@ -2862,7 +2851,7 @@ class TestMethods:
     def test_sort_descending_complex(self, dtype, stable, descending):
         a = np.arange(-50, 51, dtype=dtype) + 1j * np.arange(-50, 51, dtype=dtype)
         self._test_sort_descending_nonan(a, stable, descending)
-        self._test_sort_descending_nan(a, stable, descending)
+        self._test_sort_descending_nan(a, np.nan + 1j * np.nan, stable, descending)
 
     @pytest.mark.parametrize("dtype", [np.complex64, np.complex128, np.clongdouble])
     @pytest.mark.parametrize("stable", [True, False])
@@ -2931,8 +2920,12 @@ class TestMethods:
     @pytest.mark.parametrize('descending', [True, False])
     def test_sort_descending_dates(self, dtype, stable, descending):
         a = np.arange(0, 101, dtype=dtype)
+        if dtype == 'datetime64[D]':
+            nan = np.datetime64('NaT', 'D')
+        else:
+            nan = np.timedelta64('NaT', 'D')
         self._test_sort_descending_nonan(a, stable, descending)
-        self._test_sort_descending_nan(a, stable, descending)
+        self._test_sort_descending_nan(a, nan, stable, descending)
 
     @pytest.mark.parametrize('dtype', [np.str_, np.bytes_])
     @pytest.mark.parametrize('stable', [True, False])
@@ -2964,19 +2957,7 @@ class TestMethods:
         idx = np.argsort(a_randomized, stable=stable, descending=descending, axis=-1)
         assert_equal(idx, expected, msg)
 
-    def _test_argsort_descending_nan(self, a, stable, descending):
-        if np.issubdtype(a.dtype, np.complexfloating):
-            nan = np.nan + 1j * np.nan
-        elif np.issubdtype(a.dtype, np.floating):
-            nan = np.nan
-        elif np.issubdtype(a.dtype, np.datetime64):
-            nan = np.datetime64("NaT", "D")
-        elif np.issubdtype(a.dtype, np.timedelta64):
-            nan = np.timedelta64("NaT", "D")
-        elif np.issubdtype(a.dtype, np.object_):
-            nan = np.nan
-        else:
-            raise ValueError(f"Unsupported dtype for nan testing: {a.dtype}")
+    def _test_argsort_descending_nan(self, a, nan, stable, descending):
         a[::10] = nan
 
         # comparing datetime types directly to numerical zero fails
@@ -3070,7 +3051,7 @@ class TestMethods:
     def test_argsort_descending_floats(self, dtype, stable, descending):
         a = np.linspace(-50, 50, 101, dtype=dtype)
         self._test_argsort_descending_nonan(a, stable, descending)
-        self._test_argsort_descending_nan(a, stable, descending)
+        self._test_argsort_descending_nan(a, np.nan, stable, descending)
 
     @pytest.mark.parametrize("dtype", [np.complex64, np.complex128, np.clongdouble])
     @pytest.mark.parametrize("stable", [True, False])
@@ -3078,15 +3059,19 @@ class TestMethods:
     def test_argsort_descending_complex(self, dtype, stable, descending):
         a = np.arange(-50, 51, dtype=dtype) + 1j * np.arange(-50, 51, dtype=dtype)
         self._test_argsort_descending_nonan(a, stable, descending)
-        self._test_argsort_descending_nan(a, stable, descending)
+        self._test_argsort_descending_nan(a, np.nan + 1j * np.nan, stable, descending)
 
     @pytest.mark.parametrize("dtype", ["datetime64[D]", "timedelta64[D]"])
     @pytest.mark.parametrize("stable", [True, False])
     @pytest.mark.parametrize("descending", [True, False])
     def test_argsort_descending_datetime(self, dtype, stable, descending):
         a = np.arange(0, 101, dtype=dtype)
+        if dtype == "datetime64[D]":
+            nan = np.datetime64('NaT', 'D')
+        else:
+            nan = np.timedelta64('NaT', 'D')
         self._test_argsort_descending_nonan(a, stable, descending)
-        self._test_argsort_descending_nan(a, stable, descending)
+        self._test_argsort_descending_nan(a, nan, stable, descending)
 
     @pytest.mark.parametrize("dtype", [np.str_, np.bytes_])
     @pytest.mark.parametrize("stable", [True, False])
@@ -3101,6 +3086,189 @@ class TestMethods:
         a = np.arange(101, dtype=float).astype(object)
         self._test_argsort_descending_nonan(a, stable, descending)
         self._test_argsort_descending_nan(a, stable, descending)
+
+    def _test_partition_descending(self, a, k, nan, descending):
+        if nan is not None:
+            a[::10] = nan
+        if not descending:
+            a = a[::-1]
+
+        expected = a.copy()[::-1]
+        if nan is not None:
+            # nans sort to the end regardless of sort order
+            expected = np.concatenate((expected[~np.isnan(expected)],
+                                       expected[np.isnan(expected)]))
+
+        part = np.partition(a, k, descending=descending)
+        before, after = np.split(part, [k])
+        before.sort(descending=descending)
+        after.sort(descending=descending)
+
+        msg = f"partition, dtype={a.dtype}, k={k}, descending={descending}"
+        assert_equal(before, expected[:k], msg)
+        assert_equal(after, expected[k:], msg)
+
+        # randomized input
+        rng = np.random.default_rng(0)
+        a_randomized = a.copy()
+        rng.shuffle(a_randomized)
+
+        part = np.partition(a_randomized, k, descending=descending)
+        before, after = np.split(part, [k])
+        before.sort(descending=descending)
+        after.sort(descending=descending)
+
+        msg = f"partition, randomized, dtype={a.dtype}, k={k}, descending={descending}"
+        assert_equal(before, expected[:k], msg)
+        assert_equal(after, expected[k:], msg)
+
+    @pytest.mark.parametrize('dtype', [np.int8, np.int16, np.int32, np.int64])
+    @pytest.mark.parametrize('k', [2, 15, 50, 95])
+    @pytest.mark.parametrize('descending', [True, False])
+    def test_partition_descending_signed(self, dtype, k, descending):
+        a = np.arange(-51, 50, dtype=dtype)
+        self._test_partition_descending(a, k, None, descending)
+
+    @pytest.mark.parametrize('dtype', [np.uint8, np.uint16, np.uint32, np.uint64])
+    @pytest.mark.parametrize('k', [2, 15, 50, 95])
+    @pytest.mark.parametrize('descending', [True, False])
+    def test_partition_descending_unsigned(self, dtype, k, descending):
+        a = np.arange(0, 101, dtype=dtype)
+        self._test_partition_descending(a, k, None, descending)
+
+    @pytest.mark.parametrize(
+        'dtype', [np.float16, np.float32, np.float64, np.longdouble]
+    )
+    @pytest.mark.parametrize('k', [2, 15, 50, 95])
+    @pytest.mark.parametrize('descending', [True, False])
+    @pytest.mark.parametrize('nan', [np.nan, None])
+    def test_partition_descending_floats(self, dtype, k, descending, nan):
+        a = np.linspace(-50, 50, 101, dtype=dtype)
+        self._test_partition_descending(a, k, nan, descending)
+
+    @pytest.mark.parametrize('dtype', [np.complex64, np.complex128, np.clongdouble])
+    @pytest.mark.parametrize('k', [2, 15, 50, 95])
+    @pytest.mark.parametrize('descending', [True, False])
+    @pytest.mark.parametrize('nan', [np.nan + 1j * np.nan, None])
+    def test_partition_descending_complex(self, dtype, k, descending, nan):
+        a = np.arange(-50, 51, dtype=dtype) + 1j * np.arange(-50, 51, dtype=dtype)
+        self._test_partition_descending(a, k, nan, descending)
+
+    @pytest.mark.skip(reason="descending partitions not supported for string types yet")
+    @pytest.mark.parametrize('dtype', [np.str_, np.bytes_])
+    @pytest.mark.parametrize('k', [2, 15, 50, 95])
+    @pytest.mark.parametrize('descending', [True, False])
+    def test_partition_descending_strings(self, dtype, k, descending):
+        a = np.array([f"{i:03d}" for i in range(101)], dtype=dtype)
+        self._test_partition_descending(a, k, None, descending)
+
+    @pytest.mark.skip(reason="descending partitions not supported for date types yet")
+    @pytest.mark.parametrize('dtype', ['datetime64[D]', 'timedelta64[D]'])
+    @pytest.mark.parametrize('k', [2, 15, 50, 95])
+    @pytest.mark.parametrize('descending', [True, False])
+    def test_partition_descending_datetime(self, dtype, k, descending):
+        a = np.arange(0, 101, dtype=dtype)
+        if dtype == 'datetime64[D]':
+            nan = np.datetime64('NaT', 'D')
+        else:
+            nan = np.timedelta64('NaT', 'D')
+        self._test_partition_descending(a, k, None, descending)
+        self._test_partition_descending(a, k, nan, descending)
+
+    def _test_argpartition_descending(self, a, k, nan, descending):
+        if nan is not None:
+            # because of this decimation, we only test with k values < 90
+            # so that all nans are in the "after" partition
+            a[::10] = nan
+        if not descending:
+            a = a[::-1]
+
+        expected = np.arange(len(a))[::-1]
+        if nan is not None:
+            expected = np.concatenate((expected[~np.isnan(a)], expected[np.isnan(a)]))
+        # nan indices are not ordered, so sort for set-like comparison
+        expected_before = np.sort(expected[:k])
+        expected_after = np.sort(expected[k:])
+
+        idx = np.argpartition(a, k, descending=descending)
+        before, after = np.split(idx, [k])
+        before.sort()
+        after.sort()
+
+        msg = f"argpartition, dtype={a.dtype}, k={k}, descending={descending}"
+        assert_equal(before, expected_before, msg)
+        assert_equal(after, expected_after, msg)
+
+        # randomized input
+        rng = np.random.default_rng(0)
+        perm = rng.permutation(len(a))
+        a = a[perm]
+        perm_inv = np.argsort(perm)
+        expected_before = np.sort(perm_inv[expected[:k]])
+        expected_after = np.sort(perm_inv[expected[k:]])
+
+        idx = np.argpartition(a, k, descending=descending)
+        before, after = np.split(idx, [k])
+        before.sort()
+        after.sort()
+
+        msg = (f"argpartition, randomized, dtype={a.dtype}, k={k}, "
+               f"descending={descending}")
+        assert_equal(before, expected_before, msg)
+        assert_equal(after, expected_after, msg)
+
+    @pytest.mark.parametrize('dtype', [np.int8, np.int16, np.int32, np.int64])
+    @pytest.mark.parametrize('k', [2, 15, 50, 80])
+    @pytest.mark.parametrize('descending', [True, False])
+    def test_argpartition_descending_signed(self, dtype, k, descending):
+        a = np.arange(-51, 50, dtype=dtype)
+        self._test_argpartition_descending(a, k, None, descending)
+
+    @pytest.mark.parametrize('dtype', [np.uint8, np.uint16, np.uint32, np.uint64])
+    @pytest.mark.parametrize('k', [2, 15, 50, 80])
+    @pytest.mark.parametrize('descending', [True, False])
+    def test_argpartition_descending_unsigned(self, dtype, k, descending):
+        a = np.arange(0, 101, dtype=dtype)
+        self._test_argpartition_descending(a, k, None, descending)
+
+    @pytest.mark.parametrize(
+        'dtype', [np.float16, np.float32, np.float64, np.longdouble]
+    )
+    @pytest.mark.parametrize('k', [2, 15, 50, 80])
+    @pytest.mark.parametrize('descending', [True, False])
+    @pytest.mark.parametrize('nan', [np.nan, None])
+    def test_argpartition_descending_floats(self, dtype, k, descending, nan):
+        a = np.linspace(-50, 50, 101, dtype=dtype)
+        self._test_argpartition_descending(a, k, nan, descending)
+
+    @pytest.mark.parametrize('dtype', [np.complex64, np.complex128, np.clongdouble])
+    @pytest.mark.parametrize('k', [2, 15, 50, 80])
+    @pytest.mark.parametrize('descending', [True, False])
+    @pytest.mark.parametrize('nan', [np.nan + 1j * np.nan, None])
+    def test_argpartition_descending_complex(self, dtype, k, descending, nan):
+        a = np.arange(-50, 51, dtype=dtype) + 1j * np.arange(-50, 51, dtype=dtype)
+        self._test_argpartition_descending(a, k, nan, descending)
+
+    @pytest.mark.skip(reason="descending partitions not supported for string types yet")
+    @pytest.mark.parametrize('dtype', [np.str_, np.bytes_])
+    @pytest.mark.parametrize('k', [2, 15, 50, 80])
+    @pytest.mark.parametrize('descending', [True, False])
+    def test_argpartition_descending_strings(self, dtype, k, descending):
+        a = np.array([f"{i:03d}" for i in range(101)], dtype=dtype)
+        self._test_argpartition_descending(a, k, None, descending)
+
+    @pytest.mark.skip(reason="descending partitions not supported for date types yet")
+    @pytest.mark.parametrize('dtype', ['datetime64[D]', 'timedelta64[D]'])
+    @pytest.mark.parametrize('k', [2, 15, 50, 80])
+    @pytest.mark.parametrize('descending', [True, False])
+    def test_argpartition_descending_datetime(self, dtype, k, descending):
+        a = np.arange(0, 101, dtype=dtype)
+        if dtype == 'datetime64[D]':
+            nan = np.datetime64('NaT', 'D')
+        else:
+            nan = np.timedelta64('NaT', 'D')
+        self._test_argpartition_descending(a, k, None, descending)
+        self._test_argpartition_descending(a, k, nan, descending)
 
     @pytest.mark.parametrize('a', [
         np.array([0, 1, np.nan], dtype=np.float16),
@@ -3897,7 +4065,7 @@ class TestMethods:
         # Some dtypes use BLAS for 'dot' operation and
         # not all BLAS support floating-point errors.
         if not BLAS_SUPPORTS_FPE and dtype == np.double:
-            pytest.skip("BLAS does not support FPE")
+            pytest.mark.skip("BLAS does not support FPE")
 
         a = np.array([1, 1], dtype=dtype)
         b = np.array([-np.inf, np.inf], dtype=dtype)
@@ -9298,7 +9466,7 @@ class TestNewBufferProtocol:
         try:
             import _testbuffer
         except ImportError:
-            raise pytest.skip("_testbuffer is not available")
+            raise pytest.mark.skip("_testbuffer is not available")
 
         for shape in [(2, 3), (2, 3, 4)]:
             data = list(range(np.prod(shape)))

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3154,6 +3154,39 @@ class TestMethods:
         a = np.arange(-50, 51, dtype=dtype) + 1j * np.arange(-50, 51, dtype=dtype)
         self._test_partition_descending(a, k, nan, descending)
 
+    @pytest.mark.parametrize('dtype', [np.complex64, np.complex128, np.clongdouble])
+    @pytest.mark.parametrize('k', [2, 15, 50, 95])
+    @pytest.mark.parametrize('descending', [True, False])
+    @pytest.mark.parametrize('random_seed', [0, 1])
+    def test_partition_descending_complex_lexorder(
+        self, dtype, k, descending, random_seed
+    ):
+        arange = np.tile(np.arange(25, dtype=dtype), 4)
+        nans = np.full(100, np.nan + 1j * np.nan, dtype=dtype)
+
+        no_nans = arange + 1j * arange
+        im_nans = arange + 1j * nans
+        re_nans = nans + 1j * arange
+        all_nans = nans + 1j * nans
+
+        a = np.concatenate((no_nans, im_nans, re_nans, all_nans))
+        rng = np.random.default_rng(random_seed)
+        rng.shuffle(a)
+
+        # use sorts as a proxy for checking partitions
+        a_sort = np.sort(a, descending=descending, stable=True)
+        a_part = np.partition(a, k, descending=descending)
+
+        before_sort, after_sort = np.split(a_sort, [k])
+        before_part, after_part = np.split(a_part, [k])
+        before_part.sort(descending=descending, stable=True)
+        after_part.sort(descending=descending, stable=True)
+
+        msg = (f"complex partition lexorder, dtype={dtype}, k={k}, "
+               f"descending={descending}")
+        assert_equal(before_part, before_sort, msg)
+        assert_equal(after_part, after_sort, msg)
+
     @pytest.mark.skip(reason="descending partitions not supported for string types yet")
     @pytest.mark.parametrize('dtype', [np.str_, np.bytes_])
     @pytest.mark.parametrize('k', [2, 15, 50, 95])

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2913,7 +2913,7 @@ class TestMethods:
     def test_sort_descending_object(self, stable, descending):
         a = np.arange(101, dtype=float).astype(object)
         self._test_sort_descending_nonan(a, stable, descending)
-        self._test_sort_descending_nan(a, stable, descending)
+        self._test_sort_descending_nan(a, np.nan, stable, descending)
 
     @pytest.mark.parametrize('dtype', ['datetime64[D]', 'timedelta64[D]'])
     @pytest.mark.parametrize('stable', [True, False])
@@ -3085,7 +3085,7 @@ class TestMethods:
     def test_argsort_descending_object(self, stable, descending):
         a = np.arange(101, dtype=float).astype(object)
         self._test_argsort_descending_nonan(a, stable, descending)
-        self._test_argsort_descending_nan(a, stable, descending)
+        self._test_argsort_descending_nan(a, np.nan, stable, descending)
 
     def _test_partition_descending(self, a, k, nan, descending):
         if nan is not None:

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3275,9 +3275,9 @@ class TestMethods:
     def test_partition_and_argpartition_raise_on_descending(self, dtype):
         a = np.arange(10, dtype=np.float64).astype(dtype)
 
-        with assert_raises(TypeError, msg="type does not have descending partition"):
+        with assert_raises(TypeError, msg="type does not support descending partition"):
             np.partition(a, 5, descending=True)
-        with assert_raises(TypeError, msg="type does not have descending partition"):
+        with assert_raises(TypeError, msg="type does not support descending partition"):
             np.argpartition(a, 5, descending=True)
 
     @pytest.mark.parametrize('a', [

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -2594,8 +2594,9 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         /,
         kth: _ArrayLikeInt,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
-        order: None = None
+        kind: _PartitionKind | None = None,
+        order: None = None,
+        descending: bool | None = None,
     ) -> None: ...
     @overload
     def partition(
@@ -2603,8 +2604,9 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         /,
         kth: _ArrayLikeInt,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: str | Sequence[str] | None = None,
+        descending: bool | None = None,
     ) -> None: ...
 
     # keep in sync with ndarray.argpartition
@@ -2615,8 +2617,8 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: None,
-        kind: _PartitionKind = "introselect",
-        order: None = None,
+        kind: _PartitionKind | None = None,        order: None = None,
+        descending: bool | None = None,
     ) -> MaskedArray[tuple[int], np.dtype[intp]]: ...
     @overload  # axis: index (default)
     def argpartition(
@@ -2624,8 +2626,8 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
-        order: None = None,
+        kind: _PartitionKind | None = None,        order: None = None,
+        descending: bool | None = None,
     ) -> MaskedArray[_ShapeT_co, np.dtype[intp]]: ...
     @overload  # void, axis: None
     def argpartition(
@@ -2633,8 +2635,8 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: None,
-        kind: _PartitionKind = "introselect",
-        order: str | Sequence[str] | None = None,
+        kind: _PartitionKind | None = None,        order: str | Sequence[str] | None = None,
+        descending: bool | None = None,
     ) -> MaskedArray[tuple[int], np.dtype[intp]]: ...
     @overload  # void, axis: index (default)
     def argpartition(
@@ -2642,8 +2644,8 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
-        order: str | Sequence[str] | None = None,
+        kind: _PartitionKind | None = None,        order: str | Sequence[str] | None = None,
+        descending: bool | None = None,
     ) -> MaskedArray[_ShapeT_co, np.dtype[intp]]: ...
 
     # Keep in-sync with np.ma.take

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -2617,7 +2617,8 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: None,
-        kind: _PartitionKind | None = None,        order: None = None,
+        kind: _PartitionKind | None = None,
+        order: None = None,
         descending: bool | None = None,
     ) -> MaskedArray[tuple[int], np.dtype[intp]]: ...
     @overload  # axis: index (default)
@@ -2626,7 +2627,8 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind | None = None,        order: None = None,
+        kind: _PartitionKind | None = None,
+        order: None = None,
         descending: bool | None = None,
     ) -> MaskedArray[_ShapeT_co, np.dtype[intp]]: ...
     @overload  # void, axis: None
@@ -2635,7 +2637,8 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: None,
-        kind: _PartitionKind | None = None,        order: str | Sequence[str] | None = None,
+        kind: _PartitionKind | None = None,
+        order: str | Sequence[str] | None = None,
         descending: bool | None = None,
     ) -> MaskedArray[tuple[int], np.dtype[intp]]: ...
     @overload  # void, axis: index (default)
@@ -2644,7 +2647,8 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind | None = None,        order: str | Sequence[str] | None = None,
+        kind: _PartitionKind | None = None,
+        order: str | Sequence[str] | None = None,
         descending: bool | None = None,
     ) -> MaskedArray[_ShapeT_co, np.dtype[intp]]: ...
 


### PR DESCRIPTION
Draft to add a `descending` kwarg to `np.partition` and `np.argpartition`, analogous to the sorting functions, thus addresses part of #31424. Not sure if the `SELECTKIND` changes constitute an ABI or C-API break, but analogous to the sorts as well. cc @seberg, thanks!

Note that this does not create new-style ArrayMethod registration analogous to the sorts, but rather updates the (apparently fully internal) `partition_map` and continues using the old-style `PartitionFunc`. (In fact, the `PyArray_(Arg)Partition` functions are unchanged!) Hopefully this is minimal enough and we can just add new-style ArrayMethods (and thus enable user-dtypes to use partitions) in follow-up? (This would then also unblock work for `top_k`.)

Still needs docs, tests, and a release note!

#### AI Disclosure
No AI used.