### PR TITLE
DOC: clarify nan_to_num copy semantics

### DIFF
--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -389,10 +389,10 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     x : scalar or array_like
         Input data.
     copy : bool, optional
-        Whether to create a copy of `x` (True) or to replace values
-        in-place (False). The in-place operation only occurs if
-        casting to an array does not require a copy.
-        Default is True.
+        Whether to create a copy of `x` (True) or to replace values in-place
+        (False). When `copy` is False, a `ValueError` is raised if converting
+        `x` to an array requires a copy. Pass ``copy=None`` to allow a copy
+        only when needed. Default is True.
     nan : int, float, or bool or array_like of int, float, or bool, optional
         Values to be used to fill NaN values. If no values are passed
         then NaN values will be replaced with 0.0.


### PR DESCRIPTION
Closes #29045.

`nan_to_num(copy=...)` now documents the NumPy 2.x `copy=False` behavior more explicitly: a `ValueError` is raised when converting the input to an array would require a copy. It also points users to `copy=None` when they want to allow a copy only if needed.

Validation:
- `git diff --check`
- `PYTHONPATH=/tmp/stubreadline python -m py_compile numpy/lib/_type_check_impl.py`