### PR TITLE
TST: add 3.15t win32 CI and fix issues seen in that build (#31607)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,8 +69,8 @@ jobs:
 
 
   #=======================================================================================
-  msvc_python32bit_no_openblas:
-    name: MSVC, ${{ matrix.architecture }}, fast, no BLAS
+  msvc_python_x86_arm64_no_openblas:
+    name: MSVC, ${{ matrix.os }} ${{ matrix.architecture }}, full, no BLAS, ${{ matrix.python_version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -78,8 +78,10 @@ jobs:
         include:
           - os: windows-2022
             architecture: x86
+            python_version: '3.15t-dev'
           - os: windows-11-arm
             architecture: arm64
+            python_version: '3.12'
     # To enable this job on a fork, comment out:
     if: github.repository == 'numpy/numpy'
     steps:
@@ -93,7 +95,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python_version }}
           architecture: ${{ matrix.architecture }}
 
       - name: Setup MSVC
@@ -116,10 +118,10 @@ jobs:
         run: |
           python -m pip install -r requirements/test_requirements.txt
 
-      - name: Run test suite (fast)
+      - name: Run test suite (full)
         run: |
           cd tools
-          python -m pytest --pyargs numpy -m "not slow" -n2 --timeout=600 --durations=10
+          python -m pytest --pyargs numpy -n auto --timeout=600 --durations=10
 
   #=======================================================================================
   msvc_python64bit_openblas:

--- a/numpy/_core/tests/examples/cython/meson.build
+++ b/numpy/_core/tests/examples/cython/meson.build
@@ -15,6 +15,15 @@ if cy.version().version_compare('>=3.1.0')
   cython_args += ['-Xfreethreading_compatible=True']
 endif
 
+extra_c_args = []
+if host_machine.system() == 'windows' and host_machine.cpu_family() == 'x86'
+  # Cython's constant immortalization passes UINT32_MAX through a Py_ssize_t,
+  # which aborts module init on 32-bit free-threaded builds when asserts are
+  # enabled. See https://github.com/cython/cython/issues/7742; this should be
+  # fixed in Cython 3.2.6, after which the workaround can be removed.
+  extra_c_args += ['-DCYTHON_IMMORTAL_CONSTANTS=0']
+endif
+
 npy_include_path = run_command(py, [
     '-c',
     'import os; os.chdir(".."); import numpy; print(os.path.abspath(numpy.get_include()))'
@@ -37,7 +46,7 @@ py.extension_module(
       '-DNPY_NO_DEPRECATED_API=0',  # Cython still uses old NumPy C API
       # Require 1.25+ to test datetime additions
       '-DNPY_TARGET_VERSION=NPY_2_0_API_VERSION',
-    ],
+    ] + extra_c_args,
     include_directories: [npy_include_path],
     cython_args: cython_args,
 )

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 import sysconfig
@@ -8,6 +9,7 @@ import pytest
 
 import numpy as np
 from numpy.testing import IS_EDITABLE, IS_WASM, assert_array_equal
+from numpy.testing._private.utils import run_subprocess
 
 # This import is copied from random.tests.test_extending
 try:
@@ -40,8 +42,17 @@ def install_temp(tmpdir_factory):
     if IS_WASM:
         pytest.skip("No subprocess")
 
-    srcdir = os.path.join(os.path.dirname(__file__), 'examples', 'cython')
-    build_dir = tmpdir_factory.mktemp("cython_test") / "build"
+    # Build against a copy of the sources placed next to the build dir:
+    # meson refers to sources via paths relative to the build dir, and on
+    # Windows the unnormalized cwd + `..` chain joining the deeply nested
+    # pytest tmp dir and site-packages can exceed MAX_PATH, failing the
+    # compile with "Cannot open source file".
+    tmp_root = tmpdir_factory.mktemp("cython_test")
+    srcdir = str(tmp_root / "src")
+    shutil.copytree(
+        os.path.join(os.path.dirname(__file__), 'examples', 'cython'),
+        srcdir)
+    build_dir = tmp_root / "build"
     os.makedirs(build_dir, exist_ok=True)
     # Ensure we use the correct Python interpreter even when `meson` is
     # installed in a different Python environment (see gh-24956)
@@ -58,27 +69,16 @@ def install_temp(tmpdir_factory):
     if sysconfig.get_platform() == "win-arm64":
         pytest.skip("Meson unable to find MSVC linker on win-arm64")
     if sys.platform == "win32":
-        subprocess.check_call(["meson", "setup",
-                               "--buildtype=release",
-                               "--vsenv", "--native-file", native_file,
-                               str(srcdir)],
-                              cwd=build_dir,
-                              )
+        run_subprocess(["meson", "setup",
+                        "--buildtype=release",
+                        "--vsenv", "--native-file", native_file,
+                        str(srcdir)],
+                       build_dir)
     else:
-        subprocess.check_call(["meson", "setup",
-                               "--native-file", native_file, str(srcdir)],
-                              cwd=build_dir
-                              )
-    try:
-        subprocess.check_call(["meson", "compile", "-vv"], cwd=build_dir)
-    except subprocess.CalledProcessError:
-        print("----------------")
-        print("meson build failed when doing")
-        print(f"'meson setup --native-file {native_file} {srcdir}'")
-        print("'meson compile -vv'")
-        print(f"in {build_dir}")
-        print("----------------")
-        raise
+        run_subprocess(["meson", "setup",
+                        "--native-file", native_file, str(srcdir)],
+                       build_dir)
+    run_subprocess(["meson", "compile", "-vv"], build_dir)
 
     sys.path.append(str(build_dir))
 

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 import sysconfig
@@ -6,6 +7,7 @@ import sysconfig
 import pytest
 
 from numpy.testing import IS_EDITABLE, IS_WASM, NOGIL_BUILD
+from numpy.testing._private.utils import run_subprocess
 
 # This import is copied from random.tests.test_extending
 try:
@@ -38,8 +40,17 @@ def install_temp(tmpdir_factory):
     if IS_WASM:
         pytest.skip("No subprocess")
 
-    srcdir = os.path.join(os.path.dirname(__file__), 'examples', 'limited_api')
-    build_dir = tmpdir_factory.mktemp("limited_api") / "build"
+    # Build against a copy of the sources placed next to the build dir:
+    # meson refers to sources via paths relative to the build dir, and on
+    # Windows the unnormalized cwd + `..` chain joining the deeply nested
+    # pytest tmp dir and site-packages can exceed MAX_PATH, failing the
+    # compile with "Cannot open source file".
+    tmp_root = tmpdir_factory.mktemp("limited_api")
+    srcdir = str(tmp_root / "src")
+    shutil.copytree(
+        os.path.join(os.path.dirname(__file__), 'examples', 'limited_api'),
+        srcdir)
+    build_dir = tmp_root / "build"
     os.makedirs(build_dir, exist_ok=True)
     # Ensure we use the correct Python interpreter even when `meson` is
     # installed in a different Python environment (see gh-24956)
@@ -56,25 +67,17 @@ def install_temp(tmpdir_factory):
     if sysconfig.get_platform() == "win-arm64":
         pytest.skip("Meson unable to find MSVC linker on win-arm64")
     if sys.platform == "win32":
-        subprocess.check_call(["meson", "setup",
-                               "--werror",
-                               "--buildtype=release",
-                               "--vsenv", "--native-file", native_file,
-                               str(srcdir)],
-                              cwd=build_dir,
-                              )
+        run_subprocess(["meson", "setup",
+                        "--werror",
+                        "--buildtype=release",
+                        "--vsenv", "--native-file", native_file,
+                        str(srcdir)],
+                       build_dir)
     else:
-        subprocess.check_call(["meson", "setup", "--werror",
-                               "--native-file", native_file, str(srcdir)],
-                              cwd=build_dir
-                              )
-    try:
-        subprocess.check_call(
-            ["meson", "compile", "-vv"], cwd=build_dir)
-    except subprocess.CalledProcessError as p:
-        print(f"{p.stdout=}")
-        print(f"{p.stderr=}")
-        raise
+        run_subprocess(["meson", "setup", "--werror",
+                        "--native-file", native_file, str(srcdir)],
+                       build_dir)
+    run_subprocess(["meson", "compile", "-vv"], build_dir)
 
     sys.path.append(str(build_dir))
 

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -3,7 +3,6 @@
 """
 import itertools
 import os
-import subprocess
 import sys
 import textwrap
 import threading
@@ -44,6 +43,7 @@ from numpy.testing import (
     assert_raises,
     assert_raises_regex,
 )
+from numpy.testing._private.utils import run_subprocess
 
 try:
     import numpy.linalg.lapack_lite
@@ -2096,12 +2096,12 @@ def test_sdot_bug_8577():
     for bad_lib in bad_libs:
         code = template.format(before="import numpy as np", after="",
                                bad_lib=bad_lib)
-        subprocess.check_call([sys.executable, "-c", code])
+        run_subprocess([sys.executable, "-c", code])
 
         # Swapped import order
         code = template.format(after="import numpy as np", before="",
                                bad_lib=bad_lib)
-        subprocess.check_call([sys.executable, "-c", code])
+        run_subprocess([sys.executable, "-c", code])
 
 
 class TestMultiDot:

--- a/numpy/random/tests/test_extending.py
+++ b/numpy/random/tests/test_extending.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import subprocess
 import sys
 import sysconfig
 import warnings
@@ -10,6 +9,7 @@ import pytest
 
 import numpy as np
 from numpy.testing import IS_EDITABLE, IS_WASM
+from numpy.testing._private.utils import run_subprocess
 
 try:
     import cffi
@@ -77,18 +77,16 @@ def test_cython(tmp_path):
         f.write(f"python = '{sys.executable}'\n")
         f.write(f"python3 = '{sys.executable}'")
     if sys.platform == "win32":
-        subprocess.check_call(["meson", "setup",
-                               "--buildtype=release",
-                               "--vsenv", "--native-file", native_file,
-                               str(build_dir)],
-                              cwd=target_dir,
-                              )
+        run_subprocess(["meson", "setup",
+                        "--buildtype=release",
+                        "--vsenv", "--native-file", native_file,
+                        str(build_dir)],
+                       target_dir)
     else:
-        subprocess.check_call(["meson", "setup",
-                               "--native-file", native_file, str(build_dir)],
-                              cwd=target_dir
-                              )
-    subprocess.check_call(["meson", "compile", "-vv"], cwd=target_dir)
+        run_subprocess(["meson", "setup",
+                        "--native-file", native_file, str(build_dir)],
+                       target_dir)
+    run_subprocess(["meson", "compile", "-vv"], target_dir)
 
     # gh-16162: make sure numpy's __init__.pxd was used for cython
     # not really part of this test, but it is a convenient place to check

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -10,6 +10,7 @@ from numpy.exceptions import AxisError
 from numpy.linalg import LinAlgError
 from numpy.random import MT19937, Generator, RandomState, SeedSequence
 from numpy.testing import (
+    IS_64BIT,
     IS_WASM,
     assert_,
     assert_allclose,
@@ -1267,6 +1268,10 @@ class TestRandomDist:
 
     @pytest.mark.slow
     @pytest.mark.thread_unsafe(reason="crashes with low memory")
+    @pytest.mark.skipif(
+        not IS_64BIT,
+        reason="the 458 MiB sample array may not fit in a 32-bit "
+               "address space fragmented by earlier tests")
     def test_dirichlet_moderately_small_alpha(self):
         # Use alpha.max() < 0.1 to trigger stick breaking code path
         alpha = np.array([0.02, 0.04, 0.03])

--- a/numpy/testing/_private/extbuild.py
+++ b/numpy/testing/_private/extbuild.py
@@ -6,10 +6,11 @@ See build_and_import_extensions for usage hints
 
 import os
 import pathlib
-import subprocess
 import sys
 import sysconfig
 import textwrap
+
+from .utils import run_subprocess
 
 __all__ = ['build_and_import_extension', 'compile_extension_module']
 
@@ -225,19 +226,17 @@ def build(cfile, outputfilename, compile_extra, link_extra,
             python = '{sys.executable}'
         """))
     if sys.platform == "win32":
