### PR TITLE
TST: Use pytest.warns as ignore filters+suppress_warnings interfere (#31623)

### DIFF
--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -1803,211 +1803,226 @@ def test_clear_and_catch_warnings():
     assert_warn_len_equal(my_mod, 0)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:.*NumPy warning suppression and assertion utilities are deprecated"
-    ".*:DeprecationWarning")
 @pytest.mark.thread_unsafe(reason="checks global module & deprecated warnings")
 def test_suppress_warnings_module():
-    # Initial state of module, no warnings
-    my_mod = _get_fresh_mod()
-    assert_equal(getattr(my_mod, '__warningregistry__', {}), {})
+    # NOTE(seberg): We test for the DeprecationWarning mainly because on
+    # free-threaded Python an "ignore" warning filters seem to collide with
+    # parts of what `suppress_warnings` does (if used more than once?).
+    with pytest.warns(
+            DeprecationWarning,
+            match="suppression and assertion utilities are deprecated"):
+        # Initial state of module, no warnings
+        my_mod = _get_fresh_mod()
+        assert_equal(getattr(my_mod, '__warningregistry__', {}), {})
 
-    def warn_other_module():
-        # Apply along axis is implemented in python; stacklevel=2 means
-        # we end up inside its module, not ours.
-        def warn(arr):
-            warnings.warn("Some warning 2", stacklevel=2)
-            return arr
-        np.apply_along_axis(warn, 0, [0])
+        def warn_other_module():
+            # Apply along axis is implemented in python; stacklevel=2 means
+            # we end up inside its module, not ours.
+            def warn(arr):
+                warnings.warn("Some warning 2", stacklevel=2)
+                return arr
+            np.apply_along_axis(warn, 0, [0])
 
-    # Test module based warning suppression:
-    assert_warn_len_equal(my_mod, 0)
-    with suppress_warnings() as sup:
-        sup.record(UserWarning)
-        # suppress warning from other module (may have .pyc ending),
-        # if apply_along_axis is moved, had to be changed.
-        sup.filter(module=np.lib._shape_base_impl)
-        warnings.warn("Some warning")
-        warn_other_module()
-    # Check that the suppression did test the file correctly (this module
-    # got filtered)
-    assert_equal(len(sup.log), 1)
-    assert_equal(sup.log[0].message.args[0], "Some warning")
-    assert_warn_len_equal(my_mod, 0)
-    sup = suppress_warnings()
-    # Will have to be changed if apply_along_axis is moved:
-    sup.filter(module=my_mod)
-    with sup:
-        warnings.warn('Some warning')
-    assert_warn_len_equal(my_mod, 0)
-    # And test repeat works:
-    sup.filter(module=my_mod)
-    with sup:
-        warnings.warn('Some warning')
-    assert_warn_len_equal(my_mod, 0)
+        # Test module based warning suppression:
+        assert_warn_len_equal(my_mod, 0)
+        with suppress_warnings() as sup:
+            sup.record(UserWarning)
+            # suppress warning from other module (may have .pyc ending),
+            # if apply_along_axis is moved, had to be changed.
+            sup.filter(module=np.lib._shape_base_impl)
+            warnings.warn("Some warning")
+            warn_other_module()
+        # Check that the suppression did test the file correctly (this module
+        # got filtered)
+        assert_equal(len(sup.log), 1)
+        assert_equal(sup.log[0].message.args[0], "Some warning")
+        assert_warn_len_equal(my_mod, 0)
+        sup = suppress_warnings()
+        # Will have to be changed if apply_along_axis is moved:
+        sup.filter(module=my_mod)
+        with sup:
+            warnings.warn('Some warning')
+        assert_warn_len_equal(my_mod, 0)
+        # And test repeat works:
+        sup.filter(module=my_mod)
+        with sup:
+            warnings.warn('Some warning')
+        assert_warn_len_equal(my_mod, 0)
 
