### PR TITLE
BUG: Avoid heap buffer overflow for stringdtype searchsorted

### DIFF
--- a/numpy/_core/src/common/npy_binsearch.h
+++ b/numpy/_core/src/common/npy_binsearch.h
@@ -10,16 +10,21 @@
 extern "C" {
 #endif
 
+typedef int (PyArray_BinSearchCompareFunc)(const void*, const void*,
+                                           PyArrayObject*, PyArrayObject*);
+
 typedef void (PyArray_BinSearchFunc)(const char*, const char*, char*,
                                      npy_intp, npy_intp,
                                      npy_intp, npy_intp, npy_intp,
-                                     PyArrayObject*);
+                                     PyArrayObject*, PyArrayObject*,
+                                     PyArray_BinSearchCompareFunc*);
 
 typedef int (PyArray_ArgBinSearchFunc)(const char*, const char*,
                                        const char*, char*,
                                        npy_intp, npy_intp, npy_intp,
                                        npy_intp, npy_intp, npy_intp,
-                                       PyArrayObject*);
+                                       PyArrayObject*, PyArrayObject*,
+                                       PyArray_BinSearchCompareFunc*);
 
 NPY_NO_EXPORT PyArray_BinSearchFunc* get_binsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side);
 NPY_NO_EXPORT PyArray_ArgBinSearchFunc* get_argbinsearch_func(PyArray_Descr *dtype, NPY_SEARCHSIDE side);

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -35,6 +35,8 @@
 #include "array_coercion.h"
 #include "simd/simd.h"
 
+#include "stringdtype/dtype.h"
+
 static NPY_GCC_OPT_3 inline int
 npy_fasttake_impl(
         char *dest, char *src, const npy_intp *indices,
@@ -2061,6 +2063,16 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
 }
 
 
+static int
+binsearch_compare_default(const void *a, const void *b,
+                          PyArrayObject *arr_a, PyArrayObject *NPY_UNUSED(arr_b))
+{
+    PyArray_CompareFunc *compare =
+            PyDataType_GetArrFuncs(PyArray_DESCR(arr_a))->compare;
+    return compare(a, b, arr_a);
+}
+
+
 /*NUMPY_API
  *
  * Search the sorted array op1 for the location of the items in op2. The
@@ -2193,21 +2205,36 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
         goto fail;
     }
 
+    /*
+     * TODO: add a way to register per-dtype searchsorted loops and move all this
+     * stringdtype-specific code into a loop defined for StringDType
+     */
+    int error = 0;
+    PyArray_Descr *cmp_descrs[2] = {PyArray_DESCR(ap1), PyArray_DESCR(ap2)};
+    npy_string_allocator *allocators[2] = {NULL, NULL};
+
+    PyArray_BinSearchCompareFunc *cmp_func = &binsearch_compare_default;
+    if (NPY_DTYPE(PyArray_DESCR(ap2)) == &PyArray_StringDType) {
+        cmp_func = &stringdtype_binsearch_compare;
+    }
+
+    NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(ap2));
+
+    if (NPY_DTYPE(PyArray_DESCR(ap2)) == &PyArray_StringDType) {
+        NpyString_acquire_allocators(2, cmp_descrs, allocators);
+    }
+
     if (ap3 == NULL) {
         /* do regular binsearch */
-        NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(ap2));
         binsearch((const char *)PyArray_DATA(ap1),
                   (const char *)PyArray_DATA(ap2),
                   (char *)PyArray_DATA(ret),
                   PyArray_SIZE(ap1), PyArray_SIZE(ap2),
                   PyArray_STRIDES(ap1)[0], PyArray_ITEMSIZE(ap2),
-                  NPY_SIZEOF_INTP, ap2);
-        NPY_END_THREADS_DESCR(PyArray_DESCR(ap2));
+                  NPY_SIZEOF_INTP, ap2, ap1, cmp_func);
     }
     else {
         /* do binsearch with a sorter array */
-        int error = 0;
-        NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(ap2));
         error = argbinsearch((const char *)PyArray_DATA(ap1),
                              (const char *)PyArray_DATA(ap2),
                              (const char *)PyArray_DATA(sorter),
@@ -2215,13 +2242,21 @@ PyArray_SearchSorted(PyArrayObject *op1, PyObject *op2,
                              PyArray_SIZE(ap1), PyArray_SIZE(ap2),
                              PyArray_STRIDES(ap1)[0],
                              PyArray_ITEMSIZE(ap2),
-                             PyArray_STRIDES(sorter)[0], NPY_SIZEOF_INTP, ap2);
-        NPY_END_THREADS_DESCR(PyArray_DESCR(ap2));
-        if (error < 0) {
-            PyErr_SetString(PyExc_ValueError,
-                        "Sorter index out of range.");
-            goto fail;
-        }
+                             PyArray_STRIDES(sorter)[0], NPY_SIZEOF_INTP, ap2,
+                             ap1, cmp_func);
+    }
+
+    if (NPY_DTYPE(PyArray_DESCR(ap2)) == &PyArray_StringDType) {
+        NpyString_release_allocators(2, allocators);
+    }
+
+    NPY_END_THREADS_DESCR(PyArray_DESCR(ap2));
+
+    if (error < 0) {
+        PyErr_SetString(PyExc_ValueError, "Sorter index out of range.");
+        goto fail;
+    }
+    if (ap3 != NULL) {
         Py_DECREF(ap3);
         Py_DECREF(sorter);
     }

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -512,6 +512,15 @@ _compare(void *a, void *b, PyArray_StringDTypeObject *descr_a,
     return NpyString_cmp(&s_a, &s_b);
 }
 
