### PR TITLE
MAINT: pixi-packages: remove redundant `uv` dep

### DIFF
--- a/pixi-packages/asan/pixi.toml
+++ b/pixi-packages/asan/pixi.toml
@@ -24,4 +24,3 @@ python.rev = "55ea59e7dc35e1363b203ae4dd9cfc3a0ac0a844"  # v3.15.0a8
 
 meson-python = "*"
 cython = "*"
-uv = "*" # used to invoke the wheel build

--- a/pixi-packages/default/pixi.toml
+++ b/pixi-packages/default/pixi.toml
@@ -20,7 +20,7 @@ extra-args = ["-Csetup-args=-Dbuildtype=debug"]
 # FIXME https://github.com/numpy/numpy/issues/30478
 # python = "*" prevents downstream from building cpython from sources.
 # Workaround: fork numpy, then uncomment one of the following and
-# comment  out the other.
+# comment out the other.
 
 # Use latest cpython release from conda-forge
 python = "*"
@@ -32,4 +32,3 @@ python = "*"
 
 meson-python = "*"
 cython = "*"
-uv = "*" # used to invoke the wheel build

--- a/pixi-packages/freethreading/pixi.toml
+++ b/pixi-packages/freethreading/pixi.toml
@@ -20,7 +20,7 @@ extra-args = ["-Csetup-args=-Dbuildtype=debug"]
 # FIXME https://github.com/numpy/numpy/issues/30478
 # python = "*" prevents downstream from building cpython from sources.
 # Workaround: fork numpy, then uncomment one of the following and
-# comment  out the other.
+# comment out the other.
 
 # Use latest cpython release from conda-forge
 python-freethreading = "*"
@@ -32,4 +32,3 @@ python-freethreading = "*"
 
 meson-python = "*"
 cython = "*"
-uv = "*" # used to invoke the wheel build

--- a/pixi-packages/tsan-freethreading/pixi.toml
+++ b/pixi-packages/tsan-freethreading/pixi.toml
@@ -26,4 +26,3 @@ python.rev = "55ea59e7dc35e1363b203ae4dd9cfc3a0ac0a844"  # v3.15.0a8
 
 meson-python = "*"
 cython = "*"
-uv = "*" # used to invoke the wheel build


### PR DESCRIPTION
this is now included by default when one does not specify `pip` as a dependency

### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
