### PR TITLE
BUG: einsum: use object dtype's own additive identity in reductions

### DIFF
--- a/doc/release/upcoming_changes/31817.improvement.rst
+++ b/doc/release/upcoming_changes/31817.improvement.rst
@@ -1,0 +1,8 @@
+``np.einsum`` no longer raises ``TypeError`` on non-numeric object reductions
+------------------------------------------------------------------------------
+Previously, `numpy.einsum` initialised its reduction accumulator to the
+integer ``0`` regardless of dtype. For object arrays containing values that
+are not addable to ``int`` (e.g. ``str``, ``list``, or custom objects), this
+raised a ``TypeError`` even though the equivalent `numpy.tensordot` call on
+the same inputs succeeded. ``einsum`` now uses each dtype's own additive
+identity for object-dtype reductions, matching ``tensordot``.

--- a/numpy/_core/src/multiarray/einsum.cpp
+++ b/numpy/_core/src/multiarray/einsum.cpp
@@ -17,10 +17,9 @@
 #include <numpy/npy_common.h>
 #include <numpy/arrayobject.h>
 
-#include <array_assign.h>   //PyArray_AssignRawScalar
-
 #include <ctype.h>
 extern "C" {
+#include <array_assign.h>   //PyArray_AssignRawScalar
 #include "convert.h"
 #include "common.h"
 #include "ctors.h"
@@ -1055,10 +1054,28 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
         goto fail;
     }
 
-    /* Initialize the output to all zeros or None*/
+    /*
+     * Initialize the output: zeros for numeric loops, but None when the
+     * sum-of-products itself runs in object dtype. Object dtype has no universal
+     * additive zero — a hard int 0 made `0 + element` raise TypeError for
+     * str/list/etc. (gh-29200). None is a "no value yet" sentinel the object loop
+     * replaces with the first contribution. The decision keys on the LOOP dtype,
+     * not the output array's: `einsum(..., dtype='f8', out=object_array)` reduces
+     * in f8 and must still seed 0 (else the f8 buffer casts None to nan).
+     */
     ret = NpyIter_GetOperandArray(iter)[nop];
-    if (PyArray_AssignZero(ret, NULL) < 0) {
-        goto fail;
+    {
+        PyArray_Descr *loop_dtype = NpyIter_GetDescrArray(iter)[nop];
+        if (loop_dtype->type_num == NPY_OBJECT && PyArray_ISOBJECT(ret)) {
+            PyObject *none = Py_None;
+            if (PyArray_AssignRawScalar(ret, PyArray_DESCR(ret), (char *)&none,
+                                        NULL, NPY_SAFE_CASTING) < 0) {
+                goto fail;
+            }
+        }
+        else if (PyArray_AssignZero(ret, NULL) < 0) {
+            goto fail;
+        }
     }
 
     /***************************/
@@ -1161,6 +1178,22 @@ finish:
         ret = out;
     }
     Py_INCREF(ret);
