### PR TITLE
BUG: fix incorrect alignment handling and error handling in several code paths

### DIFF
--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -414,7 +414,7 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
 
  fail:
     Py_XDECREF(mask);
-    PyArray_ResolveWritebackIfCopy(array);
+    PyArray_DiscardWritebackIfCopy(array);
     Py_XDECREF(array);
     Py_XDECREF(values);
     return NULL;

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -439,6 +439,9 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
         Py_INCREF(PyArray_DESCR(self));
         obj = (PyArrayObject *)PyArray_FromArray(self,
                                                  PyArray_DESCR(self), flags);
+        if (obj == NULL) {
+            goto fail;
+        }
         copied = 1;
         assert(self != obj);
         self = obj;
@@ -732,6 +735,9 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
         dtype = PyArray_DESCR(self);
         Py_INCREF(dtype);
         obj = (PyArrayObject *)PyArray_FromArray(self, dtype, flags);
+        if (obj == NULL) {
+            goto fail;
+        }
         if (obj != self) {
             copied = 1;
         }

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -849,8 +849,8 @@ iter_ass_subscript(PyArrayIterObject *self, PyObject *ind, PyObject *val)
     /* set up cast to handle single-element copies into arrval */
     NPY_ARRAYMETHOD_FLAGS transfer_flags = 0;
     npy_intp one = 1;
-    /* We can assume the newly allocated array is aligned */
-    int is_aligned = IsUintAligned(self->ao);
+    /* arrval can be the caller's array, so its alignment must be checked */
+    int is_aligned = IsUintAligned(self->ao) && IsUintAligned(arrval);
     if (PyArray_GetDTypeTransferFunction(
                 is_aligned, dtype_size, dtype_size, PyArray_DESCR(arrval), dtype, 0,
                 &cast_info, &transfer_flags) < 0) {

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -1076,7 +1076,7 @@ array_boolean_subscript(PyArrayObject *self,
                 self_data += subloopsize * self_stride;
                 ret_data += subloopsize * itemsize;
             }
-        } while (iternext(iter));
+        } while (res == 0 && iternext(iter));
 
         NPY_END_THREADS;
 
@@ -1274,7 +1274,7 @@ array_assign_boolean_subscript(PyArrayObject *self,
                 self_data += subloopsize * self_stride;
                 v_data += subloopsize * v_stride;
             }
-        } while (iternext(iter));
+        } while (res == 0 && iternext(iter));
 
         if (!(cast_flags & NPY_METH_REQUIRES_PYAPI)) {
             NPY_END_THREADS;

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -1365,6 +1365,22 @@ class TestBooleanIndexing:
             "size of axis is 1 but size of corresponding boolean axis is 2",
             lambda: a[idx])
 
+    def test_assignment_cast_error_aborts_iteration(self):
+        # A failing cast must abort the assignment: no further chunks may
+        # be processed and the error must be raised. The iteration used to
+        # continue after a failed chunk, relying on every later cast call
+        # failing fast on the pending exception to keep the error alive.
+        a = np.zeros((40, 30))[:, ::2]
+        mask = np.zeros(a.shape, dtype=bool)
+        mask[:2] = True
+        mask[2:, :5] = True
+        vals = np.arange(float(mask.sum())).astype(object)
+        vals[29] = object()
+        with pytest.raises(TypeError):
+            a[mask] = vals
+        # rows after the failing chunk are untouched
+        assert not a[2:].any()
+
 
 class TestArrayToIndexDeprecation:
     """Creating an index from array not 0-D is an error.

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6904,6 +6904,21 @@ class TestFlat:
         assert_(testpassed)
         assert_(b.flat[4] == 12.0)
 
+    def test_unaligned_values(self):
+        # the value array is used as-is, so its (mis)alignment must be
+        # honored when assigning through the flat iterator
+        n = 8
+        buf = np.zeros(n * 8 + 1, dtype=np.uint8)
+        unaligned = buf[1:].view(np.float64)
+        assert not unaligned.flags.aligned
+        unaligned[:] = np.arange(n)
+
+        b = np.zeros(n)
+        b.flat = unaligned
+        assert_array_equal(b, unaligned)
+        b.flat[::2] = unaligned[:n // 2]
+        assert_array_equal(b[::2], unaligned[:n // 2])
+
     def test___array__(self):
         a0 = np.arange(20.0)
         a = a0.reshape(4, 5)


### PR DESCRIPTION
Fixes two error paths that are trivially incorrect for OOM scenarios:

* `arr_place` uses `PyArray_ResolveWritebackIfCopy` in an error path, but it probably makes more sense to use `PyArray_DiscardWritebackIfCopy`, as suggested in the docstring for that function: https://numpy.org/doc/2.4/reference/c-api/array.html#c.PyArray_DiscardWritebackIfCopy
* `PyArray_PutTo` and `PyArray_PutMask` fail to check if `PyArray_FromArray` fails.

Fixes an incorrect assumption in the flatiter assignment code - the result array might be a user-supplied unaligned array.

Fixes a logic error in boolean indexing, where if an error is raised during an iteration, the iteration is not halted and it's possible the error could be silently discarded.

Adds tests for the latter two cases.

I used Claude Fable to help out with this. This was spotted during work on #31609 and touches the same functions but the issues are unrelated to StringDType, so I'm issuing this PR separately.