### PR TITLE
PERF, BUG: speed up conversion of Python datetime/date to datetime64

### DIFF
--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2233,7 +2233,8 @@ validate_and_return:
                 }
 
             /* The utcoffset function should return a timedelta */
-            PyObject *offset = PyObject_CallMethod(tzinfo, "utcoffset", "O", obj);
+            PyObject *offset = PyObject_CallMethodOneArg(
+                    tzinfo, npy_interned_str.utcoffset, obj);
             Py_DECREF(tzinfo);
             if (offset == NULL) {
                 return -1;
@@ -2243,8 +2244,8 @@ validate_and_return:
              * The timedelta should have a function "total_seconds"
              * which contains the value we want.
              */
-            PyObject *total_seconds = PyObject_CallMethod(
-                    offset, "total_seconds", "");
+            PyObject *total_seconds = PyObject_CallMethodNoArgs(
+                    offset, npy_interned_str.total_seconds);
             Py_DECREF(offset);
             if (total_seconds == NULL) {
                 return -1;

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2079,10 +2079,10 @@ pydatetime_attr_to_long(PyObject *obj, PyObject *name, long *value)
  * Tests for and converts a Python datetime.datetime or datetime.date
  * object into a NumPy npy_datetimestruct.
  *
- * While the C API has PyDate_* and PyDateTime_* functions, the following
- * implementation just asks for attributes, and thus supports
- * datetime duck typing. The tzinfo time zone conversion would require
- * this style of access anyway.
+ * Exact datetime.date / datetime.datetime objects are read directly from
+ * the C struct via the datetime C-API.  Other objects (including
+ * date/datetime subclasses) are queried for the attributes instead, and
+ * thus support datetime duck typing.
  *
  * 'out_bestunit' gives a suggested unit based on whether the object
  *      was a datetime.date or datetime.datetime object.
@@ -2098,7 +2098,6 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
         PyObject *obj, npy_datetimestruct *out, NPY_DATETIMEUNIT *out_bestunit,
         int apply_tzinfo)
 {
-    PyObject *tmp;
     int isleap;
     int has_time;
 
@@ -2215,46 +2214,49 @@ validate_and_return:
 
     /* Apply the time zone offset if it exists */
     if (apply_tzinfo) {
-        found = PyObject_GetOptionalAttr(obj, npy_interned_str.tzinfo, &tmp);
-        if (found < 0) {
+        PyObject *tzinfo = NULL;
+        if (PyDateTime_CheckExact(obj)) {
+            /* Read straight from the C struct; Py_None when naive */
+            tzinfo = Py_NewRef(PyDateTime_DATE_GET_TZINFO(obj));
+        }
+        else if (PyObject_GetOptionalAttr(
+                        obj, npy_interned_str.tzinfo, &tzinfo) < 0) {
             return -1;
         }
-        if (found && tmp != Py_None) {
-            PyObject *offset;
+        if (tzinfo != NULL && tzinfo != Py_None) {
             int seconds_offset, minutes_offset;
             if (PyErr_WarnEx(PyExc_UserWarning,
                 "no explicit representation of timezones available for np.datetime64",
                 1) < 0) {
-                    Py_DECREF(tmp);
+                    Py_DECREF(tzinfo);
                     return -1;
                 }
 
             /* The utcoffset function should return a timedelta */
-            offset = PyObject_CallMethod(tmp, "utcoffset", "O", obj);
+            PyObject *offset = PyObject_CallMethod(tzinfo, "utcoffset", "O", obj);
+            Py_DECREF(tzinfo);
             if (offset == NULL) {
-                Py_DECREF(tmp);
                 return -1;
             }
-            Py_DECREF(tmp);
 
             /*
              * The timedelta should have a function "total_seconds"
              * which contains the value we want.
              */
-            tmp = PyObject_CallMethod(offset, "total_seconds", "");
+            PyObject *total_seconds = PyObject_CallMethod(
+                    offset, "total_seconds", "");
             Py_DECREF(offset);
-            if (tmp == NULL) {
+            if (total_seconds == NULL) {
                 return -1;
             }
             /* Rounding here is no worse than the integer division below.
              * Only whole minute offsets are supported by numpy anyway.
              */
-            seconds_offset = (int)PyFloat_AsDouble(tmp);
+            seconds_offset = (int)PyFloat_AsDouble(total_seconds);
+            Py_DECREF(total_seconds);
             if (error_converting(seconds_offset)) {
-                Py_DECREF(tmp);
                 return -1;
             }
-            Py_DECREF(tmp);
 
             /* Convert to a minutes offset and apply it */
             minutes_offset = seconds_offset / 60;
@@ -2262,8 +2264,8 @@ validate_and_return:
             add_minutes_to_datetimestruct(out, -minutes_offset);
         }
         else {
-            /* tmp is None (or NULL when the attribute is absent) */
-            Py_XDECREF(tmp);
+            /* tzinfo is None (or NULL when the attribute is absent) */
+            Py_XDECREF(tzinfo);
         }
     }
 

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -16,7 +16,8 @@
 #include "numpyos.h"
 
 #include "npy_config.h"
-
+#include "npy_pycompat.h"  // PyObject_GetOptionalAttr
+#include "npy_static_data.h"
 
 #include "common.h"
 #include "numpy/arrayscalars.h"
@@ -2051,6 +2052,28 @@ add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes)
     }
 }
 
+/*
+ * Reads attribute 'name' from 'obj' and converts it to a C long in '*value'.
+ *
+ * Returns 1 on success, 0 if the attribute is absent ('*value' untouched),
+ * and -1 with an exception set on error.
+ */
+static inline int
+pydatetime_attr_to_long(PyObject *obj, PyObject *name, long *value)
+{
+    PyObject *tmp;
+    int found = PyObject_GetOptionalAttr(obj, name, &tmp);
+    if (found <= 0) {
+        return found;  /* 0: absent, -1: error */
+    }
+    *value = PyLong_AsLong(tmp);
+    Py_DECREF(tmp);
+    if (error_converting(*value)) {
+        return -1;
+    }
+    return 1;
+}
+
 /*NUMPY_API
  *
  * Tests for and converts a Python datetime.datetime or datetime.date
@@ -2077,55 +2100,93 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
 {
     PyObject *tmp;
     int isleap;
+    int has_time;
 
     /* Initialize the output to all zeros */
     memset(out, 0, sizeof(npy_datetimestruct));
     out->month = 1;
     out->day = 1;
 
-    /* Need at least year/month/day attributes */
-    if (!PyObject_HasAttrString(obj, "year") ||
-            !PyObject_HasAttrString(obj, "month") ||
-            !PyObject_HasAttrString(obj, "day")) {
+    /*
+     * Fast path for exact datetime.date / datetime.datetime objects: read the
+     * fields straight from the C struct via the datetime C-API macros.
+     * Subclasses may override attribute access, so they take the duck-typed
+     * fallback below instead.
+     */
+    if (PyDate_CheckExact(obj) || PyDateTime_CheckExact(obj)) {
+        out->year = PyDateTime_GET_YEAR(obj);
+        out->month = PyDateTime_GET_MONTH(obj);
+        out->day = PyDateTime_GET_DAY(obj);
+
+        has_time = PyDateTime_CheckExact(obj);
+        if (has_time) {
+            out->hour = PyDateTime_DATE_GET_HOUR(obj);
+            out->min = PyDateTime_DATE_GET_MINUTE(obj);
+            out->sec = PyDateTime_DATE_GET_SECOND(obj);
+            out->us = PyDateTime_DATE_GET_MICROSECOND(obj);
+        }
+        goto validate_and_return;
+    }
+
+    /*
+     * Generic duck-typed fallback for objects that expose date/datetime
+     * attributes without being an exact datetime.date / datetime.datetime
+     * instance (this includes date/datetime subclasses).
+     */
+    long val;
+    int found = pydatetime_attr_to_long(obj, npy_interned_str.year, &val);
+    if (found < 0) {
+        return -1;
+    }
+    if (found == 0) {
         return 1;
     }
+    out->year = val;
 
-    /* Get the year */
-    tmp = PyObject_GetAttrString(obj, "year");
-    if (tmp == NULL) {
+    found = pydatetime_attr_to_long(obj, npy_interned_str.month, &val);
+    if (found < 0) {
         return -1;
     }
-    out->year = PyLong_AsLong(tmp);
-    if (error_converting(out->year)) {
-        Py_DECREF(tmp);
-        return -1;
+    if (found == 0) {
+        return 1;
     }
-    Py_DECREF(tmp);
+    out->month = val;
 
-    /* Get the month */
-    tmp = PyObject_GetAttrString(obj, "month");
-    if (tmp == NULL) {
+    found = pydatetime_attr_to_long(obj, npy_interned_str.day, &val);
+    if (found < 0) {
         return -1;
     }
-    out->month = PyLong_AsLong(tmp);
-    if (error_converting(out->month)) {
-        Py_DECREF(tmp);
-        return -1;
+    if (found == 0) {
+        return 1;
     }
-    Py_DECREF(tmp);
+    out->day = val;
 
-    /* Get the day */
-    tmp = PyObject_GetAttrString(obj, "day");
-    if (tmp == NULL) {
-        return -1;
+    /* Read the time attributes into locals, committing them only if all four
+     * are present. */
+    long time_vals[4];
+    PyObject *const time_names[4] = {
+        npy_interned_str.hour, npy_interned_str.minute,
+        npy_interned_str.second, npy_interned_str.microsecond,
+    };
+    has_time = 1;
+    for (int i = 0; i < 4; i++) {
+        found = pydatetime_attr_to_long(obj, time_names[i], &time_vals[i]);
+        if (found < 0) {
+            return -1;
+        }
+        if (found == 0) {
+            has_time = 0;
+            break;
+        }
     }
-    out->day = PyLong_AsLong(tmp);
-    if (error_converting(out->day)) {
-        Py_DECREF(tmp);
-        return -1;
+    if (has_time) {
+        out->hour = time_vals[0];
+        out->min = time_vals[1];
+        out->sec = time_vals[2];
+        out->us = time_vals[3];
     }
-    Py_DECREF(tmp);
 
+validate_and_return:
     /* Validate that the month and day are valid for the year */
     if (out->month < 1 || out->month > 12) {
         goto invalid_date;
@@ -2136,66 +2197,15 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
         goto invalid_date;
     }
 
-    /* Check for time attributes (if not there, return success as a date) */
-    if (!PyObject_HasAttrString(obj, "hour") ||
-            !PyObject_HasAttrString(obj, "minute") ||
-            !PyObject_HasAttrString(obj, "second") ||
-            !PyObject_HasAttrString(obj, "microsecond")) {
-        /* The best unit for date is 'D' */
+    /* A date with no time component resolves to the 'D' unit */
+    if (!has_time) {
         if (out_bestunit != NULL) {
             *out_bestunit = NPY_FR_D;
         }
         return 0;
     }
 
-    /* Get the hour */
-    tmp = PyObject_GetAttrString(obj, "hour");
-    if (tmp == NULL) {
-        return -1;
-    }
-    out->hour = PyLong_AsLong(tmp);
-    if (error_converting(out->hour)) {
-        Py_DECREF(tmp);
-        return -1;
-    }
-    Py_DECREF(tmp);
-
-    /* Get the minute */
-    tmp = PyObject_GetAttrString(obj, "minute");
-    if (tmp == NULL) {
-        return -1;
-    }
-    out->min = PyLong_AsLong(tmp);
-    if (error_converting(out->min)) {
-        Py_DECREF(tmp);
-        return -1;
-    }
-    Py_DECREF(tmp);
-
-    /* Get the second */
-    tmp = PyObject_GetAttrString(obj, "second");
-    if (tmp == NULL) {
-        return -1;
-    }
-    out->sec = PyLong_AsLong(tmp);
-    if (error_converting(out->sec)) {
-        Py_DECREF(tmp);
-        return -1;
-    }
-    Py_DECREF(tmp);
-
-    /* Get the microsecond */
-    tmp = PyObject_GetAttrString(obj, "microsecond");
-    if (tmp == NULL) {
-        return -1;
-    }
-    out->us = PyLong_AsLong(tmp);
-    if (error_converting(out->us)) {
-        Py_DECREF(tmp);
-        return -1;
-    }
-    Py_DECREF(tmp);
-
+    /* Validate the time */
     if (out->hour < 0 || out->hour >= 24 ||
             out->min < 0 || out->min >= 60 ||
             out->sec < 0 || out->sec >= 60 ||
@@ -2204,20 +2214,18 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
     }
 
     /* Apply the time zone offset if it exists */
-    if (apply_tzinfo && PyObject_HasAttrString(obj, "tzinfo")) {
-        tmp = PyObject_GetAttrString(obj, "tzinfo");
-        if (tmp == NULL) {
+    if (apply_tzinfo) {
+        found = PyObject_GetOptionalAttr(obj, npy_interned_str.tzinfo, &tmp);
+        if (found < 0) {
             return -1;
         }
-        if (tmp == Py_None) {
-            Py_DECREF(tmp);
-        }
-        else {
+        if (found && tmp != Py_None) {
             PyObject *offset;
             int seconds_offset, minutes_offset;
             if (PyErr_WarnEx(PyExc_UserWarning,
                 "no explicit representation of timezones available for np.datetime64",
                 1) < 0) {
+                    Py_DECREF(tmp);
                     return -1;
                 }
 
@@ -2253,6 +2261,10 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
 
             add_minutes_to_datetimestruct(out, -minutes_offset);
         }
+        else {
+            /* tmp is None (or NULL when the attribute is absent) */
+            Py_XDECREF(tmp);
+        }
     }
 
     /* The resolution of Python's datetime is 'us' */
@@ -2264,15 +2276,15 @@ NpyDatetime_ConvertPyDateTimeToDatetimeStruct(
 
 invalid_date:
     PyErr_Format(PyExc_ValueError,
-            "Invalid date (%" NPY_INT64_FMT ",%" NPY_INT32_FMT ",%" NPY_INT32_FMT ") when converting to NumPy datetime",
-            out->year, out->month, out->day);
+            "Invalid date (%lld,%d,%d) when converting to NumPy datetime",
+            (long long)out->year, (int)out->month, (int)out->day);
     return -1;
 
 invalid_time:
     PyErr_Format(PyExc_ValueError,
-            "Invalid time (%" NPY_INT32_FMT ",%" NPY_INT32_FMT ",%" NPY_INT32_FMT ",%" NPY_INT32_FMT ") when converting "
+            "Invalid time (%d,%d,%d,%d) when converting "
             "to NumPy datetime",
-            out->hour, out->min, out->sec, out->us);
+            (int)out->hour, (int)out->min, (int)out->sec, (int)out->us);
     return -1;
 }
 

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -83,6 +83,8 @@ intern_strings(void)
     INTERN_STRING(second, "second");
     INTERN_STRING(microsecond, "microsecond");
     INTERN_STRING(tzinfo, "tzinfo");
+    INTERN_STRING(utcoffset, "utcoffset");
+    INTERN_STRING(total_seconds, "total_seconds");
     return 0;
 }
 

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -75,6 +75,14 @@ intern_strings(void)
     INTERN_STRING(sort, "sort");
     INTERN_STRING(argsort, "argsort");
     INTERN_STRING(_set_dtype, "_set_dtype");
+    INTERN_STRING(year, "year");
+    INTERN_STRING(month, "month");
+    INTERN_STRING(day, "day");
+    INTERN_STRING(hour, "hour");
+    INTERN_STRING(minute, "minute");
+    INTERN_STRING(second, "second");
+    INTERN_STRING(microsecond, "microsecond");
+    INTERN_STRING(tzinfo, "tzinfo");
     return 0;
 }
 

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -54,6 +54,14 @@ typedef struct npy_interned_str_struct {
     PyObject *sort;
     PyObject *argsort;
     PyObject *_set_dtype;
+    PyObject *year;
+    PyObject *month;
+    PyObject *day;
+    PyObject *hour;
+    PyObject *minute;
+    PyObject *second;
+    PyObject *microsecond;
+    PyObject *tzinfo;
 } npy_interned_str_struct;
 
 /*

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -62,6 +62,8 @@ typedef struct npy_interned_str_struct {
     PyObject *second;
     PyObject *microsecond;
     PyObject *tzinfo;
+    PyObject *utcoffset;
+    PyObject *total_seconds;
 } npy_interned_str_struct;
 
 /*

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -756,6 +756,76 @@ class TestDateTime:
         assert_equal(np.array(datetime.date(1960, 3, 12), dtype='M8[s]'),
                      np.array(np.datetime64('1960-03-12T00:00:00')))
 
+    def test_pydatetime_subclass_and_duck_typing(self):
+        # Exact datetime.datetime/datetime.date objects are read directly from
+        # the CPython struct via the datetime C-API, while subclasses and
+        # arbitrary duck-typed objects fall back to attribute access.  All
+        # paths must agree.
+
+        # A datetime.datetime subclass goes through the attribute fallback but
+        # still converts to the same value
+        class MyDateTime(datetime.datetime):
+            pass
+        assert_equal(np.datetime64(MyDateTime(2021, 5, 17, 13, 14, 15, 678901)),
+                     np.datetime64('2021-05-17T13:14:15.678901'))
+
+        # A datetime.date subclass likewise, resolving to best unit 'D'
+        class MyDate(datetime.date):
+            pass
+        assert_equal(np.datetime64(MyDate(1999, 12, 31)),
+                     np.datetime64('1999-12-31'))
+        assert_equal(np.datetime64(MyDate(1999, 12, 31)).dtype, np.dtype('M8[D]'))
+
+        # A subclass that overrides an attribute is honored via the fallback,
+        # rather than reading the raw C struct (which would ignore the override)
+        class ShiftedYear(datetime.datetime):
+            @property
+            def year(self):
+                return super().year + 1
+        assert_equal(np.datetime64(ShiftedYear(2021, 5, 17, 13, 14, 15)),
+                     np.datetime64('2022-05-17T13:14:15'))
+
+        # A duck-typed object (not a date/datetime instance) still works via
+        # the attribute-lookup fallback path
+        class DuckDateTime:
+            year, month, day = 2000, 2, 29
+            hour, minute, second, microsecond = 1, 2, 3, 4
+            tzinfo = None
+        assert_equal(np.datetime64(DuckDateTime()),
+                     np.datetime64('2000-02-29T01:02:03.000004'))
+
+        # A duck-typed object with only date attributes -> best unit 'D'
+        class DuckDate:
+            year, month, day = 2010, 4, 16
+        assert_equal(np.datetime64(DuckDate()), np.datetime64('2010-04-16'))
+        assert_equal(np.datetime64(DuckDate()).dtype, np.dtype('M8[D]'))
+
+        # A duck-typed object with only *some* time attributes resolves as a
+        # pure date
+        class DuckPartialTime:
+            year, month, day, hour = 2010, 4, 16, 5  # no minute/second/us
+        assert_equal(np.datetime64(DuckPartialTime()), np.datetime64('2010-04-16'))
+        assert_equal(np.datetime64(DuckPartialTime()).dtype, np.dtype('M8[D]'))
+        assert_equal(np.array([DuckPartialTime()], dtype=object).astype('M8[us]')[0],
+                     np.datetime64('2010-04-16T00:00:00', 'us'))
+
+        # Invalid dates are rejected on both the fast and the fallback path
+        class DuckBadDate:
+            year, month, day = 2001, 2, 29  # not a leap year
+        with assert_raises(ValueError):
+            np.datetime64(DuckBadDate())
+
+    def test_pydatetime_timezone_fast_path(self):
+        # tz-aware datetimes take the fast field-extraction path and then
+        # apply the utcoffset (with the usual deprecation-style warning).
+        tz = datetime.timezone(datetime.timedelta(hours=-8))
+        msg = "no explicit representation of timezones available for " \
+              "np.datetime64"
+        with pytest.warns(UserWarning, match=msg):
+            assert_equal(
+                np.datetime64(datetime.datetime(2000, 1, 1, 0, tzinfo=tz)),
+                np.datetime64('2000-01-01T08'))
+
     def test_datetime_string_conversion(self):
         a = ['2011-03-16', '1920-01-01', '2013-05-19']
         str_a = np.array(a, dtype='S')


### PR DESCRIPTION
`NpyDatetime_ConvertPyDateTimeToDatetimeStruct` is the per-element worker behind casting object arrays of Python datetimes to `datetime64`, e.g. `np.asarray(list_of_datetimes).astype("M8[us]")` (the floor of matplotlib's `date2num`, and relevant to pandas/xarray too).

This PR makes two complementary changes:

- **Fast path:** for genuine `datetime.date` / `datetime.datetime` objects
  (including subclasses such as pandas `Timestamp`), read the fields straight from
  the CPython C struct via the datetime C-API macros 
- **Cheaper attribute access** for the remaining cases: the duck-typed fallback and
  the per-element `tzinfo` lookup now use a single `PyObject_GetOptionalAttr` on
  pre-interned attribute names (added to `npy_interned_str`). The `tzinfo`
  lookup runs for every datetime

Benchmark

| cast | before | after | speedup |
| --- | --- | --- | --- |
| `datetime.datetime` → `M8[us]` | ~1130 ns | ~52 ns | ~21x |
| `datetime.date` → `M8[D]` | ~490 ns | ~38 ns | ~13x |

<details>
<summary>Benchmark script and notes</summary>

```python
import time, datetime, numpy as np

def best(fn, R=20000, trials=9):
    fn()
    ts = []
    for _ in range(trials):
        s = time.perf_counter()
        for _ in range(R):
            fn()
        ts.append(time.perf_counter() - s)
    return min(ts) / R

N = 100
dts = [datetime.datetime(2000, 1, 1) + datetime.timedelta(seconds=i * 1234567)
       for i in range(N)]
a = np.asarray(dts)
dates = [datetime.date(2000, 1, 1) + datetime.timedelta(days=i) for i in range(N)]
ad = np.asarray(dates)
base = np.arange(1000.0)  # unrelated op, sanity-check for binary-layout noise

print("dt   ->M8[us]: %6.1f ns/elem" % (best(lambda: a.astype('M8[us]')) / N * 1e9))
print("date ->M8[D] : %6.1f ns/elem" % (best(lambda: ad.astype('M8[D]')) / N * 1e9))
print("baseline sum : %6.1f ns"      % (best(lambda: base.sum()) * 1e9))
```

</details>


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
Claude code was used for profiling and implementing the selection of performance improvements selected.
