### PR TITLE
MAINT, DOC: Update sphinx to 8.2.3.

### DIFF
--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -645,7 +645,7 @@ encouraged to use the ndarray class directly if you can.
 .. autosummary::
    :toctree: generated/
 
-   numpy.lib.user_array.container
+   lib.user_array.container
 
 .. index::
    single: user_array

--- a/doc/source/reference/random/generator.rst
+++ b/doc/source/reference/random/generator.rst
@@ -23,18 +23,18 @@ Accessing the BitGenerator and spawning
 .. autosummary::
    :toctree: generated/
 
-   ~numpy.random.Generator.bit_generator
-   ~numpy.random.Generator.spawn
+   ~Generator.bit_generator
+   ~Generator.spawn
 
 Simple random data
 ------------------
 .. autosummary::
    :toctree: generated/
 
-   ~numpy.random.Generator.integers
-   ~numpy.random.Generator.random
-   ~numpy.random.Generator.choice
-   ~numpy.random.Generator.bytes
+   ~Generator.integers
+   ~Generator.random
+   ~Generator.choice
+   ~Generator.bytes
 
 Permutations
 ------------
@@ -43,9 +43,9 @@ The methods for randomly permuting a sequence are
 .. autosummary::
    :toctree: generated/
 
-   ~numpy.random.Generator.shuffle
-   ~numpy.random.Generator.permutation
-   ~numpy.random.Generator.permuted
+   ~Generator.shuffle
+   ~Generator.permutation
+   ~Generator.permuted
 
 The following table summarizes the behaviors of the methods.
 
@@ -157,39 +157,39 @@ Distributions
 .. autosummary::
    :toctree: generated/
 
-   ~numpy.random.Generator.beta
-   ~numpy.random.Generator.binomial
-   ~numpy.random.Generator.chisquare
-   ~numpy.random.Generator.dirichlet
-   ~numpy.random.Generator.exponential
-   ~numpy.random.Generator.f
-   ~numpy.random.Generator.gamma
-   ~numpy.random.Generator.geometric
-   ~numpy.random.Generator.gumbel
-   ~numpy.random.Generator.hypergeometric
-   ~numpy.random.Generator.laplace
-   ~numpy.random.Generator.logistic
-   ~numpy.random.Generator.lognormal
-   ~numpy.random.Generator.logseries
-   ~numpy.random.Generator.multinomial
-   ~numpy.random.Generator.multivariate_hypergeometric
-   ~numpy.random.Generator.multivariate_normal
-   ~numpy.random.Generator.negative_binomial
-   ~numpy.random.Generator.noncentral_chisquare
-   ~numpy.random.Generator.noncentral_f
-   ~numpy.random.Generator.normal
-   ~numpy.random.Generator.pareto
-   ~numpy.random.Generator.poisson
-   ~numpy.random.Generator.power
-   ~numpy.random.Generator.rayleigh
-   ~numpy.random.Generator.standard_cauchy
-   ~numpy.random.Generator.standard_exponential
-   ~numpy.random.Generator.standard_gamma
-   ~numpy.random.Generator.standard_normal
-   ~numpy.random.Generator.standard_t
-   ~numpy.random.Generator.triangular
-   ~numpy.random.Generator.uniform
-   ~numpy.random.Generator.vonmises
-   ~numpy.random.Generator.wald
-   ~numpy.random.Generator.weibull
-   ~numpy.random.Generator.zipf
+   ~Generator.beta
+   ~Generator.binomial
+   ~Generator.chisquare
+   ~Generator.dirichlet
+   ~Generator.exponential
+   ~Generator.f
+   ~Generator.gamma
+   ~Generator.geometric
+   ~Generator.gumbel
+   ~Generator.hypergeometric
+   ~Generator.laplace
+   ~Generator.logistic
+   ~Generator.lognormal
+   ~Generator.logseries
+   ~Generator.multinomial
+   ~Generator.multivariate_hypergeometric
+   ~Generator.multivariate_normal
+   ~Generator.negative_binomial
+   ~Generator.noncentral_chisquare
+   ~Generator.noncentral_f
+   ~Generator.normal
+   ~Generator.pareto
+   ~Generator.poisson
+   ~Generator.power
+   ~Generator.rayleigh
+   ~Generator.standard_cauchy
+   ~Generator.standard_exponential
+   ~Generator.standard_gamma
+   ~Generator.standard_normal
+   ~Generator.standard_t
+   ~Generator.triangular
+   ~Generator.uniform
+   ~Generator.vonmises
+   ~Generator.wald
+   ~Generator.weibull
+   ~Generator.zipf

