### PR TITLE
BUG: For new-style wrapped legacy dtypes use old array printing path

### DIFF
--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -1576,7 +1576,7 @@ def dtype_short_repr(dtype):
     >>> dt = np.int64([1, 2]).dtype
     >>> assert eval(dtype_short_repr(dt)) == dt
     """
-    if type(dtype).__repr__ != np.dtype.__repr__:
+    if not type(dtype)._legacy:
         # TODO: Custom repr for user DTypes, logic should likely move.
         return repr(dtype)
     if dtype.names is not None:

--- a/numpy/_core/src/umath/_rational_tests.c
+++ b/numpy/_core/src/umath/_rational_tests.c
@@ -945,9 +945,18 @@ static PyTypeObject PyRational2_Type = {
     /* the rest is inherited from PyRational_Type via tp_base */
 };
 
+
+static PyObject *
+rational2_repr(PyObject *self) {
+    // Just forward, but old versions of NumPy require a repr
+    // although for "legacy" dtypes the default one works.
+    return PyArrayDescr_Type.tp_repr(self);
+}
+
 static PyArray_DTypeMeta NPY_Rational2DType = {{{
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "numpy._core._rational_tests.Rational2DType",
+    .tp_repr = (reprfunc)rational2_repr,
 }}};
 
 /*

--- a/numpy/_core/tests/test_arrayprint.py
+++ b/numpy/_core/tests/test_arrayprint.py
@@ -7,6 +7,7 @@ from hypothesis import given
 from hypothesis.extra import numpy as hynp
 
 import numpy as np
+from numpy._core._rational_tests import rational, rational2
 from numpy._core.arrayprint import _typelessdata
 from numpy._utils import _pep440
 from numpy.testing import (
@@ -1351,3 +1352,12 @@ def test_user_defined_floating_dtype_printing_does_not_corrupt_precision():
     res = np.array(str(arr).strip("[] "), dtype=QuadPrecDType())
     # Check that the string representation round-trips correctly.
     assert_array_equal(res, arr)
+
+
+@pytest.mark.parametrize("sctype", [np.int8, np.float32, rational, rational2])
+def test_array_dtype_short_repr(sctype):
+    # Mainly test that rational/rational2 (both legacy dtypes) use short repr
+    # which in the end should just be the name for these (not default dtypes).
+    arr = np.zeros(1, dtype=sctype)
+    res = repr(arr)
+    assert f"dtype={sctype.__name__}" in res


### PR DESCRIPTION
For such dtypes let's keep things mostly as things were at least on NumPy 2.5+.  In practice we may want to make things a nice more flexible here for all user-dtypes.

This doesn't change anything otherwise, the `__repr__` test was guaranteed equivalent to the new check except for this new path.

(No AI use)