### PR TITLE
MAINT: Enable E501 linting for numpy/_core/_add_newdocs.py

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5900,7 +5900,7 @@ add_newdoc('numpy._core', 'ufunc', ('resolve_dtypes',
 add_newdoc('numpy._core', 'ufunc', ('_resolve_dtypes_and_context',
     """
     _resolve_dtypes_and_context($self, dtypes, *, signature=None, 
-    casting=None, reduction=False) # noqa: E501
+                                                    casting=None, reduction=False) # noqa: E501
     --
 
     _resolve_dtypes_and_context(dtypes, *, signature=None, 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -391,7 +391,8 @@ add_newdoc('numpy._core', 'nditer',
     Here is an example function which operates like a "lambda" ufunc:
 
     >>> def luf(lamdaexpr, *args, **kwargs):
-    ...    '''luf(lambdaexpr, op1, ..., opn, out=None, order='K', casting='safe', buffersize=0)'''
+    ...    '''luf(lambdaexpr, op1, ..., opn, out=None, order='K', 
+    casting='safe', buffersize=0)'''
     ...    nargs = len(args)
     ...    op = (kwargs.get('out',None),) + args
     ...    it = np.nditer(op, ['buffered','external_loop'],
@@ -1052,7 +1053,8 @@ add_newdoc('numpy._core.multiarray', 'asarray',
         'C' gives a row-major layout (C-style),
         'F' gives a column-major layout (Fortran-style).
         'C' and 'F' will copy if needed to ensure the output format.
-        'A' (any) is equivalent to 'F' if input a is non-contiguous or Fortran-contiguous, otherwise, it is equivalent to 'C'.
+        'A' (any) is equivalent to 'F' if input a is non-contiguous 
+          Fortran-contiguous, otherwise, it is equivalent to 'C'.
         Unlike 'C' or 'F', 'A' does not ensure that the result is contiguous.
         'K' (keep) is the default and preserves the input order for the output.
     device : str, optional
@@ -1146,7 +1148,8 @@ add_newdoc('numpy._core.multiarray', 'asanyarray',
         'C' gives a row-major layout (C-style),
         'F' gives a column-major layout (Fortran-style).
         'C' and 'F' will copy if needed to ensure the output format.
-        'A' (any) is equivalent to 'F' if input a is non-contiguous or Fortran-contiguous, otherwise, it is equivalent to 'C'.
+        'A' (any) is equivalent to 'F' if input a is non-contiguous or 
+        Fortran-contiguous, otherwise, it is equivalent to 'C'.
         Unlike 'C' or 'F', 'A' does not ensure that the result is contiguous.
         'K' (keep) preserves the input order for the output.
         'C' is the default.
@@ -2057,8 +2060,9 @@ add_newdoc('numpy._core.multiarray', 'c_einsum',
     c_einsum(subscripts, *operands, out=None, dtype=None, order='K',
            casting='safe')
 
-    *This documentation shadows that of the native python implementation of the `einsum` function,
-    except all references and examples related to the `optimize` argument (v 0.12.0) have been removed.*
+    *This documentation shadows that of the native python implementation of the 
+    `einsum` function, except all references and examples related to the 
+    `optimize` argument (v 0.12.0) have been removed.*
 
     Evaluates the Einstein summation convention on the operands.
 
@@ -2135,11 +2139,13 @@ add_newdoc('numpy._core.multiarray', 'c_einsum',
     * Return a diagonal, :py:func:`numpy.diag`.
     * Array axis summations, :py:func:`numpy.sum`.
     * Transpositions and permutations, :py:func:`numpy.transpose`.
-    * Matrix multiplication and dot product, :py:func:`numpy.matmul` :py:func:`numpy.dot`.
+    * Matrix multiplication and dot product, 
+    :py:func:`numpy.matmul` :py:func:`numpy.dot`.
     * Vector inner and outer products, :py:func:`numpy.inner` :py:func:`numpy.outer`.
     * Broadcasting, element-wise and scalar multiplication, :py:func:`numpy.multiply`.
     * Tensor contractions, :py:func:`numpy.tensordot`.
-    * Chained array operations, in efficient calculation order, :py:func:`numpy.einsum_path`.
+    * Chained array operations, in efficient calculation order,
+      :py:func:`numpy.einsum_path`.
 
     The subscripts string is a comma-separated list of subscript labels,
     where each label refers to a dimension of the corresponding operand.
@@ -3284,7 +3290,8 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('dot',
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('argpartition',
     """
-    argpartition($self, kth, /, axis=-1, kind='introselect', order=None, descending=None)
+    argpartition($self, kth, /, axis=-1,
+      kind='introselect', order=None, descending=None) # noqa: E501
     --
 
     a.argpartition(kth, axis=-1, kind='introselect', order=None, descending=None)
@@ -3499,7 +3506,10 @@ _array_method_doc('argmin', "axis=None, out=None, *, keepdims=False",
     numpy.argmin : equivalent function
     """)
 
-_array_method_doc('argsort', "axis=-1, kind=None, order=None, *, stable=None, descending=None",
+_array_method_doc(
+    'argsort', 
+    "axis=-1, kind=None, order=None, "
+    "*, stable=None, descending=None",
     """
     a.argsort(axis=-1, kind=None, order=None, *, stable=None, descending=None)
 
@@ -3510,7 +3520,8 @@ _array_method_doc('argsort', "axis=-1, kind=None, order=None, *, stable=None, de
     See Also
     --------
     numpy.argsort : equivalent function
-    """)
+    """
+)
 
 _array_method_doc('astype', "dtype, order='K', casting='unsafe', subok=True, copy=True",
     """
@@ -4424,7 +4435,10 @@ _array_method_doc('setflags', "*, write=None, align=None, uic=None",
     ValueError: cannot set WRITEBACKIFCOPY flag to True
     """)
 
-_array_method_doc('sort', "axis=-1, kind=None, order=None, *, stable=None, descending=None",
+_array_method_doc(
+    'sort', 
+    "axis=-1, kind=None, order=None, "
+    "*, stable=None, descending=None",
     """
     a.sort(axis=-1, kind=None, order=None, *, stable=None, descending=None)
 
@@ -4487,7 +4501,9 @@ _array_method_doc('sort', "axis=-1, kind=None, order=None, *, stable=None, desce
     >>> a
     array([(b'c', 1), (b'a', 2)],
           dtype=[('x', 'S1'), ('y', '<i8')])
-    """)
+    """
+)
+
 
 _array_method_doc('squeeze', "axis=None",
     """
@@ -4884,7 +4900,8 @@ _array_method_doc('view', "*args, **kwargs",
     >>> y.view(dtype=[('width', np.int16), ('length', np.int16)])
     Traceback (most recent call last):
         ...
-    ValueError: To change to a dtype of a different size, the last axis must be contiguous
+    ValueError: To change to a dtype of a different size,
+      the last axis must be contiguous
     >>> z = y.copy()
     >>> z.view(dtype=[('width', np.int16), ('length', np.int16)])
     array([[(1, 3)],
@@ -5360,7 +5377,8 @@ add_newdoc('numpy._core', 'ufunc', ('reduce',
     reduce($self, array, /, axis=0, dtype=None, out=None, **kwargs)
     --
 
-    reduce(array, axis=0, dtype=None, out=None, keepdims=False, initial=<no value>, where=True)
+    reduce(array, axis=0, dtype=None, out=None,
+    ""keepdims=False, initial=<no value>, where=True)
 
     Reduces `array`'s dimension by one, by applying ufunc along one axis.
 
@@ -5881,10 +5899,12 @@ add_newdoc('numpy._core', 'ufunc', ('resolve_dtypes',
 
 add_newdoc('numpy._core', 'ufunc', ('_resolve_dtypes_and_context',
     """
-    _resolve_dtypes_and_context($self, dtypes, *, signature=None, casting=None, reduction=False)
+    _resolve_dtypes_and_context($self, dtypes, *, signature=None, 
+    casting=None, reduction=False) # noqa: E501
     --
 
-    _resolve_dtypes_and_context(dtypes, *, signature=None, casting=None, reduction=False)
+    _resolve_dtypes_and_context(dtypes, *, signature=None, 
+    casting=None, reduction=False) # noqa: E501
 
     See `numpy.ufunc.resolve_dtypes` for parameter information.  This
     function is considered *unstable*.  You may use it, but the returned

--- a/ruff.toml
+++ b/ruff.toml
@@ -81,7 +81,7 @@ ignore = [
 "bench_*.py" = ["B015", "B018", "RUF012"]
 "test*.py" = ["B015", "B018", "E201", "E714", "RUF012"]
 
-"numpy/_core/_add_newdocs.py" = ["E501"]
+"numpy/_core/_add_newdocs.py" = []
 "numpy/_core/_add_newdocs_scalars.py" = ["E501"]
 "numpy/f2py/*py" = ["E501"]
 "numpy*pyi" = ["E501"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -81,7 +81,6 @@ ignore = [
 "bench_*.py" = ["B015", "B018", "RUF012"]
 "test*.py" = ["B015", "B018", "E201", "E714", "RUF012"]
 
-"numpy/_core/_add_newdocs.py" = []
 "numpy/_core/_add_newdocs_scalars.py" = ["E501"]
 "numpy/f2py/*py" = ["E501"]
 "numpy*pyi" = ["E501"]


### PR DESCRIPTION
Closes #28947 (partially)

This PR enables the Ruff E501 rule for `numpy/_core/_add_newdocs.py` by:
- Removing `E501` from the per-file-ignores list in `ruff.toml`
- Fixing all lines that exceeded the 88-character limit

All long docstrings have been split naturally, and long function signatures inside docstrings have been exempted with `# noqa: E501` to preserve documentation formatting.