### PR TITLE
REL: Prepare for the NumPy 2.5.0 release.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -623,6 +623,7 @@ Nicholas McKibben <nicholas.bgp@gmail.com>
 Nick Minkyu Lee <mknicklee@protonmail.com> fivemok <9394929+fivemok@users.noreply.github.com>
 Nikita Zamuldinov <59732804+NIK-TIGER-BILL@users.noreply.github.com>
 Nikita Zamuldinov <59732804+NIK-TIGER-BILL@users.noreply.github.com> <NIK-TIGER-BILL@users.noreply.github.com>
+Nishidh <xnishidh.codes@gmail.com>
 Nyakku Shigure <sigure.qaq@gmail.com>
 Norwid Behrnd <nbehrnd@yahoo.com>
 Norwid Behrnd <nbehrnd@yahoo.com> <nbehrnd@users.noreply.github.com>

--- a/doc/changelog/2.5.0-changelog.rst
+++ b/doc/changelog/2.5.0-changelog.rst
@@ -1,8 +1,9 @@
+Generating change log for range v2.5.0.dev0..maintenance/2.5.x
 
 Contributors
 ============
 
-A total of 129 people contributed to this release.  People with a "+" by their
+A total of 132 people contributed to this release.  People with a "+" by their
 names contributed a patch for the first time.
 
 * !EarlMilktea
@@ -46,6 +47,7 @@ names contributed a patch for the first time.
 * Daniel Haag +
 * Daniel Koronthály +
 * Daniel Tang +
+* Daniele Parmeggiani +
 * David Cortes
 * David Woods +
 * Davis Bennett +
@@ -85,6 +87,7 @@ names contributed a patch for the first time.
 * Maanas Arora
 * Maarten Baert +
 * Majianhan +
+* Manuel Jacob +
 * Marco Edward Gorelli
 * Marten van Kerkwijk
 * Matthias Bussonnier
@@ -101,6 +104,7 @@ names contributed a patch for the first time.
 * Nathan Legendre +
 * Nathaniel Starkman +
 * Nikita Zamuldinov +
+* Nishidh +
 * Noa Levi +
 * Peter Hawkins
 * Pey Lian Lim
@@ -138,7 +142,7 @@ names contributed a patch for the first time.
 Pull requests merged
 ====================
 
-A total of 528 pull requests were merged for this release.
+A total of 555 pull requests were merged for this release.
 
 * `#25103 <https://github.com/numpy/numpy/pull/25103>`__: MAINT: Use ``spin lint`` in CI
 * `#26574 <https://github.com/numpy/numpy/pull/26574>`__: CI: replace pkgconfig-lite from Chocolatey with ``pip install``...
