### PR TITLE
ENH: Rationalize f2py callback check to just require callable

### DIFF
--- a/numpy/f2py/cfuncs.py
+++ b/numpy/f2py/cfuncs.py
@@ -1343,6 +1343,35 @@ create_cb_arglist(PyObject* fun, PyTupleObject* xa , const int maxnofargs,
     Py_ssize_t tot, opt, ext, siz, i, di = 0;
     CFUNCSMESS(\"create_cb_arglist\\n\");
     tot=opt=ext=siz=0;
+    /* Check if the function is callable */
+    if (!fun || !(PyCallable_Check(fun) || F2PyCapsule_Check(fun))) {
+#ifdef Py_LIMITED_API
+        PyObject *tp_name_obj = NULL;
+#endif
+        const char *tp_name = "NULL";
+        if (fun != NULL) {
+#ifndef Py_LIMITED_API
+            tp_name = Py_TYPE(fun)->tp_name;
+#else
+            tp_name_obj = PyType_GetQualName(Py_TYPE(fun));
+            if (!tp_name_obj) goto capi_fail;
+            tp_name = PyUnicode_AsUTF8AndSize(tp_name_obj, NULL);
+            if (!tp_name) {
+                Py_DECREF(tp_name_obj);
+                goto capi_fail;
+            }
+#endif
+        }
+        fprintf(
+            stderr,
+            \"Call-back argument must be a Python-callable|f2py-function \"
+            \"but got %s.\\n\", tp_name);
+#ifdef Py_LIMITED_API
+        Py_XDECREF(tp_name_obj);
+#endif
+        goto capi_fail;
+    }
+
     /* Get the total number of arguments */
     if (PyFunction_Check(fun)) {
         tmp_fun = fun;
@@ -1350,32 +1379,16 @@ create_cb_arglist(PyObject* fun, PyTupleObject* xa , const int maxnofargs,
     }
     else {
         di = 1;
-        if (PyObject_HasAttrString(fun,\"im_func\")) {
-            tmp_fun = PyObject_GetAttrString(fun,\"im_func\");
-        }
-        else if (PyObject_HasAttrString(fun,\"__call__\")) {
-            tmp = PyObject_GetAttrString(fun,\"__call__\");
-            if (PyObject_HasAttrString(tmp,\"im_func\"))
-                tmp_fun = PyObject_GetAttrString(tmp,\"im_func\");
-            else {
-                tmp_fun = fun; /* built-in function */
-                Py_INCREF(tmp_fun);
-                tot = maxnofargs;
-                if (PyCFunction_Check(fun)) {
-                    /* In case the function has a co_argcount */
-                    di = 0;
-                }
-                if (xa != NULL)
-                    tot += PyTuple_Size((PyObject *)xa);
-            }
-            Py_XDECREF(tmp);
-        }
-        else if (PyFortran_Check(fun) || PyFortran_Check1(fun)) {
+        if (PyObject_HasAttrString(fun,\"__call__\")) {
+            tmp_fun = fun; /* built-in function */
+            Py_INCREF(tmp_fun);
             tot = maxnofargs;
+            if (PyCFunction_Check(fun)) {
+                /* In case the function has a co_argcount */
+                di = 0;
+            }
             if (xa != NULL)
                 tot += PyTuple_Size((PyObject *)xa);
-            tmp_fun = fun;
-            Py_INCREF(tmp_fun);
         }
         else if (F2PyCapsule_Check(fun)) {
             tot = maxnofargs;
@@ -1388,14 +1401,13 @@ create_cb_arglist(PyObject* fun, PyTupleObject* xa , const int maxnofargs,
             tmp_fun = fun;
             Py_INCREF(tmp_fun);
         }
-    }
-
-    if (tmp_fun == NULL) {
-        fprintf(stderr,
-                \"Call-back argument must be function|instance|instance.__call__|f2py-function \"
-                \"but got %s.\\n\",
-                ((fun == NULL) ? \"NULL\" : Py_TYPE(fun)->tp_name));
-        goto capi_fail;
+        else {
+            tot = maxnofargs;
+            if (xa != NULL)
+                tot += PyTuple_Size((PyObject *)xa);
+            tmp_fun = fun;
+            Py_INCREF(tmp_fun);
+        }
     }
 
     if (PyObject_HasAttrString(tmp_fun,\"__code__\")) {

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -222,7 +222,7 @@ class TestF77Callback(util.F2PyTest):
     @pytest.mark.parametrize("name", ["t", "t2"])
     @pytest.mark.parametrize("cb, args",
         [((lambda x: x), ()),
-         ((lambda x, y=1: x+y), ()),
+         ((lambda x, y=1: x + y), ()),
          (C().meth, ()),
          (C().meth_with_default, ())])
     def test_wrong_arg_count(self, cb, args, name):

--- a/numpy/f2py/tests/test_callback.py
+++ b/numpy/f2py/tests/test_callback.py
@@ -54,6 +54,10 @@ class TestF77Callback(util.F2PyTest):
         t = getattr(self.module, name)
         r = t(lambda: 4)
         assert r == 4
+        r = t(lambda x=2: x)
+        assert r == 2
+        r = t(lambda x=2: x, fun_extra_args=(3, ))
+        assert r == 3
         r = t(lambda a: 5, fun_extra_args=(6, ))
         assert r == 5
         r = t(lambda a: a, fun_extra_args=(6, ))
@@ -84,6 +88,11 @@ class TestF77Callback(util.F2PyTest):
         assert r == 7
         r = t(a.mth)
         assert r == 9
+
+        r = t({8: 12}.get, fun_extra_args=(8, ))
+        assert r == 12
+        r = t(int, fun_extra_args=('15', ))
+        assert r == 15
 
     @pytest.mark.skipif(sys.platform == 'win32',
                         reason='Fails with MinGW64 Gfortran (Issue #9673)')
@@ -193,6 +202,36 @@ class TestF77Callback(util.F2PyTest):
         r = self.module.hidden_callback2(2)
         assert r == 3
 
+    @pytest.mark.parametrize("name", ["t", "t2"])
+    @pytest.mark.parametrize("cb", [1.5, None])
+    def test_invalid_callback(self, cb, name):
+        t = getattr(self.module, name)
+        err = getattr(
+            self.module,
+            f"_{self.module.__name__}_error")
+        with pytest.raises(err):
+            t(cb)
+
+    class C:
+        def meth(self, arg):
+            return arg
+
+        def meth_with_default(self, arg1, arg2=5):
+            return arg1 + arg2
+
+    @pytest.mark.parametrize("name", ["t", "t2"])
+    @pytest.mark.parametrize("cb, args",
+        [((lambda x: x), ()),
+         ((lambda x, y=1: x+y), ()),
+         (C().meth, ()),
+         (C().meth_with_default, ())])
+    def test_wrong_arg_count(self, cb, args, name):
+        t = getattr(self.module, name)
+        err = getattr(
+            self.module,
+            f"_{self.module.__name__}_error")
+        with pytest.raises(err):
+            t(cb, fun_extra_args=args)
 
 @pytest.mark.slow
 class TestF77CallbackPythonTLS(TestF77Callback):


### PR DESCRIPTION
### PR summary

... rather than specific types of callable. This means that we can eliminate the PyFortranType_Check1 (which is hard to do in the Limited API) because it's just caught by callable.

Also:
* Add some extra tests (which were already working before the changes, but good to test anyway)
* Get rid of some dead py2 code-paths (`im_func`)

#### AI Disclosure

No AI usage.