### PR TITLE
TST: Avoid sctypeDict in tests as e.g. ml_dtypes may mutate it (#31666)

### DIFF
--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8957,7 +8957,7 @@ class TestNewBufferProtocol:
         self._check_roundtrip(x)
 
     def test_roundtrip_single_types(self):
-        for typ in np._core.sctypeDict.values():
+        for typ in np.typecodes["All"]:
             dtype = np.dtype(typ)
 
             if dtype.char in 'Mm':

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -2314,7 +2314,8 @@ class TestRegression:
 
     def test_correct_hash_dict(self):
         # gh-8887 - __hash__ would be None despite tp_hash being set
-        all_types = set(np._core.sctypeDict.values()) - {np.void}
+        all_types = [np.dtype(t).type for t in np.typecodes["All"]]
+        all_types = set(all_types) - {np.void}
         for t in all_types:
             if t is np.timedelta64:
                 val = t(0, 's')


### PR DESCRIPTION
Backport of #31666.

Using the typecodes may not be the nicest but is a common pattern and gives the exact same types otherwise.

Without this, if you import `ml_dtypes` these two tests fail. This can happen if:
* There is a chain of dependencies through some plugins.
* We ever start testing with `ml_dtypes` ourselves when installed.

(no AI)