### PR TITLE
ENH: Implement MaskedArray.tofile()

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -6403,20 +6403,52 @@ class MaskedArray(ndarray):
         """
         return self.filled(fill_value).tobytes(order=order)
 
-    def tofile(self, fid, sep="", format="%s"):
+    def tofile(self, fid, sep="", format="%s", fill_value=None):
         """
-        Save a masked array to a file in binary format.
+        Save a masked array to a file in binary or text format.
 
-        .. warning::
-          This function is not implemented yet.
+        Masked values are replaced by `fill_value` before writing.
 
-        Raises
-        ------
-        NotImplementedError
-            When `tofile` is called.
+        Parameters
+        ----------
+        fid : str, bytes, os.PathLike, or file-like object
+            An open file object, or a string containing a filename.
+        sep : str, optional
+            Separator between array items for text output. If '' (empty)
+            or '\\n', a binary file is written, equivalent to
+            ``file.write(a.tobytes())``.
+        format : str, optional
+            Format string for text file output. Each entry in the array
+            is formatted to text by first converting it to the closest
+            Python type, and then using "format" % item.
+        fill_value : scalar, optional
+            Value used to fill in the masked values. Default is None, in
+            which case `MaskedArray.fill_value` is used.
+
+        Notes
+        -----
+        The mask and `fill_value` are not stored in the file. Mask
+        information is lost: loading the file back will yield an unmasked
+        array with fill values where masked entries were.
+
+        See Also
+        --------
+        numpy.ndarray.tofile
+        tobytes, tolist
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import tempfile
+        >>> x = np.ma.array([1, 2, 3], mask=[False, True, False])
+        >>> with tempfile.TemporaryFile() as f:
+        ...     x.tofile(f)
+        ...     _ = f.seek(0)
+        ...     np.fromfile(f, dtype=x.dtype)
+        array([1, 999999,      3])
 
         """
-        raise NotImplementedError("MaskedArray.tofile() not implemented yet.")
+        self.filled(fill_value).tofile(fid, sep=sep, format=format)
 
     def toflex(self):
         """

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -2,7 +2,7 @@
 
 import datetime as dt
 import types
-from _typeshed import Incomplete, SupportsLenAndGetItem
+from _typeshed import Incomplete, StrOrBytesPath, SupportsLenAndGetItem
 from collections.abc import Buffer, Callable, Iterator, Sequence
 from typing import (
     Any,
@@ -36,6 +36,7 @@ from numpy import (
     _OrderKACF,
     _PartitionKind,
     _SortKind,
+    _SupportsFileMethods,
     _ToIndices,
     amax,
     amin,
@@ -2780,9 +2781,15 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
     @overload
     def tolist(self, /, fill_value: _ScalarLike_co | None = None) -> Any: ...
 
-    # NOTE: will raise `NotImplementedError`
     @override
-    def tofile(self, /, fid: Never, sep: str = "", format: str = "%s") -> NoReturn: ...  # type: ignore[override]
+    def tofile(
+        self,
+        /,
+        fid: StrOrBytesPath | _SupportsFileMethods,
+        sep: str = "",
+        format: str = "%s",
+        fill_value: ArrayLike | None = None,
+    ) -> None: ...
 
     #
     @override

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1122,14 +1122,31 @@ class TestMaskedArray:
         mx[1].data[0] = 0.
         assert_(mx2[0] == 0.)
 
-    def test_maskedarray_tofile_raises_notimplementederror(self):
+    def test_maskedarray_tofile(self):
         xm = masked_array([1, 2, 3], mask=[False, True, False])
-        # Test case to check the NotImplementedError.
-        # It is not implemented at this point of time. We can change this in future
-        with temppath(suffix='.npy') as path:
-            with pytest.raises(NotImplementedError):
+        # Binary mode: masked value replaced by fill_value
+        with temppath(suffix='.bin') as path:
+            xm.tofile(path)
+            result = np.fromfile(path, dtype=xm.dtype)
+            assert_equal(result, [1, xm.fill_value, 3])
 
-                np.save(path, xm)
+        # Binary mode: explicit fill_value
+        with temppath(suffix='.bin') as path:
+            xm.tofile(path, fill_value=0)
+            result = np.fromfile(path, dtype=xm.dtype)
+            assert_equal(result, [1, 0, 3])
+
+        # Text mode
+        with temppath(suffix='.txt') as path:
+            xm.tofile(path, sep=",")
+            with open(path) as f:
+                assert_equal(f.read(), f"1,{xm.fill_value},3")
+
+        # np.save now works (mask info is lost on load)
+        with temppath(suffix='.npy') as path:
+            np.save(path, xm)
+            result = np.load(path)
+            assert_equal(result, [1, xm.fill_value, 3])
 
 
 @pytest.fixture(autouse=True, scope="class")


### PR DESCRIPTION
`MaskedArray.tofile()` was not implemented and always raised `NotImplementedError`. That also meant `np.save()` failed on masked arrays, since it ends up calling `tofile()`.

This delegates to `filled(fill_value).tofile()`, same as `tobytes()`. Masked entries are written using the fill value; the mask itself is not stored in the file.

Updated the stub in `core.pyi` and replaced the old test that only checked for `NotImplementedError`.