### PR TITLE
DOC: Document Cython and Numba as ways of generating ufuncs

### DIFF
--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -887,7 +887,7 @@ Numba
 -----
 
 The `Numba vectorize decorator
-<https://numba.pydata.org/numba-doc/dev/user/vectorize.html>`_ provides
+<https://numba.readthedocs.io/en/stable/user/vectorize.html>`_ provides
 a quick way to compile a subset of Python to an accelerated function that
 behaves like a ufunc. It can be used without arguments to support any
 numeric type (compiled on a "just in time" basis as you use them):

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -874,3 +874,82 @@ Sample usage::
     >>> npufunc.add_triplet(a, a)
     array([(2,  4,  6), (8, 10, 12)],
           dtype=[('f0', '<u8'), ('f1', '<u8'), ('f2', '<u8')])
+
+Alternatives to writing your own ufunc
+======================================
+
+While most people like the speed benefits that come from writing a ufunc
+using the Numpy C API, not everyone enjoys writing C code. Fortunately
+there are a few alternatives that can create ufuncs with C-like speed
+but without having to understand the Numpy C API.
+
+Numba
+-----
+
+The `Numba vectorize decorator
+<https://numba.pydata.org/numba-doc/dev/user/vectorize.html>`_ provides
+a quick way to compile a subset of Python to an accelerated function that
+behaves like a ufunc. It can be used without arguments to support any
+numeric type (compiled on a "just in time" basis as you use them):
+
+    .. code-block:: python
+
+        from numba import vectorize
+
+        @vectorize
+        def f(x, y):
+            return x * y
+
+or with arguments to support only specific numeric types (compiled when
+you define the function):
+
+    .. code-block:: python
+
+        @vectorize([int32(int32, int32),
+                    int64(int64, int64),
+                    float32(float32, float32),
+                    float64(float64, float64)])
+        def f(x, y):
+            return x + y
+
+In addition to simple ufuncs, Numba can also be used to generate
+generalized ufuncs in a very similar way.
+
+Numba is a run-time dependency (i.e. users of your library will need to
+have Numba installed), and the way that it dynamically compiles the ufuncs
+can cause a noticeable pause either on import or the first time you use
+a function with a particular set of argument types.
+
+One (usually) minor detail is that Numba ufuncs are not "true" Numpy
+ufuncs. This would only matter if you try to use them as a
+:c:type:`PyUFuncObject` from within C.
+
+Cython
+------
+
+Cython provides a `ufunc decorator
+<https://cython.readthedocs.io/en/latest/src/userguide/numpy_ufuncs.html>`_
+which can transform functions written with Python-like syntax into
+Numpy ufuncs. For example:
+
+    .. code-block:: cython
+
+        cimport cython
+
+        @cython.ufunc
+        cdef double add_one(double x):
+            return x+1
+
+To support multiple numeric types, use "fused types" as the argument types
+or return types (in the example above, ``double`` could be replaced with
+``cython.numeric`` to support the most widely available standard C integer,
+floating and complex numeric types).
+
+Cython functions need to be compiled ahead of time (and thus Cython is
+a compile-time dependency, but users of your function do not need to
+have Cython installed themselves). Numpy will be both a compile-time and
+a runtime dependency for your compiled module, since Cython itself uses
+the ufunc C API described earlier in this section.
+
+As of May 2026, only simple ufuncs are supported and generic ufuncs are
+not yet supported.

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -894,25 +894,25 @@ numeric type (compiled on a "just in time" basis as you use them):
 
     .. code-block:: python
 
-        from numba import vectorize
+        import numba as nb
 
-        @vectorize
-        def f(x, y):
-            return x * y
+        @nb.vectorize
+        def logit(p):
+            return log(p/(1-p))
 
 or with arguments to support only specific numeric types (compiled when
 you define the function):
 
     .. code-block:: python
 
-        from numba import vectorize, int32, int64, float32, float64
+        import numba as nb
 
-        @vectorize([int32(int32, int32),
-                    int64(int64, int64),
-                    float32(float32, float32),
-                    float64(float64, float64)])
-        def f(x, y):
-            return x + y
+        @nb.vectorize([nb.int32(nb.int32),
+                       nb.int64(nb.int64),
+                       nb.float32(nb.float32),
+                       nb.float64(nb.float64)])
+        def logit(p):
+            return log(p/(1-p))
 
 In addition to simple ufuncs, Numba can also be used to generate
 generalized ufuncs in a very similar way.
@@ -923,8 +923,10 @@ can cause a noticeable pause either on import or the first time you use
 a function with a particular set of argument types.
 
 One (usually) minor detail is that Numba ufuncs are not "true" Numpy
-ufuncs. This would only matter if you try to use them as a
-:c:type:`PyUFuncObject` from within C.
+ufuncs. This would normally only matter if you try to use them as a
+:c:type:`PyUFuncObject` from within C. They support most of the same
+behavior as Numpy ufuncs, including the ``__array_ufunc__``
+interoperability protocol that lets them handle other array types.
 
 Cython
 ------
@@ -937,10 +939,18 @@ Numpy ufuncs. For example:
     .. code-block:: cython
 
         cimport cython
+        from libc.math cimport log
 
         @cython.ufunc
-        cdef double add_one(double x):
-            return x+1
+        @cython.cdivision(True)
+        cdef double logit(double p) noexcept:
+            return log(p/(1-p))
+
+Here ``log`` is taken from the C standard library. The ``cdivision``
+dectorator and ``noexcept`` exception specification are Cython extensions
+and ensure that a divide by zero will not raise a Python exception.
+They are useful for this specific example but not necessary for ufuncs
+generally.
 
 To support multiple numeric types, use "fused types" as the argument types
 or return types (in the example above, ``double`` could be replaced with

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -905,6 +905,8 @@ you define the function):
 
     .. code-block:: python
 
+        from numba import vectorize, int32, int64, float32, float64
+
         @vectorize([int32(int32, int32),
                     int64(int64, int64),
                     float32(float32, float32),

--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -953,5 +953,5 @@ have Cython installed themselves). Numpy will be both a compile-time and
 a runtime dependency for your compiled module, since Cython itself uses
 the ufunc C API described earlier in this section.
 
-As of May 2026, only simple ufuncs are supported and generic ufuncs are
-not yet supported.
+As of May 2026, only simple ufuncs are supported and generalized ufuncs
+are not yet supported.


### PR DESCRIPTION
### PR summary

The ufunc C API is a little involved, so I think it's worth documenting a couple of the alternatives to generate fast ufuncs automatically. (There's already some reference to Cython and similar in the Numpy documentation in the preceding https://numpy.org/doc/stable/user/c-info.python-as-glue.html section so I don't think I'm introducing anything new here).

Examples are stolen from the respective documentation - I'm just aiming for a couple of quick examples and a link to the external library.

#### AI Disclosure

No AI tools used.