### PR TITLE
BUG: fix ma.innerproduct for object-dtype inputs

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -8343,7 +8343,10 @@ def inner(a, b):
         fa = fa.reshape((1,))
     if fb.ndim == 0:
         fb = fb.reshape((1,))
-    return np.inner(fa, fb).view(MaskedArray)
+    d = np.inner(fa, fb)
+    if np.ndim(d) == 0:
+        d = np.asarray(d)
+    return d.view(MaskedArray)
 
 
 inner.__doc__ = doc_note(np.inner.__doc__,

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1126,7 +1126,7 @@ class _MaskedBinaryOperation(_MaskedUFunc):
             tr = self.f.reduce(t, axis, dtype=dtype)
             mr = umath.logical_and.reduce(m, axis)
         
-        if np.ndim(tr) == 0:
+        if not isinstance(tr, (np.ndarray, np.generic)):
             tr = np.asarray(tr)
 
         if not tr.shape:
@@ -5179,7 +5179,7 @@ class MaskedArray(ndarray):
         if m is nomask:
             result = super().trace(offset=offset, axis1=axis1, axis2=axis2,
                                    out=out)
-            if np.ndim(result) == 0:
+            if not isinstance(result, (np.ndarray, np.generic)):
                 result = np.asarray(result)
             return result.astype(dtype)
         else:
@@ -5974,7 +5974,7 @@ class MaskedArray(ndarray):
             result = self.filled(fill_value).min(
                 axis=axis, out=out, **kwargs
             )
-            if np.ndim(result) == 0:
+            if not isinstance(result, (np.ndarray, np.generic)):
                 result = np.asarray(result)
             result = result.view(type(self))
             if result.ndim:
@@ -6083,7 +6083,7 @@ class MaskedArray(ndarray):
             result = self.filled(fill_value).max(
                 axis=axis, out=out, **kwargs
             )
-            if np.ndim(result) == 0:
+            if not isinstance(result, (np.ndarray, np.generic)):
                 result = np.asarray(result)
             result = result.view(type(self))
             if result.ndim:
@@ -8328,7 +8328,7 @@ def dot(a, b, strict=False, out=None):
     if out is None:
         d = np.dot(filled(a, 0), filled(b, 0))
         m = ~np.dot(am, bm)
-        if np.ndim(d) == 0:
+        if not isinstance(d, (np.ndarray, np.generic)):
             d = np.asarray(d)
         r = d.view(get_masked_subclass(a, b))
         r.__setmask__(m)
@@ -8357,7 +8357,7 @@ def inner(a, b):
     if fb.ndim == 0:
         fb = fb.reshape((1,))
     d = np.inner(fa, fb)
-    if np.ndim(d) == 0:
+    if not isinstance(d, (np.ndarray, np.generic)):
         d = np.asarray(d)
     return d.view(MaskedArray)
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1125,6 +1125,9 @@ class _MaskedBinaryOperation(_MaskedUFunc):
         else:
             tr = self.f.reduce(t, axis, dtype=dtype)
             mr = umath.logical_and.reduce(m, axis)
+        
+        if np.ndim(tr) == 0:
+            tr = np.asarray(tr)
 
         if not tr.shape:
             if mr:
@@ -5176,6 +5179,8 @@ class MaskedArray(ndarray):
         if m is nomask:
             result = super().trace(offset=offset, axis1=axis1, axis2=axis2,
                                    out=out)
+            if np.ndim(result) == 0:
+                result = np.asarray(result)
             return result.astype(dtype)
         else:
             D = self.diagonal(offset=offset, axis1=axis1, axis2=axis2)
@@ -5967,7 +5972,11 @@ class MaskedArray(ndarray):
         # No explicit output
         if out is None:
             result = self.filled(fill_value).min(
-                axis=axis, out=out, **kwargs).view(type(self))
+                axis=axis, out=out, **kwargs
+            )
+            if np.ndim(result) == 0:
+                result = np.asarray(result)
+            result = result.view(type(self))
             if result.ndim:
                 # Set the mask
                 result.__setmask__(newmask)
