### PR TITLE
BUG: Avoid hwcap for RVV version detection due to faulty v0.7/v1.0 re... (#30338)

### DIFF
--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -934,6 +934,16 @@ npy__cpu_init_features(void)
         // https://github.com/torvalds/linux/blob/v6.8/arch/riscv/include/uapi/asm/hwcap.h#L24
         #define COMPAT_HWCAP_ISA_V (1 << ('V' - 'A'))
     #endif
+
+    #ifdef __linux__
+        #include <asm/unistd.h>
+        #include <unistd.h>
+
+        #if defined(__has_include) && __has_include(<asm/hwprobe.h>)
+            #include <asm/hwprobe.h>
+            #define HAS_RISCV_HWPROBE
+        #endif
+    #endif
 #endif
 
 static void
@@ -942,14 +952,39 @@ npy__cpu_init_features(void)
     memset(npy__cpu_have, 0, sizeof(npy__cpu_have[0]) * NPY_CPU_FEATURE_MAX);
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #ifdef __linux__
+    #ifdef HAS_RISCV_HWPROBE
+        /*
+        * RISCV_HWPROBE_IMA_V reports the ratified RVV 1.0 extension.
+        * HWCAP's V bit may also be set for pre-standard vector extensions,
+        * so prefer hwprobe and keep HWCAP only as a compatibility fallback
+        * when hwprobe is unavailable or cannot answer the query.
+        */
+        struct riscv_hwprobe probe;
+        probe.key = RISCV_HWPROBE_KEY_IMA_EXT_0;
+        probe.value = 0;
+
+        int ret = syscall(__NR_riscv_hwprobe, &probe, 1, 0, NULL, 0);
+        if (0 == ret) {
+            if (probe.value & RISCV_HWPROBE_IMA_V){
+                npy__cpu_have[NPY_CPU_FEATURE_RVV]  = 1;
+            }
+            return;
+        }
+    #endif
+
     unsigned int hwcap = getauxval(AT_HWCAP);
-#else
-    unsigned long hwcap;
-    elf_aux_info(AT_HWCAP, &hwcap, sizeof(hwcap));
-#endif
     if (hwcap & COMPAT_HWCAP_ISA_V) {
         npy__cpu_have[NPY_CPU_FEATURE_RVV]  = 1;
     }
+
+#else         //  __FreeBSD__|| __OpenBSD__
+    unsigned long hwcap;
+    elf_aux_info(AT_HWCAP, &hwcap, sizeof(hwcap));
+    if (hwcap & COMPAT_HWCAP_ISA_V) {
+        npy__cpu_have[NPY_CPU_FEATURE_RVV]  = 1;
+    }
+#endif
+
 #endif
 }
 


### PR DESCRIPTION
Backport of #30338.


Requires a distribution with a Linux 6.5 kernel or greater.
Refer to https://github.com/ggml-org/llama.cpp/pull/17461#discussion_r2568726154

Refer to https://riscv-optimization-guide.riseproject.dev/#_detecting_risc_v_extensions_on_linux as well. It will be helpful to extend to extract the vendor and micro-architecture ID if/when we want to have per-micro-architecture optimizations.