### PR TITLE
BUG: linspace raises ValueError for non-finite values with integer dtype

### DIFF
--- a/numpy/_core/function_base.py
+++ b/numpy/_core/function_base.py
@@ -179,6 +179,12 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         y = _nx.moveaxis(y, 0, axis)
 
     if integer_dtype:
+        if not _nx.isfinite(y).all():
+            raise ValueError(
+                "Cannot convert non-finite values (inf, -inf, or NaN) to "
+                "integer dtype. Use a floating-point dtype or ensure that "
+                "start and stop are finite."
+            )
         _nx.floor(y, out=y)
 
     y = conv.wrap(y.astype(dtype, copy=False))

--- a/numpy/_core/tests/test_function_base.py
+++ b/numpy/_core/tests/test_function_base.py
@@ -482,6 +482,22 @@ class TestLinspace:
         y = linspace(start, stop, 3)
         assert_array_equal(y, array([[0.0, 1.0], [1.0, 1.0], [2.0, 1.0]]))
 
+    def test_integer_dtype_non_finite_raises(self):
+        # gh-31651: non-finite start/stop with integer dtype must raise
+        # ValueError instead of silently returning INT_MIN.
+        with pytest.raises(ValueError, match="non-finite"):
+            linspace(np.inf, np.inf, 5, dtype=int)
+        with pytest.raises(ValueError, match="non-finite"):
+            linspace(np.inf, -np.inf, 5, dtype=int)
+        with pytest.raises(ValueError, match="non-finite"):
+            linspace(-np.inf, 0, 3, dtype=int)
+        with pytest.raises(ValueError, match="non-finite"):
+            linspace(float('nan'), 5, 3, dtype=np.int32)
+        # finite values with integer dtype must still work
+        y = linspace(0, 10, 5, dtype=int)
+        assert_equal(y.dtype, dtype('int64'))
+        assert_array_equal(y, [0, 2, 5, 7, 10])
+
 
 class TestAdd_newdoc:
 


### PR DESCRIPTION
## Summary

Closes #31651.

`np.linspace` with infinite (or NaN) endpoints and an integer `dtype` silently returns `INT_MIN` for every element instead of raising an error:

```python
np.linspace(np.inf, np.inf, 5, dtype=int)
# array([-9223372036854775808, ...])  ← silent data corruption
```

## Root cause

After the float64 intermediate array is built, `floor()` is called and then `astype(dtype)` converts to the requested integer type. Casting a non-finite float to integer is undefined behaviour in C; on x86-64 it consistently yields `INT_MIN`. NumPy emits a `RuntimeWarning` but does not raise, so callers using `np.errstate(invalid='ignore')` or suppressed warnings receive corrupt data silently.

## Fix

Add a finiteness check immediately after `floor()` (inside the `if integer_dtype:` branch) that raises `ValueError` with a descriptive message before the `astype()` call. Float-dtype paths are completely unaffected.

```python
if integer_dtype:
    if not _nx.isfinite(y).all():
        raise ValueError(
            "Cannot convert non-finite values (inf, -inf, or NaN) to "
            "integer dtype. Use a floating-point dtype or ensure that "
            "start and stop are finite."
        )
    _nx.floor(y, out=y)
```

## Tests

Added `TestLinspace.test_integer_dtype_non_finite_raises` covering:
- `+inf` to `+inf`
- `+inf` to `-inf`
- `-inf` to finite
- `NaN` start
- Regression: normal integer-dtype `linspace(0, 10, 5, dtype=int)` still works