### PR TITLE
BUG: fix casts from StringDType to complex float (#31663)

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -1323,7 +1323,7 @@ string_to_complex_float(
         }
 
         npy_csetrealfunc(out, (NpyFloatType) complex_value.real);
-        npy_csetimagfunc(out, (NpyFloatType) complex_value.real);
+        npy_csetimagfunc(out, (NpyFloatType) complex_value.imag);
         in += in_stride;
         out += out_stride;
     }

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -838,6 +838,19 @@ def test_cfloat_casts(typename):
     assert sres[0] == "(0.1+0.1j)"
 
 
+@pytest.mark.parametrize("typename", ["csingle", "cdouble", "clongdouble"])
+def test_string_to_cfloat_cast_distinct_components(typename):
+    inp = np.array(
+        ["1.25+0.5j", "2.75-3.5j", "-3.125+4.25j", "27000-8j"],
+        dtype="T",
+    )
+    expected = np.array(
+        [1.25 + 0.5j, 2.75 - 3.5j, -3.125 + 4.25j, 2.7e4 - 8j],
+        dtype=typename,
+    )
+    assert_array_equal(inp.astype(typename), expected)
+
+
 def test_take(string_list):
     sarr = np.array(string_list, dtype="T")
     res = sarr.take(np.arange(len(string_list)))


### PR DESCRIPTION
Backport of #31663.

This was clearly a copy/paste bug and the tests were written in such a way that they didn't notice the bug.

This was spotted using an AI model.