### PR TITLE
TST: xfail multithreaded BLAS test more generously

### DIFF
--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -95,12 +95,19 @@ def _detected_blas():
 
 
 def _openblas_predates_gemm_fix(name, version):
+    name = (name or '').lower().strip()
+    # Assume failures using wrapper BLAS packages are buggy OpenBLAS.
+    # This may ignore a genuine bug but we can't do anything more fine-grained.
+    if name in ('blas', 'cblas', 'flexiblas', 'unknown', ''):
+        return True
     if 'openblas' not in name:
+        # e.g. MKL, accelerate, where we'd want to know about a new failure
         return False
     try:
         parsed = tuple(int(p) for p in version.split('.'))
     except ValueError:
-        return False
+        # unparseable OpenBLAS version so assume an old buggy version
+        return True
     return parsed < (0, 3, 33, 112)
 
 
@@ -143,7 +150,8 @@ def test_blas_gemm_thread_safety():
     if mismatches and _openblas_predates_gemm_fix(blas_name, blas_version):
         pytest.xfail(
             f"OpenBLAS version ({blas_version}) predates first OpenBLAS "
-            "version with a fix (0.3.33.112)"
+            "version with a fix (0.3.33.112) or BLAS metadata is not "
+            "sufficient to identify the BLAS implementation."
         )
 
     assert mismatches == 0, (


### PR DESCRIPTION
Fixes #31708.

xfail the test rather than noisily failing when we can't determine the BLAS library, either because we detect the netlib fallback version due to lack of threadpoolctl or because of a wrapper library like flexiblas.

This probably makes the test less useful for detecting buggy BLAS implementations but OpenBLAS is so ubiquitous it's going to be very noisy to make this test fail as often as I had written it originally.