### PR TITLE
BUG: Fix order of real and imaginary NaNs when sorting complex in descending order

### DIFF
--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -146,16 +146,16 @@ struct complex_type : complex_tag {
     {
         const auto ra = creal(a), rb = creal(b);
         const auto ia = cimag(a), ib = cimag(b);
-        if (ra > rb || (ra == ra && rb != rb)) {
+        if (ra > rb && (ra == ra && rb == rb)) {
             return ia == ia || ib != ib;
         }
-        if (ra < rb || (ra != ra && rb == rb)) {
+        if (ra < rb && (ra == ra && rb == rb)) {
             return ib != ib && ia == ia;
         }
         if (ra == rb || (ra != ra && rb != rb)) {
             return ia > ib || (ib != ib && ia == ia);
         }
-        return ra != ra;
+        return rb != rb;
     }
 };
 

--- a/numpy/_core/src/common/numpy_tag.hpp
+++ b/numpy/_core/src/common/numpy_tag.hpp
@@ -146,10 +146,10 @@ struct complex_type : complex_tag {
     {
         const auto ra = creal(a), rb = creal(b);
         const auto ia = cimag(a), ib = cimag(b);
-        if (ra > rb && (ra == ra && rb == rb)) {
+        if (ra > rb) {
             return ia == ia || ib != ib;
         }
-        if (ra < rb && (ra == ra && rb == rb)) {
+        if (ra < rb) {
             return ib != ib && ia == ia;
         }
         if (ra == rb || (ra != ra && rb != rb)) {

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -2859,12 +2859,11 @@ class TestMethods:
     def test_sort_descending_complex_lexorder(self, dtype,
                                               stable, descending, random_seed):
         arange = np.tile(np.arange(25, dtype=dtype), 4)
-        nans = np.full(100, np.nan + 1j * np.nan, dtype=dtype)
 
         no_nans = arange + 1j * arange
-        im_nans = arange + 1j * nans
-        re_nans = nans + 1j * arange
-        all_nans = nans + 1j * nans
+        im_nans = arange + complex(0, np.nan)
+        re_nans = complex(np.nan, 0) + 1j * arange
+        all_nans = np.full(100, complex(np.nan, np.nan), dtype=dtype)
 
         a = np.concatenate((no_nans, im_nans, re_nans, all_nans))
         immask = np.isnan(a.imag)


### PR DESCRIPTION
Fixes a bug from #31345 where complex numbers with only imaginary nans get sorted _before_ those with only real nans in descending sorts, when keeping in with our NaN semantics they should be sorted _after_ (real nans are the primary key). This should probably be backported to 2.5, cc @seberg @charris

The longstanding `less` implementation is a bit confusing, but I didn't refactor/simplify and kept this change minimal. It would be good to confirm this is the correct behavior, though, as the `greater` is a bit hard to read (hopefully less so now):

1. if greater, only push to right if the imaginary part is strictly NaN but the other is not,
2. if less, only push to right if the _other_ imaginary part is strictly NaN but _this_ one is not,
3. If real parts are equal or _both_ are NaN, break the tie by float-like comparison of imaginary,
4. Failing all (i.e., only _one_ of the real parts is NaN), push to the right only if first is NaN.

So for the real part at least:

* If both reals are non-NaN -> branch 1-2
* If exactly one real is NaN -> branch 4
* If both reals are NaN -> branch 3

Sorry, verbose, but hopefully that clears things, thank you for reviewing!

#### AI Disclosure
No AI tools used.