### PR TITLE
MAINT: Fix emscripten wheel build.

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -35,8 +35,9 @@ jobs:
           submodules: recursive
           fetch-tags: true
           persist-credentials: false
-
-      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
+      - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55  # v4.1.0
         env:
           CIBW_PLATFORM: pyodide
-          CIBW_BUILD: cp312-*
+          CIBW_BUILD: cp314-pyodide_wasm32
+          CIBW_ENABLE: pyodide-prerelease
+          CIBW_BUILD_VERBOSITY: 3


### PR DESCRIPTION
Emscripten currently fails to build wheels using
cibuildwheel >= 4.0.0.

AI suggested possible fixes.
