### PR TITLE
CI: move ``paths-ignore`` to ``pull_requests`` in the ``linux_riscv64`` workflow

### DIFF
--- a/.github/workflows/linux_riscv64.yml
+++ b/.github/workflows/linux_riscv64.yml
@@ -8,15 +8,15 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+      - maintenance/**
     paths-ignore:
       - '**.pyi'
       - '**.md'
       - '**.rst'
       - 'tools/stubtest/**'
-  pull_request:
-    branches:
-      - main
-      - maintenance/**
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
I noticed that the Linux-riscv64 Wheel builder CI job was running on my static typing PRs ([here](https://github.com/numpy/numpy/actions/runs/28385977948/job/84100598066?pr=31793), for example), which is kinda wasteful, and is also the CI bottleneck (time-wise) for static-typing PRs (also for docs-only PRs I'm guessing).

This was a seemingly unintended consequence of the placement of the `paths-ignore` in the workflow, which was placed under the `on: push:` bit, instead of the `on: pull_request:` bit like in the other related workflows. 

---

No AI.