### PR TITLE
BUG: fix out array leak in reduceat and accumulate when dtype resolution fails

### DIFF
--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2749,6 +2749,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
             arr, out, signature, NPY_TRUE, descrs, NPY_UNSAFE_CASTING,
             "accumulate");
     if (ufuncimpl == NULL) {
+        Py_XDECREF(out);
         return NULL;
     }
 
@@ -3172,6 +3173,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
             arr, out, signature, NPY_TRUE, descrs, NPY_UNSAFE_CASTING,
             "reduceat");
     if (ufuncimpl == NULL) {
+        Py_XDECREF(out);
         return NULL;
     }
 

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2733,6 +2733,18 @@ class TestUfunc:
         with pytest.raises(ValueError, match="(shape|size)"):
             np.add.accumulate(arr, out=out)
 
+    def test_reduceat_and_accumulate_out_dtype_resolution_failure(self):
+        # gh-31691: the out= error path leaked a reference to out when the
+        # ufunc dtype resolution failed (no matching loop for the out dtype).
+        arr = np.arange(3)
+        out = np.empty(3, dtype="U5")  # no add loop resolves to this
+
+        with pytest.raises(np._core._exceptions._UFuncNoLoopError):
+            np.add.reduceat(arr, [0, 1, 2], out=out)
+
+        with pytest.raises(np._core._exceptions._UFuncNoLoopError):
+            np.add.accumulate(arr, out=out)
+
     @pytest.mark.parametrize('out_shape',
                              [(), (1,), (3,), (1, 1), (1, 3), (4, 3)])
     @pytest.mark.parametrize('keepdims', [True, False])


### PR DESCRIPTION
Closes https://github.com/numpy/numpy/issues/31691

### PR summary
In both of those cases `out` reference count is incremented before `reducelike_promote_and_resolve` is called but if the dtype resolution fails, it's not decremented. One can see it with a snippet like the following:
```python
>>> import sys, numpy as np
... arr = np.arange(3)
... out = np.empty(3, dtype="U5")
...
... before = sys.getrefcount(out)
... for _ in range(10000):
...     try:
...         np.add.accumulate(arr, out=out)
...     except Exception:
...         pass
... print(sys.getrefcount(out) - before)
...
10000 # with the fix, we get 0 here
```
Let me know if you think the above should be added as a test. I found it a trivial fix and not worthy of a specialized test personally.

### First time committer introduction
N/A

#### AI Disclosure
No AI