### PR TITLE
BUG: aligned access for the descriptor fields struct on 32bit abi3t

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -616,6 +616,23 @@ typedef struct {
                                 NPY_ITEM_IS_POINTER | NPY_ITEM_REFCOUNT | \
                                 NPY_NEEDS_INIT | NPY_NEEDS_PYAPI)
 
+/*
+ * Under Py_TARGET_ABI3T these field structs are overlaid at
+ * `(char *)obj + sizeof(PyObject)`, which is only pointer-aligned on 32-bit
+ * free-threaded builds (there sizeof(PyObject) is 20 bytes). An 8-byte
+ * `npy_uint64 flags` member would be over-aligned and packing bytes would shift
+ * every later field, so expose it as two 32-bit halves.
+ */
+#if defined(Py_TARGET_ABI3T)
+    #if NPY_BYTE_ORDER == NPY_BIG_ENDIAN
+        #define NPY_DT_FLAGS_FIELD npy_uint32 _flags_hi; npy_uint32 _flags_lo;
+    #else
+        #define NPY_DT_FLAGS_FIELD npy_uint32 _flags_lo; npy_uint32 _flags_hi;
+    #endif
+#else
+    #define NPY_DT_FLAGS_FIELD npy_uint64 flags;
+#endif
+
 #if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
 /*
  * Public version of the Descriptor struct as of 2.x
@@ -647,7 +664,7 @@ typedef struct _PyArray_Descr_fields {
         /* number representing this type */
         int type_num;
         /* Space for dtype instance specific flags. */
-        npy_uint64 flags;
+        NPY_DT_FLAGS_FIELD
         /* element size (itemsize) for this type */
         npy_intp elsize;
         /* alignment needed for this type */
