### PR TITLE
TST: print more descriptive message when warning tests see unexpected warnings

### DIFF
--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2070,7 +2070,7 @@ def _assert_no_warnings_context(name=None):
         yield
         if len(l) > 0:
             name_str = f' when calling {name}' if name is not None else ''
-            raise AssertionError(f'Got warnings{name_str}: {l}')
+            raise AssertionError(f'Got warnings{name_str}: {[e.message for e in l]}')
 
 
 def assert_no_warnings(*args, **kwargs):

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -2010,6 +2010,21 @@ def test_suppress_warnings_forwarding():
         assert_equal(len(sup.log), 3)
 
 
+@pytest.mark.thread_unsafe(
+    reason="uses deprecated thread-unsafe warnings control utilities"
+)
+def test_no_warnings_message_reports_warning(self):
+    def f():
+        warnings.warn("a very specific warning text", UserWarning)
+
+    with pytest.raises(AssertionError) as exc_info:
+        assert_no_warnings(f)
+
+    msg = str(exc_info.value)
+    assert "a very specific warning text" in msg
+    assert "WarningMessage" not in msg
+
+
 def test_tempdir():
     with tempdir() as tdir:
         fpath = os.path.join(tdir, 'tmp')

--- a/numpy/testing/tests/test_utils.py
+++ b/numpy/testing/tests/test_utils.py
@@ -2010,10 +2010,7 @@ def test_suppress_warnings_forwarding():
         assert_equal(len(sup.log), 3)
 
 
-@pytest.mark.thread_unsafe(
-    reason="uses deprecated thread-unsafe warnings control utilities"
-)
-def test_no_warnings_message_reports_warning(self):
+def test_no_warnings_message_reports_warning():
     def f():
         warnings.warn("a very specific warning text", UserWarning)
 


### PR DESCRIPTION
The previous version of this code just prints 'class <warning.WarningMessage>'