### PR TITLE
ENH: Add SIMD acceleration for the Elbrus2000 (e2k) arch

### DIFF
--- a/meson.options
+++ b/meson.options
@@ -47,6 +47,7 @@ option('test-simd', type: 'array',
          'NEON', 'ASIMD',
          'VX', 'VXE', 'VXE2',
          'LSX',
+         'E2K_SSE', 'E2K_AVX'
        ],
        description: 'CPU SIMD feature sets to be tested by the NumPy SIMD test module')
 option('test-simd-args', type: 'string', value: '',

--- a/meson_cpu/e2k/meson.build
+++ b/meson_cpu/e2k/meson.build
@@ -1,0 +1,27 @@
+source_root = meson.project_source_root()
+current_dir = meson.current_source_dir()
+mod_features = import('features')
+
+E2K_SSE = mod_features.new(
+  'E2K_SSE', 1, args: ['-msse', '-msse2', '-msse3', '-mssse3', '-msse4.1',
+                       '-msse4.2', '-mpopcnt', '-mfpmath=sse',
+                       '-DHWY_WANT_SSE4', '-DHWY_DISABLE_PCLMUL_AES'],
+  # Adds compiler definitions `NPY_HAVE_SSE*`
+  group: ['SSE', 'SSE2', 'SSE3', 'SSSE3', 'SSE41', 'SSE42', 'POPCNT'],
+  detect: 'E2K_SSE',
+  # reuse the x86 features testing code
+  test_code: files(current_dir + '/../x86/test_x86_v2.c')[0],
+)
+E2K_AVX = mod_features.new(
+  'E2K_AVX', 10, args: ['-mavx', '-mavx2', '-mfma', '-mbmi', '-mbmi2',
+                        '-mlzcnt', '-mf16c'],
+  implies: E2K_SSE,
+  # Adds compiler definitions `NPY_HAVE_SSE*`
+  group: ['AVX', 'AVX2', 'FMA3', 'BMI', 'BMI2', 'LZCNT', 'F16C'],
+  detect: 'E2K_AVX',
+  test_code: files(current_dir + '/../x86/test_x86_v3.c')[0],
+)
+
+E2K_FEATURES = {
+  'E2K_SSE': E2K_SSE, 'E2K_AVX': E2K_AVX
+}

--- a/meson_cpu/meson.build
+++ b/meson_cpu/meson.build
@@ -79,6 +79,7 @@ subdir('s390x')
 subdir('arm')
 subdir('riscv64')
 subdir('loongarch64')
+subdir('e2k')
 
 CPU_FEATURES = {}
 CPU_FEATURES += ARM_FEATURES
@@ -87,6 +88,7 @@ CPU_FEATURES += PPC64_FEATURES
 CPU_FEATURES += S390X_FEATURES
 CPU_FEATURES += RV64_FEATURES
 CPU_FEATURES += LOONGARCH64_FEATURES
+CPU_FEATURES += E2K_FEATURES
 
 CPU_FEATURES_REDIRECT = {}
 CPU_FEATURES_REDIRECT += X86_REDIRECT
@@ -105,6 +107,7 @@ min_features = {
   'riscv64': [],
   'wasm32': [],
   'loongarch64': [LSX],
+  'e2k': [E2K_SSE],
 }.get(cpu_family, [])
 if host_machine.endian() == 'little' and cpu_family == 'ppc64'
   min_features = [VSX2]
@@ -121,6 +124,7 @@ max_features_dict = {
   'riscv64': RV64_FEATURES,
   'wasm32': {},
   'loongarch64': LOONGARCH64_FEATURES,
+  'e2k': E2K_FEATURES
 }.get(cpu_family, {})
 max_features = []
 foreach fet_name, fet_obj : max_features_dict

--- a/numpy/_core/include/numpy/npy_cpu.h
+++ b/numpy/_core/include/numpy/npy_cpu.h
@@ -22,6 +22,7 @@
  *              NPY_CPU_LOONGARCH
  *              NPY_CPU_SW_64
  *              NPY_CPU_WASM
+ *              NPY_CPU_E2K
  */
 #ifndef NUMPY_CORE_INCLUDE_NUMPY_NPY_CPU_H_
 #define NUMPY_CORE_INCLUDE_NUMPY_NPY_CPU_H_
@@ -118,6 +119,8 @@
     /* __EMSCRIPTEN__ is defined by emscripten: an LLVM-to-Web compiler */
     /* __wasm__ is defined by clang when targeting wasm */
     #define NPY_CPU_WASM
+#elif defined(__e2k__)
+    #define NPY_CPU_E2K
 #else
     #error Unknown CPU, please report this to numpy maintainers with \
     information about your platform (OS, CPU and compiler)

--- a/numpy/_core/include/numpy/npy_endian.h
+++ b/numpy/_core/include/numpy/npy_endian.h
@@ -51,8 +51,9 @@
             || defined(NPY_CPU_RISCV64)       \
             || defined(NPY_CPU_RISCV32)       \
             || defined(NPY_CPU_LOONGARCH)     \
-            || defined(NPY_CPU_SW_64)     \
-            || defined(NPY_CPU_WASM)
+            || defined(NPY_CPU_SW_64)         \
+            || defined(NPY_CPU_WASM)          \
+            || defined(NPY_CPU_E2K)
         #define NPY_BYTE_ORDER NPY_LITTLE_ENDIAN
 
     #elif defined(NPY_CPU_PPC)                \

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -912,7 +912,8 @@ foreach gen_mtargets : [
       X86_V4, X86_V3, X86_V2,
       VSX2,
       ASIMD, NEON,
-      VXE, VX
+      VXE, VX,
+      E2K_AVX, E2K_SSE,
     ]
   ],
 ]
