### PR TITLE
Backport 31644

### DIFF
--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -16,16 +16,15 @@ from numpy.testing import IS_64BIT, assert_array_equal
 
 
 def arraylikes():
-    """
-    Generator for functions converting an array into various array-likes.
-    If full is True (default) it includes array-likes not capable of handling
-    all dtypes.
-    """
+    """Test parameters for functions converting an array into various array-likes."""
+
+    params = []
+
     # base array:
     def ndarray(a):
         return a
 
-    yield param(ndarray, id="ndarray")
+    params.append(param(ndarray, id="ndarray"))
 
     # subclass:
     class MyArr(np.ndarray):
@@ -34,7 +33,7 @@ def arraylikes():
     def subclass(a):
         return a.view(MyArr)
 
-    yield subclass
+    params.append(subclass)
 
     class _SequenceLike:
         # Older NumPy versions, sometimes cared whether a protocol array was
@@ -56,10 +55,10 @@ def arraylikes():
                 return self.a
             return self.a.astype(dtype)
 
-    yield param(ArrayDunder, id="__array__")
+    params.append(param(ArrayDunder, id="__array__"))
 
     # memory-view
-    yield param(memoryview, id="memoryview")
+    params.append(param(memoryview, id="memoryview"))
 
     # Array-interface
     class ArrayInterface:
@@ -67,7 +66,7 @@ def arraylikes():
             self.a = a  # need to hold on to keep interface valid
             self.__array_interface__ = a.__array_interface__
 
-    yield param(ArrayInterface, id="__array_interface__")
+    params.append(param(ArrayInterface, id="__array_interface__"))
 
     # Array-Struct
     class ArrayStruct:
@@ -75,7 +74,9 @@ def arraylikes():
             self.a = a  # need to hold on to keep struct valid
             self.__array_struct__ = a.__array_struct__
 
-    yield param(ArrayStruct, id="__array_struct__")
+    params.append(param(ArrayStruct, id="__array_struct__"))
+
+    return params
 
 
 def scalar_instances(times=True, extended_precision=True, user_dtype=True):
@@ -227,7 +228,7 @@ class TestScalarDiscovery:
         assert arr.shape == ()
         assert arr.dtype == np.dtype("O")
 
-    @pytest.mark.parametrize("scalar", scalar_instances())
+    @pytest.mark.parametrize("scalar", list(scalar_instances()))
     def test_scalar(self, scalar):
         arr = np.array(scalar)
         assert arr.shape == ()
@@ -259,7 +260,7 @@ class TestScalarDiscovery:
                 # Will currently always go to object dtype
                 assert arr.dtype == np.dtype("O")
 
-    @pytest.mark.parametrize("scalar", scalar_instances())
+    @pytest.mark.parametrize("scalar", list(scalar_instances()))
     def test_scalar_coercion(self, scalar):
         # This tests various scalar coercion paths, mainly for the numerical
         # types. It includes some paths not directly related to `np.array`.
@@ -284,7 +285,7 @@ class TestScalarDiscovery:
         assert_array_equal(arr, arr4)
 
     @pytest.mark.filterwarnings("ignore::numpy.exceptions.ComplexWarning")
