### PR TITLE
MAINT/TYP: bump `pyrefly` to `1.0.0`

### DIFF
--- a/numpy/lib/_index_tricks_impl.pyi
+++ b/numpy/lib/_index_tricks_impl.pyi
@@ -125,13 +125,13 @@ class nd_grid(Generic[_BoolT_co]):
 
 @final
 class MGridClass(nd_grid[L[False]]):
-    __slots__ = ()
+    __slots__ = ()  # pyrefly:ignore[implicit-any-attribute]
 
     def __init__(self) -> None: ...
 
 @final
 class OGridClass(nd_grid[L[True]]):
-    __slots__ = ()
+    __slots__ = ()  # pyrefly:ignore[implicit-any-attribute]
 
     def __init__(self) -> None: ...
 
@@ -220,13 +220,13 @@ class AxisConcatenator(Generic[_AxisT_co, _MatrixT_co, _NDMinT_co, _Trans1DT_co]
 
 @final
 class RClass(AxisConcatenator[L[0], L[False], L[1], L[-1]]):
-    __slots__ = ()
+    __slots__ = ()  # pyrefly:ignore[implicit-any-attribute]
 
     def __init__(self, /) -> None: ...
 
 @final
 class CClass(AxisConcatenator[L[-1], L[False], L[2], L[0]]):
-    __slots__ = ()
+    __slots__ = ()  # pyrefly:ignore[implicit-any-attribute]
 
     def __init__(self, /) -> None: ...
 

--- a/numpy/lib/mixins.pyi
+++ b/numpy/lib/mixins.pyi
@@ -13,7 +13,7 @@ __all__ = ["NDArrayOperatorsMixin"]
 # As such, only little type safety can be provided here.
 
 class NDArrayOperatorsMixin(ABC):
-    __slots__ = ()
+    __slots__ = ()  # pyrefly:ignore[implicit-any-attribute]
 
     @type_check_only
     @abstractmethod

--- a/numpy/ma/extras.pyi
+++ b/numpy/ma/extras.pyi
@@ -621,7 +621,7 @@ def cov(
 def corrcoef(x: ArrayLike, y: ArrayLike | None = None, rowvar: bool = True, allow_masked: bool = True) -> _MArray[Incomplete]: ...
 
 class MAxisConcatenator(AxisConcatenator):
-    __slots__ = ()
+    __slots__ = ()  # pyrefly:ignore[implicit-any-attribute]
 
     # keep in sync with `ma.core.concatenate`
     @override  # type: ignore[override]
@@ -638,7 +638,7 @@ class MAxisConcatenator(AxisConcatenator):
     def makemat(cls, /, arr: ArrayLike) -> _MArray[Incomplete]: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleVariableOverride]
 
 class mr_class(MAxisConcatenator):
-    __slots__ = ()
+    __slots__ = ()  # pyrefly:ignore[implicit-any-attribute]
     def __init__(self) -> None: ...
 
 mr_: Final[mr_class] = ...

--- a/requirements/typing_requirements.txt
+++ b/requirements/typing_requirements.txt
@@ -3,4 +3,4 @@
 -r test_requirements.txt
 
 mypy==1.20.2
-pyrefly==0.63.1
+pyrefly==1.0.0


### PR DESCRIPTION
The upcoming Pyrefly release that includes the fix for the ignored (false positive) errors here is taking a lot longer than expected. With this, dependabot should be able do its thing again.

ref: https://github.com/numpy/numpy/pull/31516#issuecomment-4549909868

#### AI Disclosure
no ai 
