### PR TITLE
BUG: fix numpy datetime API to be compatible with older versions

### DIFF
--- a/numpy/_core/code_generators/cversions.txt
+++ b/numpy/_core/code_generators/cversions.txt
@@ -87,4 +87,4 @@
 # Version 22 (NumPy 2.5.0) Opaque PyObject ABI support and
 # NPY_DT_legacy_descriptor_proto support.
 # Version 22 (NumPy 2.6.0) No change
-0x00000016 = cdfba10e4e01454262d2293c394cbed5
+0x00000016 = 83149cba850edb61bf48e1dd180f17a6

--- a/numpy/_core/code_generators/numpy_api.py
+++ b/numpy/_core/code_generators/numpy_api.py
@@ -415,10 +415,10 @@ multiarray_funcs_api = {
     '_PyDataType_GET_ITEM_DATA':               (372, MinVersion("2.5")),
     '_PyArrayMultiIter_GET_ITEM_DATA':         (373, MinVersion("2.5")),
     '_PyArrayNeighborhoodIter_GET_ITEM_DATA':  (374, MinVersion("2.5")),
-    '_PyDatetimeScalarObject_GetMetadata':         (375,),
-    '_PyTimedeltaScalarObject_GetMetadata':        (376,),
-    '_PyDatetimeScalarObject_GetValue':            (377,),
-    '_PyTimedeltaScalarObject_GetValue':           (378,),
+    '_PyDatetimeScalarObject_GetMetadata':     (375, MinVersion("2.5")),
+    '_PyTimedeltaScalarObject_GetMetadata':    (376, MinVersion("2.5")),
+    '_PyDatetimeScalarObject_GetValue':        (377, MinVersion("2.5")),
+    '_PyTimedeltaScalarObject_GetValue':       (378, MinVersion("2.5")),
 }
 
 ufunc_types_api = {

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -1547,6 +1547,14 @@ typedef struct {
 #define _PyDataType_GET_ITEM_DATA(descr) ((PyArray_Descr_fields *)(descr))
 #undef _PyArray_LegacyDescr_GET_ITEM_DATA
 #define _PyArray_LegacyDescr_GET_ITEM_DATA(descr) ((_PyArray_LegacyDescr_fields *)(descr))
+#undef _PyDatetimeScalarObject_GetMetadata
+#define _PyDatetimeScalarObject_GetMetadata(self) ((PyDatetimeScalarObject *)self)->obmeta
+#undef _PyTimedeltaScalarObject_GetMetadata
+#define _PyTimedeltaScalarObject_GetMetadata(self) ((PyTimedeltaScalarObject *)self)->obmeta
+#undef _PyDatetimeScalarObject_GetValue
+#define _PyDatetimeScalarObject_GetValue(self) ((PyDatetimeScalarObject *)self)->obval
+#undef _PyTimedeltaScalarObject_GetValue
+#define _PyTimedeltaScalarObject_GetValue(self) (((PyTimedeltaScalarObject *)self)->obval)
 #endif
 
 /*

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -1325,24 +1325,28 @@ _PyArrayNeighborhoodIter_GET_ITEM_DATA(const PyArrayNeighborhoodIterObject *iter
 {
     return (PyArrayNeighborhoodIterObject_fields *)(((char *)iter) + sizeof(PyObject));
 }
+#undef _PyDatetimeScalarObject_GetMetadata
 /*NUMPY_API*/
 NPY_NO_EXPORT PyArray_DatetimeMetaData
 _PyDatetimeScalarObject_GetMetadata(PyObject *self)
 {
     return ((PyDatetimeScalarObject *)self)->obmeta;
 }
+#undef _PyTimedeltaScalarObject_GetMetadata
 /*NUMPY_API*/
 NPY_NO_EXPORT PyArray_DatetimeMetaData
 _PyTimedeltaScalarObject_GetMetadata(PyObject *self)
 {
     return ((PyTimedeltaScalarObject *)self)->obmeta;
 }
+#undef _PyDatetimeScalarObject_GetValue
 /*NUMPY_API*/
 NPY_NO_EXPORT npy_datetime
 _PyDatetimeScalarObject_GetValue(PyObject *self)
 {
     return ((PyDatetimeScalarObject *)self)->obval;
 }
+#undef _PyTimedeltaScalarObject_GetValue
 /*NUMPY_API*/
 NPY_NO_EXPORT npy_timedelta
 _PyTimedeltaScalarObject_GetValue(PyObject *self)


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
Fixes https://github.com/numpy/numpy/issues/31814

This PR fixes the pandas crash because cython definitons were using symbols which are only present on numpy 2.5 or above. This PR adds fallback just like other macros to directly access the fields on non-opaque so that it is compatible with numpy 2.4 or older. 

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

None used.