### PR TITLE
MAINT: Clean up use for PyObject_* APIs when PyMem_* would do (#31640)

### DIFF
--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -529,7 +529,7 @@ PyArray_Pack(PyArray_Descr *descr, void *item, PyObject *value)
         return -1;
     }
 
-    char *data = PyObject_Malloc(tmp_descr->elsize);
+    char *data = PyMem_Malloc(tmp_descr->elsize);
     if (data == NULL) {
         PyErr_NoMemory();
         Py_DECREF(tmp_descr);
@@ -539,7 +539,7 @@ PyArray_Pack(PyArray_Descr *descr, void *item, PyObject *value)
         memset(data, 0, tmp_descr->elsize);
     }
     if (NPY_DT_CALL_setitem(tmp_descr, value, data) < 0) {
-        PyObject_Free(data);
+        PyMem_Free(data);
         Py_DECREF(tmp_descr);
         return -1;
     }
@@ -551,7 +551,7 @@ PyArray_Pack(PyArray_Descr *descr, void *item, PyObject *value)
         }
     }
 
-    PyObject_Free(data);
+    PyMem_Free(data);
     Py_DECREF(tmp_descr);
     return res;
 }

--- a/numpy/_core/src/multiarray/buffer.c
+++ b/numpy/_core/src/multiarray/buffer.c
@@ -66,7 +66,7 @@ _append_char(_tmp_string_t *s, char c)
         char *p;
         size_t to_alloc = (s->allocated == 0) ? INIT_SIZE : (2 * s->allocated);
 
-        p = PyObject_Realloc(s->s, to_alloc);
+        p = PyMem_Realloc(s->s, to_alloc);
         if (p == NULL) {
             PyErr_SetString(PyExc_MemoryError, "memory allocation failed");
             return -1;
@@ -473,7 +473,7 @@ _buffer_info_new(PyObject *obj, int flags)
     int err = 0;
 
     if (PyArray_IsScalar(obj, Void)) {
-        info = PyObject_Malloc(sizeof(_buffer_info_t));
+        info = PyMem_Malloc(sizeof(_buffer_info_t));
         if (info == NULL) {
             PyErr_NoMemory();
             goto fail;
@@ -491,8 +491,8 @@ _buffer_info_new(PyObject *obj, int flags)
         assert(PyArray_Check(obj));
         PyArrayObject * arr = (PyArrayObject *)obj;
 
-        info = PyObject_Malloc(sizeof(_buffer_info_t) +
-                               sizeof(Py_ssize_t) * PyArray_NDIM(arr) * 2);
+        info = PyMem_Malloc(sizeof(_buffer_info_t) +
+                            sizeof(Py_ssize_t) * PyArray_NDIM(arr) * 2);
         if (info == NULL) {
             PyErr_NoMemory();
             goto fail;
@@ -564,8 +564,8 @@ _buffer_info_new(PyObject *obj, int flags)
     return info;
 
 fail:
-    PyObject_Free(fmt.s);
-    PyObject_Free(info);
+    PyMem_Free(fmt.s);
+    PyMem_Free(info);
     return NULL;
 }
 
@@ -659,10 +659,10 @@ _buffer_info_free_untagged(void *_buffer_info)
         _buffer_info_t *curr = next;
         next = curr->next;
         if (curr->format) {
-            PyObject_Free(curr->format);
+            PyMem_Free(curr->format);
         }
         /* Shape is allocated as part of info */
-        PyObject_Free(curr);
+        PyMem_Free(curr);
     }
 }
 
@@ -934,7 +934,7 @@ _descriptor_from_pep3118_format(char const *s)
     }
 
     /* Strip whitespace, except from field names */
-    buf = PyMem_RawMalloc(strlen(s) + 1);
+    buf = PyMem_Malloc(strlen(s) + 1);
     if (buf == NULL) {
         PyErr_NoMemory();
         return NULL;
@@ -956,7 +956,7 @@ _descriptor_from_pep3118_format(char const *s)
 
     str = PyUnicode_FromStringAndSize(buf, strlen(buf));
     if (str == NULL) {
-        PyMem_RawFree(buf);
+        PyMem_Free(buf);
         return NULL;
     }
 
@@ -964,7 +964,7 @@ _descriptor_from_pep3118_format(char const *s)
     _numpy_internal = PyImport_ImportModule("numpy._core._internal");
     if (_numpy_internal == NULL) {
         Py_DECREF(str);
-        PyMem_RawFree(buf);
+        PyMem_Free(buf);
         return NULL;
     }
     descr = PyObject_CallMethod(
@@ -977,7 +977,7 @@ _descriptor_from_pep3118_format(char const *s)
         PyErr_Format(PyExc_ValueError,
                      "'%s' is not a valid PEP 3118 buffer format string", buf);
         npy_PyErr_ChainExceptionsCause(exc, val, tb);
-        PyMem_RawFree(buf);
+        PyMem_Free(buf);
         return NULL;
     }
     if (!PyArray_DescrCheck(descr)) {
@@ -985,10 +985,10 @@ _descriptor_from_pep3118_format(char const *s)
                      "internal error: numpy._core._internal._dtype_from_pep3118 "
                      "did not return a valid dtype, got %s", buf);
         Py_DECREF(descr);
-        PyMem_RawFree(buf);
+        PyMem_Free(buf);
         return NULL;
     }
-    PyMem_RawFree(buf);
+    PyMem_Free(buf);
     return (PyArray_Descr*)descr;
 }
 

