### PR TITLE
Descending partition

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3614,8 +3614,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: None = None,
+        descending: py_bool | None = None,
     ) -> None: ...
     @overload
     def partition(
@@ -3623,8 +3624,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: str | Sequence[str] | None = None,
+        descending: py_bool | None = None,
     ) -> None: ...
 
     # keep in sync with `ma.core.MaskedArray.argpartition`
@@ -3635,8 +3637,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: None,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: None = None,
+        descending: py_bool | None = None,
     ) -> ndarray[tuple[int], _dtype[intp]]: ...
     @overload  # axis: index (default)
     def argpartition(
@@ -3644,8 +3647,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: None = None,
+        descending: py_bool | None = None,
     ) -> ndarray[_ShapeT_co, _dtype[intp]]: ...
     @overload  # void, axis: None
     def argpartition(
@@ -3653,8 +3657,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: None,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: str | Sequence[str] | None = None,
+        descending: py_bool | None = None,
     ) -> ndarray[tuple[int], _dtype[intp]]: ...
     @overload  # void, axis: index (default)
     def argpartition(
@@ -3662,8 +3667,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         kth: _ArrayLikeInt,
         /,
         axis: SupportsIndex = -1,
-        kind: _PartitionKind = "introselect",
+        kind: _PartitionKind | None = None,
         order: str | Sequence[str] | None = None,
+        descending: py_bool | None = None,
     ) -> ndarray[_ShapeT_co, _dtype[intp]]: ...
 
     # keep in sync with `ma.MaskedArray.diagonal`

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -725,12 +725,12 @@ def matrix_transpose(x, /):
     return swapaxes(x, -1, -2)
 
 
-def _partition_dispatcher(a, kth, axis=None, kind=None, order=None):
+def _partition_dispatcher(a, kth, axis=None, kind=None, order=None, descending=None):
     return (a,)
 
 
 @array_function_dispatch(_partition_dispatcher)
-def partition(a, kth, axis=-1, kind='introselect', order=None):
+def partition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
     """
     Return a partitioned copy of an array.
 
@@ -837,16 +837,20 @@ def partition(a, kth, axis=-1, kind='introselect', order=None):
         axis = -1
     else:
         a = asanyarray(a).copy(order="K")
-    a.partition(kth, axis=axis, kind=kind, order=order)
+    # Sanitize for backward compatibility
+    if descending is not np._NoValue:
+        a.partition(kth, axis=axis, kind=kind, order=order, descending=descending)
+    else:
+        a.partition(kth, axis=axis, kind=kind, order=order)
     return a
 
 
-def _argpartition_dispatcher(a, kth, axis=None, kind=None, order=None):
+def _argpartition_dispatcher(a, kth, axis=None, kind=None, order=None, descending=None):
     return (a,)
 
 
 @array_function_dispatch(_argpartition_dispatcher)
-def argpartition(a, kth, axis=-1, kind='introselect', order=None):
+def argpartition(a, kth, axis=-1, kind=None, order=None, descending=np._NoValue):
     """
     Perform an indirect partition along the given axis using the
     algorithm specified by the `kind` keyword. It returns an array of
