### PR TITLE
Fix typo in release notes: 'have have' → 'have'

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2050,7 +2050,7 @@ with the rest of the ArrayMethod API.
     The new descriptors MUST be viewable with the old ones, `NULL` must be
     supported (for output arguments) and should normally be forwarded.
 
-    The output of of this function will be used to construct
+    The output of this function will be used to construct
     views of the arguments as if they were the translated dtypes and
     does not use a cast. This means this mechanism is mostly useful for
     DTypes that "wrap" another DType implementation. For example, a unit

--- a/doc/source/release/1.22.0-notes.rst
+++ b/doc/source/release/1.22.0-notes.rst
@@ -394,7 +394,7 @@ protocol, *e.g.* ``pathlib.Path``.
 
 Add new methods for ``quantile`` and ``percentile``
 ---------------------------------------------------
-``quantile`` and ``percentile`` now have have a ``method=`` keyword argument
+``quantile`` and ``percentile`` now have a ``method=`` keyword argument
 supporting 13 different methods.  This replaces the ``interpolation=`` keyword
 argument.
 


### PR DESCRIPTION
Fixes a duplicate word typo in `doc/source/release/1.22.0-notes.rst`.