### PR TITLE
TYP: specialized ``conj[ugate]``, ``reciprocal``, and ``square`` ufuncs

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -405,6 +405,8 @@ from numpy._core.umath import (
     arctanh as atanh,
     cbrt,
     ceil,
+    conjugate,
+    conjugate as conj,
     cos,
     cosh,
     deg2rad,
@@ -421,9 +423,11 @@ from numpy._core.umath import (
     log2,
     rad2deg,
     radians,
+    reciprocal,
     rint,
     sin,
     sinh,
+    square,
     sqrt,
     tan,
     tanh,
@@ -7589,7 +7593,6 @@ bitwise_and: _UFunc_Nin2_Nout1[L["bitwise_and"], L[12], L[-1]]
 bitwise_count: _UFunc_Nin1_Nout1[L["bitwise_count"], L[11], None]
 bitwise_or: _UFunc_Nin2_Nout1[L["bitwise_or"], L[12], L[0]]
 bitwise_xor: _UFunc_Nin2_Nout1[L["bitwise_xor"], L[12], L[0]]
-conjugate: _UFunc_Nin1_Nout1[L["conjugate"], L[18], None]
 copysign: _UFunc_Nin2_Nout1[L["copysign"], L[4], None]
 divide: _UFunc_Nin2_Nout1[L["divide"], L[11], None]
 divmod: _UFunc_Nin2_Nout2[L["divmod"], L[15], None]
@@ -7631,13 +7634,11 @@ nextafter: _UFunc_Nin2_Nout1[L["nextafter"], L[4], None]
 not_equal: _UFunc_Nin2_Nout1[L["not_equal"], L[23], None]
 positive: _UFunc_Nin1_Nout1[L["positive"], L[19], None]
 power: _UFunc_Nin2_Nout1[L["power"], L[18], None]
-reciprocal: _UFunc_Nin1_Nout1[L["reciprocal"], L[18], None]
 remainder: _UFunc_Nin2_Nout1[L["remainder"], L[16], None]
 right_shift: _UFunc_Nin2_Nout1[L["right_shift"], L[11], None]
 sign: _UFunc_Nin1_Nout1[L["sign"], L[19], None]
 signbit: _UFunc_Nin1_Nout1[L["signbit"], L[4], None]
 spacing: _UFunc_Nin1_Nout1[L["spacing"], L[4], None]
-square: _UFunc_Nin1_Nout1[L["square"], L[18], None]
 subtract: _UFunc_Nin2_Nout1[L["subtract"], L[21], None]
 vecdot: _GUFunc_Nin2_Nout1[L["vecdot"], L[19], None, L["(n),(n)->()"]]
 vecmat: _GUFunc_Nin2_Nout1[L["vecmat"], L[19], None, L["(n),(n,m)->(m)"]]
@@ -7649,7 +7650,6 @@ bitwise_left_shift = left_shift
 bitwise_not = invert
 bitwise_invert = invert
 bitwise_right_shift = right_shift
-conj = conjugate
 mod = remainder
 permute_dims = transpose
 pow = power

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -30,7 +30,6 @@ from numpy import (
     bitwise_or,
     bitwise_xor,
     conj,
-    conjugate,
     copysign,
     divide,
     divmod,
@@ -77,13 +76,11 @@ from numpy import (
     pi,
     positive,
     power,
-    reciprocal,
     remainder,
     right_shift,
     sign,
     signbit,
     spacing,
-    square,
     subtract,
     true_divide,
     vecdot,
@@ -214,6 +211,7 @@ type _ErrCall = Callable[[str, int], Any] | SupportsWrite[str]
 
 type _to_integer = np.integer | np.bool
 type _to_floating = np.floating | _to_integer
+type _to_number = np.number | np.bool
 
 @type_check_only
 class _ExtOjbDict(TypedDict, total=False):
@@ -398,7 +396,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         /,
         *,
         out: EllipsisType | None = None,
-        dtype: npt.DTypeLike,
+        dtype: npt.DTypeLike | None = None,
         **kwargs: Unpack[_Kwargs11],
     ) -> Any: ...
     @overload  # out=<given>
@@ -580,7 +578,7 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
         /,
         *,
         out: EllipsisType | None = None,
-        dtype: npt.DTypeLike,
+        dtype: npt.DTypeLike | None = None,
         **kwargs: Unpack[_Kwargs11],
     ) -> Any: ...
     @overload  # out=<given>
@@ -608,6 +606,248 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
     @override
     @overload
     def at(self, a: npt.NDArray[np.inexact | np.object_], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
+    @overload
+    def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
+
+# bBhHiIlLqQefdgFDGO => bBhHiIlLqQefdgFDGO
+@type_check_only
+class _ufunc_11_ifco(_ufunc_11):  # type: ignore[misc]
+    @override
+    @overload  # known shape, known scalar/array
+    def __call__[T: np.number | npt.NDArray[np.number | np.object_]](
+        self,
+        x: T,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> T: ...
+    @overload  # Nd, bool->i8
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[np.bool]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT, np.dtype[np.int8]]: ...
+    @overload  # scalar, bool->i8
+    def __call__(
+        self,
+        x: bool | np.bool,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.int8: ...
+    @overload  # scalar, int  (overlaps with bool)
+    def __call__(
+        self,
+        x: int,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.int_ | Any: ...
+    @overload  # scalar, float  (overlaps with int)
+    def __call__(
+        self,
+        x: float,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.float64 | Any: ...
+    @overload  # scalar, complex  (overlaps with float)
+    def __call__(
+        self,
+        x: complex,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.complex128 | Any: ...
+    @overload  # 1d, bool
+    def __call__(
+        self,
+        x: Sequence[bool],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array1D[np.int8]: ...
+    @overload  # 1d, ~int
+    def __call__(
+        self,
+        x: list[int],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array1D[np.int_]: ...
+    @overload  # 1d, ~float
+    def __call__(
+        self,
+        x: list[float],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array1D[np.float64]: ...
+    @overload  # 1d, ~complex
+    def __call__(
+        self,
+        x: list[complex],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array1D[np.complex128]: ...
+    @overload  # 2d, bool
+    def __call__(
+        self,
+        x: Sequence[Sequence[bool]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array2D[np.int8]: ...
+    @overload  # 2d, ~int
+    def __call__(
+        self,
+        x: Sequence[list[int]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array2D[np.int_]: ...
+    @overload  # 2d, ~float
+    def __call__(
+        self,
+        x: Sequence[list[float]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array2D[np.float64]: ...
+    @overload  # 2d, ~complex
+    def __call__(
+        self,
+        x: Sequence[list[complex]],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> _Array2D[np.complex128]: ...
+    @overload  # scalar, dtype=<known>
+    def __call__[ScalarT: np.number](
+        self,
+        x: _NumberLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> ScalarT: ...
+    @overload  # Nd, dtype=<known>
+    def __call__[ShapeT: _Shape, ScalarT: np.number | np.object_](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_to_number | np.object_]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    @overload  # Nd, dtype=<unknown>
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_to_number | np.object_]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT]: ...
+    @overload  # Nd, dtype=<known>
+    def __call__[ScalarT: np.number | np.object_](
+        self,
+        x: _NestedSequence[complex],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # Nd, dtype=<unknown>
+    def __call__(
+        self,
+        x: _NestedSequence[complex],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray: ...
+    @overload  # ?d, dtype=<known>
+    def __call__[ScalarT: np.number | np.object_](
+        self,
+        x: _ArrayLikeNumber_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs11],
+    ) -> npt.NDArray[ScalarT] | Any: ...  # `| Any` because of overlap
+    @overload  # ?d, dtype=<unknown>
+    def __call__(
+        self,
+        x: _ArrayLikeNumber_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: npt.DTypeLike | None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> Any: ...
+    @overload  # out=<given>
+    def __call__[OutT: np.ndarray](
+        self,
+        x: _ArrayLikeNumber_co,
+        /,
+        out: OutT,
+        *,
+        dtype: npt.DTypeLike | None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> OutT: ...
+    @overload  # x.__array_ufunc__(...) -> OutT
+    def __call__[OutT](
+        self,
+        x: _CanUfuncCall1[OutT],
+        /,
+        out: object | None = None,
+        *,
+        dtype: npt.DTypeLike | None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> OutT: ...
+
+    #
+    @override
+    @overload
+    def at(self, a: npt.NDArray[np.number | np.object_], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
     @overload
     def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
 
@@ -772,7 +1012,7 @@ class _ufunc_11_bio(_ufunc_11):  # type: ignore[misc]
         /,
         *,
         out: EllipsisType | None = None,
-        dtype: npt.DTypeLike,
+        dtype: npt.DTypeLike | None = None,
         **kwargs: Unpack[_Kwargs11],
     ) -> Any: ...
     @overload  # out=<given>
@@ -994,7 +1234,7 @@ class _ufunc_11_bifo(_ufunc_11):  # type: ignore[misc]
         /,
         *,
         out: EllipsisType | None = None,
-        dtype: npt.DTypeLike,
+        dtype: npt.DTypeLike | None = None,
         **kwargs: Unpack[_Kwargs11],
     ) -> Any: ...
     @overload  # out=<given>
@@ -1053,6 +1293,10 @@ sinh: Final[_ufunc_11_fco] = ...
 sqrt: Final[_ufunc_11_fco] = ...
 tan: Final[_ufunc_11_fco] = ...
 tanh: Final[_ufunc_11_fco] = ...
+
+conjugate: Final[_ufunc_11_ifco] = ...
+reciprocal: Final[_ufunc_11_ifco] = ...
+square: Final[_ufunc_11_ifco] = ...
 
 invert: Final[_ufunc_11_bio] = ...
 

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -250,6 +250,54 @@ assert_type(np.sin(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
 
 assert_type(np.sin(_py_i_2d, out=_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
 
+# _ufunc_11_ifco
+# (conj[ugate], reciprocal, square)
+
+assert_type(np.square(_py_b_0d), np.int8)
+assert_type(np.square(_py_b_1d), np.ndarray[tuple[int], np.dtype[np.int8]])
+assert_type(np.square(_py_b_2d), np.ndarray[tuple[int, int], np.dtype[np.int8]])
+assert_type(np.square(_py_i_0d), np.int_ | Any)  # `int` overlaps with `bool`
+assert_type(np.square(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.int_]])
+assert_type(np.square(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.int_]])
+assert_type(np.square(_py_f_0d), np.float64 | Any)  # `complex` overlaps with `int`
+assert_type(np.square(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.square(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.square(_py_c_0d), np.complex128 | Any)  # `complex` overlaps with `float`
+assert_type(np.square(_py_c_1d), np.ndarray[tuple[int], np.dtype[np.complex128]])
+assert_type(np.square(_py_c_2d), np.ndarray[tuple[int, int], np.dtype[np.complex128]])
+
+assert_type(np.square(_bool_0d), np.int8)
+assert_type(np.square(_bool_1d), np.ndarray[tuple[int], np.dtype[np.int8]])
+assert_type(np.square(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.int8]])
+assert_type(np.square(_bool_nd), npt.NDArray[np.int8])
+assert_type(np.square(_i16_0d), np.int16)
+assert_type(np.square(_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
+assert_type(np.square(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.int16]])
+assert_type(np.square(_i16_nd), npt.NDArray[np.int16])
+assert_type(np.square(_f32_0d), np.float32)
+assert_type(np.square(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.square(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.square(_f32_nd), npt.NDArray[np.float32])
+assert_type(np.square(_c64_0d), np.complex64)
+assert_type(np.square(_c64_1d), np.ndarray[tuple[int], np.dtype[np.complex64]])
+assert_type(np.square(_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+assert_type(np.square(_c64_nd), npt.NDArray[np.complex64])
+assert_type(np.square(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
+assert_type(np.square(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.square(_obj_nd), npt.NDArray[np.object_])
+
+assert_type(np.square(_py_b_0d, dtype=np.float32), np.float32)
+assert_type(np.square(_py_i_1d, dtype=np.float32), npt.NDArray[np.float32])
+assert_type(np.square(_i16_2d, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+
+assert_type(np.square(_py_b_0d, dtype="f4"), Any)
+assert_type(np.square(_py_i_1d, dtype="f4"), np.ndarray)
+assert_type(np.square(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
+
+assert_type(np.square(_py_b_0d, out=_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
+assert_type(np.square(_py_i_1d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.square(_py_f_2d, out=_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+
 # _ufunc_11_bio
 # (invert)
 


### PR DESCRIPTION
Following #31741, here's another batch of ufunc specializations, targeting the unary endo-ufuncs on `number | object_`; `conj[ugate]`, `reciprocal`, and `square`. 

Boolean input, although not in the type signature, required additional overloads, since boolean input results in `int8` output, so it couldn't be "absorbed" in the `int_` overloads like with the other specialized ufuncs (`sin` for example).

I also snuck in a tiny fix, so that obscure array-likes that aren't captured by any of the other overloads, will also be accepted if no `dtype` or `out` param is required. This is probably pretty rare in the wild (e.g. no related mymy primer errors), but it's an easy fix, so we might as well.

---

No AI.