### PR TITLE
MAINT: update openblas to 0.3.33.112.0 (#31649)

### DIFF
--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -89,6 +89,69 @@ def test_eigvalsh_thread_safety():
                  pass_count=True)
 
 
+def _detected_blas():
+    blas = np.show_config('dicts').get('Build Dependencies', {}).get('blas', {})
+    return blas.get('name', 'unknown'), blas.get('version', 'unknown')
+
+
+def _openblas_predates_gemm_fix(name, version):
+    if 'openblas' not in name:
+        return False
+    try:
+        parsed = tuple(int(p) for p in version.split('.'))
+    except ValueError:
+        return False
+    return parsed < (0, 3, 33, 112)
+
+
+def test_blas_gemm_thread_safety():
+    # gh-31618: concurrently run transpose and no-transpose GEMM variants to
+    # exercise possible thread safety issues due to lock sharding between
+    # kernels, see OpenBLAS issue #5836.
+    num_threads = 8
+    num_iters = 10
+    M = 512 * 512
+
+    rng = np.random.default_rng(0x9e3779b9)
+    no_trans = rng.random((M, 4))            # C-contiguous -> NoTrans GEMM
+    no_trans_w = rng.random((4, 2))
+    trans = rng.random((2, M)).T             # F-contiguous -> Trans GEMM
+    trans_w = rng.random((2, 2))
+    expected_no_trans = no_trans @ no_trans_w
+    expected_trans = trans @ trans_w
+
+    mismatches = 0
+    lock = threading.Lock()
+
+    def closure(i, b):
+        nonlocal mismatches
+        count = 0
+        for _ in range(num_iters):
+            b.wait()
+            if i % 2:
+                ok = np.array_equal(no_trans @ no_trans_w, expected_no_trans)
+            else:
+                ok = np.array_equal(trans @ trans_w, expected_trans)
+            if not ok:
+                count += 1
+        with lock:
+            mismatches += count
+
+    run_threaded(closure, num_threads, pass_count=True, pass_barrier=True)
+
+    blas_name, blas_version = _detected_blas()
+    if mismatches and _openblas_predates_gemm_fix(blas_name, blas_version):
+        pytest.xfail(
+            f"OpenBLAS version ({blas_version}) predates first OpenBLAS "
+            "version with a fix (0.3.33.112)"
+        )
+
+    assert mismatches == 0, (
+        f"{mismatches} concurrent matmul results were corrupted "
+        f"({blas_name} {blas_version})"
+    )
+
+
 def test_printoptions_thread_safety():
     # until NumPy 2.1 the printoptions state was stored in globals
     # this verifies that they are now stored in a context variable

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.33.0.0
+scipy-openblas32==0.3.33.112.0

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.33.0.0
-scipy-openblas64==0.3.33.0.0
+scipy-openblas32==0.3.33.112.0
+scipy-openblas64==0.3.33.112.0


### PR DESCRIPTION
Backport of #21649.

Fixes #31618 and maybe #29442

Will need a parallel PR to numpy-release, but I think the CI tests here are more extensive, so the two should be looked at together.