### PR TITLE
TYP: specialized unary ``inexact | object_`` endo-ufuncs

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -390,6 +390,35 @@ from numpy._core.shape_base import (
     vstack,
     unstack,
 )
+from numpy._core.umath import (
+    arccos,
+    arccos as acos,
+    arccosh,
+    arccosh as acosh,
+    arcsin,
+    arcsin as asin,
+    arcsinh,
+    arcsinh as asinh,
+    arctan,
+    arctan as atan,
+    arctanh,
+    arctanh as atanh,
+    cos,
+    cosh,
+    exp,
+    exp2,
+    expm1,
+    log,
+    log10,
+    log1p,
+    log2,
+    rint,
+    sin,
+    sinh,
+    sqrt,
+    tan,
+    tanh,
+)
 
 from ._expired_attrs_2_0 import __expired_attributes__ as __expired_attributes__
 from ._globals import _CopyMode as _CopyMode
@@ -7545,13 +7574,7 @@ class ufunc:
 # Parameters: `__name__`, `ntypes` and `identity`
 absolute: _UFunc_Nin1_Nout1[L["absolute"], L[20], None]
 add: _UFunc_Nin2_Nout1[L["add"], L[22], L[0]]
-arccos: _UFunc_Nin1_Nout1[L["arccos"], L[8], None]
-arccosh: _UFunc_Nin1_Nout1[L["arccosh"], L[8], None]
-arcsin: _UFunc_Nin1_Nout1[L["arcsin"], L[8], None]
-arcsinh: _UFunc_Nin1_Nout1[L["arcsinh"], L[8], None]
 arctan2: _UFunc_Nin2_Nout1[L["arctan2"], L[5], None]
-arctan: _UFunc_Nin1_Nout1[L["arctan"], L[8], None]
-arctanh: _UFunc_Nin1_Nout1[L["arctanh"], L[8], None]
 bitwise_and: _UFunc_Nin2_Nout1[L["bitwise_and"], L[12], L[-1]]
 bitwise_count: _UFunc_Nin1_Nout1[L["bitwise_count"], L[11], None]
 bitwise_or: _UFunc_Nin2_Nout1[L["bitwise_or"], L[12], L[0]]
@@ -7560,16 +7583,11 @@ cbrt: _UFunc_Nin1_Nout1[L["cbrt"], L[5], None]
 ceil: _UFunc_Nin1_Nout1[L["ceil"], L[7], None]
 conjugate: _UFunc_Nin1_Nout1[L["conjugate"], L[18], None]
 copysign: _UFunc_Nin2_Nout1[L["copysign"], L[4], None]
-cos: _UFunc_Nin1_Nout1[L["cos"], L[9], None]
-cosh: _UFunc_Nin1_Nout1[L["cosh"], L[8], None]
 deg2rad: _UFunc_Nin1_Nout1[L["deg2rad"], L[5], None]
 degrees: _UFunc_Nin1_Nout1[L["degrees"], L[5], None]
 divide: _UFunc_Nin2_Nout1[L["divide"], L[11], None]
 divmod: _UFunc_Nin2_Nout2[L["divmod"], L[15], None]
 equal: _UFunc_Nin2_Nout1[L["equal"], L[23], None]
-exp2: _UFunc_Nin1_Nout1[L["exp2"], L[8], None]
-exp: _UFunc_Nin1_Nout1[L["exp"], L[10], None]
-expm1: _UFunc_Nin1_Nout1[L["expm1"], L[8], None]
 fabs: _UFunc_Nin1_Nout1[L["fabs"], L[5], None]
 float_power: _UFunc_Nin2_Nout1[L["float_power"], L[4], None]
 floor: _UFunc_Nin1_Nout1[L["floor"], L[7], None]
@@ -7593,10 +7611,6 @@ ldexp: _UFunc_Nin2_Nout1[L["ldexp"], L[8], None]
 left_shift: _UFunc_Nin2_Nout1[L["left_shift"], L[11], None]
 less: _UFunc_Nin2_Nout1[L["less"], L[23], None]
 less_equal: _UFunc_Nin2_Nout1[L["less_equal"], L[23], None]
-log10: _UFunc_Nin1_Nout1[L["log10"], L[8], None]
-log1p: _UFunc_Nin1_Nout1[L["log1p"], L[8], None]
-log2: _UFunc_Nin1_Nout1[L["log2"], L[8], None]
-log: _UFunc_Nin1_Nout1[L["log"], L[10], None]
 logaddexp2: _UFunc_Nin2_Nout1[L["logaddexp2"], L[4], float]
 logaddexp: _UFunc_Nin2_Nout1[L["logaddexp"], L[4], float]
 logical_and: _UFunc_Nin2_Nout1[L["logical_and"], L[20], L[True]]
