### PR TITLE
DOC: remove stale out reference from vstack, hstack  docstrings

### DIFF
--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -238,8 +238,7 @@ def vstack(tup, *, dtype=None, casting="same_kind"):
         each element along the zeroth axis is treated as a separate array.
 
     dtype : str or dtype
-        If provided, the destination array will have this dtype. Cannot be
-        provided together with `out`.
+        If provided, the destination array will have this dtype.
 
         .. versionadded:: 1.24
 
@@ -313,8 +312,7 @@ def hstack(tup, *, dtype=None, casting="same_kind"):
         each element along the zeroth axis is treated as a separate array.
 
     dtype : str or dtype
-        If provided, the destination array will have this dtype. Cannot be
-        provided together with `out`.
+        If provided, the destination array will have this dtype.
 
         .. versionadded:: 1.24
 


### PR DESCRIPTION
Small docstring fix for `vstack` and `hstack`.

Both list this under `dtype`:

    Cannot be provided together with `out`.

but neither function takes an `out` argument — confirmed below. The whole `dtype`/`casting` block (even the `.. versionadded:: 1.24` tag) is identical in both, which points to it being copied over from `stack`/`concatenate`. Those two do have `out`, so the line makes sense there; it just never got dropped when reused for `vstack`/`hstack`.

```python
>>> import numpy as np, inspect
>>> inspect.signature(np.vstack)
<Signature (tup, *, dtype=None, casting='same_kind')>
>>> inspect.signature(np.hstack)
<Signature (tup, *, dtype=None, casting='same_kind')>
>>> np.vstack(([1, 2], [3, 4]), out=None)
Traceback (most recent call last):
    ...
TypeError: vstack() got an unexpected keyword argument 'out'
```

Left `stack`/`concatenate` untouched since the sentence is accurate for them.

### AI Disclosure

Used an AI assistant to scan for stale/undocumented parameter mismatches across docstrings and to confirm this one via `inspect.signature` and the actual `TypeError` above. Reviewed and wrote up the fix manually.