### PR TITLE
[2.4.x backport]BUG: Fix MaskedRecords.view() dtype reset and _fill_value handling

### DIFF
--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -364,6 +364,7 @@ class MaskedRecords(ma.MaskedArray):
             try:
                 if issubclass(dtype, np.ndarray):
                     output = np.ndarray.view(self, dtype)
+                    dtype = None
                 else:
                     output = np.ndarray.view(self, dtype)
             # OK, there's the change
@@ -386,6 +387,10 @@ class MaskedRecords(ma.MaskedArray):
             mdtype = ma.make_mask_descr(output.dtype)
             output._mask = self._mask.view(mdtype, np.ndarray)
             output._mask.shape = output.shape
+        # Make sure to reset the _fill_value if needed
+        if getattr(output, '_fill_value', None) is not None:
+            if dtype is not None:
+                output._fill_value = None
         return output
 
     def harden_mask(self):

--- a/numpy/ma/tests/test_mrecords.py
+++ b/numpy/ma/tests/test_mrecords.py
@@ -384,6 +384,24 @@ class TestView:
         assert_equal(test.dtype, np.dtype(alttype))
         assert_(test._fill_value is None)
 
+    def test_view_ndarray_subclass_preserves_dtype(self):
+        mrec = self._create_data()[0]
+
+        class MySub(np.ndarray):
+            pass
+
+        test = mrec.view(MySub)
+        assert_(isinstance(test, MySub))
+        assert_equal(test.dtype, mrec.dtype)
+
+    def test_view_maskedarray_preserves_fill_value(self):
+        mrec = self._create_data()[0]
+        original_fv = mrec.fill_value
+
+        test = mrec.view(ma.MaskedArray)
+        assert_(isinstance(test, ma.MaskedArray))
+        assert_equal(test.fill_value, original_fv)
+
 
 ##############################################################################
 class TestMRecordsImport:


### PR DESCRIPTION
Reset dtype after an ndarray subclass is interpreted as the view type in MaskedRecords.view(), matching MaskedArray.view(). Reset _fill_value for real dtype views and add test coverage.

Closes #30441

### PR summary
This is a targeted backport to 2.4 for fixing #30441 based on https://github.com/numpy/numpy/pull/30837. The relevant code on 2.5+ has been refactored so the issue is not relevant there, however the changes on 2.5+ would be too invasive for 2.4.

#### AI Disclosure
No AI tools used.
