### PR TITLE
ENH: Fast-path np.pad for singleton arrays

### DIFF
--- a/doc/release/upcoming_changes/31789.performance.rst
+++ b/doc/release/upcoming_changes/31789.performance.rst
@@ -1,5 +1,5 @@
 Faster selected ``numpy.pad`` modes for singleton arrays
--------------------------------------------------------
+--------------------------------------------------------
 ``numpy.pad`` is now faster for singleton arrays when using ``mode="reflect"``,
 ``mode="symmetric"``, or ``mode="wrap"``. These modes now fill the padded
 result directly when the input has a single element.

--- a/doc/release/upcoming_changes/31789.performance.rst
+++ b/doc/release/upcoming_changes/31789.performance.rst
@@ -1,0 +1,5 @@
+Faster selected ``numpy.pad`` modes for singleton arrays
+-------------------------------------------------------
+``numpy.pad`` is now faster for singleton arrays when using ``mode="reflect"``,
+``mode="symmetric"``, or ``mode="wrap"``. These modes now fill the padded
+result directly when the input has a single element.

--- a/numpy/lib/_arraypad_impl.py
+++ b/numpy/lib/_arraypad_impl.py
@@ -834,6 +834,11 @@ def pad(array, pad_width, mode='constant', **kwargs):
         raise ValueError("unsupported keyword arguments for mode "
                          f"'{mode}': {unsupported_kwargs}")
 
+    if mode in {"reflect", "symmetric", "wrap"} and array.size == 1:
+        padded, _ = _pad_simple(array, pad_width)
+        padded[...] = array.reshape(())
+        return padded
+
     stat_functions = {"maximum": np.amax, "minimum": np.amin,
                       "mean": np.mean, "median": np.median}
 

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -132,6 +132,15 @@ class TestConditionalShortcuts:
         assert_array_equal(np.pad(test, pad_amt, mode=mode),
                            np.pad(test, pad_amt, mode=mode, stat_length=30))
 
+    @pytest.mark.parametrize("mode", ["reflect", "symmetric", "wrap"])
+    def test_singleton_shortcut(self, mode):
+        test = np.array([[[[[4]]]]])
+        pad_amt = [(0, 32) for _ in test.shape]
+        assert_array_equal(
+            np.pad(test, pad_amt, mode=mode),
+            np.full((33,) * test.ndim, 4),
+        )
+
 
 class TestStatistic:
     def test_check_mean_stat_length(self):


### PR DESCRIPTION
### PR summary

Fast-path `np.pad` for singleton input arrays when using `mode="reflect"`, `mode="symmetric"`, or `mode="wrap"`.

For an array with a single element, these modes fill the padded result with that value. This change detects that case after mode keyword validation, allocates the padded result with the existing simple-padding helper, and fills it directly instead of entering the iterative per-axis padding path.

This is limited to singleton input arrays and the three modes above; other `np.pad` modes and non-singleton inputs stay on their existing paths.

### First time committer introduction

I am new to contributing to NumPy and opened this PR after looking at Python-level performance hotspots in `np.pad`. I will handle review discussion and follow-up changes directly.

#### AI Disclosure

LLM / Harness: hybrid.

AI assistance was used to inspect the codebase, run local commands, draft this PR text, and prepare the patch. I reviewed the generated suggestions, selected the final changes, and am responsible for the code, submission, and follow-up discussion. Some PR text and candidate code edits were drafted with AI assistance; the final patch and text were reviewed and edited by me.
