### PR TITLE
BUG: account for PEP 3118 trailing padding

### DIFF
--- a/doc/release/upcoming_changes/31547.improvement.rst
+++ b/doc/release/upcoming_changes/31547.improvement.rst
@@ -1,0 +1,5 @@
+PEP 3118 structured dtype trailing padding now round-trips
+-----------------------------------------------------------
+Structured dtypes with trailing padding now expose that padding in their
+PEP 3118 buffer format and round-trip through ``memoryview`` without adding
+an explicit unnamed void field.

--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -628,6 +628,8 @@ def _dtype_from_pep3118(spec):
     return dtype
 
 def __dtype_from_pep3118(stream, is_subdtype):
+    # numpy interprets PEP 3118 formats which include named fields as
+    # structured dtypes, even if not enclosed by "T{}".
     field_spec = {
         'names': [],
         'formats': [],
@@ -678,8 +680,7 @@ def __dtype_from_pep3118(stream, is_subdtype):
         is_padding = False
 
         if stream.consume('T{'):
-            value, align = __dtype_from_pep3118(
-                stream, is_subdtype=True)
+            value, align = __dtype_from_pep3118(stream, is_subdtype=True)
         elif stream.next in type_map_chars:
             if stream.next == 'Z':
                 typechar = stream.advance(2)
@@ -704,12 +705,10 @@ def __dtype_from_pep3118(stream, is_subdtype):
                 f"Unknown PEP 3118 data type specifier {stream.s!r}"
             )
 
-        #
         # Native alignment may require padding
         #
         # Here we assume that the presence of a '@' character implicitly
         # implies that the start of the array is *already* aligned.
-        #
         extra_offset = 0
         if stream.byteorder == '@':
             start_padding = (-offset) % align
@@ -729,6 +728,19 @@ def __dtype_from_pep3118(stream, is_subdtype):
             # Update common alignment
             common_alignment = _lcm(align, common_alignment)
 
+        # Field name
+        if stream.consume(':'):
+            name = stream.consume_until(':')
+        else:
+            name = None
+
+        # The struct docs define repeat-0 elements as a way to add alignment
+        # padding. Treat them as padding only for unnamed fields.
+        if name is None and itemsize == 0:
+            offset += extra_offset
+            field_spec['itemsize'] = offset
+            continue
+
         # Convert itemsize to sub-array
         if itemsize != 1:
             value = dtype((value, (itemsize,)))
@@ -736,12 +748,6 @@ def __dtype_from_pep3118(stream, is_subdtype):
         # Sub-arrays (2)
         if shape is not None:
             value = dtype((value, shape))
-
-        # Field name
-        if stream.consume(':'):
-            name = stream.consume_until(':')
-        else:
-            name = None
 
         if not (is_padding and name is None):
             if name is not None and name in field_spec['names']:
@@ -757,8 +763,9 @@ def __dtype_from_pep3118(stream, is_subdtype):
 
         field_spec['itemsize'] = offset
 
-    # extra final padding for aligned types
-    if stream.byteorder == '@':
+    # Extra final padding for aligned types. Outside of T{}, match the struct
+    # module docs: no implicit trailing padding is added.
+    if is_subdtype and stream.byteorder == '@':
         field_spec['itemsize'] += (-offset) % common_alignment
 
     # Check if this was a simple 1-item type, and unwrap it

--- a/numpy/_core/src/multiarray/buffer.c
+++ b/numpy/_core/src/multiarray/buffer.c
@@ -90,6 +90,19 @@ _append_str(_tmp_string_t *s, char const *p)
     return 0;
 }
 
+static int
+_append_int(_tmp_string_t *s, npy_intp n)
+{
+    char buf[64];
+    int nw = PyOS_snprintf(buf, sizeof(buf), "%" NPY_INTP_FMT, n);
+    if (nw < 0 || (size_t)nw >= sizeof(buf)) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "error formatting buffer padding size");
+        return -1;
+    }
+    return _append_str(s, buf);
+}
+
 /*
  * Append a PEP3118-formatted field name, ":name:", to str
  */
@@ -287,9 +300,15 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
                 );
                 return -1;
             }
