### PR TITLE
DOC: Prevent arrow ligatures in generalized ufunc signatures fix #31625

### DIFF
--- a/doc/source/_static/numpy.css
+++ b/doc/source/_static/numpy.css
@@ -104,3 +104,8 @@ div.admonition-legacy>.admonition-title {
 .try_examples_outer_iframe {
   margin-top: 0.4em;
 }
+
+code.literal,
+code.literal .pre {
+    font-variant-ligatures: none;
+}


### PR DESCRIPTION
DOC: Prevent arrow ligatures in generalized ufunc signatures

Bug: #31625 

Disable font ligatures for inline code literals so signatures
such as ()->() render literally instead of displaying a Unicode
arrow glyph in browsers using ligature-enabled fonts.

Investigatation: 
```js
$0.textContent
// '(),()->()'
```

<img width="744" height="237" alt="image" src="https://github.com/user-attachments/assets/3c396d18-5a8a-409b-bd96-212203e961dc" />

- The generated HTML contains the literal text ()->() ($0.textContent returns (),()->()). The issue appears to be visual only. 
- The code element uses a font stack including Cascadia Code and has font-variant-ligatures: normal, which causes it to render -> as the ligature →. 
- Disabling ligatures on the code element restores the expected appearance.

Before: 
<img width="316" height="172" alt="image" src="https://github.com/user-attachments/assets/ed72d0ea-8f2e-42d9-a05c-63bd42a78d2d" />

After:
<img width="300" height="130" alt="image" src="https://github.com/user-attachments/assets/d79ed0b3-3b06-445d-be38-c8ff18a64f47" />
