### PR TITLE
DOC: fix copy-paste error in nanprod docstring ("summed" should be "multiplied")

### DIFF
--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -751,7 +751,7 @@ def nanprod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
         the product of the flattened array.
     dtype : data-type, optional
         The type of the returned array and of the accumulator in which the
-        elements are summed.  By default, the dtype of `a` is used.  An
+        elements are multiplied.  By default, the dtype of `a` is used.  An
         exception is when `a` has an integer type with less precision than
         the platform (u)intp. In that case, the default will be either
         (u)int32 or (u)int64 depending on whether the platform is 32 or 64


### PR DESCRIPTION
Just a quick docstring fix for `nanprod`.

The `dtype` parameter description says the accumulator "elements are summed," but `nanprod` computes a product, not a sum. The text is identical, word for word, to `nansum`'s `dtype` description (including the trailing sentence about (u)int32/(u)int64 fallback), which strongly suggests it was copy-pasted from `nansum` without updating "summed" to "multiplied." `numpy.prod`'s own `dtype` description correctly says "elements are multiplied."

This PR just updates that one word so the docstring matches what the function actually does.

**Quick verification:**

```python
>>> import numpy as np
>>> np.nanprod.__doc__[np.nanprod.__doc__.find("dtype"):][:120]
'dtype : data-type, optional\n        The type of the returned array and of the accumulator in which the\n        elements are summed.'
>>> np.nansum.__doc__[np.nansum.__doc__.find("dtype"):][:120]
'dtype : data-type, optional\n        The type of the returned array and of the accumulator in which the\n        elements are summed.'
# identical text, confirms the copy-paste source
>>> np.prod.__doc__[np.prod.__doc__.find("dtype"):][:130]
'dtype : dtype, optional\n        The type of the returned array, as well as of the accumulator in\n        which the elements are multiplied.'
```

### AI Disclosure

An AI assistant was used to scan the NumPy docstrings for cross-function inconsistencies and to verify this specific finding by comparing the `dtype` text of `nanprod`, `nansum`, and `prod` against the installed package. The diagnosis and final wording of this PR were reviewed manually.