### PR TITLE
BUG: fix `np.insert` ignoring out of bounds negative indices in multi element obj

### DIFF
--- a/doc/release/upcoming_changes/31782.compatibility.rst
+++ b/doc/release/upcoming_changes/31782.compatibility.rst
@@ -1,0 +1,6 @@
+`numpy.insert` out-of-bounds index detection
+---------------------------------------------
+``numpy.insert`` now consistently raises ``IndexError`` for any
+out-of-bounds index, including when out-of-bounds and in-bounds
+indices are mixed in the same call. Previously such cases could
+silently succeed or produce incorrect results.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5566,8 +5566,9 @@ def insert(arr, obj, values, axis=None):
         indices = indices.astype(intp)
 
     if indices.size > 0 and (indices.min() < -N or indices.max() > N):
+        oob = indices.min() if indices.min() < -N else indices.max()
         raise IndexError(
-            f"index {indices[oob][0]} is out of bounds "
+            f"index {oob} is out of bounds "
             f"for axis {axis} with size {N}"
         )
     indices[indices < 0] += N

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5565,8 +5565,10 @@ def insert(arr, obj, values, axis=None):
         # Can safely cast the empty list to intp
         indices = indices.astype(intp)
 
-    if indices.size > 0 and (indices.min() < -N or indices.max() > N):
-        oob = indices.min() if indices.min() < -N else indices.max()
+    min_idx = indices.min()
+    max_idx = indices.max()
+    if indices.size > 0 and (min_idx < -N or max_idx > N):
+        oob = min_idx if min_idx < -N else max_idx
         raise IndexError(
             f"index {oob} is out of bounds "
             f"for axis {axis} with size {N}"

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5565,6 +5565,12 @@ def insert(arr, obj, values, axis=None):
         # Can safely cast the empty list to intp
         indices = indices.astype(intp)
 
+    oob = (indices < -N) | (indices > N)
+    if oob.any():
+        raise IndexError(
+            f"index {indices[oob][0]} is out of bounds "
+            f"for axis {axis} with size {N}"
+        )
     indices[indices < 0] += N
 
     numnew = len(indices)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5565,14 +5565,15 @@ def insert(arr, obj, values, axis=None):
         # Can safely cast the empty list to intp
         indices = indices.astype(intp)
 
-    min_idx = indices.min()
-    max_idx = indices.max()
-    if indices.size > 0 and (min_idx < -N or max_idx > N):
-        oob = min_idx if min_idx < -N else max_idx
-        raise IndexError(
-            f"index {oob} is out of bounds "
-            f"for axis {axis} with size {N}"
-        )
+    if indices.size > 0:
+        min_idx = indices.min()
+        max_idx = indices.max()
+        if min_idx < -N or max_idx > N:
+            oob = min_idx if min_idx < -N else max_idx
+            raise IndexError(
+                f"index {oob} is out of bounds "
+                f"for axis {axis} with size {N}"
+            )
     indices[indices < 0] += N
 
     numnew = len(indices)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5565,7 +5565,7 @@ def insert(arr, obj, values, axis=None):
         # Can safely cast the empty list to intp
         indices = indices.astype(intp)
 
-    if indices.size > 0 and (indices.min() < -N or indices.max() > N)
+    if indices.size > 0 and (indices.min() < -N or indices.max() > N):
         raise IndexError(
             f"index {indices[oob][0]} is out of bounds "
             f"for axis {axis} with size {N}"

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5565,8 +5565,7 @@ def insert(arr, obj, values, axis=None):
         # Can safely cast the empty list to intp
         indices = indices.astype(intp)
 
-    oob = (indices < -N) | (indices > N)
-    if oob.any():
+    if indices.size > 0 and (indices.min() < -N or indices.max() > N)
         raise IndexError(
             f"index {indices[oob][0]} is out of bounds "
             f"for axis {axis} with size {N}"

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -698,15 +698,14 @@ class TestInsert:
         with pytest.raises(IndexError):
             np.insert([0, 1, 2], np.array([], dtype=float), [])
 
-    @pytest.mark.parametrize('idx', [4, -4])
-    def test_index_out_of_bounds(self, idx):
+    @pytest.mark.parametrize('idx,values', [
+        ([4], [3, 4]),
+        ([-4], [3, 4]),
+        ([-6, 0], [9, 8]),
+    ])
+    def test_index_out_of_bounds(self, idx, values):
         with pytest.raises(IndexError, match='out of bounds'):
-            np.insert([0, 1, 2], [idx], [3, 4])
-
-    def test_insert_negative_oob_multi_element(self):
-        a = np.arange(5)
-        with pytest.raises(IndexError, match="out of bounds"):
-            np.insert(a, [-6, 0], [9, 8])
+            np.insert([0, 1, 2], idx, values)
 
 
 class TestAmax:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -703,6 +703,11 @@ class TestInsert:
         with pytest.raises(IndexError, match='out of bounds'):
             np.insert([0, 1, 2], [idx], [3, 4])
 
+    def test_insert_negative_oob_multi_element(self):
+        a = np.arange(5)
+        with pytest.raises(IndexError, match="out of bounds"):
+            np.insert(a, [-6, 0], [9, 8])
+
 
 class TestAmax:
 


### PR DESCRIPTION
Fixes #31777 
### PR summary
- Added a bounds check for multi element obj before negative index to catch out-of-bounds indices and raise IndexError.
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.



  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
- yes to verify fix 
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
