### PR TITLE
MAINT: specify encoding in numpy/testing/_private/utils.py

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -172,7 +172,7 @@ elif sys.platform[:5] == 'linux':
         """
         _proc_pid_stat = _proc_pid_stat or f'/proc/{os.getpid()}/stat'
         try:
-            with open(_proc_pid_stat) as f:
+            with open(_proc_pid_stat, encoding='utf-8') as f:
                 l = f.readline().split(' ')
             return int(l[22])
         except Exception:
@@ -201,7 +201,7 @@ if sys.platform[:5] == 'linux':
         if not _load_time:
             _load_time.append(time.time())
         try:
-            with open(_proc_pid_stat) as f:
+            with open(_proc_pid_stat, encoding='utf-8') as f:
                 l = f.readline().split(' ')
             return int(l[13])
         except Exception:
@@ -1479,7 +1479,7 @@ def check_support_sve(__cache=[]):
     import subprocess
     cmd = 'lscpu'
     try:
-        output = subprocess.run(cmd, capture_output=True, text=True)
+        output = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8')
         result = 'sve' in output.stdout
     except (OSError, subprocess.SubprocessError):
         result = False
@@ -2756,7 +2756,7 @@ def _get_mem_available():
 
     if sys.platform.startswith('linux'):
         info = {}
-        with open('/proc/meminfo') as f:
+        with open('/proc/meminfo', encoding='utf-8') as f:
             for line in f:
                 p = line.split()
                 info[p[0].strip(':').lower()] = int(p[1]) * 1024


### PR DESCRIPTION
### PR summary
Several `open()` and `subprocess.run(..., text=True)` calls in `numpy/testing/_private/utils.py` omit an explicit `encoding`, which triggers `EncodingWarning` under `PYTHONWARNDEFAULTENCODING=1` / `python -X warn_default_encoding` on Python 3.10+.

The most recent report in gh-24115 points at the `subprocess.run(cmd, capture_output=True, text=True)` call in this module. This PR also covers nearby `open()` calls that read `/proc/<pid>/stat` and `/proc/meminfo`.

All affected call sites read Linux pseudo-files or tool output that is plain ASCII, so `encoding="utf-8"` preserves the existing decoded result while making the behavior independent of the process locale.

This is a scoped maintenance change toward gh-24115 for the `numpy/testing` area. It is intended to be mechanical only, with no behavior change.


### First time committer introduction
Hi, I’m Lawson. I use NumPy through research I conduct in school and other side projects. I have been looking for more OSS projects to contribute to in the machine learning space. This is my first NumPy contribution, so I tried to keep the change small and focused.


#### AI Disclosure
AI assisted with this PR. Tools: Claude Code (Anthropic) and OpenAI Codex. They helped identify the un-encoded `open()` / `subprocess.run()` call sites and draft the PR text. I reviewed and verified the change, understand it, and can explain it.


Thanks @jorenham reopening with the template filled in, including the AI disclosure. Apologies again for missing it the first time.