### PR TITLE
BUG: fix suppress_warnings when context-aware warnings is on (#31628)

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2478,8 +2478,8 @@ class suppress_warnings:
             raise RuntimeError("cannot enter suppress_warnings twice.")
 
         self._orig_show = warnings.showwarning
-        self._filters = warnings.filters
-        warnings.filters = self._filters[:]
+        self._catch_warnings = warnings.catch_warnings()
+        self._catch_warnings.__enter__()
 
         self._entered = True
         self._tmp_suppressions = []
@@ -2507,11 +2507,11 @@ class suppress_warnings:
 
     def __exit__(self, *exc_info):
         warnings.showwarning = self._orig_show
-        warnings.filters = self._filters
+        self._catch_warnings.__exit__(*exc_info)
         self._clear_registries()
         self._entered = False
         del self._orig_show
-        del self._filters
+        del self._catch_warnings
 
     def _showwarning(self, message, category, filename, lineno,
                      *args, use_warnmsg=None, **kwargs):


### PR DESCRIPTION
Backport of #31628.

Followup for https://github.com/numpy/numpy/pull/31623, fixing the root cause for the spurious warnings.

Ping @nascheme who wrote the new [context-aware warning](https://docs.python.org/3/library/warnings.html#concurrent-safety-of-context-managers) implementation in CPython and may want to see a case where that breaks assumptions ecosystem code.

Note that this function is deprecated but IMO it's worth it to fix this anyway.