### PR TITLE
BLD: fix build failure with PYTHONSAFEPATH=1 (#30731)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -158,6 +158,7 @@ jobs:
     - name: Install as editable
       env:
         PKG_CONFIG_PATH: ${{ github.workspace }}/.openblas
+        PYTHONSAFEPATH: 1  # regression check for gh-24907
       run: |
         pip install -e . --no-build-isolation
     - name: Run full test suite
@@ -166,6 +167,7 @@ jobs:
         # TODO: gcov
       env:
         PYTHONOPTIMIZE: 2
+        PYTHONSAFEPATH: 1
 
   armhf_test:
     # Tests NumPy on 32-bit ARM hard-float (armhf) via compatibility mode

--- a/numpy/_build_utils/tempita.py
+++ b/numpy/_build_utils/tempita.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
 import argparse
+import importlib.util
 import os
 import sys
 
-import tempita
+
+def import_tempita():
+    init_py = os.path.join(os.path.dirname(__file__), 'tempita/__init__.py')
+    spec = importlib.util.spec_from_file_location('tempita', init_py)
+    tempita = importlib.util.module_from_spec(spec)
+    sys.modules['tempita'] = tempita
+    spec.loader.exec_module(tempita)
+    return tempita
 
 
 def process_tempita(fromfile, outfile=None):
@@ -17,6 +25,7 @@ def process_tempita(fromfile, outfile=None):
         # We're dealing with a distutils build here, write in-place
         outfile = os.path.splitext(fromfile)[0]
 
+    tempita = import_tempita()
     from_filename = tempita.Template.from_filename
     template = from_filename(fromfile, encoding=sys.getdefaultencoding())
 

--- a/numpy/_core/code_generators/generate_numpy_api.py
+++ b/numpy/_core/code_generators/generate_numpy_api.py
@@ -2,9 +2,8 @@
 import argparse
 import os
 
-import genapi
-import numpy_api
-from genapi import BoolValuesApi, FunctionApi, GlobalVarApi, TypeApi
+from . import genapi, numpy_api
+from .genapi import BoolValuesApi, FunctionApi, GlobalVarApi, TypeApi
 
 # use annotated api when running under cpychecker
 h_template = r"""

--- a/numpy/_core/code_generators/generate_ufunc_api.py
+++ b/numpy/_core/code_generators/generate_ufunc_api.py
@@ -1,9 +1,8 @@
 import argparse
 import os
 
-import genapi
-import numpy_api
-from genapi import FunctionApi, TypeApi
+from . import genapi, numpy_api
+from .genapi import FunctionApi, TypeApi
 
 h_template = r"""
 #ifdef _UMATHMODULE

--- a/numpy/_core/code_generators/generate_umath_doc.py
+++ b/numpy/_core/code_generators/generate_umath_doc.py
@@ -1,12 +1,9 @@
 import argparse
 import os
-import sys
 import textwrap
 
-sys.path.insert(0, os.path.dirname(__file__))
-import ufunc_docstrings as docstrings
+from . import ufunc_docstrings as docstrings
 
-sys.path.pop(0)
 
 def normalize_doc(docstring):
     docstring = textwrap.dedent(docstring).strip()

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -694,23 +694,44 @@ endif
 # building, but we can't add it to the sources of that extension (this C file
 # doesn't compile, it's only included in another r file. Hence use the slightly
 # hacky --ignore argument to the next custom_target().
+codegen_files = [
+  'code_generators/__init__.py',
+  'code_generators/genapi.py',
+  'code_generators/generate_numpy_api.py',
+  'code_generators/generate_ufunc_api.py',
+  'code_generators/generate_umath_doc.py',
+  'code_generators/generate_umath.py',
+  'code_generators/numpy_api.py',
+  'code_generators/ufunc_docstrings.py',
+]
+codegen_env = {
+  # Explicitly set PYTHONPATH to avoid depending on the current working directory
+  # at build time, and on unsafe paths that may be prepended to sys.path and can be
+  # disabled by PYTHONSAFEPATH. See:
+  # [1] https://github.com/numpy/numpy/issues/24907
+  # [2] https://docs.python.org/3/library/sys.html#sys.path
+  'PYTHONPATH': meson.current_source_dir(),
+}
+
 src_umath_api_c = custom_target('__umath_generated',
   output : '__umath_generated.c',
-  input : 'code_generators/generate_umath.py',
-  command: [py, '@INPUT@', '-o', '@OUTPUT@'],
+  depend_files: codegen_files,
+  command: [py, '-m', 'code_generators.generate_umath', '-o', '@OUTPUT@'],
+  env: codegen_env,
 )
 
 src_umath_doc_h = custom_target('_umath_doc_generated',
   output : '_umath_doc_generated.h',
-  input : ['code_generators/generate_umath_doc.py',
-           'code_generators/ufunc_docstrings.py'],
-  command: [py, '@INPUT0@', '-o', '@OUTPUT@'],
+  depend_files: codegen_files,
+  command: [py, '-m', 'code_generators.generate_umath_doc', '-o', '@OUTPUT@'],
+  env: codegen_env,
 )
 
 src_numpy_api = custom_target('__multiarray_api',
   output : ['__multiarray_api.c', '__multiarray_api.h'],
-  input : 'code_generators/generate_numpy_api.py',
-  command: [py, '@INPUT@', '-o', '@OUTDIR@', '--ignore', src_umath_api_c],
+  depend_files: codegen_files,
+  command: [py, '-m', 'code_generators.generate_numpy_api', '-o', '@OUTDIR@', '--ignore', src_umath_api_c],
+  env: codegen_env,
   install: true,  # NOTE: setup.py build installs all, but just need .h?
   install_dir: np_dir / '_core/include/numpy',
   install_tag: 'devel'
@@ -718,8 +739,9 @@ src_numpy_api = custom_target('__multiarray_api',
 
 src_ufunc_api = custom_target('__ufunc_api',
   output : ['__ufunc_api.c', '__ufunc_api.h'],
-  input : 'code_generators/generate_ufunc_api.py',
-  command: [py, '@INPUT@', '-o', '@OUTDIR@'],
+  depend_files: codegen_files,
+  command: [py, '-m', 'code_generators.generate_ufunc_api', '-o', '@OUTDIR@'],
+  env: codegen_env,
   install: true,  # NOTE: setup.py build installs all, but just need .h?
   install_dir: np_dir / '_core/include/numpy',
   install_tag: 'devel'


### PR DESCRIPTION
Backport of #30731.

by using relative import and `python -m`.
Also fix dependency handling for code generators.

Fixes gh-24907.
