### PR TITLE
BUG: Pass DType class `np.average` to support `weights` argument for user-dtypes

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -595,13 +595,13 @@ def average(a, axis=None, weights=None, returned=False, *,
         else:
             result_dtype = np.result_type(a.dtype, wgt.dtype)
 
-        scl = wgt.sum(axis=axis, dtype=result_dtype, **keepdims_kw)
+        scl = wgt.sum(axis=axis, dtype=type(result_dtype), **keepdims_kw)
         if np.any(scl == 0.0):
             raise ZeroDivisionError(
                 "Weights sum to zero, can't be normalized")
 
         avg = avg_as_array = np.multiply(a, wgt,
-                          dtype=result_dtype).sum(axis, **keepdims_kw) / scl
+                      dtype=type(result_dtype)).sum(axis, **keepdims_kw) / scl
 
     if returned:
         if scl.shape != avg_as_array.shape:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -538,6 +538,21 @@ class TestAverage:
         a = np.array([Fraction(1, 5), Fraction(3, 5)])
         assert_equal(np.average(a), Fraction(2, 5))
 
+    def test_new_style_user_dtype(self):
+        # average forwarded a DType instance (from result_type) to the
+        # weight sum / multiply ufuncs, which reject instances of non-legacy
+        # user DTypes.  It must pass the DType class instead.
+        numpy_quaddtype = pytest.importorskip("numpy_quaddtype")
+        qd = numpy_quaddtype.QuadPrecDType()
+
+        a = np.array([1, 2, 3, 4], dtype=qd)
+        w = np.array([4, 3, 2, 1], dtype=qd)
+        assert float(np.average(a)) == 2.5
+        assert float(np.average(a, weights=w)) == 2.0
+        avg, scl = np.average(a, weights=w, returned=True)
+        assert float(avg) == 2.0
+        assert float(scl) == 10.0
+
 
 class TestSelect:
     choices = [np.array([1, 2, 3]),


### PR DESCRIPTION
### PR summary

Same fix as #31447

Discovered at https://github.com/numpy/numpy-quaddtype/issues/106

#### AI Disclosure
None
