### PR TITLE
CI: Add 3.15(t) CI for Windows and MacOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -119,7 +119,7 @@ jobs:
         build_runner:
           - [ macos-15-intel, "macos_x86_64" ]
           - [ macos-14, "macos_arm64" ]
-        version: ["3.12", "3.14t"]
+        version: ["3.12", "3.15t-dev"]
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: "3.14t"
+        python-version: "3.15t-dev"
 
     - name: Install build dependencies from PyPI
       run: |
@@ -131,7 +131,7 @@ jobs:
         include:
           - BLAS: 64
             TEST_MODE: full
-            pyver: '3.14'
+            pyver: '3.15-dev'
           - BLAS: 32
             TEST_MODE: fast
             pyver: '3.12'

--- a/numpy/_core/tests/examples/limited_api/meson.build
+++ b/numpy/_core/tests/examples/limited_api/meson.build
@@ -66,7 +66,7 @@ endif
 
 if (
      py.language_version().version_compare('>=3.15') and
-     (host_machine.system() != 'windows' or py.get_variable('Py_GIL_DISABLED', 0) == 0)
+     (host_machine.system() != 'windows' or (py.get_variable('Py_GIL_DISABLED', 0) == 1))
 )
   py.extension_module(
       'limited_api_opaque',

--- a/numpy/_core/tests/examples/limited_api/meson.build
+++ b/numpy/_core/tests/examples/limited_api/meson.build
@@ -64,7 +64,10 @@ if py.get_variable('Py_GIL_DISABLED', 0) == 0
 )
 endif
 
-if py.language_version().version_compare('>=3.15')
+if (
+     py.language_version().version_compare('>=3.15') and
+     (host_machine.system() != 'windows' or py.get_variable('Py_GIL_DISABLED', 0) == 0)
+)
   py.extension_module(
       'limited_api_opaque',
       'limited_api_opaque.c',

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -103,6 +103,12 @@ def test_limited_api(install_temp):
 @pytest.mark.skipif(
     sys.version_info < (3, 15), reason="opaque PyObject requires Python 3.15+"
 )
+@pytest.mark.skipif(
+    (sys.platform == "win32" and not
+     sysconfig.get_config_var('Py_GIL_DISABLED')),
+    reason=("Meson does not yet support building abi3t extensions on the "
+            "GIL-enabled build")
+)
 def test_limited_opaque(install_temp):
     import limited_api_opaque
 

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -104,8 +104,7 @@ def test_limited_api_abi3(install_temp):
     sys.version_info < (3, 15), reason="opaque PyObject requires Python 3.15+"
 )
 @pytest.mark.skipif(
-    (sys.platform == "win32" and not
-     sysconfig.get_config_var('Py_GIL_DISABLED')),
+    sys.platform == "win32" and not sysconfig.get_config_var('Py_GIL_DISABLED'),
     reason=("Meson does not yet support building abi3t extensions on the "
             "GIL-enabled build")
 )

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -89,9 +89,9 @@ def install_temp(tmpdir_factory):
 )
 @pytest.mark.xfail(
     NOGIL_BUILD,
-    reason="Py_GIL_DISABLED builds do not currently support the limited API",
+    reason="Py_GIL_DISABLED builds do not currently support abi3",
 )
-def test_limited_api(install_temp):
+def test_limited_api_abi3(install_temp):
     """Test building a third-party C extension with the limited API
     and building a cython extension with the limited API
     """


### PR DESCRIPTION
Over in the numpy-release repo, we [ran into a failing test](https://github.com/numpy/numpy-release/issues/43#issuecomment-4649318074) that only happens on GIL-enabled Python 3.15 on Windows.

This updates the MacOS and Windows CI to use 3.15(t) instead of 3.14(t). It also disables the test causing issues in numpy-release.