### PR TITLE
TST: Fix failing riscv64 tests.

### DIFF
--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -95,6 +95,12 @@ jobs:
           -v /:/host -v $(pwd):/numpy ${DOCKER_CONTAINER} /bin/bash -c "
           apt update &&
           apt install -y cmake git curl ca-certificates &&
+          # Fix expired Microsoft/azure-cli repo key (affects riscv64/ubuntu:22.04)
+          mkdir -p /etc/apt/keyrings &&
+          curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
+            gpg --dearmor | \
+            tee /etc/apt/keyrings/microsoft.gpg > /dev/null &&
+          chmod go+r /etc/apt/keyrings/microsoft.gpg &&
           curl -LsSf https://astral.sh/uv/0.10.8/install.sh -o /tmp/uv-install.sh &&
           echo 'eae5e1dae89cd0b74d357f549ccd6faa94b2ad6c1d89d78972a625655a4556ae  /tmp/uv-install.sh' | sha256sum -c - &&
           sh /tmp/uv-install.sh &&


### PR DESCRIPTION
The problem was an expired key.

AI suggested the fix.

