### PR TITLE
DOC: mark k as optional in mask_indices docstring

### DIFF
--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -881,7 +881,7 @@ def mask_indices(n, mask_func, k=0):
         A function whose call signature is similar to that of `triu`, `tril`.
         That is, ``mask_func(x, k)`` returns a boolean array, shaped like `x`.
         `k` is an optional argument to the function.
-    k : scalar
+    k : scalar, optional
         An optional argument which is passed through to `mask_func`. Functions
         like `triu`, `tril` take a second argument that is interpreted as an
         offset.


### PR DESCRIPTION
Just a quick docstring cleanup for `mask_indices`.

The function signature defaults to `k=0`, and the description text explicitly calls `k` "an optional argument." However, the parameter type header was missing the standard NumPy `, optional` tag. 

This PR just updates `k : scalar` to `k : scalar, optional` to properly align the docstring with the actual function signature and NumPy's standard conventions.

**Quick verification:**
```python
>>> import numpy as np, inspect
>>> inspect.signature(np.mask_indices)
<Signature (n, mask_func, k=0)>
>>> np.mask_indices(3, np.triu)  # k omitted, works as expected
(array([0, 0, 0, 1, 1, 2]), array([0, 1, 2, 1, 2, 2]))
```

### AI Disclosure
An AI assistant was used to scan the NumPy docstrings for signature/docstring inconsistencies and to verify this specific finding. The diagnosis and final wording of this PR were reviewed manually.