### PR TITLE
TYP: widen einsum subscripts param to accept complex arrays in subscript-free calling convention

### DIFF
--- a/numpy/_core/einsumfunc.pyi
+++ b/numpy/_core/einsumfunc.pyi
@@ -34,7 +34,7 @@ type _CastingUnsafe = Literal["unsafe"]
 # Something like `is_scalar = bool(__subscripts.partition("->")[-1])`
 @overload
 def einsum(
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: _ArrayLikeBool_co,
     out: None = None,
@@ -45,7 +45,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: _ArrayLikeUInt_co,
     out: None = None,
@@ -56,7 +56,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: _ArrayLikeInt_co,
     out: None = None,
@@ -67,7 +67,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: _ArrayLikeFloat_co,
     out: None = None,
@@ -78,7 +78,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: _ArrayLikeComplex_co,
     out: None = None,
@@ -89,7 +89,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: Any,
     casting: _CastingUnsafe,
@@ -100,7 +100,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum[OutT: NDArray[np.bool | np.number]](
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: _ArrayLikeComplex_co,
     out: OutT,
@@ -111,7 +111,7 @@ def einsum[OutT: NDArray[np.bool | np.number]](
 ) -> OutT: ...
 @overload
 def einsum[OutT: NDArray[np.bool | np.number]](
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: Any,
     out: OutT,
@@ -123,7 +123,7 @@ def einsum[OutT: NDArray[np.bool | np.number]](
 
 @overload
 def einsum(
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: _ArrayLikeObject_co,
     out: None = None,
@@ -134,7 +134,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum(
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: Any,
     casting: _CastingUnsafe,
@@ -145,7 +145,7 @@ def einsum(
 ) -> Any: ...
 @overload
 def einsum[OutT: NDArray[np.bool | np.number]](
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: _ArrayLikeObject_co,
     out: OutT,
@@ -156,7 +156,7 @@ def einsum[OutT: NDArray[np.bool | np.number]](
 ) -> OutT: ...
 @overload
 def einsum[OutT: NDArray[np.bool | np.number]](
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: Any,
     out: OutT,
@@ -171,7 +171,7 @@ def einsum[OutT: NDArray[np.bool | np.number]](
 # NOTE: In practice the list consists of a `str` (first element)
 # and a variable number of integer tuples.
 def einsum_path(
-    subscripts: str | _ArrayLikeInt_co,
+    subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: _ArrayLikeComplex_co | _DTypeLikeObject,
     optimize: _OptimizeKind = "greedy",

--- a/numpy/typing/tests/data/reveal/einsumfunc.pyi
+++ b/numpy/typing/tests/data/reveal/einsumfunc.pyi
@@ -36,4 +36,11 @@ assert_type(np.einsum_path("i,i->i", AR_LIKE_b, AR_LIKE_i), tuple[list[Any], str
 assert_type(np.einsum_path("i,i,i,i->i", AR_LIKE_b, AR_LIKE_u, AR_LIKE_i, AR_LIKE_c), tuple[list[Any], str])
 
 assert_type(np.einsum([[1, 1], [1, 1]], AR_LIKE_i, AR_LIKE_i), Any)
+
 assert_type(np.einsum_path([[1, 1], [1, 1]], AR_LIKE_i, AR_LIKE_i), tuple[list[Any], str])
+
+# subscript-free calling convention with float and complex arrays
+AR_f: npt.NDArray[np.float64]
+AR_c: npt.NDArray[np.complex128]
+assert_type(np.einsum(AR_f, [0, 1], AR_f, [1, 0], [0]), Any)
+assert_type(np.einsum(AR_c, [0, 1], AR_c, [1, 0], [0]), Any)


### PR DESCRIPTION
### PR summary

The `subscripts` parameter in every `np.einsum` overload was typed as `str | _ArrayLikeInt_co`. In the subscript-free calling convention (e.g. `np.einsum(a, [0,1], b, [1,0], [0])`), the first argument is the data array itself — which can be float or complex, not just integer-like. This caused false-positive `[arg-type]` mypy errors for valid code.

The fix widens `subscripts` to `str | _ArrayLikeComplex_co` across all 13 overloads, since `_ArrayLikeComplex_co` is a superset covering bool, uint, int, float, and complex arrays. A reveal test for the subscript-free convention with `float64` and `complex128` arrays is also added.

### First time committer introduction

I'm a student who uses NumPy for numerical computing work. I came across this issue while using `np.einsum` with complex arrays in a project and hitting the false-positive mypy error myself. 

#### AI Disclosure

Claude (Anthropic) was used to help navigate the codebase and identify the relevant overloads. The diagnosis, fix, and submission were done by me. All changed code was reviewed and understood before committing.
