### PR TITLE
MAINT/TYP: bump ``mypy`` to ``2.1.0``

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - pytest-xdist
   - hypothesis
   # For type annotations
-  - mypy==1.20.2
+  - mypy==2.1.0
   - orjson # makes mypy faster
   # For building docs
   - sphinx>=4.5.0

--- a/requirements/typing_requirements.txt
+++ b/requirements/typing_requirements.txt
@@ -2,5 +2,5 @@
 
 -r test_requirements.txt
 
-mypy==1.20.2
+mypy==2.1.0
 pyrefly==1.0.0


### PR DESCRIPTION
It seems like none of the behavioral mypy changes affect numpy (locally, at least), but there have been quite a lot of performance improvements according to the [relnotes](https://mypy.readthedocs.io/en/stable/changelog.html#mypy-2-1), which is always welcome.

No AI