### PR TITLE
DOC: inline-role to code, and item present twice in See-also

### DIFF
--- a/numpy/lib/_index_tricks_impl.py
+++ b/numpy/lib/_index_tricks_impl.py
@@ -742,10 +742,10 @@ class IndexExpression:
     See Also
     --------
     s_ : Predefined instance without tuple conversion:
-       `s_ = IndexExpression(maketuple=False)`.
+       ``s_ = IndexExpression(maketuple=False)``.
        The ``index_exp`` is another predefined instance that
        always returns a tuple:
-       `index_exp = IndexExpression(maketuple=True)`.
+       ``index_exp = IndexExpression(maketuple=True)``.
 
     Notes
     -----

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1504,7 +1504,7 @@ def nanquantile(
     See Also
     --------
     quantile
-    nanmean, nanmedian
+    nanmean
     nanmedian : equivalent to ``nanquantile(..., 0.5)``
     nanpercentile : same as nanquantile, but with q in the range [0, 100].
 


### PR DESCRIPTION
The two inline roles appear as unresolved-links in emphases instead of code.

[skip azp] [skip cirrus] [skip actions]

#### AI Disclosure

No AI tools used
