### PR TITLE
BUG: raise error when casting from StringDType to longdouble with trailing null (#31661)

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -1116,6 +1116,12 @@ string_to_float<npy_longdouble, NPY_LONGDOUBLE>(
 
         // allocate temporary null-terminated copy
         char *buf = (char *)PyMem_RawMalloc(s.size + 1);
+        if (buf == NULL) {
+            npy_gil_error(PyExc_MemoryError,
+                          "Failed to allocate string buffer while converting "
+                          "to a long double.");
+            goto fail;
+        }
         memcpy(buf, s.buf, s.size);
         buf[s.size] = '\0';
 
@@ -1123,6 +1129,15 @@ string_to_float<npy_longdouble, NPY_LONGDOUBLE>(
         errno = 0;
         npy_longdouble longdouble_value = NumPyOS_ascii_strtold(buf, &end);
 
+        if (end == buf || end != buf + s.size ||
+                (errno != 0 && errno != ERANGE)) {
+            npy_gil_error(PyExc_ValueError,
+                         "invalid literal for long double: %s (%s)",
+                         buf,
+                         strerror(errno));
+            PyMem_RawFree(buf);
+            goto fail;
+        }
         if (errno == ERANGE) {
             /* strtold returns INFINITY of the correct sign. */
             if (
@@ -1135,14 +1150,6 @@ string_to_float<npy_longdouble, NPY_LONGDOUBLE>(
                 PyMem_RawFree(buf);
                 goto fail;
             }
-        }
-        else if (errno || end == buf || *end) {
-            npy_gil_error(PyExc_ValueError,
-                         "invalid literal for long double: %s (%s)",
-                         buf,
-                         strerror(errno));
-            PyMem_RawFree(buf);
-            goto fail;
         }
         PyMem_RawFree(buf);
         *out = longdouble_value;

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -317,6 +317,30 @@ def test_additional_unicode_cast(dtype):
     assert_array_equal(arr, arr.astype(string_list.dtype))
 
 
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "int64",
+        "float16",
+        "float32",
+        "float64",
+        "longdouble",
+        "complex64",
+        "complex128",
+        "clongdouble",
+    ],
+)
+@pytest.mark.parametrize(
+    "invalid",
+    ["", "spam", "1abc", "1.0abc", "\0", "1\0", "1\0abc"],
+)
+def test_invalid_numeric_casts_error(dtype, invalid):
+    arr = np.array([invalid], dtype="T")
+
+    with pytest.raises(ValueError):
+        arr.astype(dtype)
+
+
 def test_insert_scalar(dtype, string_list):
     """Test that inserting a scalar works."""
     arr = np.array(string_list, dtype=dtype)


### PR DESCRIPTION
Backport of #31661.

Fixes an issue in the StringDType to longdouble cast, where:

* We failed to check for an allocation failure
* We used `NumPyOS_ascii_strtold` but did not check all possible error cases for that function. In particular, if the parsed longdouble ends before the end of the string, like with the test case that has a trailing NULL.

This fixes that by improving the error checking. Also adds test cases for converting various invalid strings to built-in numeric dtypes.
