### PR TITLE
TYP: specialized unary ``floating | object_`` endo-ufuncs

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -403,15 +403,21 @@ from numpy._core.umath import (
     arctan as atan,
     arctanh,
     arctanh as atanh,
+    cbrt,
     cos,
     cosh,
+    deg2rad,
+    degrees,
     exp,
     exp2,
     expm1,
+    fabs,
     log,
     log10,
     log1p,
     log2,
+    rad2deg,
+    radians,
     rint,
     sin,
     sinh,
@@ -7579,16 +7585,12 @@ bitwise_and: _UFunc_Nin2_Nout1[L["bitwise_and"], L[12], L[-1]]
 bitwise_count: _UFunc_Nin1_Nout1[L["bitwise_count"], L[11], None]
 bitwise_or: _UFunc_Nin2_Nout1[L["bitwise_or"], L[12], L[0]]
 bitwise_xor: _UFunc_Nin2_Nout1[L["bitwise_xor"], L[12], L[0]]
-cbrt: _UFunc_Nin1_Nout1[L["cbrt"], L[5], None]
 ceil: _UFunc_Nin1_Nout1[L["ceil"], L[7], None]
 conjugate: _UFunc_Nin1_Nout1[L["conjugate"], L[18], None]
 copysign: _UFunc_Nin2_Nout1[L["copysign"], L[4], None]
-deg2rad: _UFunc_Nin1_Nout1[L["deg2rad"], L[5], None]
-degrees: _UFunc_Nin1_Nout1[L["degrees"], L[5], None]
 divide: _UFunc_Nin2_Nout1[L["divide"], L[11], None]
 divmod: _UFunc_Nin2_Nout2[L["divmod"], L[15], None]
 equal: _UFunc_Nin2_Nout1[L["equal"], L[23], None]
-fabs: _UFunc_Nin1_Nout1[L["fabs"], L[5], None]
 float_power: _UFunc_Nin2_Nout1[L["float_power"], L[4], None]
 floor: _UFunc_Nin1_Nout1[L["floor"], L[7], None]
 floor_divide: _UFunc_Nin2_Nout1[L["floor_divide"], L[21], None]
@@ -7628,8 +7630,6 @@ nextafter: _UFunc_Nin2_Nout1[L["nextafter"], L[4], None]
 not_equal: _UFunc_Nin2_Nout1[L["not_equal"], L[23], None]
 positive: _UFunc_Nin1_Nout1[L["positive"], L[19], None]
 power: _UFunc_Nin2_Nout1[L["power"], L[18], None]
-rad2deg: _UFunc_Nin1_Nout1[L["rad2deg"], L[5], None]
-radians: _UFunc_Nin1_Nout1[L["radians"], L[5], None]
 reciprocal: _UFunc_Nin1_Nout1[L["reciprocal"], L[18], None]
 remainder: _UFunc_Nin2_Nout1[L["remainder"], L[16], None]
 right_shift: _UFunc_Nin2_Nout1[L["right_shift"], L[11], None]

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -29,19 +29,15 @@ from numpy import (
     bitwise_count,
     bitwise_or,
     bitwise_xor,
-    cbrt,
     ceil,
     conj,
     conjugate,
     copysign,
-    deg2rad,
-    degrees,
     divide,
     divmod,
     e,
     equal,
     euler_gamma,
-    fabs,
     float_power,
     floor,
     floor_divide,
@@ -84,8 +80,6 @@ from numpy import (
     pi,
     positive,
     power,
-    rad2deg,
-    radians,
     reciprocal,
     remainder,
     right_shift,
@@ -101,6 +95,7 @@ from numpy import (
 )
 from numpy._typing import (
     _ArrayLikeBool_co,
+    _ArrayLikeFloat_co,
     _ArrayLikeInt,
     _ArrayLikeNumber_co,
     _DTypeLike,
@@ -244,9 +239,8 @@ class _CanUfuncAt1[IxT, OutT](Protocol):
 # mypy: disable-error-code=override
 # pyright: reportIncompatibleMethodOverride=false
 
-# efdgFDGO => efdgFDGO
 @type_check_only
-class _ufunc_11_fco(np.ufunc):  # type: ignore[misc]
+class _ufunc_11(np.ufunc):  # type: ignore[misc]
     @property
     @override
     def identity(self) -> None: ...
@@ -264,6 +258,226 @@ class _ufunc_11_fco(np.ufunc):  # type: ignore[misc]
     def signature(self) -> None: ...
 
     #
+    @override
+    def accumulate(self, array: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
+    @override
+    def reduce(self, array: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
+    @override
+    def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    @override
+    def outer(self, A: Never, B: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
+
+# efdgO => efdgO
+@type_check_only
+class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
+    @override
+    @overload  # known shape, known scalar/array
+    def __call__[T: np.floating | npt.NDArray[np.floating | np.object_]](
+        self,
+        x: T,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> T: ...
+    @overload  # Nd, +f64
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[np.integer | np.bool]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+    @overload  # scalar, float | +f64
+    def __call__(
+        self,
+        x: float | np.integer | np.bool,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> np.float64: ...
+    @overload  # 1d, +float
+    def __call__(
+        self,
+        x: Sequence[float],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> _Array1D[np.float64]: ...
+    @overload  # 2d, +float
+    def __call__(
+        self,
+        x: Sequence[Sequence[float]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> _Array2D[np.float64]: ...
+    @overload  # scalar, dtype=<known>
+    def __call__[ScalarT: np.floating](
+        self,
+        x: _NumberLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: _DTypeLike[ScalarT],
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> ScalarT: ...
+    @overload  # Nd, dtype=<known>
+    def __call__[ShapeT: _Shape, ScalarT: np.floating](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[np.floating | np.integer | np.bool | np.object_]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    @overload  # Nd, dtype=<unknown>
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[np.floating | np.integer | np.bool | np.object_]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> np.ndarray[ShapeT]: ...
+    @overload  # Nd, dtype=<known>
+    def __call__[ScalarT: np.floating | np.object_](
+        self,
+        x: _NestedSequence[float],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # Nd, dtype=<unknown>
+    def __call__(
+        self,
+        x: _NestedSequence[float],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> np.ndarray: ...
+    @overload  # ?d, dtype=<known>
+    def __call__[ScalarT: np.floating | np.object_](
+        self,
+        x: _ArrayLikeFloat_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> npt.NDArray[ScalarT] | Any: ...  # `| Any` because of overlap
+    @overload  # ?d, dtype=<unknown>
+    def __call__(
+        self,
+        x: _ArrayLikeFloat_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> Any: ...
+    @overload  # out=<given>
+    def __call__[OutT: np.ndarray](
+        self,
+        x: _ArrayLikeFloat_co,
+        /,
+        out: OutT,
+        *,
+        dtype: npt.DTypeLike | None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> OutT: ...
+    @overload  # out=<given>
+    def __call__[OutT](
+        self,
+        x: _CanUfuncCall1[OutT],
+        /,
+        out: object | None = None,
+        *,
+        dtype: npt.DTypeLike | None = None,
+        where: _ArrayLikeBool_co = True,
+        casting: _CastingKind = "same_kind",
+        order: _OrderKACF = "K",
+        subok: bool = True,
+        signature: _Signature1 | None = None,
+    ) -> OutT: ...
+
+    #
+    @override
+    @overload
+    def at(self, a: npt.NDArray[np.floating | np.object_], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
+    @overload
+    def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
+
+# efdgFDGO => efdgFDGO
+@type_check_only
+class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
     @override
     @overload  # known shape, known scalar/array
     def __call__[T: np.inexact | npt.NDArray[np.inexact | np.object_]](
@@ -511,15 +725,12 @@ class _ufunc_11_fco(np.ufunc):  # type: ignore[misc]
     @overload
     def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
 
-    #
-    @override
-    def accumulate(self, array: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
-    @override
-    def reduce(self, array: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
-    @override
-    def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
-    @override
-    def outer(self, A: Never, B: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
+cbrt: Final[_ufunc_11_fo] = ...
+deg2rad: Final[_ufunc_11_fo] = ...
+degrees: Final[_ufunc_11_fo] = ...
+fabs: Final[_ufunc_11_fo] = ...
+rad2deg: Final[_ufunc_11_fo] = ...
+radians: Final[_ufunc_11_fo] = ...
 
 arccos: Final[_ufunc_11_fco] = ...
 arccosh: Final[_ufunc_11_fco] = ...

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -240,6 +240,14 @@ class _CanUfuncAt1[IxT, OutT](Protocol):
 # pyright: reportIncompatibleMethodOverride=false
 
 @type_check_only
+class _Kwargs11(TypedDict, total=False):
+    where: _ArrayLikeBool_co  # = True
+    casting: _CastingKind  # = "same_kind"
+    order: _OrderKACF  # = "K",
+    subok: bool  # = True,
+    signature: _Signature1
+
+@type_check_only
 class _ufunc_11(np.ufunc):  # type: ignore[misc]
     @property
     @override
@@ -279,11 +287,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> T: ...
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
@@ -293,11 +297,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
     @overload  # scalar, float | +f64
     def __call__(
@@ -307,11 +307,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> np.float64: ...
     @overload  # 1d, +float
     def __call__(
@@ -321,11 +317,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> _Array1D[np.float64]: ...
     @overload  # 2d, +float
     def __call__(
@@ -335,11 +327,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> _Array2D[np.float64]: ...
     @overload  # scalar, dtype=<known>
     def __call__[ScalarT: np.floating](
@@ -349,11 +337,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: None = None,
         dtype: _DTypeLike[ScalarT],
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> ScalarT: ...
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: np.floating](
@@ -363,11 +347,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
@@ -377,11 +357,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> np.ndarray[ShapeT]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: np.floating | np.object_](
@@ -391,11 +367,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> npt.NDArray[ScalarT]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__(
@@ -405,11 +377,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> np.ndarray: ...
     @overload  # ?d, dtype=<known>
     def __call__[ScalarT: np.floating | np.object_](
@@ -419,11 +387,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> npt.NDArray[ScalarT] | Any: ...  # `| Any` because of overlap
     @overload  # ?d, dtype=<unknown>
     def __call__(
@@ -433,11 +397,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> Any: ...
     @overload  # out=<given>
     def __call__[OutT: np.ndarray](
@@ -447,11 +407,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         out: OutT,
         *,
         dtype: npt.DTypeLike | None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> OutT: ...
     @overload  # out=<given>
     def __call__[OutT](
@@ -461,11 +417,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         out: object | None = None,
         *,
         dtype: npt.DTypeLike | None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> OutT: ...
 
     #
@@ -487,11 +439,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> T: ...
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
@@ -501,11 +449,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
     @overload  # scalar, float | +f64
     def __call__(
@@ -515,11 +459,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> np.float64: ...
     @overload  # 1d, +float
     def __call__(
@@ -529,11 +469,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> _Array1D[np.float64]: ...
     @overload  # 1d, ~complex
     def __call__(
@@ -543,11 +479,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> _Array1D[np.complex128]: ...
     @overload  # 2d, +float
     def __call__(
@@ -557,11 +489,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> _Array2D[np.float64]: ...
     @overload  # 2d, ~complex
     def __call__(
@@ -571,11 +499,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> _Array2D[np.complex128]: ...
     @overload  # scalar, +complex  (overlaps with float)
     def __call__(
@@ -585,11 +509,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: None = None,
         dtype: None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> np.complex128 | Any: ...
     @overload  # scalar, dtype=<known>
     def __call__[ScalarT: np.inexact](
@@ -599,11 +519,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: None = None,
         dtype: _DTypeLike[ScalarT],
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> ScalarT: ...
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: np.inexact](
@@ -613,11 +529,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
@@ -627,11 +539,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> np.ndarray[ShapeT]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: np.inexact | np.object_](
@@ -641,11 +549,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> npt.NDArray[ScalarT]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__(
@@ -655,11 +559,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> np.ndarray: ...
     @overload  # ?d, dtype=<known>
     def __call__[ScalarT: np.inexact | np.object_](
@@ -669,11 +569,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> npt.NDArray[ScalarT] | Any: ...  # `| Any` because of overlap
     @overload  # ?d, dtype=<unknown>
     def __call__(
@@ -683,11 +579,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> Any: ...
     @overload  # out=<given>
     def __call__[OutT: np.ndarray](
@@ -697,11 +589,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         out: OutT,
         *,
         dtype: npt.DTypeLike | None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> OutT: ...
     @overload  # out=<given>
     def __call__[OutT](
@@ -711,11 +599,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         out: object | None = None,
         *,
         dtype: npt.DTypeLike | None = None,
-        where: _ArrayLikeBool_co = True,
-        casting: _CastingKind = "same_kind",
-        order: _OrderKACF = "K",
-        subok: bool = True,
-        signature: _Signature1 | None = None,
+        **kwargs: Unpack[_Kwargs11],
     ) -> OutT: ...
 
     #

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -169,6 +169,38 @@ _obj_1d: np.ndarray[tuple[int], np.dtype[np.object_]]
 _obj_2d: np.ndarray[tuple[int, int], np.dtype[np.object_]]
 _obj_nd: npt.NDArray[np.object_]
 
+# _ufunc_11_fo
+# (cbrt, deg2rad, degrees, fabs, rad2deg, radians)
+
+assert_type(np.cbrt(_py_i_0d), np.float64)
+assert_type(np.cbrt(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.cbrt(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.cbrt(_py_f_0d), np.float64)
+assert_type(np.cbrt(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.cbrt(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+
+assert_type(np.cbrt(_i16_0d), np.float64)
+assert_type(np.cbrt(_i16_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.cbrt(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.cbrt(_i16_nd), npt.NDArray[np.float64])
+assert_type(np.cbrt(_f32_0d), np.float32)
+assert_type(np.cbrt(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.cbrt(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.cbrt(_f32_nd), npt.NDArray[np.float32])
+assert_type(np.cbrt(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
+assert_type(np.cbrt(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.cbrt(_obj_nd), npt.NDArray[np.object_])
+
+assert_type(np.cbrt(_py_i_0d, dtype=np.float32), np.float32)
+assert_type(np.cbrt(_py_i_1d, dtype=np.float32), npt.NDArray[np.float32])
+assert_type(np.cbrt(_i16_2d, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+
+assert_type(np.cbrt(_py_i_0d, dtype="f4"), Any)
+assert_type(np.cbrt(_py_i_1d, dtype="f4"), np.ndarray)
+assert_type(np.cbrt(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
+
+assert_type(np.cbrt(_py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+
 # _ufunc_11_fco
 
 assert_type(np.sin(_py_i_0d), np.float64)


### PR DESCRIPTION
Here's part two of the typed ufunc series, following #31716. This time, featuring `cbrt`, `fabs`, `deg2rad`, `rad2deg`, `degrees`, `radians`, which all share the same (static) type signature (see https://gist.github.com/jorenham/d977c63cc53ad4f00878d37ee42ab0e8 for details).

These changes are very similar to the ones in #31716, except that here, complex dtypes *aren't* supported; only the four `floating` and `object_` dtypes. So the before/after will be pretty much the same as for #31716.

---

No AI.