### PR TITLE
BUG: ppc64le: define NPY_HAVE_VSX when only higher VSX levels are enabled

### DIFF
--- a/meson_cpu/main_config.h.in
+++ b/meson_cpu/main_config.h.in
@@ -364,6 +364,20 @@
     #include <x86intrin.h>
 #endif
 
+/*
+ * VSX2/VSX3/VSX4 all imply the base VSX feature on Power. When NumPy is built
+ * with an empty baseline (cpu-baseline=none) and these levels are enabled only
+ * as dispatch targets, each target is compiled with just its own
+ * @P@HAVE_VSX{2,3,4} macro, not the implied @P@HAVE_VSX. The SIMD headers below
+ * (and the <altivec.h> include) gate on @P@HAVE_VSX as the generic any-VSX
+ * flag; without it, Power code wrongly takes the VX (s390x) branch and the
+ * AltiVec/VSX intrinsics are never declared, breaking the build. Normalize by
+ * defining @P@HAVE_VSX whenever any higher VSX level is present.
+ */
+#if !defined(@P@HAVE_VSX) && (defined(@P@HAVE_VSX2) || defined(@P@HAVE_VSX3) || defined(@P@HAVE_VSX4))
+    #define @P@HAVE_VSX 1
+#endif
+
 #if (defined(@P@HAVE_VSX) || defined(@P@HAVE_VX)) && !defined(__cplusplus) && defined(bool)
     /*
      * "altivec.h" header contains the definitions(bool, vector, pixel),


### PR DESCRIPTION
Fixes: #31593

### PR summary
This PR is for enabling HAVE_VSX flag when either HAVE_VSX2, HAVE_VSX3 or HAVE_VSX4 flags are enabled, 

### First time committer introduction
I am a first time contributor to this repository. I do not use NumPy directly. I use nix for package management on Fedora ppc64le, which brought in numpy dependency as part of its functional tests, which uses mercurial as a test fixture, which depends on python environment that included numpy. With this fix, i am able to bootstrap nix environment for ppc64le linux. Which is a tier-2 platform for Nix.

#### AI Disclosure
Claude was used to draft the language inside the PR. As i am a non native English speaker.
