### PR TITLE
BUG: Use `auxdata` in (arg)sort `strided_loop`s (#31670)

### DIFF
--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1343,7 +1343,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
             if (strided_loop != NULL) {
                 char *const data[2] = {bufptr, bufptr};
                 npy_intp strides[2] = {elsize, elsize};
-                ret = strided_loop(context, data, &N, strides, NULL);
+                ret = strided_loop(context, data, &N, strides, auxdata);
             }
             else {
                 ret = sort(bufptr, N, op);
@@ -1564,7 +1564,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
             if (strided_loop != NULL) {
                 char *const data[2] = {valptr, (char *)idxptr};
                 npy_intp strides[2] = {elsize, sizeof(npy_intp)};
-                ret = strided_loop(context, data, &N, strides, NULL);
+                ret = strided_loop(context, data, &N, strides, auxdata);
             }
             else {
                 ret = argsort(valptr, idxptr, N, op);


### PR DESCRIPTION
Backport of #31670.

This was somehow missed back in #29737, sorry :/ I've marked this for backport as it's a clear bug in the user dtype implementation for slots.

#### AI Disclosure
No AI tools used.