### PR TITLE
BUG: fix casts from StringDType to complex float

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -1323,7 +1323,7 @@ string_to_complex_float(
         }
 
         npy_csetrealfunc(out, (NpyFloatType) complex_value.real);
-        npy_csetimagfunc(out, (NpyFloatType) complex_value.real);
+        npy_csetimagfunc(out, (NpyFloatType) complex_value.imag);
         in += in_stride;
         out += out_stride;
     }

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -827,15 +827,15 @@ def test_float_nan_cast_na_object():
     ],
 )
 def test_cfloat_casts(typename):
-    inp = [1.1 + 1.1j, 2.8 + 2.8j, -3.2 - 3.2j, 2.7e4 + 2.7e4j]
+    inp = [1.25 + 0.5j, 2.75 - 3.5j, -3.125 + 4.25j, 2.7e4 - 8j]
     ainp = np.array(inp, dtype=typename)
     assert_array_equal(ainp, ainp.astype("T").astype(typename))
 
-    inp = [0.1 + 0.1j]
+    inp = [0.125 - 0.5j]
     sres = np.array(inp, dtype=typename).astype("T")
     res = sres.astype(typename)
     assert_array_equal(np.array(inp, dtype=typename), res)
-    assert sres[0] == "(0.1+0.1j)"
+    assert sres[0] == "(0.125-0.5j)"
 
 
 def test_take(string_list):

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -827,15 +827,28 @@ def test_float_nan_cast_na_object():
     ],
 )
 def test_cfloat_casts(typename):
-    inp = [1.25 + 0.5j, 2.75 - 3.5j, -3.125 + 4.25j, 2.7e4 - 8j]
+    inp = [1.1 + 1.1j, 2.8 + 2.8j, -3.2 - 3.2j, 2.7e4 + 2.7e4j]
     ainp = np.array(inp, dtype=typename)
     assert_array_equal(ainp, ainp.astype("T").astype(typename))
 
-    inp = [0.125 - 0.5j]
+    inp = [0.1 + 0.1j]
     sres = np.array(inp, dtype=typename).astype("T")
     res = sres.astype(typename)
     assert_array_equal(np.array(inp, dtype=typename), res)
-    assert sres[0] == "(0.125-0.5j)"
+    assert sres[0] == "(0.1+0.1j)"
+
+
+@pytest.mark.parametrize("typename", ["csingle", "cdouble", "clongdouble"])
+def test_string_to_cfloat_cast_distinct_components(typename):
+    inp = np.array(
+        ["1.25+0.5j", "2.75-3.5j", "-3.125+4.25j", "27000-8j"],
+        dtype="T",
+    )
+    expected = np.array(
+        [1.25 + 0.5j, 2.75 - 3.5j, -3.125 + 4.25j, 2.7e4 - 8j],
+        dtype=typename,
+    )
+    assert_array_equal(inp.astype(typename), expected)
 
 
 def test_take(string_list):


### PR DESCRIPTION
This was clearly a copy/paste bug and the tests were written in such a way that they didn't notice the bug.

This was spotted using an AI model.