### PR TITLE
MAINT: fix ruff errors in ``tools/refguide_check.py``

### DIFF
--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -39,22 +39,27 @@ import docutils.core
 from docutils.parsers.rst import directives
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'doc', 'sphinxext'))
-from numpydoc.docscrape_sphinx import get_doc_object
-
 # Enable specific Sphinx directives (Sphinx 8+)
 # Make seealso more lenient for numpydoc content (Sphinx 8+)
 from docutils.parsers.rst.directives.misc import Directive
+from numpydoc.docscrape_sphinx import get_doc_object
+
+
 class LenientSeeAlso(Directive):
     has_content = True
     required_arguments = 0
     optional_arguments = 1
     final_argument_whitespace = True
-    option_spec = {}
+    option_spec = {}  # noqa: RUF012
+
     def run(self):
         return []
+
+
 directives.register_directive('seealso', LenientSeeAlso)
 
 from sphinx.directives.other import Only
+
 directives.register_directive('only', Only)
 
 


### PR DESCRIPTION
The lint CI job apparently didn't run in #31748, so some ruff errors were missed that are now causing the lint CI job to fail on main (see e.g. https://github.com/numpy/numpy/actions/runs/28394673323/job/84130268695?pr=31797).

Nothing a `ruff check --fix` couldn't fix though.

---

No AI.