### PR TITLE
MAINT: reflect msvc lower bound in error message

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,7 @@ if cc.get_id() == 'gcc'
   endif
 elif cc.get_id() == 'msvc'
   if not cc.version().version_compare('>=19.35')
-    error('NumPy requires at least vc142 (default with Visual Studio 2019) ' + \
+    error('NumPy requires at least vc143 (default with Visual Studio 2022) ' + \
           'when building with MSVC')
   endif
   add_project_arguments('/experimental:c11atomics', language: 'c')


### PR DESCRIPTION
This was missed in #30489, which raised
```diff
-  if not cc.version().version_compare('>=19.20')
+  if not cc.version().version_compare('>=19.35')
```
without updating the corresponding error message; VS2019 corresponds to the 14.2 toolset and 19.20 compiler; VS2022 corresponds to 14.3 toolset and 19.3x compiler

CC @kumaraditya303 