### PR TITLE
BUG: fix leak in reductions when a ufunc override errors or is not found

### DIFF
--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3779,6 +3779,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
     int errval = PyUFunc_CheckOverride(ufunc, _reduce_type[operation],
             full_args.in, full_args.out, wheremask_obj, args, len_args, kwnames, &override);
     if (errval) {
+        Py_XDECREF(full_args.in);
+        Py_XDECREF(full_args.out);
         return NULL;
     }
     else if (override) {

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3779,9 +3779,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
     int errval = PyUFunc_CheckOverride(ufunc, _reduce_type[operation],
             full_args.in, full_args.out, wheremask_obj, args, len_args, kwnames, &override);
     if (errval) {
-        Py_XDECREF(full_args.in);
-        Py_XDECREF(full_args.out);
-        return NULL;
+        goto fail;
     }
     else if (override) {
         Py_XDECREF(full_args.in);

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -3954,6 +3954,21 @@ class TestSpecialMethods:
         with assert_raises_regex(TypeError, fnmatch.translate(msg)):
             np.add(A(), object(), out=1)
 
+    def test_ufunc_override_reduction_not_implemented_leak(self):
+        # gh-31731: the reduction override error path leaked references to
+        # the internal full_args.in/out tuples when __array_ufunc__ returned
+        # NotImplemented (or raised). No refcount assertion is made here; a
+        # leak sanitizer build is expected to catch the regression.
+
+        class A:
+            def __array_ufunc__(self, *args, **kwargs):
+                return NotImplemented
+
+        a = A()
+        assert_raises(TypeError, np.add.reduce, a)
+        assert_raises(TypeError, np.add.accumulate, a)
+        assert_raises(TypeError, np.add.reduceat, a, [0])
+
     def test_ufunc_override_disabled(self):
 
         class OptOut:

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -3955,7 +3955,7 @@ class TestSpecialMethods:
             np.add(A(), object(), out=1)
 
     def test_ufunc_override_reduction_not_implemented_leak(self):
-        # gh-31731: the reduction override error path leaked references to
+        # gh-31677: the reduction override error path leaked references to
         # the internal full_args.in/out tuples when __array_ufunc__ returned
         # NotImplemented (or raised). No refcount assertion is made here; a
         # leak sanitizer build is expected to catch the regression.


### PR DESCRIPTION
### PR summary
Closes https://github.com/numpy/numpy/issues/31677

Just another thing I noticed while reading reduction code and realised there's an open issue for it already. 
One can see this memory leak by doing something like the following and memory profiling that (with memray for example) and will notice the memory is just growing.
```py
import numpy as np

class Array:
    data = np.array([1,2,3])
    def __array_ufunc__(ufunc, method, *inputs, **kwargs):
        return NotImplemented

arr = Array()

if __name__ == "__main__":
    for _ in range(1_000_000):
        try:
            np.add.reduce(arr)
        except Exception as e:
            pass
```
I think `goto fail` is probably nicer than
```c
Py_XDECREF(full_args.in);
Py_XDECREF(full_args.out);
```
and I believe it's safe. Only the `else if (override)` branch right bellow cannot use `goto fail` as it needs to return the override and not NULL.

I don't think there is a way to have a test regarding the ref count in the python side because `full_args` is created internally in the function in C. But we could have a test that is just the above without the loop and a sanitizer would probably capture the leak. Let me know if you want that. cc @seberg because you wanted a similar test in https://github.com/numpy/numpy/pull/31699. 

### First time committer introduction
N/A

#### AI Disclosure
No AI