-    # Without specified modules
-    with suppress_warnings():
-        warnings.simplefilter('ignore')
-        warnings.warn('Some warning')
-    assert_warn_len_equal(my_mod, 0)
+        # Without specified modules
+        with suppress_warnings():
+            warnings.simplefilter('ignore')
+            warnings.warn('Some warning')
+        assert_warn_len_equal(my_mod, 0)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:.*NumPy warning suppression and assertion utilities are deprecated"
-    ".*:DeprecationWarning")
 @pytest.mark.thread_unsafe(reason="checks global module & deprecated warnings")
 def test_suppress_warnings_type():
-    # Initial state of module, no warnings
-    my_mod = _get_fresh_mod()
-    assert_equal(getattr(my_mod, '__warningregistry__', {}), {})
+    # NOTE(seberg): We test for the DeprecationWarning mainly because on
+    # free-threaded Python an "ignore" warning filters seem to collide with
+    # parts of what `suppress_warnings` does (if used more than once?).
+    with pytest.warns(
+            DeprecationWarning,
+            match="suppression and assertion utilities are deprecated"):
+        # Initial state of module, no warnings
+        my_mod = _get_fresh_mod()
+        assert_equal(getattr(my_mod, '__warningregistry__', {}), {})
 
-    # Test module based warning suppression:
-    with suppress_warnings() as sup:
+        # Test module based warning suppression:
+        with suppress_warnings() as sup:
+            sup.filter(UserWarning)
+            warnings.warn('Some warning')
+        assert_warn_len_equal(my_mod, 0)
+        sup = suppress_warnings()
         sup.filter(UserWarning)
-        warnings.warn('Some warning')
-    assert_warn_len_equal(my_mod, 0)
-    sup = suppress_warnings()
-    sup.filter(UserWarning)
-    with sup:
-        warnings.warn('Some warning')
-    assert_warn_len_equal(my_mod, 0)
-    # And test repeat works:
-    sup.filter(module=my_mod)
-    with sup:
-        warnings.warn('Some warning')
-    assert_warn_len_equal(my_mod, 0)
+        with sup:
+            warnings.warn('Some warning')
+        assert_warn_len_equal(my_mod, 0)
+        # And test repeat works:
+        sup.filter(module=my_mod)
+        with sup:
+            warnings.warn('Some warning')
+        assert_warn_len_equal(my_mod, 0)
 
-    # Without specified modules
-    with suppress_warnings():
-        warnings.simplefilter('ignore')
-        warnings.warn('Some warning')
-    assert_warn_len_equal(my_mod, 0)
+        # Without specified modules
+        with suppress_warnings():
+            warnings.simplefilter('ignore')
+            warnings.warn('Some warning')
+        assert_warn_len_equal(my_mod, 0)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:.*NumPy warning suppression and assertion utilities are deprecated"
-    ".*:DeprecationWarning")
 @pytest.mark.thread_unsafe(
     reason="uses deprecated thread-unsafe warnings control utilities"
 )
 def test_suppress_warnings_decorate_no_record():
-    sup = suppress_warnings()
-    sup.filter(UserWarning)
+    # NOTE(seberg): We test for the DeprecationWarning mainly because on
+    # free-threaded Python an "ignore" warning filters seem to collide with
+    # parts of what `suppress_warnings` does (if used more than once?).
+    with pytest.warns(
+            DeprecationWarning,
+            match="suppression and assertion utilities are deprecated"):
+        sup = suppress_warnings()
+        sup.filter(UserWarning)
 
-    @sup
-    def warn(category):
-        warnings.warn('Some warning', category)
+        @sup
+        def warn(category):
+            warnings.warn('Some warning', category)
 
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        warn(UserWarning)  # should be suppressed
-        warn(RuntimeWarning)
-        assert_equal(len(w), 1)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            warn(UserWarning)  # should be suppressed
+            warn(RuntimeWarning)
+            assert_equal(len(w), 1)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:.*NumPy warning suppression and assertion utilities are deprecated"
-    ".*:DeprecationWarning")
 @pytest.mark.thread_unsafe(
     reason="uses deprecated thread-unsafe warnings control utilities"
 )
 def test_suppress_warnings_record():
