### PR TITLE
DOC/NEP: promote RISC-V to a Tier 3 platform in NEP 57

### DIFF
--- a/doc/neps/nep-0057-numpy-platform-support.rst
+++ b/doc/neps/nep-0057-numpy-platform-support.rst
@@ -233,6 +233,9 @@ Tier 3 platforms:
 | Emscripten/Pyodide | We currently provide nightly wheels,   | Agriya Khetarpal, Gyeongjae Choi |
 |                    | used for interactive docs              |                                  |
 +--------------------+----------------------------------------+----------------------------------+
+| RISC-V             | Runs on RISE-provided self-hosted      | Ludovic Henry, Bruno Verachten   |
+|                    | runners, see gh-30216_                 |                                  |
++--------------------+----------------------------------------+----------------------------------+
 
 
 Unsupported platforms
@@ -274,8 +277,6 @@ Unsupported platforms (known interest in moving to a higher tier):
 | iOS      | See gh-28759_    |
 +----------+------------------+
 | Android  | See gh-30412_    |
-+----------+------------------+
-| RISC-V   | See gh-30216_    |
 +----------+------------------+
 | WASI     | See gh-25859_    |
 +----------+------------------+


### PR DESCRIPTION
Mailing list message linked from gh-30216, everyone was in favor. Now that we have a running CI job after gh-31488 was merged, we can update the NEP entry.

[skip actions]

#### AI Disclosure

No AI tools used