### PR TITLE
ENH: add mechanism to register reduction loops to ufuncs for multi-output reductions

### DIFF
--- a/doc/release/upcoming_changes/31816.c_api.rst
+++ b/doc/release/upcoming_changes/31816.c_api.rst
@@ -1,21 +1,6 @@
 New mechanism to register reduction loops to ufuncs for multi-output reductions
 -------------------------------------------------------------------------------
-``ArrayMethod`` implementations can now register a dedicated reduction loop via
-the ``NPY_METH_get_reduction_loop`` slot. This allows ufuncs with more than one
-output (a two-in/``N``-out elementwise loop) to support
-:meth:`~numpy.ufunc.reduce`, which previously only worked for single-output
-binary ufuncs. ``reduce`` still requires exactly two inputs. Only the output
-arity is generalized. The reduction loop has an
-``(N+1)``-in/``N``-out signature: it consumes the running accumulators
-together with one streamed input element and produces the updated
-accumulators. Such a loop can also register per-output reduction identities
-through the ``NPY_METH_get_multi_reduction_initials`` slot (the multi-output
-analogue of ``NPY_METH_get_reduction_initial``), used to seed empty reductions
-and reductions with a ``where=`` mask.
-:meth:`~numpy.ufunc.reduce` on such a ufunc returns a tuple with one array per
-output, its ``out`` argument accepts a tuple of output arrays (one per
-output), and its ``initial`` argument accepts either a single value
-(broadcast to every output) or a tuple with one value per output.
-
-See :ref:`c-api.reduction-loop-tutorial` for a worked example of registering a
-reduction loop on a custom ufunc.
+Ufuncs with more than one output can now support :meth:`~numpy.ufunc.reduce`
+by registering a dedicated reduction loop (and, optionally, per-output
+identities) on their ``ArrayMethod``. The reduction returns one array per
+output. See :ref:`c-api.reduction-loop-tutorial` for a worked example.

--- a/doc/release/upcoming_changes/31816.c_api.rst
+++ b/doc/release/upcoming_changes/31816.c_api.rst
@@ -1,0 +1,18 @@
+New mechanism to register reduction loops to ufuncs for multi-output reductions
+-------------------------------------------------------------------------------
+``ArrayMethod`` implementations can now register a dedicated reduction loop via
+the ``NPY_METH_get_reduction_loop`` slot. This allows ufuncs with more than one
+output (a two-in/``N``-out elementwise loop) to support
+:meth:`~numpy.ufunc.reduce`, something that was previously restricted to
+single-output binary ufuncs; ``reduce`` still requires exactly two inputs,
+only the output arity is generalized. The reduction loop has an
+``(N+1)``-in/``N``-out signature: it consumes the running accumulators
+together with one streamed input element and produces the updated
+accumulators.
+:meth:`~numpy.ufunc.reduce` on such a ufunc returns a tuple with one array per
+output, its ``out`` argument accepts a tuple of output arrays (one per
+output), and its ``initial`` argument accepts either a single value
+(broadcast to every output) or a tuple with one value per output.
+
+See :ref:`c-api.reduction-loop-tutorial` for a worked example of registering a
+reduction loop on a custom ufunc.

--- a/doc/release/upcoming_changes/31816.c_api.rst
+++ b/doc/release/upcoming_changes/31816.c_api.rst
@@ -3,12 +3,15 @@ New mechanism to register reduction loops to ufuncs for multi-output reductions
 ``ArrayMethod`` implementations can now register a dedicated reduction loop via
 the ``NPY_METH_get_reduction_loop`` slot. This allows ufuncs with more than one
 output (a two-in/``N``-out elementwise loop) to support
-:meth:`~numpy.ufunc.reduce`, something that was previously restricted to
-single-output binary ufuncs; ``reduce`` still requires exactly two inputs,
-only the output arity is generalized. The reduction loop has an
+:meth:`~numpy.ufunc.reduce`, which previously only worked for single-output
+binary ufuncs. ``reduce`` still requires exactly two inputs. Only the output
+arity is generalized. The reduction loop has an
 ``(N+1)``-in/``N``-out signature: it consumes the running accumulators
 together with one streamed input element and produces the updated
-accumulators.
+accumulators. Such a loop can also register per-output reduction identities
+through the ``NPY_METH_get_multi_reduction_initials`` slot (the multi-output
+analogue of ``NPY_METH_get_reduction_initial``), used to seed empty reductions
+and reductions with a ``where=`` mask.
 :meth:`~numpy.ufunc.reduce` on such a ufunc returns a tuple with one array per
 output, its ``out`` argument accepts a tuple of output arrays (one per
 output), and its ``initial`` argument accepts either a single value

--- a/doc/release/upcoming_changes/31816.compatibility.rst
+++ b/doc/release/upcoming_changes/31816.compatibility.rst
@@ -1,0 +1,6 @@
+``ufunc.reduce`` on a multi-output ufunc now raises ``TypeError``
+-----------------------------------------------------------------
+Calling :meth:`~numpy.ufunc.reduce` on a ufunc with more than one output
+that does not register a reduction loop now raises a :exc:`TypeError`
+instead of a :exc:`ValueError`. Of NumPy's own ufuncs only `numpy.divmod`
+is affected.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1851,6 +1851,44 @@ the functions that must be implemented for each slot.
    initial value is correct, since NumPy may call this even when it is not
    strictly necessary to do so.
 
+.. c:macro:: NPY_METH_get_reduction_loop
+
+   .. versionadded:: 2.6
+
+   Registers a dedicated loop for use by :meth:`~numpy.ufunc.reduce`,
+   implemented as a :c:type:`PyArrayMethod_GetLoop` function (the same
+   typedef used for ``NPY_METH_get_loop``). This is required to reduce
+   ufuncs with more than one output, since the "forward" elementwise loop of
+   such a ufunc cannot be used as a reduction loop the way a single-output loop
+   can (by aliasing the output to the first input). Instead, the returned
+   :c:type:`PyArrayMethod_StridedLoop` must implement the reduction
+   directly, with an ``(nout + 1)``-in/``nout``-out signature: it takes the
+   current per-output accumulators followed by one streamed input element,
+   and writes the updated accumulators. That is, for a ufunc whose forward
+   loop has ``nout`` outputs, the *data*, *strides*, and descriptor arrays
+   passed to the reduction loop are laid out as::
+
+       [acc_0, ..., acc_{nout-1}, x, out_0, ..., out_{nout-1}]
+
+   where ``x`` is the streamed element being reduced in and each ``out_i``
+   is aliased to (and typically has stride 0 relative to) the matching
+   ``acc_i``.
+
+   If ``NPY_METH_get_reduction_loop`` is not set, :meth:`~numpy.ufunc.reduce`
+   falls back to ``NPY_METH_get_loop``/``NPY_METH_strided_loop``, which only
+   works for the traditional two-input/one-output case. Calling
+   :meth:`~numpy.ufunc.reduce` on a ufunc with more than one output whose
+   resolved ArrayMethod does not register a reduction loop raises a
+   :exc:`ValueError`. See :ref:`c-api.reduction-loop-tutorial` for a
+   worked example.
+
+   This slot only relaxes the *output* arity: :meth:`~numpy.ufunc.reduce`
+   (as well as :meth:`~numpy.ufunc.accumulate` and
+   :meth:`~numpy.ufunc.reduceat`) still requires the ufunc itself to have
+   exactly two inputs, independent of this slot. Calling any of them on a
+   ufunc with ``nin != 2`` raises a :exc:`ValueError` regardless of
+   ``nout`` or whether a reduction loop is registered.
+
 Flags
 ~~~~~
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1889,6 +1889,33 @@ the functions that must be implemented for each slot.
    ufunc with ``nin != 2`` raises a :exc:`ValueError` regardless of
    ``nout`` or whether a reduction loop is registered.
 
+.. c:macro:: NPY_METH_get_multi_reduction_initials
+
+   .. versionadded:: 2.6
+
+   Registers the per-output reduction identity/initial values, implemented as
+   a :c:type:`PyArrayMethod_GetMultiReductionInitials` function. It is the
+   multi-output version of :c:macro:`NPY_METH_get_reduction_initial` and fills
+   one initial value per reduction output instead of a single one.
+   :meth:`~numpy.ufunc.reduce` uses it to seed the accumulators when the
+   reduction is empty or when a ``where=`` mask is given, for a ufunc whose
+   loop also registers a :c:macro:`NPY_METH_get_reduction_loop`.
+
+   Its signature matches :c:macro:`NPY_METH_get_reduction_initial`, except that
+   the final argument is ``void **initials``, an array of ``nout`` pointers,
+   one per reduction output, each pointing to the buffer to fill. The
+   *reduction_is_empty* argument and the -1/0/1 return value have the same
+   meaning as for :c:macro:`NPY_METH_get_reduction_initial`. A return of 1 must
+   fill every output.
+
+   A method may register at most one of
+   :c:macro:`NPY_METH_get_reduction_initial` and
+   ``NPY_METH_get_multi_reduction_initials``. The latter supports single-output
+   reductions too. For a ufunc with more than one output it must be paired with
+   a :c:macro:`NPY_METH_get_reduction_loop`, otherwise
+   :meth:`~numpy.ufunc.reduce` is unreachable and the identity would never be
+   used. See :ref:`c-api.reduction-loop-tutorial` for a worked example.
+
 Flags
 ~~~~~
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1851,6 +1851,17 @@ the functions that must be implemented for each slot.
    initial value is correct, since NumPy may call this even when it is not
    strictly necessary to do so.
 
+.. c:type:: int (PyArrayMethod_GetMultiReductionInitials)( \
+        PyArrayMethod_Context *context, npy_bool reduction_is_empty, \
+        void **initials)
+
+   Multi-output version of :c:type:`PyArrayMethod_GetReductionInitial`, used to
+   query the per-output initial values for a reduction. It behaves the same
+   way, except that *initials* is an array of ``nout`` pointers, one per
+   reduction output, each pointing to the buffer to fill. The
+   *reduction_is_empty* argument and the -1, 0, or 1 return value have the same
+   meaning. A return of 1 must fill every output.
+
 .. c:macro:: NPY_METH_get_reduction_loop
 
    .. versionadded:: 2.6
@@ -1899,14 +1910,8 @@ the functions that must be implemented for each slot.
    one initial value per reduction output instead of a single one.
    :meth:`~numpy.ufunc.reduce` uses it to seed the accumulators when the
    reduction is empty or when a ``where=`` mask is given, for a ufunc whose
-   loop also registers a :c:macro:`NPY_METH_get_reduction_loop`.
-
-   Its signature matches :c:macro:`NPY_METH_get_reduction_initial`, except that
-   the final argument is ``void **initials``, an array of ``nout`` pointers,
-   one per reduction output, each pointing to the buffer to fill. The
-   *reduction_is_empty* argument and the -1/0/1 return value have the same
-   meaning as for :c:macro:`NPY_METH_get_reduction_initial`. A return of 1 must
-   fill every output.
+   loop also registers a :c:macro:`NPY_METH_get_reduction_loop`. See
+   :c:type:`PyArrayMethod_GetMultiReductionInitials` for the signature.
 
    A method may register at most one of
    :c:macro:`NPY_METH_get_reduction_initial` and

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1879,7 +1879,7 @@ the functions that must be implemented for each slot.
    works for the traditional two-input/one-output case. Calling
    :meth:`~numpy.ufunc.reduce` on a ufunc with more than one output whose
    resolved ArrayMethod does not register a reduction loop raises a
-   :exc:`ValueError`. See :ref:`c-api.reduction-loop-tutorial` for a
+   :exc:`TypeError`. See :ref:`c-api.reduction-loop-tutorial` for a
    worked example.
 
    This slot only relaxes the *output* arity: :meth:`~numpy.ufunc.reduce`

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1856,11 +1856,13 @@ the functions that must be implemented for each slot.
         void **initials)
 
    Multi-output version of :c:type:`PyArrayMethod_GetReductionInitial`, used to
-   query the per-output initial values for a reduction. It behaves the same
-   way, except that *initials* is an array of ``nout`` pointers, one per
-   reduction output, each pointing to the buffer to fill. The
-   *reduction_is_empty* argument and the -1, 0, or 1 return value have the same
-   meaning. A return of 1 must fill every output.
+   query the per-output initial values for a reduction. It behaves the same as
+   :c:type:`PyArrayMethod_GetReductionInitial`, except that *initials*
+   is an array of ``nout`` pointers, one per reduction output, each pointing
+   to the buffer to fill. The *reduction_is_empty* argument and the -1, 0, or 1
+   return value have the same meaning as :c:type:`PyArrayMethod_GetReductionInitial`.
+   A return of 1 indicates every initial value has been successfully initialized
+   with valid data.
 
 .. c:macro:: NPY_METH_get_reduction_loop
 
@@ -1871,7 +1873,8 @@ the functions that must be implemented for each slot.
    typedef used for ``NPY_METH_get_loop``). This is required to reduce
    ufuncs with more than one output, since the "forward" elementwise loop of
    such a ufunc cannot be used as a reduction loop the way a single-output loop
-   can (by aliasing the output to the first input). Instead, the returned
+   can (by pointing the output and the first input at the same memory, so that
+   the loop accumulates in place). Instead, the returned
    :c:type:`PyArrayMethod_StridedLoop` must implement the reduction
    directly, with an ``(nout + 1)``-in/``nout``-out signature: it takes the
    current per-output accumulators followed by one streamed input element,
@@ -1881,24 +1884,25 @@ the functions that must be implemented for each slot.
 
        [acc_0, ..., acc_{nout-1}, x, out_0, ..., out_{nout-1}]
 
-   where ``x`` is the streamed element being reduced in and each ``out_i``
-   is aliased to (and typically has stride 0 relative to) the matching
-   ``acc_i``.
+   where ``x`` is the streamed element being reduced in, and each ``out_i``
+   points at the same memory as the matching ``acc_i`` (and typically has a
+   stride of 0 relative to it).
 
    If ``NPY_METH_get_reduction_loop`` is not set, :meth:`~numpy.ufunc.reduce`
    falls back to ``NPY_METH_get_loop``/``NPY_METH_strided_loop``, which only
-   works for the traditional two-input/one-output case. Calling
+   works for the typical two-input/one-output case. Calling
    :meth:`~numpy.ufunc.reduce` on a ufunc with more than one output whose
    resolved ArrayMethod does not register a reduction loop raises a
    :exc:`TypeError`. See :ref:`c-api.reduction-loop-tutorial` for a
    worked example.
 
-   This slot only relaxes the *output* arity: :meth:`~numpy.ufunc.reduce`
-   (as well as :meth:`~numpy.ufunc.accumulate` and
-   :meth:`~numpy.ufunc.reduceat`) still requires the ufunc itself to have
-   exactly two inputs, independent of this slot. Calling any of them on a
-   ufunc with ``nin != 2`` raises a :exc:`ValueError` regardless of
-   ``nout`` or whether a reduction loop is registered.
+   Note that this slot only lifts the restriction on how many outputs a
+   ufunc may have. It does not change how many inputs a ufunc may have:
+   :meth:`~numpy.ufunc.reduce` (as well as :meth:`~numpy.ufunc.accumulate`
+   and :meth:`~numpy.ufunc.reduceat`) still only works on ufuncs that take
+   exactly two inputs, whether or not a reduction loop is registered.
+   Calling any of these methods on a ufunc with a number of inputs other
+   than two raises a :exc:`ValueError`.
 
 .. c:macro:: NPY_METH_get_multi_reduction_initials
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -1888,6 +1888,15 @@ the functions that must be implemented for each slot.
    points at the same memory as the matching ``acc_i`` (and typically has a
    stride of 0 relative to it).
 
+   The *strides* argument passed to ``NPY_METH_get_reduction_loop`` itself at
+   setup time uses this same layout, so that ``strides[i]`` describes the
+   ``i``-th operand of the loop being requested. ``strides[nout]`` is the
+   stride of the streamed input, and each ``strides[nout + 1 + i]`` repeats
+   ``strides[i]``, because ``out_i`` and ``acc_i`` are the same buffer. The
+   accumulator strides are normally 0, since the reduction accumulates in
+   place. When a ``where=`` mask is used, one further entry at
+   ``strides[2 * nout + 1]`` holds the mask stride.
+
    If ``NPY_METH_get_reduction_loop`` is not set, :meth:`~numpy.ufunc.reduce`
    falls back to ``NPY_METH_get_loop``/``NPY_METH_strided_loop``, which only
    works for the typical two-input/one-output case. Calling

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -76,7 +76,7 @@ so calling its methods raises an error::
    >>> np.divmod.reduce([1, 2, 3])
    Traceback (most recent call last):
        ...
-   ValueError: reduce only supported for functions returning a single value
+   ValueError: divmod.reduce is not supported: the resolved loop does not register a reduction loop
 
 The reduce-like methods all take an *axis* keyword, a *dtype*
 keyword, and an *out* keyword, and the arrays must all have dimension >= 1.

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -65,7 +65,7 @@ Attempting to call these methods on other ufuncs will cause a
 :exc:`ValueError` (or, for :meth:`~numpy.ufunc.reduce` on a ufunc with more
 than one output, a :exc:`TypeError`), unless the ufunc's loop implementation
 registers a dedicated reduction loop, in which case :meth:`~numpy.ufunc.reduce`
-also works for ufuncs with more than one output; see
+also works for ufuncs with more than one output. See
 :doc:`c-info.reduction-loop-tutorial` for how to add one to a custom ufunc.
 
 For example, :func:`numpy.add` takes two inputs and returns one output,

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -58,11 +58,14 @@ All ufuncs have 5 methods. 4 reduce-like methods
 (:meth:`~numpy.ufunc.reduce`, :meth:`~numpy.ufunc.accumulate`,
 :meth:`~numpy.ufunc.reduceat`, :meth:`~numpy.ufunc.outer`) and one
 for inplace operations (:meth:`~numpy.ufunc.at`).
-See :ref:`ufuncs.methods` for more. However, these methods only make sense on 
+See :ref:`ufuncs.methods` for more. However, these methods only make sense on
 ufuncs that take two input arguments and return one output argument (so-called
 "scalar" ufuncs since the inner loop operates on a single scalar value).
 Attempting to call these methods on other ufuncs will cause a
-:exc:`ValueError`.
+:exc:`ValueError`, unless the ufunc's loop implementation registers a
+dedicated reduction loop, in which case :meth:`~numpy.ufunc.reduce` (but not
+the other four methods) also works for ufuncs with more than one output; see
+:doc:`c-info.reduction-loop-tutorial` for how to add one to a custom ufunc.
 
 For example, :func:`numpy.add` takes two inputs and returns one output,
 so its methods work::
@@ -70,13 +73,18 @@ so its methods work::
    >>> np.add.reduce([1, 2, 3])
    6
 
-But :func:`numpy.divmod` returns two outputs (quotient and remainder),
-so calling its methods raises an error::
+But :func:`numpy.divmod` returns two outputs (quotient and remainder) and has no
+reduction loop registered, so calling its methods raises an error::
 
    >>> np.divmod.reduce([1, 2, 3])
    Traceback (most recent call last):
        ...
    ValueError: divmod.reduce is not supported: the resolved loop does not register a reduction loop
+
+For a ufunc with more than one output whose loop *does* register a reduction
+loop, :meth:`~numpy.ufunc.reduce` instead returns a tuple with one array per
+output. Its *initial* argument then also accepts either a single value,
+broadcast to every output, or a tuple with one value per output.
 
 The reduce-like methods all take an *axis* keyword, a *dtype*
 keyword, and an *out* keyword, and the arrays must all have dimension >= 1.

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -62,9 +62,10 @@ See :ref:`ufuncs.methods` for more. However, these methods only make sense on
 ufuncs that take two input arguments and return one output argument (so-called
 "scalar" ufuncs since the inner loop operates on a single scalar value).
 Attempting to call these methods on other ufuncs will cause a
-:exc:`ValueError`, unless the ufunc's loop implementation registers a
-dedicated reduction loop, in which case :meth:`~numpy.ufunc.reduce` (but not
-the other four methods) also works for ufuncs with more than one output; see
+:exc:`ValueError` (or, for :meth:`~numpy.ufunc.reduce` on a ufunc with more
+than one output, a :exc:`TypeError`), unless the ufunc's loop implementation
+registers a dedicated reduction loop, in which case :meth:`~numpy.ufunc.reduce`
+also works for ufuncs with more than one output; see
 :doc:`c-info.reduction-loop-tutorial` for how to add one to a custom ufunc.
 
 For example, :func:`numpy.add` takes two inputs and returns one output,

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -79,7 +79,7 @@ reduction loop registered, so calling its methods raises an error::
    >>> np.divmod.reduce([1, 2, 3])
    Traceback (most recent call last):
        ...
-   ValueError: divmod.reduce is not supported: the resolved loop does not register a reduction loop
+   TypeError: divmod.reduce is not supported: the resolved loop does not register a reduction loop
 
 For a ufunc with more than one output whose loop *does* register a reduction
 loop, :meth:`~numpy.ufunc.reduce` instead returns a tuple with one array per

--- a/doc/source/user/c-info.reduction-loop-tutorial.rst
+++ b/doc/source/user/c-info.reduction-loop-tutorial.rst
@@ -46,7 +46,7 @@ on a ufunc with ``nin != 2`` (regardless of ``nout``) raises a
 
 If a ufunc has more than one output and its resolved ``ArrayMethod`` does
 not register a reduction loop, calling ``.reduce()`` on it raises a
-:exc:`ValueError`, e.g. ``numpy.divmod.reduce`` fails since ``divmod``
+:exc:`TypeError`, e.g. ``numpy.divmod.reduce`` fails since ``divmod``
 has no reduction loop.
 
 Example: a two-output ``minimummaximum`` ufunc

--- a/doc/source/user/c-info.reduction-loop-tutorial.rst
+++ b/doc/source/user/c-info.reduction-loop-tutorial.rst
@@ -91,8 +91,8 @@ with ``/* BEGIN main computation */`` and ``/* END main computation */``.
          * minmax.c
          * A minimal ufunc for a single dtype ('f8') that computes the
          * running minimum and maximum in one pass, and registers a
-         * reduction loop for it so that `minimummaximum.reduce(a)` -- the
-         * actual "minmax" operation -- works.
+         * reduction loop for it so that `minimummaximum.reduce(a)` computes
+         * the actual minmax.
          */
 
         static int
@@ -239,7 +239,7 @@ with ``/* BEGIN main computation */`` and ``/* END main computation */``.
                 return NULL;
             }
 
-            /* A 2-in/2-out ufunc; its loop(s) are registered separately below. */
+            /* A 2-in/2-out ufunc. Its loops are registered separately below. */
             PyObject *minimummaximum = PyUFunc_FromFuncAndData(
                     NULL, NULL, NULL, 0, 2, 2, PyUFunc_None,
                     "minimummaximum", "minimummaximum_docstring", 0);
@@ -380,9 +380,27 @@ real-world implementation, like the built-in :func:`numpy.add` or a fuller
   keeping their own dtype. A multi-dtype ufunc would instead register a
   loop per dtype and pick the common one, as in the built-in
   :func:`numpy.minimum`/:func:`numpy.maximum`.