-    sup = suppress_warnings()
-    log1 = sup.record()
+    # NOTE(seberg): We test for the DeprecationWarning mainly because on
+    # free-threaded Python an "ignore" warning filters seem to collide with
+    # parts of what `suppress_warnings` does (if used more than once?).
+    with pytest.warns(
+            DeprecationWarning,
+            match="suppression and assertion utilities are deprecated"):
+        sup = suppress_warnings()
+        log1 = sup.record()
 
-    with sup:
-        log2 = sup.record(message='Some other warning 2')
-        sup.filter(message='Some warning')
-        warnings.warn('Some warning')
-        warnings.warn('Some other warning')
-        warnings.warn('Some other warning 2')
-
-        assert_equal(len(sup.log), 2)
-        assert_equal(len(log1), 1)
-        assert_equal(len(log2), 1)
-        assert_equal(log2[0].message.args[0], 'Some other warning 2')
-
-    # Do it again, with the same context to see if some warnings survived:
-    with sup:
-        log2 = sup.record(message='Some other warning 2')
-        sup.filter(message='Some warning')
-        warnings.warn('Some warning')
-        warnings.warn('Some other warning')
-        warnings.warn('Some other warning 2')
-
-        assert_equal(len(sup.log), 2)
-        assert_equal(len(log1), 1)
-        assert_equal(len(log2), 1)
-        assert_equal(log2[0].message.args[0], 'Some other warning 2')
-
-    # Test nested:
-    with suppress_warnings() as sup:
-        sup.record()
-        with suppress_warnings() as sup2:
-            sup2.record(message='Some warning')
+        with sup:
+            log2 = sup.record(message='Some other warning 2')
+            sup.filter(message='Some warning')
             warnings.warn('Some warning')
             warnings.warn('Some other warning')
-            assert_equal(len(sup2.log), 1)
-        # includes a DeprecationWarning for suppress_warnings
-        assert_equal(len(sup.log), 2)
+            warnings.warn('Some other warning 2')
+
+            assert_equal(len(sup.log), 2)
+            assert_equal(len(log1), 1)
+            assert_equal(len(log2), 1)
+            assert_equal(log2[0].message.args[0], 'Some other warning 2')
+
+        # Do it again, with the same context to see if some warnings survived:
+        with sup:
+            log2 = sup.record(message='Some other warning 2')
+            sup.filter(message='Some warning')
+            warnings.warn('Some warning')
+            warnings.warn('Some other warning')
+            warnings.warn('Some other warning 2')
+
+            assert_equal(len(sup.log), 2)
+            assert_equal(len(log1), 1)
+            assert_equal(len(log2), 1)
+            assert_equal(log2[0].message.args[0], 'Some other warning 2')
+
+        # Test nested:
+        with suppress_warnings() as sup:
+            sup.record()
+            with suppress_warnings() as sup2:
+                sup2.record(message='Some warning')
+                warnings.warn('Some warning')
+                warnings.warn('Some other warning')
+                assert_equal(len(sup2.log), 1)
+            # includes a DeprecationWarning for suppress_warnings
+            assert_equal(len(sup.log), 2)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:.*NumPy warning suppression and assertion utilities are deprecated"
-    ".*:DeprecationWarning")
 @pytest.mark.thread_unsafe(
     reason="uses deprecated thread-unsafe warnings control utilities"
 )
 def test_suppress_warnings_forwarding():
-    def warn_other_module():
-        # Apply along axis is implemented in python; stacklevel=2 means
-        # we end up inside its module, not ours.
-        def warn(arr):
-            warnings.warn("Some warning", stacklevel=2)
-            return arr
-        np.apply_along_axis(warn, 0, [0])
+    # NOTE(seberg): We test for the DeprecationWarning mainly because on
+    # free-threaded Python an "ignore" warning filters seem to collide with
+    # parts of what `suppress_warnings` does (if used more than once?).
+    with pytest.warns(
+            DeprecationWarning,
+            match="suppression and assertion utilities are deprecated"):
+        def warn_other_module():
+            # Apply along axis is implemented in python; stacklevel=2 means
+            # we end up inside its module, not ours.
+            def warn(arr):
+                warnings.warn("Some warning", stacklevel=2)
+                return arr
+            np.apply_along_axis(warn, 0, [0])
 
