### PR TITLE
DOC: clarify two stage callback workflow in F2PY

### DIFF
--- a/doc/source/f2py/python-usage.rst
+++ b/doc/source/f2py/python-usage.rst
@@ -244,6 +244,23 @@ In Python:
 .. literalinclude:: ./code/results/extcallback_session.dat
   :language: python
 
+Two-stage callback workflows
+----------------------------
+
+For larger Fortran codebases, it is common to keep most host-side logic in a
+prebuilt Fortran library and expose only the Python-facing entry points through
+F2PY. A callback-facing interface can still be used in this setup:
+
+* Python callback registration happens at the final Python/F2PY boundary.
+* Callback invocation may happen later in deeper Fortran routines.
+* The callback-facing interface can participate in both the host-library build
+  and the final F2PY wrapping step.
+
+In this pattern, the generated ``.pyf`` typically needs to expose the
+Python-facing entry point(s) and callback-facing interface signatures, while
+deeper host-side routines remain outside signature generation and are linked in
+as part of the host library.
+
 .. note::
 
    When using modified Fortran code via ``callstatement`` or other directives,

--- a/doc/source/f2py/python-usage.rst
+++ b/doc/source/f2py/python-usage.rst
@@ -244,6 +244,29 @@ In Python:
 .. literalinclude:: ./code/results/extcallback_session.dat
   :language: python
 
+Two-stage callback workflows
+----------------------------
+
+In some Fortran codebases, a Python-facing entry point calls one or more
+deeper Fortran routines, and it is the deeper routine that ultimately invokes
+the Python callback. The existing ``extcallback.f`` example already
+demonstrates this pattern: ``f1`` (the entry point) calls ``f2``, and ``f2``
+is where the ``fpy`` callback is declared and invoked.
+
+The key constraint is that **F2PY only generates a callback trampoline for
+routines that appear in the wrapping step**, either directly or via a
+``cf2py intent(callback)`` directive. A deeper Fortran routine that never
+appears in the F2PY signature file has no trampoline, and the callback cannot
+reach it through module assignment alone. Therefore:
+
+* The routine that declares and calls the callback (e.g. ``f2``) must be
+  included in the F2PY wrapping step (via ``cf2py`` directives or the
+  ``.pyf`` signature file).
+* Pure host-library routines that do not themselves invoke callbacks can
+  remain outside signature generation and be linked in externally.
+* Python callback registration still happens at the final Python/F2PY
+  boundary, but the callback-bearing routine must be visible to F2PY.
+
 .. note::
 
    When using modified Fortran code via ``callstatement`` or other directives,

--- a/doc/source/f2py/signature-file.rst
+++ b/doc/source/f2py/signature-file.rst
@@ -181,6 +181,11 @@ Use statements
 * Currently F2PY uses ``use`` statements only for linking call-back modules and
   ``external`` arguments (call-back functions). See :ref:`Call-back arguments`.
 
+  In larger staged builds, this same mechanism can be used when callback
+  registration is done at the final Python/F2PY boundary while callback
+  invocation happens later in deeper Fortran routines linked from a prebuilt
+  host library. See also :ref:`Call-back arguments`.
+
 Common block statements
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -60,6 +60,9 @@ current directory.
 Here ``<fortran files>`` may also contain signature files. Among other options
 (see below), the following options can be used in this mode:
 
+For callback-related staged workflows that use signature files, see
+:ref:`Call-back arguments`.
+
 ``--debug-capi``
   Adds debugging hooks to the extension module. When using this extension
   module, various diagnostic information about the wrapper is written to the


### PR DESCRIPTION
### PR summary

This PR clarifies an existing F2PY documentation gap around callback usage in larger Fortran projects.

It adds a concise description of a two stage callback workflow in which:

- Python callback registration happens at the final Python F2PY boundary
- callback invocation can occur later in deeper Fortran routines
- callback-facing interface can be used in both the host-library build and the final F2PY wrapping step depending on how the Fortran codebase is structured and linked
- only boundary routines and callback interfaces need to be exposed in pyf generation, while deeper host logic can remain linked externally

The goal is to improve discoverability and reduce ambiguity without changing runtime behavior or introducing new backend guarantees.

Related issues:
- gh-31248
- context only: gh-31249

### First time committer introduction

I use NumPy for ML and scientific workflows, and I am trying to contribute long term to core scientific Python tooling. I picked this issue because it improves clarity for users integrating Python callbacks with larger existing Fortran codebases, which is a practical pattern in real projects.

#### AI Disclosure

I used AI assistance to help draft and refine documentation text and PR wording. I reviewed and edited all final content manually before submission. No runtime code changes were introduced.