### PR TITLE
TST: Don't run test_tuple_recursion on MacOS

### DIFF
--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -4,7 +4,6 @@ import inspect
 import operator
 import os
 import pickle
-import platform
 import sys
 import types
 import warnings
@@ -890,8 +889,8 @@ class TestMonsterType:
 
     @requires_deep_recursion
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin") and platform.machine() == "x86_64",
-        reason="test now segfaults on x86 macs",
+        sys.platform.startswith("darwin"),
+        reason="test now segfaults on some mac setups",
     )
     def test_tuple_recursion(self):
         d = np.int32


### PR DESCRIPTION
This test was always a bit flaky, then it seemed to segfault on x86 Mac, but it seems it segfaults more generally on Mac now.

As the comment mentions, best we can tell right now this seems to be a Python issue (whether serious or not) in that we should be entering recursion and Python wants to protect things but doesn't.

I can reproduce this locally on a non x86 Mac, although not if I just run the test itself in a small test on it's own...

Closes gh-31733

(No AI)