### PR TITLE
BUG: fix vdot returning None for empty object arrays

### DIFF
--- a/numpy/_core/src/multiarray/vdot.c
+++ b/numpy/_core/src/multiarray/vdot.c
@@ -145,6 +145,16 @@ OBJECT_vdot(char *ip1, npy_intp is1, char *ip2, npy_intp is2, char *op, npy_intp
     npy_intp i;
     PyObject *tmp0, *tmp1, *tmp2, *tmp = NULL;
     PyObject **tmp3;
+
+    if (n == 0) {
+        PyObject *zero = PyLong_FromLong(0);
+        if (zero == NULL) {
+            return;
+        }
+        Py_XSETREF(*((PyObject **)op), zero);
+        return;
+    }
+
     for (i = 0; i < n; i++, ip1 += is1, ip2 += is2) {
         if ((*((PyObject **)ip1) == NULL) || (*((PyObject **)ip2) == NULL)) {
             tmp1 = Py_False;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -7682,6 +7682,13 @@ class TestVdot:
         assert_(np.isscalar(res))
         assert_equal(np.vdot(b, b), True)
 
+    def test_vdot_object_empty(self):
+        x = np.empty((0,), dtype=object)
+        assert np.vdot(x, x) == 0
+
+        x2 = np.empty((1, 0), dtype=object)
+        assert_array_equal(np.vdot(x2, x2), np.array([0], dtype=object))
+
     def test_vdot_array_order(self):
         a = np.array([[1, 2], [3, 4]], order='C')
         b = np.array([[1, 2], [3, 4]], order='F')


### PR DESCRIPTION
np.vdot on zero-length object arrays returns None instead of 0,
matching the same bug that was fixed in vecdot (#31033).

Add a zero-length guard in OBJECT_vdot to return PyLong_FromLong(0),
consistent with the numeric type behavior.

Closes #31735.