### PR TITLE
fix: preserve dtype metadata for zero-sized void dtypes in array creation

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1458,11 +1458,14 @@ PyArray_ExtractDTypeAndDescriptor(PyArray_Descr *dtype,
     if (dtype != NULL) {
         *out_DType = NPY_DTYPE(dtype);
         Py_INCREF(*out_DType);
-        if (!descr_is_legacy_parametric_instance((PyArray_Descr *)dtype,
-                                                    *out_DType)) {
-            *out_descr = (PyArray_Descr *)dtype;
-            Py_INCREF(*out_descr);
-        }
+        /* Always preserve the descriptor when provided by the user.
+         * Previously, legacy parametric instances (e.g., unsized void dtypes)
+         * were discarded here, but this caused user-specified metadata to be
+         * lost in callers like PyArray_Zeros_int which fall back to
+         * _infer_descr_from_dtype() -- returning the dtype's singleton without
+         * the user's metadata. */
+        *out_descr = (PyArray_Descr *)dtype;
+        Py_INCREF(*out_descr);
     }
 }
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -927,6 +927,18 @@ class TestMetadata:
         d = np.dtype((np.void, np.dtype('i4,i4', metadata={'datum': 1})))
         assert_(d.metadata == {'datum': 1})
 
+    def test_zero_sized_void_dtype_metadata_preserved(self):
+        # Regression test for gh#31436
+        # Metadata on zero-sized void dtypes was silently dropped when
+        # using np.zeros(), np.empty(), and similar array creation functions.
+        d = np.dtype(np.void, 0, metadata={'test': 42})
+        d_zeros = np.zeros(3, dtype=d)
+        d_empty = np.empty(3, dtype=d)
+        d_ones = np.ones(3, dtype=d)
+        assert_(d_zeros.dtype.metadata == {'test': 42}, d_zeros.dtype.metadata)
+        assert_(d_empty.dtype.metadata == {'test': 42}, d_empty.dtype.metadata)
+        assert_(d_ones.dtype.metadata == {'test': 42}, d_ones.dtype.metadata)
+
 class TestString:
     def test_complex_dtype_str(self):
         dt = np.dtype([('top', [('tiles', ('>f4', (64, 64)), (1,)),


### PR DESCRIPTION
## Fix: preserve dtype metadata for zero-sized void dtypes in array creation

Fixes numpy/numpy#31436.

### Problem
When `np.zeros()`, `np.empty()`, etc. were called with a zero-sized void dtype
that had user-specified metadata, the metadata was silently dropped. For example:

```python
d = np.dtype(np.void, 0, metadata={'test': 42})
arr = np.zeros(3, dtype=d)
print(arr.dtype.metadata)  # None — should be {'test': 42}
```

### Root cause
`PyArray_ExtractDTypeAndDescriptor()` classified unsized void dtypes as "legacy
parametric instances" and discarded them, falling back to `_infer_descr_from_dtype()`
which returns the dtype's singleton — without user metadata.

### Fix
Unconditionally preserve the descriptor when provided by the user. The callers
(`PyArray_Zeros_int`, `PyArray_Empty_int`) already handle `NULL` correctly by
falling back to `_infer_descr_from_dtype()`.

### Test
Added `test_zero_sized_void_dtype_metadata_preserved` to `test_dtype.py`.