### PR TITLE
BUG: support object fields in structured_to_unstructured

### DIFF
--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -932,6 +932,27 @@ def _common_stride(offsets, counts, itemsize):
     return stride
 
 
+def _flat_field_arrays(arr):
+    """Yield each scalar leaf field of a structured array, in the same order
+    used by the view-based ``structured_to_unstructured`` path: fields
+    left-to-right, subarray elements outer, nested base fields inner. Each
+    yielded array has the same shape as ``arr``."""
+    for name in arr.dtype.names:
+        field = arr[name]
+        subshape = field.shape[arr.ndim:]
+        if subshape:
+            for idx in np.ndindex(subshape):
+                elem = field[(Ellipsis, *idx)]
+                if elem.dtype.names is not None:
+                    yield from _flat_field_arrays(elem)
+                else:
+                    yield elem
+        elif field.dtype.names is not None:
+            yield from _flat_field_arrays(field)
+        else:
+            yield field
+
+
 def _structured_to_unstructured_dispatcher(arr, dtype=None, copy=None,
                                            casting=None):
     return (arr,)
@@ -952,7 +973,8 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
     Parameters
     ----------
     arr : ndarray
-       Structured array or dtype to convert. Cannot contain object datatype.
+       Structured array or dtype to convert. If it contains object fields a
+       copy is always returned, since a view is not possible in that case.
     dtype : dtype, optional
        The dtype of the output unstructured array.
     copy : bool, optional
@@ -1023,6 +1045,21 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
                                  'formats': dts,
                                  'offsets': offsets,
                                  'itemsize': arr.dtype.itemsize})
+    if arr.dtype.hasobject:
+        # A view cannot reinterpret object fields (gh-14104), but
+        # structured_to_unstructured always uses every field, so copying each
+        # one into a new trailing axis is safe. As with copy=False elsewhere, a
+        # view is returned only when possible; for object dtypes it never is, so
+        # this branch always returns a copy. Cast each field before stacking so
+        # that `casting` is checked from the original field dtype, as in the
+        # packed-array path below.
+        columns = [field.astype(out_dtype, copy=False, casting=casting)
+                   for field in _flat_field_arrays(arr)]
+        if not columns:
+            # e.g. only zero-length subarray fields; match the view path's
+            # empty trailing axis.
+            return np.empty(arr.shape + (0,), dtype=out_dtype)
+        return np.stack(columns, axis=-1)
     arr = arr.view(flattened_fields)
 
     # we only allow a few types to be unstructured by manipulating the

--- a/numpy/lib/tests/test_recfunctions.py
+++ b/numpy/lib/tests/test_recfunctions.py
@@ -382,6 +382,38 @@ class TestRecFunctions:
         assert_equal(dd, dd_expected)
         assert_equal(ddd, dd_expected)
 
+    def test_structured_to_unstructured_with_object(self):
+        # gh-21990: object fields are supported (always returning a copy, since
+        # a view that could hide objects in padding is not possible).
+        # The empty array from the original report no longer raises.
+        out = structured_to_unstructured(np.empty(0, 'O,O'), copy=True)
+        assert_equal(out.shape, (0, 2))
+        assert_equal(out.dtype, np.dtype('O'))
+
+        a = np.array([(1, 2), (3, 4)], dtype='O,O')
+        out = structured_to_unstructured(a)
+        assert_equal(out.tolist(), [[1, 2], [3, 4]])
+        # the result is a copy: mutating it must not affect the input
+        out[0, 0] = 99
+        assert_equal(a['f0'].tolist(), [1, 3])
+
+        # subarray and nested object fields flatten left-to-right
+        a = np.zeros(3, dtype=[('x', 'O'), ('y', 'O', (2,))])
+        assert_equal(structured_to_unstructured(a).shape, (3, 3))
+        a = np.zeros(3, dtype=[('a', 'O'), ('b', [('c', 'O'), ('d', 'O')])])
+        assert_equal(structured_to_unstructured(a).shape, (3, 3))
+
+        # column order matches the (non-object) view-based path: subarray
+        # elements outer, nested base fields inner
+        a = np.zeros(1, dtype=[('x', [('a', 'O'), ('b', 'O')], (2,))])
+        a['x']['a'] = [[1, 3]]  # element 0 -> 1, element 1 -> 3
+        a['x']['b'] = [[2, 4]]  # element 0 -> 2, element 1 -> 4
+        assert_equal(structured_to_unstructured(a).tolist(), [[1, 2, 3, 4]])
+
+        # a zero-length subarray field gives an empty trailing axis
+        a = np.zeros(3, dtype=[('x', 'O', (0,))])
+        assert_equal(structured_to_unstructured(a).shape, (3, 0))
+
     def test_unstructured_to_structured(self):
         # test if dtype is the args of np.dtype
         a = np.zeros((20, 2))


### PR DESCRIPTION
### PR summary

Fixes gh-21990. `recfunctions.structured_to_unstructured` reinterprets the input
with a view (`arr.view(flattened_fields)`), which NumPy forbids for object dtypes
because objects could be hidden in field padding (gh-14104). But this function
always uses every field, so a copy is always safe.

When the dtype contains objects, the result is now built by casting each leaf
field to the output dtype and stacking them along a new trailing axis. This
matches the view path's column order (subarray elements outer, nested fields
inner) and per-field casting, and always returns a copy. Plain, subarray, nested,
structured-subarray, and zero-length-subarray object fields are handled; a new
regression test covers them and the existing test_recfunctions suite still passes.


#### AI Disclosure

This PR was prepared with AI assistance: the implementation and tests were drafted
using Claude Code (Anthropic), and the diff was additionally reviewed with OpenAI
Codex. I have reviewed and understand the change, validated it against the existing
test_recfunctions suite and a cross-check of the copy path against the canonical
view path, take full responsibility for it, and am submitting and conducting all
interactions personally.
