### PR TITLE
BUG: Fix float16/float32 index-overflow in quantile/percentile (and nan variants) for explicit-dtype q

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4792,8 +4792,13 @@ def _quantile(
             raise ValueError(
                 f"{method!r} is not a valid method. Use one of: "
                 f"{_QuantileMethods.keys()}") from None
+
+        idx_quantiles = quantiles
+        if np.issubdtype(quantiles.dtype, np.inexact):
+            idx_quantiles = quantiles.astype(np.float64, copy=False)
+
         virtual_indexes = method_props["get_virtual_index"](values_count,
-                                                            quantiles)
+                                                            idx_quantiles)
         virtual_indexes = np.asanyarray(virtual_indexes)
 
         if method_props["fix_gamma"] is None:
@@ -4840,6 +4845,8 @@ def _quantile(
             if weak_q:
                 gamma = float(gamma)
             else:
+                if np.issubdtype(quantiles.dtype, np.inexact):
+                    gamma = gamma.astype(quantiles.dtype, copy=False)
                 result_shape = virtual_indexes.shape + (1,) * (arr.ndim - 1)
                 gamma = gamma.reshape(result_shape)
             result = _lerp(previous,

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4794,8 +4794,13 @@ def _quantile(
             raise ValueError(
                 f"{method!r} is not a valid method. "
                 f"Use one of: {valid_methods}") from None
+
+        idx_quantiles = quantiles
+        if np.issubdtype(quantiles.dtype, np.inexact):
+            idx_quantiles = quantiles.astype(np.float64, copy=False)
+
         virtual_indexes = method_props["get_virtual_index"](values_count,
-                                                            quantiles)
+                                                            idx_quantiles)
         virtual_indexes = np.asanyarray(virtual_indexes)
 
         if method_props["fix_gamma"] is None:
@@ -4842,6 +4847,8 @@ def _quantile(
             if weak_q:
                 gamma = float(gamma)
             else:
+                if np.issubdtype(quantiles.dtype, np.inexact):
+                    gamma = gamma.astype(quantiles.dtype, copy=False)
                 result_shape = virtual_indexes.shape + (1,) * (arr.ndim - 1)
                 gamma = gamma.reshape(result_shape)
             result = _lerp(previous,

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -4225,6 +4225,18 @@ class TestPercentile:
         assert z == one
         assert z.dtype == a.dtype
 
+    @pytest.mark.parametrize("func", [np.percentile, np.quantile])
+    def test_float16_gh_31487(self, func):
+        # gh-31487: overflows when q is a float16 array (also see
+        # test_nanfunctions.py for nanpercentile/nanquantile).
+        a = np.zeros(65521, dtype=np.float16)
+        a[:20_000] = 1.0
+        scale = 100 if func is np.percentile else 1
+        q = np.array([0.5 * scale, 0.99 * scale], dtype=np.float16)
+        z = func(a, q)
+        assert_array_equal(z, np.array([0.0, 1.0], dtype=np.float16))
+        assert z.dtype == np.float16
+
     @pytest.mark.slow
     def test_percentile_gh_29003_Fraction(self):
         zero = Fraction(0)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -4256,6 +4256,18 @@ class TestPercentile:
         assert z == one
         assert z.dtype == a.dtype
 
+    @pytest.mark.parametrize("func", [np.percentile, np.quantile])
+    def test_float16_gh_31487(self, func):
+        # gh-31487: overflows when q is a float16 array (also see
+        # test_nanfunctions.py for nanpercentile/nanquantile).
+        a = np.zeros(65521, dtype=np.float16)
+        a[:20_000] = 1.0
+        scale = 100 if func is np.percentile else 1
+        q = np.array([0.5 * scale, 0.99 * scale], dtype=np.float16)
+        z = func(a, q)
+        assert_array_equal(z, np.array([0.0, 1.0], dtype=np.float16))
+        assert z.dtype == np.float16
+
     @pytest.mark.slow
     def test_percentile_gh_29003_Fraction(self):
         zero = Fraction(0)

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1379,6 +1379,19 @@ class TestNanFunctions_Quantile:
         assert np.isnan(out).all()
         assert out.dtype == array.dtype
 
+    @pytest.mark.parametrize("func", [np.nanquantile, np.nanpercentile])
+    def test_float16_gh_31487(self, func):
+        # gh-31487: nanquantile/nanpercentile overflowed on large float16 arrays
+        a = np.zeros(65521, dtype=np.float16)
+        a[:20_000] = 1.0
+        scale = 100 if func is np.nanpercentile else 1
+        z = func(a, np.float16(0.5 * scale))
+        assert z == np.float16(0.0)
+        assert z.dtype == np.float16
+        z = func(a, np.float16(0.99 * scale))
+        assert z == np.float16(1.0)
+        assert z.dtype == np.float16
+
 @pytest.mark.parametrize("arr, expected", [
     # array of floats with some nans
     (np.array([np.nan, 5.0, np.nan, np.inf]),

--- a/numpy/lib/tests/test_nanfunctions.py
+++ b/numpy/lib/tests/test_nanfunctions.py
@@ -1381,7 +1381,8 @@ class TestNanFunctions_Quantile:
 
     @pytest.mark.parametrize("func", [np.nanquantile, np.nanpercentile])
     def test_float16_gh_31487(self, func):
-        # gh-31487: nanquantile/nanpercentile overflowed on large float16 arrays
+        # gh-31487: overflowed on large float16 arrays (also see
+        # test_function_base.py for percentile/quantile).
         a = np.zeros(65521, dtype=np.float16)
         a[:20_000] = 1.0
         scale = 100 if func is np.nanpercentile else 1


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

`float16` maxes out at `65504` so made temporarily upcasts quantiles to float64 only for the index math to prevent the overflow.


Fixes: #31487

```python
import numpy as np
arr = np.zeros(65521, dtype=np.float16)
arr[:10] = 1
print(np.quantile(arr, np.array([0.5], dtype=np.float16)))     # [nan] (unexpected)
print(np.percentile(arr, np.array([50], dtype=np.float16)))    # [nan] (unexpected)
print(np.nanquantile(arr, np.array([0.5], dtype=np.float16)))  # [nan] (unexpected)
print(np.nanpercentile(arr, np.array([50], dtype=np.float16))) # [nan] (unexpected)
```

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

Just for research purpose. 