-    @pytest.mark.parametrize("cast_to", scalar_instances())
+    @pytest.mark.parametrize("cast_to", list(scalar_instances()))
     def test_scalar_coercion_same_as_cast_and_assignment(self, cast_to):
         """
         Test that in most cases:

--- a/numpy/_core/tests/test_casting_floatingpoint_errors.py
+++ b/numpy/_core/tests/test_casting_floatingpoint_errors.py
@@ -138,7 +138,7 @@ def check_operations(dtype, value):
     yield flat_assignment
 
 @pytest.mark.skipif(IS_WASM, reason="no wasm fp exception support")
-@pytest.mark.parametrize(["value", "dtype"], values_and_dtypes())
+@pytest.mark.parametrize(["value", "dtype"], list(values_and_dtypes()))
 @pytest.mark.filterwarnings("ignore::numpy.exceptions.ComplexWarning")
 def test_floatingpoint_errors_casting(dtype, value):
     dtype = np.dtype(dtype)

--- a/numpy/_core/tests/test_casting_unittests.py
+++ b/numpy/_core/tests/test_casting_unittests.py
@@ -28,12 +28,14 @@ simple_dtypes = [type(np.dtype(c)) for c in simple_dtypes]
 
 
 def simple_dtype_instances():
+    params = []
     for dtype_class in simple_dtypes:
         dt = dtype_class()
-        yield pytest.param(dt, id=str(dt))
+        params.append(pytest.param(dt, id=str(dt)))
         if dt.byteorder != "|":
             dt = dt.newbyteorder()
-            yield pytest.param(dt, id=str(dt))
+            params.append(pytest.param(dt, id=str(dt)))
+    return params
 
 
 def get_expected_stringlength(dtype):

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -7,14 +7,13 @@ from numpy.testing import assert_array_equal
 
 
 def new_and_old_dlpack():
-    yield np.arange(5)
 
     class OldDLPack(np.ndarray):
         # Support only the "old" version
         def __dlpack__(self, stream=None):
             return super().__dlpack__(stream=None)
 
-    yield np.arange(5).view(OldDLPack)
+    return [np.arange(5), np.arange(5).view(OldDLPack)]
 
 
 class TestDLPack:

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1911,7 +1911,7 @@ class TestFromCTypes:
         self.check(ctypes.c_uint8.__ctype_be__, np.dtype('u1'))
 
     all_types = set(np.typecodes['All'])
-    all_pairs = permutations(all_types, 2)
+    all_pairs = list(permutations(all_types, 2))
 
     @pytest.mark.parametrize("pair", all_pairs)
     def test_pairs(self, pair):

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -5263,9 +5263,11 @@ class TestArgmaxArgminCommon:
              (3, 4, 1, 2), (4, 1, 2, 3),
              (64,), (128,), (256,)]
 
-    @pytest.mark.parametrize("size, axis", itertools.chain(*[[(size, axis)
-        for axis in list(range(-len(size), len(size))) + [None]]
-        for size in sizes]))
+    @pytest.mark.parametrize("size, axis", [
+        (size, axis)
+        for size in sizes
+        for axis in [*range(-len(size), len(size)), None]
+    ])
     @pytest.mark.parametrize('method', [np.argmax, np.argmin])
     def test_np_argmin_argmax_keepdims(self, size, axis, method):
 

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1327,12 +1327,14 @@ class TestTypes:
 
     @pytest.mark.slow
     @pytest.mark.filterwarnings('ignore:Promotion of numbers:FutureWarning')
-    @pytest.mark.parametrize(["dtype1", "dtype2"],
-            itertools.product(
-                list(np.typecodes["All"]) +
-                ["i,i", "S3", "S100", "U3", "U100",
-                 rational, rational2],
-                repeat=2))
+    @pytest.mark.parametrize(
+        "dtype1",
+        [*np.typecodes["All"], "i,i", "S3", "S100", "U3", "U100", rational, rational2],
+    )
+    @pytest.mark.parametrize(
+        "dtype2",
+        [*np.typecodes["All"], "i,i", "S3", "S100", "U3", "U100", rational, rational2],
+    )
     def test_promote_types_metadata(self, dtype1, dtype2):
         """Metadata handling in promotion does not appear formalized
         right now in NumPy. This test should thus be considered to
