### PR TITLE
API: Make np.squeeze always return an ndarray for scalar inputs

### DIFF
--- a/doc/release/upcoming_changes/27709.compatibility.rst
+++ b/doc/release/upcoming_changes/27709.compatibility.rst
@@ -1,3 +1,3 @@
-``np.squeeze`` now always returns an ``ndarray`` for scalar inputs
------------------------------------------------------------------
-``np.squeeze`` now always returns a `numpy.ndarray` (specifically a 0-dimensional array), even when the input is a NumPy scalar (a subclass of `numpy.generic`), rather than returning the scalar itself.
+np.squeeze now always returns an ndarray for scalar inputs
+-----------------------------------------------------------
+``np.squeeze`` now always returns a ``numpy.ndarray`` (specifically a 0-dimensional array), even when the input is a NumPy scalar (a subclass of ``numpy.generic``), rather than returning the scalar itself.

--- a/doc/release/upcoming_changes/27709.compatibility.rst
+++ b/doc/release/upcoming_changes/27709.compatibility.rst
@@ -1,0 +1,3 @@
+``np.squeeze`` now always returns an ``ndarray`` for scalar inputs
+-----------------------------------------------------------------
+``np.squeeze`` now always returns a `numpy.ndarray` (specifically a 0-dimensional array), even when the input is a NumPy scalar (a subclass of `numpy.generic`), rather than returning the scalar itself.

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -1691,6 +1691,8 @@ def squeeze(a, axis=None):
     1234
 
     """
+    if isinstance(a, np.generic):
+        a = a[...]
     try:
         squeeze = a.squeeze
     except AttributeError:

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -645,9 +645,6 @@ def resize[AnyShapeT: (_0D, _1D, _2D, _3D, _4D)](a: ArrayLike, new_shape: AnySha
 @overload
 def resize(a: ArrayLike, new_shape: _ShapeLike) -> NDArray[Any]: ...
 
-# TODO: Fix overlapping overloads: https://github.com/numpy/numpy/issues/27032
-@overload
-def squeeze[ScalarT: np.generic](a: ScalarT, axis: _ShapeLike | None = None) -> ScalarT: ...
 @overload
 def squeeze[ScalarT: np.generic](a: _ArrayLike[ScalarT], axis: _ShapeLike | None = None) -> NDArray[ScalarT]: ...
 @overload

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2257,6 +2257,29 @@ class TestMethods:
         assert_raises(ValueError, a.squeeze, axis=(1,))
         assert_equal(a.squeeze(axis=(2,)), [[1, 2, 3]])
 
+    def test_squeeze_scalar_returns_0d_array(self):
+        # np.squeeze should always return an ndarray, even for
+        # np.generic scalar inputs (gh-27709)
+        for scalar in [np.int_(1), np.float64(2.5), np.complex128(1+2j)]:
+            result = np.squeeze(scalar)
+            assert isinstance(result, np.ndarray), (
+                f"np.squeeze({scalar!r}) returned {type(result)}, "
+                f"expected np.ndarray"
+            )
+            assert result.ndim == 0
+            assert result.dtype == scalar.dtype
+            assert result[()] == scalar
+
+        # axis=0 should also work for scalar inputs
+        result = np.squeeze(np.int_(1), axis=0)
+        assert isinstance(result, np.ndarray)
+        assert result.ndim == 0
+
+        # plain Python scalars should still return 0d arrays too
+        result = np.squeeze(1)
+        assert isinstance(result, np.ndarray)
+        assert result.ndim == 0
+
     def test_transpose(self):
         a = np.array([[1, 2], [3, 4]])
         assert_equal(a.transpose(), [[1, 3], [2, 4]])


### PR DESCRIPTION
### PR summary
Closes #30109.
Currently, `np.squeeze` behaves inconsistently with scalar-like inputs:
```python
>>> np.squeeze(1)           # Python int → 0d array
array(1)
>>> np.squeeze(np.array(1)) # 0d ndarray → 0d array
array(1)
>>> np.squeeze(np.int_(1))  # np.generic scalar → scalar (unexpected behavior)
np.int64(1)
```
The issue is that `np.generic` subclasses have a `.squeeze()` method that returns `self` (the scalar itself). The current `squeeze` implementation in `fromnumeric.py` tries `a.squeeze` first, which succeeds for `np.generic` scalars and returns the scalar unchanged. This contradicts the docstring, which states:
> *"Note that if all axes are squeezed, the result is a 0d array and not a scalar."*
This PR converts `np.generic` inputs to 0d arrays using ellipsis indexing `a[...]` before invoking `a.squeeze`.
#### Changes:
* **Runtime Fix**: Converts `np.generic` inputs to 0d arrays in `numpy/_core/fromnumeric.py`.
* **Type Stubs**: Updates `numpy/_core/fromnumeric.pyi` to remove the scalar-returning overload of `squeeze` (so it falls back to returning `NDArray[ScalarT]`).
* **Tests**: Adds tests in `numpy/_core/tests/test_multiarray.py` checking various scalar types, `axis=0`, and Python scalars.
* **Release Note**: Adds a compatibility news fragment in `doc/release/upcoming_changes/27709.compatibility.rst`.
***
### First time committer introduction
Hi everyone! I am Spandan. I use NumPy for development/data science work, and noticed the inconsistent behavior when squeezing NumPy scalars compared to Python scalars. I wanted to contribute to the repository to clean up this edge case.
***
#### AI Disclosure
Antigravity  was used to assist in researching the issue and drafting the test cases. 