@@ -7619,28 +7633,16 @@ radians: _UFunc_Nin1_Nout1[L["radians"], L[5], None]
 reciprocal: _UFunc_Nin1_Nout1[L["reciprocal"], L[18], None]
 remainder: _UFunc_Nin2_Nout1[L["remainder"], L[16], None]
 right_shift: _UFunc_Nin2_Nout1[L["right_shift"], L[11], None]
-rint: _UFunc_Nin1_Nout1[L["rint"], L[10], None]
 sign: _UFunc_Nin1_Nout1[L["sign"], L[19], None]
 signbit: _UFunc_Nin1_Nout1[L["signbit"], L[4], None]
-sin: _UFunc_Nin1_Nout1[L["sin"], L[9], None]
-sinh: _UFunc_Nin1_Nout1[L["sinh"], L[8], None]
 spacing: _UFunc_Nin1_Nout1[L["spacing"], L[4], None]
-sqrt: _UFunc_Nin1_Nout1[L["sqrt"], L[10], None]
 square: _UFunc_Nin1_Nout1[L["square"], L[18], None]
 subtract: _UFunc_Nin2_Nout1[L["subtract"], L[21], None]
-tan: _UFunc_Nin1_Nout1[L["tan"], L[8], None]
-tanh: _UFunc_Nin1_Nout1[L["tanh"], L[8], None]
 trunc: _UFunc_Nin1_Nout1[L["trunc"], L[7], None]
 vecdot: _GUFunc_Nin2_Nout1[L["vecdot"], L[19], None, L["(n),(n)->()"]]
 vecmat: _GUFunc_Nin2_Nout1[L["vecmat"], L[19], None, L["(n),(n,m)->(m)"]]
 
 abs = absolute
-acos = arccos
-acosh = arccosh
-asin = arcsin
-asinh = arcsinh
-atan = arctan
-atanh = arctanh
 atan2 = arctan2
 concat = concatenate
 bitwise_left_shift = left_shift

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -1,19 +1,30 @@
 import contextvars
 from _typeshed import SupportsWrite
-from collections.abc import Callable
-from typing import Any, Final, Literal, TypedDict, Unpack, type_check_only
+from collections.abc import Callable, Sequence
+from types import EllipsisType
+from typing import (
+    Any,
+    Final,
+    Literal,
+    Never,
+    Protocol,
+    Self,
+    TypedDict,
+    Unpack,
+    overload,
+    override,
+    type_check_only,
+)
 from typing_extensions import CapsuleType
 
