### PR TITLE
DOC: fix typo in `PyUFunc_FromFuncAndData` call in "Writing your own ufunc" docs

### DIFF
--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -590,7 +590,7 @@ is the primary thing that must be changed to create your own ufunc.
                 return NULL;
             }
 
-            logit = PyUFunc_FromFuncAndData(funcs, NULL, types, 4, 1, 1,
+            logit = PyUFunc_FromFuncAndData(funcs, NULL, types, 3, 1, 1,
                                             PyUFunc_None, "logit",
                                             "logit_docstring", 0);
 


### PR DESCRIPTION
### PR summary
Just a small typo I noticed while learning about ufuncs and gufuncs. I'm pretty sure the `ntypes` argument should be 3 there as the ufunc is defined for 3 dtypes.

https://github.com/numpy/numpy/blob/d0bc7b7fa0473af73080d604f4c266293700b64a/doc/source/user/c-info.ufunc-tutorial.rst?plain=1#L560-L567

#### AI Disclosure
N / A
