### PR TITLE
BUG: fix linspace returning NaN for equal infinite endpoints (gh-26699)

### DIFF
--- a/doc/release/upcoming_changes/31620.improvement.rst
+++ b/doc/release/upcoming_changes/31620.improvement.rst
@@ -1,0 +1,4 @@
+``np.linspace`` no longer returns NaN for equal infinite endpoints
+------------------------------------------------------------------
+``np.linspace(np.inf, np.inf, N)`` (and ``-np.inf``) now correctly returns
+an array filled with ``inf`` instead of ``nan``.

--- a/numpy/_core/function_base.py
+++ b/numpy/_core/function_base.py
@@ -137,8 +137,19 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
     else:
         integer_dtype = _nx.issubdtype(dtype, _nx.integer)
 
-    # Use `dtype=type(dt)` to enforce a floating point evaluation:
-    delta = np.subtract(stop, start, dtype=type(dt))
+    # Use `dtype=type(dt)` to enforce a floating point evaluation.
+    # Equal endpoints (including equal infinities) must produce a zero step,
+    # so skip the subtraction there: `inf - inf` would otherwise yield a
+    # spurious nan and an "invalid value" warning.  Using `where=` avoids the
+    # bad element entirely rather than suppressing warnings globally, so
+    # genuine invalid operations (e.g. mixed infinities) still warn.
+    equal = start == stop
+    if equal.ndim == 0:
+        delta = dt.type(0) if equal else np.subtract(
+            stop, start, dtype=type(dt))
+    else:
+        delta = np.subtract(stop, start, dtype=type(dt), where=~equal,
+                            out=np.zeros(equal.shape, dtype=type(dt)))
     y = _nx.arange(
         0, num, dtype=dt, device=device
     ).reshape((-1,) + (1,) * ndim(delta))

--- a/numpy/_core/tests/test_function_base.py
+++ b/numpy/_core/tests/test_function_base.py
@@ -1,5 +1,6 @@
 import platform
 import sys
+import warnings
 
 import pytest
 
@@ -21,6 +22,7 @@ from numpy import (
 from numpy._core import sctypes
 from numpy._core.function_base import add_newdoc
 from numpy.testing import (
+    IS_WASM,
     assert_,
     assert_allclose,
     assert_array_equal,
@@ -481,6 +483,58 @@ class TestLinspace:
         stop = array([2.0, 1.0])
         y = linspace(start, stop, 3)
         assert_array_equal(y, array([[0.0, 1.0], [1.0, 1.0], [2.0, 1.0]]))
+
+    def test_inf_equal_endpoints(self):
+        # Regression test for gh-26699, equal infinite endpoint were returning NaN.
+        # Equal endpoints skip the `inf - inf` subtraction entirely, so no
+        # spurious "invalid value" RuntimeWarning must be emitted (the fix does
+        # not rely on suppressing warnings via errstate).
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            for inf in [np.inf, -np.inf]:
+                assert_array_equal(linspace(inf, inf, 0), array([]))
+                assert_array_equal(linspace(inf, inf, 1), array([inf]))
+                for num in [2, 5, 50]:
+                    assert_array_equal(linspace(inf, inf, num), np.full(num, inf))
+
+            assert_array_equal(linspace(np.inf, np.inf, 5, endpoint=False),
+                               np.full(5, np.inf))
+
+            y, step = linspace(np.inf, np.inf, 2, retstep=True)
+            assert_array_equal(y, array([np.inf, np.inf]))
+            assert_equal(step, 0.0)
+
+            start = array([np.inf, 1.0])
+            stop = array([np.inf, 3.0])
+            result = linspace(start, stop, 3)
+            assert_array_equal(result,
+                               array([[np.inf, 1.0], [np.inf, 2.0],
+                                      [np.inf, 3.0]]))
+
+            # Complex infinities
+            for cinf in [complex(np.inf, 0), complex(0, np.inf),
+                         complex(np.inf, np.inf), complex(-np.inf, -np.inf)]:
+                assert_array_equal(linspace(cinf, cinf, 3), np.full(3, cinf))
+
+    @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
+    def test_inf_mixed_endpoints_warns(self):
+        # Mixed infinite endpoints produce NaN interior points and should warn.
+        cases = [(np.inf, -np.inf, -np.inf), (-np.inf, np.inf, np.inf)]
+        for num in [3, 5]:
+            for start, stop, expected_stop in cases:
+                with pytest.warns(RuntimeWarning, match="invalid value"):
+                    mixed = linspace(start, stop, num)
+                assert_(isnan(mixed[:-1]).all())
+                assert_equal(mixed[-1], expected_stop)
+
+    def test_nan_endpoints(self):
+        # NaN inputs: behavior unchanged by gh-26699 fix (nan != nan so no
+        # replacement occurs; delta stays nan and propagates normally).
+        assert_(isnan(linspace(np.nan, np.nan, 5)).all())
+        assert_(isnan(linspace(np.nan, np.nan, 1)).all())
+        result = linspace(np.nan, 1.0, 5)
+        assert_(isnan(result[:-1]).all())
+        assert_equal(result[-1], 1.0)
 
 
 class TestAdd_newdoc:


### PR DESCRIPTION
### PR summary

Fixes gh-26699.
  
np.linspace(np.inf, np.inf, N) returned [nan nan ... nan inf] instead of [inf inf ... inf]. The root cause is delta = stop - start producing nan via inf - inf which propagates through all subsequent multiplications,only the last element was rescued by the y[-1] = stop assignment

Fix: replace any nan in delta with zero wherever start == stop. The nan == nan is False identity ensures NaN inputs are unaffected in this case

#### AI Disclosure

Used Claude to make sure I didn't miss anything 