+
+    /*
+     * An empty object reduction (a contracted axis of size 0, so the whole
+     * iteration is empty) never reaches the sum-of-products and keeps its None
+     * identity. Collapse that to 0 so empty object sums match np.dot/np.sum
+     * (gh-29200). einsum contracts the same axes for every output element, so a
+     * zero iteration size means ALL outputs are empty — never the data-None case,
+     * where the loop ran (iter size > 0) and already used real contributions.
+     */
+    if (PyArray_ISOBJECT(ret) && PyArray_SIZE(ret) > 0
+            && NpyIter_GetIterSize(iter) == 0) {
+        if (PyArray_AssignZero(ret, NULL) < 0) {
+            Py_DECREF(ret);
+            goto fail;
+        }
+    }
 
     NpyIter_Deallocate(iter);
     for (iop = 0; iop < nop; ++iop) {

--- a/numpy/_core/src/multiarray/einsum.cpp
+++ b/numpy/_core/src/multiarray/einsum.cpp
@@ -1055,13 +1055,12 @@ PyArray_EinsteinSum(char *subscripts, npy_intp nop,
     }
 
     /*
-     * Initialize the output: zeros for numeric loops, but None when the
-     * sum-of-products itself runs in object dtype. Object dtype has no universal
-     * additive zero — a hard int 0 made `0 + element` raise TypeError for
-     * str/list/etc. (gh-29200). None is a "no value yet" sentinel the object loop
-     * replaces with the first contribution. The decision keys on the LOOP dtype,
-     * not the output array's: `einsum(..., dtype='f8', out=object_array)` reduces
-     * in f8 and must still seed 0 (else the f8 buffer casts None to nan).
+     * Initialize the output: zeros for numeric loops, None for object-dtype
+     * loops. Object dtype has no universal additive identity, so the object
+     * sum-of-products loop treats None as "no value yet" and seeds the
+     * reduction with the first contribution. Key on the loop dtype, not the
+     * output array's dtype: einsum(..., dtype='f8', out=object_array) reduces
+     * in f8 and must seed 0 (the f8 buffer cannot hold None).
      */
     ret = NpyIter_GetOperandArray(iter)[nop];
     {
@@ -1180,12 +1179,12 @@ finish:
     Py_INCREF(ret);
 
     /*
-     * An empty object reduction (a contracted axis of size 0, so the whole
-     * iteration is empty) never reaches the sum-of-products and keeps its None
-     * identity. Collapse that to 0 so empty object sums match np.dot/np.sum
-     * (gh-29200). einsum contracts the same axes for every output element, so a
-     * zero iteration size means ALL outputs are empty — never the data-None case,
-     * where the loop ran (iter size > 0) and already used real contributions.
+     * When the iteration is empty (a contracted axis of size 0) the
+     * sum-of-products loop never runs, so an object output still holds the
+     * None seed. Collapse it to 0 to match np.sum/np.dot on empty object
+     * arrays. A zero iteration size means every output element is empty
+     * (einsum contracts the same axes for all of them), so this cannot
+     * overwrite real contributions.
      */
     if (PyArray_ISOBJECT(ret) && PyArray_SIZE(ret) > 0
             && NpyIter_GetIterSize(iter) == 0) {

--- a/numpy/_core/src/multiarray/einsum_sumprod.c.src
+++ b/numpy/_core/src/multiarray/einsum_sumprod.c.src
@@ -1065,11 +1065,8 @@ static void
         PyObject *accum = *(PyObject **)dataptr[nop];
         PyObject *sum;
         if (accum == NULL || accum == Py_None) {
-            /*
-             * Identity element for object reductions: the first contribution
-             * wins instead of being forced through `0 + prod`, so str/list/etc.
-             * object elements reduce correctly (gh-29200).
-             */
+            /* None/NULL means no contribution yet; the first one is used
+             * as-is since object dtype has no universal additive zero. */
             sum = prod;
             Py_INCREF(sum);
         }

--- a/numpy/_core/src/multiarray/einsum_sumprod.c.src
+++ b/numpy/_core/src/multiarray/einsum_sumprod.c.src
@@ -1062,7 +1062,20 @@ static void
             }
         }
 
-        PyObject *sum = PyNumber_Add(*(PyObject **)dataptr[nop], prod);
+        PyObject *accum = *(PyObject **)dataptr[nop];
+        PyObject *sum;
+        if (accum == NULL || accum == Py_None) {
+            /*
+             * Identity element for object reductions: the first contribution
+             * wins instead of being forced through `0 + prod`, so str/list/etc.
+             * object elements reduce correctly (gh-29200).
+             */
+            sum = prod;
+            Py_INCREF(sum);
+        }
+        else {
+            sum = PyNumber_Add(accum, prod);
+        }
         Py_DECREF(prod);
         if (!sum) {
             return;

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -724,6 +724,29 @@ class TestEinsum:
         self.check_einsum_sums('object')
         self.check_einsum_sums('object', True)
 
+    def test_einsum_object_dtype_non_numeric(self):
+        # gh-29200: object-dtype reductions must use each element's own additive
+        # identity, not a hard int 0 -- which made `0 + element` raise TypeError
+        # for str/list/etc. object elements.
+        a = np.arange(1, 9).reshape(2, 2, 2)
+        A = np.array(('a', 'b', 'c', 'd'), dtype=object).reshape(2, 2)
+        # einsum must agree with tensordot, which already handles object dtype
+        assert_equal(np.einsum('ijk,jk->i', a, A), np.tensordot(a, A))
+        # a plain string-concatenation reduction
+        assert_equal(np.einsum('i->', np.array(['x', 'y', 'z'], dtype=object)),
+                     'xyz')
+        # numeric object reductions are unchanged
+        assert_equal(np.einsum('ijk,jk->i', a,
+                               np.array([[1, 10], [100, 1000]], dtype=object)),
+                     np.array([4321, 8765], dtype=object))
+        # out= is fully reinitialized, not used as an accumulator seed
+        out = np.array(['', ''], dtype=object)
+        np.einsum('ijk,jk->i', a, A, out=out)
+        assert_equal(out, np.tensordot(a, A))
+        # an empty object reduction yields the additive identity 0 (as np.sum/dot)
+        empty = np.array([], dtype=object)
+        assert_equal(np.einsum('i,i', empty, empty), 0)
+
     def test_einsum_misc(self):
         # This call used to crash because of a bug in
         # PyArray_AssignZero


### PR DESCRIPTION
## Summary

Fixes gh-29200. `np.einsum` zero-initialised its reduction accumulator to the
integer `0` for every dtype. For object arrays whose elements are not
int-addable (`str`, `list`, custom objects), the first accumulation step
computed `0 + element` and raised `TypeError`; supplying an initialised `out=`
did not help because the output buffer was overwritten with `0` first.

## Fix

- Initialise the einsum output to `None` when the sum-of-products runs in
  **object** dtype. The decision keys on the loop dtype, so
  `einsum(..., dtype='f8', out=object_array)` still seeds `0` (otherwise the f8
  buffer would cast `None` to `nan`).
- Treat a `None`/`NULL` accumulator in the object sum-of-products as the
  identity — the first contribution wins, so each element's own additive
  identity is used instead of a hard `0`.
- Empty object reductions still collapse to `0` (matching `np.sum`/`np.dot`),
  guarded by a zero iteration size, which can never be the data-`None` case
  (where the loop ran).

## Behaviour

```python
>>> a = np.arange(1, 9).reshape(2, 2, 2)
>>> A = np.array(('a', 'b', 'c', 'd'), dtype=object).reshape(2, 2)
>>> np.einsum('ijk,jk->i', a, A)        # before: TypeError
array(['abbcccdddd', 'aaaaabbbbbbcccccccdddddddd'], dtype=object)
>>> np.tensordot(a, A)                  # already worked — now matches
array(['abbcccdddd', 'aaaaabbbbbbcccccccdddddddd'], dtype=object)
```

## Tests

Adds `test_einsum_object_dtype_non_numeric` covering string reductions,
`tensordot` parity, unchanged numeric-object reductions, `out=`
reinitialisation, and the empty-reduction identity. The full `test_einsum.py`
suite passes (79 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