-            while (*offset < new_offset) {
+            /* Add padding bytes: repeat count plus 'x'. */
+            if (*offset < new_offset) {
+                if (new_offset - *offset > 1) {
+                    if (_append_int(str, (npy_intp)(new_offset - *offset)) < 0) {
+                        return -1;
+                    }
+                }
                 if (_append_char(str, 'x') < 0) return -1;
-                ++*offset;
+                *offset = new_offset;
             }
 
             /* Insert child item */
@@ -302,6 +321,17 @@ _buffer_format_string(PyArray_Descr *descr, _tmp_string_t *str,
             /* Insert field name */
             if (_append_field_name(str, name) < 0) return -1;
         }
+
+        /* Add any trailing padding. */
+        if (*offset < base_offset + descr->elsize) {
+            Py_ssize_t padding = base_offset + descr->elsize - *offset;
+            if (padding > 1) {
+                if (_append_int(str, (npy_intp)padding) < 0) return -1;
+            }
+            if (_append_char(str, 'x') < 0) return -1;
+            *offset = base_offset + descr->elsize;
+        }
+
         if (_append_char(str, '}') < 0) return -1;
     }
     else {

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8750,8 +8750,6 @@ class TestPEP3118Dtype:
         self._check('^x3T{xi}', {'f0': (({'f0': ('i', 1)}, (3,)), 1)})
 
     def test_trailing_padding(self):
-        # Trailing padding should be included, *and*, the item size
-        # should match the alignment if in aligned mode
         align = np.dtype('i').alignment
         size = np.dtype('i').itemsize
 
@@ -8759,18 +8757,62 @@ class TestPEP3118Dtype:
             return align * (1 + (n - 1) // align)
 
         base = {"formats": ['i'], "names": ['f0']}
+        bbase = {"formats": ['b'], "names": ['f0']}
 
-        self._check('ix',    dict(itemsize=aligned(size + 1), **base))
-        self._check('ixx',   dict(itemsize=aligned(size + 2), **base))
-        self._check('ixxx',  dict(itemsize=aligned(size + 3), **base))
-        self._check('ixxxx', dict(itemsize=aligned(size + 4), **base))
-        self._check('i7x',   dict(itemsize=aligned(size + 7), **base))
+        self._check('ix',    dict(itemsize=size + 1, **base))
+        self._check('ixx',   dict(itemsize=size + 2, **base))
+        self._check('ixxx',  dict(itemsize=size + 3, **base))
+        self._check('ixxxx', dict(itemsize=size + 4, **base))
+        self._check('i7x',   dict(itemsize=size + 7, **base))
+        self._check('ix0i',  dict(itemsize=2 * size, **base))
+        self._check('b0i',   dict(itemsize=size, **bbase))
+
+        # Our interpretation of the PEP 3118/struct spec is that trailing
+        # padding for alignment is assumed only inside of T{}.
+        self._check('T{ix}',    dict(itemsize=aligned(size + 1), **base))
+        self._check('T{ixx}',   dict(itemsize=aligned(size + 2), **base))
+        self._check('T{ixxx}',  dict(itemsize=aligned(size + 3), **base))
+        self._check('T{ixxxx}', dict(itemsize=aligned(size + 4), **base))
+        self._check('T{i7x}',   dict(itemsize=aligned(size + 7), **base))
+        self._check('T{ix0i}',  dict(itemsize=2 * size, **base))
+        self._check('T{b0i}',   dict(itemsize=size, **bbase))
+        self._check('T{=ix}',   dict(itemsize=size + 1, **base))
 
         self._check('^ix',    dict(itemsize=size + 1, **base))
         self._check('^ixx',   dict(itemsize=size + 2, **base))
         self._check('^ixxx',  dict(itemsize=size + 3, **base))
         self._check('^ixxxx', dict(itemsize=size + 4, **base))
         self._check('^i7x',   dict(itemsize=size + 7, **base))
+        self._check('^ixx0i', dict(itemsize=size + 2, **base))
+        self._check('^b0i', np.dtype('b'))
+
+        arr = np.zeros(3, dtype=np.dtype('u1,i4,u1', align=True))
+        assert_equal(arr.dtype, np.array(memoryview(arr)).dtype)
+
+        arr = np.zeros(3, dtype=np.dtype('u1,i4,u1', align=False))
+        assert_equal(arr.dtype, np.array(memoryview(arr)).dtype)
+
+        arr = np.empty(0, np.dtype({
+            "formats": ['u1'], "offsets": [0],
+            "names": ['x'], "itemsize": 4}))
+        assert_equal(arr.dtype, np.array(memoryview(arr)).dtype)
+
+        self._check('B:f0:B:f1:', [('f0', 'u1'), ('f1', 'u1')])
+        self._check('B:f0:0iB:f1:0i', {
+            "names": ['f0', 'f1'],
+            "formats": ['u1', 'u1'],
+            "offsets": [0, 4],
+            "itemsize": 8})
+        self._check('=B:f0:0iB:f1:0i', [('f0', 'u1'), ('f1', 'u1')])
+
+        arr = np.empty(3, dtype={
+            "names": ['a', 'b'],
+            "formats": ['i4', 'i2'],
+            "offsets": [0, 2]})
+        assert_raises(ValueError, memoryview, arr)
+
+        arr = np.empty(3, dtype='i4,i4')[['f1', 'f0']]
+        assert_raises(ValueError, memoryview, arr)
 
     def test_native_padding_3(self):
         dt = np.dtype(
@@ -8799,18 +8841,11 @@ class TestPEP3118Dtype:
 
     def test_intra_padding(self):
         # Natively aligned sub-arrays may require some internal padding
-        align = np.dtype('i').alignment
-        size = np.dtype('i').itemsize
-
-        def aligned(n):
-            return (align * (1 + (n - 1) // align))
-
-        self._check('(3)T{ix}', ({
+        expected_dtype = {
             "names": ['f0'],
             "formats": ['i'],
-            "offsets": [0],
-            "itemsize": aligned(size + 1)
-        }, (3,)))
+            "itemsize": np.dtype('i,V1', align=True).itemsize}
+        self._check('(3)T{ix}', (expected_dtype, (3,)))
 
     def test_char_vs_string(self):
         dt = np.dtype('c')


### PR DESCRIPTION
Closes #7797.

This revives and updates the old #7798 approach for current main. Structured dtypes with trailing padding now include that padding in their generated PEP 3118 buffer format, so `array -> memoryview -> array` can round-trip without converting the padding into an explicit unnamed void field.

Changes:
- emit compact explicit padding runs in structured buffer formats, including trailing padding
- parse trailing padding outside `T{}` without implicit final alignment, matching the `struct` docs
- preserve aligned trailing padding inside `T{}`
- support unnamed repeat-0 PEP 3118 elements as alignment padding
- add focused regression coverage and a release note

Validation:
- `spin build -- -Dallow-noblas=true`
- `spin test -v -t numpy/_core/tests/test_multiarray.py::TestPEP3118Dtype`
  - 10 passed
- `spin test -v -t numpy/_core/tests/test_multiarray.py::TestNewBufferProtocol`
  - 29 passed, 1 skipped (`_testbuffer` unavailable)
- Direct local reproduction:
  - `memoryview(arr).format == "T{B:x:3x}"`
  - `memoryview(arr).itemsize == 4`
  - `np.array(memoryview(arr)).dtype == arr.dtype`