-        subprocess.check_call(["meson", "setup",
-                               "--buildtype=release",
-                               "--vsenv", ".."],
-                              cwd=build_dir,
-                              )
+        run_subprocess(["meson", "setup",
+                        "--buildtype=release",
+                        "--vsenv", ".."],
+                       build_dir)
     else:
-        subprocess.check_call(["meson", "setup", "--vsenv",
-                               "..", f'--native-file={os.fspath(native_file_name)}'],
-                              cwd=build_dir
-                              )
+        run_subprocess(["meson", "setup", "--vsenv",
+                        "..", f'--native-file={os.fspath(native_file_name)}'],
+                       build_dir)
 
     so_name = outputfilename.parts[-1] + get_so_suffix()
-    subprocess.check_call(["meson", "compile"], cwd=build_dir)
+    run_subprocess(["meson", "compile"], build_dir)
     os.rename(str(build_dir / so_name), cfile.parent / so_name)
     return cfile.parent / so_name
 

--- a/numpy/testing/_private/utils.py
+++ b/numpy/testing/_private/utils.py
@@ -2868,3 +2868,32 @@ def requires_deep_recursion(func):
                         "deep recursion")
         return func(*args, **kwargs)
     return wrapper
+
+
+def run_subprocess(cmd, cwd=None, **kwargs):
+    """Run ``cmd`` in a subprocess, failing the test with its captured output
+    if it exits with a nonzero status.
+
+    Output that a subprocess merely inherits is lost in pytest-xdist workers
+    when a test fails, making CI failures hard to debug.  Routing a
+    build/compile/run step through this helper captures the child's stdout and
+    stderr and folds them into the failure message so they reach the report.
+    Returns the ``subprocess.CompletedProcess`` for callers that want to
+    inspect the output.  Extra keyword arguments are passed to
+    ``subprocess.run``.
+    """
+    import subprocess
+
+    import pytest
+
+    res = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True,
+                         errors="replace", **kwargs)
+    if res.returncode != 0:
+        cmd_str = cmd if isinstance(cmd, str) else " ".join(map(str, cmd))
+        in_dir = f" in {cwd}" if cwd is not None else ""
+        pytest.fail(
+            f"`{cmd_str}` failed (exit {res.returncode}){in_dir}\n"
+            f"----- stdout -----\n{res.stdout}\n"
+            f"----- stderr -----\n{res.stderr}",
+            pytrace=False)
+    return res