-- It has no :c:macro:`NPY_METH_get_reduction_initial`, so
-  ``minimummaximum.reduce`` of an empty array raises a :exc:`ValueError`,
-  matching the "no identity" behaviour of e.g. ``numpy.maximum.reduce``.
+- It registers no reduction identity, so ``minimummaximum.reduce`` of an
+  empty array raises a :exc:`ValueError`, the same as ``numpy.maximum.reduce``.
+  A multi-output ufunc can provide per-output identities with the
+  :c:macro:`NPY_METH_get_multi_reduction_initials` slot, the multi-output
+  version of :c:macro:`NPY_METH_get_reduction_initial`. Its function fills one
+  initial value per output, for example ``+inf`` for the running minimum and
+  ``-inf`` for the running maximum. Reducing an empty array, or reducing with
+  a ``where=`` mask, then returns those identities instead of raising::
+
+      static int
+      minimummaximum_get_multi_reduction_initials(
+              PyArrayMethod_Context *NPY_UNUSED(context),
+              npy_bool NPY_UNUSED(reduction_is_empty), void **initials)
+      {
+          *(double *)initials[0] = NPY_INFINITY;   /* min identity */
+          *(double *)initials[1] = -NPY_INFINITY;  /* max identity */
+          return 1;
+      }
+
+  registered alongside the reduction loop as
+  ``{NPY_METH_get_multi_reduction_initials, (void *)&minimummaximum_get_multi_reduction_initials}``.
 - :meth:`~numpy.ufunc.accumulate`, :meth:`~numpy.ufunc.reduceat`, and
   :meth:`~numpy.ufunc.at` are not supported for multi-output ufuncs yet,
   only :meth:`~numpy.ufunc.reduce` is.

--- a/doc/source/user/c-info.reduction-loop-tutorial.rst
+++ b/doc/source/user/c-info.reduction-loop-tutorial.rst
@@ -1,0 +1,395 @@
+.. _c-api.reduction-loop-tutorial:
+
+***********************************
+Adding a reduction loop to a ufunc
+***********************************
+
+.. index::
+   pair: ufunc; reduction
+
+This tutorial assumes you are already familiar with writing a basic ufunc,
+as described in :doc:`c-info.ufunc-tutorial`.
+
+Background
+==========
+
+:meth:`~numpy.ufunc.reduce` (and the ``.sum()``/``.prod()``/... methods
+built on top of it for functions like :func:`numpy.add` and
+:func:`numpy.multiply`) historically only worked for ufuncs with exactly
+one output. The trick that makes this possible is that the ordinary
+two-input/one-output elementwise loop can be used as the reduction loop:
+if the output pointer is aliased to the first input pointer (with stride 0)
+and left unmoved, the loop keeps accumulating into the same location as it
+walks over the array.
+
+That trick does not generalize to ufuncs with more than one output, because
+their forward elementwise loop has a two-in/``nout``-out signature that has
+no natural way to alias an accumulator the same way. To support ``reduce``
+for such ufuncs, an ``ArrayMethod`` can instead register a *dedicated*
+reduction loop through the ``NPY_METH_get_reduction_loop`` slot. Unlike the
+forward loop, this loop has an ``(nout + 1)``-in/``nout``-out signature: it
+takes the current per-output accumulators plus one streamed input element,
+and writes the updated accumulators. The reason we require this signature is
+that it naturally collapses down to the nominal two-input/one-output case
+when ``nout = 1``. See :c:macro:`NPY_METH_get_reduction_loop` in the
+:doc:`ArrayMethod API reference </reference/c-api/array>` for the exact
+data/stride layout.
+
+``reduce`` (like ``accumulate`` and ``reduceat``) still requires the ufunc's
+forward loop to have exactly two inputs as reducing folds an accumulator and
+one new element together at each step, which is only well-defined for a
+binary combining operation. This is unrelated to the number of outputs and
+was already true before multi-output reduction existed: calling ``reduce``
+on a ufunc with ``nin != 2`` (regardless of ``nout``) raises a
+:exc:`ValueError` ("... only supported for binary functions"). Only the
+*output* arity is generalized here.
+
+If a ufunc has more than one output and its resolved ``ArrayMethod`` does
+not register a reduction loop, calling ``.reduce()`` on it raises a
+:exc:`ValueError`, e.g. ``numpy.divmod.reduce`` fails since ``divmod``
+has no reduction loop.
+
+Example: a two-output ``minimummaximum`` ufunc
+===============================================
+
+The example below defines a ``minimummaximum`` ufunc for the ``'f8'``
+(``double``) dtype only, computing the running minimum and maximum in a
+single reduction pass: ``minimummaximum.reduce(a)`` returns the pair
+``(a.min(), a.max())``, computed in one loop over ``a`` rather than in two.
+
+Because ``NPY_METH_get_reduction_loop`` is an ``ArrayMethod`` slot, the
+ufunc's loop must be registered through the new-style ``PyArrayMethod_Spec``
+API (:c:func:`PyUFunc_AddLoopFromSpec`) rather than the legacy
+``PyUFunc_FromFuncAndData`` loop table used in the previous tutorial. The
+ufunc itself is still created with :c:func:`PyUFunc_FromFuncAndData`, just
+without any loops attached yet. The loop is added separately, via its
+``ArrayMethod`` spec.
+
+The forward (elementwise) loop is 2-in/2-out::
+
+    (a, b) -> (min(a, b), max(a, b))
+
+and the reduction loop is 3-in/2-out (``nout = 2`` outputs, so
+``nout + 1 = 3`` inputs)::
+
+    (acc_min, acc_max, x) -> (min(acc_min, x), max(acc_max, x))
+
+The place in the code corresponding to the actual computations is marked
+with ``/* BEGIN main computation */`` and ``/* END main computation */``.
+
+    .. code-block:: c
+
+        #define PY_SSIZE_T_CLEAN
+        #define NPY_TARGET_VERSION NPY_2_6_API_VERSION
+        #define NPY_NO_DEPRECATED_API NPY_API_VERSION
+        #include <Python.h>
+        #include "numpy/ndarraytypes.h"
+        #include "numpy/ufuncobject.h"
+        #include "numpy/dtype_api.h"
+
+        /*
+         * minmax.c
+         * A minimal ufunc for a single dtype ('f8') that computes the
+         * running minimum and maximum in one pass, and registers a
+         * reduction loop for it so that `minimummaximum.reduce(a)` -- the
+         * actual "minmax" operation -- works.
+         */
+
+        static int
+        double_minimummaximum_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                char *const data[], npy_intp const dimensions[],
+                npy_intp const strides[], NpyAuxData *NPY_UNUSED(auxdata))
+        {
+            npy_intp n = dimensions[0];
+            char *in1 = data[0], *in2 = data[1];
+            char *out1 = data[2], *out2 = data[3];
+            npy_intp is1 = strides[0], is2 = strides[1];
+            npy_intp os1 = strides[2], os2 = strides[3];
+
+            for (npy_intp i = 0; i < n; i++) {
+                /* BEGIN main computation */
+                double a = *(double *)in1;
+                double b = *(double *)in2;
+                *(double *)out1 = a < b ? a : b;
+                *(double *)out2 = a < b ? b : a;
+                /* END main computation */
+                in1 += is1; in2 += is2; out1 += os1; out2 += os2;
+            }
+            return 0;
+        }
+
+        /*
+         * The reduce machinery aliases out_i to acc_i (with stride 0), so
+         * this both reads the running accumulators and writes the new ones.
+         */
+        static int
+        double_minimummaximum_reduce_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                char *const data[], npy_intp const dimensions[],
+                npy_intp const strides[], NpyAuxData *NPY_UNUSED(auxdata))
+        {
+            npy_intp n = dimensions[0];
+            char *acc_min = data[0], *acc_max = data[1], *x = data[2];
+            char *out_min = data[3], *out_max = data[4];
+            npy_intp s_amin = strides[0], s_amax = strides[1], s_x = strides[2];
+            npy_intp s_omin = strides[3], s_omax = strides[4];
+
+            for (npy_intp i = 0; i < n; i++) {
+                /* BEGIN main computation */
+                double cur_min = *(double *)acc_min;
+                double cur_max = *(double *)acc_max;
+                double val = *(double *)x;
+                *(double *)out_min = val < cur_min ? val : cur_min;
+                *(double *)out_max = val > cur_max ? val : cur_max;
+                /* END main computation */
+                acc_min += s_amin; acc_max += s_amax; x += s_x;
+                out_min += s_omin; out_max += s_omax;
+            }
+            return 0;
+        }
+
+        /*
+         * get_reduction_loop is called by the reduce machinery in place of
+         * get_strided_loop.  It hands back the (nout+1)->nout loop above
+         * instead of the forward elementwise one.
+         */
+        static int
+        minimummaximum_get_reduction_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+                int NPY_UNUSED(aligned), int NPY_UNUSED(move_references),
+                const npy_intp *NPY_UNUSED(strides),
+                PyArrayMethod_StridedLoop **out_loop,
+                NpyAuxData **out_transferdata,
+                NPY_ARRAYMETHOD_FLAGS *flags)
+        {
+            *out_loop = &double_minimummaximum_reduce_loop;
+            *out_transferdata = NULL;
+            *flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
+            return 0;
+        }
+
+        /*
+         * Only one loop is registered ('f8'), so the promoter always
+         * requests float64 for every input/output that isn't already
+         * pinned by `signature` (e.g. via `dtype=`). This is what lets
+         * plain Python floats/ints, or other numeric dtypes, be used
+         * directly. Without it, only exact `np.float64` inputs would
+         * match the loop registered below. A ufunc that registers loops
+         * for several dtypes would instead pick the common dtype of its
+         * inputs here (see `PyArray_PromoteDTypeSequence`). This one only
+         * ever has a single dtype to offer.
+         */
+        static int
+        minimummaximum_promoter(PyObject *NPY_UNUSED(ufunc),
+                PyArray_DTypeMeta *const NPY_UNUSED(op_dtypes[]),
+                PyArray_DTypeMeta *const signature[],
+                PyArray_DTypeMeta *new_op_dtypes[])
+        {
+            PyArray_Descr *double_descr = PyArray_DescrFromType(NPY_DOUBLE);
+            if (double_descr == NULL) {
+                return -1;
+            }
+            PyArray_DTypeMeta *double_dt = NPY_DTYPE(double_descr);
+
+            for (int i = 0; i < 4; i++) {
+                PyArray_DTypeMeta *dt = signature[i] != NULL ? signature[i] : double_dt;
+                Py_INCREF(dt);
+                new_op_dtypes[i] = dt;
+            }
+            Py_DECREF(double_descr);
+            return 0;
+        }
+
+        static int
+        register_minimummaximum_promoter(PyObject *minimummaximum)
+        {
+            /* All-None tuple -> catch-all fallback (a concrete loop always wins). */
+            PyObject *none_tuple = PyTuple_Pack(
+                    4, Py_None, Py_None, Py_None, Py_None);
+            if (none_tuple == NULL) {
+                return -1;
+            }
+            PyObject *promoter = PyCapsule_New(
+                    (void *)&minimummaximum_promoter,
+                    "numpy._ufunc_promoter", NULL);
+            if (promoter == NULL) {
+                Py_DECREF(none_tuple);
+                return -1;
+            }
+            int res = PyUFunc_AddPromoter(minimummaximum, none_tuple, promoter);
+            Py_DECREF(none_tuple);
+            Py_DECREF(promoter);
+            return res;
+        }
+
+        static PyMethodDef MinMaxMethods[] = {
+            {NULL, NULL, 0, NULL}
+        };
+
+        static struct PyModuleDef moduledef = {
+            PyModuleDef_HEAD_INIT, "minmax", NULL, -1, MinMaxMethods,
+            NULL, NULL, NULL, NULL
+        };
+
+        PyMODINIT_FUNC PyInit_minmax(void)
+        {
+            import_array();
+            import_umath();
+
+            PyObject *m = PyModule_Create(&moduledef);
+            if (m == NULL) {
+                return NULL;
+            }
+
+            /* A 2-in/2-out ufunc; its loop(s) are registered separately below. */
+            PyObject *minimummaximum = PyUFunc_FromFuncAndData(
+                    NULL, NULL, NULL, 0, 2, 2, PyUFunc_None,
+                    "minimummaximum", "minimummaximum_docstring", 0);
+            if (minimummaximum == NULL) {
+                Py_DECREF(m);
+                return NULL;
+            }
+
+            PyArray_Descr *double_descr = PyArray_DescrFromType(NPY_DOUBLE);
+            PyArray_DTypeMeta *dt = NPY_DTYPE(double_descr);
+            PyArray_DTypeMeta *dtypes[4] = {dt, dt, dt, dt};
+
+            PyType_Slot slots[] = {
+                {NPY_METH_strided_loop, (void *)&double_minimummaximum_loop},
+                {NPY_METH_get_reduction_loop,
+                 (void *)&minimummaximum_get_reduction_loop},
+                {0, NULL},
+            };
+
+            PyArrayMethod_Spec spec = {
+                .name = "double_minimummaximum",
+                .nin = 2,
+                .nout = 2,
+                .casting = NPY_NO_CASTING,
+                /* Needed for axis=None / multi-axis reductions. */
+                .flags = NPY_METH_IS_REORDERABLE,
+                .dtypes = dtypes,
+                .slots = slots,
+            };
+
+            int res = PyUFunc_AddLoopFromSpec(minimummaximum, &spec);
+            Py_DECREF(double_descr);
+            if (res < 0 || register_minimummaximum_promoter(minimummaximum) < 0
+                    || PyModule_AddObject(m, "minimummaximum", minimummaximum) < 0) {
+                Py_XDECREF(minimummaximum);
+                Py_DECREF(m);
+                return NULL;
+            }
+            return m;
+        }
+
+As with the ufuncs in the previous tutorial, the module needs to declare a
+dependency on NumPy to build:
+
+.. tab-set::
+
+   .. tab-item:: meson
+
+      Sample ``pyproject.toml`` and ``meson.build``.
+
+      .. code-block:: toml
+
+         [project]
+         name = "minmax"
+         dependencies = ["numpy"]
+         version = "0.1"
+
+         [build-system]
+         requires = ["meson-python", "numpy"]
+         build-backend = "mesonpy"
+
+      .. code-block:: meson
+
+         project('minmax', 'c')
+
+         py = import('python').find_installation()
+         np_dep = dependency('numpy')
+
+         sources = files('minmax.c')
+
+         extension_module = py.extension_module(
+           'minmax',
+           sources,
+           dependencies: [np_dep],
+           install: true,
+         )
+
+   .. tab-item:: setuptools
+
+      Sample ``pyproject.toml`` and ``setup.py``.
+
+      .. code-block:: toml
+
+         [project]
+         name = "minmax"
+         dependencies = ["numpy"]
+         version = "0.1"
+
+         [build-system]
+         requires = ["setuptools", "numpy"]
+         build-backend = "setuptools.build_meta"
+
+      .. code-block:: python
+
+         from setuptools import setup, Extension
+         from numpy import get_include
+
+         minmax = Extension('minmax',
+                            sources=['minmax.c'],
+                            include_dirs=[get_include()])
+
+         setup(name='minmax', version='1.0', ext_modules=[minmax])
+
+After the above has been installed, it can be imported and used as
+follows. Note that plain Python floats and ints work directly, thanks to
+the promoter, no explicit ``np.float64(...)`` wrapping is needed::
+
+    >>> import numpy as np
+    >>> import minmax
+    >>> minmax.minimummaximum(3.0, 5.0)
+    (np.float64(3.0), np.float64(5.0))
+    >>> minmax.minimummaximum(3, 5)
+    (np.float64(3.0), np.float64(5.0))
+    >>> a = [3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0]
+    >>> minmax.minimummaximum.reduce(a)
+    (np.float64(1.0), np.float64(9.0))
+    >>> b = np.array(a).reshape(2, 4)
+    >>> minmax.minimummaximum.reduce(b, axis=None)
+    (np.float64(1.0), np.float64(9.0))
+    >>> minmax.minimummaximum.reduce(b, axis=1)
+    (array([1., 2.]), array([4., 9.]))
+
+Note that ``minimummaximum.reduce`` returns a tuple with one array per
+output (``lo, hi = minimummaximum.reduce(a)``), rather than a single array.
+If ``initial`` is passed to ``reduce`` on a multi-output ufunc, it can
+either be a single scalar (broadcast to seed every output) or a tuple with
+one value per output.
+
+Limitations
+===========
+
+This example is intentionally minimal and leaves out several things a
+real-world implementation, like the built-in :func:`numpy.add` or a fuller
+``minimummaximum``, would normally have:
+
+- The promoter always resolves to ``'f8'`` regardless of the input dtypes,
+  so e.g. integer input arrays are silently cast to ``float64`` rather than
+  keeping their own dtype. A multi-dtype ufunc would instead register a
+  loop per dtype and pick the common one, as in the built-in
+  :func:`numpy.minimum`/:func:`numpy.maximum`.
+- It has no :c:macro:`NPY_METH_get_reduction_initial`, so
+  ``minimummaximum.reduce`` of an empty array raises a :exc:`ValueError`,
+  matching the "no identity" behaviour of e.g. ``numpy.maximum.reduce``.
+- :meth:`~numpy.ufunc.accumulate`, :meth:`~numpy.ufunc.reduceat`, and
+  :meth:`~numpy.ufunc.at` are not supported for multi-output ufuncs yet,
+  only :meth:`~numpy.ufunc.reduce` is.
+
+.. seealso::
+
+   * :doc:`ArrayMethod API reference </reference/c-api/array>` for the full
+     :c:macro:`NPY_METH_get_reduction_loop` reference documentation.
+   * :ref:`ufuncs-basics` for the Python-level behavior of
+     :meth:`~numpy.ufunc.reduce` on multi-output ufuncs.

--- a/doc/source/user/c-info.reduction-loop-tutorial.rst
+++ b/doc/source/user/c-info.reduction-loop-tutorial.rst
@@ -384,7 +384,9 @@ Note that ``minimummaximum.reduce`` returns a tuple with one array per
 output, rather than a single array, so it is usually unpacked as
 ``lo, hi = minimummaximum.reduce(a)``. The ``initial`` argument of a
 multi-output ``reduce`` accepts either a single scalar, which seeds every
-output, or a tuple with one value per output.
+output, or a tuple with one value per output. The entries of such a tuple
+cannot be ``None``; a plain ``initial=None`` still unsets the initial value
+for the whole reduction.
 
 Limitations
 ===========

--- a/doc/source/user/c-info.reduction-loop-tutorial.rst
+++ b/doc/source/user/c-info.reduction-loop-tutorial.rst
@@ -13,53 +13,70 @@ as described in :doc:`c-info.ufunc-tutorial`.
 Background
 ==========
 
-:meth:`~numpy.ufunc.reduce` (and the ``.sum()``/``.prod()``/... methods
+:meth:`~numpy.ufunc.reduce` historically only worked for ufuncs with
+exactly one output. This covers the ``.sum()``/``.prod()``/... methods
 built on top of it for functions like :func:`numpy.add` and
-:func:`numpy.multiply`) historically only worked for ufuncs with exactly
-one output. The trick that makes this possible is that the ordinary
-two-input/one-output elementwise loop can be used as the reduction loop:
-if the output pointer is aliased to the first input pointer (with stride 0)
-and left unmoved, the loop keeps accumulating into the same location as it
-walks over the array.
+:func:`numpy.multiply`.
 
-That trick does not generalize to ufuncs with more than one output, because
-their forward elementwise loop has a two-in/``nout``-out signature that has
-no natural way to alias an accumulator the same way. To support ``reduce``
-for such ufuncs, an ``ArrayMethod`` can instead register a *dedicated*
-reduction loop through the ``NPY_METH_get_reduction_loop`` slot. Unlike the
-forward loop, this loop has an ``(nout + 1)``-in/``nout``-out signature: it
-takes the current per-output accumulators plus one streamed input element,
-and writes the updated accumulators. The reason we require this signature is
-that it naturally collapses down to the nominal two-input/one-output case
-when ``nout = 1``. See :c:macro:`NPY_METH_get_reduction_loop` in the
+What makes those work is that the ordinary two-input/one-output elementwise
+loop can double as the reduction loop. NumPy points the loop's output and
+its first input at the same piece of memory. It also gives that pointer a
+stride of zero, so the pointer never advances. The loop then reads the
+running result and writes the updated result back to that same location as
+it walks over the array.
+
+That trick does not generalize to ufuncs with more than one output, such as
+:func:`numpy.divmod`. Their forward loop has a two-in/``nout``-out
+signature. There is no natural way to pair each output up with an input
+that could hold its running result.
+
+To support ``reduce`` for such ufuncs, an ``ArrayMethod`` can register a
+*dedicated* reduction loop through the ``NPY_METH_get_reduction_loop``
+slot. That loop has an ``(nout + 1)``-in/``nout``-out signature. It takes
+the current per-output accumulators plus one streamed input element, and
+writes the updated accumulators. We use this signature because it collapses
+down to the usual two-input/one-output case when ``nout`` is 1. See
+:c:macro:`NPY_METH_get_reduction_loop` in the
 :doc:`ArrayMethod API reference </reference/c-api/array>` for the exact
 data/stride layout.
 
-``reduce`` (like ``accumulate`` and ``reduceat``) still requires the ufunc's
-forward loop to have exactly two inputs as reducing folds an accumulator and
-one new element together at each step, which is only well-defined for a
-binary combining operation. This is unrelated to the number of outputs and
-was already true before multi-output reduction existed: calling ``reduce``
-on a ufunc with ``nin != 2`` (regardless of ``nout``) raises a
-:exc:`ValueError` ("... only supported for binary functions"). Only the
-*output* arity is generalized here.
+Only the restriction on the number of *outputs* is lifted. The number of
+inputs is unchanged: ``reduce`` still requires exactly two, as do
+``accumulate`` and ``reduceat``. Reducing repeatedly combines an
+accumulated result with one new element, which only makes sense for a
+ufunc taking two inputs.
 
-If a ufunc has more than one output and its resolved ``ArrayMethod`` does
-not register a reduction loop, calling ``.reduce()`` on it raises a
-:exc:`TypeError`, e.g. ``numpy.divmod.reduce`` fails since ``divmod``
-has no reduction loop.
+The three cases look like this::
+
+    >>> import numpy as np
+    >>> np.add.reduce([1.0, 2.0, 3.0])  # 2 inputs, 1 output
+    np.float64(6.0)
+    >>> np.modf.reduce([1.0, 2.0, 3.0])  # 1 input, 2 outputs
+    Traceback (most recent call last):
+        ...
+    ValueError: reduce only supported for binary functions
+    >>> np.divmod.reduce([1.0, 2.0, 3.0])  # 2 inputs, 2 outputs
+    Traceback (most recent call last):
+        ...
+    TypeError: divmod.reduce is not supported: the resolved loop does not register a reduction loop
+
+The first two behaviours are unchanged by this feature. :func:`numpy.modf`
+takes a single input, so it can never be reduced. Only the third case is
+new: :func:`numpy.divmod` has the right number of inputs, and fails purely
+because no reduction loop is registered for it. The rest of this tutorial
+shows how to write and register such a loop.
 
 Example: a two-output ``minimummaximum`` ufunc
 ===============================================
 
 The example below defines a ``minimummaximum`` ufunc for the ``'f8'``
-(``double``) dtype only, computing the running minimum and maximum in a
-single reduction pass: ``minimummaximum.reduce(a)`` returns the pair
-``(a.min(), a.max())``, computed in one loop over ``a`` rather than in two.
+(``double``) dtype only. It computes the running minimum and maximum in a
+single pass, so ``minimummaximum.reduce(a)`` returns the pair
+``(a.min(), a.max())`` using one loop over ``a`` rather than two.
 
-Because ``NPY_METH_get_reduction_loop`` is an ``ArrayMethod`` slot, the
-ufunc's loop must be registered through the new-style ``PyArrayMethod_Spec``
-API (:c:func:`PyUFunc_AddLoopFromSpec`) rather than the legacy
+``NPY_METH_get_reduction_loop`` is an ``ArrayMethod`` slot. The ufunc's loop
+must therefore be registered through the ``PyArrayMethod_Spec``
+API (:c:func:`PyUFunc_AddLoopFromSpec`), not the legacy
 ``PyUFunc_FromFuncAndData`` loop table used in the previous tutorial. The
 ufunc itself is still created with :c:func:`PyUFunc_FromFuncAndData`, just
 without any loops attached yet. The loop is added separately, via its
