### PR TITLE
MAINT: Bump the python-deps group in /requirements with 3 updates

### DIFF
--- a/requirements/delvewheel_requirements.txt
+++ b/requirements/delvewheel_requirements.txt
@@ -1,1 +1,1 @@
-delvewheel==1.12.0 ; sys_platform == 'win32'
+delvewheel==1.12.1 ; sys_platform == 'win32'

--- a/requirements/linter_requirements.txt
+++ b/requirements/linter_requirements.txt
@@ -1,5 +1,5 @@
 # keep in sync with `environment.yml`
 cython-lint
-ruff==0.15.12
-GitPython>=3.1.49
+ruff==0.15.13
+GitPython>=3.1.50
 spin

--- a/requirements/release_requirements.txt
+++ b/requirements/release_requirements.txt
@@ -3,7 +3,7 @@
 
 # changelog.py
 pygithub
-gitpython>=3.1.49
+gitpython>=3.1.50
 
 # uploading release documentation
 packaging


### PR DESCRIPTION
Backport of #31519.

Updates the requirements on [gitpython](https://github.com/gitpython-developers/GitPython), [ruff](https://github.com/astral-sh/ruff) and [delvewheel](https://github.com/adang1345/delvewheel) to permit the latest version.

Updates `gitpython` to 3.1.50
- [Release notes](https://github.com/gitpython-developers/GitPython/releases)
- [Changelog](https://github.com/gitpython-developers/GitPython/blob/main/CHANGES)
- [Commits](https://github.com/gitpython-developers/GitPython/compare/3.1.49...3.1.50)

Updates `ruff` from 0.15.12 to 0.15.13
- [Release notes](https://github.com/astral-sh/ruff/releases)
- [Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md)
- [Commits](https://github.com/astral-sh/ruff/compare/0.15.12...0.15.13)

Updates `delvewheel` from 1.12.0 to 1.12.1
- [Changelog](https://github.com/adang1345/delvewheel/blob/master/CHANGELOG.md)
- [Commits](https://github.com/adang1345/delvewheel/commits)

---
updated-dependencies:
- dependency-name: gitpython dependency-version: 3.1.50 dependency-type: direct:production dependency-group: python-deps
- dependency-name: ruff dependency-version: 0.15.13 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: python-deps
- dependency-name: delvewheel dependency-version: 1.12.1 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: python-deps ...

