### PR TITLE
BUG: fix StringDType embedded and trailing NULL handling in several operations

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
+++ b/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
@@ -251,7 +251,9 @@ utf8_buffer_size(const uint8_t *s, size_t max_bytes)
 
 
 // calculate the number of UTF-32 code points in the UTF-8 encoded string
-// stored in **s**, which is **max_bytes** long.
+// stored in **s**, which is **max_bytes** long. Unlike the fixed-width
+// conversion helpers above, this is length-explicit and does not trim trailing
+// null bytes.
 NPY_NO_EXPORT int
 num_codepoints_for_utf8_bytes(const unsigned char *s, size_t *num_codepoints, size_t max_bytes)
 {
@@ -259,11 +261,6 @@ num_codepoints_for_utf8_bytes(const unsigned char *s, size_t *num_codepoints, si
     uint32_t state = 0;
     size_t num_bytes = 0;
     *num_codepoints = 0;
-
-    // ignore trailing nulls
-    while (max_bytes > 0 && s[max_bytes - 1] == 0) {
-        max_bytes--;
-    }
 
     if (max_bytes == 0) {
         return UTF8_ACCEPT;

--- a/numpy/_core/src/umath/string_buffer.h
+++ b/numpy/_core/src/umath/string_buffer.h
@@ -642,7 +642,9 @@ struct Buffer {
     {
         Buffer<enc> tmp(after, 0);
         tmp--;
-        while (tmp >= *this && (*tmp == '\0' || NumPyOS_ascii_isspace(*tmp))) {
+        while (tmp >= *this && (
+                NumPyOS_ascii_isspace(*tmp) ||
+                (enc != ENCODING::UTF8 && *tmp == '\0'))) {
             tmp--;
         }
         tmp++;
@@ -1194,7 +1196,8 @@ string_lrstrip_whitespace(Buffer<enc> buf, Buffer<enc> out, STRIPTYPE strip_type
 
     if (strip_type != STRIPTYPE::LEFTSTRIP) {
         while (new_stop > new_start) {
-            if (*traverse_buf != 0 && !traverse_buf.first_character_isspace()) {
+            if (!traverse_buf.first_character_isspace() &&
+                    (enc == ENCODING::UTF8 || *traverse_buf != 0)) {
                 break;
             }
 

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2273,11 +2273,6 @@ slice_strided_loop(PyArrayMethod_Context *context, char *const data[],
             const char *inbuf_ptr = is.buf;
             const char *inbuf_ptr_end = is.buf + is.size;
 
-            // ignore trailing nulls
-            while (inbuf_ptr < inbuf_ptr_end && *(inbuf_ptr_end - 1) == 0) {
-                inbuf_ptr_end--;
-            }
-
             while (inbuf_ptr < inbuf_ptr_end) {
                 num_codepoints++;
                 int num_bytes = num_bytes_for_utf8_character(

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1577,6 +1577,33 @@ def test_replace_non_default_repeat(count):
     assert_array_equal(result, np.array(["🐍--", "🦜†🦜†"], "T"))
 
 
+def test_trailing_null_is_not_padding():
+    arr = np.array(["x\0", "\0", "x\0y\0", "abc"], dtype=StringDType())
+    nul = np.array("\0", dtype=StringDType())
+
+    assert_array_equal(np.strings.str_len(arr), [2, 1, 4, 3])
+    assert_array_equal(np.strings.find(arr, nul), [1, 0, 1, -1])
+    assert_array_equal(np.strings.rfind(arr, nul), [1, 0, 3, -1])
+    assert_array_equal(np.strings.count(arr, nul), [1, 1, 2, 0])
+    assert_array_equal(np.strings.endswith(arr, nul),
+                       [True, True, True, False])
+    assert_array_equal(np.strings.slice(arr, -1, None),
+                       np.array(["\0", "\0", "\0", "c"],
+                                dtype=StringDType()))
+
+
+def test_trailing_null_is_not_stripped_as_whitespace():
+    arr = np.array(["x\0", "\0 ", " \0", "x\0 \t"],
+                   dtype=StringDType())
+
+    assert_array_equal(
+            np.strings.rstrip(arr),
+            np.array(["x\0", "\0", " \0", "x\0"], dtype=StringDType()))
+    assert_array_equal(
+            np.strings.strip(arr),
+            np.array(["x\0", "\0", "\0", "x\0"], dtype=StringDType()))
+
+
 def test_strip_ljust_rjust_consistency(string_array, unicode_array):
     rjs = np.char.rjust(string_array, 1000)
     rju = np.char.rjust(unicode_array, 1000)


### PR DESCRIPTION
Several StringDType ufunc operations (`str_len`, `find`, `count`, `rstrip`, `endswith`, `slice`) didn't handle trailing and/or embedded nulls correctly, see new tests for specific examples.