### PR TITLE
MAINT: Rename subroutine for crackfortran tests

### DIFF
--- a/numpy/f2py/tests/src/crackfortran/gh23879.f90
+++ b/numpy/f2py/tests/src/crackfortran/gh23879.f90
@@ -5,14 +5,14 @@ module gh23879
 
  contains
 
-    subroutine foo(a, b)
+    subroutine foo42bar(a, b)
        integer, intent(in) :: a
        integer, intent(out) :: b
        b = a
        call bar(b)
     end subroutine
 
-    subroutine bar(x)
+    subroutine bar1337baz(x)
         integer, intent(inout) :: x
         x = 2*x
      end subroutine

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -66,7 +66,7 @@ class TestPublicPrivate:
         mod = crackfortran.crackfortran([str(fpath)])
         assert len(mod) == 1
         pyf = crackfortran.crack2fortran(mod)
-        assert 'bar' not in pyf
+        assert 'bar1337baz' not in pyf
 
 class TestModuleProcedure:
     def test_moduleOperators(self, tmp_path):


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

When importing `numpy` version 2.4.4 through Nix, its store path (path the package lives in) resulted in `/nix/store/r7i744barr4p4vr65110rh4n60w6p93i-python3.14-numpy-2.4.4`. This happens to contain the word `bar`: `...r7i744--bar--r4p4vr...`. Unfortunately, this makes one of the tests fail when building the Nix package locally. This is because the test checks for `bar` in a Fortran module(?) path, since that is a subroutine's name in that Fortran module.

By making the subroutine's name more unique, a collision with a Nix store path is less likely to happen.

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->
I work as a software engineering lead for @channable and this package is being imported as a dependency as well as for some calculations for our service. The reason for contributing to your project is to ensure the collision with a Nix store path outlined above is less likely to happen again.

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

No AI tools used.