@@ -119,8 +136,9 @@ with ``/* BEGIN main computation */`` and ``/* END main computation */``.
         }
 
         /*
-         * The reduce machinery aliases out_i to acc_i (with stride 0), so
-         * this both reads the running accumulators and writes the new ones.
+         * The reduce machinery points each out_i at the same memory as the
+         * matching acc_i (with stride 0), so this both reads the running
+         * accumulators and writes the new ones.
          */
         static int
         double_minimummaximum_reduce_loop(PyArrayMethod_Context *NPY_UNUSED(context),
@@ -343,9 +361,9 @@ dependency on NumPy to build:
 
          setup(name='minmax', version='1.0', ext_modules=[minmax])
 
-After the above has been installed, it can be imported and used as
-follows. Note that plain Python floats and ints work directly, thanks to
-the promoter, no explicit ``np.float64(...)`` wrapping is needed::
+After the above has been installed, it can be imported and used as follows.
+Plain Python floats and ints work directly, thanks to the promoter. No
+explicit ``np.float64(...)`` wrapping is needed::
 
     >>> import numpy as np
     >>> import minmax
@@ -363,10 +381,10 @@ the promoter, no explicit ``np.float64(...)`` wrapping is needed::
     (array([1., 2.]), array([4., 9.]))
 
 Note that ``minimummaximum.reduce`` returns a tuple with one array per
-output (``lo, hi = minimummaximum.reduce(a)``), rather than a single array.
-If ``initial`` is passed to ``reduce`` on a multi-output ufunc, it can
-either be a single scalar (broadcast to seed every output) or a tuple with
-one value per output.
+output, rather than a single array, so it is usually unpacked as
+``lo, hi = minimummaximum.reduce(a)``. The ``initial`` argument of a
+multi-output ``reduce`` accepts either a single scalar, which seeds every
+output, or a tuple with one value per output.
 
 Limitations
 ===========
@@ -375,19 +393,19 @@ This example is intentionally minimal and leaves out several things a
 real-world implementation, like the built-in :func:`numpy.add` or a fuller
 ``minimummaximum``, would normally have:
 
-- The promoter always resolves to ``'f8'`` regardless of the input dtypes,
-  so e.g. integer input arrays are silently cast to ``float64`` rather than
-  keeping their own dtype. A multi-dtype ufunc would instead register a
-  loop per dtype and pick the common one, as in the built-in
-  :func:`numpy.minimum`/:func:`numpy.maximum`.
-- It registers no reduction identity, so ``minimummaximum.reduce`` of an
-  empty array raises a :exc:`ValueError`, the same as ``numpy.maximum.reduce``.
-  A multi-output ufunc can provide per-output identities with the
+- The promoter always resolves to ``'f8'``, regardless of the input dtypes.
+  Integer input arrays are therefore silently cast to ``float64`` instead of
+  keeping their own dtype. A multi-dtype ufunc would register a loop per
+  dtype and pick the common one, as the built-in
+  :func:`numpy.minimum`/:func:`numpy.maximum` do.
+- It registers no reduction identity. Reducing an empty array therefore
+  raises a :exc:`ValueError`, the same as ``numpy.maximum.reduce``. A
+  multi-output ufunc can provide per-output identities with the
   :c:macro:`NPY_METH_get_multi_reduction_initials` slot, the multi-output
-  version of :c:macro:`NPY_METH_get_reduction_initial`. Its function fills one
-  initial value per output, for example ``+inf`` for the running minimum and
-  ``-inf`` for the running maximum. Reducing an empty array, or reducing with
-  a ``where=`` mask, then returns those identities instead of raising::
+  version of :c:macro:`NPY_METH_get_reduction_initial`. Its function fills
+  one initial value per output, for example ``+inf`` for the running minimum
+  and ``-inf`` for the running maximum. Reducing an empty array, or reducing
+  with a ``where=`` mask, then returns those identities instead of raising::
 
       static int
       minimummaximum_get_multi_reduction_initials(
@@ -399,7 +417,8 @@ real-world implementation, like the built-in :func:`numpy.add` or a fuller
           return 1;
       }
 
-  registered alongside the reduction loop as
+  It is registered alongside the reduction loop, by adding this entry to the
+  ``slots`` array above:
   ``{NPY_METH_get_multi_reduction_initials, (void *)&minimummaximum_get_multi_reduction_initials}``.
 - :meth:`~numpy.ufunc.accumulate`, :meth:`~numpy.ufunc.reduceat`, and
   :meth:`~numpy.ufunc.at` are not supported for multi-output ufuncs yet,

--- a/doc/source/user/c-info.rst
+++ b/doc/source/user/c-info.rst
@@ -7,4 +7,5 @@ Using NumPy C-API
    c-info.how-to-extend
    c-info.python-as-glue
    c-info.ufunc-tutorial
+   c-info.reduction-loop-tutorial
    c-info.beyond-basics

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5446,7 +5446,7 @@ add_newdoc('numpy._core', 'ufunc', ('reduce',
     ``reduce`` normally only supports ufuncs with a single output. A ufunc
     with more than one output can still be reduced if its loop implementation
     registers a dedicated reduction loop. Otherwise, calling ``reduce`` on it
-    raises a ``ValueError``.
+    raises a ``TypeError``.
 
     Examples
     --------

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5406,8 +5406,10 @@ add_newdoc('numpy._core', 'ufunc', ('reduce',
         If not provided or None, a freshly-allocated array is returned.
         If passed as a keyword argument, can be Ellipses (``out=...``) to
         ensure an array is returned even if the result is 0-dimensional
-        (which is useful especially for object dtype), or a 1-element tuple
-        (latter for consistency with ``ufunc.__call__``).
+        (which is useful especially for object dtype), or a tuple with one
+        entry per output (latter for consistency with ``ufunc.__call__``).
+        For a ufunc with a single output, a 1-element tuple is also
+        accepted, as before.
 
         .. versionadded:: 2.3
             Support for ``out=...`` was added.
@@ -5416,12 +5418,15 @@ add_newdoc('numpy._core', 'ufunc', ('reduce',
         If this is set to True, the axes which are reduced are left
         in the result as dimensions with size one. With this option,
         the result will broadcast correctly against the original ``array``.
-    initial : scalar, optional
+    initial : scalar or tuple of scalars, optional
         The value with which to start the reduction.
         If the ufunc has no identity or the dtype is object, this defaults
         to None - otherwise it defaults to ufunc.identity.
         If ``None`` is given, the first element of the reduction is used,
         and an error is thrown if the reduction is empty.
+        For a ufunc with more than one output (see the note on multiple
+        outputs below), a tuple with one value per output may be given
+        instead of a single scalar. A scalar still seeds every output.
     where : array_like of bool, optional
         A boolean array which is broadcasted to match the dimensions
         of ``array``, and selects elements to include in the reduction. Note
@@ -5430,8 +5435,18 @@ add_newdoc('numpy._core', 'ufunc', ('reduce',
 
     Returns
     -------
-    r : ndarray
+    r : ndarray or tuple of ndarray
         The reduced array. If `out` was supplied, `r` is a reference to it.
+        For a ufunc with more than one output whose loop implementation
+        registers a reduction loop (see the note below), `r` is instead a
+        tuple with one array per output.
+
+    Notes
+    -----
+    ``reduce`` normally only supports ufuncs with a single output. A ufunc
+    with more than one output can still be reduced if its loop implementation
+    registers a dedicated reduction loop. Otherwise, calling ``reduce`` on it
+    raises a ``ValueError``.
 
     Examples
     --------

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5427,6 +5427,9 @@ add_newdoc('numpy._core', 'ufunc', ('reduce',
         For a ufunc with more than one output (see the note on multiple
         outputs below), a tuple with one value per output may be given
         instead of a single scalar. A scalar still seeds every output.
+        The entries of such a tuple cannot be ``None``, since "no initial
+        value" cannot be requested for individual outputs; pass a plain
+        ``None`` to unset the initial value for the whole reduction.
     where : array_like of bool, optional
         A boolean array which is broadcasted to match the dimensions
         of ``array``, and selects elements to include in the reduction. Note

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -171,6 +171,7 @@ typedef struct {
 #define NPY_METH_unaligned_contiguous_loop 8
 #define NPY_METH_contiguous_indexed_loop 9
 #define _NPY_METH_static_data 10
+#define NPY_METH_get_reduction_loop 11
 
 /*
  * The resolve descriptors function, must be able to handle NULL values for

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -177,6 +177,12 @@ typedef struct {
  * output whose forward loop cannot double as a reduction loop.
  */
 #define NPY_METH_get_reduction_loop 11
+/*
+ * A `PyArrayMethod_GetMultiReductionInitials` that fills the per-output
+ * reduction identity/initial values.  It is the multi-output generalization of
+ * NPY_METH_get_reduction_initial (and also handles the single-output case).
+ * A method may register at most one of the two initial-value slots.
+ */
 #define NPY_METH_get_multi_reduction_initials 12
 
 /*
@@ -264,6 +270,24 @@ typedef int (PyArrayMethod_GetReductionInitial)(
         void *initial);
 
 
+/**
+ * Multi-output counterpart of `PyArrayMethod_GetReductionInitial`: query an
+ * ArrayMethod for the per-output initial values used in a reduction.  This is
+ * the identity slot for multi-output reductions (registered via
+ * NPY_METH_get_multi_reduction_initials), but it also supports single-output
+ * reductions.  It behaves exactly like `PyArrayMethod_GetReductionInitial`,
+ * except that `initials` is an array of `nout` pointers, one per reduction
+ * output, each pointing to the buffer to fill.
+ *
+ * @param context The arraymethod context, mainly to access the descriptors.
+ * @param reduction_is_empty Whether the reduction is empty, see
+ *     `PyArrayMethod_GetReductionInitial` for the (per-output) semantics.
+ * @param initials Array of `nout` pointers to the initial buffers to fill.
+ *
+ * @returns -1, 0, or 1 indicating error, no initial value, and the initials
+ *     being successfully filled.  A return of 1 must fill every output.  As
+ *     with the single-output slot, errors must not be given where 0 is correct.
+ */
 typedef int (PyArrayMethod_GetMultiReductionInitials)(
         PyArrayMethod_Context *context, npy_bool reduction_is_empty,
         void **initials);

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -171,6 +171,11 @@ typedef struct {
 #define NPY_METH_unaligned_contiguous_loop 8
 #define NPY_METH_contiguous_indexed_loop 9
 #define _NPY_METH_static_data 10
+/*
+ * A `PyArrayMethod_GetLoop` that returns the dedicated (nout+1)->nout
+ * reduction loop for `ufunc.reduce`, needed for ufuncs with more than one
+ * output whose forward loop cannot double as a reduction loop.
+ */
 #define NPY_METH_get_reduction_loop 11
 
 /*

--- a/numpy/_core/include/numpy/dtype_api.h
+++ b/numpy/_core/include/numpy/dtype_api.h
@@ -177,6 +177,7 @@ typedef struct {
  * output whose forward loop cannot double as a reduction loop.
  */
 #define NPY_METH_get_reduction_loop 11
+#define NPY_METH_get_multi_reduction_initials 12
 
 /*
  * The resolve descriptors function, must be able to handle NULL values for
@@ -261,6 +262,11 @@ typedef int (PyArrayMethod_GetLoop)(
 typedef int (PyArrayMethod_GetReductionInitial)(
         PyArrayMethod_Context *context, npy_bool reduction_is_empty,
         void *initial);
+
+
+typedef int (PyArrayMethod_GetMultiReductionInitials)(
+        PyArrayMethod_Context *context, npy_bool reduction_is_empty,
+        void **initials);
 
 /*
  * The following functions are only used by the wrapping array method defined

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -885,6 +885,7 @@ test_modules_src = [
   ['_rational_tests', 'src/umath/_rational_tests.c', []],
   ['_struct_ufunc_tests', 'src/umath/_struct_ufunc_tests.c', []],
   ['_operand_flag_tests', 'src/umath/_operand_flag_tests.c', []],
+  ['_reduction_loop_tests', 'src/umath/_reduction_loop_tests.c', []],
 ]
 foreach gen: test_modules_src
   py.extension_module(gen[0],

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -252,6 +252,7 @@ fill_arraymethod_from_slots(
     /* Set the defaults */
     meth->get_strided_loop = &npy_default_get_strided_loop;
     meth->resolve_descriptors = &default_resolve_descriptors;
+    meth->get_reduction_loop = NULL;
     meth->get_reduction_initial = NULL;  /* no initial/identity by default */
 
     /* Fill in the slots passed by the user */
@@ -300,6 +301,9 @@ fill_arraymethod_from_slots(
                 continue;
             case NPY_METH_get_reduction_initial:
                 meth->get_reduction_initial = slot->pfunc;
+                continue;
+            case NPY_METH_get_reduction_loop:
+                meth->get_reduction_loop = slot->pfunc;
                 continue;
             case NPY_METH_contiguous_indexed_loop:
                 meth->contiguous_indexed_loop = slot->pfunc;
@@ -950,6 +954,48 @@ PyArrayMethod_GetMaskedStridedLoop(
     data->nargs = nargs;
 
     if (context->method->get_strided_loop(context,
+            aligned, 0, fixed_strides,
+            &data->unmasked_stridedloop, &data->unmasked_auxdata, flags) < 0) {
+        PyMem_Free(data);
+        return -1;
+    }
+    *out_transferdata = (NpyAuxData *)data;
+    *out_loop = generic_masked_strided_loop;
+    return 0;
+}
+
+
+/*
+ * Reduction counterpart of `PyArrayMethod_GetMaskedStridedLoop`, used for the
+ * `where=` keyword of reductions.  It wraps the (N+1)->N reduction loop
+ * (arity `2 * nout + 1`) rather than the forward elementwise loop, but reuses
+ * `generic_masked_strided_loop` and its auxdata since the masked iteration
+ * itself is identical.
+ */
+NPY_NO_EXPORT int
+PyArrayMethod_GetMaskedReductionLoop(
+        PyArrayMethod_Context *context,
+        int aligned, npy_intp *fixed_strides,
+        PyArrayMethod_StridedLoop **out_loop,
+        NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags)
+{
+    _masked_stridedloop_data *data;
+    int nargs = 2 * context->method->nout + 1;
+
+    /* Add working memory for the data pointers, to modify them in-place */
+    data = PyMem_Malloc(sizeof(_masked_stridedloop_data) +
+                        sizeof(char *) * nargs);
+    if (data == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    data->base.free = _masked_stridedloop_data_free;
+    data->base.clone = NULL;  /* not currently used */
+    data->unmasked_stridedloop = NULL;
+    data->nargs = nargs;
+
+    if (reduction_get_loop_func(context->method)(context,
             aligned, 0, fixed_strides,
             &data->unmasked_stridedloop, &data->unmasked_auxdata, flags) < 0) {
         PyMem_Free(data);

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -335,6 +335,35 @@ fill_arraymethod_from_slots(
         }
     }
 
+    if (meth->get_reduction_initial != NULL &&
+            meth->get_multi_reduction_initials != NULL) {
+        PyErr_Format(PyExc_ValueError,
+                "ArrayMethod cannot register both get_reduction_initial and "
+                "get_multi_reduction_initials; use get_multi_reduction_initials "
+                "alone (it supports single-output reductions too). "
+                "(method: %s)",
+                spec->name);
+        return -1;
+    }
+    if (meth->nout > 1 && meth->get_reduction_initial != NULL) {
+        PyErr_Format(PyExc_ValueError,
+                "get_reduction_initial does not support multi-output "
+                "reductions; use get_multi_reduction_initials instead. "
+                "(method: %s)",
+                spec->name);
+        return -1;
+    }
+    if (meth->nout > 1 && meth->get_multi_reduction_initials != NULL &&
+            meth->get_reduction_loop == NULL) {
+        PyErr_Format(PyExc_ValueError,
+                "get_multi_reduction_initials was registered without a "
+                "get_reduction_loop; reduce() is unreachable for a "
+                "multi-output ArrayMethod without a reduction loop, so this "
+                "identity would never be used. (method: %s)",
+                spec->name);
+        return -1;
+    }
+
     /* Check whether the slots are valid: */
     if (meth->resolve_descriptors == &default_resolve_descriptors) {
         if (spec->casting == -1) {

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -254,6 +254,7 @@ fill_arraymethod_from_slots(
     meth->resolve_descriptors = &default_resolve_descriptors;
     meth->get_reduction_loop = NULL;
     meth->get_reduction_initial = NULL;  /* no initial/identity by default */
+    meth->get_multi_reduction_initials = NULL;  /* no initial/identity by default */
 
     /* Fill in the slots passed by the user */
     /*
@@ -304,6 +305,9 @@ fill_arraymethod_from_slots(
                 continue;
             case NPY_METH_get_reduction_loop:
                 meth->get_reduction_loop = slot->pfunc;
+                continue;
+            case NPY_METH_get_multi_reduction_initials:
+                meth->get_multi_reduction_initials = slot->pfunc;
                 continue;
             case NPY_METH_contiguous_indexed_loop:
                 meth->contiguous_indexed_loop = slot->pfunc;

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -339,7 +339,7 @@ fill_arraymethod_from_slots(
             meth->get_multi_reduction_initials != NULL) {
         PyErr_Format(PyExc_ValueError,
                 "ArrayMethod cannot register both get_reduction_initial and "
-                "get_multi_reduction_initials; use get_multi_reduction_initials "
+                "get_multi_reduction_initials. Use get_multi_reduction_initials "
                 "alone (it supports single-output reductions too). "
                 "(method: %s)",
                 spec->name);
@@ -348,7 +348,7 @@ fill_arraymethod_from_slots(
     if (meth->nout > 1 && meth->get_reduction_initial != NULL) {
         PyErr_Format(PyExc_ValueError,
                 "get_reduction_initial does not support multi-output "
-                "reductions; use get_multi_reduction_initials instead. "
+                "reductions. Use get_multi_reduction_initials instead. "
                 "(method: %s)",
                 spec->name);
         return -1;
@@ -357,9 +357,9 @@ fill_arraymethod_from_slots(
             meth->get_reduction_loop == NULL) {
         PyErr_Format(PyExc_ValueError,
                 "get_multi_reduction_initials was registered without a "
-                "get_reduction_loop; reduce() is unreachable for a "
-                "multi-output ArrayMethod without a reduction loop, so this "
-                "identity would never be used. (method: %s)",
+                "get_reduction_loop. Without a reduction loop, reduce() is "
+                "unreachable for a multi-output ArrayMethod, so this identity "
+                "would never be used. (method: %s)",
                 spec->name);
         return -1;
     }

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -1039,8 +1039,14 @@ PyArrayMethod_GetMaskedReductionLoop(
     data->unmasked_stridedloop = NULL;
     data->nargs = nargs;
 
+    /* Copy so the strides passed on are always fully initialized (+1 for the mask) */
+    npy_intp reduction_strides[NPY_MAXARGS];
+    for (int i = 0; i < nargs + 1; i++) {
+        reduction_strides[i] = fixed_strides[i];
+    }
+
     if (reduction_get_loop_func(context->method)(context,
-            aligned, 0, fixed_strides,
+            aligned, 0, reduction_strides,
             &data->unmasked_stridedloop, &data->unmasked_auxdata, flags) < 0) {
         PyMem_Free(data);
         return -1;

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -320,6 +320,17 @@ fill_arraymethod_from_slots(
         return -1;
     }
 
+    if (meth->get_reduction_loop != NULL) {
+        int max_reduce_outputs = (NPY_MAXARGS - 2) / 2;
+        if (meth->nout > max_reduce_outputs) {
+            PyErr_Format(PyExc_ValueError,
+                    "ArrayMethod reduction loops are limited to at most %d "
+                    "outputs. (method: %s)",
+                    max_reduce_outputs, spec->name);
+            return -1;
+        }
+    }
+
     /* Check whether the slots are valid: */
     if (meth->resolve_descriptors == &default_resolve_descriptors) {
         if (spec->casting == -1) {

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -345,7 +345,8 @@ fill_arraymethod_from_slots(
                 spec->name);
         return -1;
     }
-    if (meth->nout > 1 && meth->get_reduction_initial != NULL) {
+    if (meth->nout > 1 && meth->get_reduction_initial != NULL
+            && meth->get_reduction_loop != NULL) {
         PyErr_Format(PyExc_ValueError,
                 "get_reduction_initial does not support multi-output "
                 "reductions. Use get_multi_reduction_initials instead. "

--- a/numpy/_core/src/multiarray/array_method.h
+++ b/numpy/_core/src/multiarray/array_method.h
@@ -81,6 +81,12 @@ typedef struct PyArrayMethodObject_tag {
      * reduction's loop which requires an (nout+1)->nout signature.
      */
     PyArrayMethod_GetLoop *get_reduction_loop;
+    /*
+     * Optional per-output reduction identity/initial values
+     * (NPY_METH_get_multi_reduction_initials), the multi-output generalization
+     * of `get_reduction_initial`.  At most one of the two may be set. This one
+     * also handles the single-output case.  See `reduction_get_initial`.
+     */
     PyArrayMethod_GetMultiReductionInitials *get_multi_reduction_initials;
 } PyArrayMethodObject;
 
@@ -96,7 +102,7 @@ reduction_get_loop_func(PyArrayMethodObject *meth)
 
 
 /* Returns the reduction identity/initial value(s) from whichever slot
- * `context->method` registered; registration guarantees at most one is set. */
+ * `context->method` registered. Registration guarantees at most one is set. */
 static inline int
 reduction_get_initial(PyArrayMethod_Context *context,
         npy_bool reduction_is_empty, void **initials)

--- a/numpy/_core/src/multiarray/array_method.h
+++ b/numpy/_core/src/multiarray/array_method.h
@@ -81,6 +81,7 @@ typedef struct PyArrayMethodObject_tag {
      * reduction's loop which requires an (nout+1)->nout signature.
      */
     PyArrayMethod_GetLoop *get_reduction_loop;
+    PyArrayMethod_GetMultiReductionInitials *get_multi_reduction_initials;
 } PyArrayMethodObject;
 
 

--- a/numpy/_core/src/multiarray/array_method.h
+++ b/numpy/_core/src/multiarray/array_method.h
@@ -113,6 +113,7 @@ reduction_get_initial(PyArrayMethod_Context *context,
                 context, reduction_is_empty, initials);
     }
     if (meth->get_reduction_initial != NULL) {
+        assert(meth->nout == 1);
         return meth->get_reduction_initial(
                 context, reduction_is_empty, initials[0]);
     }

--- a/numpy/_core/src/multiarray/array_method.h
+++ b/numpy/_core/src/multiarray/array_method.h
@@ -74,7 +74,15 @@ typedef struct PyArrayMethodObject_tag {
      */
     void *cached_loop;  /* really a PyUFuncGenericFunction */
     void *cached_loop_data;
+    PyArrayMethod_GetLoop *get_reduction_loop;
 } PyArrayMethodObject;
+
+
+static inline PyArrayMethod_GetLoop *
+reduction_get_loop_func(PyArrayMethodObject *meth)
+{
+    return meth->get_reduction_loop != NULL ? meth->get_reduction_loop : meth->get_strided_loop;
+}
 
 
 /*
@@ -118,6 +126,15 @@ PyArrayMethod_GetMaskedStridedLoop(
         NpyAuxData **out_transferdata,
         NPY_ARRAYMETHOD_FLAGS *flags);
 
+
+NPY_NO_EXPORT int
+PyArrayMethod_GetMaskedReductionLoop(
+        PyArrayMethod_Context *context,
+        int aligned,
+        npy_intp *fixed_strides,
+        PyArrayMethod_StridedLoop **out_loop,
+        NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags);
 
 
 NPY_NO_EXPORT PyObject *

--- a/numpy/_core/src/multiarray/array_method.h
+++ b/numpy/_core/src/multiarray/array_method.h
@@ -74,10 +74,19 @@ typedef struct PyArrayMethodObject_tag {
      */
     void *cached_loop;  /* really a PyUFuncGenericFunction */
     void *cached_loop_data;
+    /*
+     * Optional dedicated reduction loop (NPY_METH_get_reduction_loop), used
+     * by `ufunc.reduce` instead of `get_strided_loop` when set.  Required
+     * for `nout > 1` since the forward loop's arity cannot be used as the
+     * reduction's loop which requires an (nout+1)->nout signature.
+     */
     PyArrayMethod_GetLoop *get_reduction_loop;
 } PyArrayMethodObject;
 
 
+/* Returns the loop `ufunc.reduce` should use: the dedicated reduction loop
+ * if the method registered one, otherwise the forward `get_strided_loop`
+ * (only valid when nout == 1). */
 static inline PyArrayMethod_GetLoop *
 reduction_get_loop_func(PyArrayMethodObject *meth)
 {

--- a/numpy/_core/src/multiarray/array_method.h
+++ b/numpy/_core/src/multiarray/array_method.h
@@ -95,6 +95,25 @@ reduction_get_loop_func(PyArrayMethodObject *meth)
 }
 
 
+/* Returns the reduction identity/initial value(s) from whichever slot
+ * `context->method` registered; registration guarantees at most one is set. */
+static inline int
+reduction_get_initial(PyArrayMethod_Context *context,
+        npy_bool reduction_is_empty, void **initials)
+{
+    PyArrayMethodObject *meth = context->method;
+    if (meth->get_multi_reduction_initials != NULL) {
+        return meth->get_multi_reduction_initials(
+                context, reduction_is_empty, initials);
+    }
+    if (meth->get_reduction_initial != NULL) {
+        return meth->get_reduction_initial(
+                context, reduction_is_empty, initials[0]);
+    }
+    return 0;
+}
+
+
 /*
  * We will sometimes have to create an ArrayMethod and allow passing it around,
  * similar to `instance.method` returning a bound method, e.g. a function like

--- a/numpy/_core/src/umath/_reduction_loop_tests.c
+++ b/numpy/_core/src/umath/_reduction_loop_tests.c
@@ -2,9 +2,11 @@
 
 /*
  * _reduction_loop_tests.c
- * A minimal float64-only `minimummaximum` ufunc exercising the
- * NPY_METH_get_reduction_loop ArrayMethod slot: a 2-in/2-out forward loop
- * plus a 3-in/2-out reduction loop, so `minimummaximum.reduce(a)` works.
+ * Two minimal float64-only `minimummaximum` ufuncs exercising the
+ * NPY_METH_get_reduction_loop ArrayMethod slot: a 2-in/2-out forward
+ * loop plus a 3-in/2-out reduction loop, so `.reduce(a)` returns
+ * (min, max). `minimummaximum_with_identity` additionally registers
+ * NPY_METH_get_multi_reduction_initials (+inf/-inf).
  */
 
 #define PY_SSIZE_T_CLEAN
@@ -97,6 +99,17 @@ minimummaximum_get_reduction_loop(PyArrayMethod_Context *NPY_UNUSED(context),
 
 
 static int
+minimummaximum_get_multi_reduction_initials(
+        PyArrayMethod_Context *NPY_UNUSED(context),
+        npy_bool NPY_UNUSED(reduction_is_empty), void **initials)
+{
+    *(double *)initials[0] = NPY_INFINITY;
+    *(double *)initials[1] = -NPY_INFINITY;
+    return 1;
+}
+
+
+static int
 minimummaximum_promoter(PyObject *NPY_UNUSED(ufunc),
         PyArray_DTypeMeta *const NPY_UNUSED(op_dtypes[]),
         PyArray_DTypeMeta *const signature[],
@@ -139,11 +152,10 @@ register_minimummaximum_promoter(PyObject *minimummaximum)
 
 
 static int
-add_minimummaximum(PyObject *module)
+add_minimummaximum(PyObject *module, const char *name, int with_identity)
 {
     PyObject *minimummaximum = PyUFunc_FromFuncAndData(
-            NULL, NULL, NULL, 0, 2, 2, PyUFunc_None,
-            "minimummaximum", "minimummaximum_docstring", 0);
+            NULL, NULL, NULL, 0, 2, 2, PyUFunc_None, name, NULL, 0);
     if (minimummaximum == NULL) {
         return -1;
     }
@@ -159,11 +171,13 @@ add_minimummaximum(PyObject *module)
     PyType_Slot slots[] = {
         {NPY_METH_strided_loop, (void *)&double_minimummaximum_loop},
         {NPY_METH_get_reduction_loop, (void *)&minimummaximum_get_reduction_loop},
+        {NPY_METH_get_multi_reduction_initials, with_identity ?
+         (void *)&minimummaximum_get_multi_reduction_initials : NULL},
         {0, NULL},
     };
 
     PyArrayMethod_Spec spec = {
-        .name = "double_minimummaximum",
+        .name = name,
         .nin = 2,
         .nout = 2,
         .casting = NPY_NO_CASTING,
@@ -175,7 +189,7 @@ add_minimummaximum(PyObject *module)
     int res = PyUFunc_AddLoopFromSpec(minimummaximum, &spec);
     Py_DECREF(double_descr);
     if (res < 0 || register_minimummaximum_promoter(minimummaximum) < 0
-            || PyModule_AddObject(module, "minimummaximum", minimummaximum) < 0) {
+            || PyModule_AddObject(module, name, minimummaximum) < 0) {
         Py_XDECREF(minimummaximum);
         return -1;
     }
@@ -215,7 +229,11 @@ PyMODINIT_FUNC PyInit__reduction_loop_tests(void)
         return NULL;
     }
 
-    if (add_minimummaximum(m) < 0) {
+    if (add_minimummaximum(m, "minimummaximum", 0) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+    if (add_minimummaximum(m, "minimummaximum_with_identity", 1) < 0) {
         Py_DECREF(m);
         return NULL;
     }

--- a/numpy/_core/src/umath/_reduction_loop_tests.c
+++ b/numpy/_core/src/umath/_reduction_loop_tests.c
@@ -168,13 +168,16 @@ add_minimummaximum(PyObject *module, const char *name, int with_identity)
     PyArray_DTypeMeta *dt = NPY_DTYPE(double_descr);
     PyArray_DTypeMeta *dtypes[4] = {dt, dt, dt, dt};
 
-    PyType_Slot slots[] = {
+    PyType_Slot slots[4] = {
         {NPY_METH_strided_loop, (void *)&double_minimummaximum_loop},
         {NPY_METH_get_reduction_loop, (void *)&minimummaximum_get_reduction_loop},
-        {NPY_METH_get_multi_reduction_initials, with_identity ?
-         (void *)&minimummaximum_get_multi_reduction_initials : NULL},
+        {0, NULL},
         {0, NULL},
     };
+    if (with_identity) {
+        slots[2].slot = NPY_METH_get_multi_reduction_initials;
+        slots[2].pfunc = (void *)&minimummaximum_get_multi_reduction_initials;
+    }
 
     PyArrayMethod_Spec spec = {
         .name = name,

--- a/numpy/_core/src/umath/_reduction_loop_tests.c
+++ b/numpy/_core/src/umath/_reduction_loop_tests.c
@@ -109,6 +109,108 @@ minimummaximum_get_multi_reduction_initials(
 }
 
 
+static inline PyObject *
+object_min(PyObject *a, PyObject *b)
+{
+    int cmp = PyObject_RichCompareBool(a, b, Py_LE);
+    if (cmp < 0) {
+        return NULL;
+    }
+    PyObject *r = cmp ? a : b;
+    Py_INCREF(r);
+    return r;
+}
+
+static inline PyObject *
+object_max(PyObject *a, PyObject *b)
+{
+    int cmp = PyObject_RichCompareBool(a, b, Py_GE);
+    if (cmp < 0) {
+        return NULL;
+    }
+    PyObject *r = cmp ? a : b;
+    Py_INCREF(r);
+    return r;
+}
+
+
+static int
+object_minimummaximum_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+        char *const data[], npy_intp const dimensions[],
+        npy_intp const strides[], NpyAuxData *NPY_UNUSED(auxdata))
+{
+    npy_intp n = dimensions[0];
+    char *in1 = data[0], *in2 = data[1];
+    char *out1 = data[2], *out2 = data[3];
+
+    for (npy_intp i = 0; i < n; i++) {
+        PyObject *a = *(PyObject **)in1, *b = *(PyObject **)in2;
+        if (a == NULL) a = Py_None;
+        if (b == NULL) b = Py_None;
+        PyObject *lo = object_min(a, b);
+        PyObject *hi = lo != NULL ? object_max(a, b) : NULL;
+        if (lo == NULL || hi == NULL) {
+            Py_XDECREF(lo);
+            Py_XDECREF(hi);
+            return -1;
+        }
+        Py_XSETREF(*(PyObject **)out1, lo);
+        Py_XSETREF(*(PyObject **)out2, hi);
+        in1 += strides[0]; in2 += strides[1];
+        out1 += strides[2]; out2 += strides[3];
+    }
+    return 0;
+}
+
+
+static int
+object_minimummaximum_reduce_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+        char *const data[], npy_intp const dimensions[],
+        npy_intp const strides[], NpyAuxData *NPY_UNUSED(auxdata))
+{
+    npy_intp n = dimensions[0];
+    char *acc_min = data[0], *acc_max = data[1], *x = data[2];
+    char *out_min = data[3], *out_max = data[4];
+
+    for (npy_intp i = 0; i < n; i++) {
+        PyObject *cur_min = *(PyObject **)acc_min;
+        PyObject *cur_max = *(PyObject **)acc_max;
+        PyObject *val = *(PyObject **)x;
+        if (cur_min == NULL) cur_min = Py_None;
+        if (cur_max == NULL) cur_max = Py_None;
+        if (val == NULL) val = Py_None;
+        PyObject *lo = object_min(cur_min, val);
+        PyObject *hi = lo != NULL ? object_max(cur_max, val) : NULL;
+        if (lo == NULL || hi == NULL) {
+            Py_XDECREF(lo);
+            Py_XDECREF(hi);
+            return -1;
+        }
+        Py_XSETREF(*(PyObject **)out_min, lo);
+        Py_XSETREF(*(PyObject **)out_max, hi);
+        acc_min += strides[0]; acc_max += strides[1]; x += strides[2];
+        out_min += strides[3]; out_max += strides[4];
+    }
+    return 0;
+}
+
+
+static int
+object_minimummaximum_get_reduction_loop(
+        PyArrayMethod_Context *NPY_UNUSED(context),
+        int NPY_UNUSED(aligned), int NPY_UNUSED(move_references),
+        const npy_intp *NPY_UNUSED(strides),
+        PyArrayMethod_StridedLoop **out_loop,
+        NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags)
+{
+    *out_loop = &object_minimummaximum_reduce_loop;
+    *out_transferdata = NULL;
+    *flags = NPY_METH_REQUIRES_PYAPI;
+    return 0;
+}
+
+
 static int
 minimummaximum_promoter(PyObject *NPY_UNUSED(ufunc),
         PyArray_DTypeMeta *const NPY_UNUSED(op_dtypes[]),
@@ -191,6 +293,39 @@ add_minimummaximum(PyObject *module, const char *name, int with_identity)
 
     int res = PyUFunc_AddLoopFromSpec(minimummaximum, &spec);
     Py_DECREF(double_descr);
+    if (res < 0) {
+        Py_DECREF(minimummaximum);
+        return -1;
+    }
+
+    /* An object loop as well, to exercise refcounted (REFCHK) descriptors */
+    PyArray_Descr *object_descr = PyArray_DescrFromType(NPY_OBJECT);
+    if (object_descr == NULL) {
+        Py_DECREF(minimummaximum);
+        return -1;
+    }
+    PyArray_DTypeMeta *odt = NPY_DTYPE(object_descr);
+    PyArray_DTypeMeta *object_dtypes[4] = {odt, odt, odt, odt};
+
+    PyType_Slot object_slots[] = {
+        {NPY_METH_strided_loop, (void *)&object_minimummaximum_loop},
+        {NPY_METH_get_reduction_loop,
+         (void *)&object_minimummaximum_get_reduction_loop},
+        {0, NULL},
+    };
+
+    PyArrayMethod_Spec object_spec = {
+        .name = "object_minimummaximum",
+        .nin = 2,
+        .nout = 2,
+        .casting = NPY_NO_CASTING,
+        .flags = NPY_METH_IS_REORDERABLE | NPY_METH_REQUIRES_PYAPI,
+        .dtypes = object_dtypes,
+        .slots = object_slots,
+    };
+
+    res = PyUFunc_AddLoopFromSpec(minimummaximum, &object_spec);
+    Py_DECREF(object_descr);
     if (res < 0 || register_minimummaximum_promoter(minimummaximum) < 0
             || PyModule_AddObject(module, name, minimummaximum) < 0) {
         Py_XDECREF(minimummaximum);

--- a/numpy/_core/src/umath/_reduction_loop_tests.c
+++ b/numpy/_core/src/umath/_reduction_loop_tests.c
@@ -1,0 +1,229 @@
+/* -*- c -*- */
+
+/*
+ * _reduction_loop_tests.c
+ * A minimal float64-only `minimummaximum` ufunc exercising the
+ * NPY_METH_get_reduction_loop ArrayMethod slot: a 2-in/2-out forward loop
+ * plus a 3-in/2-out reduction loop, so `minimummaximum.reduce(a)` works.
+ */
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+#if defined(NPY_INTERNAL_BUILD)
+#undef NPY_INTERNAL_BUILD
+#endif
+// for NPY_METH_get_reduction_loop
+#define NPY_TARGET_VERSION NPY_2_6_API_VERSION
+#include "numpy/arrayobject.h"
+#include "numpy/ufuncobject.h"
+#include "numpy/dtype_api.h"
+#include "numpy/npy_math.h"
+
+
+static inline double
+nan_min(double a, double b)
+{
+    return (a <= b || npy_isnan(a)) ? a : b;
+}
+
+static inline double
+nan_max(double a, double b)
+{
+    return (a >= b || npy_isnan(a)) ? a : b;
+}
+
+
+static int
+double_minimummaximum_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+        char *const data[], npy_intp const dimensions[],
+        npy_intp const strides[], NpyAuxData *NPY_UNUSED(auxdata))
+{
+    npy_intp n = dimensions[0];
+    char *in1 = data[0], *in2 = data[1];
+    char *out1 = data[2], *out2 = data[3];
+    npy_intp is1 = strides[0], is2 = strides[1];
+    npy_intp os1 = strides[2], os2 = strides[3];
+
+    for (npy_intp i = 0; i < n; i++) {
+        double a = *(double *)in1;
+        double b = *(double *)in2;
+        *(double *)out1 = nan_min(a, b);
+        *(double *)out2 = nan_max(a, b);
+        in1 += is1; in2 += is2; out1 += os1; out2 += os2;
+    }
+    return 0;
+}
+
+
+static int
+double_minimummaximum_reduce_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+        char *const data[], npy_intp const dimensions[],
+        npy_intp const strides[], NpyAuxData *NPY_UNUSED(auxdata))
+{
+    npy_intp n = dimensions[0];
+    char *acc_min = data[0], *acc_max = data[1], *x = data[2];
+    char *out_min = data[3], *out_max = data[4];
+    npy_intp s_amin = strides[0], s_amax = strides[1], s_x = strides[2];
+    npy_intp s_omin = strides[3], s_omax = strides[4];
+
+    for (npy_intp i = 0; i < n; i++) {
+        double cur_min = *(double *)acc_min;
+        double cur_max = *(double *)acc_max;
+        double val = *(double *)x;
+        *(double *)out_min = nan_min(cur_min, val);
+        *(double *)out_max = nan_max(cur_max, val);
+        acc_min += s_amin; acc_max += s_amax; x += s_x;
+        out_min += s_omin; out_max += s_omax;
+    }
+    return 0;
+}
+
+
+static int
+minimummaximum_get_reduction_loop(PyArrayMethod_Context *NPY_UNUSED(context),
+        int NPY_UNUSED(aligned), int NPY_UNUSED(move_references),
+        const npy_intp *NPY_UNUSED(strides),
+        PyArrayMethod_StridedLoop **out_loop,
+        NpyAuxData **out_transferdata,
+        NPY_ARRAYMETHOD_FLAGS *flags)
+{
+    *out_loop = &double_minimummaximum_reduce_loop;
+    *out_transferdata = NULL;
+    *flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
+    return 0;
+}
+
+
+static int
+minimummaximum_promoter(PyObject *NPY_UNUSED(ufunc),
+        PyArray_DTypeMeta *const NPY_UNUSED(op_dtypes[]),
+        PyArray_DTypeMeta *const signature[],
+        PyArray_DTypeMeta *new_op_dtypes[])
+{
+    PyArray_Descr *double_descr = PyArray_DescrFromType(NPY_DOUBLE);
+    if (double_descr == NULL) {
+        return -1;
+    }
+    PyArray_DTypeMeta *double_dt = NPY_DTYPE(double_descr);
+
+    for (int i = 0; i < 4; i++) {
+        PyArray_DTypeMeta *dt = signature[i] != NULL ? signature[i] : double_dt;
+        Py_INCREF(dt);
+        new_op_dtypes[i] = dt;
+    }
+    Py_DECREF(double_descr);
+    return 0;
+}
+
+
+static int
+register_minimummaximum_promoter(PyObject *minimummaximum)
+{
+    PyObject *none_tuple = PyTuple_Pack(4, Py_None, Py_None, Py_None, Py_None);
+    if (none_tuple == NULL) {
+        return -1;
+    }
+    PyObject *promoter = PyCapsule_New(
+            (void *)&minimummaximum_promoter, "numpy._ufunc_promoter", NULL);
+    if (promoter == NULL) {
+        Py_DECREF(none_tuple);
+        return -1;
+    }
+    int res = PyUFunc_AddPromoter(minimummaximum, none_tuple, promoter);
+    Py_DECREF(none_tuple);
+    Py_DECREF(promoter);
+    return res;
+}
+
+
+static int
+add_minimummaximum(PyObject *module)
+{
+    PyObject *minimummaximum = PyUFunc_FromFuncAndData(
+            NULL, NULL, NULL, 0, 2, 2, PyUFunc_None,
+            "minimummaximum", "minimummaximum_docstring", 0);
+    if (minimummaximum == NULL) {
+        return -1;
+    }
+
+    PyArray_Descr *double_descr = PyArray_DescrFromType(NPY_DOUBLE);
+    if (double_descr == NULL) {
+        Py_DECREF(minimummaximum);
+        return -1;
+    }
+    PyArray_DTypeMeta *dt = NPY_DTYPE(double_descr);
+    PyArray_DTypeMeta *dtypes[4] = {dt, dt, dt, dt};
+
+    PyType_Slot slots[] = {
+        {NPY_METH_strided_loop, (void *)&double_minimummaximum_loop},
+        {NPY_METH_get_reduction_loop, (void *)&minimummaximum_get_reduction_loop},
+        {0, NULL},
+    };
+
+    PyArrayMethod_Spec spec = {
+        .name = "double_minimummaximum",
+        .nin = 2,
+        .nout = 2,
+        .casting = NPY_NO_CASTING,
+        .flags = NPY_METH_IS_REORDERABLE | NPY_METH_NO_FLOATINGPOINT_ERRORS,
+        .dtypes = dtypes,
+        .slots = slots,
+    };
+
+    int res = PyUFunc_AddLoopFromSpec(minimummaximum, &spec);
+    Py_DECREF(double_descr);
+    if (res < 0 || register_minimummaximum_promoter(minimummaximum) < 0
+            || PyModule_AddObject(module, "minimummaximum", minimummaximum) < 0) {
+        Py_XDECREF(minimummaximum);
+        return -1;
+    }
+    return 0;
+}
+
+
+static PyMethodDef ReductionLoopTestsMethods[] = {
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "_reduction_loop_tests",
+    NULL,
+    -1,
+    ReductionLoopTestsMethods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC PyInit__reduction_loop_tests(void)
+{
+    PyObject *m = PyModule_Create(&moduledef);
+    if (m == NULL) {
+        return NULL;
+    }
+
+    if (PyArray_ImportNumPyAPI() < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+    if (PyUFunc_ImportUFuncAPI() < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+
+    if (add_minimummaximum(m) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+
+#ifdef Py_GIL_DISABLED
+    // signal this module supports running with the GIL disabled
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
+    return m;
+}

--- a/numpy/_core/src/umath/loops_minmax.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_minmax.dispatch.c.src
@@ -34,7 +34,7 @@
 
 // special optimization for fp scalars propagates NaNs
 // since there're no C99 support for it
-#ifndef NPY_DISABLE_OPTIMIZATION
+#if 0 // benchmark: disable manual scalar optimization, use naive ternary SCALAR_OP
 /**begin repeat
  * #type = npy_float, npy_double#
  * #sfx = f32, f64#
@@ -321,7 +321,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2],
              len = dimensions[0];
     npy_intp i = 0;
-#ifdef TO_SIMD_SFX
+#if 0 // benchmark: manual SIMD path disabled, naive loop only
     #undef STYPE
     #define STYPE TO_SIMD_SFX(npyv_lanetype)
     if (IS_BINARY_REDUCE) {
@@ -359,7 +359,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     #endif
     }
 #endif // TO_SIMD_SFX
-#ifndef NPY_DISABLE_OPTIMIZATION
+#if 0 // benchmark: scalar unrolls disabled, naive loop only
     // scalar unrolls
     if (IS_BINARY_REDUCE) {
         // Note, 8x unroll was chosen for best results on Apple M1
@@ -436,7 +436,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
         const @type@ in2 = *(@type@ *)ip2;
         *((@type@ *)op1) = SCALAR_OP(in1, in2);
     }
-#ifdef TO_SIMD_SFX
+#if 0 // benchmark: SIMD cleanup removed (no goto targets remain)
 clear_fp:
     npyv_cleanup();
 #endif

--- a/numpy/_core/src/umath/loops_minmax.dispatch.c.src
+++ b/numpy/_core/src/umath/loops_minmax.dispatch.c.src
@@ -34,7 +34,7 @@
 
 // special optimization for fp scalars propagates NaNs
 // since there're no C99 support for it
-#if 0 // benchmark: disable manual scalar optimization, use naive ternary SCALAR_OP
+#ifndef NPY_DISABLE_OPTIMIZATION
 /**begin repeat
  * #type = npy_float, npy_double#
  * #sfx = f32, f64#
@@ -321,7 +321,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2],
              len = dimensions[0];
     npy_intp i = 0;
-#if 0 // benchmark: manual SIMD path disabled, naive loop only
+#ifdef TO_SIMD_SFX
     #undef STYPE
     #define STYPE TO_SIMD_SFX(npyv_lanetype)
     if (IS_BINARY_REDUCE) {
@@ -359,7 +359,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     #endif
     }
 #endif // TO_SIMD_SFX
-#if 0 // benchmark: scalar unrolls disabled, naive loop only
+#ifndef NPY_DISABLE_OPTIMIZATION
     // scalar unrolls
     if (IS_BINARY_REDUCE) {
         // Note, 8x unroll was chosen for best results on Apple M1
@@ -436,7 +436,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
         const @type@ in2 = *(@type@ *)ip2;
         *((@type@ *)op1) = SCALAR_OP(in1, in2);
     }
-#if 0 // benchmark: SIMD cleanup removed (no goto targets remain)
+#ifdef TO_SIMD_SFX
 clear_fp:
     npyv_cleanup();
 #endif

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -174,9 +174,9 @@ PyArray_CopyInitialReduceValues(
  * would be quite nice to support axis= and keepdims etc. for arbitrary
  * generalized ufuncs!)
  */
-NPY_NO_EXPORT PyArrayObject *
+NPY_NO_EXPORT PyObject *
 PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
-        PyArrayObject *operand, PyArrayObject *out, PyArrayObject *wheremask,
+        PyArrayObject *operand, PyArrayObject **out, PyArrayObject *wheremask,
         npy_bool *axis_flags, int keepdims,
         PyObject *initial, PyArray_ReduceLoopFunc *loop,
         npy_intp buffersize, const char *funcname, int errormask)
@@ -184,23 +184,28 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
     assert(loop != NULL);
     PyArrayObject *result = NULL;
     npy_intp skip_first_count = 0;
+    int nout = context->method->nout;
 
     /* Iterator parameters */
     NpyIter *iter = NULL;
-    PyArrayObject *op[3];
-    PyArray_Descr *op_dtypes[3];
-    npy_uint32 it_flags, op_flags[3];
+    PyArrayObject *op[NPY_MAXARGS];
+    PyArray_Descr *op_dtypes[NPY_MAXARGS];
+    npy_uint32 it_flags, op_flags[NPY_MAXARGS];
     /* Loop auxdata (must be freed on error) */
     NpyAuxData *auxdata = NULL;
 
     /* Set up the iterator */
-    op[0] = out;
-    op[1] = operand;
-    op_dtypes[0] = context->descriptors[0];
-    op_dtypes[1] = context->descriptors[1];
+    for (int i = 0; i < nout; i++) {
+        op[i] = out[i];
+        op_dtypes[i] = context->descriptors[i];
+    }
+    op[nout] = operand;
+    op_dtypes[nout] = context->descriptors[nout];
 
-    /* Buffer to use when we need an initial value */
-    char *initial_buf = NULL;
+    /* Per-output buffer to use when we need an initial value */
+    char *initial_buf[NPY_MAXARGS] = {NULL};
+    /* Whether `initial` is a per-output tuple (one entry per output) */
+    npy_bool initial_is_tuple = NPY_FALSE;
 
     /* More than one axis means multiple orders are possible */
     if (!(context->method->flags & NPY_METH_IS_REORDERABLE)
@@ -225,27 +230,34 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
             NPY_ITER_DONT_NEGATE_STRIDES |
             NPY_ITER_COPY_IF_OVERLAP;
 
-    op_flags[0] = NPY_ITER_READWRITE |
-                  NPY_ITER_ALIGNED |
-                  NPY_ITER_ALLOCATE |
-                  NPY_ITER_NO_SUBTYPE;
-    op_flags[1] = NPY_ITER_READONLY |
+    for (int i = 0; i < nout; i++) {
+        op_flags[i] = NPY_ITER_READWRITE |
+                      NPY_ITER_ALIGNED |
+                      NPY_ITER_ALLOCATE |
+                      NPY_ITER_NO_SUBTYPE;
+    }
+    op_flags[nout] = NPY_ITER_READONLY |
                   NPY_ITER_ALIGNED |
                   NPY_ITER_NO_BROADCAST;
 
     if (wheremask != NULL) {
-        op[2] = wheremask;
+        op[nout + 1] = wheremask;
         /* wheremask is guaranteed to be NPY_BOOL, so borrow its reference */
-        op_dtypes[2] = PyArray_DESCR(wheremask);
-        assert(op_dtypes[2]->type_num == NPY_BOOL);
-        if (op_dtypes[2] == NULL) {
+        op_dtypes[nout + 1] = PyArray_DESCR(wheremask);
+        assert(op_dtypes[nout + 1]->type_num == NPY_BOOL);
+        if (op_dtypes[nout + 1] == NULL) {
             goto fail;
         }
-        op_flags[2] = NPY_ITER_READONLY;
+        op_flags[nout + 1] = NPY_ITER_READONLY;
     }
     /* Set up result array axes mapping, operand and wheremask use default */
     int result_axes[NPY_MAXDIMS];
-    int *op_axes[3] = {result_axes, NULL, NULL};
+    int *op_axes[NPY_MAXARGS];
+    for (int i = 0; i < nout; i++) {
+        op_axes[i] = result_axes;
+    }
+    op_axes[nout] = NULL;
+    op_axes[nout + 1] = NULL;
 
     int curr_axis = 0;
     for (int i = 0; i < PyArray_NDIM(operand); i++) {
@@ -263,27 +275,30 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
             curr_axis++;
         }
     }
-    if (out != NULL) {
+    for (int i = 0; i < nout; i++) {
+        if (out[i] == NULL) {
+            continue;
+        }
         /* NpyIter does not raise a good error message in this common case. */
-        if (NPY_UNLIKELY(curr_axis != PyArray_NDIM(out))) {
+        if (NPY_UNLIKELY(curr_axis != PyArray_NDIM(out[i]))) {
             if (keepdims) {
                 PyErr_Format(PyExc_ValueError,
                         "output parameter for reduction operation %s has the "
                         "wrong number of dimensions: Found %d but expected %d "
                         "(must match the operand's when keepdims=True)",
-                        funcname, PyArray_NDIM(out), curr_axis);
+                        funcname, PyArray_NDIM(out[i]), curr_axis);
             }
             else {
                 PyErr_Format(PyExc_ValueError,
                         "output parameter for reduction operation %s has the "
                         "wrong number of dimensions: Found %d but expected %d",
-                        funcname, PyArray_NDIM(out), curr_axis);
+                        funcname, PyArray_NDIM(out[i]), curr_axis);
             }
             goto fail;
         }
     }
 
-    iter = NpyIter_AdvancedNew(wheremask == NULL ? 2 : 3, op, it_flags,
+    iter = NpyIter_AdvancedNew(wheremask == NULL ? nout + 1 : nout + 2, op, it_flags,
                                NPY_KEEPORDER, NPY_UNSAFE_CASTING,
                                op_flags,
                                op_dtypes,
@@ -302,21 +317,42 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
      * in any case.  (`np.sum(np.zeros((0, 3)), axis=0)` is a length 3
      * reduction but has an empty result.)
      */
+    /*
+     * A per-output `initial` may be given as a tuple with one entry per
+     * reduction output; a scalar seeds every output.  Single-output reductions
+     * keep their historical behaviour (the value is packed as-is).
+     */
+    if (initial != NULL && initial != Py_None && nout > 1 && PyTuple_Check(initial)) {
+        initial_is_tuple = NPY_TRUE;
+        if (PyTuple_GET_SIZE(initial) != nout) {
+            PyErr_Format(PyExc_ValueError,
+                    "'initial' must be a scalar or a tuple with one entry "
+                    "per reduction output (%d), got length %zd",
+                    nout, PyTuple_GET_SIZE(initial));
+            goto fail;
+        }
+    }
+
     if ((initial == NULL && context->method->get_reduction_initial == NULL)
             || initial == Py_None) {
         /* There is no initial value, or initial value was explicitly unset */
     }
     else {
         /* Not all functions will need initialization, but init always: */
-        initial_buf = PyMem_Calloc(1, op_dtypes[0]->elsize);
-        if (initial_buf == NULL) {
-            PyErr_NoMemory();
-            goto fail;
+        for (int i = 0; i < nout; i++) {
+            initial_buf[i] = PyMem_Calloc(1, op_dtypes[i]->elsize);
+            if (initial_buf[i] == NULL) {
+                PyErr_NoMemory();
+                goto fail;
+            }
         }
         if (initial != NULL) {
-            /* must use user provided initial value */
-            if (PyArray_Pack(op_dtypes[0], initial_buf, initial) < 0) {
-                goto fail;
+            /* must use user provided initial value(s) */
+            for (int i = 0; i < nout; i++) {
+                PyObject *initial_i = initial_is_tuple ? PyTuple_GET_ITEM(initial, i) : initial;
+                if (PyArray_Pack(op_dtypes[i], initial_buf[i], initial_i) < 0) {
+                    goto fail;
+                }
             }
         }
         else {
@@ -324,16 +360,25 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
              * Fetch initial from ArrayMethod, we pretend the reduction is
              * empty when the iteration is.  This may be wrong, but when it is,
              * we will not need the identity as the result is also empty.
+             * The identity seeds output 0 and is broadcast to the rest (the
+             * reduction outputs share a dtype).
              */
             int has_initial = context->method->get_reduction_initial(
-                    context, empty_iteration, initial_buf);
+                    context, empty_iteration, initial_buf[0]);
             if (has_initial < 0) {
                 goto fail;
             }
             if (!has_initial) {
-                /* We have no initial value available, free buffer to indicate */
-                PyMem_FREE(initial_buf);
-                initial_buf = NULL;
+                /* We have no initial value available, free buffers to indicate */
+                for (int i = 0; i < nout; i++) {
+                    PyMem_FREE(initial_buf[i]);
+                    initial_buf[i] = NULL;
+                }
+            }
+            else {
+                for (int i = 1; i < nout; i++) {
+                    memcpy(initial_buf[i], initial_buf[0], op_dtypes[i]->elsize);
+                }
             }
         }
     }
@@ -343,13 +388,13 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
 
     npy_intp *strideptr = NpyIter_GetInnerStrideArray(iter);
     if (wheremask != NULL) {
-        if (PyArrayMethod_GetMaskedStridedLoop(context,
+        if (PyArrayMethod_GetMaskedReductionLoop(context,
                 1, strideptr, &strided_loop, &auxdata, &flags) < 0) {
             goto fail;
         }
     }
     else {
-        if (context->method->get_strided_loop(context,
+        if (reduction_get_loop_func(context->method)(context,
                 1, 0, strideptr, &strided_loop, &auxdata, &flags) < 0) {
             goto fail;
         }
@@ -366,15 +411,18 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
      * Initialize the result to the reduction unit if possible,
      * otherwise copy the initial values and get a view to the rest.
      */
-    if (initial_buf != NULL) {
+    if (initial_buf[0] != NULL) {
         /* Loop provided an identity or default value, assign to result. */
-        int ret = raw_array_assign_scalar(
-                PyArray_NDIM(result), PyArray_DIMS(result),
-                PyArray_DESCR(result),
-                PyArray_BYTES(result), PyArray_STRIDES(result),
-                op_dtypes[0], initial_buf, NPY_UNSAFE_CASTING);
-        if (ret < 0) {
-            goto fail;
+        for (int i = 0; i < nout; i++) {
+            PyArrayObject *res_i = NpyIter_GetOperandArray(iter)[i];
+            int ret = raw_array_assign_scalar(
+                    PyArray_NDIM(res_i), PyArray_DIMS(res_i),
+                    PyArray_DESCR(res_i),
+                    PyArray_BYTES(res_i), PyArray_STRIDES(res_i),
+                    op_dtypes[i], initial_buf[i], NPY_UNSAFE_CASTING);
+            if (ret < 0) {
+                goto fail;
+            }
         }
     }
     else {
@@ -392,10 +440,13 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
          * reductions are not super common.
          * (see also comment in CopyInitialReduceValues)
          */
-        skip_first_count = PyArray_CopyInitialReduceValues(
-                result, operand, axis_flags, funcname, keepdims);
-        if (skip_first_count < 0) {
-            goto fail;
+        for (int i = 0; i < nout; i++) {
+            PyArrayObject *res_i = NpyIter_GetOperandArray(iter)[i];
+            skip_first_count = PyArray_CopyInitialReduceValues(
+                    res_i, operand, axis_flags, funcname, keepdims);
+            if (skip_first_count < 0) {
+                goto fail;
+            }
         }
     }
 
@@ -429,27 +480,46 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
         }
     }
 
-    if (out != NULL) {
-        result = out;
+    PyObject *ret;
+    if (nout == 1 && out[0] != NULL) {
+        result = out[0];
     }
-    Py_INCREF(result);
+    if (nout == 1) {
+        Py_INCREF(result);
+        ret = (PyObject *)result;
+    }
+    else {
+        ret = PyTuple_New(nout);
+        if (ret == NULL) {
+            goto fail;
+        }
+        for (int i = 0; i < nout; i++) {
+            PyArrayObject *res_i = NpyIter_GetOperandArray(iter)[i];
+            Py_INCREF(res_i);
+            PyTuple_SET_ITEM(ret, i, (PyObject *)res_i);
+        }
+    }
 
-    if (initial_buf != NULL && PyDataType_REFCHK(PyArray_DESCR(result))) {
-        PyArray_ClearBuffer(PyArray_DESCR(result), initial_buf, 0, 1, 1);
+    for (int i = 0; i < nout; i++) {
+        if (initial_buf[i] != NULL && PyDataType_REFCHK(op_dtypes[i])) {
+            PyArray_ClearBuffer(op_dtypes[i], initial_buf[i], 0, 1, 1);
+        }
+        PyMem_FREE(initial_buf[i]);
     }
-    PyMem_FREE(initial_buf);
     NPY_AUXDATA_FREE(auxdata);
     if (!NpyIter_Deallocate(iter)) {
-        Py_DECREF(result);
+        Py_DECREF(ret);
         return NULL;
     }
-    return result;
+    return ret;
 
 fail:
-    if (initial_buf != NULL && PyDataType_REFCHK(op_dtypes[0])) {
-        PyArray_ClearBuffer(op_dtypes[0], initial_buf, 0, 1, 1);
+    for (int i = 0; i < nout; i++) {
+        if (initial_buf[i] != NULL && PyDataType_REFCHK(op_dtypes[i])) {
+            PyArray_ClearBuffer(op_dtypes[i], initial_buf[i], 0, 1, 1);
+        }
+        PyMem_FREE(initial_buf[i]);
     }
-    PyMem_FREE(initial_buf);
     NPY_AUXDATA_FREE(auxdata);
     if (iter != NULL) {
         NpyIter_Deallocate(iter);

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -383,14 +383,7 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
     NPY_ARRAYMETHOD_FLAGS flags;
 
     npy_intp *strideptr = NpyIter_GetInnerStrideArray(iter);
-    /*
-     * Expand the iterator's strides, which are laid out as
-     *     [out_0 .. out_{nout-1}, operand, (wheremask)]
-     * into the layout the reduction loop is called with,
-     *     [acc_0 .. acc_{nout-1}, x, out_0 .. out_{nout-1}, (mask)]
-     * so that `get_reduction_loop` sees the same layout at setup time as the
-     * loop does at call time (see `reduce_loop`).
-     */
+    /* Expand the iterator strides into the loop layout (see reduce_loop) */
     npy_intp fixed_strides[NPY_MAXARGS];
     for (int i = 0; i < nout; i++) {
         fixed_strides[i] = strideptr[i];

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -14,6 +14,7 @@
 #include <Python.h>
 
 #include "npy_config.h"
+#include "npy_pycompat.h"
 #include "numpy/arrayobject.h"
 
 
@@ -489,14 +490,9 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
         ret = (PyObject *)result;
     }
     else {
-        ret = PyTuple_New(nout);
+        ret = PyTuple_FromArray((PyObject *const *)NpyIter_GetOperandArray(iter), nout);
         if (ret == NULL) {
             goto fail;
-        }
-        for (int i = 0; i < nout; i++) {
-            PyArrayObject *res_i = NpyIter_GetOperandArray(iter)[i];
-            Py_INCREF(res_i);
-            PyTuple_SET_ITEM(ret, i, (PyObject *)res_i);
         }
     }
 

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -352,6 +352,16 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
             /* must use user provided initial value(s) */
             for (int i = 0; i < nout; i++) {
                 PyObject *initial_i = initial_is_tuple ? PyTuple_GET_ITEM(initial, i) : initial;
+                /*
+                 * `initial=None` means "no initial value", which we cannot
+                 * express per-output.  Reject it rather than let PyArray_Pack
+                 * turn it into a value (e.g. NaN for floats).
+                 */
+                if (initial_is_tuple && initial_i == Py_None) {
+                    PyErr_SetString(PyExc_ValueError,
+                                    "entries of a tuple 'initial' cannot be None");
+                    goto fail;
+                }
                 if (PyArray_Pack(op_dtypes[i], initial_buf[i], initial_i) < 0) {
                     goto fail;
                 }
@@ -493,9 +503,15 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
         ret = (PyObject *)result;
     }
     else {
-        ret = PyTuple_FromArray((PyObject *const *)NpyIter_GetOperandArray(iter), nout);
+        ret = PyTuple_New(nout);
         if (ret == NULL) {
             goto fail;
+        }
+        for (int i = 0; i < nout; i++) {
+            /* iterator operand may be a writeback temporary (COPY_IF_OVERLAP) */
+            PyArrayObject *res_i = out[i] != NULL ? out[i] : NpyIter_GetOperandArray(iter)[i];
+            Py_INCREF(res_i);
+            PyTuple_SET_ITEM(ret, i, (PyObject *)res_i);
         }
     }
 

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -383,15 +383,30 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
     NPY_ARRAYMETHOD_FLAGS flags;
 
     npy_intp *strideptr = NpyIter_GetInnerStrideArray(iter);
+    /*
+     * Expand the iterator's strides, which are laid out as
+     *     [out_0 .. out_{nout-1}, operand, (wheremask)]
+     * into the layout the reduction loop is called with,
+     *     [acc_0 .. acc_{nout-1}, x, out_0 .. out_{nout-1}, (mask)]
+     * so that `get_reduction_loop` sees the same layout at setup time as the
+     * loop does at call time (see `reduce_loop`).
+     */
+    npy_intp fixed_strides[NPY_MAXARGS];
+    for (int i = 0; i < nout; i++) {
+        fixed_strides[i] = strideptr[i];
+        fixed_strides[nout + 1 + i] = strideptr[i];
+    }
+    fixed_strides[nout] = strideptr[nout];
     if (wheremask != NULL) {
+        fixed_strides[2 * nout + 1] = strideptr[nout + 1];
         if (PyArrayMethod_GetMaskedReductionLoop(context,
-                1, strideptr, &strided_loop, &auxdata, &flags) < 0) {
+                1, fixed_strides, &strided_loop, &auxdata, &flags) < 0) {
             goto fail;
         }
     }
     else {
         if (reduction_get_loop_func(context->method)(context,
-                1, 0, strideptr, &strided_loop, &auxdata, &flags) < 0) {
+                1, 0, fixed_strides, &strided_loop, &auxdata, &flags) < 0) {
             goto fail;
         }
     }

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -334,7 +334,8 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
         }
     }
 
-    if ((initial == NULL && context->method->get_reduction_initial == NULL)
+    if ((initial == NULL && context->method->get_reduction_initial == NULL
+                && context->method->get_multi_reduction_initials == NULL)
             || initial == Py_None) {
         /* There is no initial value, or initial value was explicitly unset */
     }
@@ -358,14 +359,13 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
         }
         else {
             /*
-             * Fetch initial from ArrayMethod, we pretend the reduction is
-             * empty when the iteration is.  This may be wrong, but when it is,
-             * we will not need the identity as the result is also empty.
-             * The identity seeds output 0 and is broadcast to the rest (the
-             * reduction outputs share a dtype).
+             * Fetch initial value(s) from the ArrayMethod, we pretend the
+             * reduction is empty when the iteration is.  This may be wrong,
+             * but when it is, we will not need the identity as the result is
+             * also empty.
              */
-            int has_initial = context->method->get_reduction_initial(
-                    context, empty_iteration, initial_buf[0]);
+            int has_initial = reduction_get_initial(context,
+                    empty_iteration, (void **)initial_buf);
             if (has_initial < 0) {
                 goto fail;
             }
@@ -374,11 +374,6 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
                 for (int i = 0; i < nout; i++) {
                     PyMem_FREE(initial_buf[i]);
                     initial_buf[i] = NULL;
-                }
-            }
-            else {
-                for (int i = 1; i < nout; i++) {
-                    memcpy(initial_buf[i], initial_buf[0], op_dtypes[i]->elsize);
                 }
             }
         }

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -320,7 +320,7 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
      */
     /*
      * A per-output `initial` may be given as a tuple with one entry per
-     * reduction output; a scalar seeds every output.  Single-output reductions
+     * reduction output. A scalar seeds every output. Single-output reductions
      * keep their historical behaviour (the value is packed as-is).
      */
     if (initial != NULL && initial != Py_None && nout > 1 && PyTuple_Check(initial)) {

--- a/numpy/_core/src/umath/reduction.h
+++ b/numpy/_core/src/umath/reduction.h
@@ -61,9 +61,9 @@ typedef int (PyArray_ReduceLoopFunc)(PyArrayMethod_Context *context,
  * funcname    : The name of the reduction function, for error messages.
  * errormask   : forwarded from _get_bufsize_errmask
  */
-NPY_NO_EXPORT PyArrayObject *
+NPY_NO_EXPORT PyObject *
 PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
-        PyArrayObject *operand, PyArrayObject *out, PyArrayObject *wheremask,
+        PyArrayObject *operand, PyArrayObject **out, PyArrayObject *wheremask,
         npy_bool *axis_flags, int keepdims,
         PyObject *initial, PyArray_ReduceLoopFunc *loop,
         npy_intp buffersize, const char *funcname, int errormask);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2287,8 +2287,12 @@ PyUFunc_GenericFunctionInternal(PyUFuncObject *ufunc,
  *      which is what the downstream reduce machinery and the (N+1)->N loop
  *      consume.
  *
- * The reduction is assumed homogeneous: accumulators, the streamed input and
- * the outputs all share one dtype (true for min/max-like reductions).
+ * The outputs need not share a dtype: each `out_i` (and its aliased
+ * accumulator `acc_i`) takes the i-th resolved *forward output* descriptor,
+ * so they can differ from one another.  Only the single streamed input has a
+ * separate dtype, taken from the resolved forward *input* descriptor (the
+ * forward inputs all correspond to the array being reduced).  The sole
+ * cross-operand constraint is the structural one that `acc_i` aliases `out_i`.
  */
 static PyArrayMethodObject *
 reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
@@ -2300,18 +2304,9 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
     int nin = ufunc->nin;
     int nout = ufunc->nout;
     int fwd_nargs = nin + nout;
-    int rnargs = 2 * nout + 1;
 
-    PyArray_DTypeMeta *res_DType;
-    if (out[0] != NULL) {
-        res_DType = NPY_DTYPE(PyArray_DESCR(out[0]));
-    }
-    else if (signature[0] != NULL) {
-        res_DType = signature[0];
-    }
-    else {
-        res_DType = NPY_DTYPE(PyArray_DESCR(arr));
-    }
+    /* The forward inputs all correspond to the array being reduced. */
+    PyArray_DTypeMeta *stream_DType = NPY_DTYPE(PyArray_DESCR(arr));
 
     PyArrayObject *ops[NPY_MAXARGS];
     PyArray_DTypeMeta *operation_DTypes[NPY_MAXARGS] = {NULL};
@@ -2319,13 +2314,25 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
 
     for (int i = 0; i < nin; i++) {
         ops[i] = arr;
-        Py_INCREF(res_DType);
-        operation_DTypes[i] = res_DType;
+        Py_INCREF(stream_DType);
+        operation_DTypes[i] = stream_DType;
     }
+    /*
+     * Each forward output may have its own dtype: prefer the provided out[i]'s
+     * dtype, else a user-supplied `dtype=` (signature[0]) seeds it, else leave
+     * NULL so promotion decides.
+     */
     for (int i = 0; i < nout; i++) {
         ops[nin + i] = out[i];
-        Py_INCREF(res_DType);
-        operation_DTypes[nin + i] = res_DType;
+        PyArray_DTypeMeta *out_DType = NULL;
+        if (out[i] != NULL) {
+            out_DType = NPY_DTYPE(PyArray_DESCR(out[i]));
+        }
+        else if (signature[0] != NULL) {
+            out_DType = signature[0];
+        }
+        Py_XINCREF(out_DType);
+        operation_DTypes[nin + i] = out_DType;
     }
 
     PyArrayMethodObject *ufuncimpl = promote_and_get_ufuncimpl(ufunc,
@@ -2369,15 +2376,23 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
     }
 
     /*
-     * Expand the resolved forward descriptors into the reduction layout
-     * [acc_0..acc_{n-1}, stream, out_0..out_{n-1}].  Homogeneous reduction:
-     * every reduction operand shares the first resolved output descriptor.
+     * Expand the resolved forward descriptors
+     *     [in_0 .. in_{nin-1}, out_0 .. out_{nout-1}]
+     * into the reduction layout
+     *     [acc_0 .. acc_{nout-1}, stream, out_0 .. out_{nout-1}].
+     * Each acc_i and out_i take the i-th forward *output* descriptor (so the
+     * outputs keep their individual dtypes), while the single streamed input
+     * takes the forward *input* descriptor.
      */
-    PyArray_Descr *res_descr = fwd_descrs[nin];
-    for (int i = 0; i < rnargs; i++) {
-        Py_INCREF(res_descr);
-        out_descrs[i] = res_descr;
+    for (int i = 0; i < nout; i++) {
+        PyArray_Descr *out_descr = fwd_descrs[nin + i];
+        Py_INCREF(out_descr);
+        out_descrs[i] = out_descr;            /* acc_i */
+        Py_INCREF(out_descr);
+        out_descrs[nout + 1 + i] = out_descr; /* out_i (aliased to acc_i) */
     }
+    Py_INCREF(fwd_descrs[0]);
+    out_descrs[nout] = fwd_descrs[0];         /* stream */
     for (int i = 0; i < fwd_nargs; i++) {
         Py_DECREF(fwd_descrs[i]);
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2733,19 +2733,15 @@ try_reduce_contiguous(
         accum[i] = PyArray_BYTES(result[i]);
     }
     int has_initial = 0;
-    if (ufuncimpl->get_reduction_initial != NULL) {
-        has_initial = ufuncimpl->get_reduction_initial(
-                context, /*reduction_is_empty=*/0, accum[0]);
+    if (ufuncimpl->get_reduction_initial != NULL
+            || ufuncimpl->get_multi_reduction_initials != NULL) {
+        has_initial = reduction_get_initial(context,
+                /*reduction_is_empty=*/0, (void **)accum);
         if (has_initial < 0) {
             for (int i = 0; i < nout; i++) {
                 Py_DECREF(result[i]);
             }
             return -1;
-        }
-        if (has_initial) {
-            for (int i = 1; i < nout; i++) {
-                memcpy(accum[i], accum[0], stream_descr->elsize);
-            }
         }
     }
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2361,10 +2361,7 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
     }
 
     if (ufuncimpl->get_reduction_loop == NULL) {
-        PyErr_Format(PyExc_ValueError,
-                "%s.%s is not supported: the resolved loop does not register "
-                "a reduction loop",
-                ufunc_get_name_cstr(ufunc), method);
+        raise_no_loop_found_error(ufunc, (PyObject **)fwd_descrs);
         goto fail;
     }
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2380,7 +2380,16 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
      * Each acc_i and out_i take the i-th forward *output* descriptor (so the
      * outputs keep their individual dtypes), while the single streamed input
      * takes the forward *input* descriptor.
+     *
+     * There is only one streamed operand, but the forward loop has `nin`
+     * inputs -- all of which are the array being reduced, resolved with the
+     * same DType.  A sane resolver therefore assigns them equivalent
+     * descriptors, and we collapse them into the single stream dtype by
+     * taking the first (asserted below); the rest are discarded.
      */
+    for (int i = 1; i < nin; i++) {
+        assert(PyArray_EquivTypes(fwd_descrs[0], fwd_descrs[i]));
+    }
     for (int i = 0; i < nout; i++) {
         PyArray_Descr *out_descr = fwd_descrs[nin + i];
         Py_INCREF(out_descr);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2312,14 +2312,10 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
     PyArray_DTypeMeta *operation_DTypes[NPY_MAXARGS] = {NULL};
     PyArray_DTypeMeta *fwd_signature[NPY_MAXARGS] = {NULL};
 
-    /* A `dtype=` (signature[0]), if given, is forced across every operand. */
     for (int i = 0; i < nin; i++) {
         ops[i] = arr;
-        PyArray_DTypeMeta *in_DType = signature[0] ? signature[0] : stream_DType;
-        Py_INCREF(in_DType);
-        operation_DTypes[i] = in_DType;
-        Py_XINCREF(signature[0]);
-        fwd_signature[i] = signature[0];
+        Py_INCREF(stream_DType);
+        operation_DTypes[i] = stream_DType;
     }
     /*
      * Each forward output may have its own dtype: prefer the provided out[i]'s
@@ -2345,7 +2341,6 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
             ops, fwd_signature, operation_DTypes, NPY_FALSE, NPY_FALSE, NPY_FALSE);
 
     if (ufuncimpl == NULL) {
-        /* Let promotion's standard "no loop matching" error propagate. */
         for (int i = 0; i < fwd_nargs; i++) {
             Py_XDECREF(operation_DTypes[i]);
             Py_XDECREF(fwd_signature[i]);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2382,10 +2382,9 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
      * takes the forward *input* descriptor.
      *
      * There is only one streamed operand, but the forward loop has `nin`
-     * inputs -- all of which are the array being reduced, resolved with the
-     * same DType.  A sane resolver therefore assigns them equivalent
-     * descriptors, and we collapse them into the single stream dtype by
-     * taking the first (asserted below); the rest are discarded.
+     * inputs. They are all the array being reduced, resolved with the same
+     * DType, so a sane resolver gives them equivalent descriptors. We keep the
+     * first as the stream dtype (asserted below) and discard the rest.
      */
     for (int i = 1; i < nin; i++) {
         assert(PyArray_EquivTypes(fwd_descrs[0], fwd_descrs[i]));
@@ -2762,7 +2761,7 @@ try_reduce_contiguous(
     char *src = PyArray_BYTES(arr);
     if (!has_initial) {
         /*
-         * No identity available -- seed each accumulator with arr[0] and
+         * No identity available, so seed each accumulator with arr[0] and
          * reduce over arr[1:].
          */
         for (int i = 0; i < nout; i++){

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2312,10 +2312,14 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
     PyArray_DTypeMeta *operation_DTypes[NPY_MAXARGS] = {NULL};
     PyArray_DTypeMeta *fwd_signature[NPY_MAXARGS] = {NULL};
 
+    /* A `dtype=` (signature[0]), if given, is forced across every operand. */
     for (int i = 0; i < nin; i++) {
         ops[i] = arr;
-        Py_INCREF(stream_DType);
-        operation_DTypes[i] = stream_DType;
+        PyArray_DTypeMeta *in_DType = signature[0] ? signature[0] : stream_DType;
+        Py_INCREF(in_DType);
+        operation_DTypes[i] = in_DType;
+        Py_XINCREF(signature[0]);
+        fwd_signature[i] = signature[0];
     }
     /*
      * Each forward output may have its own dtype: prefer the provided out[i]'s
@@ -2333,21 +2337,19 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
         }
         Py_XINCREF(out_DType);
         operation_DTypes[nin + i] = out_DType;
+        Py_XINCREF(signature[0]);
+        fwd_signature[nin + i] = signature[0];
     }
 
     PyArrayMethodObject *ufuncimpl = promote_and_get_ufuncimpl(ufunc,
             ops, fwd_signature, operation_DTypes, NPY_FALSE, NPY_FALSE, NPY_FALSE);
 
     if (ufuncimpl == NULL) {
+        /* Let promotion's standard "no loop matching" error propagate. */
         for (int i = 0; i < fwd_nargs; i++) {
             Py_XDECREF(operation_DTypes[i]);
             Py_XDECREF(fwd_signature[i]);
         }
-        PyErr_Clear();
-        PyErr_Format(PyExc_ValueError,
-                "%s does not support reduction over input type %s",
-                ufunc_get_name_cstr(ufunc),
-                NPY_DTYPE(PyArray_DESCR(arr))->singleton->typeobj->tp_name);
         return NULL;
     }
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2361,7 +2361,10 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
     }
 
     if (ufuncimpl->get_reduction_loop == NULL) {
-        raise_no_loop_found_error(ufunc, (PyObject **)fwd_descrs);
+        PyErr_Format(PyExc_TypeError,
+                "%s.%s is not supported: the resolved loop does not register "
+                "a reduction loop",
+                ufunc_get_name_cstr(ufunc), method);
         goto fail;
     }
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2273,6 +2273,123 @@ PyUFunc_GenericFunctionInternal(PyUFuncObject *ufunc,
     }
 }
 
+/*
+ * Resolve the ArrayMethod and descriptors for a multi-output (N+1)->N
+ * reduction.  Unlike the single-output case (which reuses the binary forward
+ * loop directly), here the reduction loop is a *separate* function stored on
+ * the forward ArrayMethod via NPY_METH_get_reduction_loop.  We therefore:
+ *
+ *   1. Resolve against the *forward* elementwise loops (arity nin+nout) to
+ *      find the matching ArrayMethod.
+ *   2. Require that method to carry a reduction loop.
+ *   3. Emit descriptors in the reduction layout
+ *          [acc_0 .. acc_{n-1}, stream, out_0 .. out_{n-1}]   (2*nout+1)
+ *      which is what the downstream reduce machinery and the (N+1)->N loop
+ *      consume.
+ *
+ * The reduction is assumed homogeneous: accumulators, the streamed input and
+ * the outputs all share one dtype (true for min/max-like reductions).
+ */
+static PyArrayMethodObject *
+reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
+        PyArrayObject *arr, PyArrayObject *out[],
+        PyArray_DTypeMeta *signature[],
+        PyArray_Descr *out_descrs[],
+        NPY_CASTING casting, char *method)
+{
+    int nin = ufunc->nin;
+    int nout = ufunc->nout;
+    int fwd_nargs = nin + nout;
+    int rnargs = 2 * nout + 1;
+
+    PyArray_DTypeMeta *res_DType;
+    if (out[0] != NULL) {
+        res_DType = NPY_DTYPE(PyArray_DESCR(out[0]));
+    }
+    else if (signature[0] != NULL) {
+        res_DType = signature[0];
+    }
+    else {
+        res_DType = NPY_DTYPE(PyArray_DESCR(arr));
+    }
+
+    PyArrayObject *ops[NPY_MAXARGS];
+    PyArray_DTypeMeta *operation_DTypes[NPY_MAXARGS] = {NULL};
+    PyArray_DTypeMeta *fwd_signature[NPY_MAXARGS] = {NULL};
+
+    for (int i = 0; i < nin; i++) {
+        ops[i] = arr;
+        Py_INCREF(res_DType);
+        operation_DTypes[i] = res_DType;
+    }
+    for (int i = 0; i < nout; i++) {
+        ops[nin + i] = out[i];
+        Py_INCREF(res_DType);
+        operation_DTypes[nin + i] = res_DType;
+    }
+
+    PyArrayMethodObject *ufuncimpl = promote_and_get_ufuncimpl(ufunc,
+            ops, fwd_signature, operation_DTypes, NPY_FALSE, NPY_FALSE, NPY_FALSE);
+
+    if (ufuncimpl == NULL) {
+        for (int i = 0; i < fwd_nargs; i++) {
+            Py_XDECREF(operation_DTypes[i]);
+            Py_XDECREF(fwd_signature[i]);
+        }
+        PyErr_Clear();
+        PyErr_Format(PyExc_ValueError,
+                "%s does not support reduction over input type %s",
+                ufunc_get_name_cstr(ufunc),
+                NPY_DTYPE(PyArray_DESCR(arr))->singleton->typeobj->tp_name);
+        return NULL;
+    }
+
+    PyArray_Descr *fwd_descrs[NPY_MAXARGS];
+    int res = resolve_descriptors(fwd_nargs, ufunc, ufuncimpl,
+            ops, fwd_descrs, fwd_signature, operation_DTypes, NULL, casting);
+
+    for (int i = 0; i < fwd_nargs; i++) {
+        Py_XDECREF(operation_DTypes[i]);
+        Py_XDECREF(fwd_signature[i]);
+    }
+    if (res < 0) {
+        return NULL;
+    }
+
+    if (ufuncimpl->get_reduction_loop == NULL) {
+        PyErr_Format(PyExc_ValueError,
+                "%s.%s is not supported: the resolved loop does not register "
+                "a reduction loop",
+                ufunc_get_name_cstr(ufunc), method);
+        goto fail;
+    }
+
+    if (validate_casting(ufuncimpl, ufunc, ops, fwd_descrs, casting) < 0) {
+        goto fail;
+    }
+
+    /*
+     * Expand the resolved forward descriptors into the reduction layout
+     * [acc_0..acc_{n-1}, stream, out_0..out_{n-1}].  Homogeneous reduction:
+     * every reduction operand shares the first resolved output descriptor.
+     */
+    PyArray_Descr *res_descr = fwd_descrs[nin];
+    for (int i = 0; i < rnargs; i++) {
+        Py_INCREF(res_descr);
+        out_descrs[i] = res_descr;
+    }
+    for (int i = 0; i < fwd_nargs; i++) {
+        Py_DECREF(fwd_descrs[i]);
+    }
+    return ufuncimpl;
+
+  fail:
+    for (int i = 0; i < fwd_nargs; i++) {
+        Py_DECREF(fwd_descrs[i]);
+    }
+    return NULL;
+}
+
 
 /*
  * Promote and resolve a reduction like operation.
@@ -2295,18 +2412,23 @@ PyUFunc_GenericFunctionInternal(PyUFuncObject *ufunc,
  */
 static PyArrayMethodObject *
 reducelike_promote_and_resolve(PyUFuncObject *ufunc,
-        PyArrayObject *arr, PyArrayObject *out,
-        PyArray_DTypeMeta *signature[3],
-        npy_bool enforce_uniform_args, PyArray_Descr *out_descrs[3],
+        PyArrayObject *arr, PyArrayObject *out[],
+        PyArray_DTypeMeta *signature[],
+        npy_bool enforce_uniform_args, PyArray_Descr *out_descrs[],
         NPY_CASTING casting, char *method)
 {
+    if (ufunc->nout > 1) {
+        return reducelike_promote_and_resolve_multi(
+                ufunc, arr, out, signature, out_descrs, casting, method);
+    }
+    PyArrayObject *_out = out[0];
      /*
       * If no dtype is specified and out is not specified, we override the
       * integer and bool dtype used for add and multiply.
       *
       * TODO: The following should be handled by a promoter!
       */
-    if (signature[0] == NULL && out == NULL) {
+    if (signature[0] == NULL && _out == NULL) {
         /*
          * For integer types --- make sure at least a long
          * is used for add and multiply reduction to avoid overflow
@@ -2338,7 +2460,7 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
      * cannot quite handle the correct ops (e.g. a NULL first item if `out`
      * is NULL) so we pass `arr` instead in that case.
      */
-    PyArrayObject *ops[3] = {out ? out : arr, arr, out};
+    PyArrayObject *ops[3] = {_out ? _out : arr, arr, _out};
 
     /*
      * TODO: If `out` is not provided, arguably `initial` could define
@@ -2351,8 +2473,8 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
             NULL, NPY_DTYPE(PyArray_DESCR(arr)), NULL};
     Py_INCREF(operation_DTypes[1]);
 
-    if (out != NULL) {
-        operation_DTypes[0] = NPY_DTYPE(PyArray_DESCR(out));
+    if (_out != NULL) {
+        operation_DTypes[0] = NPY_DTYPE(PyArray_DESCR(_out));
         Py_INCREF(operation_DTypes[0]);
         operation_DTypes[2] = operation_DTypes[0];
         Py_INCREF(operation_DTypes[2]);
@@ -2434,13 +2556,14 @@ reduce_loop(PyArrayMethod_Context *context,
         int needs_api, npy_intp skip_first_count)
 {
     int retval = 0;
-    char *dataptrs_copy[4];
-    npy_intp strides_copy[4];
+    int nout = context->method->nout;
+    char *dataptrs_copy[NPY_MAXARGS];
+    npy_intp strides_copy[NPY_MAXARGS];
     npy_bool masked;
 
     NPY_BEGIN_THREADS_DEF;
     /* Get the number of operands, to determine whether "where" is used */
-    masked = (NpyIter_GetNOp(iter) == 3);
+    masked = (NpyIter_GetNOp(iter) == nout + 2);
 
     if (!needs_api) {
         NPY_BEGIN_THREADS_THRESHOLDED(NpyIter_GetIterSize(iter));
@@ -2456,7 +2579,7 @@ reduce_loop(PyArrayMethod_Context *context,
                 if (strides[0] == 0) {
                     --count;
                     --skip_first_count;
-                    dataptrs[1] += strides[1];
+                    dataptrs[nout] += strides[nout];
                 }
                 else {
                     skip_first_count -= count;
@@ -2464,13 +2587,15 @@ reduce_loop(PyArrayMethod_Context *context,
                 }
             }
             if (count > 0) {
-                /* Turn the two items into three for the inner loop */
-                dataptrs_copy[0] = dataptrs[0];
-                dataptrs_copy[1] = dataptrs[1];
-                dataptrs_copy[2] = dataptrs[0];
-                strides_copy[0] = strides[0];
-                strides_copy[1] = strides[1];
-                strides_copy[2] = strides[0];
+                /* Expand N+1 iterator operands into the (N+1)->N loop args */
+                for (int i = 0; i < nout; ++i) {
+                    dataptrs_copy[i] = dataptrs[i];
+                    strides_copy[i] = strides[i];
+                    dataptrs_copy[nout + 1 +i] = dataptrs[i];
+                    strides_copy[nout + 1 + i] = strides[i];
+                }
+                dataptrs_copy[nout] = dataptrs[nout];
+                strides_copy[nout] = strides[nout];
 
                 retval = strided_loop(context,
                         dataptrs_copy, &count, strides_copy, auxdata);
@@ -2492,16 +2617,18 @@ reduce_loop(PyArrayMethod_Context *context,
     }
 
     do {
-        /* Turn the two items into three for the inner loop */
-        dataptrs_copy[0] = dataptrs[0];
-        dataptrs_copy[1] = dataptrs[1];
-        dataptrs_copy[2] = dataptrs[0];
-        strides_copy[0] = strides[0];
-        strides_copy[1] = strides[1];
-        strides_copy[2] = strides[0];
+        /* Expand N+1 iterator operands into the (N+1)->N loop args */
+        for (int i = 0; i < nout; ++i) {
+            dataptrs_copy[i] = dataptrs[i];
+            strides_copy[i] = strides[i];
+            dataptrs_copy[nout + 1 + i] = dataptrs[i];
+            strides_copy[nout + 1 + i] = strides[i];
+        }
+        dataptrs_copy[nout] = dataptrs[nout];
+        strides_copy[nout] = strides[nout];
         if (masked) {
-            dataptrs_copy[3] = dataptrs[2];
-            strides_copy[3] = strides[2];
+            dataptrs_copy[2 * nout + 1] = dataptrs[nout + 1];
+            strides_copy[2 * nout + 1] = strides[nout + 1];
         }
 
         retval = strided_loop(context,
@@ -2535,22 +2662,39 @@ static inline int
 try_reduce_contiguous(
         PyArrayMethod_Context *context, PyArrayObject *arr,
         PyArray_Descr *const *descrs,
-        PyArrayObject *out, PyArrayObject *wheremask, PyObject *initial,
+        PyArrayObject **out, PyArrayObject *wheremask, PyObject *initial,
         int ndim, int naxes, int keepdims,
         int errormask,
-        PyArrayObject **out_result)
+        PyObject **out_result)
 {
     NPY_BEGIN_THREADS_DEF;
     *out_result = NULL;
 
     PyArrayMethodObject *ufuncimpl = context->method;
-    if (!(out == NULL && wheremask == NULL && initial == NULL && keepdims == 0
+    int nout = ufuncimpl->nout;
+
+    npy_bool any_out = NPY_FALSE;
+    for (int i = 0; i < nout; i++) {
+        if (out[i] != NULL) {
+            any_out = NPY_TRUE;
+            break;
+        }
+    }
+    PyArray_Descr *stream_descr = descrs[nout];
+    npy_bool descrs_ok = PyArray_DESCR(arr) == stream_descr && !PyDataType_REFCHK(stream_descr);
+    for (int i = 0; i < nout; i++) {
+        if (descrs[i] != stream_descr) {
+            descrs_ok = NPY_FALSE;
+            break;
+        }
+    }
+
+
+    if (!(!any_out && wheremask == NULL && initial == NULL && keepdims == 0
             && naxes == ndim
             && PyArray_TRIVIALLY_ITERABLE(arr)
             && PyArray_ISALIGNED(arr)
-            && PyArray_DESCR(arr) == descrs[1]
-            && descrs[0] == descrs[1]
-            && !PyDataType_REFCHK(descrs[0])
+            && descrs_ok
             && (ndim <= 1
                 || (ufuncimpl->flags & NPY_METH_IS_REORDERABLE)))) {
         return 0;
@@ -2561,21 +2705,35 @@ try_reduce_contiguous(
         return 0;
     }
 
-    /* Allocate the 0-d result first so the loop can write into it. */
-    Py_INCREF(descrs[0]);
-    PyArrayObject *result = (PyArrayObject *)PyArray_NewFromDescr(
-            &PyArray_Type, descrs[0], 0, NULL, NULL, NULL, 0, NULL);
-    if (result == NULL) {
-        return -1;
+    /* Allocate one 0-d result per output so the loop can write into them. */
+    PyArrayObject *result[NPY_MAXARGS];
+    char *accum[NPY_MAXARGS];
+    for (int i = 0; i < nout; i++) {
+        Py_INCREF(descrs[i]);
+        result[i] = (PyArrayObject *)PyArray_NewFromDescr(
+                &PyArray_Type, descrs[i], 0, NULL, NULL, NULL, 0, NULL);
+        if (result[i] == NULL) {
+            for (int j = 0; j < i; j++) {
+                Py_DECREF(result[j]);
+            }
+            return -1;
+        }
+        accum[i] = PyArray_BYTES(result[i]);
     }
-    char *accum = PyArray_BYTES(result);
     int has_initial = 0;
     if (ufuncimpl->get_reduction_initial != NULL) {
         has_initial = ufuncimpl->get_reduction_initial(
-                context, /*reduction_is_empty=*/0, accum);
+                context, /*reduction_is_empty=*/0, accum[0]);
         if (has_initial < 0) {
-            Py_DECREF(result);
+            for (int i = 0; i < nout; i++) {
+                Py_DECREF(result[i]);
+            }
             return -1;
+        }
+        if (has_initial) {
+            for (int i = 1; i < nout; i++) {
+                memcpy(accum[i], accum[0], stream_descr->elsize);
+            }
         }
     }
 
@@ -2587,59 +2745,87 @@ try_reduce_contiguous(
     char *src = PyArray_BYTES(arr);
     if (!has_initial) {
         /*
-         * No identity available -- seed the accumulator with arr[0] and
+         * No identity available -- seed each accumulator with arr[0] and
          * reduce over arr[1:].
          */
-        memcpy(accum, src, descrs[1]->elsize);
+        for (int i = 0; i < nout; i++){
+            memcpy(accum[i], src, stream_descr->elsize);
+        }
         src += arr_stride;
         count -= 1;
     }
-    if (count == 0) {
-        /* Single-element input with no identity -- accum already holds arr[0]. */
-        *out_result = result;
-        return 1;
-    }
 
-    npy_intp strides[3] = {0, arr_stride, 0};
-    PyArrayMethod_StridedLoop *strided_loop;
-    NpyAuxData *auxdata = NULL;
-    NPY_ARRAYMETHOD_FLAGS flags = 0;
-    if (ufuncimpl->get_strided_loop(context, /*aligned=*/1,
-            /*move_references=*/0, strides,
-            &strided_loop, &auxdata, &flags) < 0) {
-        Py_DECREF(result);
-        return -1;
-    }
-    int needs_fperr = !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS);
-    if (needs_fperr) {
-        npy_clear_floatstatus_barrier((char *)context);
-    }
-    if (!(flags & NPY_METH_REQUIRES_PYAPI)) {
-        NPY_BEGIN_THREADS_THRESHOLDED(count);
-    }
-    char *data[3] = {accum, src, accum};
-    int res = strided_loop(context, data, &count, strides, auxdata);
-    NPY_END_THREADS;
-    NPY_AUXDATA_FREE(auxdata);
-    if (res == 0 && PyErr_Occurred()) {
-        res = -1;
-    }
-    if (res == 0 && needs_fperr) {
-        res = _check_ufunc_fperr(errormask, "reduce");
+    int res = 0;
+    if (count > 0) {
+        npy_intp strides[NPY_MAXARGS];
+        char *data[NPY_MAXARGS];
+        for (int i = 0; i < nout; i++) {
+            strides[i] = 0;
+            strides[nout + 1 + i] = 0;
+            data[i] = accum[i];
+            data[nout + 1 + i] = accum[i];
+        }
+        strides[nout] = arr_stride;
+        data[nout] = src;
+
+        PyArrayMethod_StridedLoop *strided_loop;
+        NpyAuxData *auxdata = NULL;
+        NPY_ARRAYMETHOD_FLAGS flags = 0;
+        if (reduction_get_loop_func(ufuncimpl)(context, /*aligned=*/1,
+                /*move_references=*/0, strides,
+                &strided_loop, &auxdata, &flags) < 0) {
+            for (int i = 0; i < nout; i++) {
+                Py_DECREF(result[i]);
+            }
+            return -1;
+        }
+        int needs_fperr = !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS);
+        if (needs_fperr) {
+            npy_clear_floatstatus_barrier((char *)context);
+        }
+        if (!(flags & NPY_METH_REQUIRES_PYAPI)) {
+            NPY_BEGIN_THREADS_THRESHOLDED(count);
+        }
+        res = strided_loop(context, data, &count, strides, auxdata);
+        NPY_END_THREADS;
+        NPY_AUXDATA_FREE(auxdata);
+        if (res == 0 && PyErr_Occurred()) {
+            res = -1;
+        }
+        if (res == 0 && needs_fperr) {
+            res = _check_ufunc_fperr(errormask, "reduce");
+        }
     }
     if (res < 0) {
-        Py_DECREF(result);
+        for (int i = 0; i < nout; i++) {
+            Py_DECREF(result[i]);
+        }
         return -1;
     }
-    *out_result = result;
+    if (nout == 1) {
+        *out_result = (PyObject *)result[0];
+    }
+    else {
+        PyObject *tup = PyTuple_New(nout);
+        if (tup == NULL) {
+            for (int i = 0; i < nout; i++) {
+                Py_DECREF(result[i]);
+            }
+            return -1;
+        }
+        for (int i = 0; i < nout; i++) {
+            PyTuple_SET_ITEM(tup, i, (PyObject *)result[i]);
+        }
+        *out_result = tup;
+    }
     return 1;
 }
 
 
-static PyArrayObject *
+static PyObject *
 PyUFunc_Reduce(PyUFuncObject *ufunc,
-        PyArrayObject *arr, PyArrayObject *out,
-        int naxes, int *axes, PyArray_DTypeMeta *signature[3], int keepdims,
+        PyArrayObject *arr, PyArrayObject *out[],
+        int naxes, int *axes, PyArray_DTypeMeta *signature[], int keepdims,
         PyObject *initial, PyArrayObject *wheremask)
 {
     int iaxes, ndim;
@@ -2669,7 +2855,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc,
         return NULL;
     }
 
-    PyArray_Descr *descrs[3];
+    PyArray_Descr *descrs[NPY_MAXARGS];
     PyArrayMethodObject *ufuncimpl = reducelike_promote_and_resolve(ufunc,
             arr, out, signature, NPY_FALSE, descrs, NPY_UNSAFE_CASTING, "reduce");
     if (ufuncimpl == NULL) {
@@ -2681,7 +2867,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc,
     context.caller = (PyObject *)ufunc;
     context.method = ufuncimpl;
 
-    PyArrayObject *result = NULL;
+    PyObject *result = NULL;
 
     int fast_status = try_reduce_contiguous(
             &context, arr, descrs, out, wheremask, initial,
@@ -2693,7 +2879,7 @@ PyUFunc_Reduce(PyUFuncObject *ufunc,
                 initial, reduce_loop, buffersize, ufunc_name, errormask);
     }
     /* Fall through to shared cleanup of `descrs`. */
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 2 * ufunc->nout + 1; i++) {
         Py_DECREF(descrs[i]);
     }
     return result;
@@ -2746,7 +2932,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
     PyArray_Descr *descrs[3];
     PyArrayMethodObject *ufuncimpl = reducelike_promote_and_resolve(ufunc,
-            arr, out, signature, NPY_TRUE, descrs, NPY_UNSAFE_CASTING,
+            arr, &out, signature, NPY_TRUE, descrs, NPY_UNSAFE_CASTING,
             "accumulate");
     if (ufuncimpl == NULL) {
         Py_XDECREF(out);
@@ -3170,7 +3356,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
 
     PyArray_Descr *descrs[3];
     PyArrayMethodObject *ufuncimpl = reducelike_promote_and_resolve(ufunc,
-            arr, out, signature, NPY_TRUE, descrs, NPY_UNSAFE_CASTING,
+            arr, &out, signature, NPY_TRUE, descrs, NPY_UNSAFE_CASTING,
             "reduceat");
     if (ufuncimpl == NULL) {
         Py_XDECREF(out);
@@ -3644,11 +3830,12 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
 
     ufunc_full_args full_args = {NULL, NULL};
     PyObject *axes_obj = NULL;
-    PyArrayObject *mp = NULL, *wheremask = NULL, *ret = NULL;
+    PyArrayObject *mp = NULL, *wheremask = NULL;
     PyObject *op = NULL;
+    PyObject *ret = NULL;
     PyArrayObject *indices = NULL;
-    PyArray_DTypeMeta *signature[3] = {NULL, NULL, NULL};
-    PyArrayObject *out = NULL;
+    PyArray_DTypeMeta *signature[NPY_MAXARGS] = {NULL};
+    PyArrayObject *out[NPY_MAXARGS] = {NULL};
     int keepdims = 0;
     PyObject *initial = NULL;
     npy_bool out_is_passed_by_position;
@@ -3671,7 +3858,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
                      _reduce_type[operation]);
         return NULL;
     }
-    if (ufunc->nout != 1) {
+    if (operation != UFUNC_REDUCE && ufunc->nout != 1) {
         PyErr_Format(PyExc_ValueError,
                      "%s only supported for functions "
                      "returning a single value",
@@ -3747,17 +3934,13 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
 
     /* Normalize output for PyUFunc_CheckOverride and conversion. */
     if (out_is_passed_by_position) {
-        /* in this branch, out is always wrapped in a tuple. */
         if (out_obj == Py_Ellipsis) {
             PyErr_SetString(PyExc_TypeError,
                 "out=... is only allowed as a keyword argument.");
             goto fail;
         }
-        if (out_obj != Py_None) {
-            full_args.out = PyTuple_FromArray(&out_obj, 1);
-            if (full_args.out == NULL) {
-                goto fail;
-            }
+        if (out_obj != Py_None && _set_full_args_out(ufunc->nout, out_obj, &full_args) < 0) {
+            goto fail;
         }
     }
     else if (out_obj) {
@@ -3765,12 +3948,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             out_obj = NULL;
             return_scalar = NPY_FALSE;
         }
-        else if (_set_full_args_out(1, out_obj, &full_args) < 0) {
+        else if (_set_full_args_out(ufunc->nout, out_obj, &full_args) < 0) {
             goto fail;
-        }
-        /* Ensure that out_obj is the array, not the tuple: */
-        if (full_args.out != NULL) {
-            out_obj = PyTuple_GET_ITEM(full_args.out, 0);
         }
     }
 
@@ -3804,8 +3983,12 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             goto fail;
         }
     }
-    if (out_obj && _set_out_array(out_obj, &out) < 0) {
-        goto fail;
+    if (full_args.out != NULL) {
+        for (int i = 0; i < ufunc->nout; i++) {
+            if (_set_out_array(PyTuple_GET_ITEM(full_args.out, i), &out[i]) < 0) {
+                goto fail;
+            }
+        }
     }
     if (keepdims_obj && !PyArray_PythonPyIntFromInt(keepdims_obj, &keepdims)) {
         goto fail;
@@ -3844,8 +4027,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
                         "accumulate does not allow multiple axes");
             goto fail;
         }
-        ret = (PyArrayObject *)PyUFunc_Accumulate(ufunc,
-                mp, out, axes[0], signature);
+        ret = PyUFunc_Accumulate(ufunc,
+                mp, out[0], axes[0], signature);
         break;
     case UFUNC_REDUCEAT:
         if (ndim == 0) {
@@ -3857,8 +4040,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
                         "reduceat does not allow multiple axes");
             goto fail;
         }
-        ret = (PyArrayObject *)PyUFunc_Reduceat(ufunc,
-                mp, indices, out, axes[0], signature);
+        ret = PyUFunc_Reduceat(ufunc,
+                mp, indices, out[0], axes[0], signature);
         Py_SETREF(indices, NULL);
         break;
     }
@@ -3866,38 +4049,77 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         goto fail;
     }
 
-    Py_XDECREF(out);
+    for (int i = 0; i < ufunc->nout; i++) {
+        Py_XDECREF(out[i]);
+    }
 
-    Py_DECREF(signature[0]);
-    Py_DECREF(signature[1]);
-    Py_DECREF(signature[2]);
+    for (int i = 0; i < NPY_MAXARGS; i++) {
+        Py_XDECREF(signature[i]);
+    }
 
     Py_DECREF(mp);
     Py_XDECREF(full_args.in);
-    Py_XDECREF(full_args.out);
 
     /* Wrap and return the output */
     PyObject *wrap, *wrap_type;
     if (npy_find_array_wrap(1, &op, &wrap, &wrap_type) < 0) {
         Py_DECREF(ret);
+        Py_XDECREF(full_args.out);
         return NULL;
     }
 
     /* TODO: Data is mutated, so force_wrap like a normal ufunc call does */
-    PyObject *wrapped_result = npy_apply_wrap(
-            (PyObject *)ret, out_obj, wrap, wrap_type, NULL,
-            PyArray_NDIM(ret) == 0 && return_scalar, NPY_FALSE);
+    PyObject *wrapped_result;
+    if (PyTuple_Check(ret)) {
+        Py_ssize_t n = PyTuple_GET_SIZE(ret);
+        wrapped_result = PyTuple_New(n);
+        if (wrapped_result == NULL) {
+            Py_DECREF(ret);
+            Py_DECREF(wrap);
+            Py_DECREF(wrap_type);
+            Py_XDECREF(full_args.out);
+            return NULL;
+        }
+        for (Py_ssize_t i = 0; i < n; i++) {
+            PyArrayObject *item = (PyArrayObject *)PyTuple_GET_ITEM(ret, i);
+            /* Wrap each output with its own `out` object, if one was given. */
+            PyObject *original_out = full_args.out != NULL ?
+                    PyTuple_GET_ITEM(full_args.out, i) : NULL;
+            PyObject *wrapped_item = npy_apply_wrap(
+                    (PyObject *)item, original_out, wrap, wrap_type, NULL,
+                    PyArray_NDIM(item) == 0 && return_scalar, NPY_FALSE);
+            if (wrapped_item == NULL) {
+                Py_DECREF(wrapped_result);
+                Py_DECREF(ret);
+                Py_DECREF(wrap);
+                Py_DECREF(wrap_type);
+                Py_XDECREF(full_args.out);
+                return NULL;
+            }
+            PyTuple_SET_ITEM(wrapped_result, i, wrapped_item);
+        }
+    }
+    else {
+        PyObject *original_out = full_args.out != NULL ?
+                PyTuple_GET_ITEM(full_args.out, 0) : NULL;
+        wrapped_result = npy_apply_wrap(
+                ret, original_out, wrap, wrap_type, NULL,
+                PyArray_NDIM((PyArrayObject *)ret) == 0 && return_scalar, NPY_FALSE);
+    }
     Py_DECREF(ret);
     Py_DECREF(wrap);
     Py_DECREF(wrap_type);
+    Py_XDECREF(full_args.out);
     return wrapped_result;
 
 fail:
-    Py_XDECREF(out);
+    for (int i = 0; i < ufunc->nout; i++) {
+        Py_XDECREF(out[i]);
+    }
 
-    Py_XDECREF(signature[0]);
-    Py_XDECREF(signature[1]);
-    Py_XDECREF(signature[2]);
+    for (int i = 0; i < NPY_MAXARGS; i++) {
+        Py_XDECREF(signature[i]);
+    }
 
     Py_XDECREF(mp);
     Py_XDECREF(wheremask);
@@ -6617,7 +6839,7 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
         }
 
         ufuncimpl = reducelike_promote_and_resolve(ufunc,
-                dummy_arrays[1], dummy_arrays[0], signature, NPY_FALSE,
+                dummy_arrays[1], &dummy_arrays[0], signature, NPY_FALSE,
                 operation_descrs, casting, "resolve_dtypes");
 
         if (ufuncimpl == NULL) {

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2383,11 +2383,20 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
      *
      * There is only one streamed operand, but the forward loop has `nin`
      * inputs. They are all the array being reduced, resolved with the same
-     * DType, so a sane resolver gives them equivalent descriptors. We keep the
-     * first as the stream dtype (asserted below) and discard the rest.
+     * DType, so a resolver should give them equivalent descriptors. We keep
+     * the first as the stream dtype and discard the rest, so reject the case
+     * where they disagree rather than silently using the first.
      */
     for (int i = 1; i < nin; i++) {
-        assert(PyArray_EquivTypes(fwd_descrs[0], fwd_descrs[i]));
+        if (!PyArray_EquivTypes(fwd_descrs[0], fwd_descrs[i])) {
+            PyErr_Format(PyExc_TypeError,
+                    "%s.%s is not supported: the resolved loop requires "
+                    "different descriptors for its inputs (%R and %R), but a "
+                    "reduction streams only a single input.",
+                    ufunc_get_name_cstr(ufunc), method,
+                    fwd_descrs[0], fwd_descrs[i]);
+            goto fail;
+        }
     }
     for (int i = 0; i < nout; i++) {
         PyArray_Descr *out_descr = fwd_descrs[nin + i];
@@ -2611,7 +2620,7 @@ reduce_loop(PyArrayMethod_Context *context,
                 for (int i = 0; i < nout; ++i) {
                     dataptrs_copy[i] = dataptrs[i];
                     strides_copy[i] = strides[i];
-                    dataptrs_copy[nout + 1 +i] = dataptrs[i];
+                    dataptrs_copy[nout + 1 + i] = dataptrs[i];
                     strides_copy[nout + 1 + i] = strides[i];
                 }
                 dataptrs_copy[nout] = dataptrs[nout];
@@ -2764,7 +2773,7 @@ try_reduce_contiguous(
          * No identity available, so seed each accumulator with arr[0] and
          * reduce over arr[1:].
          */
-        for (int i = 0; i < nout; i++){
+        for (int i = 0; i < nout; i++) {
             memcpy(accum[i], src, stream_descr->elsize);
         }
         src += arr_stride;
@@ -3964,7 +3973,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             out_obj = NULL;
             return_scalar = NPY_FALSE;
         }
-        else if (_set_full_args_out(ufunc->nout, out_obj, &full_args) < 0) {
+        else if (out_obj != Py_None
+                    && _set_full_args_out(ufunc->nout, out_obj, &full_args) < 0) {
             goto fail;
         }
     }
@@ -6702,6 +6712,15 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
         return NULL;
     }
 
+    /*
+     * TODO: `nout != 1` could be supported here by resolving the forward loop
+     *       and returning its descriptors, so that
+     *       `resolve_dtypes((f8, f8, None, None), reduction=True)` would give
+     *       `(stream, stream, out_0, out_1)`.  This is mainly useful for
+     *       projects wrapping NumPy, such as Numba.  The `&dummy_arrays[0]`
+     *       passed to `reducelike_promote_and_resolve` below would have to be
+     *       relaxed at the same time.
+     */
     if (reduction && (ufunc->nin != 2 || ufunc->nout != 1)) {
         PyErr_SetString(PyExc_ValueError,
                 "ufunc is not compatible with reduction operations.");

--- a/numpy/_core/src/umath/wrapping_array_method.c
+++ b/numpy/_core/src/umath/wrapping_array_method.c
@@ -203,8 +203,9 @@ wrapping_method_get_identity_function(
             nin, nout, dtypes, context->descriptors, orig_descrs) < 0) {
         return -1;
     }
-    int res = context->method->wrapped_meth->get_reduction_initial(
-            &orig_context, reduction_is_empty, item);
+    void *initials[1] = {item};
+    int res = reduction_get_initial(
+            &orig_context, reduction_is_empty, initials);
     for (int i = 0; i < nin + nout; i++) {
         Py_DECREF(orig_descrs[i]);
     }

--- a/numpy/_core/tests/test_reduction_loop.py
+++ b/numpy/_core/tests/test_reduction_loop.py
@@ -3,7 +3,10 @@ import itertools
 import pytest
 
 import numpy as np
-from numpy._core._reduction_loop_tests import minimummaximum as mm
+from numpy._core._reduction_loop_tests import (
+    minimummaximum as mm,
+    minimummaximum_with_identity as mmi,
+)
 
 SHAPES = [(12,), (3, 4), (2, 3, 4)]
 EMPTY_SHAPES = [(0,), (0, 3), (3, 0), (2, 0, 4)]
@@ -211,6 +214,26 @@ class TestReductionLoop:
                 with pytest.raises(
                         ValueError, match="zero-size array to reduction operation"):
                     op.reduce(a, axis=axis, keepdims=keepdims)
+
+    @pytest.mark.parametrize("shape", EMPTY_SHAPES, ids=str)
+    @pytest.mark.parametrize("keepdims", [False, True])
+    def test_reduce_empty_uses_registered_identity(self, shape, keepdims):
+        a = np.zeros(shape, np.float64)
+        for axis in reduce_axes(a.ndim):
+            if not reduces_over_empty(shape, axis):
+                continue
+            got_min, got_max = mmi.reduce(a, axis=axis, keepdims=keepdims)
+            np.testing.assert_array_equal(
+                got_min,
+                np.minimum.reduce(a, axis=axis, keepdims=keepdims, initial=np.inf))
+            np.testing.assert_array_equal(
+                got_max,
+                np.maximum.reduce(a, axis=axis, keepdims=keepdims, initial=-np.inf))
+
+    def test_reduce_empty_returns_identity(self):
+        got_min, got_max = mmi.reduce(np.array([], dtype=np.float64))
+        assert got_min == np.inf
+        assert got_max == -np.inf
 
     @pytest.mark.parametrize("shape", EMPTY_SHAPES, ids=str)
     @pytest.mark.parametrize("keepdims", [False, True])

--- a/numpy/_core/tests/test_reduction_loop.py
+++ b/numpy/_core/tests/test_reduction_loop.py
@@ -3,6 +3,7 @@ import itertools
 import pytest
 
 import numpy as np
+from numpy._core._exceptions import _UFuncNoLoopError
 from numpy._core._reduction_loop_tests import minimummaximum as mm
 
 SHAPES = [(12,), (3, 4), (2, 3, 4)]
@@ -252,7 +253,7 @@ class TestReductionLoop:
 
     def test_no_reduction_loop_raises(self):
         with pytest.raises(
-                ValueError, match="resolved loop does not register a reduction loop"):
+                _UFuncNoLoopError, match="did not contain a loop with signature"):
             np.divmod.reduce([1, 2, 3])
 
     def test_forward_python_scalars(self):

--- a/numpy/_core/tests/test_reduction_loop.py
+++ b/numpy/_core/tests/test_reduction_loop.py
@@ -209,6 +209,17 @@ class TestReductionLoop:
         np.testing.assert_array_equal(got_min, np.minimum.reduce(a))
         np.testing.assert_array_equal(got_max, np.maximum.reduce(a))
 
+    @pytest.mark.parametrize("which", [0, 1])
+    def test_reduce_out_partial(self, which):
+        # Only some entries of the `out` tuple given, the rest allocated.
+        a = make_array((3, 4), seed=9)
+        given = np.empty(4)
+        out = (given, None) if which == 0 else (None, given)
+        got = mm.reduce(a, axis=0, out=out)
+        assert got[which] is given
+        np.testing.assert_array_equal(got[0], np.minimum.reduce(a, axis=0))
+        np.testing.assert_array_equal(got[1], np.maximum.reduce(a, axis=0))
+
     def test_reduce_out_bare_array_raises(self):
         a = make_array((4,), seed=9)
         with pytest.raises(TypeError, match="must be a tuple of arrays"):
@@ -239,6 +250,27 @@ class TestReductionLoop:
                 got_min, np.minimum.reduce(a, axis=axis, where=mask, initial=initial))
             np.testing.assert_array_equal(
                 got_max, np.maximum.reduce(a, axis=axis, where=mask, initial=initial))
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=str)
+    def test_reduce_where_uses_registered_identity(self, shape):
+        # Without `initial`, the registered identity seeds the masked-out
+        # slots, including slots where the mask excludes everything.
+        a = make_array(shape, seed=11)
+        mask = np.random.default_rng(12).integers(0, 2, size=shape).astype(bool)
+        for axis in reduce_axes(a.ndim):
+            got_min, got_max = mmi.reduce(a, axis=axis, where=mask)
+            np.testing.assert_array_equal(
+                got_min,
+                np.minimum.reduce(a, axis=axis, where=mask, initial=np.inf))
+            np.testing.assert_array_equal(
+                got_max,
+                np.maximum.reduce(a, axis=axis, where=mask, initial=-np.inf))
+
+    def test_reduce_where_fully_masked_gives_identity(self):
+        a = make_array((3, 4), seed=11)
+        mask = np.array([[True] * 4, [False] * 4, [True] * 4])
+        got_min, got_max = mmi.reduce(a, axis=1, where=mask)
+        assert got_min[1] == np.inf and got_max[1] == -np.inf
 
     @pytest.mark.parametrize("shape", EMPTY_SHAPES, ids=str)
     @pytest.mark.parametrize("keepdims", [False, True])
@@ -368,3 +400,25 @@ class TestReductionLoop:
         got_min, got_max = mm.outer(a, b)
         np.testing.assert_array_equal(got_min, np.minimum.outer(a, b))
         np.testing.assert_array_equal(got_max, np.maximum.outer(a, b))
+
+    # `minimummaximum` also registers an object loop, so the reduction
+    # machinery is exercised with refcounted (NPY_ITEM_REFCOUNT) descriptors.
+    @pytest.mark.parametrize("shape", SHAPES, ids=str)
+    def test_object_reduce(self, shape):
+        a = np.random.default_rng(30).integers(-50, 51, size=shape).astype(object)
+        for axis in reduce_axes(a.ndim):
+            got_min, got_max = mm.reduce(a, axis=axis)
+            np.testing.assert_array_equal(got_min, np.minimum.reduce(a, axis=axis))
+            np.testing.assert_array_equal(got_max, np.maximum.reduce(a, axis=axis))
+
+    def test_object_reduce_initial(self):
+        # `initial` is packed into refcounted buffers, which the reduction
+        # machinery has to clear again.
+        a = np.random.default_rng(31).integers(-50, 51, size=12).astype(object)
+        got_min, got_max = mm.reduce(a, initial=(7, -7))
+        assert got_min == np.minimum.reduce(a, initial=7)
+        assert got_max == np.maximum.reduce(a, initial=-7)
+
+    def test_object_reduce_incomparable_raises(self):
+        with pytest.raises(TypeError):
+            mm.reduce(np.array([1, "x", 2], dtype=object))

--- a/numpy/_core/tests/test_reduction_loop.py
+++ b/numpy/_core/tests/test_reduction_loop.py
@@ -3,7 +3,6 @@ import itertools
 import pytest
 
 import numpy as np
-from numpy._core._exceptions import _UFuncNoLoopError
 from numpy._core._reduction_loop_tests import minimummaximum as mm
 
 SHAPES = [(12,), (3, 4), (2, 3, 4)]
@@ -253,7 +252,7 @@ class TestReductionLoop:
 
     def test_no_reduction_loop_raises(self):
         with pytest.raises(
-                _UFuncNoLoopError, match="did not contain a loop with signature"):
+                TypeError, match="resolved loop does not register a reduction loop"):
             np.divmod.reduce([1, 2, 3])
 
     def test_forward_python_scalars(self):

--- a/numpy/_core/tests/test_reduction_loop.py
+++ b/numpy/_core/tests/test_reduction_loop.py
@@ -288,13 +288,13 @@ class TestReductionLoop:
     def test_accumulate_raises(self):
         a = make_array((4,), seed=20)
         with pytest.raises(
-                ValueError, match="only supported for functions returning a single value"):
+                ValueError, match="only supported for functions returning a single"):
             mm.accumulate(a)
 
     def test_reduceat_raises(self):
         a = make_array((4,), seed=21)
         with pytest.raises(
-                ValueError, match="only supported for functions returning a single value"):
+                ValueError, match="only supported for functions returning a single"):
             mm.reduceat(a, [0, 2])
 
     def test_at_raises(self):

--- a/numpy/_core/tests/test_reduction_loop.py
+++ b/numpy/_core/tests/test_reduction_loop.py
@@ -157,6 +157,22 @@ class TestReductionLoop:
         with pytest.raises(ValueError, match="one entry per reduction output"):
             mm.reduce(a, initial=(1.0, 2.0, 3.0))
 
+    @pytest.mark.parametrize("initial", [(None, 5.0), (5.0, None), (None, None)])
+    def test_reduce_initial_tuple_none_raises(self, initial):
+        # `initial=None` means "no initial value", which cannot be expressed
+        # per-output, so it must not be packed as a value (NaN for floats).
+        a = make_array((4,), seed=7)
+        with pytest.raises(ValueError, match="cannot be None"):
+            mm.reduce(a, initial=initial)
+
+    def test_reduce_initial_scalar_none(self):
+        # A scalar None is still "no initial value", as for single-output
+        # reductions, so it falls back to seeding from the first element.
+        a = make_array((4,), seed=7)
+        got_min, got_max = mm.reduce(a, initial=None)
+        np.testing.assert_array_equal(got_min, np.minimum.reduce(a, initial=None))
+        np.testing.assert_array_equal(got_max, np.maximum.reduce(a, initial=None))
+
     @pytest.mark.parametrize("shape", SHAPES, ids=str)
     @pytest.mark.parametrize("keepdims", [False, True])
     def test_reduce_out_tuple(self, shape, keepdims):
@@ -171,6 +187,27 @@ class TestReductionLoop:
             assert got_min is omin and got_max is omax
             np.testing.assert_array_equal(omin, ref_min)
             np.testing.assert_array_equal(omax, ref_max)
+
+    def test_reduce_out_overlapping_input(self):
+        # `out` views into the reduced array make the iterator use a writeback
+        # temporary, but the arrays that were passed in must still be the ones
+        # returned and updated.
+        a = np.arange(12, dtype=np.float64).reshape(3, 4)
+        ref_min = np.minimum.reduce(a, axis=0)
+        ref_max = np.maximum.reduce(a, axis=0)
+        omin, omax = a[0], a[1]
+        got_min, got_max = mm.reduce(a, axis=0, out=(omin, omax))
+        assert got_min is omin and got_max is omax
+        np.testing.assert_array_equal(omin, ref_min)
+        np.testing.assert_array_equal(omax, ref_max)
+
+    @pytest.mark.parametrize("out", [None, (None, None)])
+    def test_reduce_out_none(self, out):
+        # `out=None` means no output was given, as for single-output reduce.
+        a = make_array((4,), seed=9)
+        got_min, got_max = mm.reduce(a, out=out)
+        np.testing.assert_array_equal(got_min, np.minimum.reduce(a))
+        np.testing.assert_array_equal(got_max, np.maximum.reduce(a))
 
     def test_reduce_out_bare_array_raises(self):
         a = make_array((4,), seed=9)

--- a/numpy/_core/tests/test_reduction_loop.py
+++ b/numpy/_core/tests/test_reduction_loop.py
@@ -1,0 +1,310 @@
+import itertools
+
+import pytest
+
+import numpy as np
+from numpy._core._reduction_loop_tests import minimummaximum as mm
+
+SHAPES = [(12,), (3, 4), (2, 3, 4)]
+EMPTY_SHAPES = [(0,), (0, 3), (3, 0), (2, 0, 4)]
+SPECIALS = {
+    "nan": [np.nan],
+    "inf": [np.inf, -np.inf],
+    "nan_inf": [np.nan, np.inf, -np.inf],
+}
+
+
+def make_array(shape, seed):
+    rng = np.random.default_rng(seed)
+    return (rng.standard_normal(shape) * 10).astype(np.float64)
+
+
+def reduce_axes(ndim):
+    axes = [None]
+    for r in range(1, ndim + 1):
+        axes.extend(itertools.combinations(range(ndim), r))
+    if ndim >= 1:
+        axes.append(-1)
+    return [ax[0] if isinstance(ax, tuple) and len(ax) == 1 else ax
+            for ax in axes]
+
+
+def reduces_over_empty(shape, axis):
+    ndim = len(shape)
+    if axis is None:
+        reduced = set(range(ndim))
+    elif isinstance(axis, tuple):
+        reduced = {ax % ndim for ax in axis}
+    else:
+        reduced = {axis % ndim}
+    empty_reduced = any(shape[ax] == 0 for ax in reduced)
+    result_nonempty = all(shape[i] > 0 for i in range(ndim) if i not in reduced)
+    return empty_reduced and result_nonempty
+
+
+class TestReductionLoop:
+    @pytest.mark.parametrize("shape", SHAPES, ids=str)
+    def test_forward(self, shape):
+        a = make_array(shape, seed=1)
+        b = make_array(shape, seed=2)
+        got_min, got_max = mm(a, b)
+        np.testing.assert_array_equal(got_min, np.minimum(a, b))
+        np.testing.assert_array_equal(got_max, np.maximum(a, b))
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=str)
+    def test_forward_strided(self, shape):
+        a = make_array(shape, seed=1)[::-1]
+        b = make_array(shape, seed=2)[::-1]
+        got_min, got_max = mm(a, b)
+        np.testing.assert_array_equal(got_min, np.minimum(a, b))
+        np.testing.assert_array_equal(got_max, np.maximum(a, b))
+
+    def test_forward_mixed_dtype_inputs(self):
+        a = np.array([1, 2, 3], dtype=np.int32)
+        b = np.array([2.5, 1.5, 0.5], dtype=np.float64)
+        got_min, got_max = mm(a, b)
+        assert got_min.dtype == np.float64
+        np.testing.assert_array_equal(got_min, np.minimum(a, b))
+        np.testing.assert_array_equal(got_max, np.maximum(a, b))
+
+    @pytest.mark.parametrize("kind", list(SPECIALS))
+    def test_forward_specials(self, kind):
+        vals = [1.0, -2.0, 3.5, 0.0, -1.0] + SPECIALS[kind]
+        a = np.array(vals, dtype=np.float64)
+        b = np.array(vals[::-1], dtype=np.float64)
+        got_min, got_max = mm(a, b)
+        np.testing.assert_array_equal(got_min, np.minimum(a, b))
+        np.testing.assert_array_equal(got_max, np.maximum(a, b))
+
+    def test_scalar_and_0d(self):
+        v1 = make_array((), seed=13).item()
+        v2 = make_array((), seed=14).item()
+        for a, b in ((np.array(v1), np.array(v2)),
+                     (np.float64(v1), np.float64(v2))):
+            got_min, got_max = mm(a, b)
+            np.testing.assert_array_equal(got_min, np.minimum(a, b))
+            np.testing.assert_array_equal(got_max, np.maximum(a, b))
+            red_min, red_max = mm.reduce(a)
+            np.testing.assert_array_equal(red_min, np.minimum.reduce(a))
+            np.testing.assert_array_equal(red_max, np.maximum.reduce(a))
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=str)
+    @pytest.mark.parametrize("keepdims", [False, True])
+    def test_reduce(self, shape, keepdims):
+        a = make_array(shape, seed=3)
+        for axis in reduce_axes(a.ndim):
+            got_min, got_max = mm.reduce(a, axis=axis, keepdims=keepdims)
+            np.testing.assert_array_equal(
+                got_min, np.minimum.reduce(a, axis=axis, keepdims=keepdims))
+            np.testing.assert_array_equal(
+                got_max, np.maximum.reduce(a, axis=axis, keepdims=keepdims))
+
+    def test_reduce_returns_tuple(self):
+        a = make_array((5,), seed=4)
+        result = mm.reduce(a)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_reduce_single_element(self):
+        a = np.array([7.0])
+        got_min, got_max = mm.reduce(a)
+        assert got_min == 7.0 and got_max == 7.0
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=str)
+    def test_reduce_strided(self, shape):
+        a = make_array(shape, seed=15)[::-1]
+        for axis in reduce_axes(a.ndim):
+            got_min, got_max = mm.reduce(a, axis=axis)
+            np.testing.assert_array_equal(got_min, np.minimum.reduce(a, axis=axis))
+            np.testing.assert_array_equal(got_max, np.maximum.reduce(a, axis=axis))
+
+    @pytest.mark.parametrize("kind", list(SPECIALS))
+    def test_reduce_specials(self, kind):
+        vals = [1.0, -2.0, 3.5, 0.0, -1.0] + SPECIALS[kind]
+        a = np.array(vals, dtype=np.float64)
+        got_min, got_max = mm.reduce(a)
+        np.testing.assert_array_equal(got_min, np.minimum.reduce(a))
+        np.testing.assert_array_equal(got_max, np.maximum.reduce(a))
+
+    @pytest.mark.parametrize("initial_kind", ["small", "large"])
+    def test_reduce_initial_scalar(self, initial_kind):
+        a = make_array((3, 4), seed=5)
+        initial = float(a.min()) - 1.0 if initial_kind == "small" \
+            else float(a.max()) + 1.0
+        for axis in reduce_axes(a.ndim):
+            got_min, got_max = mm.reduce(a, axis=axis, initial=initial)
+            np.testing.assert_array_equal(
+                got_min, np.minimum.reduce(a, axis=axis, initial=initial))
+            np.testing.assert_array_equal(
+                got_max, np.maximum.reduce(a, axis=axis, initial=initial))
+
+    def test_reduce_initial_tuple(self):
+        a = make_array((3, 4), seed=6)
+        small = float(a.min()) - 1.0
+        large = float(a.max()) + 1.0
+        for axis in reduce_axes(a.ndim):
+            got_min, got_max = mm.reduce(a, axis=axis, initial=(small, large))
+            np.testing.assert_array_equal(
+                got_min, np.minimum.reduce(a, axis=axis, initial=small))
+            np.testing.assert_array_equal(
+                got_max, np.maximum.reduce(a, axis=axis, initial=large))
+
+    def test_reduce_initial_wrong_length_raises(self):
+        a = make_array((4,), seed=7)
+        with pytest.raises(ValueError, match="one entry per reduction output"):
+            mm.reduce(a, initial=(1.0, 2.0, 3.0))
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=str)
+    @pytest.mark.parametrize("keepdims", [False, True])
+    def test_reduce_out_tuple(self, shape, keepdims):
+        a = make_array(shape, seed=8)
+        for axis in reduce_axes(a.ndim):
+            ref_min = np.minimum.reduce(a, axis=axis, keepdims=keepdims)
+            ref_max = np.maximum.reduce(a, axis=axis, keepdims=keepdims)
+            omin = np.empty(np.shape(ref_min), np.float64)
+            omax = np.empty(np.shape(ref_max), np.float64)
+            got_min, got_max = mm.reduce(
+                a, axis=axis, keepdims=keepdims, out=(omin, omax))
+            assert got_min is omin and got_max is omax
+            np.testing.assert_array_equal(omin, ref_min)
+            np.testing.assert_array_equal(omax, ref_max)
+
+    def test_reduce_out_bare_array_raises(self):
+        a = make_array((4,), seed=9)
+        with pytest.raises(TypeError, match="must be a tuple of arrays"):
+            mm.reduce(a, out=np.empty(()))
+
+    def test_reduce_out_wrong_length_raises(self):
+        a = make_array((4,), seed=10)
+        with pytest.raises(ValueError, match="exactly one entry per ufunc output"):
+            mm.reduce(a, out=(np.empty(()),))
+
+    def test_reduce_out_and_initial(self):
+        a = make_array((4,), seed=19)
+        omin = np.empty(())
+        omax = np.empty(())
+        got_min, got_max = mm.reduce(a, initial=100.0, out=(omin, omax))
+        assert got_min is omin and got_max is omax
+        np.testing.assert_array_equal(omin, np.minimum.reduce(a, initial=100.0))
+        np.testing.assert_array_equal(omax, np.maximum.reduce(a, initial=100.0))
+
+    @pytest.mark.parametrize("shape", SHAPES, ids=str)
+    def test_reduce_where(self, shape):
+        a = make_array(shape, seed=11)
+        mask = np.random.default_rng(12).integers(0, 2, size=shape).astype(bool)
+        initial = float(a.max()) + 1.0
+        for axis in reduce_axes(a.ndim):
+            got_min, got_max = mm.reduce(a, axis=axis, where=mask, initial=initial)
+            np.testing.assert_array_equal(
+                got_min, np.minimum.reduce(a, axis=axis, where=mask, initial=initial))
+            np.testing.assert_array_equal(
+                got_max, np.maximum.reduce(a, axis=axis, where=mask, initial=initial))
+
+    @pytest.mark.parametrize("shape", EMPTY_SHAPES, ids=str)
+    @pytest.mark.parametrize("keepdims", [False, True])
+    def test_reduce_empty_no_initial_raises(self, shape, keepdims):
+        a = np.zeros(shape, np.float64)
+        for axis in reduce_axes(a.ndim):
+            if not reduces_over_empty(shape, axis):
+                continue
+            for op in (np.minimum, np.maximum, mm):
+                with pytest.raises(
+                        ValueError, match="zero-size array to reduction operation"):
+                    op.reduce(a, axis=axis, keepdims=keepdims)
+
+    @pytest.mark.parametrize("shape", EMPTY_SHAPES, ids=str)
+    @pytest.mark.parametrize("keepdims", [False, True])
+    def test_reduce_empty_axis_survives(self, shape, keepdims):
+        a = np.zeros(shape, np.float64)
+        for axis in reduce_axes(a.ndim):
+            if reduces_over_empty(shape, axis):
+                continue
+            got_min, got_max = mm.reduce(a, axis=axis, keepdims=keepdims)
+            np.testing.assert_array_equal(
+                got_min, np.minimum.reduce(a, axis=axis, keepdims=keepdims))
+            np.testing.assert_array_equal(
+                got_max, np.maximum.reduce(a, axis=axis, keepdims=keepdims))
+
+    @pytest.mark.parametrize("shape", EMPTY_SHAPES, ids=str)
+    def test_reduce_empty_scalar_initial(self, shape):
+        a = np.zeros(shape, np.float64)
+        for axis in reduce_axes(a.ndim):
+            got_min, got_max = mm.reduce(a, axis=axis, initial=0.0)
+            np.testing.assert_array_equal(
+                got_min, np.minimum.reduce(a, axis=axis, initial=0.0))
+            np.testing.assert_array_equal(
+                got_max, np.maximum.reduce(a, axis=axis, initial=0.0))
+
+    @pytest.mark.parametrize("shape", EMPTY_SHAPES, ids=str)
+    def test_reduce_empty_tuple_initial(self, shape):
+        a = np.zeros(shape, np.float64)
+        for axis in reduce_axes(a.ndim):
+            got_min, got_max = mm.reduce(a, axis=axis, initial=(0.0, 1.0))
+            np.testing.assert_array_equal(
+                got_min, np.minimum.reduce(a, axis=axis, initial=0.0))
+            np.testing.assert_array_equal(
+                got_max, np.maximum.reduce(a, axis=axis, initial=1.0))
+
+    def test_unsupported_dtype_raises(self):
+        a = np.array(["a", "b", "c"])
+        with pytest.raises(ValueError, match="could not convert string to float"):
+            mm.reduce(a)
+
+    def test_no_reduction_loop_raises(self):
+        with pytest.raises(
+                ValueError, match="resolved loop does not register a reduction loop"):
+            np.divmod.reduce([1, 2, 3])
+
+    def test_forward_python_scalars(self):
+        got_min, got_max = mm(3.0, 5.0)
+        assert (got_min, got_max) == (3.0, 5.0)
+
+    def test_forward_python_ints(self):
+        got_min, got_max = mm(3, 5)
+        assert (got_min, got_max) == (3.0, 5.0)
+        assert got_min.dtype == np.float64
+
+    def test_forward_dtype_propagates_to_inputs(self):
+        got_min, got_max = mm(1, 5, dtype=np.float64)
+        assert got_min == 1.0 and got_max == 5.0
+
+    def test_reduce_dtype_same(self):
+        a = make_array((4,), seed=16)
+        got_min, got_max = mm.reduce(a, dtype=np.float64)
+        assert got_min.dtype == np.float64 and got_max.dtype == np.float64
+        np.testing.assert_array_equal(got_min, np.minimum.reduce(a, dtype=np.float64))
+        np.testing.assert_array_equal(got_max, np.maximum.reduce(a, dtype=np.float64))
+
+    def test_reduce_dtype_forced_no_loop_raises(self):
+        a = make_array((4,), seed=17)
+        with pytest.raises(TypeError, match="did not contain a loop"):
+            mm.reduce(a, dtype=np.int64)
+
+    def test_reduce_dtype_mismatched_tuple_raises(self):
+        a = make_array((4,), seed=18)
+        with pytest.raises(ValueError, match="mismatch in size"):
+            mm.reduce(a, dtype=(np.int32, np.int64))
+
+    def test_accumulate_raises(self):
+        a = make_array((4,), seed=20)
+        with pytest.raises(
+                ValueError, match="only supported for functions returning a single value"):
+            mm.accumulate(a)
+
+    def test_reduceat_raises(self):
+        a = make_array((4,), seed=21)
+        with pytest.raises(
+                ValueError, match="only supported for functions returning a single value"):
+            mm.reduceat(a, [0, 2])
+
+    def test_at_raises(self):
+        a = make_array((4,), seed=22)
+        with pytest.raises(ValueError, match="single output"):
+            mm.at(a, [0], a)
+
+    def test_outer(self):
+        a = make_array((3,), seed=23)
+        b = make_array((4,), seed=24)
+        got_min, got_max = mm.outer(a, b)
+        np.testing.assert_array_equal(got_min, np.minimum.outer(a, b))
+        np.testing.assert_array_equal(got_max, np.maximum.outer(a, b))

--- a/numpy/_core/tests/test_reduction_loop.py
+++ b/numpy/_core/tests/test_reduction_loop.py
@@ -403,6 +403,13 @@ class TestReductionLoop:
 
     # `minimummaximum` also registers an object loop, so the reduction
     # machinery is exercised with refcounted (NPY_ITEM_REFCOUNT) descriptors.
+    def test_object_forward(self):
+        a = np.array([3, -7, 12], dtype=object)
+        b = np.array([1, 9, -2], dtype=object)
+        got_min, got_max = mm(a, b)
+        assert got_min.tolist() == [1, -7, -2]
+        assert got_max.tolist() == [3, 9, 12]
+
     @pytest.mark.parametrize("shape", SHAPES, ids=str)
     def test_object_reduce(self, shape):
         a = np.random.default_rng(30).integers(-50, 51, size=shape).astype(object)

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -233,6 +233,7 @@ if HAVE_SCPDT:
     dt_config.pytest_extra_xfail = {
         'how-to-verify-bug.rst': '',
         'c-info.ufunc-tutorial.rst': '',
+        'c-info.reduction-loop-tutorial.rst': '',
         'basics.interoperability.rst': 'needs pandas',
         'basics.dispatch.rst': 'errors out in /testing/overrides.py',
         'basics.subclassing.rst': '.. testcode:: admonitions not understood',


### PR DESCRIPTION
### PR summary
This is adding the ability to add reduction loops to ufuncs as it was being recently discussed in the numpy community meetings. The current reductions are implemented using the binary ufunc loops which are 2 -> 1 (2 inputs 1 output) and by setting the output pointer equal to the first input pointer which makes it the accumulation location and not moving it. We generalize this logic for ufuncs that return N outputs. However the normal ufunc loop cannot be used in a similar way in this case. The trick is not possible. So we add the ability to add reduction loops to ufuncs that are N + 1 -> N loops while their nominal/forward loops are 2 -> N.

This is done via a single new function pointer on the array method called `get_reduction_loop` similar to `get_strided_loop`. The whole reduction machinery is then generalized to support loops that are N + 1 -> N instead of hardcoding the assumption that the loop is 2 -> 1. In the nominal binary ufunc case, everything collapses down to the old 2 -> 1 assumption. This generalization was the "easy" part. I kept it to `reduce` right now to minimize the diff for comments but can done for `reduceat` and `accumulate` in a similar manner. The "difficult" algorithmically part for me was the `reducelike_promote_and_resolve_multi` function mainly because since the reduction loops live on the array method via the `get_reduction_loop` function pointer, we have to resolve the dtypes for the "forward pass" loop, get the array method from ufunc object's `_loops` and then get the reduction loop from it. This potentially needs some discussion about how it's best to do so. I generally like the fact that I have to touch only a few files to implement this whole machinery here.

An example of how this machinery can be used by numpy or an extension is here: https://gist.github.com/ikrommyd/51dddb52e54c6f99aa86637b16a11d22
The PR/design should be reviewed in alignment with that.
Here I have a `minmax.cpp` extension with a `setup.py` that implements a `minmummaximum` ufunc and registers  reduction loops for it which would be `minmax`.  I also include a test file `test_minmax.py` in the gist.

This is obviously not ready, I'm just opening it as a draft for comments about the core ideas. We definitely need to consolidate the design and add better checks and error messages in a few places. Currently on my macos and linux machines both the numpy testing suite and `test_minmax.py` pass so I'm curious to see what the full CI does.

I plan to make a PR on my fork soon (next couple of days) that targets the PR branch that implements minmax as part of numpy using the reduction loop mechanism instead of having it in a separate extension.

This is towards https://github.com/numpy/numpy/issues/9836

### First time committer introduction
N/A

#### AI Disclosure
Claude Opus 4.8 via the Claude Code harness has been used for A) querying around the numpy codebase as a fancier grep B) reviewing for logic or reference counting bugs and C) to write comments that I was too lazy to write myself. The whole design and ideas are my own and most of the C code is my own. The AI has mainly fixed my bugs and wrote code to register the reduction loops on the ufunc in my minmax.cpp extension in the gist.

cc @ngoldbaum @seberg please tag anyone else who might be interested in taking a look at the design.

P.S. ignore the changes in `numpy/_core/src/umath/loops_minmax.dispatch.c.src`, they are just for benchmarking purposes because my minmax.cpp extension has no SIMD right now.