### PR TITLE
MAINT: Update pytest pins to 9.1.0

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -40,4 +40,3 @@ jobs:
         env:
           CIBW_PLATFORM: pyodide
           CIBW_BUILD: cp312-*
-

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -40,3 +40,4 @@ jobs:
         env:
           CIBW_PLATFORM: pyodide
           CIBW_BUILD: cp312-*
+

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -383,6 +383,7 @@ class TestIntent:
 class TestSharedMemory:
 
     @pytest.fixture(autouse=True, scope="class", params=_type_names)
+    @classmethod
     def setup_type(self, request):
         request.cls.type = Type(request.param)
         request.cls.array = lambda self, dims, intent, obj: Array(

--- a/numpy/f2py/tests/test_array_from_pyobj.py
+++ b/numpy/f2py/tests/test_array_from_pyobj.py
@@ -384,9 +384,9 @@ class TestSharedMemory:
 
     @pytest.fixture(autouse=True, scope="class", params=_type_names)
     @classmethod
-    def setup_type(self, request):
+    def setup_type(cls, request):
         request.cls.type = Type(request.param)
-        request.cls.array = lambda self, dims, intent, obj: Array(
+        request.cls.array = lambda cls, dims, intent, obj: Array(
             Type(request.param), dims, intent, obj)
 
     @property

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2640,13 +2640,6 @@ class TestUfuncs:
         return (array([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
                   array([1.0, 0, -1, pi / 2] * 2, mask=[1, 0] + [0] * 6),)
 
-    @pytest.fixture(autouse=True, scope="class")
-    def err_status(self):
-        err = np.geterr()
-        np.seterr(divide='ignore', invalid='ignore')
-        yield err
-        np.seterr(**err)
-
     def test_testUfuncRegression(self):
         # Tests new ufuncs on MaskedArrays.
         for f in ['sqrt', 'log', 'log10', 'exp', 'conjugate',

--- a/numpy/polynomial/tests/test_printing.py
+++ b/numpy/polynomial/tests/test_printing.py
@@ -14,6 +14,7 @@ from numpy.testing import assert_, assert_equal
 class TestStrUnicodeSuperSubscripts:
 
     @pytest.fixture(scope='class', autouse=True)
+    @classmethod
     def use_unicode(self):
         poly.set_default_printstyle('unicode')
 
@@ -97,6 +98,7 @@ class TestStrUnicodeSuperSubscripts:
 class TestStrAscii:
 
     @pytest.fixture(scope='class', autouse=True)
+    @classmethod
     def use_ascii(self):
         poly.set_default_printstyle('ascii')
 
@@ -183,6 +185,7 @@ class TestStrAscii:
 class TestLinebreaking:
 
     @pytest.fixture(scope='class', autouse=True)
+    @classmethod
     def use_ascii(self):
         poly.set_default_printstyle('ascii')
 
@@ -507,6 +510,7 @@ class TestPrintOptions:
     """
 
     @pytest.fixture(scope='class', autouse=True)
+    @classmethod
     def use_ascii(self):
         poly.set_default_printstyle('ascii')
 

--- a/numpy/polynomial/tests/test_printing.py
+++ b/numpy/polynomial/tests/test_printing.py
@@ -15,7 +15,7 @@ class TestStrUnicodeSuperSubscripts:
 
     @pytest.fixture(scope='class', autouse=True)
     @classmethod
-    def use_unicode(self):
+    def use_unicode(cls):
         poly.set_default_printstyle('unicode')
 
     @pytest.mark.parametrize(('inp', 'tgt'), (
@@ -99,7 +99,7 @@ class TestStrAscii:
 
     @pytest.fixture(scope='class', autouse=True)
     @classmethod
-    def use_ascii(self):
+    def use_ascii(cls):
         poly.set_default_printstyle('ascii')
 
     @pytest.mark.parametrize(('inp', 'tgt'), (
@@ -186,7 +186,7 @@ class TestLinebreaking:
 
     @pytest.fixture(scope='class', autouse=True)
     @classmethod
-    def use_ascii(self):
+    def use_ascii(cls):
         poly.set_default_printstyle('ascii')
 
     def test_single_line_one_less(self):
@@ -511,7 +511,7 @@ class TestPrintOptions:
 
     @pytest.fixture(scope='class', autouse=True)
     @classmethod
-    def use_ascii(self):
+    def use_ascii(cls):
         poly.set_default_printstyle('ascii')
 
     def test_str(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,7 +226,12 @@ repair-wheel-command = ""
 before-test = "pip install -r {project}/requirements/emscripten_test_requirements.txt"
 # Pyodide ensures that the wheels are already repaired by auditwheel-emscripten
 repair-wheel-command = ""
-test-command = "python -m pytest --pyargs numpy -m 'not slow'"
+test-command = """
+    python -m pytest --pyargs numpy \
+        -m 'not slow' \
+        -W ignore::PendingDeprecationWarning \
+        -p no:cacheprovider
+"""
 
 [tool.cibuildwheel.pyodide.config-settings]
 build-dir = "build"

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,8 +14,8 @@ filterwarnings =
     ignore: divide by zero encountered in log
     ignore: invalid value encountered in log
 # Matrix PendingDeprecationWarning.
-    ignore:the matrix subclass is not
-    ignore:Importing from numpy.matlib is
+    ignore:the matrix subclass is not:PendingDeprecationWarning
+    ignore:Importing from numpy.matlib is:PendingDeprecationWarning
 # pytest warning when using PYTHONOPTIMIZE
     ignore:assertions not in test modules or plugins:pytest.PytestConfigWarning
 # ignore matplotlib headless warning for pyplot

--- a/requirements/emscripten_test_requirements.txt
+++ b/requirements/emscripten_test_requirements.txt
@@ -1,4 +1,4 @@
 hypothesis==6.152.1
-pytest==9.0.3
+pytest==9.1.0
 tzdata
 pytest-xdist

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,6 +1,6 @@
 Cython
 hypothesis==6.152.1
-pytest==9.0.3
+pytest==9.1.0
 pytest-cov==7.1.0
 meson
 ninja; sys_platform != "emscripten"


### PR DESCRIPTION
This exposes 9.1.0 problems that were not yet fixed. Then we fix them.

Grok suggested the emscripten fix, but frankly, Grok wasn't all the helpful.