### PR TITLE
MAINT, TST: Pin unpinned pytest usage

### DIFF
--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -114,9 +114,10 @@ jobs:
           git config --global --add safe.directory /numpy &&
           # No need to build ninja from source, the host ninja is used for the build
           grep -v ninja /numpy/requirements/build_requirements.txt > /tmp/build_requirements.txt &&
+          grep -v ninja /numpy/requirements/test_requirements.txt > /tmp/test_requirements.txt &&
           uv venv --python 3.12 .venv &&
           source .venv/bin/activate &&
-          uv pip install -r /tmp/build_requirements.txt pytest pytest-xdist hypothesis pytest-timeout
+          uv pip install -r /tmp/build_requirements.txt -r /tmp/test_requirements.txt
           rm -f /usr/local/bin/ninja && mkdir -p /usr/local/bin && ln -s /host/usr/bin/ninja /usr/local/bin/ninja
         "
         docker commit the_container the_container
@@ -220,11 +221,12 @@ jobs:
           git config --global --add safe.directory /numpy &&
           # No need to build ninja from source, the host ninja is used for the build
           grep -v ninja /numpy/requirements/build_requirements.txt > /tmp/build_requirements.txt &&
+          grep -v ninja /numpy/requirements/test_requirements.txt > /tmp/test_requirements.txt &&
           python -m pip install --break-system-packages uv --extra-index-url https://mirrors.loong64.com/pypi/simple &&
           export PATH="/root/.local/bin:$PATH" &&
           uv venv --python 3.12 .venv &&
           source .venv/bin/activate &&
-          uv pip install -r /tmp/build_requirements.txt pytest pytest-xdist hypothesis &&
+          uv pip install -r /tmp/build_requirements.txt -r /tmp/test_requirements.txt &&
           rm -f /usr/local/bin/ninja && mkdir -p /usr/local/bin && ln -s /host/usr/bin/ninja /usr/local/bin/ninja
         "
         docker commit the_container the_container


### PR DESCRIPTION
The recent release of pytest 9.1.0 broke tests where it was not pinned. This uses the requirements files in those tests so that next time there is a problem it won't be a surprise. 

No AI was used.