### PR TITLE
DOC: Add element-wise repeat example to numpy.repeat

### DIFF
--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -466,6 +466,8 @@ def repeat(a, repeats, axis=None):
     >>> import numpy as np
     >>> np.repeat(3, 4)
     array([3, 3, 3, 3])
+    >>> np.repeat([4, 5, 6], [1, 2, 3])
+    array([4, 5, 5, 6, 6, 6])
     >>> x = np.array([[1,2],[3,4]])
     >>> np.repeat(x, 2)
     array([1, 1, 2, 2, 3, 3, 4, 4])


### PR DESCRIPTION
The current examples in the numpy.repeat docstring only show cases where broadcasting occurs.

This new example demonstrates the less obvious case where repeats is a sequence with the same length as the input array, allowing each element to be repeated a different number of times without broadcasting.

### PR summary
See above.

### First time committer introduction
I am an academic and a long-time numpy user (approx 2008).
Numpy is part of my research toolboxes in machine learning and biomedical engineering.

#### AI Disclosure
AI was used to refine the wording of the commit message.
