### PR TITLE
MAINT: Avoid compiling uv for loongarch

### DIFF
--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -222,7 +222,9 @@ jobs:
           # No need to build ninja from source, the host ninja is used for the build
           grep -v ninja /numpy/requirements/build_requirements.txt > /tmp/build_requirements.txt &&
           grep -v ninja /numpy/requirements/test_requirements.txt > /tmp/test_requirements.txt &&
-          python -m pip install --break-system-packages uv --extra-index-url https://mirrors.loong64.com/pypi/simple &&
+          python -m pip install --break-system-packages \
+              --extra-index-url https://mirrors.loong64.com/pypi/simple \
+              --only-binary=":all:" uv &&
           export PATH="/root/.local/bin:$PATH" &&
           uv venv --python 3.12 .venv &&
           source .venv/bin/activate &&


### PR DESCRIPTION
The uv package is pip installed, add `--only-binary` flag. That will allow upgrades, but only when they are
compiled. Rust compilation is very slow in emulation. The reason this is needed now is that uv had a new
release today 6/19/2026.

Used AI to discuss the problem and check the loongarch pip repo.
