### PR TITLE
BUG: Fix signed integer overflow in datetime.c

### DIFF
--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -167,12 +167,27 @@ static npy_int64
 days_to_yearsdays(npy_int64 *days_)
 {
     const npy_int64 days_per_400years = (400*365 + 100 - 4 + 1);
+    const npy_int64 days_offset = (365*30 + 7);
     /* Adjust so it's relative to the year 2000 (divisible by 400) */
-    npy_int64 days = (*days_) - (365*30 + 7);
+    npy_int64 days;
     npy_int64 year;
 
+    if (*days_ < NPY_MIN_INT64 + days_offset) {
+        /* Extract 400-year cycles first to reduce magnitude */
+        days = *days_;
+        year = 400 * extract_unit_64(&days, days_per_400years);
+        days -= days_offset;
+        if (days < 0) {
+            days += days_per_400years;
+            year -= 400;
+        }
+    }
+    else {
+        days = (*days_) - days_offset;
+        year = 400 * extract_unit_64(&days, days_per_400years);
+    }
+
     /* Break down the 400 year cycle to get the year and day within the year */
-    year = 400 * extract_unit_64(&days, days_per_400years);
 
     /* Work out the year/day within the 400 year cycle */
     if (days >= 366) {

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -174,13 +174,9 @@ days_to_yearsdays(npy_int64 *days_)
 
     if (*days_ < NPY_MIN_INT64 + days_offset) {
         /* Extract 400-year cycles first to reduce magnitude */
-        days = *days_;
+        days = *days_ + (days_per_400years - days_offset);
         year = 400 * extract_unit_64(&days, days_per_400years);
-        days -= days_offset;
-        if (days < 0) {
-            days += days_per_400years;
-            year -= 400;
-        }
+        year -= 400;
     }
     else {
         days = (*days_) - days_offset;

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1268,18 +1268,12 @@ class TestDateTime:
     def test_datetime64_item_int64_min_edge_case(self):
         info = np.iinfo(np.int64)
 
-        # Test INT64_MIN + 1
-        dt64 = np.datetime64(info.min + 1, "D")
-        result = dt64.item()
-        # For dates outside Python's datetime range (year 1-9999),
-        # NumPy returns the raw integer value
-        assert isinstance(result, (int, datetime.date))
-
-        # Test a few more extreme negative values
         for offset in [1, 2, 100, 1000, 10000]:
             dt64 = np.datetime64(info.min + offset, "D")
             result = dt64.item()
-            assert isinstance(result, (int, datetime.date))
+            # expected integer value
+            assert result == info.min + offset
+            assert isinstance(result, int)
 
     def test_pyobject_roundtrip(self):
         # All datetime types should be able to roundtrip through object

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1265,6 +1265,22 @@ class TestDateTime:
         assert small * np.int64(7) == np.timedelta64(21, "s")
         assert np.int64(7) * small == np.timedelta64(21, "s")
 
+    def test_datetime64_item_int64_min_edge_case(self):
+        info = np.iinfo(np.int64)
+
+        # Test INT64_MIN + 1
+        dt64 = np.datetime64(info.min + 1, "D")
+        result = dt64.item()
+        # For dates outside Python's datetime range (year 1-9999),
+        # NumPy returns the raw integer value
+        assert isinstance(result, (int, datetime.date))
+
+        # Test a few more extreme negative values
+        for offset in [1, 2, 100, 1000, 10000]:
+            dt64 = np.datetime64(info.min + offset, "D")
+            result = dt64.item()
+            assert isinstance(result, (int, datetime.date))
+
     def test_pyobject_roundtrip(self):
         # All datetime types should be able to roundtrip through object
         a = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0,


### PR DESCRIPTION

### Fix #31686

### PR summary

PR fixes a signed integer overflow in `numpy/_core/src/multiarray/datetime.c `that occurs when converting datetime64 values near INT64_MIN to Python objects via `.item().the days_to_yearsdays() `function performs `(*days_) - (365*30 + 7)` which causes undefined behavior when `*days_ is near INT64_MIN` . this solution will Reordered arithmetic operations to avoid overflow

### First time committer introduction
NA
