### PR TITLE
BUG: avoid SystemError in np.dot object loop when an error is already set

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -3646,6 +3646,14 @@ OBJECT_dot(char *ip1, npy_intp is1, char *ip2, npy_intp is2, char *op, npy_intp 
     npy_intp i;
     PyObject *tmp1, *tmp2, *tmp = NULL;
     PyObject **tmp3;
+    /*
+     * np.dot can re-enter this loop with an error already set from an earlier
+     * failed element operation; bail out so we don't run with a pending
+     * exception and raise a confusing SystemError. See gh-29688.
+     */
+    if (PyErr_Occurred()) {
+        return;
+    }
     for (i = 0; i < n; i++, ip1 += is1, ip2 += is2) {
         if ((*((PyObject **)ip1) == NULL) || (*((PyObject **)ip2) == NULL)) {
             tmp1 = Py_False;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -3889,6 +3889,14 @@ class TestMethods:
         assert_raises(TypeError, np.dot, c, A)
         assert_raises(TypeError, np.dot, A, c)
 
+    def test_dot_object_unsupported_multiply(self):
+        # gh-29688: an unsupported object multiply must raise the real error
+        # (TypeError), not a SystemError.
+        a = np.zeros((2, 2), dtype=complex)
+        b = np.array([[np.timedelta64(123, "s")],
+                      [np.timedelta64(321, "s")]], dtype=object)
+        assert_raises(TypeError, np.dot, a, b)
+
     def test_dot_out_mem_overlap(self):
         np.random.seed(1)
 


### PR DESCRIPTION
### PR summary
`np.dot` on certain incompatible types raises a confusing `SystemError` instead of the real `TypeError` (gh-29688):

```python
a = np.zeros((2, 2), dtype=complex)
b = np.array([[np.timedelta64(123, "s")], [np.timedelta64(321, "s")]], dtype=object)
np.dot(a, b)   # SystemError: ... returned a result with an exception set
```

`OBJECT_dot` has a void return and can't signal failure, so on an unsupported element multiply it sets the exception and returns. But `matrixproduct2` re-enters `OBJECT_dot` for later output slots with the exception still pending, and running Python C-API calls with an error set is what surfaces as the `SystemError`. Per @seberg's suggestion in the issue, this checks `PyErr_Occurred()` at the top of `OBJECT_dot` and bails, preserving the original error; the repro then raises the expected `TypeError`. Adds a regression test.

@seberg asked to confirm the guard is unnoticeable (it is one `PyErr_Occurred()` per call). Object-dtype `np.dot`, before vs after the guard:

| n | before | after |
|------|---------------|---------------|
| 1 | 0.613 us/call | 0.630 us/call |
| 8 | 4.391 us/call | 4.401 us/call |
| 1000 | 567.7 us/call | 563.9 us/call |

Differences are within run-to-run noise.

Closes #29688.

#### AI Disclosure
AI assisted with this PR. Tools: Claude Code (Anthropic) and OpenAI Codex. They helped locate the missing `PyErr_Occurred()` check in `OBJECT_dot` and draft the fix, the regression test, and this PR text. I reviewed and verified the change, built NumPy locally to confirm the repro is fixed and the test passes, ran the before/after benchmark, understand it, and can explain it.