+NPY_NO_EXPORT int
+stringdtype_binsearch_compare(const void *a, const void *b,
+                              PyArrayObject *arr_a, PyArrayObject *arr_b)
+{
+    return _compare((void *)a, (void *)b,
+                    (PyArray_StringDTypeObject *)PyArray_DESCR(arr_a),
+                    (PyArray_StringDTypeObject *)PyArray_DESCR(arr_b));
+}
+
 int
 _sort_compare(const void *a, const void *b, void *context)
 {

--- a/numpy/_core/src/multiarray/stringdtype/dtype.h
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.h
@@ -26,6 +26,10 @@ _compare(void *a, void *b, PyArray_StringDTypeObject *descr_a,
          PyArray_StringDTypeObject *descr_b);
 
 NPY_NO_EXPORT int
+stringdtype_binsearch_compare(const void *a, const void *b,
+                              PyArrayObject *arr_a, PyArrayObject *arr_b);
+
+NPY_NO_EXPORT int
 init_string_na_object(PyObject *mod);
 
 NPY_NO_EXPORT int

--- a/numpy/_core/src/npysort/binsearch.cpp
+++ b/numpy/_core/src/npysort/binsearch.cpp
@@ -60,7 +60,8 @@ template <class Tag, side_t side>
 static void
 binsearch(const char *arr, const char *key, char *ret, npy_intp arr_len,
           npy_intp key_len, npy_intp arr_str, npy_intp key_str,
-          npy_intp ret_str, PyArrayObject *)
+          npy_intp ret_str, PyArrayObject *, PyArrayObject *,
+          PyArray_BinSearchCompareFunc *)
 {
     using T = typename Tag::type;
     auto cmp = side_to_cmp<Tag, side>::value;
@@ -177,7 +178,7 @@ static int
 argbinsearch(const char *arr, const char *key, const char *sort, char *ret,
              npy_intp arr_len, npy_intp key_len, npy_intp arr_str,
              npy_intp key_str, npy_intp sort_str, npy_intp ret_str,
-             PyArrayObject *)
+             PyArrayObject *, PyArrayObject *, PyArray_BinSearchCompareFunc *)
 {
     using T = typename Tag::type;
     auto cmp = side_to_cmp<Tag, side>::value;
@@ -244,10 +245,10 @@ template <side_t side>
 static void
 npy_binsearch(const char *arr, const char *key, char *ret, npy_intp arr_len,
               npy_intp key_len, npy_intp arr_str, npy_intp key_str,
-              npy_intp ret_str, PyArrayObject *cmp)
+              npy_intp ret_str, PyArrayObject *key_arr, PyArrayObject *arr_arr,
+              PyArray_BinSearchCompareFunc *compare)
 {
     using Cmp = typename side_to_generic_cmp<side>::type;
-    PyArray_CompareFunc *compare = PyDataType_GetArrFuncs(PyArray_DESCR(cmp))->compare;
     npy_intp min_idx = 0;
     npy_intp max_idx = arr_len;
     const char *last_key = key;
@@ -258,7 +259,8 @@ npy_binsearch(const char *arr, const char *key, char *ret, npy_intp arr_len,
          * gives the search a big boost when keys are sorted, but slightly
          * slows down things for purely random ones.
          */
-        if (Cmp{}(compare(last_key, key, cmp), 0)) {
+        /* last_key and key are both elements of the key array */
+        if (Cmp{}(compare(last_key, key, key_arr, key_arr), 0)) {
             max_idx = arr_len;
         }
         else {
@@ -272,7 +274,8 @@ npy_binsearch(const char *arr, const char *key, char *ret, npy_intp arr_len,
             const npy_intp mid_idx = min_idx + ((max_idx - min_idx) >> 1);
             const char *arr_ptr = arr + mid_idx * arr_str;
 
-            if (Cmp{}(compare(arr_ptr, key, cmp), 0)) {
+            /* arr_ptr belongs to the haystack, key to the key array */
+            if (Cmp{}(compare(arr_ptr, key, arr_arr, key_arr), 0)) {
                 min_idx = mid_idx + 1;
             }
             else {
@@ -288,10 +291,10 @@ static int
 npy_argbinsearch(const char *arr, const char *key, const char *sort, char *ret,
                  npy_intp arr_len, npy_intp key_len, npy_intp arr_str,
                  npy_intp key_str, npy_intp sort_str, npy_intp ret_str,
-                 PyArrayObject *cmp)
+                 PyArrayObject *key_arr, PyArrayObject *arr_arr,
+                 PyArray_BinSearchCompareFunc *compare)
 {
     using Cmp = typename side_to_generic_cmp<side>::type;
-    PyArray_CompareFunc *compare = PyDataType_GetArrFuncs(PyArray_DESCR(cmp))->compare;
     npy_intp min_idx = 0;
     npy_intp max_idx = arr_len;
     const char *last_key = key;
@@ -302,7 +305,8 @@ npy_argbinsearch(const char *arr, const char *key, const char *sort, char *ret,
          * gives the search a big boost when keys are sorted, but slightly
          * slows down things for purely random ones.
          */
-        if (Cmp{}(compare(last_key, key, cmp), 0)) {
+        /* last_key and key are both elements of the key array */
+        if (Cmp{}(compare(last_key, key, key_arr, key_arr), 0)) {
             max_idx = arr_len;
         }
         else {
@@ -323,7 +327,8 @@ npy_argbinsearch(const char *arr, const char *key, const char *sort, char *ret,
 
             arr_ptr = arr + sort_idx * arr_str;
 
-            if (Cmp{}(compare(arr_ptr, key, cmp), 0)) {
+            /* arr_ptr belongs to the haystack, key to the key array */
+            if (Cmp{}(compare(arr_ptr, key, arr_arr, key_arr), 0)) {
                 min_idx = mid_idx + 1;
             }
             else {

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -492,6 +492,24 @@ def test_sort(dtype, strings):
     test_sort(strings, arr_sorted)
 
 
+def test_searchsorted_gh31533():
+    n = 100_000
+    # all > 15 bytes -> arena
+    values = [f"{i:020d}" for i in range(n)]
+    haystack = np.array(values, dtype="T")
+    # a handful of needles -> tiny arena
+    needle_values = values[:: n // 23]
+    expected = np.searchsorted(
+        np.array(values, dtype="U20"), np.array(needle_values, dtype="U20")
+    )
+
+    needles = np.array(needle_values, dtype="T")
+    assert_array_equal(np.searchsorted(haystack, needles), expected)
+    assert_array_equal(
+        np.searchsorted(haystack, needles, sorter=np.arange(n)), expected
+    )
+
+
 @pytest.mark.parametrize(
     "strings",
     [


### PR DESCRIPTION
Backport of #31535.

### PR summary

Fixes #31533.

Currently the low-level searchsorted implementation is wired up to assume the needle and haystack arrays share a descriptor. This breaks that assumption and adds a hacky special-case in the searchsorted implementation.

I'm deferring a nicer, less hacky fix for later in the 2.6 development cycle (ping @MaanasArora if you're interested in taking that on).


#### AI Disclosure

I used Claude to help analyze the bug.
