### PR TITLE
TYP: specialized ``ceil``, ``floor``, ``trunc``, and ``invert`` ufuncs

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -404,6 +404,7 @@ from numpy._core.umath import (
     arctanh,
     arctanh as atanh,
     cbrt,
+    ceil,
     cos,
     cosh,
     deg2rad,
@@ -412,6 +413,7 @@ from numpy._core.umath import (
     exp2,
     expm1,
     fabs,
+    floor,
     log,
     log10,
     log1p,
@@ -424,6 +426,7 @@ from numpy._core.umath import (
     sqrt,
     tan,
     tanh,
+    trunc,
 )
 
 from ._expired_attrs_2_0 import __expired_attributes__ as __expired_attributes__
@@ -7585,14 +7588,12 @@ bitwise_and: _UFunc_Nin2_Nout1[L["bitwise_and"], L[12], L[-1]]
 bitwise_count: _UFunc_Nin1_Nout1[L["bitwise_count"], L[11], None]
 bitwise_or: _UFunc_Nin2_Nout1[L["bitwise_or"], L[12], L[0]]
 bitwise_xor: _UFunc_Nin2_Nout1[L["bitwise_xor"], L[12], L[0]]
-ceil: _UFunc_Nin1_Nout1[L["ceil"], L[7], None]
 conjugate: _UFunc_Nin1_Nout1[L["conjugate"], L[18], None]
 copysign: _UFunc_Nin2_Nout1[L["copysign"], L[4], None]
 divide: _UFunc_Nin2_Nout1[L["divide"], L[11], None]
 divmod: _UFunc_Nin2_Nout2[L["divmod"], L[15], None]
 equal: _UFunc_Nin2_Nout1[L["equal"], L[23], None]
 float_power: _UFunc_Nin2_Nout1[L["float_power"], L[4], None]
-floor: _UFunc_Nin1_Nout1[L["floor"], L[7], None]
 floor_divide: _UFunc_Nin2_Nout1[L["floor_divide"], L[21], None]
 fmax: _UFunc_Nin2_Nout1[L["fmax"], L[21], None]
 fmin: _UFunc_Nin2_Nout1[L["fmin"], L[21], None]
@@ -7638,7 +7639,6 @@ signbit: _UFunc_Nin1_Nout1[L["signbit"], L[4], None]
 spacing: _UFunc_Nin1_Nout1[L["spacing"], L[4], None]
 square: _UFunc_Nin1_Nout1[L["square"], L[18], None]
 subtract: _UFunc_Nin2_Nout1[L["subtract"], L[21], None]
-trunc: _UFunc_Nin1_Nout1[L["trunc"], L[7], None]
 vecdot: _GUFunc_Nin2_Nout1[L["vecdot"], L[19], None, L["(n),(n)->()"]]
 vecmat: _GUFunc_Nin2_Nout1[L["vecmat"], L[19], None, L["(n),(n,m)->(m)"]]
 

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -414,6 +414,7 @@ from numpy._core.umath import (
     expm1,
     fabs,
     floor,
+    invert,
     log,
     log10,
     log1p,
@@ -7604,7 +7605,6 @@ greater: _UFunc_Nin2_Nout1[L["greater"], L[23], None]
 greater_equal: _UFunc_Nin2_Nout1[L["greater_equal"], L[23], None]
 heaviside: _UFunc_Nin2_Nout1[L["heaviside"], L[4], None]
 hypot: _UFunc_Nin2_Nout1[L["hypot"], L[5], L[0]]
-invert: _UFunc_Nin1_Nout1[L["invert"], L[12], None]
 isfinite: _UFunc_Nin1_Nout1[L["isfinite"], L[20], None]
 isinf: _UFunc_Nin1_Nout1[L["isinf"], L[20], None]
 isnan: _UFunc_Nin1_Nout1[L["isnan"], L[20], None]

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -49,7 +49,6 @@ from numpy import (
     greater_equal,
     heaviside,
     hypot,
-    invert,
     isfinite,
     isinf,
     isnan,
@@ -94,8 +93,11 @@ from numpy._typing import (
     _ArrayLikeBool_co,
     _ArrayLikeFloat_co,
     _ArrayLikeInt,
+    _ArrayLikeInt_co,
     _ArrayLikeNumber_co,
     _DTypeLike,
+    _FloatLike_co,
+    _IntLike_co,
     _NestedSequence,
     _NumberLike_co,
     _Shape,
@@ -210,7 +212,8 @@ type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[S
 type _ErrKind = Literal["ignore", "warn", "raise", "call", "print", "log"]
 type _ErrCall = Callable[[str, int], Any] | SupportsWrite[str]
 
-type _to_floating = np.floating | np.integer | np.bool
+type _to_integer = np.integer | np.bool
+type _to_floating = np.floating | _to_integer
 
 @type_check_only
 class _ExtOjbDict(TypedDict, total=False):
@@ -608,6 +611,198 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
     @overload
     def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
 
+# ?bBhHiIlLqQO => ?bBhHiIlLqQO
+@type_check_only
+class _ufunc_11_bio(_ufunc_11):  # type: ignore[misc]
+    @override
+    @overload  # known shape, known scalar/array
+    def __call__[T: _to_integer | npt.NDArray[_to_integer | np.object_]](
+        self,
+        x: T,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> T: ...
+    @overload  # scalar, bool
+    def __call__(
+        self,
+        x: bool,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.bool: ...
+    @overload  # scalar, int (overlaps with bool)
+    def __call__(
+        self,
+        x: int,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.int_ | Any: ...
+    @overload  # 1d, bool
+    def __call__(
+        self,
+        x: Sequence[bool],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array1D[np.bool]: ...
+    @overload  # 1d, ~int
+    def __call__(
+        self,
+        x: list[int],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array1D[np.int_]: ...
+    @overload  # 1d, +int
+    def __call__(
+        self,
+        x: Sequence[int],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array1D[np.int_ | Any]: ...
+    @overload  # 2d, bool
+    def __call__(
+        self,
+        x: Sequence[Sequence[bool]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array2D[np.bool]: ...
+    @overload  # 2d, ~int
+    def __call__(
+        self,
+        x: Sequence[list[int]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array2D[np.int_]: ...
+    @overload  # 2d, +int
+    def __call__(
+        self,
+        x: Sequence[Sequence[int]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array2D[np.int_ | Any]: ...
+    @overload  # scalar, dtype=<known>
+    def __call__[ScalarT: _to_integer](
+        self,
+        x: _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> ScalarT: ...
+    @overload  # Nd, dtype=<known>
+    def __call__[ShapeT: _Shape, ScalarT: _to_integer | np.object_](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_to_integer | np.object_]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    @overload  # Nd, dtype=<unknown>
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_to_integer | np.object_]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT]: ...
+    @overload  # Nd, dtype=<known>
+    def __call__[ScalarT: _to_integer | np.object_](
+        self,
+        x: _NestedSequence[int],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # Nd, dtype=<unknown>
+    def __call__(
+        self,
+        x: _NestedSequence[int],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray: ...
+    @overload  # ?d, dtype=<known>
+    def __call__[ScalarT: _to_integer | np.object_](
+        self,
+        x: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> npt.NDArray[ScalarT] | Any: ...  # `| Any` because of overlap
+    @overload  # ?d, dtype=<unknown>
+    def __call__(
+        self,
+        x: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> Any: ...
+    @overload  # out=<given>
+    def __call__[OutT: np.ndarray](
+        self,
+        x: _ArrayLikeInt_co,
+        /,
+        out: OutT,
+        *,
+        dtype: npt.DTypeLike | None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> OutT: ...
+    @overload  # out=<given>
+    def __call__[OutT](
+        self,
+        x: _CanUfuncCall1[OutT],
+        /,
+        out: object | None = None,
+        *,
+        dtype: npt.DTypeLike | None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> OutT: ...
+
+    #
+    @override
+    @overload
+    def at(self, a: npt.NDArray[_to_integer | np.object_], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
+    @overload
+    def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
+
 # ?bBhHiIlLqQefdgO => ?bBhHiIlLqQefdgO
 @type_check_only
 class _ufunc_11_bifo(_ufunc_11):  # type: ignore[misc]
@@ -735,7 +930,7 @@ class _ufunc_11_bifo(_ufunc_11):  # type: ignore[misc]
     @overload  # scalar, dtype=<known>
     def __call__[ScalarT: _to_floating](
         self,
-        x: _NumberLike_co,
+        x: _FloatLike_co,
         /,
         *,
         out: None = None,
@@ -858,6 +1053,8 @@ sinh: Final[_ufunc_11_fco] = ...
 sqrt: Final[_ufunc_11_fco] = ...
 tan: Final[_ufunc_11_fco] = ...
 tanh: Final[_ufunc_11_fco] = ...
+
+invert: Final[_ufunc_11_bio] = ...
 
 ceil: Final[_ufunc_11_bifo] = ...
 floor: Final[_ufunc_11_bifo] = ...

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -29,7 +29,6 @@ from numpy import (
     bitwise_count,
     bitwise_or,
     bitwise_xor,
-    ceil,
     conj,
     conjugate,
     copysign,
@@ -39,7 +38,6 @@ from numpy import (
     equal,
     euler_gamma,
     float_power,
-    floor,
     floor_divide,
     fmax,
     fmin,
@@ -89,7 +87,6 @@ from numpy import (
     square,
     subtract,
     true_divide,
-    trunc,
     vecdot,
     vecmat,
 )
@@ -212,6 +209,8 @@ type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[S
 
 type _ErrKind = Literal["ignore", "warn", "raise", "call", "print", "log"]
 type _ErrCall = Callable[[str, int], Any] | SupportsWrite[str]
+
+type _to_floating = np.floating | np.integer | np.bool
 
 @type_check_only
 class _ExtOjbDict(TypedDict, total=False):
@@ -342,7 +341,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: np.floating](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.floating | np.integer | np.bool | np.object_]],
+        x: np.ndarray[ShapeT, np.dtype[_to_floating | np.object_]],
         /,
         *,
         out: EllipsisType | None = None,
@@ -352,7 +351,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.floating | np.integer | np.bool | np.object_]],
+        x: np.ndarray[ShapeT, np.dtype[_to_floating | np.object_]],
         /,
         *,
         out: EllipsisType | None = None,
@@ -609,6 +608,228 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
     @overload
     def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
 
+# ?bBhHiIlLqQefdgO => ?bBhHiIlLqQefdgO
+@type_check_only
+class _ufunc_11_bifo(_ufunc_11):  # type: ignore[misc]
+    @override
+    @overload  # known shape, known scalar/array
+    def __call__[T: _to_floating | npt.NDArray[_to_floating | np.object_]](
+        self,
+        x: T,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> T: ...
+    @overload  # scalar, bool
+    def __call__(
+        self,
+        x: bool,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.bool: ...
+    @overload  # scalar, int (overlaps with bool)
+    def __call__(
+        self,
+        x: int,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.int_ | Any: ...
+    @overload  # scalar, float (overlaps with int)
+    def __call__(
+        self,
+        x: float,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.float64 | Any: ...
+    @overload  # 1d, bool
+    def __call__(
+        self,
+        x: Sequence[bool],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array1D[np.bool]: ...
+    @overload  # 1d, ~int
+    def __call__(
+        self,
+        x: list[int],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array1D[np.int_]: ...
+    @overload  # 1d, ~float
+    def __call__(
+        self,
+        x: list[float],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array1D[np.float64]: ...
+    @overload  # 1d, +float
+    def __call__(
+        self,
+        x: Sequence[float],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array1D[np.float64 | Any]: ...
+    @overload  # 2d, bool
+    def __call__(
+        self,
+        x: Sequence[Sequence[bool]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array2D[np.bool]: ...
+    @overload  # 2d, ~int
+    def __call__(
+        self,
+        x: Sequence[list[int]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array2D[np.int_]: ...
+    @overload  # 2d, ~float
+    def __call__(
+        self,
+        x: Sequence[list[float]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array2D[np.float64]: ...
+    @overload  # 2d, +float
+    def __call__(
+        self,
+        x: Sequence[Sequence[float]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array2D[np.float64 | Any]: ...
+    @overload  # scalar, dtype=<known>
+    def __call__[ScalarT: _to_floating](
+        self,
+        x: _NumberLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> ScalarT: ...
+    @overload  # Nd, dtype=<known>
+    def __call__[ShapeT: _Shape, ScalarT: _to_floating | np.object_](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_to_floating | np.object_]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    @overload  # Nd, dtype=<unknown>
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_to_floating | np.object_]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT]: ...
+    @overload  # Nd, dtype=<known>
+    def __call__[ScalarT: _to_floating | np.object_](
+        self,
+        x: _NestedSequence[float],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # Nd, dtype=<unknown>
+    def __call__(
+        self,
+        x: _NestedSequence[float],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray: ...
+    @overload  # ?d, dtype=<known>
+    def __call__[ScalarT: _to_floating | np.object_](
+        self,
+        x: _ArrayLikeFloat_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> npt.NDArray[ScalarT] | Any: ...  # `| Any` because of overlap
+    @overload  # ?d, dtype=<unknown>
+    def __call__(
+        self,
+        x: _ArrayLikeFloat_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> Any: ...
+    @overload  # out=<given>
+    def __call__[OutT: np.ndarray](
+        self,
+        x: _ArrayLikeFloat_co,
+        /,
+        out: OutT,
+        *,
+        dtype: npt.DTypeLike | None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> OutT: ...
+    @overload  # out=<given>
+    def __call__[OutT](
+        self,
+        x: _CanUfuncCall1[OutT],
+        /,
+        out: object | None = None,
+        *,
+        dtype: npt.DTypeLike | None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> OutT: ...
+
+    #
+    @override
+    @overload
+    def at(self, a: npt.NDArray[_to_floating | np.object_], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
+    @overload
+    def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
+
 cbrt: Final[_ufunc_11_fo] = ...
 deg2rad: Final[_ufunc_11_fo] = ...
 degrees: Final[_ufunc_11_fo] = ...
@@ -637,6 +858,10 @@ sinh: Final[_ufunc_11_fco] = ...
 sqrt: Final[_ufunc_11_fco] = ...
 tan: Final[_ufunc_11_fco] = ...
 tanh: Final[_ufunc_11_fco] = ...
+
+ceil: Final[_ufunc_11_bifo] = ...
+floor: Final[_ufunc_11_bifo] = ...
+trunc: Final[_ufunc_11_bifo] = ...
 
 ###
 # re-exports from `_core._multiarray_umath` that are used by `_core._ufunc_config`

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -143,6 +143,9 @@ def test_matmul_at_invalid() -> None:
 
 ###
 
+_py_b_0d: bool
+_py_b_1d: list[bool]
+_py_b_2d: list[list[bool]]
 _py_i_0d: int
 _py_i_1d: list[int]
 _py_i_2d: list[list[int]]
@@ -153,7 +156,15 @@ _py_c_0d: complex
 _py_c_1d: list[complex]
 _py_c_2d: list[list[complex]]
 
-_i16_0d: np.int64
+_bool_0d: np.bool
+_bool_1d: np.ndarray[tuple[int], np.dtype[np.bool]]
+_bool_2d: np.ndarray[tuple[int, int], np.dtype[np.bool]]
+_bool_nd: npt.NDArray[np.bool]
+_u8_0d: np.uint8
+_u8_1d: np.ndarray[tuple[int], np.dtype[np.uint8]]
+_u8_2d: np.ndarray[tuple[int, int], np.dtype[np.uint8]]
+_u8_nd: npt.NDArray[np.uint8]
+_i16_0d: np.int16
 _i16_1d: np.ndarray[tuple[int], np.dtype[np.int16]]
 _i16_2d: np.ndarray[tuple[int, int], np.dtype[np.int16]]
 _i16_nd: npt.NDArray[np.int16]
@@ -238,3 +249,47 @@ assert_type(np.sin(_py_i_1d, dtype="f4"), np.ndarray)
 assert_type(np.sin(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
 
 assert_type(np.sin(_py_i_2d, out=_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+
+# _ufunc_11_bifo
+# (ceil, floor, trunc)
+
+assert_type(np.ceil(_py_b_0d), np.bool)
+assert_type(np.ceil(_py_b_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.ceil(_py_b_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.ceil(_py_i_0d), np.int_ | Any)
+assert_type(np.ceil(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.int_]])
+assert_type(np.ceil(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.int_]])
+assert_type(np.ceil(_py_f_0d), np.float64 | Any)
+assert_type(np.ceil(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.ceil(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+
+assert_type(np.ceil(_bool_0d), np.bool)
+assert_type(np.ceil(_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.ceil(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.ceil(_bool_nd), npt.NDArray[np.bool])
+assert_type(np.ceil(_u8_0d), np.uint8)
+assert_type(np.ceil(_u8_1d), np.ndarray[tuple[int], np.dtype[np.uint8]])
+assert_type(np.ceil(_u8_2d), np.ndarray[tuple[int, int], np.dtype[np.uint8]])
+assert_type(np.ceil(_u8_nd), npt.NDArray[np.uint8])
+assert_type(np.ceil(_i16_0d), np.int16)
+assert_type(np.ceil(_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
+assert_type(np.ceil(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.int16]])
+assert_type(np.ceil(_i16_nd), npt.NDArray[np.int16])
+assert_type(np.ceil(_f32_0d), np.float32)
+assert_type(np.ceil(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.ceil(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.ceil(_f32_nd), npt.NDArray[np.float32])
+assert_type(np.ceil(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
+assert_type(np.ceil(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.ceil(_obj_nd), npt.NDArray[np.object_])
+
+assert_type(np.ceil(_py_b_0d, dtype=np.uint8), np.uint8)
+assert_type(np.ceil(_py_i_1d, dtype=np.float32), npt.NDArray[np.float32])
+assert_type(np.ceil(_u8_2d, dtype=np.bool), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+
+assert_type(np.ceil(_py_b_0d, dtype="f4"), Any)
+assert_type(np.ceil(_py_i_1d, dtype="f4"), np.ndarray)
+assert_type(np.ceil(_u8_2d, dtype="f4"), np.ndarray[tuple[int, int]])
+
+assert_type(np.ceil(_py_b_1d, out=_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
+assert_type(np.ceil(_py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -250,6 +250,42 @@ assert_type(np.sin(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
 
 assert_type(np.sin(_py_i_2d, out=_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
 
+# _ufunc_11_bio
+# (invert)
+
+assert_type(np.invert(_py_b_0d), np.bool)
+assert_type(np.invert(_py_b_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.invert(_py_b_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.invert(_py_i_0d), np.int_ | Any)
+assert_type(np.invert(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.int_]])
+assert_type(np.invert(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.int_]])
+
+assert_type(np.invert(_bool_0d), np.bool)
+assert_type(np.invert(_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.invert(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.invert(_bool_nd), npt.NDArray[np.bool])
+assert_type(np.invert(_u8_0d), np.uint8)
+assert_type(np.invert(_u8_1d), np.ndarray[tuple[int], np.dtype[np.uint8]])
+assert_type(np.invert(_u8_2d), np.ndarray[tuple[int, int], np.dtype[np.uint8]])
+assert_type(np.invert(_u8_nd), npt.NDArray[np.uint8])
+assert_type(np.invert(_i16_0d), np.int16)
+assert_type(np.invert(_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
+assert_type(np.invert(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.int16]])
+assert_type(np.invert(_i16_nd), npt.NDArray[np.int16])
+assert_type(np.invert(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
+assert_type(np.invert(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.invert(_obj_nd), npt.NDArray[np.object_])
+
+assert_type(np.invert(_py_b_0d, dtype=np.uint8), np.uint8)
+assert_type(np.invert(_py_i_1d, dtype=np.int16), npt.NDArray[np.int16])
+assert_type(np.invert(_u8_2d, dtype=np.bool), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+
+assert_type(np.invert(_py_b_0d, dtype="i4"), Any)
+assert_type(np.invert(_py_i_1d, dtype="i4"), np.ndarray)
+assert_type(np.invert(_u8_2d, dtype="i4"), np.ndarray[tuple[int, int]])
+
+assert_type(np.invert(_py_b_1d, out=_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
+
 # _ufunc_11_bifo
 # (ceil, floor, trunc)
 


### PR DESCRIPTION
Following #31730, this adds specialized typing support for the `bool | integer | object_` and `bool | integer | floating | object_` unary endo-ufuncs; `ceil`, `floor`, `trunc`, and `invert`.

No AI.