@@ -1020,6 +1021,7 @@ foreach gen_mtargets : [
       VSX3, VSX2,
       VXE, VX,
       LSX,
+      E2K_AVX, E2K_SSE,
     ]
   ],
   [
@@ -1031,6 +1033,7 @@ foreach gen_mtargets : [
       VSX4, VSX2,
       VX,
       LSX,
+      E2K_AVX, E2K_SSE,
     ]
   ],
   [
@@ -1042,6 +1045,7 @@ foreach gen_mtargets : [
       NEON,
       VXE, VX,
       LSX,
+      E2K_AVX, E2K_SSE,
     ]
   ],
   [
@@ -1049,6 +1053,7 @@ foreach gen_mtargets : [
     src_file.process('src/umath/loops_exponent_log.dispatch.c.src'),
     [
       X86_V4, X86_V3,
+      E2K_AVX, E2K_SSE,
     ]
   ],
   [
@@ -1060,6 +1065,7 @@ foreach gen_mtargets : [
       NEON_VFPV4,
       VXE,
       LSX,
+      E2K_AVX, E2K_SSE,
     ]
   ],
   [
@@ -1072,6 +1078,7 @@ foreach gen_mtargets : [
       VX,
       LSX,
       RVV,
+      E2K_AVX, E2K_SSE,
     ]
   ],
   [
@@ -1083,6 +1090,7 @@ foreach gen_mtargets : [
       VSX2,
       VXE, VX,
       LSX,
+      E2K_AVX, E2K_SSE,
     ]
   ],
   [
@@ -1101,6 +1109,7 @@ foreach gen_mtargets : [
       NEON_VFPV4,
       VXE2, VXE,
       LSX,
+      E2K_AVX, E2K_SSE,
     ]
   ],
   [
@@ -1117,6 +1126,7 @@ foreach gen_mtargets : [
       VSX2,
       VXE, VX,
       LSX,
+      E2K_AVX, E2K_SSE,
     ]
   ],
   [
@@ -1128,6 +1138,7 @@ foreach gen_mtargets : [
       ASIMD, NEON,
       VXE, VX,
       LSX,
+      E2K_SSE,
     ]
   ],
   [
@@ -1138,6 +1149,7 @@ foreach gen_mtargets : [
       VSX2,
       ASIMD, NEON,
       LSX,
+      E2K_SSE,
     ]
   ],
   [
@@ -1149,6 +1161,7 @@ foreach gen_mtargets : [
       VSX3, VSX2,
       VXE, VX,
       LSX,
+      E2K_AVX, E2K_SSE,
     ]
   ],
   [
@@ -1160,7 +1173,8 @@ foreach gen_mtargets : [
       VSX2,
       VX,
       LSX,
-      RVV
+      RVV,
+      E2K_AVX, E2K_SSE,
     ]
   ],
   [

--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -139,7 +139,9 @@ static struct {
                 {NPY_CPU_FEATURE_ASIMDFHM, "ASIMDFHM"},
                 {NPY_CPU_FEATURE_SVE, "SVE"},
                 {NPY_CPU_FEATURE_RVV, "RVV"},
-                {NPY_CPU_FEATURE_LSX, "LSX"}};
+                {NPY_CPU_FEATURE_LSX, "LSX"},
+                {NPY_CPU_FEATURE_E2K_SSE, "E2K_SSE"},
+                {NPY_CPU_FEATURE_E2K_AVX, "E2K_AVX"}};
 
 
 NPY_VISIBILITY_HIDDEN PyObject *
@@ -990,6 +992,17 @@ npy__cpu_init_features(void)
 #endif
 
 #endif
+}
+
+/************** Elbrus2000 ***************/
+
+#elif defined(NPY_CPU_E2K)
+
+static void
+npy__cpu_init_features(void)
+{
+    npy__cpu_have[NPY_CPU_FEATURE_E2K_SSE] = 1;
+    npy__cpu_have[NPY_CPU_FEATURE_E2K_AVX] = 1;
 }
 
 /*********** Unsupported ARCH ***********/

--- a/numpy/_core/src/common/npy_cpu_features.h
+++ b/numpy/_core/src/common/npy_cpu_features.h
@@ -120,6 +120,10 @@ enum npy_cpu_features
     // LOONGARCH
     NPY_CPU_FEATURE_LSX               = 500,
 
+    // Elbrus2000, SIMD via x86 intrinsics
+    NPY_CPU_FEATURE_E2K_SSE           = NPY_CPU_FEATURE_X86_V2,
+    NPY_CPU_FEATURE_E2K_AVX           = NPY_CPU_FEATURE_X86_V3,
+
     NPY_CPU_FEATURE_MAX
 };
 


### PR DESCRIPTION
e2k implements MMX, SSE and AVX via compiler intrinsics, which allows it to
piggy-back on the X86 code paths for SIMD.

The test suite is mostly green and I'm working on fixing the remaining failures. They weren't numpy-specific so far, but rather bugs in the compiler, Meson (see https://github.com/numpy/meson/pull/26 ) and other tools.

### First time committer introduction
I'm working on a company that develops an RPM-based Linux distribution for LoongArch and Elbrus2000 arches. The distribution ships the numpy package and I'm working on making the build work and the test suite to pass.

#### AI Disclosure
No AI tools were used.