### PR TITLE
MAINT: add gitattribute to make all line endings LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
+# We want all text files to be /n
+# Specific settings below this can still override it
+# e.g.
+# *.bat   text eol=crlf
+* text=auto eol=lf
+
 # Highlight our custom templating language as C, since it's hopefully better
 # than nothing. This also affects repo statistics.
 *.c.src   text linguist-language=C


### PR DESCRIPTION
### PR summary
Specify gitattribute to make line endings for text files \n. This should help prevent things like #31603 being necessary.

#### AI Disclosure
No AI used.