### PR TITLE
DOC: fix return dtypes in percentile/quantile docstrings

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4147,10 +4147,9 @@ def percentile(a,
         is a scalar. If multiple percentiles are given, first axis of
         the result corresponds to the percentiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
-        contains integers or floats smaller than ``float64``, the output
-        data-type is ``float64``. Otherwise, the output data-type is the
-        same as that of the input. If `out` is specified, that array is
-        returned instead.
+        contains integers, the output data-type is ``float64``.
+        Otherwise, the output data-type is the same as that of the
+        input. If `out` is specified, that array is returned instead.
 
     See Also
     --------
@@ -4350,10 +4349,9 @@ def quantile(a,
         is a scalar. If multiple probability levels are given, first axis
         of the result corresponds to the quantiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
-        contains integers or floats smaller than ``float64``, the output
-        data-type is ``float64``. Otherwise, the output data-type is the
-        same as that of the input. If `out` is specified, that array is
-        returned instead.
+        contains integers, the output data-type is ``float64``.
+        Otherwise, the output data-type is the same as that of the
+        input. If `out` is specified, that array is returned instead.
 
     See Also
     --------

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1319,10 +1319,9 @@ def nanpercentile(
         is a scalar. If multiple percentiles are given, first axis of
         the result corresponds to the percentiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
-        contains integers or floats smaller than ``float64``, the output
-        data-type is ``float64``. Otherwise, the output data-type is the
-        same as that of the input. If `out` is specified, that array is
-        returned instead.
+        contains integers, the output data-type is ``float64``.
+        Otherwise, the output data-type is the same as that of the
+        input. If `out` is specified, that array is returned instead.
 
     See Also
     --------
@@ -1493,13 +1492,12 @@ def nanquantile(
     -------
     quantile : scalar or ndarray
         If `q` is a single probability and `axis=None`, then the result
-        is a scalar. If multiple probability levels are given, first axis of
-        the result corresponds to the quantiles. The other axes are
+        is a scalar. If multiple probability levels are given, first axis
+        of the result corresponds to the quantiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
-        contains integers or floats smaller than ``float64``, the output
-        data-type is ``float64``. Otherwise, the output data-type is the
-        same as that of the input. If `out` is specified, that array is
-        returned instead.
+        contains integers, the output data-type is ``float64``.
+        Otherwise, the output data-type is the same as that of the
+        input. If `out` is specified, that array is returned instead.
 
     See Also
     --------

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -1492,8 +1492,8 @@ def nanquantile(
     -------
     quantile : scalar or ndarray
         If `q` is a single probability and `axis=None`, then the result
-        is a scalar. If multiple probability levels are given, first axis
-        of the result corresponds to the quantiles. The other axes are
+        is a scalar. If multiple probability levels are given, first axis of
+        the result corresponds to the quantiles. The other axes are
         the axes that remain after the reduction of `a`. If the input
         contains integers, the output data-type is ``float64``.
         Otherwise, the output data-type is the same as that of the


### PR DESCRIPTION
Updated docs to reflect that small floats (like float16) preserve their dtype instead of upcasting to float64. Relates to #31486.

### PR summary
The previous docstrings for `percentile`, `quantile`, `nanpercentile`, and `nanquantile` incorrectly claimed that floating-point inputs smaller than `float64` (such as `float16` and `float32`) are promoted to `float64` in the output. 

Runtime verification confirms that NumPy actually preserves the exact dtype for these floating-point inputs; only integers are upcast. This PR updates the `Returns` block across these four functions to accurately reflect this true runtime behavior while maintaining the original sentence structure.

* Relates to issue #31486 (which highlighted this stale claim for `ma.median`).

**Quick Reproducer:**
```python
>>> import numpy as np
>>> arr = np.array([1.0, 2.0, 3.0], dtype=np.float16)

# OLD DOC CLAIM: The output data-type is `float64`
# ACTUAL RUNTIME BEHAVIOR:
>>> np.percentile(arr, 50).dtype
dtype('float16')
```

### First time committer introduction
Hi everyone! I am an engineering undergrad based in Pune, currently diving deep into machine learning, statistics, and data structures. I use NumPy constantly for my coursework and personal data projects. I was reading through the discussion on #31486, ran some local runtime tests to verify the other functions mentioned there, and wanted to help clean up the rest of this stale documentation family for my first contribution! 

#### AI Disclosure
*I used an AI assistant to locate the stale phrasing across the codebase, but I manually wrote the runtime verifications and formatted the text to comply with NumPy's guidelines.*