### PR TITLE
BUG: Fix thread safety issue in f2py allocatable arrays

### DIFF
--- a/numpy/f2py/f90mod_rules.py
+++ b/numpy/f2py/f90mod_rules.py
@@ -65,7 +65,7 @@ fgetdims2 = """\
          end do
       end if
       flag = 1
-      call f2pysetdata(d,allocated(d))"""
+      call f2pysetdata(d,allocated(d), out_data)"""
 
 fgetdims2_sa = """\
       end if
@@ -76,7 +76,7 @@ fgetdims2_sa = """\
          !s(r) must be equal to len(d(1))
       end if
       flag = 2
-      call f2pysetdata(d,allocated(d))"""
+      call f2pysetdata(d,allocated(d), out_data)"""
 
 
 def buildhooks(pymod):
@@ -171,10 +171,10 @@ def buildhooks(pymod):
                 fargs.append(f"f2py_{m['name']}_getdims_{n}")
                 efargs.append(fargs[-1])
                 sargs.append(
-                    f'void (*{n})(int*,npy_intp*,void(*)(char*,npy_intp*),int*)')
-                sargsp.append('void (*)(int*,npy_intp*,void(*)(char*,npy_intp*),int*)')
+                    f'f2py_init_func {n}')
+                sargsp.append('f2py_init_func')
                 iadd(f"\tf2py_{m['name']}_def[i_f2py++].func = {n};")
-                fadd(f'subroutine {fargs[-1]}(r,s,f2pysetdata,flag)')
+                fadd(f'subroutine {fargs[-1]}(r,s,f2pysetdata,flag, out_data)')
                 fadd(f"use {m['name']}, only: d => {undo_rmbadname1(n)}\n")
                 fadd('integer flag\n')
                 fhooks[0] = fhooks[0] + fgetdims1

--- a/numpy/f2py/src/fortranobject.c
+++ b/numpy/f2py/src/fortranobject.c
@@ -291,21 +291,44 @@ fortran_doc(FortranDataDef def)
     }
 }
 
-static FortranDataDef *save_def; /* save pointer of an allocatable array */
 static void
-set_data(char *d, npy_intp *f)
+set_data(char *d, npy_intp *f, char **out_data)
 {           /* callback from Fortran */
     if (*f) /* In fortran f=allocated(d) */
-        save_def->data = d;
+        *out_data = d;
     else
-        save_def->data = NULL;
+        *out_data = NULL;
     /* printf("set_data: d=%p,f=%d\n",d,*f); */
+}
+
+static PyObject *
+fortran_getattr_allocatable(PyFortranObject *fp, FortranDataDef *fp_defs_i) {
+    int k, flag;
+    for (k = 0; k < fp_defs_i->rank; ++k) fp_defs_i->dims.d[k] = -1;
+    (*(fp_defs_i->func))(&fp_defs_i->rank, fp_defs_i->dims.d,
+                            set_data, &flag, &fp_defs_i->data);
+    if (flag == 2)
+        k = fp_defs_i->rank + 1;
+    else
+        k = fp_defs_i->rank;
+    if (fp_defs_i->data != NULL) { /* array is allocated */
+        PyObject *v = PyArray_New(
+                &PyArray_Type, k, fp_defs_i->dims.d, fp_defs_i->type,
+                NULL, fp_defs_i->data, 0, NPY_ARRAY_FARRAY, NULL);
+        if (v == NULL)
+            return NULL;
+        return v;
+    }
+    else { /* array is not allocated */
+        Py_RETURN_NONE;
+    }
 }
 
 static PyObject *
 fortran_getattr(PyFortranObject *fp, char *name)
 {
-    int i, j, k, flag;
+    int i, j;
+    PyObject *result;
     if (fp->dict != NULL) {
         // python 3.13 added PyDict_GetItemRef
 #if PY_VERSION_HEX < 0x030D0000
@@ -336,26 +359,14 @@ fortran_getattr(PyFortranObject *fp, char *name)
         if (fp->defs[i].rank != -1) { /* F90 allocatable array */
             if (fp->defs[i].func == NULL)
                 return NULL;
-            for (k = 0; k < fp->defs[i].rank; ++k) fp->defs[i].dims.d[k] = -1;
-            save_def = &fp->defs[i];
-            (*(fp->defs[i].func))(&fp->defs[i].rank, fp->defs[i].dims.d,
-                                  set_data, &flag);
-            if (flag == 2)
-                k = fp->defs[i].rank + 1;
-            else
-                k = fp->defs[i].rank;
-            if (fp->defs[i].data != NULL) { /* array is allocated */
-                PyObject *v = PyArray_New(
-                        &PyArray_Type, k, fp->defs[i].dims.d, fp->defs[i].type,
-                        NULL, fp->defs[i].data, 0, NPY_ARRAY_FARRAY, NULL);
-                if (v == NULL)
-                    return NULL;
-                /* Py_INCREF(v); */
-                return v;
-            }
-            else { /* array is not allocated */
-                Py_RETURN_NONE;
-            }
+            #ifdef Py_GIL_DISABLED
+            Py_BEGIN_CRITICAL_SECTION(fp);
+            #endif
+            result = fortran_getattr_allocatable(fp, &fp->defs[i]);
+            #ifdef Py_GIL_DISABLED
+            Py_END_CRITICAL_SECTION()
+            #endif
+            return result;
         }
     if (strcmp(name, "__dict__") == 0) {
         Py_INCREF(fp->dict);
@@ -397,10 +408,70 @@ fortran_getattr(PyFortranObject *fp, char *name)
 }
 
 static int
+fortran_setattr_array(FortranDataDef *fp_defs_i, PyObject *v)
+{
+    int k, flag;
+    npy_intp dims[F2PY_MAX_DIMS];
+    PyArrayObject *arr = NULL;
+
+    if (fp_defs_i->func != NULL) { /* is allocatable array */
+        if (v != Py_None) { /* set new value (reallocate if needed --
+                            see f2py generated code for more
+                            details ) */
+            for (k = 0; k < fp_defs_i->rank; k++) dims[k] = -1;
+            if ((arr = array_from_pyobj(fp_defs_i->type, dims,
+                                        fp_defs_i->rank, F2PY_INTENT_IN,
+                                        v)) == NULL)
+                return -1;
+            (*(fp_defs_i->func))(&fp_defs_i->rank, PyArray_DIMS(arr),
+                                    set_data, &flag, &fp_defs_i->data);
+        }
+        else { /* deallocate */
+            for (k = 0; k < fp_defs_i->rank; k++) dims[k] = 0;
+            (*(fp_defs_i->func))(&fp_defs_i->rank, dims, set_data,
+                                    &flag, &fp_defs_i->data);
+            for (k = 0; k < fp_defs_i->rank; k++) dims[k] = -1;
+        }
+        memcpy(fp_defs_i->dims.d, dims,
+                fp_defs_i->rank * sizeof(npy_intp));
+    }
+    else { /* not allocatable array */
+        if ((arr = array_from_pyobj(fp_defs_i->type, fp_defs_i->dims.d,
+                                    fp_defs_i->rank, F2PY_INTENT_IN,
+                                    v)) == NULL)
+            return -1;
+    }
+    if (fp_defs_i->data !=
+        NULL) { /* copy Python object to Fortran array */
+        npy_intp s = PyArray_MultiplyList(fp_defs_i->dims.d,
+                                            PyArray_NDIM(arr));
+        if (s == -1)
+            s = PyArray_MultiplyList(PyArray_DIMS(arr), PyArray_NDIM(arr));
+        if (s < 0 || (memcpy(fp_defs_i->data, PyArray_DATA(arr),
+                                s * PyArray_ITEMSIZE(arr))) == NULL) {
+            if ((PyObject *)arr != v) {
+                Py_DECREF(arr);
+            }
+            return -1;
+        }
+        if ((PyObject *)arr != v) {
+            Py_DECREF(arr);
+        }
+    }
+    else if (fp_defs_i->func == NULL) {
+        PyErr_SetString(
+            PyExc_AttributeError,
+            "Attempt to set non-allocatable fortran array failed"
+        );
+        return -1;
+    }
+    return 0; /* successful */
+}
+
+static int
 fortran_setattr(PyFortranObject *fp, char *name, PyObject *v)
 {
-    int i, j, flag;
-    PyArrayObject *arr = NULL;
+    int i, j, result;
     for (i = 0, j = 1; i < fp->len && (j = strcmp(name, fp->defs[i].name));
          i++)
         ;
@@ -410,56 +481,14 @@ fortran_setattr(PyFortranObject *fp, char *name, PyObject *v)
                             "over-writing fortran routine");
             return -1;
         }
-        if (fp->defs[i].func != NULL) { /* is allocatable array */
-            npy_intp dims[F2PY_MAX_DIMS];
-            int k;
-            save_def = &fp->defs[i];
-            if (v != Py_None) { /* set new value (reallocate if needed --
-                                   see f2py generated code for more
-                                   details ) */
-                for (k = 0; k < fp->defs[i].rank; k++) dims[k] = -1;
-                if ((arr = array_from_pyobj(fp->defs[i].type, dims,
-                                            fp->defs[i].rank, F2PY_INTENT_IN,
-                                            v)) == NULL)
-                    return -1;
-                (*(fp->defs[i].func))(&fp->defs[i].rank, PyArray_DIMS(arr),
-                                      set_data, &flag);
-            }
-            else { /* deallocate */
-                for (k = 0; k < fp->defs[i].rank; k++) dims[k] = 0;
-                (*(fp->defs[i].func))(&fp->defs[i].rank, dims, set_data,
-                                      &flag);
-                for (k = 0; k < fp->defs[i].rank; k++) dims[k] = -1;
-            }
-            memcpy(fp->defs[i].dims.d, dims,
-                   fp->defs[i].rank * sizeof(npy_intp));
-        }
-        else { /* not allocatable array */
-            if ((arr = array_from_pyobj(fp->defs[i].type, fp->defs[i].dims.d,
-                                        fp->defs[i].rank, F2PY_INTENT_IN,
-                                        v)) == NULL)
-                return -1;
-        }
-        if (fp->defs[i].data !=
-            NULL) { /* copy Python object to Fortran array */
-            npy_intp s = PyArray_MultiplyList(fp->defs[i].dims.d,
-                                              PyArray_NDIM(arr));
-            if (s == -1)
-                s = PyArray_MultiplyList(PyArray_DIMS(arr), PyArray_NDIM(arr));
-            if (s < 0 || (memcpy(fp->defs[i].data, PyArray_DATA(arr),
-                                 s * PyArray_ITEMSIZE(arr))) == NULL) {
-                if ((PyObject *)arr != v) {
-                    Py_DECREF(arr);
-                }
-                return -1;
-            }
-            if ((PyObject *)arr != v) {
-                Py_DECREF(arr);
-            }
-        }
-        else
-            return (fp->defs[i].func == NULL ? -1 : 0);
-        return 0; /* successful */
+        #if Py_GIL_DISABLED
+        Py_BEGIN_CRITICAL_SECTION(fp);
+        #endif
+        result = fortran_setattr_array(&fp->defs[i], v);
+        #if Py_GIL_DISABLED
+        Py_END_CRITICAL_SECTION()
+        #endif
+        return result;
     }
     if (fp->dict == NULL) {
         fp->dict = PyDict_New();

--- a/numpy/f2py/src/fortranobject.h
+++ b/numpy/f2py/src/fortranobject.h
@@ -48,9 +48,9 @@ Author: Pearu Peterson <pearu@cens.ioc.ee>
 
 #define F2PY_MAX_DIMS 40
 
-typedef void (*f2py_set_data_func)(char *, npy_intp *);
+typedef void (*f2py_set_data_func)(char *, npy_intp *, char **);
 typedef void (*f2py_void_func)(void);
-typedef void (*f2py_init_func)(int *, npy_intp *, f2py_set_data_func, int *);
+typedef void (*f2py_init_func)(int *, npy_intp *, f2py_set_data_func, int *, char **);
 
 /*typedef void* (*f2py_c_func)(void*,...);*/
 

--- a/numpy/f2py/tests/src/allocatable/alloc.f90
+++ b/numpy/f2py/tests/src/allocatable/alloc.f90
@@ -1,0 +1,36 @@
+module mod
+  real, allocatable, dimension(:) :: one_d
+  integer, allocatable, dimension(:, :) :: two_d 
+  double complex, allocatable, dimension(:, :, :) :: three_d
+contains
+  subroutine probe_one_d(a, value)
+    integer, intent(in) :: a
+    real, intent(out) :: value
+    if (allocated(one_d)) then
+      value = one_d(a)
+    else
+      value = -1
+    endif
+  end subroutine probe_one_d
+
+  subroutine probe_two_d(a, b, value)
+    integer, intent(in) :: a, b
+    integer, intent(out) :: value
+    if (allocated(two_d)) then
+      value = two_d(a, b)
+    else
+      value = -1
+    endif
+  end subroutine probe_two_d
+
+  subroutine probe_three_d(a, b, c, value)
+    integer, intent(in) :: a, b, c
+    double complex, intent(out) :: value
+    if (allocated(three_d)) then
+      value = three_d(a, b, c)
+    else
+      value = -1
+    endif
+  end subroutine probe_three_d
+end module mod
+

--- a/numpy/f2py/tests/test_allocatable.py
+++ b/numpy/f2py/tests/test_allocatable.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pytest
+
+from . import util
+
+
+@pytest.mark.slow
+class TestAllocatable(util.F2PyTest):
+    sources = [
+        util.getpath("tests", "src", "allocatable", "alloc.f90")
+    ]
+
+    def test_one_d(self):
+        v = self.module.mod.probe_one_d(1)
+        assert v == -1
+
+        self.module.mod.one_d = np.linspace(1, 10, 5, dtype=np.float32)
+
+        v = self.module.mod.probe_one_d(1)
+        assert np.allclose(v, 1.0)
+        v = self.module.mod.probe_one_d(5)
+        assert np.allclose(v, 10.0)
+
+        assert np.allclose(self.module.mod.one_d[0], 1.0)
+        assert np.allclose(self.module.mod.one_d[4], 10.0)
+
+        self.module.mod.one_d = None
+        assert self.module.mod.probe_one_d(1) == -1
+
+        #with pytest.raises(ValueError):
+        #    self.module.mod.one_d = [[1, 2, 3], [9, 9, 11]]
+        with pytest.raises(TypeError):
+            self.module.mod.one_d = [1.j]
+        with pytest.raises(TypeError):
+            self.module.mod.one_d = ...
+
+    def test_two_d(self):
+        v = self.module.mod.probe_two_d(1, 1)
+        assert v == -1
+
+        self.module.mod.two_d = [[1, 2, 3],
+                                 [4, 5, 6]]
+        v = self.module.mod.probe_two_d(1, 1)
+        assert np.allclose(v, 1)
+        v = self.module.mod.probe_two_d(2, 2)
+        assert np.allclose(v, 5)
+        v = self.module.mod.probe_two_d(2, 3)
+        assert np.allclose(v, 6)
+
+    def test_three_d(self):
+        v = self.module.mod.probe_three_d(1, 1, 1)
+        assert v == -1
+
+        self.module.mod.three_d = (
+            np.linspace(0, 27-27j, 27, dtype=np.complex64)
+        ).reshape(3, 3, 3)
+
+        v = self.module.mod.probe_three_d(1, 1, 1)
+        assert np.allclose(v, 0)
+        v = self.module.mod.probe_three_d(2, 2, 2)
+        assert np.allclose(v, 13.5-13.5j)
+        v = self.module.mod.probe_three_d(3, 3, 3)
+        assert np.allclose(v, 27-27.j)
+
+        self.module.mod.three_d[1, 1, 1] = 42j
+        v = self.module.mod.probe_three_d(2, 2, 2)
+        assert np.allclose(v, 42j)

--- a/numpy/f2py/tests/test_allocatable.py
+++ b/numpy/f2py/tests/test_allocatable.py
@@ -1,8 +1,8 @@
 import pytest
 
-from . import util
-
 import numpy as np
+
+from . import util
 
 
 @pytest.mark.slow

--- a/numpy/f2py/tests/test_allocatable.py
+++ b/numpy/f2py/tests/test_allocatable.py
@@ -1,7 +1,8 @@
-import numpy as np
 import pytest
 
 from . import util
+
+import numpy as np
 
 
 @pytest.mark.slow
@@ -52,15 +53,15 @@ class TestAllocatable(util.F2PyTest):
         assert v == -1
 
         self.module.mod.three_d = (
-            np.linspace(0, 27-27j, 27, dtype=np.complex64)
+            np.linspace(0, 27 - 27j, 27, dtype=np.complex64)
         ).reshape(3, 3, 3)
 
         v = self.module.mod.probe_three_d(1, 1, 1)
         assert np.allclose(v, 0)
         v = self.module.mod.probe_three_d(2, 2, 2)
-        assert np.allclose(v, 13.5-13.5j)
+        assert np.allclose(v, 13.5 - 13.5j)
         v = self.module.mod.probe_three_d(3, 3, 3)
-        assert np.allclose(v, 27-27.j)
+        assert np.allclose(v, 27 - 27.j)
 
         self.module.mod.three_d[1, 1, 1] = 42j
         v = self.module.mod.probe_three_d(2, 2, 2)


### PR DESCRIPTION
### PR summary

There were two separate issues:
1. The target data was being passed as a global variable. This means that even assigning individual attributes from different threads is unsafe. Fixed this by passing it through the generated Fortran function call instead.
2. Second (less important), use critical sections to guard the parts where PyFortranObject internals are modified, so that assigning the same attribute from different threads won't corrupt the structure.

I haven't tried to guard anything except the internals of f2py for thread-safety. There's no real point trying to lock the contents of these variables since Fortran itself can access them without the lock.

Also add some tests for allocatable arrays (although not specifically a thread safety test).

This will generate some small merge conflicts with https://github.com/numpy/numpy/pull/31598 but nothing difficult to fix.

#### AI Disclosure

No AI tools used.