--- a/numpy/tests/test_lazyloading.py
+++ b/numpy/tests/test_lazyloading.py
@@ -1,10 +1,10 @@
-import subprocess
 import sys
 import textwrap
 
 import pytest
 
 from numpy.testing import IS_WASM
+from numpy.testing._private.utils import run_subprocess
 
 
 @pytest.mark.skipif(IS_WASM, reason="can't start subprocess")
@@ -32,11 +32,4 @@ def test_lazy_load():
         # test triggering the import of the package
         np.ndarray
         """)
-    p = subprocess.run(
-        (sys.executable, '-c', code),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        encoding='utf-8',
-        check=False,
-    )
-    assert p.returncode == 0, p.stdout
+    run_subprocess((sys.executable, '-c', code))

--- a/numpy/tests/test_public_api.py
+++ b/numpy/tests/test_public_api.py
@@ -2,7 +2,6 @@ import functools
 import importlib
 import inspect
 import pkgutil
-import subprocess
 import sys
 import sysconfig
 import types
@@ -13,6 +12,7 @@ import pytest
 import numpy
 import numpy as np
 from numpy.testing import IS_WASM
+from numpy.testing._private.utils import run_subprocess
 
 try:
     import ctypes
@@ -62,8 +62,8 @@ def test_import_lazy_import(name):
 
     """
     exe = (sys.executable, '-c', "import numpy; numpy." + name)
