### PR TITLE
DOC: fix median docstrings around float16/float32 inputs

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3948,10 +3948,9 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     Returns
     -------
     median : ndarray
-        A new array holding the result. Return data-type is "float64" 
-        for integer input. For floating-point input, the return data-type 
-        is the same as the input data-type. If `out` is specified, that 
-        array is returned instead.
+        A new array holding the result. Return data-type is ``float64``
+        for integer input, or the input data-type, otherwise. If `out` is
+        specified, that array is returned instead.
 
     See Also
     --------
@@ -4146,10 +4145,9 @@ def percentile(a,
         is a scalar. If multiple percentiles are given, first axis of
         the result corresponds to the percentiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
-        contains integers or floats smaller than ``float64``, the output
-        data-type is ``float64``. Otherwise, the output data-type is the
-        same as that of the input. If `out` is specified, that array is
-        returned instead.
+        contains integers, the output data-type is ``float64``. Otherwise,
+        the output data-type is the same as that of the input. If `out` 
+        is specified, that array is returned instead.
 
     See Also
     --------
@@ -4349,10 +4347,9 @@ def quantile(a,
         is a scalar. If multiple probability levels are given, first axis
         of the result corresponds to the quantiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
-        contains integers or floats smaller than ``float64``, the output
-        data-type is ``float64``. Otherwise, the output data-type is the
-        same as that of the input. If `out` is specified, that array is
-        returned instead.
+        contains integers, the output data-type is ``float64``. Otherwise,
+        the output data-type is the same as that of the input. If `out` is
+        specified, that array is returned instead.
 
     See Also
     --------

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3948,11 +3948,10 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     Returns
     -------
     median : ndarray
-        A new array holding the result. If the input contains integers
-        or floats smaller than ``float64``, then the output data-type is
-        ``np.float64``.  Otherwise, the data-type of the output is the
-        same as that of the input. If `out` is specified, that array is
-        returned instead.
+        A new array holding the result. Return data-type is "float64" 
+        for integer input. For floating-point input, the return data-type 
+        is the same as the input data-type. If `out` is specified, that 
+        array is returned instead.
 
     See Also
     --------

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3952,7 +3952,7 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
         the output data-type is ``float64``. Otherwise, the output data-type
         is the same as that of the input. If `out` is specified, that array is
         returned instead.
-        
+
     See Also
     --------
     mean, percentile

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3948,10 +3948,11 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     Returns
     -------
     median : ndarray
-        A new array holding the result. Return data-type is ``float64``
-        for integer input, or the input data-type, otherwise. If `out` is
-        specified, that array is returned instead.
-
+        A new array holding the result. If the input contains integers,
+        the output data-type is ``float64``. Otherwise, the output data-type
+        is the same as that of the input. If `out` is specified, that array is
+        returned instead.
+        
     See Also
     --------
     mean, percentile

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4147,7 +4147,7 @@ def percentile(a,
         the result corresponds to the percentiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
         contains integers, the output data-type is ``float64``. Otherwise,
-        the output data-type is the same as that of the input. If `out` 
+        the output data-type is the same as that of the input. If `out`
         is specified, that array is returned instead.
 
     See Also

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1163,8 +1163,8 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=np._NoValu
     Returns
     -------
     median : ndarray
-        A new array holding the result. If the input contains integers
-        output data-type is ``float64``.  Otherwise, the output data-type
+        A new array holding the result. If the input contains integers,
+        the output data-type is ``float64``. Otherwise, the output data-type
         is the same as that of the input. If `out` is specified, that array is
         returned instead.
 

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1319,10 +1319,9 @@ def nanpercentile(
         is a scalar. If multiple percentiles are given, first axis of
         the result corresponds to the percentiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
-        contains integers or floats smaller than ``float64``, the output
-        data-type is ``float64``. Otherwise, the output data-type is the
-        same as that of the input. If `out` is specified, that array is
-        returned instead.
+        contains integers, the output data-type is ``float64``. Otherwise,
+        the output data-type is the same as that of the input. If `out` is 
+        specified, that array is returned instead.
 
     See Also
     --------
@@ -1496,10 +1495,9 @@ def nanquantile(
         is a scalar. If multiple probability levels are given, first axis of
         the result corresponds to the quantiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
-        contains integers or floats smaller than ``float64``, the output
-        data-type is ``float64``. Otherwise, the output data-type is the
-        same as that of the input. If `out` is specified, that array is
-        returned instead.
+        contains integers, the output data-type is ``float64``. Otherwise,
+        the output data-type is the same as that of the input. If `out` is specified, 
+        that array is returned instead.
 
     See Also
     --------

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1164,9 +1164,8 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=np._NoValu
     -------
     median : ndarray
         A new array holding the result. If the input contains integers
-        or floats smaller than ``float64``, then the output data-type is
-        ``np.float64``.  Otherwise, the data-type of the output is the
-        same as that of the input. If `out` is specified, that array is
+        output data-type is ``float64``.  Otherwise, the output data-type
+        is the same as that of the input. If `out` is specified, that array is
         returned instead.
 
     See Also
@@ -1320,7 +1319,7 @@ def nanpercentile(
         the result corresponds to the percentiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
         contains integers, the output data-type is ``float64``. Otherwise,
-        the output data-type is the same as that of the input. If `out` is 
+        the output data-type is the same as that of the input. If `out` is
         specified, that array is returned instead.
 
     See Also
@@ -1496,7 +1495,7 @@ def nanquantile(
         the result corresponds to the quantiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
         contains integers, the output data-type is ``float64``. Otherwise,
-        the output data-type is the same as that of the input. If `out` is specified, 
+        the output data-type is the same as that of the input. If `out` is specified,
         that array is returned instead.
 
     See Also

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -713,6 +713,7 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
         If the input contains integers, the output data-type is ``float64``.
         Otherwise, the output data-type is the same as that of the input.
         If `out` is specified, that array is returned instead.
+
     See Also
     --------
     mean

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -710,10 +710,9 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     median : ndarray
         A new array holding the result is returned unless out is
         specified, in which case a reference to out is returned.
-        Return data-type is "float64" for integer input. For 
-        floating-point input, the return data-type is the same as 
-        the input data-type.
-
+        If the input contains integers, the output data-type is ``float64``.
+        Otherwise, the output data-type is the same as that of the input.
+        If `out` is specified, that array is returned instead.
     See Also
     --------
     mean

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -710,9 +710,9 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     median : ndarray
         A new array holding the result is returned unless out is
         specified, in which case a reference to out is returned.
-        Return data-type is "float64" for integer input. For 
-        floating-point input, the return data-type is the same as 
-        the input data-type.
+        For integer input, the output data-type is ``float64``.
+        Otherwise, the output data-type is the same as that
+        of the input.
 
     See Also
     --------

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -710,8 +710,9 @@ def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     median : ndarray
         A new array holding the result is returned unless out is
         specified, in which case a reference to out is returned.
-        Return data-type is `float64` for integers and floats smaller than
-        `float64`, or the input data-type, otherwise.
+        Return data-type is "float64" for integer input. For 
+        floating-point input, the return data-type is the same as 
+        the input data-type.
 
     See Also
     --------


### PR DESCRIPTION
**PR summary**
np.ma.median does not promote float16 and float32 inputs to float64 as documented. The docstring states the return type should be float64 for floats smaller than float64, but the result stays in the input dtype instead.
The bug is in _median in numpy/ma/extras.py. Two code paths,  the 1D path and the N-D path, use np.true_divide without first casting to the correct output dtype. The fix computes out_dtype = np.result_type(asorted.dtype, np.float64) and casts before dividing in both paths.

**UPDATE**: After reviewer feedback, it was found that both np.median and np.ma.median return the same dtype as the input consistently. The issue is in the docstring, not the code. This PR now corrects the docstring in numpy/ma/extras.py to accurately reflect the actual behavior.
  
 Closes #31486 Related to: #29003 

**First time committer introduction**
I am Atharva, I use NumPy for academic projects, but it's my first time contributing to this open source project. I kept the change small and focused on a single well-defined bug.

** AI Disclosure**
AI was used to reword the PR description in more suitable language.
