### PR TITLE
MAINT: specify encoding in numpy/testing/_private/utils.py

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -172,7 +172,7 @@ elif sys.platform[:5] == 'linux':
         """
         _proc_pid_stat = _proc_pid_stat or f'/proc/{os.getpid()}/stat'
         try:
-            with open(_proc_pid_stat) as f:
+            with open(_proc_pid_stat, encoding='utf-8') as f:
                 l = f.readline().split(' ')
             return int(l[22])
         except Exception:
@@ -201,7 +201,7 @@ if sys.platform[:5] == 'linux':
         if not _load_time:
             _load_time.append(time.time())
         try:
-            with open(_proc_pid_stat) as f:
+            with open(_proc_pid_stat, encoding='utf-8') as f:
                 l = f.readline().split(' ')
             return int(l[13])
         except Exception:
@@ -1479,7 +1479,7 @@ def check_support_sve(__cache=[]):
     import subprocess
     cmd = 'lscpu'
     try:
-        output = subprocess.run(cmd, capture_output=True, text=True)
+        output = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8')
         result = 'sve' in output.stdout
     except (OSError, subprocess.SubprocessError):
         result = False
@@ -2756,7 +2756,7 @@ def _get_mem_available():
 
     if sys.platform.startswith('linux'):
         info = {}
-        with open('/proc/meminfo') as f:
+        with open('/proc/meminfo', encoding='utf-8') as f:
             for line in f:
                 p = line.split()
                 info[p[0].strip(':').lower()] = int(p[1]) * 1024


### PR DESCRIPTION
Several `open()` and `subprocess.run()` calls in `numpy/testing/_private/utils.py` omit the `encoding` argument, which triggers `EncodingWarning` under `PYTHONWARNDEFAULTENCODING=1` (Python 3.10+) — for example when downstream projects run their test suites with that flag set.

The most recent report on gh-24115 points specifically at the `subprocess.run(cmd, capture_output=True, text=True)` call here; this PR also covers the sibling `open()` calls in the same module. All of these read ASCII data (from `/proc/<pid>/stat`, `/proc/meminfo`) or the output of `lscpu`, so `utf-8` is the correct explicit encoding.

```python
$ python -X warn_default_encoding -W error::EncodingWarning ...
EncodingWarning: 'encoding' argument not specified
```

This is a scoped step toward gh-24115 (the `numpy/testing` portion); the umbrella issue also covers adding the flag in CI, which can follow once the remaining modules are clean.

- [x] Pure mechanical change (adds `encoding='utf-8'`), no behavior change for the ASCII content these calls read.