@@ -668,4 +672,31 @@ A total of 528 pull requests were merged for this release.
 * `#31537 <https://github.com/numpy/numpy/pull/31537>`__: BUG: Avoid heap buffer overflow for stringdtype searchsorted
 * `#31538 <https://github.com/numpy/numpy/pull/31538>`__: BUG: Avoid hwcap for RVV version detection due to faulty v0.7/v1.0...
 * `#31539 <https://github.com/numpy/numpy/pull/31539>`__: BLD: fix build failure with PYTHONSAFEPATH=1 (#30731)
+* `#31548 <https://github.com/numpy/numpy/pull/31548>`__: REL: Prepare for the NumPy 2.5.0rc1 release.
+* `#31569 <https://github.com/numpy/numpy/pull/31569>`__: DOC: add Python-level parallelism tips section (#30820)
+* `#31570 <https://github.com/numpy/numpy/pull/31570>`__: TYP: Annotate untyped attributes and dunder methods (#31550)
+* `#31571 <https://github.com/numpy/numpy/pull/31571>`__: BUG,TST: Fix condition for whether long double is “IBM double...
+* `#31572 <https://github.com/numpy/numpy/pull/31572>`__: BUG: Fix order of real and imaginary NaNs when sorting complex...
+* `#31629 <https://github.com/numpy/numpy/pull/31629>`__: TYP: Fix ``ma.[as[any]]array`` fallback overloads (#31482)
+* `#31630 <https://github.com/numpy/numpy/pull/31630>`__: BUG: For new-style wrapped legacy dtypes use old array printing...
+* `#31631 <https://github.com/numpy/numpy/pull/31631>`__: BUG: fix incorrect alignment handling and error handling in several...
+* `#31632 <https://github.com/numpy/numpy/pull/31632>`__: TST: Use pytest.warns as ignore filters+suppress_warnings interfere...
+* `#31634 <https://github.com/numpy/numpy/pull/31634>`__: BUG: fix suppress_warnings when context-aware warnings is on...
+* `#31636 <https://github.com/numpy/numpy/pull/31636>`__: MAINT, TST: Pin pytest to 9.0.3
+* `#31646 <https://github.com/numpy/numpy/pull/31646>`__: TST, TYP: Pin to windows-2022 for typecheck on windows.
+* `#31668 <https://github.com/numpy/numpy/pull/31668>`__: MAINT: Update pytest pins to 9.1.0
+* `#31671 <https://github.com/numpy/numpy/pull/31671>`__: TST: add 3.15t win32 CI and fix issues seen in that build (#31607)
+* `#31672 <https://github.com/numpy/numpy/pull/31672>`__: BUG: raise error when casting from StringDType to longdouble...
+* `#31673 <https://github.com/numpy/numpy/pull/31673>`__: BUG: NpyString comparison should use memcmp instead of strncmp...
+* `#31674 <https://github.com/numpy/numpy/pull/31674>`__: BUG: fix casts from StringDType to complex float (#31663)
+* `#31675 <https://github.com/numpy/numpy/pull/31675>`__: BUG: fix StringDType embedded and trailing NULL handling in several...
+* `#31679 <https://github.com/numpy/numpy/pull/31679>`__: DOC: Prevent arrow ligatures in generalized ufunc signatures
+* `#31683 <https://github.com/numpy/numpy/pull/31683>`__: MAINT: Clean up use for PyObject_\* APIs when PyMem_\* would...
+* `#31684 <https://github.com/numpy/numpy/pull/31684>`__: TST: Avoid sctypeDict in tests as e.g. ml_dtypes may mutate it...
+* `#31685 <https://github.com/numpy/numpy/pull/31685>`__: BUG: Use ``auxdata`` in (arg)sort ``strided_loop``\ s (#31670)
+* `#31697 <https://github.com/numpy/numpy/pull/31697>`__: MAINT: Avoid compiling uv for loongarch
+* `#31698 <https://github.com/numpy/numpy/pull/31698>`__: MAINT: Fix emscripten wheel build.
+* `#31700 <https://github.com/numpy/numpy/pull/31700>`__: MAINT: Bump pypa/cibuildwheel from 3.4.1 to 4.1.0
+* `#31703 <https://github.com/numpy/numpy/pull/31703>`__: BUG: fix StringDType distinct-allocator bugs and add tests (#31609)
+* `#31704 <https://github.com/numpy/numpy/pull/31704>`__: MAINT: update openblas to 0.3.33.112.0 (#31649)
 

--- a/doc/source/release/2.5.0-notes.rst
+++ b/doc/source/release/2.5.0-notes.rst
@@ -4,11 +4,12 @@
 NumPy 2.5.0 Release Notes
 ==========================
 
-Numpy 3.5.0 is a transitional release. It drops support for Python 3.11,
+Numpy 2.5.0 is a transitional release. It drops support for Python 3.11,
 marking the end of distutils, and expires a large number of deprecations made
 in the 2.0.x release. It also improves free threading and brings sorting into
 compliance with the array-api standard with the addition of descending sorts.
-Python 3.15 will be supported when it is released.
+There is also a fair amount of preparation for Python 3.15, which will be
+supported starting with the first rc.
 
 This release supports Python versions 3.12-3.14.
 
@@ -19,9 +20,9 @@ Highlights
 * Distutils has been removed,
 * Many expired deprecations, see below,
 * Many new deprecations, see below,
-* Many static typing improvements.
+* Many static typing improvements,
 * Improved support for free threading,
-* Support for descending sorts,
+* Support for descending sorts.
 
 See New Features below for other additions.
 
@@ -29,7 +30,8 @@ See New Features below for other additions.
 Deprecations
 ============
 
-* ``numpy.char.chararray`` is deprecated. Use an ``ndarray`` with a string or bytes dtype instead.
+* ``numpy.char.chararray`` is deprecated. Use an ``ndarray`` with a string or
+  bytes dtype instead.
 
   (`gh-30605 <https://github.com/numpy/numpy/pull/30605>`__)
 
@@ -55,10 +57,9 @@ Deprecations
 
 * Setting the ``shape`` attribute is deprecated because mutating an array is
   unsafe if an array is shared, especially by multiple threads.  As an
-  alternative, you can create a new view via ``np.reshape`` or
-  ``np.ndarray.reshape``. For example: ``x = np.arange(15); x = np.reshape(x,
-  (3, 5))``.  To ensure no copy is made from the data, one can use
-  ``np.reshape(..., copy=False)``.
+  alternative, you can create a new view via ``np.reshape`` or ``np.ndarray.reshape``.
+  For example: ``x = np.arange(15); x = np.reshape(x, (3, 5))``. To ensure
+  that no copy is made from the data, one can use ``np.reshape(..., copy=False)``.
 
   While setting the shape on an array is discouraged, for cases where it is
   difficult to work around, e.g., in ``__array_finalize__``, it is possible
@@ -597,8 +598,9 @@ arguments.
 
 ``numpy.triu_indices`` now accepts ``unsigned integers``
 --------------------------------------------------------
-``numpy.triu_indices`` previously used to error in some cases when ``unsigned
-integers`` were given as arguments. Now, it accepts them in all cases.
+``numpy.triu_indices`` previously used to error in some cases when
+``unsigned integers`` were given as arguments. Now, it accepts them in all
+cases.
 
 (`gh-30869 <https://github.com/numpy/numpy/pull/30869>`__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 
 [project]
 name = "numpy"
-version = "2.5.0rc1"
+version = "2.5.0"
 description = "Fundamental package for array computing in Python"
 authors = [{name = "Travis E. Oliphant et al."}]
 maintainers = [


### PR DESCRIPTION
- Update 2.5.0-changelog.rst
- Update 2.5.0-notes.rst
- Update .mailmap
- Update pyproject.toml

AI helped with .mailmap entries.

[skip actions] [skip azp] 