-    with suppress_warnings() as sup:
-        sup.record()
-        with suppress_warnings("always"):
-            for i in range(2):
-                warnings.warn("Some warning")
+        with suppress_warnings() as sup:
+            sup.record()
+            with suppress_warnings("always"):
+                for i in range(2):
+                    warnings.warn("Some warning")
 
-        # includes a DeprecationWarning for suppress_warnings
-        assert_equal(len(sup.log), 3)
+            # includes a DeprecationWarning for suppress_warnings
+            assert_equal(len(sup.log), 3)
 
-    with suppress_warnings() as sup:
-        sup.record()
-        with suppress_warnings("location"):
-            for i in range(2):
-                warnings.warn("Some warning")
-                warnings.warn("Some warning")
+        with suppress_warnings() as sup:
+            sup.record()
+            with suppress_warnings("location"):
+                for i in range(2):
+                    warnings.warn("Some warning")
+                    warnings.warn("Some warning")
 
-        # includes a DeprecationWarning for suppress_warnings
-        assert_equal(len(sup.log), 3)
+            # includes a DeprecationWarning for suppress_warnings
+            assert_equal(len(sup.log), 3)
 
-    with suppress_warnings() as sup:
-        sup.record()
-        with suppress_warnings("module"):
-            for i in range(2):
-                warnings.warn("Some warning")
-                warnings.warn("Some warning")
-                warn_other_module()
+        with suppress_warnings() as sup:
+            sup.record()
+            with suppress_warnings("module"):
+                for i in range(2):
+                    warnings.warn("Some warning")
+                    warnings.warn("Some warning")
+                    warn_other_module()
 
-        # includes a DeprecationWarning for suppress_warnings
-        assert_equal(len(sup.log), 3)
+            # includes a DeprecationWarning for suppress_warnings
+            assert_equal(len(sup.log), 3)
 
-    with suppress_warnings() as sup:
-        sup.record()
-        with suppress_warnings("once"):
-            for i in range(2):
-                warnings.warn("Some warning")
-                warnings.warn("Some other warning")
-                warn_other_module()
+        with suppress_warnings() as sup:
+            sup.record()
+            with suppress_warnings("once"):
+                for i in range(2):
+                    warnings.warn("Some warning")
+                    warnings.warn("Some other warning")
+                    warn_other_module()
 
-        # includes a DeprecationWarning for suppress_warnings
-        assert_equal(len(sup.log), 3)
+            # includes a DeprecationWarning for suppress_warnings
+            assert_equal(len(sup.log), 3)
 
 
 def test_tempdir():


### PR DESCRIPTION
Backport of #31623.

I am not sure why, it it seems that maybe when used multiple times (and actually capturing?) `suppress_warnings` somehow disrupts the pytest "ignore" filter *only* on free-threaded builds.
(That part is maybe not so weird, since free-threaded builds do more things to make warning filters thread-safe I think.)

I would think it has something to do with messing with `__warning_registery__`, i.e. after the first captured warning we clear it or so and then the second one pytest is in a bad state.

(I feel it's a waste of time to truly understand, as this should be fine)

Either way, it seems just asserting the warning is enough to fix it. One of the tests didn't need it but I added it for symmetry. I omitted `TestWarns`, for some reason it seems unaffected (it only uses `assert_warns()` once per test with actual capture.

**Large diff, but just whitespace, because `pytest.warns` isn't a decorator.**

CC @charris and @ngoldbaum alternative to Chuck's PR that doesn't quite skip them fully but seems to work fine to hide these warnings on free-threaded.

(No AI)