@@ -2218,7 +2220,7 @@ def _test_array_equal_parametrizations():
 
 class TestArrayComparisons:
     @pytest.mark.parametrize(
-        "bx,by,equal_nan,expected", _test_array_equal_parametrizations()
+        "bx,by,equal_nan,expected", list(_test_array_equal_parametrizations())
     )
     def test_array_equal_equal_nan(self, bx, by, equal_nan, expected):
         """

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -1791,7 +1791,7 @@ class TestUfunc:
         a = a[1:, 1:, 1:]
         yield a
 
-    @pytest.mark.parametrize("arrs", identityless_reduce_arrs())
+    @pytest.mark.parametrize("arrs", list(identityless_reduce_arrs()))
     @pytest.mark.parametrize("pos", [(1, 0, 0), (0, 1, 0), (0, 0, 1)])
     def test_identityless_reduction(self, arrs, pos):
         # np.minimum.reduce is an identityless reduction

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -479,31 +479,30 @@ class TestDivision:
         assert_equal(x % 100, [5, 10, 90, 0, 95, 90, 10, 0, 80])
 
     @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
-    @pytest.mark.parametrize("dtype,ex_val", itertools.product(
-        sctypes['int'] + sctypes['uint'], (
-            (
-                # dividend
-                "np.array(range(fo.max-lsize, fo.max)).astype(dtype),"
-                # divisors
-                "np.arange(lsize).astype(dtype),"
-                # scalar divisors
-                "range(15)"
-            ),
-            (
-                # dividend
-                "np.arange(fo.min, fo.min+lsize).astype(dtype),"
-                # divisors
-                "np.arange(lsize//-2, lsize//2).astype(dtype),"
-                # scalar divisors
-                "range(fo.min, fo.min + 15)"
-            ), (
-                # dividend
-                "np.array(range(fo.max-lsize, fo.max)).astype(dtype),"
-                # divisors
-                "np.arange(lsize).astype(dtype),"
-                # scalar divisors
-                "[1,3,9,13,neg, fo.min+1, fo.min//2, fo.max//3, fo.max//4]"
-            )
+    @pytest.mark.parametrize("dtype", sctypes['int'] + sctypes['uint'])
+    @pytest.mark.parametrize("ex_val", (
+        (
+            # dividend
+            "np.array(range(fo.max-lsize, fo.max)).astype(dtype),"
+            # divisors
+            "np.arange(lsize).astype(dtype),"
+            # scalar divisors
+            "range(15)"
+        ),
+        (
+            # dividend
+            "np.arange(fo.min, fo.min+lsize).astype(dtype),"
+            # divisors
+            "np.arange(lsize//-2, lsize//2).astype(dtype),"
+            # scalar divisors
+            "range(fo.min, fo.min + 15)"
+        ), (
+            # dividend
+            "np.array(range(fo.max-lsize, fo.max)).astype(dtype),"
+            # divisors
+            "np.arange(lsize).astype(dtype),"
+            # scalar divisors
+            "[1,3,9,13,neg, fo.min+1, fo.min//2, fo.max//3, fo.max//4]"
         )
     ))
     def test_division_int_boundary(self, dtype, ex_val):
@@ -565,13 +564,12 @@ class TestDivision:
             np.array([], dtype=dtype) // 0
 
     @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
-    @pytest.mark.parametrize("dtype,ex_val", itertools.product(
-        sctypes['int'] + sctypes['uint'], (
-            "np.array([fo.max, 1, 2, 1, 1, 2, 3], dtype=dtype)",
-            "np.array([fo.min, 1, -2, 1, 1, 2, -3]).astype(dtype)",
-            "np.arange(fo.min, fo.min+(100*10), 10, dtype=dtype)",
-            "np.array(range(fo.max-(100*7), fo.max, 7)).astype(dtype)",
-        )
+    @pytest.mark.parametrize("dtype", sctypes['int'] + sctypes['uint'])
+    @pytest.mark.parametrize("ex_val", (
+        "np.array([fo.max, 1, 2, 1, 1, 2, 3], dtype=dtype)",
+        "np.array([fo.min, 1, -2, 1, 1, 2, -3]).astype(dtype)",
+        "np.arange(fo.min, fo.min+(100*10), 10, dtype=dtype)",
+        "np.array(range(fo.max-(100*7), fo.max, 7)).astype(dtype)",
     ))
     def test_division_int_reduce(self, dtype, ex_val):
         fo = np.iinfo(dtype)
@@ -2966,7 +2964,7 @@ class TestBitwiseUFuncs:
             assert_(type(f.reduce(btype)) is bool, msg)
 
     @pytest.mark.parametrize("input_dtype_obj, bitsize",
-            zip(bitwise_types, bitwise_bits))
+            list(zip(bitwise_types, bitwise_bits)))
     def test_bitwise_count(self, input_dtype_obj, bitsize):
         input_dtype = input_dtype_obj.type
 

--- a/numpy/lib/tests/test_packbits.py
+++ b/numpy/lib/tests/test_packbits.py
@@ -1,5 +1,3 @@
-from itertools import chain
-
 import pytest
 
 import numpy as np
@@ -300,7 +298,7 @@ class TestCount:
     padded2[:7, :7] = x
 
     @pytest.mark.parametrize('bitorder', ('little', 'big'))
-    @pytest.mark.parametrize('count', chain(range(58), range(-1, -57, -1)))
+    @pytest.mark.parametrize('count', [*range(58), *range(-1, -57, -1)])
     def test_roundtrip(self, bitorder, count):
         if count < 0:
             # one extra zero of padding
@@ -324,7 +322,7 @@ class TestCount:
 
     @pytest.mark.parametrize('bitorder', ('little', 'big'))
     # delta==-1 when count<0 because one extra zero of padding
-    @pytest.mark.parametrize('count', chain(range(8), range(-1, -9, -1)))
+    @pytest.mark.parametrize('count', [*range(8), *range(-1, -9, -1)])
     def test_roundtrip_axis(self, bitorder, count):
         if count < 0:
             # one extra zero of padding

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1128,7 +1128,16 @@ class TestMaskedArray:
         # It is not implemented at this point of time. We can change this in future
         with temppath(suffix='.npy') as path:
             with pytest.raises(NotImplementedError):
+
                 np.save(path, xm)
+
+
+@pytest.fixture(autouse=True, scope="class")
+def err_status():
+    err = np.geterr()
+    np.seterr(divide='ignore', invalid='ignore')
+    yield err
+    np.seterr(**err)
 
 
 class TestMaskedArrayArithmetic:
@@ -1147,13 +1156,6 @@ class TestMaskedArrayArithmetic:
         xf = np.where(m1, 1e+20, x)
         xm.set_fill_value(1e+20)
         return x, y, a10, m1, m2, xm, ym, z, zm, xf
-
-    @pytest.fixture(autouse=True, scope="class")
-    def err_status(self):
-        err = np.geterr()
-        np.seterr(divide='ignore', invalid='ignore')
-        yield err
-        np.seterr(**err)
 
     def test_basic_arithmetic(self):
         # Test of basic arithmetic.

--- a/numpy/typing/tests/test_typing.py
+++ b/numpy/typing/tests/test_typing.py
@@ -30,8 +30,6 @@ else:
     NO_MYPY = False
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     # We need this as annotation, but it's located in a private namespace.
     # As a compromise, do *not* import it during runtime
     from _pytest.mark.structures import ParameterSet
@@ -116,7 +114,8 @@ def run_mypy() -> None:
                 filename = None
 
 
-def get_test_cases(*directories: str) -> "Iterator[ParameterSet]":
+def get_test_cases(*directories: str) -> list["ParameterSet"]:
+    test_cases = []
     for directory in directories:
         for root, _, files in os.walk(directory):
             for fname in files:
@@ -125,7 +124,8 @@ def get_test_cases(*directories: str) -> "Iterator[ParameterSet]":
                     continue
 
                 fullpath = os.path.join(root, fname)
-                yield pytest.param(fullpath, id=short_fname)
+                test_cases.append(pytest.param(fullpath, id=short_fname))
+    return test_cases
 
 
 _FAIL_INDENT = " " * 4


### PR DESCRIPTION
Backport of #31644.

Pytest 9.1.0 (https://github.com/pytest-dev/pytest/releases/tag/9.1.0) deprecated using non-collection iterators (generators and such) to parametrize tests. IMO that's a good call, so instead of ignoring those deprecation warnings, I updated the tests to use collection types (lists usually) for parametric tests.

There was also another new warning about class-scoped instance method fixtures now being deprecated that this fixes.

This should fix (at least) some of the recent CI test failures we've been seeing.

#### AI Disclosure
No AI
