### PR TITLE
CI: fix new ``cython-lint`` errors

### DIFF
--- a/numpy/random/_common.pyx
+++ b/numpy/random/_common.pyx
@@ -30,14 +30,14 @@ cdef uint64_t MAXSIZE = <uint64_t>sys.maxsize
 
 cdef object benchmark(bitgen_t *bitgen, object lock, Py_ssize_t cnt, object method):
     """Benchmark command used by BitGenerator"""
-    cdef Py_ssize_t i
+    cdef Py_ssize_t _i
     if method=='uint64':
         with lock, nogil:
-            for i in range(cnt):
+            for _i in range(cnt):
                 bitgen.next_uint64(bitgen.state)
     elif method=='double':
         with lock, nogil:
-            for i in range(cnt):
+            for _i in range(cnt):
                 bitgen.next_double(bitgen.state)
     else:
         raise ValueError('Unknown method')
@@ -87,7 +87,7 @@ cdef object random_raw(bitgen_t *bitgen, object lock, object size, object output
             return None
         n = np.asarray(size).sum()
         with lock, nogil:
-            for i in range(n):
+            for _i in range(n):
                 bitgen.next_raw(bitgen.state)
         return None
 
@@ -184,7 +184,7 @@ cdef double kahan_sum(double *darr, np.npy_intp n) noexcept:
         Address of values to sum
     n : intp
         Length of d
-    
+
     Returns
     -------
     float
@@ -253,7 +253,7 @@ cdef validate_output_shape(iter_shape, np.ndarray output):
 cdef check_output(object out, object dtype, object size, bint require_c_array):
     """
     Check user-supplied output array properties and shape
-    
+
     Parameters
     ----------
     out : {ndarray, None}
@@ -761,7 +761,7 @@ cdef object discrete_broadcast_di(void *func, void *state, object size, object l
     cdef np.ndarray randoms
     cdef np.broadcast it
     cdef random_uint_di f = (<random_uint_di>func)
-    cdef np.npy_intp i, n
+    cdef np.npy_intp _i, n
 
     if a_constraint != CONS_NONE:
         check_array_constraint(a_arr, a_name, a_constraint)
@@ -781,7 +781,7 @@ cdef object discrete_broadcast_di(void *func, void *state, object size, object l
     validate_output_shape(it.shape, randoms)
 
     with lock, nogil:
-        for i in range(n):
+        for _i in range(n):
             a_val = (<double*>np.PyArray_MultiIter_DATA(it, 1))[0]
             b_val = (<int64_t*>np.PyArray_MultiIter_DATA(it, 2))[0]
             (<int64_t*>np.PyArray_MultiIter_DATA(it, 0))[0] = f(state, a_val, b_val)

--- a/numpy/random/_generator.pyx
+++ b/numpy/random/_generator.pyx
@@ -3074,7 +3074,7 @@ cdef class Generator:
         cdef double _dp = 0
         cdef int64_t _in = 0
         cdef bint is_scalar = True
-        cdef np.npy_intp i, cnt
+        cdef np.npy_intp _i, i, cnt
         cdef np.ndarray randoms
         cdef np.int64_t *randoms_data
         cdef np.broadcast it
@@ -3098,7 +3098,7 @@ cdef class Generator:
             it = np.PyArray_MultiIterNew3(randoms, p_arr, n_arr)
             validate_output_shape(it.shape, randoms)
             with self.lock, nogil:
-                for i in range(cnt):
+                for _i in range(cnt):
                     _dp = (<double*>np.PyArray_MultiIter_DATA(it, 1))[0]
                     _in = (<int64_t*>np.PyArray_MultiIter_DATA(it, 2))[0]
                     (<int64_t*>np.PyArray_MultiIter_DATA(it, 0))[0] = random_binomial(&self._bitgen, _dp, _in, &self._binomial)
@@ -4089,7 +4089,7 @@ cdef class Generator:
 
         """
 
-        cdef np.npy_intp d, i, sz, offset, pi
+        cdef np.npy_intp d, _i, sz, offset, pi
         cdef np.ndarray parr, mnarr, on, temp_arr
         cdef double *pix
         cdef int ndim
@@ -4170,7 +4170,7 @@ cdef class Generator:
             offset = 0
             sz = it.size
             with self.lock, nogil:
-                for i in range(sz):
+                for _i in range(sz):
                     ni = (<int64_t*>np.PyArray_MultiIter_DATA(it, 0))[0]
                     pi = (<np.npy_intp*>np.PyArray_MultiIter_DATA(it, 1))[0]
                     random_multinomial(&self._bitgen, ni, &mnix[offset], &pix[pi], d, &self._binomial)
@@ -4194,7 +4194,7 @@ cdef class Generator:
         check_constraint(ni, 'n', CONS_NON_NEGATIVE)
         offset = 0
         with self.lock, nogil:
-            for i in range(sz // d):
+            for _i in range(sz // d):
                 random_multinomial(&self._bitgen, ni, &mnix[offset], pix, d, &self._binomial)
                 offset += d
 

--- a/numpy/random/_mt19937.pyx
+++ b/numpy/random/_mt19937.pyx
@@ -205,8 +205,8 @@ cdef class MT19937(BitGenerator):
         iter : integer, positive
             Number of times to jump the state of the rng.
         """
-        cdef np.npy_intp i
-        for i in range(iter):
+        cdef np.npy_intp _i
+        for _i in range(iter):
             mt19937_jump(&self.rng_state)
 
 

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -3464,7 +3464,7 @@ cdef class RandomState:
         cdef double _dp = 0
         cdef np.npy_intp _in = 0
         cdef bint is_scalar = True
-        cdef np.npy_intp i, cnt
+        cdef np.npy_intp _i, i, cnt
         cdef np.ndarray randoms
         cdef long *randoms_data
         cdef np.broadcast it
@@ -3488,7 +3488,7 @@ cdef class RandomState:
             it = np.PyArray_MultiIterNew3(randoms, p_arr, n_arr)
             validate_output_shape(it.shape, randoms)
             with self.lock, nogil:
-                for i in range(cnt):
+                for _i in range(cnt):
                     _dp = (<double*>np.PyArray_MultiIter_DATA(it, 1))[0]
                     _in = (<np.npy_intp*>np.PyArray_MultiIter_DATA(it, 2))[0]
                     (<long*>np.PyArray_MultiIter_DATA(it, 0))[0] = \
@@ -4365,7 +4365,7 @@ cdef class RandomState:
         ValueError: pvals < 0, pvals > 1 or pvals contains NaNs
 
         """
-        cdef np.npy_intp d, i, sz, offset, niter
+        cdef np.npy_intp d, _i, sz, offset, niter
         cdef np.ndarray parr, mnarr
         cdef double *pix
         cdef long *mnix
@@ -4411,7 +4411,7 @@ cdef class RandomState:
         # gh-20483: Avoids divide by 0
         niter = sz // d if d else 0
         with self.lock, nogil:
-            for i in range(niter):
+            for _i in range(niter):
                 legacy_random_multinomial(&self._bitgen, ni, &mnix[offset], pix, d, &self._binomial)
                 offset += d
 


### PR DESCRIPTION
Since the new cython-lint release (https://github.com/MarcoGorelli/cython-lint/releases/tag/v0.21.0) from yesterday, CI started failing. See e.g. https://github.com/numpy/numpy/actions/runs/27959511404/job/82736864889?pr=31710

This fixes it by prefixing the unused loop variables with `_`, as suggested in the error messages.

No AI