### PR TITLE
DOC: fix duplicated-word and grammar typos in C-API reference

### DIFF
--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -2050,7 +2050,7 @@ with the rest of the ArrayMethod API.
     The new descriptors MUST be viewable with the old ones, `NULL` must be
     supported (for output arguments) and should normally be forwarded.
 
-    The output of of this function will be used to construct
+    The output of this function will be used to construct
     views of the arguments as if they were the translated dtypes and
     does not use a cast. This means this mechanism is mostly useful for
     DTypes that "wrap" another DType implementation. For example, a unit
@@ -4083,7 +4083,7 @@ Other conversions
 
     Convert any Python sequence (or single Python number) passed in as
     *seq* to (up to) *maxvals* pointer-sized integers and place them
-    in the *vals* array. The sequence can be smaller then *maxvals* as
+    in the *vals* array. The sequence can be smaller than *maxvals* as
     the number of converted objects is returned.
 
 .. _including-the-c-api:

--- a/doc/source/reference/c-api/datetimes.rst
+++ b/doc/source/reference/c-api/datetimes.rst
@@ -3,7 +3,7 @@ Datetime API
 
 NumPy represents dates internally using an int64 counter and a unit metadata
 struct. Time differences are represented similarly using an int64 and a unit
-metadata struct. The functions described below are available to to facilitate
+metadata struct. The functions described below are available to facilitate
 converting between ISO 8601 date strings, NumPy datetimes, and Python datetime
 objects in C.
 

--- a/numpy/_core/__init__.py
+++ b/numpy/_core/__init__.py
@@ -49,7 +49,7 @@ except ImportError as exc:
             tag = sys.implementation.cache_tag or sys.implementation.name
             bad_c_module_info = (
                 f"The following compiled module files exist, but seem incompatible\n"
-                f"with with either python '{tag}' or the "
+                f"with either python '{tag}' or the "
                 f"platform '{sys.platform}':\n\n  * {candidate_str}\n"
             )
     else:


### PR DESCRIPTION
### PR summary
Removes duplicated-word and grammar typos in the C-API reference docs (array.rst, datetimes.rst) and a duplicated word in an error-message string (`numpy/_core/__init__.py`).

### First time committer introduction
Hello! I'm new to the NumPy community. I use Python in my project work and have been learning NumPy for some time. I've also served as a technical reviewer for programming books, including a Python title. I'd like to start spending time on open source contribution, and this is my first PR toward that.


#### AI Disclosure
An AI assistant (Anthropic's Claude, via the Claude desktop app) was used to scan
the documentation and source for duplicated-word and grammar typos and to suggest
the corrected wording. I reviewed and verified each change myself. No program logic
was AI-generated — the changes are limited to documentation text and one duplicated
word in an error-message string. This PR summary and my introduction were written by me.
