### PR TITLE
DOC:fix NumPy capitalization in Python source files

### DIFF
--- a/benchmarks/benchmarks/bench_app.py
+++ b/benchmarks/benchmarks/bench_app.py
@@ -70,7 +70,7 @@ class MaxesOfDots(Benchmark):
 
         Arrays must agree only on the first dimension.
 
-        Numpy uses this as a simultaneous benchmark of 1) dot products
+        NumPy uses this as a simultaneous benchmark of 1) dot products
         and 2) max(<array>, axis=<int>).
         """
         feature_scores = ([0] * len(arrays))

--- a/benchmarks/benchmarks/bench_overrides.py
+++ b/benchmarks/benchmarks/bench_overrides.py
@@ -3,7 +3,7 @@ from .common import Benchmark
 try:
     from numpy._core.overrides import array_function_dispatch
 except ImportError:
-    # Don't fail at import time with old Numpy versions
+    # Don't fail at import time with old NumPy versions
     def array_function_dispatch(*args, **kwargs):
         def wrap(*args, **kwargs):
             return None

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -322,7 +322,7 @@ class TestDeprecatedDTypeParenthesizedRepeatCount(_DeprecationTestCase):
 
 
 class TestDTypeAlignBool(_VisibleDeprecationTestCase):
-    # Deprecated in Numpy 2.4, 2025-07
+    # Deprecated in NumPy 2.4, 2025-07
     # NOTE: As you can see, finalizing this deprecation breaks some (very) old
     # pickle files.  This may be fine, but needs to be done with some care since
     # it breaks all of them and not just some.
@@ -349,7 +349,7 @@ class TestDTypeAlignBool(_VisibleDeprecationTestCase):
 
 
 class TestFlatiterIndexing0dBoolIndex(_DeprecationTestCase):
-    # Deprecated in Numpy 2.4, 2025-07
+    # Deprecated in NumPy 2.4, 2025-07
     message = r"Indexing flat iterators with a 0-dimensional boolean index"
 
     def test_0d_boolean_index_deprecated(self):
@@ -407,7 +407,7 @@ class TestWarningUtilityDeprecations(_DeprecationTestCase):
 
 
 class TestTooManyArgsExtremum(_DeprecationTestCase):
-    # Deprecated in Numpy 2.4, 2025-08, gh-27639
+    # Deprecated in NumPy 2.4, 2025-08, gh-27639
     message = "Passing more than 2 positional arguments to np.maximum and np.minimum "
 
     @pytest.mark.parametrize("ufunc", [np.minimum, np.maximum])
@@ -416,7 +416,7 @@ class TestTooManyArgsExtremum(_DeprecationTestCase):
 
 
 class TestTypenameDeprecation(_DeprecationTestCase):
-    # Deprecation in Numpy 2.5, 2026-02
+    # Deprecation in NumPy 2.5, 2026-02
 
     def test_typename_emits_deprecation_warning(self):
         self.assert_deprecated(lambda: np.typename("S1"))
@@ -434,7 +434,7 @@ class TestRoundDeprecation(_DeprecationTestCase):
 
 
 class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
-    # Deprecated in Numpy 2.5, 2025-11
+    # Deprecated in NumPy 2.5, 2025-11
     # See gh-29619 for scalar operations
     # See gh-31255 for array operations
     message = "The 'generic' unit for NumPy timedelta is deprecated"
@@ -549,7 +549,7 @@ class TestTriDeprecationWithNonInteger(_DeprecationTestCase):
 
 
 class TestTakeOutDtype(_DeprecationTestCase):
-    # Deprecated in Numpy 2.5, 2026-01
+    # Deprecated in NumPy 2.5, 2026-01
     message = "Implicit casting of output to a different kind."
 
     def test_out_dtype_deprecated(self):

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -9246,7 +9246,7 @@ class TestNewBufferProtocol:
 
     def test_invalid_buffer_format(self):
         # datetime64 cannot be used fully in a buffer yet
-        # Should be fixed in the next Numpy major release
+        # Should be fixed in the next NumPy major release
         dt = np.dtype([('a', 'uint16'), ('b', 'M8[s]')])
         a = np.empty(3, dt)
         assert_raises((ValueError, BufferError), memoryview, a)

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -36,7 +36,7 @@ hypothesis.configuration.set_hypothesis_home_dir(
     os.path.join(tempfile.gettempdir(), ".hypothesis")
 )
 
-# We register two custom profiles for Numpy - for details see
+# We register two custom profiles for NumPy - for details see
 # https://hypothesis.readthedocs.io/en/latest/settings.html
 # The first is designed for our own CI runs; the latter also
 # forces determinism and is designed for use via np.test()

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -642,11 +642,11 @@ class TestIntegers:
                               endpoint=endpoint, dtype=dtype)
 
     def test_int64_uint64_corner_case(self, endpoint):
-        # When stored in Numpy arrays, `lbnd` is casted
+        # When stored in NumPy arrays, `lbnd` is casted
         # as np.int64, and `ubnd` is casted as np.uint64.
         # Checking whether `lbnd` >= `ubnd` used to be
         # done solely via direct comparison, which is incorrect
-        # because when Numpy tries to compare both numbers,
+        # because when NumPy tries to compare both numbers,
         # it casts both to np.float64 because there is
         # no integer superset of np.int64 and np.uint64. However,
         # `ubnd` is too large to be represented in np.float64,

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -261,11 +261,11 @@ class TestRandint:
         assert_(tgt[np.dtype(bool).name] == res)
 
     def test_int64_uint64_corner_case(self):
-        # When stored in Numpy arrays, `lbnd` is casted
+        # When stored in NumPy arrays, `lbnd` is casted
         # as np.int64, and `ubnd` is casted as np.uint64.
         # Checking whether `lbnd` >= `ubnd` used to be
         # done solely via direct comparison, which is incorrect
-        # because when Numpy tries to compare both numbers,
+        # because when NumPy tries to compare both numbers,
         # it casts both to np.float64 because there is
         # no integer superset of np.int64 and np.uint64. However,
         # `ubnd` is too large to be represented in np.float64,

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -407,11 +407,11 @@ class TestRandint:
             assert_array_equal(x, desired if size is not None else desired[0])
 
     def test_int64_uint64_corner_case(self):
-        # When stored in Numpy arrays, `lbnd` is casted
+        # When stored in NumPy arrays, `lbnd` is casted
         # as np.int64, and `ubnd` is casted as np.uint64.
         # Checking whether `lbnd` >= `ubnd` used to be
         # done solely via direct comparison, which is incorrect
-        # because when Numpy tries to compare both numbers,
+        # because when NumPy tries to compare both numbers,
         # it casts both to np.float64 because there is
         # no integer superset of np.int64 and np.uint64. However,
         # `ubnd` is too large to be represented in np.float64,


### PR DESCRIPTION
PR summary
This PR corrects inconsistent usage of the project name by replacing "Numpy" with the standardized form "NumPy" across Python source files.
First time committer introduction
I am a student interested in Artificial Intelligence and Machine Learning. I use Python and NumPy as core tools for learning data preprocessing and matrix operations. This is my first contribution to the NumPy project, and I am excited to start contributing to open-source.
AI Disclosure
No AI tools used

