### PR TITLE
BUG: fix empty object-array reductions in vdot and matvec

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -3654,6 +3654,14 @@ OBJECT_dot(char *ip1, npy_intp is1, char *ip2, npy_intp is2, char *op, npy_intp 
     if (PyErr_Occurred()) {
         return;
     }
+    if (n == 0) {
+        PyObject *zero = PyLong_FromLong(0);
+        if (zero == NULL) {
+            return;
+        }
+        Py_XSETREF(*((PyObject **)op), zero);
+        return;
+    }
     for (i = 0; i < n; i++, ip1 += is1, ip2 += is2) {
         if ((*((PyObject **)ip1) == NULL) || (*((PyObject **)ip2) == NULL)) {
             tmp1 = Py_False;

--- a/numpy/_core/src/multiarray/vdot.c
+++ b/numpy/_core/src/multiarray/vdot.c
@@ -145,6 +145,16 @@ OBJECT_vdot(char *ip1, npy_intp is1, char *ip2, npy_intp is2, char *op, npy_intp
     npy_intp i;
     PyObject *tmp0, *tmp1, *tmp2, *tmp = NULL;
     PyObject **tmp3;
+
+    if (n == 0) {
+        PyObject *zero = PyLong_FromLong(0);
+        if (zero == NULL) {
+            return;
+        }
+        Py_XSETREF(*((PyObject **)op), zero);
+        return;
+    }
+    
     for (i = 0; i < n; i++, ip1 += is1, ip2 += is2) {
         if ((*((PyObject **)ip1) == NULL) || (*((PyObject **)ip2) == NULL)) {
             tmp1 = Py_False;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -7714,6 +7714,13 @@ class TestVdot:
             assert_equal(np.vdot(a, b.copy('F')),
                          np.vdot(a.flatten(), b.flatten()))
 
+    def test_vdot_object_empty_is_zero(self):
+        x = np.empty((0,), dtype=object)
+        assert np.vdot(x, x) == 0
+
+        x2 = np.empty((1, 0), dtype=object)
+        assert_array_equal(np.vdot(x2, x2), np.array([0], dtype=object))
+
 
 class TestDot:
     N = 7

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -908,6 +908,12 @@ class TestUfunc:
         assert c is b
         assert_allclose(c, expected)
 
+    def test_matvec_empty_object_is_zero(self):
+        A = np.empty((3, 0), dtype=object)
+        v = np.empty((0,), dtype=object)
+        result = np.matvec(A, v)
+        assert_array_equal(result, np.zeros(3, dtype=object))
+
     def test_vecdot_subclass(self):
         class MySubclass(np.ndarray):
             pass


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

Fixes #31735. Referenced the fix in #31033.

While working on that, I found `np.matvec` has the same root cause for object dtype arrays.  An empty contraction axis returns None instead of 0, because it calls `OBJECT_dot`, which doesnt handle the zero length case


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

No AI
