### PR TITLE
BUG: Fix interaction between warnings and the promotion cache (#31617)

### DIFF
--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -180,8 +180,13 @@ initialize_static_globals(void)
         return -1;
     }
 
-    npy_static_pydata.kwnames_is_copy =
-            Py_BuildValue("(O)", npy_interned_str.copy);
+    npy_static_pydata.legacy_resolver_promoting =
+            PyContextVar_New("numpy._legacy_resolver_promoting", Py_False);
+    if (npy_static_pydata.legacy_resolver_promoting == NULL) {
+        return -1;
+    }
+
+    npy_static_pydata.kwnames_is_copy = PyTuple_Pack(1, npy_interned_str.copy);
     if (npy_static_pydata.kwnames_is_copy == NULL) {
         return -1;
     }

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -133,6 +133,13 @@ typedef struct npy_static_pydata_struct {
     PyObject *format_options;
 
     /*
+     * Context variable set to True while the legacy ufunc type resolvers
+     * run for promotion, to suppress their deprecation warnings (the
+     * resolution step warns on every call).
+     */
+    PyObject *legacy_resolver_promoting;
+
+    /*
      * Used in the __array__ internals to avoid building a tuple inline
      */
     PyObject *kwnames_is_copy;

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -735,9 +735,18 @@ legacy_promote_using_legacy_type_resolver(PyUFuncObject *ufunc,
      * difference.  Whether the actual operands can be casts must be checked
      * during the type resolution step (which may _also_ calls this!).
      */
-    if (ufunc->type_resolver(ufunc,
+    PyObject *promotion_token = npy_begin_legacy_resolver_promotion();
+    if (promotion_token == NULL) {
+        Py_XDECREF(type_tuple);
+        return -1;
+    }
+    int resolver_result = ufunc->type_resolver(ufunc,
             NPY_UNSAFE_CASTING, (PyArrayObject **)ops, type_tuple,
-            out_descrs) < 0) {
+            out_descrs);
+    if (npy_end_legacy_resolver_promotion(promotion_token) < 0) {
+        resolver_result = -1;
+    }
+    if (resolver_result < 0) {
         Py_XDECREF(type_tuple);
         /* Not all legacy resolvers clean up on failures: */
         for (int i = 0; i < nargs; i++) {

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -38,6 +38,7 @@
 #include "numpy/ndarraytypes.h"
 #include "numpy/ufuncobject.h"
 #include "npy_import.h"
+#include "npy_static_data.h"
 #include "ufunc_type_resolution.h"
 #include "ufunc_object.h"
 #include "common.h"
@@ -69,6 +70,51 @@ npy_casting_to_py_object(NPY_CASTING casting)
         default:
             return PyLong_FromLong(casting);
     }
+}
+
+
+/*
+ * The dispatching code calls the legacy type resolvers a second time to
+ * promote (`legacy_promote_using_legacy_type_resolver`); that result is
+ * cached while the type-resolution call happens on every ufunc invocation.
+ * The promotion call is bracketed with this context variable so each
+ * invocation warns exactly once, no matter the promotion cache state.
+ * The warnings machinery cannot deduplicate the two emissions for us:
+ * under `simplefilter("always")` it delivers everything by design.
+ */
+NPY_NO_EXPORT PyObject *
+npy_begin_legacy_resolver_promotion(void)
+{
+    return PyContextVar_Set(
+            npy_static_pydata.legacy_resolver_promoting, Py_True);
+}
+
+NPY_NO_EXPORT int
+npy_end_legacy_resolver_promotion(PyObject *token)
+{
+    int result = PyContextVar_Reset(
+            npy_static_pydata.legacy_resolver_promoting, token);
+    Py_DECREF(token);
+    return result;
+}
+
+static int
+deprecate_integer_datetime_operation(void)
+{
+    PyObject *promoting;
+    if (PyContextVar_Get(npy_static_pydata.legacy_resolver_promoting,
+                         Py_False, &promoting) < 0) {
+        return -1;
+    }
+    int skip = (promoting == Py_True);
+    Py_DECREF(promoting);
+    if (skip) {
+        return 0;
+    }
+    return DEPRECATE(
+            "The 'generic' unit for NumPy timedelta is deprecated, "
+            "and will raise an error in the future. "
+            "Please convert the integer with an explicit unit.");
 }
 
 
@@ -818,6 +864,9 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
         /* m8[<A>] + int => m8[<A>] + m8[<A>] */
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                                     PyTypeNum_ISBOOL(type_num2)) {
+            if (deprecate_integer_datetime_operation() < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[0]));
             if (out_dtypes[0] == NULL) {
@@ -855,6 +904,9 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
         /* M8[<A>] + int => M8[<A>] + m8[<A>] */
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                     PyTypeNum_ISBOOL(type_num2)) {
+            if (deprecate_integer_datetime_operation() < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[0]));
             if (out_dtypes[0] == NULL) {
@@ -880,6 +932,9 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
     else if (PyTypeNum_ISINTEGER(type_num1) || PyTypeNum_ISBOOL(type_num1)) {
         /* int + m8[<A>] => m8[<A>] + m8[<A>] */
         if (type_num2 == NPY_TIMEDELTA) {
+            if (deprecate_integer_datetime_operation() < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[1]));
             if (out_dtypes[0] == NULL) {
@@ -893,6 +948,9 @@ PyUFunc_AdditionTypeResolver(PyUFuncObject *ufunc,
             type_num1 = NPY_TIMEDELTA;
         }
         else if (type_num2 == NPY_DATETIME) {
+            if (deprecate_integer_datetime_operation() < 0) {
+                return -1;
+            }
             /* Make a new NPY_TIMEDELTA, and copy type2's metadata */
             out_dtypes[0] = timedelta_dtype_with_copied_meta(
                                             PyArray_DESCR(operands[1]));
@@ -991,6 +1049,9 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
         /* m8[<A>] - int => m8[<A>] - m8[<A>] */
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                                         PyTypeNum_ISBOOL(type_num2)) {
+            if (deprecate_integer_datetime_operation() < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[0]));
             if (out_dtypes[0] == NULL) {
@@ -1028,6 +1089,9 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
         /* M8[<A>] - int => M8[<A>] - m8[<A>] */
         else if (PyTypeNum_ISINTEGER(type_num2) ||
                     PyTypeNum_ISBOOL(type_num2)) {
+            if (deprecate_integer_datetime_operation() < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[0]));
             if (out_dtypes[0] == NULL) {
@@ -1069,6 +1133,9 @@ PyUFunc_SubtractionTypeResolver(PyUFuncObject *ufunc,
     else if (PyTypeNum_ISINTEGER(type_num1) || PyTypeNum_ISBOOL(type_num1)) {
         /* int - m8[<A>] => m8[<A>] - m8[<A>] */
         if (type_num2 == NPY_TIMEDELTA) {
+            if (deprecate_integer_datetime_operation() < 0) {
+                return -1;
+            }
             out_dtypes[0] = NPY_DT_CALL_ensure_canonical(
                     PyArray_DESCR(operands[1]));
             if (out_dtypes[0] == NULL) {

--- a/numpy/_core/src/umath/ufunc_type_resolution.h
+++ b/numpy/_core/src/umath/ufunc_type_resolution.h
@@ -5,6 +5,17 @@
 extern "C" {
 #endif
 
+/*
+ * Bracket legacy type resolver calls made (only) for promotion, so they
+ * do not emit deprecation warnings.  `begin` returns a context variable
+ * token (or NULL with an error set); `end` consumes the token.
+ */
+NPY_NO_EXPORT PyObject *
+npy_begin_legacy_resolver_promotion(void);
+
+NPY_NO_EXPORT int
+npy_end_legacy_resolver_promotion(PyObject *token);
+
 NPY_NO_EXPORT int
 PyUFunc_SimpleBinaryComparisonTypeResolver(PyUFuncObject *ufunc,
                                            NPY_CASTING casting,

--- a/numpy/_core/tests/test_deprecations.py
+++ b/numpy/_core/tests/test_deprecations.py
@@ -5,6 +5,8 @@ to document how deprecations should eventually be turned into errors.
 """
 import contextlib
 import re
+import sys
+import textwrap
 import warnings
 from collections.abc import Callable
 
@@ -12,7 +14,8 @@ import pytest
 
 import numpy as np
 from numpy._core._multiarray_tests import fromstring_null_term_c_api  # noqa: F401
-from numpy.testing import assert_raises
+from numpy.testing import IS_WASM, assert_raises
+from numpy.testing._private.utils import run_subprocess
 
 
 class _DeprecationTestCase:
@@ -469,6 +472,74 @@ class TestDeprecatedGenericTimedelta(_DeprecationTestCase):
     def test_raise_warning_for_NAT_construction(self):
         self.assert_deprecated(lambda: np.datetime64('NaT'))
         self.assert_deprecated(lambda: np.datetime64(None))
+
+    # Array operations
+    @pytest.mark.parametrize('timedelta_arr', [
+        np.array([1, 2, 3], dtype="m8[s]"),
+        np.array([1], dtype="m8[ms]"),
+    ])
+    @pytest.mark.parametrize('int_arr', [
+        np.array([1, 2, 3]),
+        np.array([1]),
+    ])
+    @pytest.mark.parametrize("op", [np.add, np.subtract])
+    def test_timedelta_array_integer_array_arithmetic(
+        self, timedelta_arr, int_arr, op
+    ):
+        """Test that timedelta64 array + integer array triggers deprecation."""
+        # timedelta op int
+        self.assert_deprecated(op, num=None, args=(timedelta_arr, int_arr))
+        # int op timedelta
+        self.assert_deprecated(op, num=None, args=(int_arr, timedelta_arr))
+
+    @pytest.mark.parametrize('datetime_arr', [
+        np.array(['2020-01-01', '2020-01-02'], dtype="M8[D]"),
+        np.array(['2020-01-01T00:00:00'], dtype="M8[s]"),
+    ])
+    @pytest.mark.parametrize('int_arr', [
+        np.array([1, 2]),
+        np.array([1]),
+    ])
+    @pytest.mark.parametrize("op", [np.add, np.subtract])
+    def test_datetime_array_integer_array_arithmetic(
+        self, datetime_arr, int_arr, op
+    ):
+        """Test that datetime64 array + integer array triggers deprecation."""
+        # datetime op int
+        self.assert_deprecated(op, num=None, args=(datetime_arr, int_arr))
+        # int op datetime
+        if op == np.add:
+            self.assert_deprecated(op, num=None, args=(int_arr, datetime_arr))
+
+    def test_non_associative_case_warns(self):
+        """Verify the specific non-associative case from gh-31255 warns."""
+        a = np.array([1], dtype="m8[s]")
+        b = np.array([1])
+        c = np.array([1], dtype="m8[ms]")
+
+        # Both intermediate operations should trigger warnings
+        self.assert_deprecated(np.add, num=None, args=(a, b))
+        self.assert_deprecated(np.add, num=None, args=(b, c))
+
+    @pytest.mark.skipif(IS_WASM, reason="wasm doesn't have support for subprocess")
+    def test_first_call_warns_once(self):
+        # The legacy type resolver used to also warn when invoked to populate
+        # the ufunc promotion cache, so the first call in a process emitted
+        # two warnings and later calls one.  Use a fresh process to test with
+        # a cold cache.
+        code = textwrap.dedent("""
+            import warnings
+            import numpy as np
+
+            for args in [(np.timedelta64(3, "s"), 5),
+                         (np.array([3], dtype="m8[s]"), np.array([5]))]:
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
+                    np.subtract(*args)
+                assert len(w) == 1, [str(x.message) for x in w]
+            """)
+        p = run_subprocess([sys.executable, "-c", code])
+        assert p.returncode == 0, p.stderr
 
 
 class TestTriDeprecationWithNonInteger(_DeprecationTestCase):


### PR DESCRIPTION
Backport of #31617.

Fixes #31758

This fixes an issue that was introduced recently that causes duplicate warnings to be emitted for the integer/timedelta deprecation.

If accessing the promotion cache leads to a miss, the deprecation is emitted to fill the cache and then emitted *again* during type resolution.

This means warnings would sometimes be emitted twice.

The fix is to disable warnings when the promotion cache is filled. This happens using a new context variable. This is all happening outside the hot path for these operations so I'm not worried about performance.

I used Claude Fable to help investigate and fix this issue.

Ping @riku-sakamoto and @may12day since you were both involved in the PR that added these warnings.