--- a/numpy/_core/src/multiarray/nditer_constr.c
+++ b/numpy/_core/src/multiarray/nditer_constr.c
@@ -193,7 +193,7 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
 
     /* Allocate memory for the iterator */
     iter = (NpyIter*)
-                PyObject_Malloc(NIT_SIZEOF_ITERATOR(itflags, ndim, nop));
+                PyMem_Malloc(NIT_SIZEOF_ITERATOR(itflags, ndim, nop));
     if (iter == NULL) {
         return NULL;
     }
@@ -219,7 +219,7 @@ NpyIter_AdvancedNew(int nop, PyArrayObject **op_in, npy_uint32 flags,
                         flags,
                         op_flags, op_itflags,
                         &NIT_MASKOP(iter))) {
-        PyObject_Free(iter);
+        PyMem_Free(iter);
         return NULL;
     }
     /* Set resetindex to zero as well (it's just after the resetdataptr) */
@@ -537,7 +537,7 @@ NpyIter_Copy(NpyIter *iter)
 
     /* Allocate memory for the new iterator */
     size = NIT_SIZEOF_ITERATOR(itflags, ndim, nop);
-    newiter = (NpyIter*)PyObject_Malloc(size);
+    newiter = (NpyIter*)PyMem_Malloc(size);
     if (newiter == NULL) {
         PyErr_NoMemory();
         return NULL;
@@ -717,7 +717,7 @@ NpyIter_Deallocate(NpyIter *iter)
     }
 
     /* Deallocate the iterator memory */
-    PyObject_Free(iter);
+    PyMem_Free(iter);
     return success;
 }
 

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -20,7 +20,7 @@
 #include "mapping.h"
 #include "ctors.h"
 #include "dtypemeta.h"
-#include "descriptor.h" 
+#include "descriptor.h"
 #include "usertypes.h"
 #include "number.h"
 #include "numpyos.h"
@@ -233,7 +233,7 @@ find_binary_operation_path(
     }
 
     if (!was_scalar || PyArray_DESCR(arr)->type_num != NPY_OBJECT) {
-        /* 
+        /*
          * The array is OK for usage and we can simply forward it.  There
          * is a theoretical subtlety here:  If the other object implements
          * `__array_wrap__`, we may ignore that.  However, this only matters
@@ -1827,7 +1827,7 @@ gentype_interface_get(PyObject *self, void *NPY_UNUSED(ignored))
     if (strides == NULL) {
         goto finish;
     }
-    
+
     /* descr */
     descr = array_protocol_descr_get(array_descr);
     if (descr == NULL) {
@@ -2177,7 +2177,7 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
         descr = PyArray_DescrFromScalar(self);
         data = (void *)scalar_value(self, descr);
 
-        newmem = PyObject_Malloc(descr->elsize);
+        newmem = PyMem_Malloc(descr->elsize);
         if (newmem == NULL) {
             Py_DECREF(descr);
             return PyErr_NoMemory();
@@ -2186,7 +2186,7 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
             PyDataType_GetArrFuncs(descr)->copyswap(newmem, data, 1, NULL);
         }
         new = PyArray_Scalar(newmem, descr, NULL);
-        PyObject_Free(newmem);
+        PyMem_Free(newmem);
         Py_DECREF(descr);
         return new;
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -6329,7 +6329,7 @@ free_ufunc_call_info(PyObject *self)
     Py_DECREF(context->method);
     NPY_AUXDATA_FREE(call_info->auxdata);
 
-    PyObject_Free(call_info);
+    PyMem_Free(call_info);
 }
 
 
@@ -6528,8 +6528,8 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
 
     /* We may have to return the context: */
     ufunc_call_info *call_info;
-    call_info = PyObject_Malloc(sizeof(ufunc_call_info)
-                              + ufunc->nargs * sizeof(PyArray_Descr *));
+    call_info = PyMem_Malloc(sizeof(ufunc_call_info)
+                             + ufunc->nargs * sizeof(PyArray_Descr *));
     if (call_info == NULL) {
         PyErr_NoMemory();
         goto finish;
@@ -6547,7 +6547,7 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
     PyObject *capsule = PyCapsule_New(
             call_info, "numpy_1.24_ufunc_call_info", &free_ufunc_call_info);
     if (capsule == NULL) {
-        PyObject_Free(call_info);
+        PyMem_Free(call_info);
         goto finish;
     }
 


### PR DESCRIPTION
Backport of #31640.

We were historically a bit sloppy using PyObject_* allocation API for many non-object cases.
This cleans up the rest of those completely, I did change one RawMalloc to not be raw, because the GIL is held and we shouldn't use `RawMalloc` either for this type of allocation.

So this is just a small general improvement (I dunno how bad it is to use the other for non-objects, but I think the Python docs could be clearer about it if it is now on free-threaded).

The original motivation is weird and maybe doesn't matter: The 3.15b2 free-threaded Ubuntu 22.04 builds of the setup-python action fail with segfault for ``PyObject_Realloc(0, ...)``. On the build `PyMem_Realloc()` works fine, so it "solves" the issue although it may be a real issue with the build.

(Of course I am not sure that this is a build issue or a Python issue, I had opened a setup-python issue though.)

(No AI use, just double checked with it I didn't miss anything)

---

I am tempted to backport, just in case the setup-python issue isn't a one-off and because it is trivial.

CC @ngoldbaum in case you are interested about the crash issue.  I suppose @kumaraditya303 could have a brief look to review.