### PR TITLE
MAINT: Prefer `PyTuple_Pack` over `Py_BuildValue`

### DIFF
--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -180,8 +180,7 @@ initialize_static_globals(void)
         return -1;
     }
 
-    npy_static_pydata.kwnames_is_copy =
-            Py_BuildValue("(O)", npy_interned_str.copy);
+    npy_static_pydata.kwnames_is_copy = PyTuple_Pack(1, npy_interned_str.copy);
     if (npy_static_pydata.kwnames_is_copy == NULL) {
         return -1;
     }
@@ -197,9 +196,9 @@ initialize_static_globals(void)
     }
 
     npy_static_pydata.dl_call_kwnames =
-            Py_BuildValue("(OOO)", npy_interned_str.dl_device,
-                                   npy_interned_str.copy,
-                                   npy_interned_str.max_version);
+            PyTuple_Pack(3, npy_interned_str.dl_device,
+                            npy_interned_str.copy,
+                            npy_interned_str.max_version);
     if (npy_static_pydata.dl_call_kwnames == NULL) {
         return -1;
     }


### PR DESCRIPTION
### PR summary

In a micro-benchmark that builds the tuple `(0, 1)` from two existing PyObjects, `PyTuple_Pack(2, zero, one)` is twice as fast as `Py_BuildValue("(OO)", zero, one)`, with runtimes of 17.7 nsec and 36.1 nsec per loop, respectively, as measured by `timeit` with Python 3.13.5 on x86_64 GNU/Linux.  (It makes sense that it's faster not having to parse a format string.)

So, I thought, why not use it in NumPy?

#### AI Disclosure

No AI tools used