### PR TITLE
DOC: Update comment to advise keeping ``__dlpack__()`` v0

### DIFF
--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -543,12 +543,12 @@ array_dlpack(PyArrayObject *self,
     }
 
     /*
-     * TODO: The versioned and non-versioned structs of DLPack are very
-     * similar but not ABI compatible so that the function called here requires
-     * branching (templating didn't seem worthwhile).
+     * The versioned and non-versioned structs of DLPack are very similar but
+     * not ABI compatible so that the function called here requires branching
+     * (templating didn't seem worthwhile).
      *
-     * Version 0 support should be deprecated in NumPy 2.1 and the branches
-     * can then be removed again.
+     * Version 0 support should not be removed since it's faster for callers
+     * to omit max_version if they're OK with getting an unversioned tensor.
      */
     PyObject *res = create_dlpack_capsule(
             self, major_version >= 1, &result_device,


### PR DESCRIPTION
### PR summary

This PR updates a comment in `dlpack.c` to advise against removing support for `__dlpack__()` version 0.

For the recently released nanobind v2.13.0, @wjakob observed that importing a NumPy array into a C++ Python module is 9% faster if `array.__dlpack__()` is called without specifying `max_version=(1, 0)`.  Furthermore, it is safe to do so when the module will only be reading from the array (i.e., on the C++ side the data is `const`).  Consequently, this is now done.  See: https://github.com/wjakob/nanobind/pull/1375/changes/439a0eb5db52009046ec767f8c75db3ac12ea854

Note that some (most?) frameworks (including older versions of NumPy) may return a `dltensor` regardless of whether the array is read-only or writable.  That's fine, again, since nanobind defaults to omitting `max_version` only when the C++ module wants only read access.

Currently, NumPy raises a BufferError if `array.__dlpack__()` is called on a read-only NumPy array.  In practice, it is believed that users typically do not `a.setflags(write=False)`.  If they do, nanobind will see the BufferError and try `array.__dlpack__(max_version=(1, 0))`, which will succeed.  [Sadly, the C++ module is slower when it wants read-only access to a read-only NumPy array than when it wants read-only access to a writable NumPy array.  When DLPack was first designed [PEP-3118](https://peps.python.org/pep-3118/)'s access flag `PyBUF_WRITABLE` was not yet well known.  DLPack version 1 added `DLPACK_FLAG_BITMASK_READ_ONLY`.]

Note that the performance results can be confirmed with Python 3.15.0b2 and NumPy 2.4.4.
First, version 0:
```
python -m timeit -n 10000000 -r 10 -s "import numpy as np; a = np.array([1.0, 2.0, 3.0])" "a.__dlpack__()"
10000000 loops, best of 10: 51.3 nsec per loop
```
Then creating the tuple `(1,0)` once in the setup and timing with the keyword argument:
```
python -m timeit -n 10000000 -r 10 -s "import numpy as np; a = np.array([1.0, 2.0, 3.0]); tpl=(1,0)" "a.__dlpack__(max_version=tpl)"
10000000 loops, best of 10: 68.9 nsec per loop
```

There may be better ideas and solutions moving forward, and I'd be happy if this PR is closed in favor of something else.  My thinking is that changing the comment is a good idea so that a conversation can happen if someone thinks to start a deprecation process (as the comment currently indicates).

#### AI Disclosure

No AI tools used
