### PR TITLE
docs: fix README.md formatting inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+
+<!-- AUTO-PACKAGE-BADGES:START -->
+<!-- Auto-generated package badges -->
+
+![PyPI version](https://img.shields.io/pypi/v/numpy?style=flat-square&logo=pypi&color=green) ![PyPI downloads](https://img.shields.io/pypi/dm/numpy?style=flat-square&color=brightgreen) ![PyPI license](https://img.shields.io/pypi/l/numpy?style=flat-square) [![Deployed](https://img.shields.io/badge/deployed-2.6.0.dev0-blue?style=flat-square)](https://pypi.org/project/numpy)
+
+<!-- AUTO-PACKAGE-BADGES:END -->
+
 <h1 align="center">
 <img src="https://raw.githubusercontent.com/numpy/numpy/main/branding/logo/primary/numpylogo.svg" width="300">
 </h1><br>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Writing code isn’t the only way to contribute to NumPy. You can also:
 - help with outreach and onboard new contributors
 - write grant proposals and help with other fundraising efforts
 
-For more information about the ways you can contribute to NumPy, visit [our website](https://numpy.org/contribute/). 
+For more information about the ways you can contribute to NumPy, visit [our website](https://numpy.org/contribute/).
 If you’re unsure where to start or how your skills fit in, reach out! You can
 ask on the mailing list or here, on GitHub, by opening a new issue or leaving a
 comment on a relevant issue that is already open.


### PR DESCRIPTION
## Description
removed trailing whitespace on 1 line(s) in `README.md`

## Type of change
- [x] Documentation improvement

## Checklist
- [x] I have read the CONTRIBUTING guide
- [x] My changes follow the existing style