### PR TITLE
BUG: fix StringDType distinct-allocator bugs and add tests

### DIFF
--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -463,15 +463,6 @@ def _promote_fields(dt1, dt2):
     return res
 
 
-def _check_stringdtype_view(oldtype, newtype):
-    # equal StringDType instances can still own separate allocators
-    if oldtype.kind == "T" and not _is_view_safe_cast(oldtype, newtype):
-        raise TypeError(
-            "Cannot view StringDType array data through a different dtype "
-            "instance; use astype to copy the data to the new dtype "
-            "instance")
-
-
 def _getfield_is_safe(oldtype, newtype, offset):
     """ Checks safety of getfield for object arrays.
 
@@ -494,8 +485,7 @@ def _getfield_is_safe(oldtype, newtype, offset):
 
     """
     if newtype.hasobject or oldtype.hasobject:
-        if offset == 0 and newtype == oldtype:
-            _check_stringdtype_view(oldtype, newtype)
+        if offset == 0 and _is_view_safe_cast(oldtype, newtype):
             return
         if oldtype.names is not None:
             for name in oldtype.names:
@@ -525,10 +515,10 @@ def _view_is_safe(oldtype, newtype):
 
     """
 
-    # if the types are equivalent, there is no problem.
-    # for example: dtype((np.record, 'i4,i4')) == dtype((np.void, 'i4,i4'))
-    if oldtype == newtype:
-        _check_stringdtype_view(oldtype, newtype)
+    # more precise than ``oldtype == newtype``: e.g. dtype((np.record, 'i4,i4'))
+    # views safely as dtype((np.void, 'i4,i4')), while two equal StringDType
+    # instances with separate allocators do not
+    if _is_view_safe_cast(oldtype, newtype):
         return
 
     if newtype.hasobject or oldtype.hasobject:

--- a/numpy/_core/_internal.py
+++ b/numpy/_core/_internal.py
@@ -13,6 +13,7 @@ import warnings
 from numpy import _NoValue
 from numpy.exceptions import DTypePromotionError
 
+from ._multiarray_umath import _is_view_safe_cast
 from .multiarray import StringDType, array, dtype, promote_types
 
 try:
@@ -462,6 +463,15 @@ def _promote_fields(dt1, dt2):
     return res
 
 
+def _check_stringdtype_view(oldtype, newtype):
+    # equal StringDType instances can still own separate allocators
+    if oldtype.kind == "T" and not _is_view_safe_cast(oldtype, newtype):
+        raise TypeError(
+            "Cannot view StringDType array data through a different dtype "
+            "instance; use astype to copy the data to the new dtype "
+            "instance")
+
+
 def _getfield_is_safe(oldtype, newtype, offset):
     """ Checks safety of getfield for object arrays.
 