+import numpy as np
+import numpy.typing as npt
 from numpy import (
+    _CastingKind,
+    _OrderKACF,
     absolute,
     add,
-    arccos,
-    arccosh,
-    arcsin,
-    arcsinh,
-    arctan,
     arctan2,
-    arctanh,
     bitwise_and,
     bitwise_count,
     bitwise_or,
@@ -23,8 +34,6 @@ from numpy import (
     conj,
     conjugate,
     copysign,
-    cos,
-    cosh,
     deg2rad,
     degrees,
     divide,
@@ -32,9 +41,6 @@ from numpy import (
     e,
     equal,
     euler_gamma,
-    exp,
-    exp2,
-    expm1,
     fabs,
     float_power,
     floor,
@@ -59,10 +65,6 @@ from numpy import (
     left_shift,
     less,
     less_equal,
-    log,
-    log1p,
-    log2,
-    log10,
     logaddexp,
     logaddexp2,
     logical_and,
@@ -87,21 +89,24 @@ from numpy import (
     reciprocal,
     remainder,
     right_shift,
-    rint,
     sign,
     signbit,
-    sin,
-    sinh,
     spacing,
-    sqrt,
     square,
     subtract,
-    tan,
-    tanh,
     true_divide,
     trunc,
     vecdot,
     vecmat,
+)
+from numpy._typing import (
+    _ArrayLikeBool_co,
+    _ArrayLikeInt,
+    _ArrayLikeNumber_co,
+    _DTypeLike,
+    _NestedSequence,
+    _NumberLike_co,
+    _Shape,
 )
 
 __all__ = [
@@ -206,6 +211,10 @@ __all__ = [
 
 ###
 
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
+type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
+
 type _ErrKind = Literal["ignore", "warn", "raise", "call", "print", "log"]
 type _ErrCall = Callable[[str, int], Any] | SupportsWrite[str]
 
@@ -218,6 +227,323 @@ class _ExtOjbDict(TypedDict, total=False):
     call: _ErrCall | None
     bufsize: int
 
+type _Signature1 = tuple[str | None, str | None] | str
+
+@type_check_only
+class _CanUfuncCall1[OutT](Protocol):
+    def __array_ufunc__(self, ufunc: np.ufunc, method: Literal["__call__"], /, *args: Any, **kwargs: Any) -> OutT: ...
+
+@type_check_only
+class _CanUfuncAt1[IxT, OutT](Protocol):
+    def __array_ufunc__(self, ufunc: np.ufunc, method: Literal["at"], a: Self, indices: IxT, /) -> OutT: ...
+
+###
+# ufunc specializations
+
+# NOTE: ignoring LSP errors here is harmless, because ufuncs are final at runtime
+# mypy: disable-error-code=override
+# pyright: reportIncompatibleMethodOverride=false
+
+# efdgFDGO => efdgFDGO
+@type_check_only
+class _ufunc_11_fco(np.ufunc):  # type: ignore[misc]
+    @property
+    @override
+    def identity(self) -> None: ...
+    @property
+    @override
+    def nin(self) -> Literal[1]: ...
+    @property
+    @override
+    def nout(self) -> Literal[1]: ...
+    @property
+    @override
+    def nargs(self) -> Literal[2]: ...
+    @property
+    @override
+    def signature(self) -> None: ...
+
+    #
+    @override
+    @overload  # known shape, known scalar/array
+    def __call__[T: np.inexact | npt.NDArray[np.inexact | np.object_]](
+        self,
+        x: T,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> T: ...
+    @overload  # Nd, +f64
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[np.integer | np.bool]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+    @overload  # scalar, float | +f64
+    def __call__(
+        self,
+        x: float | np.integer | np.bool,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> np.float64: ...
+    @overload  # 1d, +float
+    def __call__(
+        self,
+        x: Sequence[float],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> _Array1D[np.float64]: ...
+    @overload  # 1d, ~complex
+    def __call__(
+        self,
+        x: list[complex],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> _Array1D[np.complex128]: ...
+    @overload  # 2d, +float
+    def __call__(
+        self,
+        x: Sequence[Sequence[float]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> _Array2D[np.float64]: ...
+    @overload  # 2d, ~complex
+    def __call__(
+        self,
+        x: Sequence[list[complex]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> _Array2D[np.complex128]: ...
+    @overload  # scalar, +complex  (overlaps with float)
+    def __call__(
+        self,
+        x: complex,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> np.complex128 | Any: ...
+    @overload  # scalar, dtype=<known>
+    def __call__[ScalarT: np.inexact](
+        self,
+        x: _NumberLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: _DTypeLike[ScalarT],
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> ScalarT: ...
+    @overload  # Nd, dtype=<known>
+    def __call__[ShapeT: _Shape, ScalarT: np.inexact](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[np.number | np.bool | np.object_]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    @overload  # Nd, dtype=<unknown>
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[np.number | np.bool | np.object_]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> np.ndarray[ShapeT]: ...
+    @overload  # Nd, dtype=<known>
+    def __call__[ScalarT: np.inexact | np.object_](
+        self,
+        x: _NestedSequence[complex],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # Nd, dtype=<unknown>
+    def __call__(
+        self,
+        x: _NestedSequence[complex],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> np.ndarray: ...
+    @overload  # ?d, dtype=<known>
+    def __call__[ScalarT: np.inexact | np.object_](
+        self,
+        x: _ArrayLikeNumber_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> npt.NDArray[ScalarT] | Any: ...  # `| Any` because of overlap
+    @overload  # ?d, dtype=<unknown>
+    def __call__(
+        self,
+        x: _ArrayLikeNumber_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> Any: ...
+    @overload  # out=<given>
+    def __call__[OutT: np.ndarray](
+        self,
+        x: _ArrayLikeNumber_co,
+        /,
+        out: OutT,
+        *,
+        dtype: npt.DTypeLike | None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> OutT: ...
+    @overload  # out=<given>
+    def __call__[OutT](
+        self,
+        x: _CanUfuncCall1[OutT],
+        /,
+        out: object | None = None,
+        *,
+        dtype: npt.DTypeLike | None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> OutT: ...
+
+    #
+    @override
+    @overload
+    def at(self, a: npt.NDArray[np.inexact | np.object_], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
+    @overload
+    def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
+
+    #
+    @override
+    def accumulate(self, array: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
+    @override
+    def reduce(self, array: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
+    @override
+    def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    @override
+    def outer(self, A: Never, B: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
+
+arccos: Final[_ufunc_11_fco] = ...
+arccosh: Final[_ufunc_11_fco] = ...
+arcsin: Final[_ufunc_11_fco] = ...
+arcsinh: Final[_ufunc_11_fco] = ...
+arctan: Final[_ufunc_11_fco] = ...
+arctanh: Final[_ufunc_11_fco] = ...
+cos: Final[_ufunc_11_fco] = ...
+cosh: Final[_ufunc_11_fco] = ...
+exp: Final[_ufunc_11_fco] = ...
+exp2: Final[_ufunc_11_fco] = ...
+expm1: Final[_ufunc_11_fco] = ...
+log: Final[_ufunc_11_fco] = ...
+log10: Final[_ufunc_11_fco] = ...
+log1p: Final[_ufunc_11_fco] = ...
+log2: Final[_ufunc_11_fco] = ...
+rint: Final[_ufunc_11_fco] = ...
+sin: Final[_ufunc_11_fco] = ...
+sinh: Final[_ufunc_11_fco] = ...
+sqrt: Final[_ufunc_11_fco] = ...
+tan: Final[_ufunc_11_fco] = ...
+tanh: Final[_ufunc_11_fco] = ...
+
+###
 # re-exports from `_core._multiarray_umath` that are used by `_core._ufunc_config`
 
 NAN: Final[float] = float("nan")

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -140,3 +140,69 @@ def test_divmod_at_invalid() -> None:
     assert_type(np.divmod.at(AR_f8, i8, AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_matmul_at_invalid() -> None:
     assert_type(np.matmul.at(AR_f8, i8, AR_f8), NoReturn)  # type: ignore[arg-type]
+
+###
+
+_py_i_0d: int
+_py_i_1d: list[int]
+_py_i_2d: list[list[int]]
+_py_f_0d: float
+_py_f_1d: list[float]
+_py_f_2d: list[list[float]]
+_py_c_0d: complex
+_py_c_1d: list[complex]
+_py_c_2d: list[list[complex]]
+
+_i16_0d: np.int64
+_i16_1d: np.ndarray[tuple[int], np.dtype[np.int16]]
+_i16_2d: np.ndarray[tuple[int, int], np.dtype[np.int16]]
+_i16_nd: npt.NDArray[np.int16]
+_f32_0d: np.float32
+_f32_1d: np.ndarray[tuple[int], np.dtype[np.float32]]
+_f32_2d: np.ndarray[tuple[int, int], np.dtype[np.float32]]
+_f32_nd: npt.NDArray[np.float32]
+_c64_0d: np.complex64
+_c64_1d: np.ndarray[tuple[int], np.dtype[np.complex64]]
+_c64_2d: np.ndarray[tuple[int, int], np.dtype[np.complex64]]
+_c64_nd: npt.NDArray[np.complex64]
+_obj_1d: np.ndarray[tuple[int], np.dtype[np.object_]]
+_obj_2d: np.ndarray[tuple[int, int], np.dtype[np.object_]]
+_obj_nd: npt.NDArray[np.object_]
+
+# _ufunc_11_fco
+
+assert_type(np.sin(_py_i_0d), np.float64)
+assert_type(np.sin(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.sin(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.sin(_py_f_0d), np.float64)
+assert_type(np.sin(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.sin(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.sin(_py_c_0d), np.complex128 | Any)  # `complex` overlaps with `float`, hence the `Any`
+assert_type(np.sin(_py_c_1d), np.ndarray[tuple[int], np.dtype[np.complex128]])
+assert_type(np.sin(_py_c_2d), np.ndarray[tuple[int, int], np.dtype[np.complex128]])
+
+assert_type(np.sin(_i16_0d), np.float64)
+assert_type(np.sin(_i16_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.sin(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.sin(_i16_nd), npt.NDArray[np.float64])
+assert_type(np.sin(_f32_0d), np.float32)
+assert_type(np.sin(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.sin(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.sin(_f32_nd), npt.NDArray[np.float32])
+assert_type(np.sin(_c64_0d), np.complex64)
+assert_type(np.sin(_c64_1d), np.ndarray[tuple[int], np.dtype[np.complex64]])
+assert_type(np.sin(_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+assert_type(np.sin(_c64_nd), npt.NDArray[np.complex64])
+assert_type(np.sin(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
+assert_type(np.sin(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.sin(_obj_nd), npt.NDArray[np.object_])
+
+assert_type(np.sin(_py_i_0d, dtype=np.float32), np.float32)
+assert_type(np.sin(_py_i_1d, dtype=np.float32), npt.NDArray[np.float32])
+assert_type(np.sin(_i16_2d, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+
+assert_type(np.sin(_py_i_0d, dtype="f4"), Any)
+assert_type(np.sin(_py_i_1d, dtype="f4"), np.ndarray)
+assert_type(np.sin(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
+
+assert_type(np.sin(_py_i_2d, out=_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])


### PR DESCRIPTION
This is the first in a series of PRs where I'll be specializing individual (groups of) ufuncs so that they have proper typing support. Because currently, all ufuncs are (roughly speaking) annotated in the same "one size first all" way, causing all shape-typing and dtype information to be lost when they're used. 

I think this is the biggest typing-hole in numpy at the moment, but unfortunately it's going to be a lot of work to specialize each of the ufuncs. 

After experimenting (a lot) with this, I found that this "type-check-only subtyping" approach is the way to go (most robust, maintainable, and minimal differences between type-checkers). I've successfully been using this approach in scipy-stubs to specialize the `scipy.special` ufuncs, and so far I've had no issues with it, so it's a battle tested approach in that sense.

This is the first batch of ufuncs that tackles the 21 (excluding aliases) unary ufuncs with floating/complex/object input- and output-types (which is what I meant with "endo-ufuncs" in the title). As can be seen in https://gist.github.com/jorenham/d977c63cc53ad4f00878d37ee42ab0e8, it's the largest group of ufuncs sharing the same signature, so that's why I started with these ones. 

---

**TLDR**-ish;

For those that prefer code over my ramblings (so probabably everyone here), here's a quick little demonstration (using `pyrefly check`):

<details>
<summary>code for repro</summary>

```py
from typing import reveal_type

import numpy as np

reveal_type(np.sin(3.14))
reveal_type(np.sin([1, 2, 3]))
reveal_type(np.sin(np.eye(3, dtype=np.float64)))
```

</details>

*Before:*

(shape-type and dtype don't propagate)

```
 INFO revealed type: Any [reveal-type]
 --> ufunc_demo.py:5:12
  |
5 | reveal_type(np.sin(3.14))
  |            --------------
  |
 INFO revealed type: ndarray [reveal-type]
 --> ufunc_demo.py:6:12
  |
6 | reveal_type(np.sin([1, 2, 3]))
  |            -------------------
  |
 INFO revealed type: ndarray [reveal-type]
 --> ufunc_demo.py:7:12
  |
7 | reveal_type(np.sin(np.eye(3, dtype=np.float64)))
  |            -------------------------------------
  |
```

*After:*

```
 INFO revealed type: float64 [reveal-type]
 --> ufunc_demo.py:5:12
  |
5 | reveal_type(np.sin(3.14))
  |            --------------
  |
 INFO revealed type: ndarray[tuple[int], dtype[float64]] [reveal-type]
 --> ufunc_demo.py:6:12
  |
6 | reveal_type(np.sin([1, 2, 3]))
  |            -------------------
  |
 INFO revealed type: ndarray[tuple[int, int], dtype[float64]] [reveal-type]
 --> ufunc_demo.py:7:12
  |
7 | reveal_type(np.sin(np.eye(3, dtype=np.float64)))
  |            -------------------------------------
  |
```

You'd see the same results if you'd replace `sin` here with any of

- `a[rc]cos`
- `a[rc]cosh`
- `a[rc]sin`
- `a[rc]sinh`
- `a[rc]tan`
- `a[rc]tanh`
- `cos`
- `cosh`
- `exp`
- `exp2`
- `expm1`
- `log`
- `log10`
- `log1p`
- `log2`
- `rint`
- `sin`
- `sinh`
- `sqrt`
- `tan`
- `tanh`

---

Fun fact: Before mypy 1.20, stubtest would get mad if you'd try to do this. But this was "fixed" (or improved, depending on how you look at it) in https://github.com/python/mypy/pull/20352 over half a year ago, with this specific use-case in mind. It's always nice to see a long-term plan come together :)

---

No AI (wouldn't have worked anyway).