### PR TITLE
BUG: ppc64le: define NPY_HAVE_VSX when only higher VSX levels are enabled

### DIFF
--- a/meson_cpu/main_config.h.in
+++ b/meson_cpu/main_config.h.in
@@ -364,6 +364,20 @@
     #include <x86intrin.h>
 #endif
 
+/*
+ * VSX2/VSX3/VSX4 all imply the base VSX feature on Power. When NumPy is built
+ * with an empty baseline (cpu-baseline=none) and these levels are enabled only
+ * as dispatch targets, each target is compiled with just its own
+ * @P@HAVE_VSX{2,3,4} macro, not the implied @P@HAVE_VSX. The SIMD headers below
+ * (and the <altivec.h> include) gate on @P@HAVE_VSX as the generic any-VSX
+ * flag; without it, Power code wrongly takes the VX (s390x) branch and the
+ * AltiVec/VSX intrinsics are never declared, breaking the build. Normalize by
+ * defining @P@HAVE_VSX whenever any higher VSX level is present.
+ */
+#if !defined(@P@HAVE_VSX) && (defined(@P@HAVE_VSX2) || defined(@P@HAVE_VSX3) || defined(@P@HAVE_VSX4))
+    #define @P@HAVE_VSX 1
+#endif
+
 #if (defined(@P@HAVE_VSX) || defined(@P@HAVE_VX)) && !defined(__cplusplus) && defined(bool)
     /*
      * "altivec.h" header contains the definitions(bool, vector, pixel),


### PR DESCRIPTION
Fixes #31593.

## Problem

On ppc64le, building with `-Dcpu-baseline=none` fails: the VSX dispatch-target
sources hit `implicit declaration of function 'vec_load_len'` (an s390x/VX
intrinsic) and a cascade of undeclared `vec_*` errors, because `<altivec.h>`
is never included.

`NPY_HAVE_VSX` is used throughout the Power SIMD headers as the generic
"any VSX" flag — both to gate the `<altivec.h>` include in
`meson_cpu/main_config.h.in` and to select the Power (vs. s390x/VX) code path
in `simd/vec/*.h`. VSX2/VSX3/VSX4 all imply VSX.

But with an empty baseline, VSX2/3/4 are enabled only as **dispatch targets**,
each compiled in isolation with just its own `NPY_HAVE_VSX{2,3,4}` macro — not
the implied `NPY_HAVE_VSX`. The failing compile line shows `-DNPY_HAVE_VSX2`
with no `-DNPY_HAVE_VSX`. The Power code then falls into the `#else // VX`
branch and `<altivec.h>` is skipped.

Default CI builds don't catch this because the standard ppc64le baseline is
VSX2, which defines `NPY_HAVE_VSX` project-wide; dispatch targets inherit it.

## Fix

Normalize the flag in `meson_cpu/main_config.h.in`: define `NPY_HAVE_VSX`
whenever any of `NPY_HAVE_VSX2/VSX3/VSX4` is defined, before the `<altivec.h>`
include and the SIMD headers consume it.

```c
#if !defined(@P@HAVE_VSX) && (defined(@P@HAVE_VSX2) || defined(@P@HAVE_VSX3) || defined(@P@HAVE_VSX4))
    #define @P@HAVE_VSX 1
#endif
```

The guard is self-gating: it's a no-op on non-Power targets and on any build
that already defines `NPY_HAVE_VSX` (e.g. the default VSX2 baseline). It encodes
the existing implication (VSX2 contains VSX) that the headers already assume.

## Testing

- Minimal reproducer compiles cleanly with the fix; errors without it.
- Full build with `-Dcpu-baseline=none -Dcpu-dispatch=max` on ppc64le (POWER9,
  GCC 15.2) now succeeds; test suite passes (47899 passed, the only failure being
  an unrelated ppc64 long-double string-formatting test,
  `test_ppc64_ibm_double_double128`).

## Alternative considered

Making the meson `features` module propagate implied-feature macros to every
dispatch target generically (which would also help x86 SSE/AVX chains). That's a
larger, riskier change touching the build module; this header-level normalization
is minimal and targeted. Happy to pursue the broader fix if maintainers prefer.