### PR TITLE
DOC: match tensordot parameter name to its docstring

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1019,6 +1019,7 @@ def tensordot(a, b, axes=2):
           second to `b`. Both elements array_like must be of the same length.
           Each axis may appear at most once; repeated axes are not allowed.
           For example, ``axes=([1, 1], [0, 0])`` is invalid.
+
     Returns
     -------
     output : ndarray

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -3375,13 +3375,14 @@ def matmul(x1, x2, /):
 
 # tensordot
 
-def _tensordot_dispatcher(x1, x2, /, *, axes=None):
-    return (x1, x2)
+
+def _tensordot_dispatcher(a, b, /, *, axes=None):
+    return (a, b)
 
 
 @array_function_dispatch(_tensordot_dispatcher)
-def tensordot(x1, x2, /, *, axes=2):
-    return _core_tensordot(x1, x2, axes=axes)
+def tensordot(a, b, /, *, axes=2):
+    return _core_tensordot(a, b, axes=axes)
 
 
 tensordot.__doc__ = _core_tensordot.__doc__


### PR DESCRIPTION
This should not be a change of API as the parameters are positional only
because of the `/`,

It just happens that the parameter in the docstrings are `a` and `b`,
and so for example in IPython; using `?` with have them mismatch.

Also adds a blank line just before the `Return` section in the
docstrings as I believe it is the norm.

I update the function signature and not the docstring as ~all the other
tensordot definition use a, b and not x1, x2, which means that after
this patch all definition are matching.

```
numpy/_core/numeric.py
992:def _tensordot_dispatcher(a, b, axes=None):
996:@array_function_dispatch(_tensordot_dispatcher)

numpy/linalg/_linalg.py
3404:def _tensordot_dispatcher(a, b, /, *, axes=None):
3408:@array_function_dispatch(_tensordot_dispatcher)
```

```
numpy/_core/numeric.py
997:def tensordot(a, b, axes=2):
998-    """

numpy/_core/numeric.pyi
1112:def tensordot(  # noqa: UP047
1113-    a: _ArrayLike[_AnyNumericScalarT], b: _ArrayLike[_AnyNumericScalarT], axes: int | tuple[_ShapeLike, _ShapeLike] = 2
--
1116:def tensordot(a: _ArrayLikeBool_co, b: _ArrayLikeBool_co, axes: int | tuple[_ShapeLike, _ShapeLike] = 2) -> NDArray[np.bool]: ...
1117-@overload
1118:def tensordot(
1119-    a: _ArrayLikeInt_co, b: _ArrayLikeInt_co, axes: int | tuple[_ShapeLike, _ShapeLike] = 2
--
1122:def tensordot(
1123-    a: _ArrayLikeFloat_co, b: _ArrayLikeFloat_co, axes: int | tuple[_ShapeLike, _ShapeLike] = 2
--
1126:def tensordot(
1127-    a: _ArrayLikeComplex_co, b: _ArrayLikeComplex_co, axes: int | tuple[_ShapeLike, _ShapeLike] = 2

numpy/linalg/_linalg.pyi
880:def tensordot[ScalarT: np.number | np.timedelta64 | np.object_](
881-    a: _ArrayLike[ScalarT], b: _ArrayLike[ScalarT], /, *, axes: int | tuple[_ShapeLike, _ShapeLike] = 2
--
884:def tensordot(
885-    a: _ArrayLikeBool_co, b: _ArrayLikeBool_co, /, *, axes: int | tuple[_ShapeLike, _ShapeLike] = 2
--
888:def tensordot(
889-    a: _ArrayLikeInt_co, b: _ArrayLikeInt_co, /, *, axes: int | tuple[_ShapeLike, _ShapeLike] = 2
--
892:def tensordot(
893-    a: _ArrayLikeFloat_co, b: _ArrayLikeFloat_co, /, *, axes: int | tuple[_ShapeLike, _ShapeLike] = 2
--
896:def tensordot(
897-    a: _ArrayLikeComplex_co, b: _ArrayLikeComplex_co, /, *, axes: int | tuple[_ShapeLike, _ShapeLike] = 2

numpy/linalg/_linalg.py
3409:def tensordot(a, b, /, *, axes=2):
3410-    return _core_tensordot(a, b, axes=axes)
```

I'll note that the definition in numeric.py(i) don't use positional only
only the others; so the naming _does_ matter; and can't just be changed
to x1/x2