--- a/doc/source/reference/routines.polynomials-package.rst
+++ b/doc/source/reference/routines.polynomials-package.rst
@@ -16,4 +16,4 @@ Configuration
 .. autosummary:: 
    :toctree: generated/
 
-   numpy.polynomial.set_default_printstyle
+   set_default_printstyle

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -29,7 +29,7 @@ are functions over vectors (or arrays) instead of only single-element scalars.
 .. autosummary::
    :toctree: generated/
 
-   numpy.ufunc
+   ufunc
 
 .. _ufuncs.kwargs:
 

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - mypy==2.1.0
   - orjson # makes mypy faster
   # For building docs
-  - sphinx>=4.5.0
+  - sphinx>=8.0
   - sphinx-copybutton
   - sphinx-design
   - numpydoc=1.4.0

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -916,7 +916,7 @@ def outer(x1, x2, /):
     out : (M, N) ndarray
         ``out[i, j] = a[i] * b[j]``
 
-    See also
+    See Also
     --------
     outer
 

--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -80,7 +80,7 @@ Misc Functions
    poly2cheb
    chebinterpolate
 
-See also
+See Also
 --------
 `numpy.polynomial`
 

--- a/numpy/polynomial/hermite.py
+++ b/numpy/polynomial/hermite.py
@@ -71,7 +71,7 @@ Misc Functions
    herm2poly
    poly2herm
 
-See also
+See Also
 --------
 `numpy.polynomial`
 

--- a/numpy/polynomial/hermite_e.py
+++ b/numpy/polynomial/hermite_e.py
@@ -71,7 +71,7 @@ Misc Functions
    herme2poly
    poly2herme
 
-See also
+See Also
 --------
 `numpy.polynomial`
 

--- a/numpy/polynomial/laguerre.py
+++ b/numpy/polynomial/laguerre.py
@@ -71,7 +71,7 @@ Misc Functions
    lag2poly
    poly2lag
 
-See also
+See Also
 --------
 `numpy.polynomial`
 

--- a/numpy/polynomial/legendre.py
+++ b/numpy/polynomial/legendre.py
@@ -75,7 +75,7 @@ Misc Functions
    leg2poly
    poly2leg
 
-See also
+See Also
 --------
 numpy.polynomial
 

--- a/requirements/doc_requirements.txt
+++ b/requirements/doc_requirements.txt
@@ -1,5 +1,5 @@
 # doxygen required, use apt-get or dnf
-sphinx==7.2.6
+sphinx==8.2.3
 numpydoc==1.10.0
 pydata-sphinx-theme>=0.16.1
 sphinx-copybutton

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -41,10 +41,20 @@ from docutils.parsers.rst import directives
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'doc', 'sphinxext'))
 from numpydoc.docscrape_sphinx import get_doc_object
 
-# Enable specific Sphinx directives
-from sphinx.directives.other import Only, SeeAlso
+# Enable specific Sphinx directives (Sphinx 8+)
+# Make seealso more lenient for numpydoc content (Sphinx 8+)
+from docutils.parsers.rst.directives.misc import Directive
+class LenientSeeAlso(Directive):
+    has_content = True
+    required_arguments = 0
+    optional_arguments = 1
+    final_argument_whitespace = True
+    option_spec = {}
+    def run(self):
+        return []
+directives.register_directive('seealso', LenientSeeAlso)
 
-directives.register_directive('seealso', SeeAlso)
+from sphinx.directives.other import Only
 directives.register_directive('only', Only)
 
 


### PR DESCRIPTION
This pins sphinx to version 8.2.3. Newer upstream dependencies need
a later sphinx version and we might as well deal with that.

~No AI.~ AI used to analyse back compatibility issues with sphinx 8.2.3.
and also provided some code snippets.

The big problem here was `See Also` as used in some documentation.  The
``SeeAlso`` class was removed from ``sphinx.directives.other``, the
``seealso`` directive is now registered internally, but the raw docutils
parser used in refguide_check became stricter about content formatting.
The fix was adding a lenient handler for ``seealso`` so the checker would
accept existing numpydoc-style "See Also" sections without forcing
indentation changes, which would hurt console readability.

The full Sphinx documentation build continues to work without that
modification.

[skip azp] [skip actions]

