### PR TITLE
ENH: Add np.median_sorted_arrays with O(log(min(m,n))) implementation

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -105,6 +105,24 @@ class Median(Benchmark):
         np.median(self.wide, axis=0)
 
 
+class MedianSortedArrays(Benchmark):
+    params = [
+        [(1000, 1000), (100000, 100000), (10, 100000), (1, 1000000)],
+    ]
+    param_names = ['sizes']
+
+    def setup(self, sizes):
+        m, n = sizes
+        self.a = np.sort(np.random.random(m))
+        self.b = np.sort(np.random.random(n))
+
+    def time_median_sorted_arrays(self, sizes):
+        np.median_sorted_arrays(self.a, self.b)
+
+    def time_median_concatenate(self, sizes):
+        np.median(np.concatenate((self.a, self.b)))
+
+
 class Percentile(Benchmark):
     def setup(self):
         self.e = np.arange(10000, dtype=np.float32)

--- a/doc/source/reference/routines.statistics.rst
+++ b/doc/source/reference/routines.statistics.rst
@@ -23,6 +23,7 @@ Averages and variances
    :toctree: generated/
 
    median
+   median_sorted_arrays
    average
    mean
    std

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -492,6 +492,7 @@ else:
         iterable,
         kaiser,
         median,
+        median_sorted_arrays,
         meshgrid,
         percentile,
         piecewise,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -488,6 +488,7 @@ from numpy.lib._function_base_impl import (
     cov,
     corrcoef,
     median,
+    median_sorted_arrays,
     sinc,
     hamming,
     hanning,
@@ -720,7 +721,7 @@ __all__ = [
     "select", "piecewise", "trim_zeros", "copy", "iterable", "percentile", "diff",
     "gradient", "angle", "unwrap", "sort_complex", "flip", "rot90", "extract", "place",
     "vectorize", "asarray_chkfinite", "average", "bincount", "digitize", "cov",
-    "corrcoef", "median", "sinc", "hamming", "hanning", "bartlett", "blackman",
+    "corrcoef", "median", "median_sorted_arrays", "sinc", "hamming", "hanning", "bartlett", "blackman",
     "kaiser", "trapezoid", "i0", "meshgrid", "delete", "insert", "append",
     "interp", "quantile",
     # lib._twodim_base_impl.__all__

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4056,6 +4056,129 @@ def _median(a, axis=None, out=None, overwrite_input=False):
     return rout
 
 
+def _median_sorted_arrays_dispatcher(a, b):
+    return (a, b)
+
+
+@array_function_dispatch(_median_sorted_arrays_dispatcher)
+def median_sorted_arrays(a, b):
+    """
+    Compute the median of two sorted 1-D arrays without merging them.
+
+    Uses the binary-search partition algorithm to find the median in
+    O(log(min(m, n))) time and O(1) extra space, where *m* and *n* are
+    the lengths of `a` and `b` respectively.
+
+    Both input arrays must already be sorted in ascending order.
+    The function does **not** verify that the inputs are sorted.
+
+    Parameters
+    ----------
+    a : array_like
+        First sorted 1-D input array.
+    b : array_like
+        Second sorted 1-D input array.
+
+    Returns
+    -------
+    median : float
+        The median value of the combined data as a Python float.
+
+    Raises
+    ------
+    ValueError
+        If both input arrays are empty, or if either input is not
+        one-dimensional.
+
+    See Also
+    --------
+    median : Compute the median along the specified axis.
+    nanmedian : Compute the median along the specified axis, ignoring NaNs.
+
+    Notes
+    -----
+    The algorithm partitions the two arrays such that the left halves
+    contain elements that are all less than or equal to the elements in
+    the right halves.  A binary search is performed on the shorter array
+    to achieve O(log(min(m, n))) time complexity.
+
+    Unlike `median`, this function assumes the inputs are already sorted
+    and avoids the O((m + n) log(m + n)) cost of sorting or the O(m + n)
+    cost of merging.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> a = np.array([1, 3])
+    >>> b = np.array([2])
+    >>> np.median_sorted_arrays(a, b)
+    2.0
+
+    >>> a = np.array([1, 2])
+    >>> b = np.array([3, 4])
+    >>> np.median_sorted_arrays(a, b)
+    2.5
+
+    >>> a = np.array([])
+    >>> b = np.array([1, 2, 3])
+    >>> np.median_sorted_arrays(a, b)
+    2.0
+
+    """
+    a = np.asarray(a)
+    b = np.asarray(b)
+
+    # Validate dimensions
+    if a.ndim != 1 or b.ndim != 1:
+        raise ValueError(
+            "Both input arrays must be one-dimensional, got arrays with "
+            f"dimensions {a.ndim} and {b.ndim}."
+        )
+
+    m, n = len(a), len(b)
+    total = m + n
+
+    if total == 0:
+        raise ValueError(
+            "Both input arrays are empty; cannot compute the median of "
+            "an empty set of values."
+        )
+
+    # Always binary-search the smaller array.
+    if m > n:
+        a, b = b, a
+        m, n = n, m
+
+    half = (total + 1) // 2  # size of the combined left partition
+
+    lo, hi = 0, m  # binary search bounds on partition index in `a`
+
+    while lo <= hi:
+        i = (lo + hi) // 2   # elements taken from `a`
+        j = half - i          # elements taken from `b`
+
+        a_left  = a[i - 1] if i > 0 else -np.inf
+        a_right = a[i]     if i < m else  np.inf
+        b_left  = b[j - 1] if j > 0 else -np.inf
+        b_right = b[j]     if j < n else  np.inf
+
+        if a_left <= b_right and b_left <= a_right:
+            # Correct partition found
+            if total % 2 == 1:
+                return float(max(a_left, b_left))
+            else:
+                max_left  = max(a_left, b_left)
+                min_right = min(a_right, b_right)
+                return float((max_left + min_right) / 2)
+        elif a_left > b_right:
+            hi = i - 1   # take fewer from `a`
+        else:
+            lo = i + 1   # take more from `a`
+
+    # Should never reach here for valid sorted input
+    raise RuntimeError("Unexpected error in median_sorted_arrays")  # pragma: no cover
+
+
 def _percentile_dispatcher(a, q, axis=None, out=None, overwrite_input=None,
                            method=None, keepdims=None, *, weights=None):
     return (a, q, out, weights)

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -63,6 +63,7 @@ __all__ = [
     "cov",
     "corrcoef",
     "median",
+    "median_sorted_arrays",
     "sinc",
     "hamming",
     "hanning",
@@ -1469,6 +1470,11 @@ def median(
     overwrite_input: bool = False,
     keepdims: bool = False,
 ) -> Incomplete: ...
+
+def median_sorted_arrays(
+    a: ArrayLike,
+    b: ArrayLike,
+) -> float: ...
 
 # NOTE: keep in sync with `quantile`
 @overload  # inexact, scalar, axis=None

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -4760,6 +4760,132 @@ class TestMedian:
         assert_array_equal(np.isnat(res), [False, True, False])
 
 
+class TestMedianSortedArrays:
+
+    def test_odd_total_length(self):
+        a = np.array([1, 3, 5])
+        b = np.array([2, 4])
+        # merged sorted = [1,2,3,4,5], median = 3
+        assert_equal(np.median_sorted_arrays(a, b), 3.0)
+
+    def test_even_total_length(self):
+        a = np.array([1, 2])
+        b = np.array([3, 4])
+        # merged sorted = [1,2,3,4], median = 2.5
+        assert_equal(np.median_sorted_arrays(a, b), 2.5)
+
+    def test_one_empty_array_a(self):
+        a = np.array([])
+        b = np.array([1, 2, 3])
+        assert_equal(np.median_sorted_arrays(a, b), 2.0)
+
+    def test_one_empty_array_b(self):
+        a = np.array([1, 2, 3, 4])
+        b = np.array([])
+        assert_equal(np.median_sorted_arrays(a, b), 2.5)
+
+    def test_both_empty_raises(self):
+        a = np.array([])
+        b = np.array([])
+        assert_raises(ValueError, np.median_sorted_arrays, a, b)
+
+    def test_duplicate_values(self):
+        a = np.array([1, 1, 1])
+        b = np.array([1, 1, 1])
+        assert_equal(np.median_sorted_arrays(a, b), 1.0)
+
+    def test_duplicate_mixed(self):
+        a = np.array([1, 2, 2])
+        b = np.array([2, 3, 3])
+        # merged = [1,2,2,2,3,3], median = (2+2)/2 = 2.0
+        assert_equal(np.median_sorted_arrays(a, b), 2.0)
+
+    def test_negative_values(self):
+        a = np.array([-5, -3, -1])
+        b = np.array([-4, -2, 0])
+        # merged = [-5,-4,-3,-2,-1,0], median = (-3+-2)/2 = -2.5
+        assert_equal(np.median_sorted_arrays(a, b), -2.5)
+
+    def test_float_arrays(self):
+        a = np.array([1.1, 2.2, 3.3])
+        b = np.array([4.4, 5.5])
+        # merged = [1.1, 2.2, 3.3, 4.4, 5.5], median = 3.3
+        assert_almost_equal(np.median_sorted_arrays(a, b), 3.3)
+
+    def test_different_sizes(self):
+        a = np.array([1])
+        b = np.array([2, 3, 4, 5, 6])
+        # merged = [1,2,3,4,5,6], median = (3+4)/2 = 3.5
+        assert_equal(np.median_sorted_arrays(a, b), 3.5)
+
+    def test_very_large_size_imbalance(self):
+        a = np.array([50])
+        b = np.arange(1, 101)  # 1..100
+        # merged = 1..100 with 50 already in it -> 101 elements
+        # Actually a has [50] and b has [1..100], combined 101 elements
+        expected = np.median(np.concatenate((a, b)))
+        assert_almost_equal(
+            np.median_sorted_arrays(a, b), float(expected))
+
+    def test_invalid_2d_input(self):
+        a = np.array([[1, 2], [3, 4]])
+        b = np.array([5, 6])
+        assert_raises(ValueError, np.median_sorted_arrays, a, b)
+
+    def test_invalid_both_2d(self):
+        a = np.array([[1, 2]])
+        b = np.array([[3, 4]])
+        assert_raises(ValueError, np.median_sorted_arrays, a, b)
+
+    def test_single_element_each(self):
+        a = np.array([1])
+        b = np.array([2])
+        assert_equal(np.median_sorted_arrays(a, b), 1.5)
+
+    def test_single_element_one(self):
+        a = np.array([3])
+        b = np.array([])
+        assert_equal(np.median_sorted_arrays(a, b), 3.0)
+
+    def test_returns_python_float(self):
+        a = np.array([1, 2, 3])
+        b = np.array([4, 5, 6])
+        result = np.median_sorted_arrays(a, b)
+        assert isinstance(result, float)
+
+    def test_int_dtypes(self):
+        for dtype in [np.int8, np.int16, np.int32, np.int64]:
+            a = np.array([1, 3, 5], dtype=dtype)
+            b = np.array([2, 4], dtype=dtype)
+            assert_equal(np.median_sorted_arrays(a, b), 3.0)
+
+    def test_float_dtypes(self):
+        for dtype in [np.float32, np.float64]:
+            a = np.array([1.0, 3.0, 5.0], dtype=dtype)
+            b = np.array([2.0, 4.0], dtype=dtype)
+            assert_almost_equal(np.median_sorted_arrays(a, b), 3.0)
+
+    def test_agreement_with_naive_median(self):
+        # Verify against np.median(np.concatenate(...)) on random sorted data
+        rng = np.random.RandomState(42)
+        for _ in range(20):
+            m = rng.randint(0, 50)
+            n = rng.randint(0, 50)
+            if m == 0 and n == 0:
+                n = 1
+            a = np.sort(rng.randn(m))
+            b = np.sort(rng.randn(n))
+            expected = float(np.median(np.concatenate((a, b))))
+            result = np.median_sorted_arrays(a, b)
+            assert_almost_equal(result, expected)
+
+    def test_large_arrays(self):
+        a = np.arange(0, 100000, 2)     # 50000 even numbers
+        b = np.arange(1, 100000, 2)     # 50000 odd numbers
+        expected = float(np.median(np.concatenate((a, b))))
+        assert_almost_equal(np.median_sorted_arrays(a, b), expected)
+
+
 class TestSortComplex:
 
     @pytest.mark.parametrize("type_in, type_out", [


### PR DESCRIPTION
# Proposed Feature: `np.median_sorted_arrays`

## PR Summary

This pull request proposes adding a new public API, `np.median_sorted_arrays`, for efficiently computing the median of two already sorted one-dimensional arrays.

Unlike existing approaches that concatenate or merge the input arrays before computing the median, this implementation uses the binary-search partition algorithm to compute the median directly without merging the inputs.

### Highlights

* Introduces `np.median_sorted_arrays(a, b)`.
* Computes the median without concatenating or merging the input arrays.
* Uses the optimal binary-search partition algorithm.
* Time complexity: **O(log(min(m, n)))**.
* Extra space complexity: **O(1)**.
* Supports both odd and even total lengths.
* Handles duplicate values, negative values, floating-point arrays, and cases where one input array is empty.
* Includes comprehensive unit tests and documentation.

## Motivation

Many applications operate on datasets that are already sorted. While NumPy provides `np.median`, there is currently no API that exploits this property to compute the median asymptotically faster than approaches requiring merging or sorting.

This proposal aims to provide an efficient implementation for that specific use case while keeping the interface simple and consistent with existing NumPy APIs.

## First-time contributor

This is my first contribution to NumPy. I use NumPy extensively for numerical computing and algorithmic programming, and I wanted to contribute an implementation of a well-known optimal algorithm that could be useful when working with pre-sorted data.