### PR TITLE
ENH: add cpp based uniform histogram calculation for optimization

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1206,6 +1206,7 @@ src_multiarray = multiarray_gen_headers + [
   'src/multiarray/flagsobject.c',
   'src/multiarray/getset.c',
   'src/multiarray/hashdescr.c',
+  'src/multiarray/histogram.cpp',
   'src/multiarray/item_selection.c',
   'src/multiarray/iterators.c',
   'src/multiarray/legacy_dtype_implementation.c',

--- a/numpy/_core/src/multiarray/histogram.cpp
+++ b/numpy/_core/src/multiarray/histogram.cpp
@@ -1,0 +1,205 @@
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#define _MULTIARRAYMODULE
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include "numpy/arrayobject.h"
+#include "numpy/npy_math.h"
+extern "C" {
+#include "npy_argparse.h"
+}
+#include "common.h"
+
+#include "histogram.h"
+
+static inline void
+accum(npy_intp &out, const npy_intp *, npy_intp) { out++; }
+
+template <typename T>
+static inline void
+accum(T &out, const T *w, npy_intp i) { out += w[i]; }
+
+static inline void
+accum(npy_cdouble &out, const npy_cdouble *w, npy_intp i)
+{
+    npy_csetreal(&out, npy_creal(out) + npy_creal(w[i]));
+    npy_csetimag(&out, npy_cimag(out) + npy_cimag(w[i]));
+}
+
+
+// Helper function to find in which (indiced) uniform bins the data lies
+template <typename FP, typename T>
+static void
+digitize_uniform(
+        const FP *a, const T *weights, npy_intp len,
+        FP first_edge, FP last_edge, npy_intp n_bins,
+        const FP *bin_edges,
+        T *out)
+{
+    // we only calculate the range outside the loop for overflow reasons
+    const FP range = last_edge - first_edge;
+    for (npy_intp i = 0; i < len; i++)
+    {
+        const FP v = a[i];
+        if (!((v >= first_edge) & (v <= last_edge))) continue;
+
+        npy_intp idx = (npy_intp)((v - first_edge) / range * (FP)n_bins);
+        // If the value lies on the last edge, substract one
+        if (NPY_UNLIKELY(idx >= n_bins)) idx = n_bins - 1;
+
+        if (v < bin_edges[idx]) --idx;
+        else if (idx < n_bins - 1 && v >= bin_edges[idx + 1]) ++idx;
+        accum(out[idx], weights, i);
+    }
+}
+
+// Helper function to run digitize_uniform over the data
+template <typename FP, typename T>
+static PyObject *
+make_weighted_digitize(PyArrayObject *a, const FP *bin_edges,
+                   PyArrayObject *weights, npy_intp n_bins,
+                   int typenum)
+{
+    const npy_intp len_a = PyArray_SIZE(a);
+
+    PyArrayObject *out = (PyArrayObject *)PyArray_ZEROS(1, &n_bins, typenum, 0);
+    if (out == NULL) return NULL;
+
+    NPY_BEGIN_THREADS_DEF;
+    NPY_BEGIN_THREADS_THRESHOLDED(len_a);
+    digitize_uniform(
+            (const FP *)PyArray_DATA(a),
+            (const T *)PyArray_DATA(weights), len_a,
+            bin_edges[0], bin_edges[n_bins], n_bins, bin_edges,
+            (T *)PyArray_DATA(out));
+    NPY_END_THREADS;
+    return (PyObject *)out;
+}
+
+template <typename FP>
+static PyObject *
+histogram_uniform_impl(PyArrayObject *a, PyArrayObject *bin_edges_obj,
+                       PyArrayObject *weights, npy_intp n_bins,
+                       int dtype_num)
+{
+    const FP *bin_edges = (const FP *)PyArray_DATA(bin_edges_obj);
+
+    if (weights == NULL) 
+    {
+        const npy_intp len_a = PyArray_SIZE(a);
+        PyArrayObject *out =
+                (PyArrayObject *)PyArray_ZEROS(1, &n_bins, NPY_INTP, 0);
+        if (out == NULL) return NULL;
+
+        NPY_BEGIN_THREADS_DEF;
+        NPY_BEGIN_THREADS_THRESHOLDED(len_a);
+        digitize_uniform<FP, npy_intp>(
+                (const FP *)PyArray_DATA(a),
+                (const npy_intp *)nullptr, len_a,
+                bin_edges[0], bin_edges[n_bins], n_bins, bin_edges,
+                (npy_intp *)PyArray_DATA(out));
+        NPY_END_THREADS;
+        return (PyObject *)out;
+    }
+    if (PyArray_TYPE(weights) == NPY_CDOUBLE) 
+    {
+        return make_weighted_digitize<FP, npy_cdouble>(
+                a, bin_edges, weights, n_bins, NPY_CDOUBLE);
+    }
+    else return make_weighted_digitize<FP, FP>(
+            a, bin_edges, weights, n_bins, dtype_num);
+}
+
+NPY_NO_EXPORT PyObject *
+arr_histogram_uniform(PyObject *NPY_UNUSED(self), PyObject *const *args,
+                      Py_ssize_t len_args, PyObject *kwnames)
+{
+    PyObject *a_obj = NULL;
+    PyObject *n_equal_bins_obj = NULL, *bin_edges_obj = NULL;
+    PyObject *weights_obj = Py_None;
+    PyArrayObject *a = NULL, *bin_edges = NULL, *weights = NULL;
+    npy_intp n_bins;
+    int use_ld, dtype;
+    const int flags = NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS;
+
+    NPY_PREPARE_ARGPARSER;
+    if (npy_parse_arguments("_histogram_uniform", args, len_args, kwnames,
+                {"a",            NULL, &a_obj},
+                {"n_equal_bins", NULL, &n_equal_bins_obj},
+                {"bin_edges",    NULL, &bin_edges_obj},
+                {"weights",     NULL, &weights_obj}) < 0) 
+    {
+        return NULL;
+    }
+
+    use_ld = (PyArray_Check(bin_edges_obj) &&
+              PyArray_TYPE((PyArrayObject *)bin_edges_obj) == NPY_LONGDOUBLE);
+    dtype = use_ld ? NPY_LONGDOUBLE : NPY_DOUBLE;
+
+    a = (PyArrayObject *)PyArray_FROMANY(a_obj, dtype, 1, 1, flags);
+    if (a == NULL) goto fail;
+
+    bin_edges = (PyArrayObject *)PyArray_FROMANY(bin_edges_obj, dtype, 1, 1, flags);
+    if (bin_edges == NULL) goto fail;
+
+    if (weights_obj != Py_None) 
+    {
+        int w_typenum;
+        if (PyArray_Check(weights_obj) &&
+                PyArray_TYPE((PyArrayObject *)weights_obj) == NPY_CDOUBLE)
+            w_typenum = NPY_CDOUBLE;
+        else
+            w_typenum = dtype;
+        weights = (PyArrayObject *)PyArray_FROMANY(
+                weights_obj, w_typenum, 1, 1, flags);
+        if (weights == NULL) goto fail;
+    }
+
+    n_bins = PyArray_PyIntAsIntp(n_equal_bins_obj);
+    if (error_converting(n_bins)) goto fail;
+
+    if (n_bins <= 0) 
+    {
+        PyErr_SetString(PyExc_ValueError, "n_equal_bins must be at least 1");
+        goto fail;
+    }
+    if (PyArray_SIZE(bin_edges) != n_bins + 1) 
+    {
+        PyErr_SetString(PyExc_ValueError, "length of bin_edges must be n_bins + 1");
+        goto fail;
+    }
+
+    if (PyArray_SIZE(a) == 0) 
+    {
+        int out_typenum;
+        if (weights == NULL) out_typenum = NPY_INTP;
+        else if (PyArray_TYPE(weights) == NPY_CDOUBLE) out_typenum = NPY_CDOUBLE;
+        else out_typenum = dtype;
+        PyObject *out = PyArray_ZEROS(1, &n_bins, out_typenum, 0);
+        Py_DECREF(a);
+        Py_DECREF(bin_edges);
+        Py_XDECREF(weights);
+        return out;
+    }
+
+    {
+        PyObject *out;
+        if (use_ld)
+            out = histogram_uniform_impl<npy_longdouble>(
+                    a, bin_edges, weights, n_bins, NPY_LONGDOUBLE);
+        else
+            out = histogram_uniform_impl<npy_double>(
+                    a, bin_edges, weights, n_bins, NPY_DOUBLE);
+        Py_DECREF(a);
+        Py_DECREF(bin_edges);
+        Py_XDECREF(weights);
+        return out;
+    }
+
+fail:
+    Py_XDECREF(a);
+    Py_XDECREF(bin_edges);
+    Py_XDECREF(weights);
+    return NULL;
+}

--- a/numpy/_core/src/multiarray/histogram.cpp
+++ b/numpy/_core/src/multiarray/histogram.cpp
@@ -37,6 +37,13 @@ accum(npy_cdouble &out, const npy_cdouble *w, npy_intp i)
     npy_csetimag(&out, npy_cimag(out) + npy_cimag(w[i]));
 }
 
