### PR TITLE
DOC: Clarify tuple vs list indexing in ufunc.at

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5801,6 +5801,27 @@ add_newdoc('numpy._core', 'ufunc', ('at',
     >>> np.add.at(a, [0, 1], b)
     >>> a
     array([2, 4, 3, 4])
+    
+    Note the difference between passing a tuple of lists versus a list of 
+    lists as indices for a multi-dimensional array. Passing a tuple of 
+    lists indexes across multiple dimensions:
+
+    >>> a = np.arange(1, 10).reshape(3, 3)
+    >>> np.add.at(a, ([0, 1], [2, 2]), 10)
+    >>> a
+    array([[ 1,  2, 13],
+           [ 4,  5, 16],
+           [ 7,  8,  9]])
+
+    Conversely, passing a list of lists treats the input as a single index 
+    array operating row-wise along the first dimension:
+
+    >>> b = np.arange(1, 10).reshape(3, 3)
+    >>> np.add.at(b, [[0, 1], [2, 2]], 10)
+    >>> b
+    array([[11, 12, 13],
+           [14, 15, 16],
+           [27, 28, 29]])
 
     """))
 


### PR DESCRIPTION
### PR summary
Closes #31579.

This PR adds an explanation and clear examples to the `ufunc.at` docstring to clarify the distinct advanced indexing behaviors encountered when passing `indices` as a tuple versus a list/array for multi-dimensional inputs.
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction
Hi! I'm an undergraduate computer science student making my first contribution to NumPy. I noticed this open documentation gap regarding advanced indexing styles in `ufunc.at` and wanted to help clear it up for future users.
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
I used an AI assistant to verify Python REPL string syntax and alignment constraints to ensure the docstring matches NumPyDoc/Sphinx formatting standards. The technical behavior text and code logic were drafted and verified manually.
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