@@ -6072,7 +6081,11 @@ class MaskedArray(ndarray):
         # No explicit output
         if out is None:
             result = self.filled(fill_value).max(
-                axis=axis, out=out, **kwargs).view(type(self))
+                axis=axis, out=out, **kwargs
+            )
+            if np.ndim(result) == 0:
+                result = np.asarray(result)
+            result = result.view(type(self))
             if result.ndim:
                 # Set the mask
                 result.__setmask__(newmask)

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -660,6 +660,8 @@ def average(a, axis=None, weights=None, returned=False, *,
 
     if weights is None:
         avg = a.mean(axis, **keepdims_kw)
+        if np.ndim(avg) == 0:
+            avg = np.asarray(avg)
         scl = avg.dtype.type(a.count(axis))
     else:
         wgt = asarray(weights)

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -660,7 +660,7 @@ def average(a, axis=None, weights=None, returned=False, *,
 
     if weights is None:
         avg = a.mean(axis, **keepdims_kw)
-        if np.ndim(avg) == 0:
+        if not isinstance(avg, (np.ndarray, np.generic)):
             avg = np.asarray(avg)
         scl = avg.dtype.type(a.count(axis))
     else:

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2679,6 +2679,22 @@ class TestUfuncs:
         assert_equal(product(a, axis=0), 0)
         assert_equal(add.reduce(a), pi)
 
+    def test_alltrue_object():
+        a = np.ma.array([True, True], dtype=object)
+
+        result = np.ma.alltrue(a)
+
+        assert result.shape == ()
+        assert result.item() is True
+
+    def test_sometrue_object():
+        a = np.ma.array([False, True], dtype=object)
+
+        result = np.ma.sometrue(a)
+
+        assert result.shape == ()
+        assert result.item() is True
+
     def test_minmax(self):
         # Tests extrema on MaskedArrays.
         a = arange(1, 13).reshape(3, 4)
@@ -4162,6 +4178,24 @@ class TestMaskedArrayMathMethods:
             result = xmmeth(axis=0, out=output)
             assert_(result is output)
 
+    def test_max_object(self):
+        a = np.ma.array([1, 2, 3], dtype=object)
+
+        result = np.ma.max(a)
+
+        assert isinstance(result, np.ma.MaskedArray)
+        assert result.shape == ()
+        assert result.item() == 3
+
+    def test_min_object(self):
+        a = np.ma.array([1, 2, 3], dtype=object)
+
+        result = np.ma.min(a)
+
+        assert isinstance(result, np.ma.MaskedArray)
+        assert result.shape == ()
+        assert result.item() == 1
+
     def test_ptp(self):
         # Tests ptp on MaskedArrays.
         _, X, _, m, mx, mX, _, _, _, _ = self._create_data()
@@ -4175,6 +4209,15 @@ class TestMaskedArrayMathMethods:
             rows[k] = np.ptp(mX[k].compressed())
         assert_equal(mX.ptp(0), cols)
         assert_equal(mX.ptp(1), rows)
+
+    def test_ptp_object(self):
+        a = np.ma.array([1, 2, 3], dtype=object)
+
+        result = np.ma.ptp(a)
+
+        assert isinstance(result, np.ma.MaskedArray)
+        assert result.shape == ()
+        assert result.item() == 2
 
     def test_add_object(self):
         x = masked_array(['a', 'b'], mask=[1, 0], dtype=object)
@@ -4208,6 +4251,16 @@ class TestMaskedArrayMathMethods:
 
         expected = np.inner(a, b)
         result = np.ma.innerproduct(a, b)
+
+        assert_equal(result, expected)
+        assert_(isinstance(result, MaskedArray))
+
+    def test_inner_object(self):
+        a = np.array([1, 2, 3], dtype=object)
+        b = np.array([0, 1, 0], dtype=object)
+
+        expected = np.inner(a, b)
+        result = np.ma.inner(a, b)
 
         assert_equal(result, expected)
         assert_(isinstance(result, MaskedArray))
@@ -4250,6 +4303,15 @@ class TestMaskedArrayMathMethods:
         arr = np.arange(2 * 4 * 4).reshape(2, 4, 4)
         m_arr = np.ma.masked_array(arr, False)
         assert_equal(arr.trace(axis1=1, axis2=2), m_arr.trace(axis1=1, axis2=2))
+
+    def test_trace_object(self):
+        a = np.ma.array([[1, 2], [3, 4]], dtype=object)
+
+        result = np.ma.trace(a)
+
+        assert isinstance(result, np.ma.MaskedArray)
+        assert result.shape == ()
+        assert result.item() == 5
 
     def test_dot(self):
         # Tests dot on MaskedArrays.

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4202,6 +4202,16 @@ class TestMaskedArrayMathMethods:
         assert_equal(a.mean(), 2)
         assert_equal(a.anom(), [-1, 0, 1])
 
+    def test_innerproduct_object(self):
+        a = np.array([1, 2, 3], dtype=object)
+        b = np.array([0, 1, 0], dtype=object)
+
+        expected = np.inner(a, b)
+        result = np.ma.innerproduct(a, b)
+
+        assert_equal(result, expected)
+        assert_(isinstance(result, MaskedArray))
+
     def test_anom_shape(self):
         a = masked_array([1, 2, 3])
         assert_equal(a.anom().shape, a.shape)

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -456,6 +456,14 @@ class TestAverage:
         assert_almost_equal(avg_masked, avg_expected)
         assert_equal(avg_masked.mask, avg_expected.mask)
 
+    def test_average_object(self):
+        a = np.ma.array([1, 2, 3], dtype=object)
+
+        result = np.ma.average(a)
+
+        assert result.shape == ()
+        assert result.item() == 2
+
 
 class TestConcatenator:
     # Tests for mr_, the equivalent of r_ for masked arrays.


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.
  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

fix `np.ma.innerproduct` for object-dtype arrays.

previously, calling `np.ma.innerproduct` on object-dtype arrays could raise an `AttributeError ('int' object has no attribute 'view')` even though the equivalent `np.inner` call completed successfully and returned the expected scalar result.

update to correctly handle object-dtype scalar results and add a regression test

fixed #31736 

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

hi! im rayson, a quant developer who uses np regularly for data analysis, research, and personal projects.

im interested in contributing to open source software and was looking for issues that would be a good fit for a first contribution. I came across this bug, investigated the root cause, and worked on a fix together with a regression test.

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

No AI
