### PR TITLE
BUG: restore ndarray.conjugate() for legacy user-defined dtypes

### DIFF
--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -828,8 +828,16 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
 NPY_NO_EXPORT PyObject *
 PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
 {
-    if (NPY_DT_SLOTS(NPY_DTYPE(PyArray_DTYPE(self)))->imag_meth != NULL) {
-        /* The dtype has `arr.imag` so `conjugate` must exist (or error) */
+    if (NPY_DT_SLOTS(NPY_DTYPE(PyArray_DTYPE(self)))->imag_meth != NULL
+            || PyArray_ISUSERDEF(self)) {
+        /*
+         * The dtype has `arr.imag` so `conjugate` must exist (or error).
+         * Legacy user-defined dtypes (`type_num >= NPY_USERDEF`) have no
+         * `imag_meth` and are not flagged numeric, but they may register a
+         * `conjugate` ufunc loop (e.g., quaternion), so dispatch to the ufunc
+         * for them as well, preserving the pre-2.5 behavior.  (New-style
+         * user dtypes have `type_num == -1` and are unaffected by this.)
+         */
         if (out == NULL) {
             return PyArray_GenericUnaryFunction(self,
                                                 n_ops.conjugate);

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -4535,6 +4535,14 @@ class TestMethods:
         with pytest.raises(TypeError, match="cannot conjugate non-numeric dtype"):
             a.conj()
 
+    def test_conjugate_legacy_user_dtype(self):
+        # gh-31754 : legacy user-defined dtypes are not flagged numeric and have
+        # no `.imag`, but `conjugate` must still dispatch to the ufunc (which
+        # falls back to a cast for `rational`) rather than raising.
+        a = np.array([1, 2, 3], dtype=rational)
+        assert_array_equal(a.conjugate(), np.conjugate(a))
+        assert_array_equal(a.conjugate(), [1, 2, 3])
+
     def test_conjugate_out(self):
         # Minimal test for the out argument being passed on correctly
         # NOTE: The ability to pass `out` is currently undocumented!


### PR DESCRIPTION
### PR summary

#31264 rewrote PyArray_Conjugate to dispatch to the conjugate ufunc only when the DType defines an `imag_meth` slot, dropping the explicit `PyArray_ISUSERDEF` route. Legacy user dtypes have no `imag_meth` and are not flagged numeric, so `arr.conjugate()` began raising "cannot conjugate non-numeric dtype" in 2.5.0, even when a conjugate ufunc loop is registered (e.g. numpy-quaternion).

Restore the legacy user-dtype route so these dtypes dispatch to the ufunc as before, while leaving the new-style view/numeric behavior intact.

Closes #31754


#### AI Disclosure
I used Claude to find where the original bug came from, and to check through the docs and commit history to convince myself that this was the right approach.
