### PR TITLE
DOC: Fix a few duplicate word types

### DIFF
--- a/doc/neps/nep-0054-simd-cpp-highway.rst
+++ b/doc/neps/nep-0054-simd-cpp-highway.rst
@@ -227,7 +227,7 @@ Our experience of the past four years says that bugs with "invalid instruction"
 type crashes are invariably due to issues with feature detection - most often
 because users are running under emulation, and sometimes because there are
 actual issues with our CPU feature detection code. There is little evidence
-we're aware of of the linker pulling in a function which is compiled multiple
+we're aware of the linker pulling in a function which is compiled multiple
 times for different architectures and picking the one with unsupported
 instructions. To ensure to avoid the issue, it's advisable to keep numerical
 kernels inside the source code and refrain from defining non-inlined functions

--- a/doc/source/release/1.8.1-notes.rst
+++ b/doc/source/release/1.8.1-notes.rst
@@ -54,7 +54,7 @@ Issues fixed
 * gh-4354: byte_bounds fails with datetime dtypes
 * gh-4486: segfault/error converting from/to high-precision datetime64 objects
 * gh-4428: einsum(None, None, None, None) causes segfault
-* gh-4134: uninitialized use for for size 1 object reductions
+* gh-4134: uninitialized use for size 1 object reductions
 
 Changes
 =======

--- a/doc/source/release/1.8.2-notes.rst
+++ b/doc/source/release/1.8.2-notes.rst
@@ -9,7 +9,7 @@ Issues fixed
 
 * gh-4836: partition produces wrong results for multiple selections in equal ranges
 * gh-4656: Make fftpack._raw_fft threadsafe
-* gh-4628: incorrect argument order to _copyto in in np.nanmax, np.nanmin
+* gh-4628: incorrect argument order to _copyto in np.nanmax, np.nanmin
 * gh-4642: Hold GIL for converting dtypes types with fields
 * gh-4733: fix np.linalg.svd(b, compute_uv=False)
 * gh-4853: avoid unaligned simd load on reductions on i386


### PR DESCRIPTION
Fixes a duplicate word typo in `doc/source/release/1.8.1-notes.rst`.