### PR TITLE
BUG: Limited API fix for INCREF/DECREF in Numpy headers

### DIFF
--- a/numpy/_core/include/numpy/ndarrayobject.h
+++ b/numpy/_core/include/numpy/ndarrayobject.h
@@ -59,7 +59,7 @@ extern "C" {
 
 
 #define PyArray_GETCONTIGUOUS(m) (PyArray_ISCONTIGUOUS(m) ?                   \
-                                  Py_INCREF(m), (m) :                         \
+                                  Py_INCREF((PyObject*)m), (m) :                         \
                                   (PyArrayObject *)(PyArray_Copy(m)))
 
 #define PyArray_SAMESHAPE(a1,a2) ((PyArray_NDIM(a1) == PyArray_NDIM(a2)) &&   \
@@ -161,7 +161,7 @@ PyArray_DiscardWritebackIfCopy(PyArrayObject *arr)
 #define PyArray_DESCR_REPLACE(descr) do { \
                 PyArray_Descr *_new_; \
                 _new_ = PyArray_DescrNew(descr); \
-                Py_XDECREF(descr); \
+                Py_XDECREF((PyObject*)descr); \
                 descr = _new_; \
         } while(0)
 

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -371,7 +371,7 @@ static inline int PyArrayInitDTypeMeta_FromSpec(
     DType->flags |= 1;
 
     /* Re-type the descriptor so it belongs to the user's DType class. */
-    Py_INCREF(DType);
+    Py_INCREF((PyObject*)DType);
     Py_SET_TYPE(descr, (PyTypeObject *)(DType));
     Py_DECREF(old_meta);
 
@@ -380,8 +380,8 @@ static inline int PyArrayInitDTypeMeta_FromSpec(
      * PyBaseObject_Type in step 1 by PyArray_RegisterDataType copying
      * proto->typeobj).
      */
-    Py_INCREF(proto->typeobj);
-    Py_XDECREF(descr->typeobj);
+    Py_INCREF((PyObject*)proto->typeobj);
+    Py_XDECREF((PyObject*)descr->typeobj);
     descr->typeobj = proto->typeobj;
 
     /*


### PR DESCRIPTION
### PR summary

In the Limited API, `Py_INCREF` (and similar) don't contain a cast and thus the object has to be a `PyObject*`.

I'm not completely sure if npy_2_compat is intended to be Limited API compatible but it's easy enough to adjust anyway.

#### AI Disclosure

No AI tools used