@@ -485,6 +495,7 @@ def _getfield_is_safe(oldtype, newtype, offset):
     """
     if newtype.hasobject or oldtype.hasobject:
         if offset == 0 and newtype == oldtype:
+            _check_stringdtype_view(oldtype, newtype)
             return
         if oldtype.names is not None:
             for name in oldtype.names:
@@ -517,6 +528,7 @@ def _view_is_safe(oldtype, newtype):
     # if the types are equivalent, there is no problem.
     # for example: dtype((np.record, 'i4,i4')) == dtype((np.void, 'i4,i4'))
     if oldtype == newtype:
+        _check_stringdtype_view(oldtype, newtype)
         return
 
     if newtype.hasobject or oldtype.hasobject:

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -393,17 +393,18 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     src = PyArray_DATA(values);
     j = 0;
 
-    if (PyDataType_REFCHK(PyArray_DESCR(array))) {
-        /* dtypes with references may not define copyswap */
+    copyswap = PyDataType_GetArrFuncs(PyArray_DESCR(array))->copyswap;
+    if (copyswap == NULL) {
         NPY_cast_info cast_info;
         NPY_ARRAYMETHOD_FLAGS flags;
         const npy_intp one = 1;
-        const npy_intp strides[2] = {chunk, chunk};
+        const npy_intp elsize = chunk;
+        const npy_intp strides[2] = {elsize, elsize};
 
         NPY_cast_info_init(&cast_info);
         if (PyArray_GetDTypeTransferFunction(
                 PyArray_ISALIGNED(values) && PyArray_ISALIGNED(array),
-                chunk, chunk,
+                strides[0], strides[1],
                 PyArray_DESCR(values), PyArray_DESCR(array), 0,
                 &cast_info, &flags) < 0) {
             goto fail;
@@ -432,7 +433,6 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
         NPY_cast_info_xfree(&cast_info);
     }
     else {
-        copyswap = PyDataType_GetArrFuncs(PyArray_DESCR(array))->copyswap;
         NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(array));
         for (i = 0; i < ni; i++) {
             if (mask_data[i]) {

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -16,6 +16,7 @@
 #include "ctors.h"
 #include "common.h"
 #include "dtypemeta.h"
+#include "dtype_transfer.h"
 #include "simd/simd.h"
 
 #include <string.h>
@@ -392,19 +393,59 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     src = PyArray_DATA(values);
     j = 0;
 
-    copyswap = PyDataType_GetArrFuncs(PyArray_DESCR(array))->copyswap;
-    NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(array));
-    for (i = 0; i < ni; i++) {
-        if (mask_data[i]) {
-            if (j >= nv) {
-                j = 0;
-            }
+    if (PyDataType_REFCHK(PyArray_DESCR(array))) {
+        /* dtypes with references may not define copyswap */
+        NPY_cast_info cast_info;
+        NPY_ARRAYMETHOD_FLAGS flags;
+        const npy_intp one = 1;
+        const npy_intp strides[2] = {chunk, chunk};
 
-            copyswap(dest + i*chunk, src + j*chunk, 0, array);
-            j++;
+        NPY_cast_info_init(&cast_info);
+        if (PyArray_GetDTypeTransferFunction(
+                PyArray_ISALIGNED(values) && PyArray_ISALIGNED(array),
+                chunk, chunk,
+                PyArray_DESCR(values), PyArray_DESCR(array), 0,
+                &cast_info, &flags) < 0) {
+            goto fail;
         }
+        if (!(flags & NPY_METH_REQUIRES_PYAPI)) {
+            NPY_BEGIN_THREADS;
+        }
+        for (i = 0; i < ni; i++) {
+            if (mask_data[i]) {
+                if (j >= nv) {
+                    j = 0;
+                }
+
+                char *data[2] = {src + j*chunk, dest + i*chunk};
+                if (cast_info.func(
+                        &cast_info.context, data, &one, strides,
+                        cast_info.auxdata) < 0) {
+                    NPY_END_THREADS;
+                    NPY_cast_info_xfree(&cast_info);
+                    goto fail;
+                }
+                j++;
+            }
+        }
+        NPY_END_THREADS;
+        NPY_cast_info_xfree(&cast_info);
     }
-    NPY_END_THREADS;
+    else {
+        copyswap = PyDataType_GetArrFuncs(PyArray_DESCR(array))->copyswap;
+        NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(array));
+        for (i = 0; i < ni; i++) {
+            if (mask_data[i]) {
+                if (j >= nv) {
+                    j = 0;
+                }
+
+                copyswap(dest + i*chunk, src + j*chunk, 0, array);
+                j++;
+            }
+        }
+        NPY_END_THREADS;
+    }
 
     Py_XDECREF(values);
     Py_XDECREF(mask);

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -655,19 +655,25 @@ PyArray_SafeCast(PyArray_Descr *type1, PyArray_Descr *type2,
  * separate internal state (e.g. StringDType allocators).
  */
 NPY_NO_EXPORT PyObject *
-_is_view_safe_cast(PyObject *NPY_UNUSED(module), PyObject *args)
+_is_view_safe_cast(PyObject *NPY_UNUSED(module), PyObject *const *args,
+                   Py_ssize_t len_args)
 {
-    PyArray_Descr *from, *to;
-    if (!PyArg_ParseTuple(args, "O!O!:_is_view_safe_cast",
-            &PyArrayDescr_Type, &from, &PyArrayDescr_Type, &to)) {
+    if (len_args != 2) {
+        PyErr_SetString(PyExc_TypeError,
+                "_is_view_safe_cast() takes exactly two arguments");
         return NULL;
     }
+    if (!PyArray_DescrCheck(args[0]) || !PyArray_DescrCheck(args[1])) {
+        PyErr_SetString(PyExc_TypeError,
+                "_is_view_safe_cast() arguments must be dtype instances");
+        return NULL;
+    }
+    PyArray_Descr *from = (PyArray_Descr *)args[0];
+    PyArray_Descr *to = (PyArray_Descr *)args[1];
     npy_intp view_offset = NPY_MIN_INTP;
+    /* ignore_error=1: dtype pairs with no resolvable cast are simply not views */
     npy_intp is_safe = PyArray_SafeCast(from, to, &view_offset,
-                                        NPY_NO_CASTING, 0);
-    if (is_safe < 0) {
-        return NULL;
-    }
+                                        NPY_NO_CASTING, 1);
     return PyBool_FromLong(is_safe && view_offset == 0);
 }
 

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -648,6 +648,30 @@ PyArray_SafeCast(PyArray_Descr *type1, PyArray_Descr *type2,
 }
 
 
+/*
+ * Python-level helper answering whether reinterpreting data of dtype *from*
+ * as dtype *to* is a view. Unlike descriptor equality or `np.can_cast` with
+ * "no" casting, this distinguishes equivalent descriptor instances with
+ * separate internal state (e.g. StringDType allocators).
+ */
+NPY_NO_EXPORT PyObject *
+_is_view_safe_cast(PyObject *NPY_UNUSED(module), PyObject *args)
+{
+    PyArray_Descr *from, *to;
+    if (!PyArg_ParseTuple(args, "O!O!:_is_view_safe_cast",
+            &PyArrayDescr_Type, &from, &PyArrayDescr_Type, &to)) {
+        return NULL;
+    }
+    npy_intp view_offset = NPY_MIN_INTP;
+    npy_intp is_safe = PyArray_SafeCast(from, to, &view_offset,
+                                        NPY_NO_CASTING, 0);
+    if (is_safe < 0) {
+        return NULL;
+    }
+    return PyBool_FromLong(is_safe && view_offset == 0);
+}
+
+
 /* Provides an ordering for the dtype 'kind' character codes */
 NPY_NO_EXPORT int
 dtype_kind_to_ordering(char kind)

--- a/numpy/_core/src/multiarray/convert_datatype.h
+++ b/numpy/_core/src/multiarray/convert_datatype.h
@@ -16,7 +16,8 @@ NPY_NO_EXPORT PyObject *
 _get_castingimpl(PyObject *NPY_UNUSED(module), PyObject *args);
 
 NPY_NO_EXPORT PyObject *
-_is_view_safe_cast(PyObject *NPY_UNUSED(module), PyObject *args);
+_is_view_safe_cast(PyObject *NPY_UNUSED(module), PyObject *const *args,
+                   Py_ssize_t len_args);
 
 NPY_NO_EXPORT PyArray_VectorUnaryFunc *
 PyArray_GetCastFunc(PyArray_Descr *descr, int type_num);

--- a/numpy/_core/src/multiarray/convert_datatype.h
+++ b/numpy/_core/src/multiarray/convert_datatype.h
@@ -15,6 +15,9 @@ PyArray_GetCastingImpl(PyArray_DTypeMeta *from, PyArray_DTypeMeta *to);
 NPY_NO_EXPORT PyObject *
 _get_castingimpl(PyObject *NPY_UNUSED(module), PyObject *args);
 
+NPY_NO_EXPORT PyObject *
+_is_view_safe_cast(PyObject *NPY_UNUSED(module), PyObject *args);
+
 NPY_NO_EXPORT PyArray_VectorUnaryFunc *
 PyArray_GetCastFunc(PyArray_Descr *descr, int type_num);
 

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -12,10 +12,13 @@
 
 #include "npy_import.h"
 
+#include "array_assign.h"
 #include "common.h"
 #include "conversion_utils.h"
 #include "ctors.h"
+#include "dtype_transfer.h"
 #include "dtypemeta.h"
+#include "lowlevel_strided_loops.h"
 #include "scalartypes.h"
 #include "descriptor.h"
 #include "flagsobject.h"
@@ -671,15 +674,28 @@ array_flat_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
         retval = 0;
         goto exit;
     }
-    swap = PyArray_ISNOTSWAPPED(self) != PyArray_ISNOTSWAPPED(arr);
-    copyswap = PyDataType_GetArrFuncs(PyArray_DESCR(self))->copyswap;
     if (PyDataType_REFCHK(PyArray_DESCR(self))) {
+        /* dtypes with references may not define copyswap */
+        NPY_cast_info cast_info;
+        NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
+        npy_intp one = 1;
+        npy_intp itemsize = PyArray_ITEMSIZE(self);
+        npy_intp transfer_strides[2] = {itemsize, itemsize};
+
+        NPY_cast_info_init(&cast_info);
+        if (PyArray_GetDTypeTransferFunction(
+                IsUintAligned(self) && IsUintAligned(arr),
+                itemsize, itemsize,
+                PyArray_DESCR(arr), PyArray_DESCR(self), 0,
+                &cast_info, &transfer_flags) < 0) {
+            goto exit;
+        }
         while (selfit->index < selfit->size) {
-            PyArray_Item_XDECREF(selfit->dataptr, PyArray_DESCR(self));
-            PyArray_Item_INCREF(arrit->dataptr, PyArray_DESCR(arr));
-            memmove(selfit->dataptr, arrit->dataptr, sizeof(PyObject **));
-            if (swap) {
-                copyswap(selfit->dataptr, NULL, swap, self);
+            char *args[2] = {arrit->dataptr, selfit->dataptr};
+            if (cast_info.func(&cast_info.context, args, &one,
+                               transfer_strides, cast_info.auxdata) < 0) {
+                NPY_cast_info_xfree(&cast_info);
+                goto exit;
             }
             PyArray_ITER_NEXT(selfit);
             PyArray_ITER_NEXT(arrit);
@@ -687,10 +703,13 @@ array_flat_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
                 PyArray_ITER_RESET(arrit);
             }
         }
+        NPY_cast_info_xfree(&cast_info);
         retval = 0;
         goto exit;
     }
 
+    swap = PyArray_ISNOTSWAPPED(self) != PyArray_ISNOTSWAPPED(arr);
+    copyswap = PyDataType_GetArrFuncs(PyArray_DESCR(self))->copyswap;
     while(selfit->index < selfit->size) {
         copyswap(selfit->dataptr, arrit->dataptr, swap, self);
         PyArray_ITER_NEXT(selfit);

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -674,8 +674,10 @@ array_flat_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
         retval = 0;
         goto exit;
     }
-    if (PyDataType_REFCHK(PyArray_DESCR(self))) {
-        /* dtypes with references may not define copyswap */
+    copyswap = PyDataType_GetArrFuncs(PyArray_DESCR(self))->copyswap;
+    if (copyswap == NULL || PyDataType_REFCHK(PyArray_DESCR(self))) {
+        /* reference dtypes have copyswap, but the transfer path handles
+           refcounts and is better for structured dtypes */
         NPY_cast_info cast_info;
         NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
         npy_intp one = 1;
@@ -709,7 +711,6 @@ array_flat_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
     }
 
     swap = PyArray_ISNOTSWAPPED(self) != PyArray_ISNOTSWAPPED(arr);
-    copyswap = PyDataType_GetArrFuncs(PyArray_DESCR(self))->copyswap;
     while(selfit->index < selfit->size) {
         copyswap(selfit->dataptr, arrit->dataptr, swap, self);
         PyArray_ITER_NEXT(selfit);

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -781,14 +781,14 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
                 }
             }
         }
+        NPY_END_THREADS;
         NPY_cast_info_xfree(&cast_info);
     }
     else {
         NPY_BEGIN_THREADS;
         npy_fastputmask(dest, src, mask_data, ni, nv, itemsize);
+        NPY_END_THREADS;
     }
-
-    NPY_END_THREADS;
 
     Py_XDECREF(values);
     Py_XDECREF(mask);

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1027,7 +1027,10 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     PyArrayObject **mps, *ap;
     PyArrayMultiIterObject *multi = NULL;
     npy_intp mi;
-    NPY_cast_info *cast_infos = NULL;
+    /* PyArray_MultiIterFromObjects below bounds n by NPY_MAXARGS */
+    NPY_cast_info cast_infos[NPY_MAXARGS];
+    int needs_transfer = 0;
+    NPY_BEGIN_THREADS_DEF;
     ap = NULL;
 
     /*
@@ -1121,13 +1124,9 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     npy_intp transfer_strides[2] = {elsize, elsize};
     npy_intp one = 1;
     NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
-    if (PyDataType_REFCHK(dtype)) {
+    needs_transfer = PyDataType_REFCHK(dtype);
+    if (needs_transfer) {
         PyArray_Descr *obj_dtype = PyArray_DESCR(obj);
-        cast_infos = PyMem_New(NPY_cast_info, n);
-        if (cast_infos == NULL) {
-            PyErr_NoMemory();
-            goto fail;
-        }
         for (i = 0; i < n; i++) {
             NPY_cast_info_init(&cast_infos[i]);
         }
@@ -1145,11 +1144,15 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
         }
     }
 
+    if (!(transfer_flags & NPY_METH_REQUIRES_PYAPI)) {
+        NPY_BEGIN_THREADS_THRESHOLDED(multi->size);
+    }
     while (PyArray_MultiIter_NOTDONE(multi)) {
         mi = *((npy_intp *)PyArray_MultiIter_DATA(multi, n));
         if (mi < 0 || mi >= n) {
             switch(clipmode) {
             case NPY_RAISE:
+                NPY_END_THREADS;
                 PyErr_SetString(PyExc_ValueError,
                         "invalid entry in choice "\
                         "array");
@@ -1176,7 +1179,7 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
                 break;
             }
         }
-        if (cast_infos == NULL) {
+        if (!needs_transfer) {
             /* We ensure memory doesn't overlap, so can use memcpy */
             memcpy(ret_data, PyArray_MultiIter_DATA(multi, mi), elsize);
         }
@@ -1191,12 +1194,12 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
         ret_data += elsize;
         PyArray_MultiIter_NEXT(multi);
     }
+    NPY_END_THREADS;
 
-    if (cast_infos != NULL) {
+    if (needs_transfer) {
         for (i = 0; i < n; i++) {
             NPY_cast_info_xfree(&cast_infos[i]);
         }
-        PyMem_Free(cast_infos);
     }
     Py_DECREF(multi);
     for (i = 0; i < n; i++) {
@@ -1215,11 +1218,11 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     return (PyObject *)obj;
 
  fail:
-    if (cast_infos != NULL) {
+    NPY_END_THREADS;
+    if (needs_transfer) {
         for (i = 0; i < n; i++) {
             NPY_cast_info_xfree(&cast_infos[i]);
         }
-        PyMem_Free(cast_infos);
     }
     Py_XDECREF(multi);
     for (i = 0; i < n; i++) {

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -457,9 +457,10 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
         NPY_BEGIN_THREADS_THRESHOLDED(ni);
     }
     else {
-        PyArray_Descr *dtype = PyArray_DESCR(self);
         if (PyArray_GetDTypeTransferFunction(
-                PyArray_ISALIGNED(self), itemsize, itemsize, dtype, dtype, 0,
+                PyArray_ISALIGNED(self) && PyArray_ISALIGNED(values),
+                itemsize, itemsize,
+                PyArray_DESCR(values), PyArray_DESCR(self), 0,
                 &cast_info, &flags) < 0) {
             goto fail;
         }
@@ -755,7 +756,9 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
 
         NPY_cast_info_init(&cast_info);
         if (PyArray_GetDTypeTransferFunction(
-                PyArray_ISALIGNED(self), itemsize, itemsize, dtype, dtype, 0,
+                PyArray_ISALIGNED(self) && PyArray_ISALIGNED(values),
+                itemsize, itemsize,
+                PyArray_DESCR(values), PyArray_DESCR(self), 0,
                 &cast_info, &flags) < 0) {
             goto fail;
         }
@@ -1024,7 +1027,7 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     PyArrayObject **mps, *ap;
     PyArrayMultiIterObject *multi = NULL;
     npy_intp mi;
-    NPY_cast_info cast_info = {.func = NULL};
+    NPY_cast_info *cast_infos = NULL;
     ap = NULL;
 
     /*
@@ -1119,15 +1122,27 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     npy_intp one = 1;
     NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
     if (PyDataType_REFCHK(dtype)) {
-        int is_aligned = IsUintAligned(obj);
         PyArray_Descr *obj_dtype = PyArray_DESCR(obj);
-        PyArray_GetDTypeTransferFunction(
-                    is_aligned,
-                    dtype->elsize,
-                    obj_dtype->elsize,
-                    dtype,
-                    obj_dtype, 0, &cast_info,
-                    &transfer_flags);
+        cast_infos = PyMem_New(NPY_cast_info, n);
+        if (cast_infos == NULL) {
+            PyErr_NoMemory();
+            goto fail;
+        }
+        for (i = 0; i < n; i++) {
+            NPY_cast_info_init(&cast_infos[i]);
+        }
+        for (i = 0; i < n; i++) {
+            int is_aligned = IsUintAligned(obj) && IsUintAligned(mps[i]);
+            if (PyArray_GetDTypeTransferFunction(
+                        is_aligned,
+                        PyArray_DESCR(mps[i])->elsize,
+                        obj_dtype->elsize,
+                        PyArray_DESCR(mps[i]),
+                        obj_dtype, 0, &cast_infos[i],
+                        &transfer_flags) < 0) {
+                goto fail;
+            }
+        }
     }
 
     while (PyArray_MultiIter_NOTDONE(multi)) {
@@ -1161,14 +1176,15 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
                 break;
             }
         }
-        if (cast_info.func == NULL) {
+        if (cast_infos == NULL) {
             /* We ensure memory doesn't overlap, so can use memcpy */
             memcpy(ret_data, PyArray_MultiIter_DATA(multi, mi), elsize);
         }
         else {
             char *args[2] = {PyArray_MultiIter_DATA(multi, mi), ret_data};
-            if (cast_info.func(&cast_info.context, args, &one,
-                                transfer_strides, cast_info.auxdata) < 0) {
+            if (cast_infos[mi].func(&cast_infos[mi].context, args, &one,
+                                    transfer_strides,
+                                    cast_infos[mi].auxdata) < 0) {
                 goto fail;
             }
         }
@@ -1176,7 +1192,12 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
         PyArray_MultiIter_NEXT(multi);
     }
 
-    NPY_cast_info_xfree(&cast_info);
+    if (cast_infos != NULL) {
+        for (i = 0; i < n; i++) {
+            NPY_cast_info_xfree(&cast_infos[i]);
+        }
+        PyMem_Free(cast_infos);
+    }
     Py_DECREF(multi);
     for (i = 0; i < n; i++) {
         Py_XDECREF(mps[i]);
@@ -1194,7 +1215,12 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     return (PyObject *)obj;
 
  fail:
-    NPY_cast_info_xfree(&cast_info);
+    if (cast_infos != NULL) {
+        for (i = 0; i < n; i++) {
+            NPY_cast_info_xfree(&cast_infos[i]);
+        }
+        PyMem_Free(cast_infos);
+    }
     Py_XDECREF(multi);
     for (i = 0; i < n; i++) {
         Py_XDECREF(mps[i]);

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -392,6 +392,18 @@ iter_subscript_Bool(PyArrayIterObject *self, PyArrayObject *ind,
         return NULL;
     }
     if (count > 0) {
+        /* set up a cast to handle item copying */
+        NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
+        /* We can assume the newly allocated output array is aligned */
+        int is_aligned = IsUintAligned(self->ao);
+        if (PyArray_GetDTypeTransferFunction(
+                    is_aligned, itemsize, itemsize,
+                    dtype, PyArray_DESCR(ret), 0,
+                    cast_info, &transfer_flags) < 0) {
+            Py_DECREF(ret);
+            return NULL;
+        }
+
         /* Set up loop */
         optr = PyArray_DATA(ret);
         counter = PyArray_DIMS(ind)[0];
@@ -403,6 +415,7 @@ iter_subscript_Bool(PyArrayIterObject *self, PyArrayObject *ind,
                 npy_intp transfer_strides[2] = {itemsize, itemsize};
                 if (cast_info->func(&cast_info->context, args, &one,
                                     transfer_strides, cast_info->auxdata) < 0) {
+                    Py_DECREF(ret);
                     return NULL;
                 }
                 optr += itemsize;
@@ -452,6 +465,19 @@ iter_subscript_int(PyArrayIterObject *self, PyArrayObject *ind,
     if (ret == NULL) {
         return NULL;
     }
+
+    /* set up a cast to handle item copying */
+    NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
+    /* We can assume the newly allocated output array is aligned */
+    int is_aligned = IsUintAligned(self->ao);
+    if (PyArray_GetDTypeTransferFunction(
+                is_aligned, dtype->elsize, dtype->elsize,
+                dtype, PyArray_DESCR(ret), 0,
+                cast_info, &transfer_flags) < 0) {
+        Py_DECREF(ret);
+        return NULL;
+    }
+
     optr = PyArray_DATA(ret);
     ind_it = (PyArrayIterObject *)PyArray_IterNew((PyObject *)ind);
     if (ind_it == NULL) {
@@ -565,17 +591,7 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
         goto finish;
     }
 
-    /* set up a cast to handle item copying */
-    NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
     npy_intp one = 1;
-
-    /* We can assume the newly allocated output array is aligned */
-    int is_aligned = IsUintAligned(self->ao);
-    if (PyArray_GetDTypeTransferFunction(
-                is_aligned, dtype_size, dtype_size, dtype, dtype, 0, &cast_info,
-                &transfer_flags) < 0) {
-        goto finish;
-    }
 
     if (index_type == HAS_SLICE) {
         if (PySlice_GetIndicesEx(indices[0].object,
@@ -595,12 +611,25 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
             goto finish;
         }
 
+        /* set up a cast to handle item copying */
+        NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
+        /* We can assume the newly allocated output array is aligned */
+        int is_aligned = IsUintAligned(self->ao);
+        if (PyArray_GetDTypeTransferFunction(
+                    is_aligned, dtype_size, dtype_size,
+                    dtype, PyArray_DESCR((PyArrayObject *)ret), 0,
+                    &cast_info, &transfer_flags) < 0) {
+            Py_CLEAR(ret);
+            goto finish;
+        }
+
         char *dptr = PyArray_DATA((PyArrayObject *) ret);
         while (n_steps--) {
             char *args[2] = {self->dataptr, dptr};
             npy_intp transfer_strides[2] = {dtype_size, dtype_size};
             if (cast_info.func(&cast_info.context, args, &one,
                                transfer_strides, cast_info.auxdata) < 0) {
+                Py_CLEAR(ret);
                 goto finish;
             }
             start += step;

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3411,6 +3411,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
                         if (x_cast_info.func(
                                 &x_cast_info.context, args, &one,
                                 x_strides, x_cast_info.auxdata) < 0) {
+                            NPY_END_THREADS;
                             goto fail;
                         }
                     }
@@ -3420,6 +3421,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
                         if (y_cast_info.func(
                                 &y_cast_info.context, args, &one,
                                 y_strides, y_cast_info.auxdata) < 0) {
+                            NPY_END_THREADS;
                             goto fail;
                         }
                     }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -4696,6 +4696,8 @@ static struct PyMethodDef array_module_methods[] = {
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"_get_castingimpl",  (PyCFunction)_get_castingimpl,
         METH_VARARGS | METH_KEYWORDS, NULL},
+    {"_is_view_safe_cast",  (PyCFunction)_is_view_safe_cast,
+        METH_VARARGS, NULL},
     {"_load_from_filelike", (PyCFunction)_load_from_filelike,
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"_populate_finfo_constants", (PyCFunction)_populate_finfo_constants,

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -3258,6 +3258,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
 
     NPY_cast_info x_cast_info = {.func = NULL};
     NPY_cast_info y_cast_info = {.func = NULL};
+    NPY_BEGIN_THREADS_DEF;
 
     ax = (PyArrayObject*)PyArray_FROM_O(x);
     if (ax == NULL) {
@@ -3322,8 +3323,6 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
     }
     /* `PyArray_DescrFromType` cannot fail for simple builtin types: */
     PyArray_Descr * op_dt[4] = {common_dt, PyArray_DescrFromType(NPY_BOOL), x_dt, y_dt};
-
-    NPY_BEGIN_THREADS_DEF;
 
     iter =  NpyIter_MultiNew(
             4, op_in, flags, NPY_KEEPORDER, NPY_UNSAFE_CASTING,
@@ -3411,7 +3410,6 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
                         if (x_cast_info.func(
                                 &x_cast_info.context, args, &one,
                                 x_strides, x_cast_info.auxdata) < 0) {
-                            NPY_END_THREADS;
                             goto fail;
                         }
                     }
@@ -3421,7 +3419,6 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
                         if (y_cast_info.func(
                                 &y_cast_info.context, args, &one,
                                 y_strides, y_cast_info.auxdata) < 0) {
-                            NPY_END_THREADS;
                             goto fail;
                         }
                     }
@@ -3452,6 +3449,7 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
     return ret;
 
 fail:
+    NPY_END_THREADS;
     Py_DECREF(arr);
     Py_XDECREF(ax);
     Py_XDECREF(ay);
@@ -4699,7 +4697,7 @@ static struct PyMethodDef array_module_methods[] = {
     {"_get_castingimpl",  (PyCFunction)_get_castingimpl,
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"_is_view_safe_cast",  (PyCFunction)_is_view_safe_cast,
-        METH_VARARGS, NULL},
+        METH_FASTCALL, NULL},
     {"_load_from_filelike", (PyCFunction)_load_from_filelike,
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"_populate_finfo_constants", (PyCFunction)_populate_finfo_constants,

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6921,6 +6921,14 @@ class TestFlat:
         b.flat[::2] = unaligned[:n // 2]
         assert_array_equal(b[::2], unaligned[:n // 2])
 
+    def test_assignment_structured_with_objects(self):
+        # whole elements must be copied, not just the leading object field
+        dt = np.dtype([('x', 'O'), ('y', 'i8')])
+        a = np.array([('A', 1), ('B', 2)], dtype=dt)
+        b = np.zeros(2, dtype=dt)
+        b.flat = a
+        assert_array_equal(b, a)
+
     def test___array__(self):
         a0 = np.arange(20.0)
         a = a0.reshape(4, 5)

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -2006,12 +2006,13 @@ def test_view_distinct_instance():
 
     assert_array_equal(a.view(a.dtype), a)
 
-    # a view through any other instance would attach an unrelated allocator
-    with pytest.raises(TypeError, match="different dtype instance"):
+    # a view through any other instance would attach an unrelated allocator,
+    # which the generalized reference-safety check rejects
+    with pytest.raises(TypeError, match="Cannot change data-type"):
         a.view(StringDType())
-    with pytest.raises(TypeError, match="different dtype instance"):
+    with pytest.raises(TypeError, match="Cannot get/set field"):
         a.getfield(StringDType())
-    with pytest.raises(TypeError, match="different dtype instance"):
+    with pytest.raises(TypeError, match="Cannot change data-type"):
         with pytest.warns(DeprecationWarning, match="Setting the dtype"):
             a.dtype = StringDType()
 

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1869,3 +1869,404 @@ class TestImplementation:
         assert_array_equal(c, self.a)
         assert_array_equal(self.in_arena(c), False)
         assert_array_equal(self.is_on_heap(c), self.in_arena(self.a))
+
+
+# Tests for operations that mix several StringDType arrays. Independently
+# created arrays always have distinct descriptor instances, each owning the
+# allocator and arena backing its strings; see _make_distinct_arena_arrays
+# for how the test data makes misdirected reads detectable.
+
+
+def _make_distinct_arena_arrays(n, prefix_a="A", prefix_b="B"):
+    """Make two arrays with distinct dtype instances and equal arena layouts.
+
+    All strings are longer than 15 bytes, so every entry lives in its
+    descriptor's arena. Lengths match between the two arrays but contents
+    differ, so an entry resolved through the wrong descriptor's arena reads
+    detectably wrong data.
+    """
+    a_list = [f"{prefix_a * 10}{i:06d}" for i in range(n)]
+    b_list = [f"{prefix_b * 10}{i:06d}" for i in range(n)]
+    a = np.array(a_list, dtype="T")
+    b = np.array(b_list, dtype="T")
+    assert a.dtype is not b.dtype
+    return a, b, np.array(a_list, dtype=object), np.array(b_list, dtype=object)
+
+
+@pytest.mark.parametrize("mode", ["raise", "wrap", "clip"])
+def test_put_distinct_allocators(mode):
+    a, b, a_obj, b_obj = _make_distinct_arena_arrays(100)
+    inds = np.arange(0, 100, 2)
+    np.put(a, inds, b[:50], mode=mode)
+    np.put(a_obj, inds, b_obj[:50], mode=mode)
+    assert_array_equal(a, a_obj)
+
+    # values must cycle when there are fewer of them than indices
+    np.put(a, inds, b[:3], mode=mode)
+    np.put(a_obj, inds, b_obj[:3], mode=mode)
+    assert_array_equal(a, a_obj)
+
+    # all-short-string destination, so its arena is empty
+    c = np.array(["x"] * 100, dtype="T")
+    np.put(c, inds, b[:50], mode=mode)
+    assert_array_equal(c[inds], b_obj[:50])
+    assert_array_equal(c[1::2], "x")
+
+    # a non-contiguous destination is written through a writeback copy
+    d, _, d_obj, _ = _make_distinct_arena_arrays(100, prefix_a="D")
+    np.put(d[::2], np.arange(50), b[:50], mode=mode)
+    np.put(d_obj[::2], np.arange(50), b_obj[:50], mode=mode)
+    assert_array_equal(d, d_obj)
+
+
+def test_putmask_distinct_allocators():
+    a, b, a_obj, b_obj = _make_distinct_arena_arrays(100)
+    mask = np.arange(100) % 3 == 0
+    np.putmask(a, mask, b)
+    np.putmask(a_obj, mask, b_obj)
+    assert_array_equal(a, a_obj)
+
+    # fewer values than mask entries exercises value cycling
+    np.putmask(a, ~mask, b[:7])
+    np.putmask(a_obj, ~mask, b_obj[:7])
+    assert_array_equal(a, a_obj)
+
+    # all-short-string destination, so its arena is empty
+    c = np.array(["x"] * 100, dtype="T")
+    np.putmask(c, mask, b)
+    assert_array_equal(c[mask], b_obj[mask])
+    assert_array_equal(c[~mask], "x")
+
+    # a non-contiguous destination is written through a writeback copy
+    d, _, d_obj, _ = _make_distinct_arena_arrays(100, prefix_a="D")
+    np.putmask(d[::2], mask[::2], b[:50])
+    np.putmask(d_obj[::2], mask[::2], b_obj[:50])
+    assert_array_equal(d, d_obj)
+
+
+def test_putmask_distinct_allocators_na(string_list):
+    dt_a = get_dtype(None)
+    dt_b = get_dtype(None)
+    a = np.array(string_list, dtype=dt_a)
+    b = np.array([None] + string_list[:0:-1], dtype=dt_b)
+    assert a.dtype is not b.dtype
+    mask = np.arange(len(string_list)) % 2 == 0
+    np.putmask(a, mask, b)
+    for i in range(len(string_list)):
+        if i == 0:
+            assert a[i] is None
+        elif mask[i]:
+            assert a[i] == string_list[-i]
+        else:
+            assert a[i] == string_list[i]
+
+
+@pytest.mark.parametrize("mode", ["raise", "wrap"])
+def test_choose_distinct_allocators(mode):
+    n = 100
+    idx = np.arange(n) % 2
+    # an all-short-string choice mixed with arena-string choices
+    c0 = np.array(["x"] * n, dtype="T")
+    c1, c2, c1_obj, c2_obj = _make_distinct_arena_arrays(n)
+    c0_obj = np.array(["x"] * n, dtype=object)
+
+    expected = np.choose(idx, [c0_obj, c1_obj], mode=mode)
+    assert_array_equal(np.choose(idx, [c0, c1], mode=mode), expected)
+
+    expected = np.choose(idx, [c1_obj, c2_obj], mode=mode)
+    assert_array_equal(np.choose(idx, [c1, c2], mode=mode), expected)
+
+    # out= with its own independently created instance
+    out = np.empty(n, dtype="T")
+    np.choose(idx, [c1, c2], mode=mode, out=out)
+    assert_array_equal(out, expected)
+
+
+def test_place_distinct_allocators():
+    a = np.array(["ab", "cd", "ef"], dtype="T")
+    np.place(a, [True, False, True], np.array(["xy", "zw"], dtype="T"))
+    assert_array_equal(a, ["xy", "cd", "zw"])
+
+    a, b, a_obj, b_obj = _make_distinct_arena_arrays(100)
+    mask = np.arange(100) % 3 == 0
+    # fewer values than selected entries exercises value cycling
+    np.place(a, mask, b[:7])
+    np.place(a_obj, mask, b_obj[:7])
+    assert_array_equal(a, a_obj)
+
+    # all-short-string destination, so its arena is empty
+    c = np.array(["x"] * 100, dtype="T")
+    np.place(c, mask, b)
+    assert_array_equal(c[mask], b_obj[: mask.sum()])
+    assert_array_equal(c[~mask], "x")
+
+
+def test_view_distinct_instance():
+    a = np.array(["a" * 20, "b" * 20], dtype="T")
+
+    assert_array_equal(a.view(a.dtype), a)
+
+    # a view through any other instance would attach an unrelated allocator
+    with pytest.raises(TypeError, match="different dtype instance"):
+        a.view(StringDType())
+    with pytest.raises(TypeError, match="different dtype instance"):
+        a.getfield(StringDType())
+    with pytest.raises(TypeError, match="different dtype instance"):
+        with pytest.warns(DeprecationWarning, match="Setting the dtype"):
+            a.dtype = StringDType()
+
+    res = a.astype(StringDType())
+    assert res.dtype is not a.dtype
+    assert_array_equal(res, a)
+
+
+def test_concatenate_distinct_allocators():
+    a, b, a_obj, b_obj = _make_distinct_arena_arrays(50)
+    expected = np.concatenate([a_obj, b_obj])
+    assert_array_equal(np.concatenate([a, b]), expected)
+    assert_array_equal(np.concatenate([a, b], axis=None), expected)
+
+    out = np.empty(100, dtype="T")
+    np.concatenate([a, b], out=out)
+    assert_array_equal(out, expected)
+
+    assert_array_equal(np.stack([a, b]), np.stack([a_obj, b_obj]))
+    assert_array_equal(np.vstack([a, b]), np.vstack([a_obj, b_obj]))
+    assert_array_equal(np.hstack([a, b]), expected)
+
+
+def test_where_distinct_allocators():
+    a, b, a_obj, b_obj = _make_distinct_arena_arrays(101)
+    mask = np.arange(101) % 3 == 0
+    assert_array_equal(np.where(mask, a, b), np.where(mask, a_obj, b_obj))
+
+
+def test_indexing_ops_distinct_allocators():
+    a, b, a_obj, b_obj = _make_distinct_arena_arrays(60)
+    idx = np.array([5, 3, 50, 7] * 3)
+
+    out = np.empty(len(idx), dtype="T")
+    np.take(a, idx, out=out)
+    assert_array_equal(out, a_obj[idx])
+
+    assert_array_equal(np.tile(a[:5], 3), np.tile(a_obj[:5], 3))
+    assert_array_equal(np.roll(a, 7), np.roll(a_obj, 7))
+    assert_array_equal(np.repeat(a[:10], 3), np.repeat(a_obj[:10], 3))
+    assert_array_equal(np.delete(a, idx[:4]), np.delete(a_obj, idx[:4]))
+    assert_array_equal(
+        np.insert(a, 3, b[:4]), np.insert(a_obj, 3, b_obj[:4])
+    )
+    assert_array_equal(np.append(a, b), np.append(a_obj, b_obj))
+
+
+def test_setops_distinct_allocators():
+    vals = [f"{'v' * 16}{i:04d}" for i in range(90)]
+    a = np.array(vals[:60], dtype="T")
+    b = np.array(vals[30:], dtype="T")
+    assert a.dtype is not b.dtype
+    au = np.array(vals[:60], dtype="U20")
+    bu = np.array(vals[30:], dtype="U20")
+
+    assert_array_equal(np.isin(a, b), np.isin(au, bu))
+    assert_array_equal(np.union1d(a, b), np.union1d(au, bu))
+    assert_array_equal(np.intersect1d(a, b), np.intersect1d(au, bu))
+    assert_array_equal(np.setdiff1d(a, b), np.setdiff1d(au, bu))
+    assert_array_equal(np.setxor1d(a, b), np.setxor1d(au, bu))
+
+    # StringDType has hasobject set, so isin always takes the
+    # element-comparison loop and 'table' only supports integers
+    assert_array_equal(
+        np.isin(a, b, invert=True), np.isin(au, bu, invert=True)
+    )
+    assert_array_equal(np.isin(a, b[:4]), np.isin(au, bu[:4]))
+    with pytest.raises(ValueError, match="table"):
+        np.isin(a, b, kind="table")
+
+    assert_array_equal(
+        np.intersect1d(a, b, assume_unique=True),
+        np.intersect1d(au, bu, assume_unique=True),
+    )
+
+    # duplicated entries exercise the sort-based unique path that
+    # return_indices uses internally
+    a_dup = np.array((vals[:40] * 2)[::-1], dtype="T")
+    b_dup = np.array(vals[20:] + vals[60:], dtype="T")
+    res = np.intersect1d(a_dup, b_dup, return_indices=True)
+    expected = np.intersect1d(
+        a_dup.astype("U20"), b_dup.astype("U20"), return_indices=True
+    )
+    for r, e in zip(res, expected):
+        assert_array_equal(r, e)
+
+
+def test_unique_arena_strings():
+    # _unique_hash has a dedicated StringDType loop
+    vals = [f"{'u' * 16}{i % 7:04d}" for i in range(50)] + ["ab", "ab", ""]
+    arr = np.array(vals, dtype="T")
+    arr_u = arr.astype("U20")
+    assert_array_equal(np.unique(arr), np.unique(arr_u))
+    assert_array_equal(np.sort(np.unique_values(arr)), np.unique(arr_u))
+
+    # index/inverse/counts go through the sort-based path
+    res = np.unique(
+        arr, return_index=True, return_inverse=True, return_counts=True
+    )
+    expected = np.unique(
+        arr_u, return_index=True, return_inverse=True, return_counts=True
+    )
+    for r, e in zip(res, expected):
+        assert_array_equal(r, e)
+
+
+def test_lexsort_distinct_allocators():
+    n = 40
+    # ties in the primary key so the secondary key matters
+    prim = np.array([f"{'p' * 20}{i % 5:03d}" for i in range(n)], dtype="T")
+    sec = np.array(
+        [f"{'s' * 20}{(7 * i) % n:03d}" for i in range(n)], dtype="T"
+    )
+    assert prim.dtype is not sec.dtype
+    expected = np.lexsort((sec.astype("U30"), prim.astype("U30")))
+    assert_array_equal(np.lexsort((sec, prim)), expected)
+
+
+def test_strings_ufuncs_distinct_allocators():
+    n = 50
+    a_list = [f"{'AB' * 10}{i:06d}" for i in range(n)]
+    # equal to a in every other entry, all arena strings
+    b_list = [s if i % 2 else s[:-1] + "Z" for i, s in enumerate(a_list)]
+    a = np.array(a_list, dtype="T")
+    b = np.array(b_list, dtype="T")
+    assert a.dtype is not b.dtype
+    au = a.astype("U40")
+    bu = b.astype("U40")
+
+    expected = np.add(np.array(a_list, dtype=object),
+                      np.array(b_list, dtype=object))
+    assert_array_equal(np.add(a, b), expected)
+    out = np.empty(n, dtype="T")
+    np.add(a, b, out=out)
+    assert_array_equal(out, expected)
+
+    for op in [
+        np.equal, np.not_equal, np.less, np.less_equal, np.greater,
+        np.greater_equal,
+    ]:
+        assert_array_equal(op(a, b), op(au, bu))
+
+    # no fixed-width unicode loops for maximum/minimum, so use object
+    a_obj = np.array(a_list, dtype=object)
+    b_obj = np.array(b_list, dtype=object)
+    assert_array_equal(np.maximum(a, b), np.maximum(a_obj, b_obj))
+    assert_array_equal(np.minimum(a, b), np.minimum(a_obj, b_obj))
+    np.maximum(a, b, out=out)
+    assert_array_equal(out, np.maximum(a_obj, b_obj))
+
+    # needles long enough to live in the arena, found in half the entries
+    needles_list = [
+        a_list[i][:16] if i % 3 else "Z" * 16 for i in range(n)
+    ]
+    needles = np.array(needles_list, dtype="T")
+    needles_u = needles.astype("U20")
+    for func in [
+        np.strings.find, np.strings.count, np.strings.startswith,
+        np.strings.endswith,
+    ]:
+        assert_array_equal(func(a, needles), func(au, needles_u))
+
+    # three distinct instances feeding one ufunc
+    old = np.array(["AB" * 8] * n, dtype="T")
+    new = np.array(["xy" * 9] * n, dtype="T")
+    assert_array_equal(
+        np.strings.replace(a, old, new),
+        np.strings.replace(au, old.astype("U16"), new.astype("U18")),
+    )
+
+    chars = np.array(["BA0123456789" + "C" * 8] * n, dtype="T")
+    assert_array_equal(
+        np.strings.strip(a, chars), np.strings.strip(au, chars.astype("U20"))
+    )
+
+    sep = np.array(["AB" * 8] * n, dtype="T")
+    for part, part_u in zip(
+        np.strings.partition(a, sep),
+        np.strings.partition(au, sep.astype("U16")),
+    ):
+        assert_array_equal(part, part_u)
+
+
+def test_assignment_distinct_allocators():
+    a, b, a_obj, b_obj = _make_distinct_arena_arrays(40)
+    mask = np.arange(40) % 4 == 0
+
+    a[mask] = b[mask]
+    a_obj[mask] = b_obj[mask]
+    assert_array_equal(a, a_obj)
+
+    idx = np.array([1, 2, 3])
+    a[idx] = b[:3]
+    a_obj[idx] = b_obj[:3]
+    assert_array_equal(a, a_obj)
+
+    np.copyto(a, b, where=~mask)
+    np.copyto(a_obj, b_obj, where=~mask)
+    assert_array_equal(a, a_obj)
+
+    res = np.select([mask, ~mask], [a, b], default="d" * 20)
+    expected = np.select([mask, ~mask], [a_obj, b_obj], default="d" * 20)
+    assert_array_equal(res, expected)
+
+
+def test_ufunc_at_distinct_allocators():
+    a, b, a_obj, b_obj = _make_distinct_arena_arrays(10)
+    idx = np.array([0, 3, 3, 7])
+
+    np.maximum.at(a, idx, b[:4])
+    np.maximum.at(a_obj, idx, b_obj[:4])
+    assert_array_equal(a, a_obj)
+
+    c, d, c_obj, d_obj = _make_distinct_arena_arrays(10, "C", "D")
+    np.add.at(c, idx, d[:4])
+    np.add.at(c_obj, idx, d_obj[:4])
+    assert_array_equal(c, c_obj)
+
+
+def test_flatiter_subscript_distinct_allocators():
+    a, _, a_obj, _ = _make_distinct_arena_arrays(20)
+
+    assert_array_equal(np.array(a.flat[:1]), a_obj[:1])
+
+    for index in [
+        slice(None, 1), slice(1, None), slice(None, None, 3),
+        np.array([3, 0, 17]),
+        np.arange(20) % 3 == 0,
+    ]:
+        res = a.flat[index]
+        expected = a_obj[index]
+        assert_array_equal(res, expected)
+        # element reads resolve through res's own descriptor
+        for i in range(len(expected)):
+            assert res[i] == expected[i]
+
+    assert a.flat[3] == a_obj[3]
+    assert_array_equal(np.array(a.flat), a_obj)
+    assert_array_equal(a.flat.copy(), a_obj)
+
+
+def test_flat_assignment_distinct_allocators():
+    a, b, a_obj, b_obj = _make_distinct_arena_arrays(20)
+    b.flat = a
+    b_obj.flat = a_obj
+    assert_array_equal(b, b_obj)
+
+    # fewer values than elements exercises value cycling
+    c, _, c_obj, _ = _make_distinct_arena_arrays(20, prefix_a="C")
+    c.flat = a[:3]
+    c_obj.flat = a_obj[:3]
+    assert_array_equal(c, c_obj)
+
+    # short (inline) values into an arena-string destination
+    d, _, d_obj, _ = _make_distinct_arena_arrays(20, prefix_a="D")
+    d.flat = ["xy"]
+    d_obj.flat = ["xy"]
+    assert_array_equal(d, d_obj)


### PR DESCRIPTION
Fixes bugs when multiple distinct stringdtype arrays are passed to `np.choose`, `np.put`, `np.putmask`, `np.place`, flatiter reads, and a bug that could lead to unsafe views being created for StringDType and object arrays.

Also exposes a new C helper function `_is_safe_view_cast` which takes `view_offset` into account and uses it in the Python helper functions for view safety. It only uses this function for StringDType. We could use it more generally but that might lead to breakage, so just fixing StringDType seemed like a practical first pass.

The C changes all work out to fixing the same couple patterns: legacy paths that used copyswap (e.g. #24859, which this might obviate the need for?) or code paths that assumed all input arrays have the same descriptor instance.

Also adds tests for functionality that is fixed here or is poorly tested currently. It makes use of a new helper function that allocates two distinct arrays of strings with allocations that live in the arena buffer to trigger these bugs.

I milestoned this for 2.5.0 and marked it for backport because these are all bugs that can cause segfaults.

I used Claude Fable 5 to work on this, including for the implementation and new tests.