@@ -708,7 +725,7 @@ typedef struct {
         char byteorder;
         char _former_flags;
         int type_num;
-        npy_uint64 flags;
+        NPY_DT_FLAGS_FIELD
         npy_intp elsize;
         npy_intp alignment;
         PyObject *metadata;

--- a/numpy/_core/include/numpy/npy_2_compat.h
+++ b/numpy/_core/include/numpy/npy_2_compat.h
@@ -151,7 +151,11 @@ PyArray_ImportNumPyAPI(void)
     static inline npy_uint64
     PyDataType_FLAGS(const PyArray_Descr *dtype)
     {
-    #if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+    #if defined(Py_TARGET_ABI3T)
+        /* flags is stored as two 32-bit halves here (see ndarraytypes.h). */
+        const PyArray_Descr_fields *_f = _PyDataType_GET_ITEM_DATA(dtype);
+        return ((npy_uint64)_f->_flags_hi << 32) | (npy_uint64)_f->_flags_lo;
+    #elif NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
         return _PyDataType_GET_ITEM_DATA(dtype)->flags;
     #else
         return (unsigned char)dtype->flags;  /* Need unsigned cast on 1.x */

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -2522,6 +2522,19 @@ static struct PyModuleDef moduledef = {
     .m_slots = _multiarray_tests_slots,
 };
 
+#ifdef Py_GIL_DISABLED
+/*
+ * The abi3t ABI splits the descriptor's `flags` into 32-bit halves (see
+ * NPY_DT_FLAGS_FIELD in ndarraytypes.h); that only matches the real layout while
+ * `flags` immediately follows `type_num`.  Catch a future sizeof(PyObject) change
+ * here instead of letting it silently corrupt 32-bit free-threaded reads.
+ */
+_Static_assert(
+    offsetof(_PyArray_LegacyDescr_fields, flags) ==
+        offsetof(_PyArray_LegacyDescr_fields, type_num) + sizeof(int),
+    "abi3t flags split assumes no padding between type_num and flags");
+#endif
+
 PyMODINIT_FUNC PyInit__multiarray_tests(void)
 {
     return PyModuleDef_Init(&moduledef);

--- a/numpy/_core/tests/examples/limited_api/limited_api_opaque.c
+++ b/numpy/_core/tests/examples/limited_api/limited_api_opaque.c
@@ -318,6 +318,28 @@ limited_api_opaque_multi_iter_nexti(PyObject *mod, PyObject *args)
     return PyFloat_FromDouble(val);
 }
 
+/*
+ * Read a datetime descriptor's flags and c_metadata through the opaque accessors
+ * and return (flags, unit, num).  Regression test for the 32-bit free-threaded
+ * field layout, where c_metadata previously read back as NULL.
+ */
+static PyObject *limited_api_opaque_datetime_metadata(PyObject *mod,
+                                                      PyArrayObject *arr)
+{
+    PyArray_Descr *descr = PyArray_DESCR(arr);
+    npy_uint64 flags = PyDataType_FLAGS(descr);
+    PyArray_DatetimeDTypeMetaData *dt_meta =
+            (PyArray_DatetimeDTypeMetaData *)PyDataType_C_METADATA(descr);
+    if (dt_meta == NULL) {
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "PyDataType_C_METADATA() returned NULL for a datetime descriptor");
+        return NULL;
+    }
+    return Py_BuildValue("Kii", (unsigned long long)flags,
+                         (int)dt_meta->meta.base, dt_meta->meta.num);
+}
+
 static PyMethodDef limited_api_opaque_methods[] = {
     {"nonzero", (PyCFunction)limited_api_opaque_nonzero, METH_O,
      "Count the number of non-zero elements in the array."},
@@ -341,6 +363,10 @@ static PyMethodDef limited_api_opaque_methods[] = {
     {"multi_iter_nexti", (PyCFunction)limited_api_opaque_multi_iter_nexti,
      METH_VARARGS,
      "Advance only iter 0 N steps using PyArray_MultiIter_NEXTi."},
+    {"datetime_metadata", (PyCFunction)limited_api_opaque_datetime_metadata,
+     METH_O,
+     "Return (flags, unit, num) read from a datetime array's descriptor via the "
+     "opaque descr accessors."},
     {NULL, NULL, 0, NULL}  /* Sentinel */
 };
 

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -157,3 +157,12 @@ def test_limited_opaque(install_temp):
     b = np.zeros((2, 3))
     # Advance iter 0 by 3 steps → flat index 3 → value 3.0
     assert limited_api_opaque.multi_iter_nexti(a, b, 3) == 3.0
+
+    # Regression test for descriptor field access via the opaque ABI: on 32-bit
+    # free-threaded builds c_metadata used to read back as NULL (flags alignment).
+    dt = np.dtype("timedelta64[s]")
+    td = np.zeros(3, dtype=dt)
+    flags, unit, num = limited_api_opaque.datetime_metadata(td)
+    assert flags == dt.flags, (flags, dt.flags)
+    assert unit == 7  # NPY_FR_s
+    assert num == 1


### PR DESCRIPTION
Over in https://github.com/PyO3/rust-numpy/pull/556 work is ongoing to add abi3t support for crates that depend on PyO3 and rust-numpy.

There is [a failing test run](https://github.com/PyO3/rust-numpy/actions/runs/27867012031/job/82473307007?pr=556) for win32 3.15t, in a test that accesses the `metadata` field for a datetime dtype instance.

I was able to track this down to the uint64 `flags` field on the `PyArray_Descr_fields` and `_PyArray_LegacyDescr_fields` structs.

On a 32 bit free-threaded build, `sizeof(PyObject)` is 20 bytes. That places the `flags` field at a 4-byte aligned address instead of an 8-byte aligned address, the compiler inserts some padding bytes, and suddenly the fields access function is returning addresses at the wrong offset for all fields *after* the `flags` entry.

The fix I landed on was to define the `flags` as two 32 bit integers. Each gets read individually, and the compiler inserts no more packing bytes into the struct. Inside the `flags` access macro, we re-assemble the lo and hi parts of the 64 bit int.

Also adds a static assert in case a future change to `sizeof(PyObject)` breaks our assumptions here. Also adds a regression test to access the datetime metadata field, like the rust-numpy test did.

I used Claude to help identify and fix this bug.