### PR TITLE
MAINT: Tell dependabot to ignore pkgconf

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,4 @@ updates:
       - dependency-name: "scipy-openblas64"
       - dependency-name: "jupyterlite-pyodide-kernel"
       - dependency-name: "sphinx"
+      - dependency-name: "pkgconf"


### PR DESCRIPTION
We currently use pkgconf 2.5.1.post1, 2.5.1.post2 has problems.

No AI.

[skip azp] [skip actions]