-    result = subprocess.check_output(exe)
-    assert not result
+    result = run_subprocess(exe)
+    assert not result.stdout
 
     # Make sure they are still in the __dir__
     assert name in dir(np)

--- a/numpy/tests/test_reloading.py
+++ b/numpy/tests/test_reloading.py
@@ -1,5 +1,4 @@
 import pickle
-import subprocess
 import sys
 import textwrap
 from importlib import reload
@@ -8,6 +7,7 @@ import pytest
 
 import numpy.exceptions as ex
 from numpy.testing import IS_WASM, assert_, assert_equal, assert_raises
+from numpy.testing._private.utils import run_subprocess
 
 
 @pytest.mark.thread_unsafe(reason="reloads global module")
@@ -66,11 +66,4 @@ def test_full_reimport():
         else:
             raise SystemExit("DID NOT RAISE ImportError")
         """)
-    p = subprocess.run(
-        (sys.executable, '-c', code),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        encoding='utf-8',
-        check=False,
-    )
-    assert p.returncode == 0, p.stdout
+    run_subprocess((sys.executable, '-c', code))


### PR DESCRIPTION
Backport of #31607.

Adds win32 3.15t CI and fixes issues seen in the numpy-release automation. I also enabled "full" tests using the same test command as the windows wheel builder.

The Cython issues were reported upstream in https://github.com/cython/cython/issues/7742 and will be fixed in the next Cython release.

I adjusted tests that run meson to use a new helper that embeds debug info into the pytest failure message. That way debug output is no longer swallowed by pytest-xdist and we'll see errors in CI.

Fixed an issue in the cython tests that led to file paths longer than MAX_PATH so I updated the tests to copy the build tree to generate shorter paths.

Disabled `test_dirichlet_moderately_small_alpha` on 32 bit builds. 458 MiB is almost 10% of a 32 bit address space and on a test runner with 4 workers it's possible or even likely for memory to get sufficiently fragmented such that this test triggers OOM errors. mimalloc and the free-threaded build might make this situation worse?

ping @seberg @charris since this got reasonably involved.

I used Claude Fable 5 to help with this PR.