### PR TITLE
DOC: clarify ufunc.at behavior with tuple vs list indices

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5776,6 +5776,13 @@ add_newdoc('numpy._core', 'ufunc', ('at',
         Second operand for ufuncs requiring two operands. Operand must be
         broadcastable over first operand after indexing or slicing.
 
+    Notes
+    -----
+    The distinction between tuple and list indices follows the same
+    rules as standard NumPy array indexing: a tuple separates indices
+    by dimension (row, column), while a list or array provides multiple
+    indices along the first dimension. This is not specific to ``at``.
+
     Examples
     --------
     Set items 0 and 1 to their negative values:
@@ -5802,10 +5809,8 @@ add_newdoc('numpy._core', 'ufunc', ('at',
     >>> a
     array([2, 4, 3, 4])
 
-    Note that tuple indices and list or array indices behave differently
-    for multidimensional arrays. A tuple separates indices by dimension
-    (row, column). In contrast, a list or array provides multiple indices
-    along the first dimension:
+    Tuple indices select across dimensions, while list or array
+    indices select along the first dimension only:
 
     >>> a = np.zeros((3, 3))
     >>> np.add.at(a, ([0, 1, 2], [0, 1, 2]), 1)

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5802,6 +5802,25 @@ add_newdoc('numpy._core', 'ufunc', ('at',
     >>> a
     array([2, 4, 3, 4])
 
+    Note that tuple indices and list or array indices behave differently
+    for multidimensional arrays. A tuple separates indices by dimension
+    (row, column). In contrast, a list or array provides multiple indices
+    along the first dimension:
+
+    >>> a = np.zeros((3, 3))
+    >>> np.add.at(a, ([0, 1, 2], [0, 1, 2]), 1)
+    >>> a
+    array([[1., 0., 0.],
+           [0., 1., 0.],
+           [0., 0., 1.]])
+
+    >>> a = np.zeros((3, 3))
+    >>> np.add.at(a, [[0, 1, 2], [0, 1, 2]], 1)
+    >>> a
+    array([[2., 2., 2.],
+           [2., 2., 2.],
+           [2., 2., 2.]])
+
     """))
 
 add_newdoc('numpy._core', 'ufunc', ('resolve_dtypes',


### PR DESCRIPTION
### PR Summary
Adds an example to the `ufunc.at` documentation showing how
multidimensional indexing works differently.

When using `ufunc.at` on a 2D array, I noticed that passing indices
as a tuple treats them as (row, column) pairs, but passing the same
indices as a list treats them as indices along the first dimension.
The results look very different, and no warning is thrown.

I found this confusing because the difference is not mentioned anywhere
in the docs. This PR adds an example showing both behaviors clearly.

Closes gh-31579

### First-time Contributor
Hi! I am second-year Data Science student and this is my first 
contribution to NumPy.

### AI Disclosure
I used Claude (Anthropic) to help me understand the issue and plan 
my approach. The docstring example, verification, and PR description 
were written by me. I ran and verified all examples locally against 
NumPy main.