### PR TITLE
BUG,TST: Fix condition for whether long double is “IBM double double” (#31375)

### DIFF
--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -3,7 +3,6 @@ Test the scalar constructors, which also do type-coercion
 """
 import fractions
 import inspect
-import platform
 import sys
 import types
 from typing import Any, Literal
@@ -13,6 +12,7 @@ import pytest
 import numpy as np
 from numpy._core import sctypes
 from numpy.testing import assert_equal, assert_raises
+from numpy.testing._private.utils import LONG_DOUBLE_IS_IBM_DOUBLE_DOUBLE
 
 
 class TestAsIntegerRatio:
@@ -87,7 +87,7 @@ class TestAsIntegerRatio:
                     np.finfo(np.double) == np.finfo(np.longdouble),
                     reason="long double is same as double"),
                 pytest.mark.skipif(
-                    platform.machine().startswith("ppc"),
+                    LONG_DOUBLE_IS_IBM_DOUBLE_DOUBLE,
                     reason="IBM double double"),
             ]
         )

--- a/numpy/_core/tests/test_scalarmath.py
+++ b/numpy/_core/tests/test_scalarmath.py
@@ -23,6 +23,7 @@ from numpy.testing import (
     assert_raises,
     check_support_sve,
 )
+from numpy.testing._private.utils import LONG_DOUBLE_IS_IBM_DOUBLE_DOUBLE
 
 types = [np.bool, np.byte, np.ubyte, np.short, np.ushort, np.intc, np.uintc,
          np.int_, np.uint, np.longlong, np.ulonglong,
@@ -521,7 +522,7 @@ class TestConversion:
 
     @pytest.mark.skipif(np.finfo(np.double) == np.finfo(np.longdouble),
                         reason="long double is same as double")
-    @pytest.mark.skipif(platform.machine().startswith("ppc"),
+    @pytest.mark.skipif(LONG_DOUBLE_IS_IBM_DOUBLE_DOUBLE,
                         reason="IBM double double")
     def test_int_from_huge_longdouble(self):
         # Produce a longdouble that would overflow a double,

--- a/numpy/_core/tests/test_scalarprint.py
+++ b/numpy/_core/tests/test_scalarprint.py
@@ -1,12 +1,12 @@
 """ Test printing of scalar types.
 
 """
-import platform
 
 import pytest
 
 import numpy as np
 from numpy.testing import IS_MUSL, assert_, assert_equal, assert_raises
+from numpy.testing._private.utils import LONG_DOUBLE_IS_IBM_DOUBLE_DOUBLE
 
 
 class TestRealScalars:
@@ -329,8 +329,8 @@ class TestRealScalars:
         assert_equal(fsci(tp('1.0'), unique=False, precision=4),
                         "1.0000e+00")
 
-    @pytest.mark.skipif(not platform.machine().startswith("ppc64"),
-                        reason="only applies to ppc float128 values")
+    @pytest.mark.skipif(not LONG_DOUBLE_IS_IBM_DOUBLE_DOUBLE,
+                        reason="only applies to ppc double-double values")
     def test_ppc64_ibm_double_double128(self):
         # check that the precision decreases once we get into the subnormal
         # range. Unlike float64, this starts around 1e-292 instead of 1e-308,

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -31,7 +31,10 @@ from numpy.testing import (
     assert_raises,
     assert_raises_regex,
 )
-from numpy.testing._private.utils import _glibc_older_than
+from numpy.testing._private.utils import (
+    LONG_DOUBLE_IS_IBM_DOUBLE_DOUBLE,
+    _glibc_older_than,
+)
 
 UFUNCS = [obj for obj in np._core.umath.__dict__.values()
          if isinstance(obj, np.ufunc)]
@@ -4808,7 +4811,7 @@ def test_nextafterf():
 
 @pytest.mark.skipif(np.finfo(np.double) == np.finfo(np.longdouble),
                     reason="long double is same as double")
-@pytest.mark.xfail(condition=platform.machine().startswith("ppc64"),
+@pytest.mark.xfail(condition=LONG_DOUBLE_IS_IBM_DOUBLE_DOUBLE,
                     reason="IBM double double")
 def test_nextafterl():
     return _test_nextafter(np.longdouble)
@@ -4869,7 +4872,7 @@ def test_spacingf():
 
 @pytest.mark.skipif(np.finfo(np.double) == np.finfo(np.longdouble),
                     reason="long double is same as double")
-@pytest.mark.xfail(condition=platform.machine().startswith("ppc64"),
+@pytest.mark.xfail(condition=LONG_DOUBLE_IS_IBM_DOUBLE_DOUBLE,
                     reason="IBM double double")
 def test_spacingl():
     return _test_spacing(np.longdouble)

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -107,6 +107,10 @@ if 'musl' in _v:
 NOGIL_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 IS_64BIT = np.dtype(np.intp).itemsize == 8
 
+LONG_DOUBLE_IS_IBM_DOUBLE_DOUBLE = (platform.machine().startswith("ppc")
+                                    and str(np.finfo(np.longdouble).max)
+                                    == "1.79769313486231580793728971405301e+308")
+
 def assert_(val, msg=''):
     """
     Assert that works in release mode.


### PR DESCRIPTION
Backport of #31375.

Some distributions changed the default for long double on 64-bit PowerPC (at least little-endian) from the “IBM double double” format to the IEEE 754 binary128 format. The implementation already handles that by detecting the format at build time (longdouble_format property). Before this change, the tests checked only the CPU architecture name, possibly falsely assuming that long double has the “IBM double double” format when it actually has the IEEE 754 binary128 format. After this change, the tests assume the “IBM double double” format only if the maximum value, determined by calling numpy.finfo(), is the maximum value characteristic for the “IBM double double” format. On CPU architectures other than PowerPC, the “IBM double double” format is never assumed. I found no evidence that any other CPU architecture ever used that format.

On a system where long double has the “IBM double double” format, the test results don’t change:

47406 passed, 1047 skipped, 2845 deselected, 32 xfailed, 4 xpassed

On a system where long double has the IEEE 754 binary128 format, the test results change from:

1 failed, 47404 passed, 1049 skipped, 2845 deselected, 32 xfailed, 4 xpassed

to:

47408 passed, 1048 skipped, 2845 deselected, 32 xfailed, 2 xpassed

Fixes #21094.

### First time committer introduction

I rarely use NumPy directly. I encountered one of the previous test failures when building the NumPy package in the Nix package collection (which runs the tests).

#### AI Disclosure

No AI tools used