+static inline void
+accum(npy_clongdouble &out, const npy_clongdouble *w, npy_intp i)
+{
+    npy_csetreall(&out, npy_creall(out) + npy_creall(w[i]));
+    npy_csetimagl(&out, npy_cimagl(out) + npy_cimagl(w[i]));
+}
+
 
 // Helper function to find in which (indiced) uniform bins the data lies
 template <typename FP, typename T>
@@ -126,9 +133,10 @@ histogram_uniform_impl(PyArrayObject *a, PyArrayObject *bin_edges_obj,
         case NPY_HALF:    return make_weighted_digitize<FP, npy_half>   (a, bin_edges, weights, n_bins);
         case NPY_FLOAT:   return make_weighted_digitize<FP, npy_float>  (a, bin_edges, weights, n_bins);
         case NPY_DOUBLE:  return make_weighted_digitize<FP, npy_double> (a, bin_edges, weights, n_bins);
+        case NPY_LONGDOUBLE: return make_weighted_digitize<FP, npy_longdouble>   (a, bin_edges, weights, n_bins);
         case NPY_CFLOAT:  return make_weighted_digitize<FP, npy_cfloat> (a, bin_edges, weights, n_bins);
         case NPY_CDOUBLE:    return make_weighted_digitize<FP, npy_cdouble>   (a, bin_edges, weights, n_bins);
-        case NPY_LONGDOUBLE: return make_weighted_digitize<FP, npy_longdouble>(a, bin_edges, weights, n_bins);
+        case NPY_CLONGDOUBLE:   return make_weighted_digitize<FP, npy_clongdouble>  (a, bin_edges, weights, n_bins);
         default:
             PyErr_SetString(PyExc_TypeError, "unsupported weights dtype");
             return NULL;

--- a/numpy/_core/src/multiarray/histogram.cpp
+++ b/numpy/_core/src/multiarray/histogram.cpp
@@ -127,7 +127,8 @@ histogram_uniform_impl(PyArrayObject *a, PyArrayObject *bin_edges_obj,
         case NPY_FLOAT:   return make_weighted_digitize<FP, npy_float>  (a, bin_edges, weights, n_bins);
         case NPY_DOUBLE:  return make_weighted_digitize<FP, npy_double> (a, bin_edges, weights, n_bins);
         case NPY_CFLOAT:  return make_weighted_digitize<FP, npy_cfloat> (a, bin_edges, weights, n_bins);
-        case NPY_CDOUBLE: return make_weighted_digitize<FP, npy_cdouble>(a, bin_edges, weights, n_bins);
+        case NPY_CDOUBLE:    return make_weighted_digitize<FP, npy_cdouble>   (a, bin_edges, weights, n_bins);
+        case NPY_LONGDOUBLE: return make_weighted_digitize<FP, npy_longdouble>(a, bin_edges, weights, n_bins);
         default:
             PyErr_SetString(PyExc_TypeError, "unsupported weights dtype");
             return NULL;

--- a/numpy/_core/src/multiarray/histogram.cpp
+++ b/numpy/_core/src/multiarray/histogram.cpp
@@ -13,12 +13,22 @@ extern "C" {
 
 #include "histogram.h"
 
-static inline void
-accum(npy_intp &out, const npy_intp *, npy_intp) { out++; }
-
 template <typename T>
 static inline void
-accum(T &out, const T *w, npy_intp i) { out += w[i]; }
+accum(T &out, const T *w, npy_intp i)
+{
+    if (w != nullptr)
+        out += w[i];
+    else
+        out++;
+}
+
+static inline void
+accum(npy_cfloat &out, const npy_cfloat *w, npy_intp i)
+{
+    npy_csetrealf(&out, npy_crealf(out) + npy_crealf(w[i]));
+    npy_csetimagf(&out, npy_cimagf(out) + npy_cimagf(w[i]));
+}
 
 static inline void
 accum(npy_cdouble &out, const npy_cdouble *w, npy_intp i)
@@ -58,12 +68,12 @@ digitize_uniform(
 template <typename FP, typename T>
 static PyObject *
 make_weighted_digitize(PyArrayObject *a, const FP *bin_edges,
-                   PyArrayObject *weights, npy_intp n_bins,
-                   int typenum)
+                   PyArrayObject *weights, npy_intp n_bins)
 {
     const npy_intp len_a = PyArray_SIZE(a);
 
-    PyArrayObject *out = (PyArrayObject *)PyArray_ZEROS(1, &n_bins, typenum, 0);
+    PyArrayObject *out = (PyArrayObject *)PyArray_ZEROS(
+            1, &n_bins, PyArray_TYPE(weights), 0);
     if (out == NULL) return NULL;
 
     NPY_BEGIN_THREADS_DEF;
@@ -80,12 +90,11 @@ make_weighted_digitize(PyArrayObject *a, const FP *bin_edges,
 template <typename FP>
 static PyObject *
 histogram_uniform_impl(PyArrayObject *a, PyArrayObject *bin_edges_obj,
-                       PyArrayObject *weights, npy_intp n_bins,
-                       int dtype_num)
+                       PyArrayObject *weights, npy_intp n_bins)
 {
     const FP *bin_edges = (const FP *)PyArray_DATA(bin_edges_obj);
 
-    if (weights == NULL) 
+    if (weights == NULL)
     {
         const npy_intp len_a = PyArray_SIZE(a);
         PyArrayObject *out =
@@ -102,13 +111,27 @@ histogram_uniform_impl(PyArrayObject *a, PyArrayObject *bin_edges_obj,
         NPY_END_THREADS;
         return (PyObject *)out;
     }
-    if (PyArray_TYPE(weights) == NPY_CDOUBLE) 
+
+    switch (PyArray_TYPE(weights))
     {
-        return make_weighted_digitize<FP, npy_cdouble>(
-                a, bin_edges, weights, n_bins, NPY_CDOUBLE);
+        case NPY_BOOL:    return make_weighted_digitize<FP, npy_bool>   (a, bin_edges, weights, n_bins);
+        case NPY_INT8:    return make_weighted_digitize<FP, npy_int8>   (a, bin_edges, weights, n_bins);
+        case NPY_INT16:   return make_weighted_digitize<FP, npy_int16>  (a, bin_edges, weights, n_bins);
+        case NPY_INT32:   return make_weighted_digitize<FP, npy_int32>  (a, bin_edges, weights, n_bins);
+        case NPY_INT64:   return make_weighted_digitize<FP, npy_int64>  (a, bin_edges, weights, n_bins);
+        case NPY_UINT8:   return make_weighted_digitize<FP, npy_uint8>  (a, bin_edges, weights, n_bins);
+        case NPY_UINT16:  return make_weighted_digitize<FP, npy_uint16> (a, bin_edges, weights, n_bins);
+        case NPY_UINT32:  return make_weighted_digitize<FP, npy_uint32> (a, bin_edges, weights, n_bins);
+        case NPY_UINT64:  return make_weighted_digitize<FP, npy_uint64> (a, bin_edges, weights, n_bins);
+        case NPY_HALF:    return make_weighted_digitize<FP, npy_half>   (a, bin_edges, weights, n_bins);
+        case NPY_FLOAT:   return make_weighted_digitize<FP, npy_float>  (a, bin_edges, weights, n_bins);
+        case NPY_DOUBLE:  return make_weighted_digitize<FP, npy_double> (a, bin_edges, weights, n_bins);
+        case NPY_CFLOAT:  return make_weighted_digitize<FP, npy_cfloat> (a, bin_edges, weights, n_bins);
+        case NPY_CDOUBLE: return make_weighted_digitize<FP, npy_cdouble>(a, bin_edges, weights, n_bins);
+        default:
+            PyErr_SetString(PyExc_TypeError, "unsupported weights dtype");
+            return NULL;
     }
-    else return make_weighted_digitize<FP, FP>(
-            a, bin_edges, weights, n_bins, dtype_num);
 }
 
 NPY_NO_EXPORT PyObject *
@@ -128,7 +151,7 @@ arr_histogram_uniform(PyObject *NPY_UNUSED(self), PyObject *const *args,
                 {"a",            NULL, &a_obj},
                 {"n_equal_bins", NULL, &n_equal_bins_obj},
                 {"bin_edges",    NULL, &bin_edges_obj},
-                {"weights",     NULL, &weights_obj}) < 0) 
+                {"weights",     NULL, &weights_obj}) < 0)
     {
         return NULL;
     }
@@ -143,39 +166,29 @@ arr_histogram_uniform(PyObject *NPY_UNUSED(self), PyObject *const *args,
     bin_edges = (PyArrayObject *)PyArray_FROMANY(bin_edges_obj, dtype, 1, 1, flags);
     if (bin_edges == NULL) goto fail;
 
-    if (weights_obj != Py_None) 
+    if (weights_obj != Py_None)
     {
-        int w_typenum;
-        if (PyArray_Check(weights_obj) &&
-                PyArray_TYPE((PyArrayObject *)weights_obj) == NPY_CDOUBLE)
-            w_typenum = NPY_CDOUBLE;
-        else
-            w_typenum = dtype;
-        weights = (PyArrayObject *)PyArray_FROMANY(
-                weights_obj, w_typenum, 1, 1, flags);
+        weights = (PyArrayObject *)PyArray_FROM_OF(weights_obj, flags);
         if (weights == NULL) goto fail;
     }
 
     n_bins = PyArray_PyIntAsIntp(n_equal_bins_obj);
     if (error_converting(n_bins)) goto fail;
 
-    if (n_bins <= 0) 
+    if (n_bins <= 0)
     {
         PyErr_SetString(PyExc_ValueError, "n_equal_bins must be at least 1");
         goto fail;
     }
-    if (PyArray_SIZE(bin_edges) != n_bins + 1) 
+    if (PyArray_SIZE(bin_edges) != n_bins + 1)
     {
         PyErr_SetString(PyExc_ValueError, "length of bin_edges must be n_bins + 1");
         goto fail;
     }
 
-    if (PyArray_SIZE(a) == 0) 
+    if (PyArray_SIZE(a) == 0)
     {
-        int out_typenum;
-        if (weights == NULL) out_typenum = NPY_INTP;
-        else if (PyArray_TYPE(weights) == NPY_CDOUBLE) out_typenum = NPY_CDOUBLE;
-        else out_typenum = dtype;
+        int out_typenum = (weights == NULL) ? NPY_INTP : PyArray_TYPE(weights);
         PyObject *out = PyArray_ZEROS(1, &n_bins, out_typenum, 0);
         Py_DECREF(a);
         Py_DECREF(bin_edges);
@@ -186,11 +199,9 @@ arr_histogram_uniform(PyObject *NPY_UNUSED(self), PyObject *const *args,
     {
         PyObject *out;
         if (use_ld)
-            out = histogram_uniform_impl<npy_longdouble>(
-                    a, bin_edges, weights, n_bins, NPY_LONGDOUBLE);
+            out = histogram_uniform_impl<npy_longdouble>(a, bin_edges, weights, n_bins);
         else
-            out = histogram_uniform_impl<npy_double>(
-                    a, bin_edges, weights, n_bins, NPY_DOUBLE);
+            out = histogram_uniform_impl<npy_double>(a, bin_edges, weights, n_bins);
         Py_DECREF(a);
         Py_DECREF(bin_edges);
         Py_XDECREF(weights);

--- a/numpy/_core/src/multiarray/histogram.h
+++ b/numpy/_core/src/multiarray/histogram.h
@@ -1,0 +1,17 @@
+#ifndef NUMPY_CORE_SRC_MULTIARRAY_HISTOGRAM_H_
+#define NUMPY_CORE_SRC_MULTIARRAY_HISTOGRAM_H_
+
+#include "numpy/ndarraytypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NPY_NO_EXPORT PyObject *
+arr_histogram_uniform(PyObject *, PyObject *const *, Py_ssize_t, PyObject *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* NUMPY_CORE_SRC_MULTIARRAY_HISTOGRAM_H_ */

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -83,7 +83,7 @@ NPY_NO_EXPORT int NPY_NUMUSERTYPES = 0;
 #include "npy_dlpack.h"
 
 #include "umathmodule.h"
-
+#include "histogram.h"
 #include "unique.h"
 
 /*
@@ -4671,6 +4671,8 @@ static struct PyMethodDef array_module_methods[] = {
         "Insert vals sequentially into equivalent 1-d positions "
         "indicated by mask."},
     {"bincount", (PyCFunction)arr_bincount,
+        METH_FASTCALL | METH_KEYWORDS, NULL},
+    {"_histogram_uniform", (PyCFunction)arr_histogram_uniform,
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"_monotonicity", (PyCFunction)arr__monotonicity,
         METH_VARARGS | METH_KEYWORDS, NULL},

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -806,7 +806,7 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     # of weight
     simple_weights = (
         weights is None or
-        np.can_cast(weights.dtype, np.double) or
+        np.can_cast(weights.dtype, np.longdouble) or
         np.can_cast(weights.dtype, complex)
     )
 

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -811,37 +811,8 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     )
 
     if uniform_bins is not None and simple_weights:
-        first_edge, last_edge, n_equal_bins = uniform_bins
-
-        # When bin_edges are longdouble, preserve that precision end-to-end so
-        # that values within one longdouble-epsilon of a boundary land in the
-        # correct bin.  Otherwise cast everything to float64.
-        if bin_edges.dtype == np.longdouble:
-            a_cast = a.astype(np.longdouble, copy=False)
-            bin_edges_cast = bin_edges
-            if weights is None:
-                w_cast = None
-            elif ntype.kind == 'c':
-                w_cast = weights.astype(np.complex128, copy=False)
-            else:
-                w_cast = weights.astype(np.longdouble, copy=False)
-        else:
-            a_cast = a.astype(np.float64, copy=False)
-            bin_edges_cast = bin_edges.astype(np.float64, copy=False)
-            if weights is None:
-                w_cast = None
-            elif ntype.kind == 'c':
-                w_cast = weights.astype(np.complex128, copy=False)
-            else:
-                w_cast = weights.astype(np.float64, copy=False)
-
-        n = _histogram_uniform(a_cast, n_equal_bins, bin_edges_cast, w_cast)
-
-        # _histogram_uniform returns intp (no weights), float64/longdouble
-        # (real weights), or complex128 (complex weights).  Cast back when the
-        # caller requested a narrower dtype.
-        if weights is not None:
-            n = n.astype(ntype, copy=False)
+        n_equal_bins = uniform_bins[2]
+        n = _histogram_uniform(a, n_equal_bins, bin_edges, weights)
     else:
         # Compute via cumulative histogram
         cum_n = np.zeros(bin_edges.shape, ntype)

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -807,7 +807,7 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     simple_weights = (
         weights is None or
         np.can_cast(weights.dtype, np.longdouble) or
-        np.can_cast(weights.dtype, complex)
+        np.can_cast(weights.dtype, np.clongdouble)
     )
 
     if uniform_bins is not None and simple_weights:

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -8,6 +8,7 @@ import warnings
 
 import numpy as np
 from numpy._core import overrides
+from numpy._core._multiarray_umath import _histogram_uniform
 
 __all__ = ['histogram', 'histogramdd', 'histogram_bin_edges']
 
@@ -810,67 +811,37 @@ def histogram(a, bins=10, range=None, density=None, weights=None):
     )
 
     if uniform_bins is not None and simple_weights:
-        # Fast algorithm for equal bins
-        # We now convert values of a to bin indices, under the assumption of
-        # equal bin widths (which is valid here).
         first_edge, last_edge, n_equal_bins = uniform_bins
 
-        # Initialize empty histogram
-        n = np.zeros(n_equal_bins, ntype)
-
-        # Pre-compute histogram scaling factor
-        norm_numerator = n_equal_bins
-        norm_denom = _unsigned_subtract(last_edge, first_edge)
-
-        # We iterate over blocks here for two reasons: the first is that for
-        # large arrays, it is actually faster (for example for a 10^8 array it
-        # is 2x as fast) and it results in a memory footprint 3x lower in the
-        # limit of large arrays.
-        for i in _range(0, len(a), BLOCK):
-            tmp_a = a[i:i + BLOCK]
+        # When bin_edges are longdouble, preserve that precision end-to-end so
+        # that values within one longdouble-epsilon of a boundary land in the
+        # correct bin.  Otherwise cast everything to float64.
+        if bin_edges.dtype == np.longdouble:
+            a_cast = a.astype(np.longdouble, copy=False)
+            bin_edges_cast = bin_edges
             if weights is None:
-                tmp_w = None
+                w_cast = None
+            elif ntype.kind == 'c':
+                w_cast = weights.astype(np.complex128, copy=False)
             else:
-                tmp_w = weights[i:i + BLOCK]
-
-            # Only include values in the right range
-            keep = (tmp_a >= first_edge)
-            keep &= (tmp_a <= last_edge)
-            if not np.logical_and.reduce(keep):
-                tmp_a = tmp_a[keep]
-                if tmp_w is not None:
-                    tmp_w = tmp_w[keep]
-
-            # This cast ensures no type promotions occur below, which gh-10322
-            # make unpredictable. Getting it wrong leads to precision errors
-            # like gh-8123.
-            tmp_a = tmp_a.astype(bin_edges.dtype, copy=False)
-
-            # Compute the bin indices, and for values that lie exactly on
-            # last_edge we need to subtract one
-            f_indices = ((_unsigned_subtract(tmp_a, first_edge) / norm_denom)
-                         * norm_numerator)
-            indices = f_indices.astype(np.intp)
-            indices[indices == n_equal_bins] -= 1
-
-            # The index computation is not guaranteed to give exactly
-            # consistent results within ~1 ULP of the bin edges.
-            decrement = tmp_a < bin_edges[indices]
-            indices[decrement] -= 1
-            # The last bin includes the right edge. The other bins do not.
-            increment = ((tmp_a >= bin_edges[indices + 1])
-                         & (indices != n_equal_bins - 1))
-            indices[increment] += 1
-
-            # We now compute the histogram using bincount
-            if ntype.kind == 'c':
-                n.real += np.bincount(indices, weights=tmp_w.real,
-                                      minlength=n_equal_bins)
-                n.imag += np.bincount(indices, weights=tmp_w.imag,
-                                      minlength=n_equal_bins)
+                w_cast = weights.astype(np.longdouble, copy=False)
+        else:
+            a_cast = a.astype(np.float64, copy=False)
+            bin_edges_cast = bin_edges.astype(np.float64, copy=False)
+            if weights is None:
+                w_cast = None
+            elif ntype.kind == 'c':
+                w_cast = weights.astype(np.complex128, copy=False)
             else:
-                n += np.bincount(indices, weights=tmp_w,
-                                 minlength=n_equal_bins).astype(ntype)
+                w_cast = weights.astype(np.float64, copy=False)
+
+        n = _histogram_uniform(a_cast, n_equal_bins, bin_edges_cast, w_cast)
+
+        # _histogram_uniform returns intp (no weights), float64/longdouble
+        # (real weights), or complex128 (complex weights).  Cast back when the
+        # caller requested a narrower dtype.
+        if weights is not None:
+            n = n.astype(ntype, copy=False)
     else:
         # Compute via cumulative histogram
         cum_n = np.zeros(bin_edges.shape, ntype)


### PR DESCRIPTION
Related: https://github.com/numpy/numpy/pull/9910
### PR summary
This PR makes the fast path of the histogram significantly fast. The current benchmark vs main:
```
| Change   | Before [fefe4f5f] <main>   | After [fa366b8a] <hist-C>   |   Ratio | Benchmark (Parameter)                               |
|----------|----------------------------|-----------------------------|---------|-----------------------------------------------------|
| -        | 61.4±1μs                   | 40.4±0.7μs                  |    0.66 | bench_function_base.Histogram1D.time_small_coverage |
| -        | 883±40μs                   | 170±0.9μs                   |    0.19 | bench_function_base.Histogram1D.time_fine_binning   |
| -        | 861±40μs                   | 156±1μs                     |    0.18 | bench_function_base.Histogram1D.time_full_coverage  |
```
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
1) Introduces a optimization  that were first discussed in https://github.com/numpy/numpy/pull/9910
2) Fixes a (unknown?) bug where `histogram` would not go fast path for long double
3) adds new histogram files (which I am not sure if it is a good idea). this is mainly because it is possible to make histogram way more faster than this PR and histogram is a important function so I think it deserves its own file?

### Other comments
I want to discuss this with someone experienced before I refine, implement the logic further into multidimensional case (for histogramdd). I tried to make the code look like other C files as much as possible (not sure if its smart thing to do)

I also feel like histogram deserves a couple of more benchmarks (especially for the slow path)

#### AI Disclosure
Claude was used as an AI tool.
Some parts (e.g template bodies) are written by me, some are recycled from the old python code, some are  recycled from old PR (e.g error handling, numpy API etc) and some are written by AI  (especially the weight type parts) and reviewed manually.
AI was also used extensively on Numpy API/Cpython specific parts, in parallel I have read some documentation and checked if I used them correctly, so be warned
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
