### PR TITLE
TST: use setup-sde instead of curl to get SDE binaries (#31727)

### DIFF
--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -1,8 +1,7 @@
 name: Linux SIMD tests
 
-# To update Intel SDE (not handled by Dependabot): download new version from
-# https://www.intel.com/content/www/us/en/developer/articles/tool/software-development-emulator.html
-# and update SDE_URL and SDE_SHA256 (curl -sL <url> | sha256sum)
+# To update the Intel SDE version (not handled by Dependabot setup-sde updates):
+# update the sdeVersion inputs in the Intel SDE jobs below.
 #
 # This file is meant for testing different SIMD-related build options and
 # optimization levels. See `meson_options.txt` for the available build options.
@@ -200,13 +199,14 @@ jobs:
         python-version: '3.12'
 
     - name: Install Intel SDE
-      run: |
-        SDE_URL="https://downloadmirror.intel.com/859732/sde-external-9.58.0-2025-06-16-lin.tar.xz"
-        SDE_SHA256="f849acecad4c9b108259c643b2688fd65c35723cd23368abe5dd64b917cc18c0"
-        curl -o /tmp/sde.tar.xz "$SDE_URL"
-        echo "$SDE_SHA256  /tmp/sde.tar.xz" | sha256sum -c -
-        mkdir /tmp/sde && tar -xvf /tmp/sde.tar.xz -C /tmp/sde/
-        sudo mv /tmp/sde/* /opt/sde && sudo ln -s /opt/sde/sde64 /usr/bin/sde
+      # setup-sde v5.0 installs Intel SDE 9.58.0 when requested below.
+      uses: petarpetrovt/setup-sde@31aa4a8e85e109bef00f1d838613fcc6ec421271 # v5.0
+      with:
+        environmentVariableName: SDE_PATH
+        sdeVersion: 9.58.0
+
+    - name: Add Intel SDE to PATH
+      run: echo "$SDE_PATH" >> "$GITHUB_PATH"
 
     - name: Install dependencies
       run: |
@@ -253,13 +253,14 @@ jobs:
         python-version: '3.12'
 
     - name: Install Intel SDE
-      run: |
-        SDE_URL="https://downloadmirror.intel.com/859732/sde-external-9.58.0-2025-06-16-lin.tar.xz"
-        SDE_SHA256="f849acecad4c9b108259c643b2688fd65c35723cd23368abe5dd64b917cc18c0"
-        curl -o /tmp/sde.tar.xz "$SDE_URL"
-        echo "$SDE_SHA256  /tmp/sde.tar.xz" | sha256sum -c -
-        mkdir /tmp/sde && tar -xvf /tmp/sde.tar.xz -C /tmp/sde/
-        sudo mv /tmp/sde/* /opt/sde && sudo ln -s /opt/sde/sde64 /usr/bin/sde
+      # setup-sde v5.0 installs Intel SDE 9.58.0 when requested below.
+      uses: petarpetrovt/setup-sde@31aa4a8e85e109bef00f1d838613fcc6ec421271 # v5.0
+      with:
+        environmentVariableName: SDE_PATH
+        sdeVersion: 9.58.0
+
+    - name: Add Intel SDE to PATH
+      run: echo "$SDE_PATH" >> "$GITHUB_PATH"
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Backport of #31727.

Fixes #31591