### PR TITLE
MAINT: Enable E501 linting for numpy/f2py/tests

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -84,6 +84,7 @@ ignore = [
 "numpy/_core/_add_newdocs.py" = ["E501"]
 "numpy/_core/_add_newdocs_scalars.py" = ["E501"]
 "numpy/f2py/*py" = ["E501"]
+"numpy/f2py/tests/**/*.py" = []
 "numpy*pyi" = ["E501"]
 # "useless assignments" aren't so useless when you're testing that they don't make type checkers scream
 "numpy/typing/tests/data/*" = ["B015", "B018", "E501"]


### PR DESCRIPTION
Follow-up to #28947.

This PR enables the Ruff E501 rule for `numpy/f2py/tests/` by:
- Adding `"numpy/f2py/tests/**/*.py" = []` to override the exclusion in `ruff.toml`

No code changes were needed because all files in this folder already comply with the 88-character limit.

### AI Usage (required disclosure)
- [x] I have disclosed any use of AI tools below:
- **AI tools used**: Claude (AI assistant)
- **How they were used**: Guidance on contribution workflow and understanding Ruff E501 rule.
- **Review notes**: All changes were manually reviewed and understood.