### PR TITLE
fix: correct 'paramters' typo in LAPACK source comments

### DIFF
--- a/numpy/linalg/lapack_lite/f2c_d_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_d_lapack.c
@@ -31388,7 +31388,7 @@ L80:
     =====================================================================
 
 
-       Test the input paramters.
+       Test the input parameters.
 */
 
     /* Parameter adjustments */

--- a/numpy/linalg/lapack_lite/f2c_s_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_s_lapack.c
@@ -31271,7 +31271,7 @@ L80:
     =====================================================================
 
 
-       Test the input paramters.
+       Test the input parameters.
 */
 
     /* Parameter adjustments */


### PR DESCRIPTION
Fixes a misspelling in LAPACK source comments: 'paramters' → 'parameters'.