@@ -929,7 +933,23 @@ def argpartition(a, kth, axis=-1, kind='introselect', order=None):
            [1, 1, 3]])
 
     """
-    return _wrapfunc(a, 'argpartition', kth, axis=axis, kind=kind, order=order)
+    if descending is not np._NoValue:
+        return _wrapfunc(
+            a,
+            'argpartition',
+            kth, axis=axis,
+            kind=kind,
+            order=order,
+            descending=descending
+        )
+    return _wrapfunc(
+        a,
+        'argpartition',
+        kth,
+        axis=axis,
+        kind=kind,
+        order=order
+    )
 
 
 def _sort_dispatcher(

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -350,40 +350,45 @@ def partition[ArrayT: np.ndarray](
     a: ArrayT,
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> ArrayT: ...
 @overload  # ?d
 def partition[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> NDArray[ScalarT]: ...
 @overload  # axis: None
 def partition[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> _Array1D[ScalarT]: ...
 @overload  # fallback
 def partition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> NDArray[Any]: ...
 @overload  # fallback, axis: None
 def partition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> _Array1D[Any]: ...
 
 # keep roughly in sync with `ndarray.argpartition`
@@ -392,56 +397,63 @@ def argpartition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int], np.dtype[np.intp]]: ...
 @overload  # known shape, axis: index (default)
 def argpartition[ShapeT: _Shape](
     a: np.ndarray[ShapeT],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...
 @overload  # 1d array-like, axis: index (default)
 def argpartition(
     a: Sequence[np.generic | complex],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int], np.dtype[np.intp]]: ...
 @overload  # 2d array-like, axis: index (default)
 def argpartition(
     a: Sequence[Sequence[np.generic | complex]],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int, int], np.dtype[np.intp]]: ...
 @overload  # ?d array-like, axis: index (default)
 def argpartition(
     a: ArrayLike,
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: None = None,
+    descending: bool | _NoValueType = ...,
 ) -> NDArray[np.intp]: ...
 @overload  # void, axis: None
 def argpartition(
     a: _SupportsArray[np.dtype[np.void]],
     kth: _ArrayLikeInt,
     axis: None,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[tuple[int], np.dtype[intp]]: ...
 @overload  # void, axis: index (default)
 def argpartition[ShapeT: _Shape](
     a: np.ndarray[ShapeT, np.dtype[np.void]],
     kth: _ArrayLikeInt,
     axis: SupportsIndex = -1,
-    kind: _PartitionKind = "introselect",
+    kind: _PartitionKind | None = None,
     order: str | Sequence[str] | None = None,
+    descending: bool | _NoValueType = ...,
 ) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...
 
 #

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -197,9 +197,13 @@ typedef enum {
 
 
 typedef enum {
-        NPY_INTROSELECT=0
+        _NPY_SELECT_UNDEFINED = -1,
+        NPY_INTROSELECT = 0,
+        // new style names
+        NPY_SELECT_DEFAULT = 0,
+        NPY_SELECT_DESCENDING = 1,
 } NPY_SELECTKIND;
-#define NPY_NSELECTS (NPY_INTROSELECT + 1)
+#define NPY_NSELECTS (NPY_SELECT_DESCENDING + 1)
 
 
 typedef enum {

--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -634,6 +634,10 @@ static int selectkind_parser(char const *str, Py_ssize_t length, void *data)
 NPY_NO_EXPORT int
 PyArray_SelectkindConverter(PyObject *obj, NPY_SELECTKIND *selectkind)
 {
+    /* Leave the desired default from the caller for Py_None */
+    if (obj == Py_None) {
+        return NPY_SUCCEED;
+    }
     return string_converter_helper(
         obj, (void *)selectkind, selectkind_parser, "select kind",
         "must be 'introselect'");

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1343,20 +1343,37 @@ array_partition(PyArrayObject *self,
 {
     int axis=-1;
     int val;
-    NPY_SELECTKIND sortkind = NPY_INTROSELECT;
+    NPY_SELECTKIND sortkind = _NPY_SELECT_UNDEFINED;
     PyObject *order = NULL;
     PyArray_Descr *saved = NULL;
     PyArray_Descr *newd;
     PyArrayObject * ktharray;
     PyObject * kthobj;
+    int descending = -1;
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("partition", args, len_args, kwnames,
             {"kth", NULL, &kthobj},
             {"|axis", &PyArray_PythonPyIntFromInt, &axis},
             {"|kind", &PyArray_SelectkindConverter, &sortkind},
-            {"|order", NULL, &order}) < 0) {
+            {"|order", NULL, &order},
+            {"$descending", &PyArray_OptionalBoolConverter, &descending}
+            ) < 0) {
         return NULL;
+    }
+
+    if (sortkind == _NPY_SELECT_UNDEFINED) {
+        // keywords only if sortkind not passed
+        sortkind = descending > 0? NPY_SELECT_DESCENDING: NPY_SELECT_DEFAULT;
+    }
+    else {
+        // Check that no keywords are used
+        if (descending != -1) {
+            PyErr_SetString(PyExc_ValueError,
+                    "`kind` and keyword parameters can't be provided at "
+                    "the same time. Use only one of them.");
+            return NULL;
+        }
     }
 
     if (order == Py_None) {
@@ -1499,20 +1516,37 @@ array_argpartition(PyArrayObject *self,
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     int axis = -1;
-    NPY_SELECTKIND sortkind = NPY_INTROSELECT;
+    NPY_SELECTKIND sortkind = _NPY_SELECT_UNDEFINED;
     PyObject *order = NULL, *res;
     PyArray_Descr *newd, *saved=NULL;
     PyObject * kthobj;
     PyArrayObject * ktharray;
+    int descending = -1;
     NPY_PREPARE_ARGPARSER;
 
     if (npy_parse_arguments("argpartition", args, len_args, kwnames,
             {"kth", NULL, &kthobj},
             {"|axis", &PyArray_AxisConverter, &axis},
             {"|kind", &PyArray_SelectkindConverter, &sortkind},
-            {"|order", NULL, &order}) < 0) {
+            {"|order", NULL, &order},
+            {"|descending", &PyArray_OptionalBoolConverter, &descending}) < 0) {
         return NULL;
     }
+
+    if (sortkind == _NPY_SELECT_UNDEFINED) {
+        // keywords only if sortkind not passed
+        sortkind = descending > 0? NPY_SELECT_DESCENDING: NPY_SELECT_DEFAULT;
+    }
+    else {
+        // Check that no keywords are used
+        if (descending != -1) {
+            PyErr_SetString(PyExc_ValueError,
+                    "`kind` and keyword parameters can't be provided at "
+                    "the same time. Use only one of them.");
+            return NULL;
+        }
+    }
+
     if (order == Py_None) {
         order = NULL;
     }

--- a/numpy/_core/src/npysort/selection.cpp
+++ b/numpy/_core/src/npysort/selection.cpp
@@ -85,7 +85,7 @@ inline bool argquickselect_dispatch(T* v, npy_intp* arg, npy_intp num, npy_intp 
     return false;
 }
 
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 NPY_NO_EXPORT int
 introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth, npy_intp *pivots, npy_intp *npiv);
 
@@ -159,7 +159,7 @@ inexact()
  * gets min and median and moves median to low and min to low + 1
  * for efficient partitioning, see unguarded_partition
  */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 static inline void
 median3_swap_(type *v, npy_intp *tosort, npy_intp low, npy_intp mid,
               npy_intp high)
@@ -167,14 +167,14 @@ median3_swap_(type *v, npy_intp *tosort, npy_intp low, npy_intp mid,
     Idx<arg> idx(tosort);
     Sortee<type, arg> sortee(v, tosort);
 
-    if (Tag::less(v[idx(high)], v[idx(mid)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(high)], v[idx(mid)])) {
         std::swap(sortee(high), sortee(mid));
     }
-    if (Tag::less(v[idx(high)], v[idx(low)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(high)], v[idx(low)])) {
         std::swap(sortee(high), sortee(low));
     }
     /* move pivot to low */
-    if (Tag::less(v[idx(low)], v[idx(mid)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(low)], v[idx(mid)])) {
         std::swap(sortee(low), sortee(mid));
     }
     /* move 3-lowest element to low + 1 */
@@ -182,7 +182,7 @@ median3_swap_(type *v, npy_intp *tosort, npy_intp low, npy_intp mid,
 }
 
 /* select index of median of five elements */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 static npy_intp
 median5_(type *v, npy_intp *tosort)
 {
@@ -190,23 +190,23 @@ median5_(type *v, npy_intp *tosort)
     Sortee<type, arg> sortee(v, tosort);
 
     /* could be optimized as we only need the index (no swaps) */
-    if (Tag::less(v[idx(1)], v[idx(0)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(1)], v[idx(0)])) {
         std::swap(sortee(1), sortee(0));
     }
-    if (Tag::less(v[idx(4)], v[idx(3)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(4)], v[idx(3)])) {
         std::swap(sortee(4), sortee(3));
     }
-    if (Tag::less(v[idx(3)], v[idx(0)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(3)], v[idx(0)])) {
         std::swap(sortee(3), sortee(0));
     }
-    if (Tag::less(v[idx(4)], v[idx(1)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(4)], v[idx(1)])) {
         std::swap(sortee(4), sortee(1));
     }
-    if (Tag::less(v[idx(2)], v[idx(1)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(2)], v[idx(1)])) {
         std::swap(sortee(2), sortee(1));
     }
-    if (Tag::less(v[idx(3)], v[idx(2)])) {
-        if (Tag::less(v[idx(3)], v[idx(1)])) {
+    if (npy::cmp<Tag, reverse>(v[idx(3)], v[idx(2)])) {
+        if (npy::cmp<Tag, reverse>(v[idx(3)], v[idx(1)])) {
             return 1;
         }
         else {
@@ -225,7 +225,7 @@ median5_(type *v, npy_intp *tosort)
  *                  ll ... hh
  * lower-than-pivot [x x x x] larger-than-pivot
  */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 static inline void
 unguarded_partition_(type *v, npy_intp *tosort, const type pivot, npy_intp *ll,
                      npy_intp *hh)
@@ -236,10 +236,10 @@ unguarded_partition_(type *v, npy_intp *tosort, const type pivot, npy_intp *ll,
     for (;;) {
         do {
             (*ll)++;
-        } while (Tag::less(v[idx(*ll)], pivot));
+        } while (npy::cmp<Tag, reverse>(v[idx(*ll)], pivot));
         do {
             (*hh)--;
-        } while (Tag::less(pivot, v[idx(*hh)]));
+        } while (npy::cmp<Tag, reverse>(pivot, v[idx(*hh)]));
 
         if (*hh < *ll) {
             break;
@@ -254,7 +254,7 @@ unguarded_partition_(type *v, npy_intp *tosort, const type pivot, npy_intp *ll,
  * if used as partition pivot it splits the range into at least 30%/70%
  * allowing linear time worst-case quickselect
  */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 static npy_intp
 median_of_median5_(type *v, npy_intp *tosort, const npy_intp num,
                    npy_intp *pivots, npy_intp *npiv)
@@ -266,13 +266,13 @@ median_of_median5_(type *v, npy_intp *tosort, const npy_intp num,
     npy_intp right = num - 1;
     npy_intp nmed = (right + 1) / 5;
     for (i = 0, subleft = 0; i < nmed; i++, subleft += 5) {
-        npy_intp m = median5_<Tag, arg>(v + (arg ? 0 : subleft),
+        npy_intp m = median5_<Tag, arg, reverse>(v + (arg ? 0 : subleft),
                                         tosort + (arg ? subleft : 0));
         std::swap(sortee(subleft + m), sortee(i));
     }
 
     if (nmed > 2) {
-        introselect_<Tag, arg>(v, tosort, nmed, nmed / 2, pivots, npiv);
+        introselect_<Tag, arg, reverse>(v, tosort, nmed, nmed / 2, pivots, npiv);
     }
     return nmed / 2;
 }
@@ -282,7 +282,7 @@ median_of_median5_(type *v, npy_intp *tosort, const npy_intp num,
  * useful for close multiple partitions
  * (e.g. even element median, interpolating percentile)
  */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 static int
 dumb_select_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth)
 {
@@ -295,7 +295,7 @@ dumb_select_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth)
         type minval = v[idx(i)];
         npy_intp k;
         for (k = i + 1; k < num; k++) {
-            if (Tag::less(v[idx(k)], minval)) {
+            if (npy::cmp<Tag, reverse>(v[idx(k)], minval)) {
                 minidx = k;
                 minval = v[idx(k)];
             }
@@ -319,7 +319,7 @@ dumb_select_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth)
  * kth 8:   0  1  2  3  4  5  6 [8  7] -> stack []
  *
  */
-template <typename Tag, bool arg, typename type>
+template <typename Tag, bool arg, bool reverse, typename type>
 NPY_NO_EXPORT int
 introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
              npy_intp *pivots, npy_intp *npiv)
@@ -357,7 +357,7 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
      * e.g. for interpolating percentile
      */
     if (kth - low < 3) {
-        dumb_select_<Tag, arg>(v + (arg ? 0 : low), tosort + (arg ? low : 0),
+        dumb_select_<Tag, arg, reverse>(v + (arg ? 0 : low), tosort + (arg ? low : 0),
                                high - low + 1, kth - low);
         store_pivot(kth, kth, pivots, npiv);
         return 0;
@@ -369,7 +369,7 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
         npy_intp maxidx = low;
         type maxval = v[idx(low)];
         for (k = low + 1; k < num; k++) {
-            if (!Tag::less(v[idx(k)], maxval)) {
+            if (!npy::cmp<Tag, reverse>(v[idx(k)], maxval)) {
                 maxidx = k;
                 maxval = v[idx(k)];
             }
@@ -394,12 +394,12 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
             const npy_intp mid = low + (high - low) / 2;
             /* median of 3 pivot strategy,
              * swapping for efficient partition */
-            median3_swap_<Tag, arg>(v, tosort, low, mid, high);
+            median3_swap_<Tag, arg, reverse>(v, tosort, low, mid, high);
         }
         else {
             npy_intp mid;
             /* FIXME: always use pivots to optimize this iterative partition */
-            mid = ll + median_of_median5_<Tag, arg>(v + (arg ? 0 : ll),
+            mid = ll + median_of_median5_<Tag, arg, reverse>(v + (arg ? 0 : ll),
                                                     tosort + (arg ? ll : 0),
                                                     hh - ll, NULL, NULL);
             std::swap(sortee(mid), sortee(low));
@@ -415,7 +415,7 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
          * previous swapping removes need for bound checks
          * pivot 3-lowest [x x x] 3-highest
          */
-        unguarded_partition_<Tag, arg>(v, tosort, v[idx(low)], &ll, &hh);
+        unguarded_partition_<Tag, arg, reverse>(v, tosort, v[idx(low)], &ll, &hh);
 
         /* move pivot into position */
         std::swap(sortee(low), sortee(hh));
@@ -435,7 +435,7 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
 
     /* two elements */
     if (high == low + 1) {
-        if (Tag::less(v[idx(high)], v[idx(low)])) {
+        if (npy::cmp<Tag, reverse>(v[idx(high)], v[idx(low)])) {
             std::swap(sortee(high), sortee(low));
         }
     }
@@ -450,30 +450,34 @@ introselect_(type *v, npy_intp *tosort, npy_intp num, npy_intp kth,
  *****************************************************************************
  */
 
-template <typename Tag>
+template <typename Tag, bool reverse>
 static int
 introselect_noarg(void *v, npy_intp num, npy_intp kth, npy_intp *pivots,
                   npy_intp *npiv, npy_intp nkth, void *)
 {
     using T = typename std::conditional<std::is_same_v<Tag, npy::half_tag>, np::Half, typename Tag::type>::type;
-    if ((nkth == 1) && (quickselect_dispatch((T *)v, num, kth))) {
-        return 0;
+    if constexpr (!reverse) {
+        if ((nkth == 1) && (quickselect_dispatch((T *)v, num, kth))) {
+            return 0;
+        }
     }
-    return introselect_<Tag, false>((typename Tag::type *)v, nullptr, num, kth,
-                                    pivots, npiv);
+    return introselect_<Tag, false, reverse>((typename Tag::type *)v, nullptr, num, kth,
+                                             pivots, npiv);
 }
 
-template <typename Tag>
+template <typename Tag, bool reverse>
 static int
 introselect_arg(void *v, npy_intp *tosort, npy_intp num, npy_intp kth,
                 npy_intp *pivots, npy_intp *npiv, npy_intp nkth, void *)
 {
     using T = typename Tag::type;
-    if ((nkth == 1) && (argquickselect_dispatch((T *)v, tosort, num, kth))) {
-        return 0;
+    if constexpr (!reverse) {
+        if ((nkth == 1) && (argquickselect_dispatch((T *)v, tosort, num, kth))) {
+            return 0;
+        }
     }
-    return introselect_<Tag, true>((typename Tag::type *)v, tosort, num, kth,
-                                   pivots, npiv);
+    return introselect_<Tag, true, reverse>((typename Tag::type *)v, tosort, num, kth,
+                                            pivots, npiv);
 }
 
 struct arg_map {
@@ -487,8 +491,9 @@ static constexpr std::array<arg_map, sizeof...(Tags)>
 make_partition_map(npy::taglist<Tags...>)
 {
     return std::array<arg_map, sizeof...(Tags)>{
-            arg_map{Tags::type_value, {&introselect_noarg<Tags>},
-                {&introselect_arg<Tags>}}...};
+            arg_map{Tags::type_value,
+                {&introselect_noarg<Tags, false>, &introselect_noarg<Tags, true>},
+                {&introselect_arg<Tags, false>, &introselect_arg<Tags, true>}}...};
 }
 
 struct partition_t {

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -11275,6 +11275,7 @@ def test_partition_int(N, dtype):
             np.partition(arr, k, kind='introselect'))
     assert_arr_partitioned(np.sort(arr)[k], k,
             arr[np.argpartition(arr, k, kind='introselect')])
+            
 
     # (2) random data with max value at the end of array
     arr = rnd.randint(low=minv, high=maxv, size=N, dtype=dtype)
@@ -11284,6 +11285,74 @@ def test_partition_int(N, dtype):
     assert_arr_partitioned(np.sort(arr)[k], k,
             arr[np.argpartition(arr, k, kind='introselect')])
 
+@pytest.mark.parametrize("N", np.arange(2, 512))
+@pytest.mark.parametrize("dtype", [np.int16, np.uint16,
+                        np.int32, np.uint32, np.int64, np.uint64])
+def test_partition_int(N, dtype):
+    rnd = np.random.RandomState(1100710816)
+
+    # (1) random data with min and max values
+    minv = np.iinfo(dtype).min
+    maxv = np.iinfo(dtype).max
+    arr = rnd.randint(low=minv, high=maxv, size=N, dtype=dtype)
+    i, j = rnd.choice(N, 2, replace=False)
+    arr[i] = minv
+    arr[j] = maxv
+    k = rnd.choice(N, 1)[0]
+
+    assert_arr_partitioned(np.sort(arr)[k], k,
+            np.partition(arr, k, kind='introselect'))
+    assert_arr_partitioned(np.sort(arr)[k], k,
+            arr[np.argpartition(arr, k, kind='introselect')])
+
+    # (2) random data with max value at the end of array
+    arr = rnd.randint(low=minv, high=maxv, size=N, dtype=dtype)
+    arr[N - 1] = maxv
+
+    assert_arr_partitioned(np.sort(arr)[k], k,
+            np.partition(arr, k, kind='introselect'))
+    assert_arr_partitioned(np.sort(arr)[k], k,
+            arr[np.argpartition(arr, k, kind='introselect')])
+
+
+@pytest.mark.parametrize("N", np.arange(2, 512))
+@pytest.mark.parametrize("dtype", [np.int16, np.uint16,
+                        np.int32, np.uint32, np.int64, np.uint64])
+def test_partition_descending_int(N, dtype):
+    rnd = np.random.RandomState(1100710816)
+
+    minv = np.iinfo(dtype).min
+    maxv = np.iinfo(dtype).max
+
+    arr = rnd.randint(low=minv, high=maxv, size=N, dtype=dtype)
+
+    i, j = rnd.choice(N, 2, replace=False)
+    arr[i] = minv
+    arr[j] = maxv
+
+    k = rnd.choice(N, 1)[0]
+
+    sorted_desc = np.sort(arr)[::-1]
+
+    part = np.partition(arr, k, descending=True)
+    assert part[k] == sorted_desc[k]
+
+    if k > 0:
+        assert np.all(part[:k] >= part[k])
+
+    if k < N - 1:
+        assert np.all(part[k:] <= part[k])
+
+    argpart_idx = np.argpartition(arr, k, descending=True)
+    argpart = arr[argpart_idx]
+
+    assert argpart[k] == sorted_desc[k]
+
+    if k > 0:
+        assert np.all(argpart[:k] >= argpart[k])
+
+    if k < N - 1:
+        assert np.all(argpart[k:] <= argpart[k])
 
 @pytest.mark.parametrize("N", np.arange(2, 512))
 @pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])


### PR DESCRIPTION
**# Summary**

Adds a `descending` keyword argument to `np.partition`
and `np.argpartition`, analogous to the sorting APIs.

This enables descending-order partition selection without
requiring users to reverse arrays manually.

**## Changes**

* Added `descending` kwarg support to:

np.partition
np.argpartition
Added tests for integer arrays
Verified tests pass locally

**#Testing**
bash
python -m pytest numpy/_core/tests/test_multiarray.py

Local result:

**```text**
17325 passed, 4 skipped
```
