### PR TITLE
BUG: accept NumPy integer scalars in datetime64

### DIFF
--- a/doc/release/upcoming_changes/10004.change.rst
+++ b/doc/release/upcoming_changes/10004.change.rst
@@ -1,0 +1,5 @@
+``datetime64`` accepts NumPy integer scalars
+------------------------------------------------
+``np.datetime64`` can now be constructed from NumPy integer scalars
+when an explicit datetime unit is provided, matching construction from
+Python integers.

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2402,6 +2402,19 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
         }
         return 0;
     }
+    /* Do no conversion on NumPy integer scalars */
+    else if (PyArray_IsScalar(obj, Integer)) {
+        if (meta->base == NPY_FR_ERROR || meta->base == NPY_FR_GENERIC) {
+            PyErr_SetString(PyExc_ValueError, "Converting an integer to a "
+                            "NumPy datetime requires a specified unit");
+            return -1;
+        }
+        *out = PyLong_AsLongLong(obj);
+        if (error_converting(*out)) {
+            return -1;
+        }
+        return 0;
+    }
     /* Datetime scalar */
     else if (PyArray_IsScalar(obj, Datetime)) {
         PyDatetimeScalarObject *dts = (PyDatetimeScalarObject *)obj;

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2388,28 +2388,24 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
         Py_DECREF(utf8);
         return 0;
     }
-    /* Do no conversion on raw integers */
-    else if (PyLong_Check(obj)) {
+    /* Do no conversion on integers (Python int, NumPy integer scalars, 0-D integer arrays) */
+    else if (PyLong_Check(obj) ||
+             PyArray_IsScalar(obj, Integer) ||
+             (PyArray_Check(obj) &&
+              PyArray_NDIM((PyArrayObject *)obj) == 0 &&
+              PyArray_ISINTEGER((PyArrayObject *)obj))) {
         /* Don't allow conversion from an integer without specifying a unit */
         if (meta->base == NPY_FR_ERROR || meta->base == NPY_FR_GENERIC) {
             PyErr_SetString(PyExc_ValueError, "Converting an integer to a "
                             "NumPy datetime requires a specified unit");
             return -1;
         }
-        *out = PyLong_AsLongLong(obj);
-        if (error_converting(*out)) {
+        PyObject *as_long = PyNumber_Index(obj);
+        if (as_long == NULL) {
             return -1;
         }
-        return 0;
-    }
-    /* Do no conversion on NumPy integer scalars */
-    else if (PyArray_IsScalar(obj, Integer)) {
-        if (meta->base == NPY_FR_ERROR || meta->base == NPY_FR_GENERIC) {
-            PyErr_SetString(PyExc_ValueError, "Converting an integer to a "
-                            "NumPy datetime requires a specified unit");
-            return -1;
-        }
-        *out = PyLong_AsLongLong(obj);
+        *out = PyLong_AsLongLong(as_long);
+        Py_DECREF(as_long);
         if (error_converting(*out)) {
             return -1;
         }

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -397,6 +397,34 @@ class TestDateTime:
         assert_equal(arr.dtype, np.dtype('M8[us]'))
 
     @pytest.mark.parametrize("unit", [
+        "Y", "M", "W", "D", "h", "m",
+        "s", "ms", "us", "ns", "ps", "fs", "as",
+    ])
+    @pytest.mark.parametrize("int_type", [
+        np.int8, np.int16, np.int32, np.int64, np.intp,
+        np.uint8, np.uint16, np.uint32, np.uint64, np.uintp,
+    ])
+    def test_datetime_np_int_construction(self, unit, int_type):
+        # regression test for gh-10004
+        actual = np.datetime64(int_type(123), unit)
+        expected = np.datetime64(123, unit)
+        assert_equal(actual, expected)
+        assert_equal(actual.dtype, expected.dtype)
+
+    @pytest.mark.parametrize("value", [np.int64(123), np.uint64(123)])
+    def test_datetime_np_int_construction_requires_unit(self, value):
+        # Construction from integers requires a specified unit including
+        # NumPy integer scalars.
+        with pytest.raises(ValueError, match="requires a specified unit"):
+            np.datetime64(value)
+        with pytest.raises(ValueError, match="requires a specified unit"):
+            np.datetime64(value, "generic")
+
+    def test_datetime_np_uint_construction_overflow(self):
+        with pytest.raises(OverflowError):
+            np.datetime64(np.uint64(2**63), "s")
+
+    @pytest.mark.parametrize("unit", [
     # test all date / time units and use
     # "generic" to select generic unit
     ("Y"), ("M"), ("W"), ("D"), ("h"), ("m"),

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -425,6 +425,31 @@ class TestDateTime:
             np.datetime64(np.uint64(2**63), "s")
 
     @pytest.mark.parametrize("unit", [
+        "Y", "M", "W", "D", "h", "m",
+        "s", "ms", "us", "ns", "ps", "fs", "as",
+    ])
+    @pytest.mark.parametrize("int_type", [
+        np.int8, np.int16, np.int32, np.int64, np.intp,
+        np.uint8, np.uint16, np.uint32, np.uint64, np.uintp,
+    ])
+    def test_datetime_0d_int_array_construction(self, unit, int_type):
+        # 0-D integer arrays should be accepted the same as integers scalars
+        actual = np.datetime64(np.array(123, dtype=int_type), unit)
+        expected = np.datetime64(123, unit)
+        assert_equal(actual, expected)
+        assert_equal(actual.dtype, expected.dtype)
+
+    def test_datetime_0d_int_array_construction_requires_unit(self):
+        with pytest.raises(ValueError, match="requires a specified unit"):
+            np.datetime64(np.array(123))
+        with pytest.raises(ValueError, match="requires a specified unit"):
+            np.datetime64(np.array(123), "generic")
+
+    def test_datetime_0d_uint_array_construction_overflow(self):
+        with pytest.raises(OverflowError):
+            np.datetime64(np.array(2**63, dtype=np.uint64), "s")
+
+    @pytest.mark.parametrize("unit", [
     # test all date / time units and use
     # "generic" to select generic unit
     ("Y"), ("M"), ("W"), ("D"), ("h"), ("m"),


### PR DESCRIPTION
### PR summary

Closes gh-10004.

This fixes construction of `datetime64` scalars from NumPy integer scalars when an explicit datetime unit is provided. So `np.datetime64(np.int64(1478476800), "s")` now matches `np.datetime64(1478476800, "s")`.

The change mirrors the existing Python integer constructor behavior and preserves the current rule that integer-based `datetime64` construction requires an explicit unit. Construction without a unit or with `"generic"` still raises theexplicit-unit `ValueError`.

Tests cover signed and unsigned NumPy integer scalar construction, missing/generic unit errors and unsigned overflow behavior

#### AI Disclosure

I've used codex to run through my code and make sure I've missed nothing stupid