### PR TITLE
There is typo error in absolute_beginners.html docs file of numpy

### DIFF
--- a/doc/source/user/absolute_beginners.rst
+++ b/doc/source/user/absolute_beginners.rst
@@ -152,7 +152,7 @@ data in the original array. The original array can be mutated using the view.
 
     >>> b = a[3:]
     >>> b
-    array([4, 5, 6])
+    array([40, 5, 6])
     >>> b[0] = 40
     >>> a
     array([ 10,  2,  3, 40,  5,  6])


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.
  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
There is an typo error in absolute_beginner.rst which has example to shown in docs of numpy official 
originally it was written
>>>b = a[3:]
>>>b
>>>array([4, 5, 6]) -> array([40,5,6])  This is changes made
>>>b[0] = 40
>>a
array([ 10,  2,  3, 40,  5,  6])

example is used to show is incorrect

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->
Hello! This is my first contribution to NumPy.

I am an engineering student learning Python frameworks and libraries. While reading the documentation and working through examples, I noticed that the displayed output in this example was inconsistent with the code execution, so I submitted a fix.

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
ChatGPT was used to help draft the text of this pull request description. The identification of the documentation issue, code changes, review, and submission were performed by me.
