### PR TITLE
BUG: avoid deadlocks using NpyString API (#31682)

### DIFF
--- a/doc/source/reference/c-api/strings.rst
+++ b/doc/source/reference/c-api/strings.rst
@@ -188,8 +188,8 @@ Functions
      Acquire the mutex locking the allocator attached to
      ``descr``. ``NpyString_release_allocator`` must be called on the allocator
      returned by this function exactly once. Note that functions requiring the
-     GIL should not be called while the allocator mutex is held, as doing so may
-     cause deadlocks.
+     GIL should not be called while the allocator mutex is held unless
+     re-entrancy is impossible, as doing so may cause deadlocks.
 
 .. c:function:: void NpyString_acquire_allocators( \
         size_t n_descriptors, PyArray_Descr *const descrs[], \
@@ -212,7 +212,8 @@ Functions
      ``NpyString_release_allocators``.
 
      Note that functions requiring the GIL should not be called while the
-     allocator mutex is held, as doing so may cause deadlocks.
+     allocator mutex is held and reentrancy is possible, as doing so may cause
+     deadlocks.
 
 .. c:function:: void NpyString_release_allocator( \
         npy_string_allocator *allocator)

--- a/numpy/_core/src/common/raii_utils.hpp
+++ b/numpy/_core/src/common/raii_utils.hpp
@@ -148,7 +148,7 @@ public:
     }
 
     ~NpyStringAcquireAllocator() {
-        NpyString_release_allocator(_allocator);
+        release();
     }
 
     NpyStringAcquireAllocator(const NpyStringAcquireAllocator&) = delete;
@@ -158,6 +158,18 @@ public:
 
     npy_string_allocator *allocator() {
         return _allocator;
+    }
+
+    // Release the allocator lock early, before this object goes out of scope.
+    // Use this when a scope must drop the lock partway through, e.g. before
+    // running Python C API code that must not hold the allocator lock (which
+    // could otherwise deadlock on re-entrancy). Idempotent: the destructor
+    // also calls it, so an explicit call never double-releases.
+    void release() {
+        if (_allocator != NULL) {
+            NpyString_release_allocator(_allocator);
+            _allocator = NULL;
+        }
     }
 };
 

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -1918,8 +1918,6 @@ string_to_bytes(PyArrayMethod_Context *context, char *const data[],
                 NpyAuxData *NPY_UNUSED(auxdata))
 {
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)context->descriptors[0];
-    np::raii::NpyStringAcquireAllocator alloc(descr);
-
     int has_null = descr->na_object != NULL;
     int has_string_na = descr->has_string_na;
     const npy_static_string *default_string = &descr->default_string;
@@ -1931,6 +1929,8 @@ string_to_bytes(PyArrayMethod_Context *context, char *const data[],
     npy_intp out_stride = strides[1];
     size_t max_out_size = context->descriptors[1]->elsize;
 
+    np::raii::NpyStringAcquireAllocator alloc(descr);
+
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
@@ -1940,11 +1940,29 @@ string_to_bytes(PyArrayMethod_Context *context, char *const data[],
             return -1;
         }
 
-        for (size_t i=0; i<s.size; i++) {
+        for (size_t i = 0; i < s.size; i++) {
             if (((unsigned char *)s.buf)[i] > 127) {
+                // Building the UnicodeEncodeError needs the GIL and must not
+                // run while the allocator is held (re-entrant Python could
+                // deadlock on it), so copy the offending bytes out, release the
+                // allocator, then raise.
+                char *bad = (char *)PyMem_RawMalloc(s.size);
+                if (bad == NULL) {
+                    alloc.release();
+                    npy_gil_error(PyExc_MemoryError,
+                                  "Failed to allocate memory for unicode "
+                                  "encoding error");
+                    return -1;
+                }
+                memcpy(bad, s.buf, s.size);
+                size_t bad_size = s.size;
+                size_t bad_pos = i;
+                alloc.release();
+
                 np::raii::EnsureGIL ensure_gil{};
 
-                PyObject *str = PyUnicode_FromStringAndSize(s.buf, s.size);
+                PyObject *str = PyUnicode_FromStringAndSize(bad, bad_size);
+                PyMem_RawFree(bad);
 
                 if (str == NULL) {
                     PyErr_SetString(
@@ -1958,8 +1976,8 @@ string_to_bytes(PyArrayMethod_Context *context, char *const data[],
                     "sOnns",
                     "ascii",
                     str,
-                    (Py_ssize_t)i,
-                    (Py_ssize_t)(i+1),
+                    (Py_ssize_t)bad_pos,
+                    (Py_ssize_t)(bad_pos + 1),
                     "ordinal not in range(128)"
                 );
 

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -315,62 +315,55 @@ stringdtype_setitem(PyArray_StringDTypeObject *descr, PyObject *obj, char **data
 {
     npy_packed_static_string *sdata = (npy_packed_static_string *)dataptr;
 
-    // borrow reference
+    // borrowed reference
     PyObject *na_object = descr->na_object;
 
-    // We need the result of the comparison after acquiring the allocator, but
-    // cannot use functions requiring the GIL when the allocator is acquired,
-    // so we do the comparison before acquiring the allocator.
-
+    // We need the result of the comparison before packing below, but cannot
+    // use functions requiring the GIL when the allocator is acquired.
     int na_cmp = na_eq_cmp(obj, na_object);
     if (na_cmp == -1) {
         return -1;
     }
 
-    npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
-
-    if (na_object != NULL) {
-        if (na_cmp) {
-            if (NpyString_pack_null(allocator, sdata) < 0) {
-                PyErr_SetString(PyExc_MemoryError,
-                                "Failed to pack null string during StringDType "
-                                "setitem");
-                goto fail;
-            }
-            goto success;
+    if (na_object != NULL && na_cmp) {
+        npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
+        int pack_status = NpyString_pack_null(allocator, sdata);
+        NpyString_release_allocator(allocator);
+        if (pack_status < 0) {
+            PyErr_SetString(PyExc_MemoryError,
+                            "Failed to pack null string during StringDType "
+                            "setitem");
+            return -1;
         }
+        return 0;
     }
+
     PyObject *val_obj = as_pystring(obj, descr->coerce);
 
     if (val_obj == NULL) {
-        goto fail;
+        return -1;
     }
 
     Py_ssize_t length = 0;
     const char *val = PyUnicode_AsUTF8AndSize(val_obj, &length);
     if (val == NULL) {
         Py_DECREF(val_obj);
-        goto fail;
+        return -1;
     }
 
-    if (NpyString_pack(allocator, sdata, val, length) < 0) {
+    npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
+    int pack_status = NpyString_pack(allocator, sdata, val, length);
+    NpyString_release_allocator(allocator);
+    Py_DECREF(val_obj);
+
+    if (pack_status < 0) {
         PyErr_SetString(PyExc_MemoryError,
                         "Failed to pack string during StringDType "
                         "setitem");
-        Py_DECREF(val_obj);
-        goto fail;
+        return -1;
     }
-    Py_DECREF(val_obj);
-
-success:
-    NpyString_release_allocator(allocator);
 
     return 0;
-
-fail:
-    NpyString_release_allocator(allocator);
-
-    return -1;
 }
 
 static PyObject *

--- a/numpy/_core/src/multiarray/stringdtype/static_string.c
+++ b/numpy/_core/src/multiarray/stringdtype/static_string.c
@@ -229,6 +229,37 @@ arena_free(npy_string_arena *arena, _npy_static_string_u *str)
 
 static npy_string_arena NEW_ARENA = {0, 0, NULL};
 
+static void
+acquire_allocator_lock(npy_string_allocator *allocator)
+{
+#if PY_VERSION_HEX < 0x30d00b3
+    if (!PyThread_acquire_lock(allocator->allocator_lock, NOWAIT_LOCK)) {
+        if (PyGILState_Check()) {
+            Py_BEGIN_ALLOW_THREADS
+            PyThread_acquire_lock(allocator->allocator_lock, WAIT_LOCK);
+            Py_END_ALLOW_THREADS
+        }
+        else {
+            PyThread_acquire_lock(allocator->allocator_lock, WAIT_LOCK);
+        }
+    }
+#else
+    PyMutex_Lock(&allocator->allocator_lock);
+#endif
+}
+
+static int
+allocator_seen(npy_string_allocator *allocator,
+               npy_string_allocator *allocators[], size_t end)
+{
+    for (size_t i = 0; i < end; i++) {
+        if (allocators[i] == allocator) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 NPY_NO_EXPORT npy_string_allocator *
 NpyString_new_allocator(npy_string_malloc_func m, npy_string_free_func f,
                         npy_string_realloc_func r)
@@ -281,18 +312,13 @@ NpyString_free_allocator(npy_string_allocator *allocator)
  * by this function exactly once.
  *
  * Note that functions requiring the GIL should not be called while the
- * allocator mutex is held, as doing so may cause deadlocks.
+ * allocator mutex is held and reentrant calls are possible, as doing so may
+ * cause deadlocks.
  */
 NPY_NO_EXPORT npy_string_allocator *
 NpyString_acquire_allocator(const PyArray_StringDTypeObject *descr)
 {
-#if PY_VERSION_HEX < 0x30d00b3
-    if (!PyThread_acquire_lock(descr->allocator->allocator_lock, NOWAIT_LOCK)) {
-        PyThread_acquire_lock(descr->allocator->allocator_lock, WAIT_LOCK);
-    }
-#else
-    PyMutex_Lock(&descr->allocator->allocator_lock);
-#endif
+    acquire_allocator_lock(descr->allocator);
     return descr->allocator;
 }
 
@@ -309,42 +335,64 @@ NpyString_acquire_allocator(const PyArray_StringDTypeObject *descr)
  * ignored. A buffer overflow will happen if the *descrs* array does not
  * contain n_descriptors elements.
  *
- * If pointers to the same descriptor are passed multiple times, only acquires
+ * If pointers to the same allocator are passed multiple times, only acquires
  * the allocator mutex once but sets identical allocator pointers appropriately.
+ * Distinct allocator mutexes are acquired in ascending allocator address order
+ * to avoid lock-ordering deadlocks when callers pass different descriptor
+ * orders.
  *
  * The allocator mutexes must be released after this function returns, see
  * NpyString_release_allocators.
  *
  * Note that functions requiring the GIL should not be called while the
- * allocator mutex is held, as doing so may cause deadlocks.
+ * allocator mutex is held and reentrant calls are possible, as doing so may
+ * cause deadlocks.
  */
 NPY_NO_EXPORT void
 NpyString_acquire_allocators(size_t n_descriptors,
                              PyArray_Descr *const descrs[],
                              npy_string_allocator *allocators[])
 {
-    for (size_t i=0; i<n_descriptors; i++) {
+    for (size_t i = 0; i < n_descriptors; i++) {
         if (NPY_DTYPE(descrs[i]) != &PyArray_StringDType) {
             allocators[i] = NULL;
             continue;
         }
-        int allocators_match = 0;
-        for (size_t j=0; j<i; j++) {
-            if (allocators[j] == NULL) {
+        allocators[i] = ((PyArray_StringDTypeObject *)descrs[i])->allocator;
+    }
+
+    uintptr_t last_locked_addr = 0;
+    int have_last_locked_addr = 0;
+
+    for (;;) {
+        npy_string_allocator *next_allocator = NULL;
+        uintptr_t next_addr = UINTPTR_MAX;
+
+        for (size_t i = 0; i < n_descriptors; i++) {
+            npy_string_allocator *allocator = allocators[i];
+
+            if (allocator == NULL || allocator_seen(allocator, allocators, i)) {
                 continue;
             }
-            if (((PyArray_StringDTypeObject *)descrs[i])->allocator ==
-                ((PyArray_StringDTypeObject *)descrs[j])->allocator)
-            {
-                allocators[i] = allocators[j];
-                allocators_match = 1;
-                break;
+
+            uintptr_t addr = (uintptr_t)allocator;
+
+            if (have_last_locked_addr && addr <= last_locked_addr) {
+                continue;
+            }
+            if (next_allocator == NULL || addr < next_addr) {
+                next_allocator = allocator;
+                next_addr = addr;
             }
         }
-        if (!allocators_match) {
-            allocators[i] = NpyString_acquire_allocator(
-                    (PyArray_StringDTypeObject *)descrs[i]);
+
+        if (next_allocator == NULL) {
+            break;
         }
+
+        acquire_allocator_lock(next_allocator);
+        last_locked_addr = next_addr;
+        have_last_locked_addr = 1;
     }
 }
 

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -357,8 +357,8 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
     {
         PyArray_StringDTypeObject *descr =
             reinterpret_cast<PyArray_StringDTypeObject *>(PyArray_DESCR(self));
-        np::raii::NpyStringAcquireAllocator alloc(descr);
         np::raii::SaveThreadState save_thread_state{};
+        np::raii::NpyStringAcquireAllocator alloc(descr);
 
         char *idata = PyArray_BYTES(self);
         npy_intp istride = PyArray_STRIDES(self)[0];
@@ -387,8 +387,8 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
     {
         PyArray_StringDTypeObject *res_descr =
             reinterpret_cast<PyArray_StringDTypeObject *>(PyArray_DESCR(res_obj));
-        np::raii::NpyStringAcquireAllocator alloc(res_descr);
         np::raii::SaveThreadState save_thread_state{};
+        np::raii::NpyStringAcquireAllocator alloc(res_descr);
 
         char *odata = PyArray_BYTES(res_obj);
         npy_intp ostride = PyArray_STRIDES(res_obj)[0];

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -1,4 +1,8 @@
 import concurrent.futures
+import inspect
+import subprocess
+import sys
+import textwrap
 import threading
 
 import pytest
@@ -7,7 +11,7 @@ import numpy as np
 from numpy._core import _rational_tests
 from numpy._core.tests.test_stringdtype import random_unicode_string_list
 from numpy.testing import IS_64BIT, IS_WASM
-from numpy.testing._private.utils import run_threaded
+from numpy.testing._private.utils import run_subprocess, run_threaded
 
 if IS_WASM:
     pytest.skip(allow_module_level=True, reason="no threading support in wasm")
@@ -466,3 +470,226 @@ def test_void_dtype__buffer__thread_safety():
             x.__buffer__(flags[i % 2])
 
     run_threaded(func, max_workers=8, pass_barrier=True)
+
+
+def assert_no_deadlock(workload, *, args=(), helpers=(), timeout=30,
+                       reason="deadlock"):
+    """Run ``workload`` in a fresh subprocess; fail if it does not finish in time.
+
+    ``workload`` is a self-contained function: its source is extracted with
+    ``inspect.getsource`` and executed in a clean interpreter. It must do its
+    own imports and may only reference arguments and helpers explicitly passed
+    to this function.
+
+    For regression tests whose failure mode is a hang. Delegates to
+    ``run_subprocess`` (which folds the child's output into the failure on a
+    nonzero exit); this only adds the timeout watchdog, reporting a likely
+    ``reason`` if the child is killed.
+
+    """
+    source = "\n".join(
+        textwrap.dedent(inspect.getsource(helper)) for helper in helpers
+    )
+    source += "\n" + textwrap.dedent(inspect.getsource(workload))
+    script = (
+        "import faulthandler\n"
+        f"faulthandler.dump_traceback_later({timeout}, exit=True)\n"
+        f"{source}\n"
+        f"{workload.__name__}(*{args!r})\n"
+        "faulthandler.cancel_dump_traceback_later()\n"
+    )
+    try:
+        run_subprocess([sys.executable, "-c", script], timeout=timeout + 15)
+    except subprocess.TimeoutExpired:
+        raise AssertionError(
+            f"subprocess did not finish within {timeout}s -- likely {reason}"
+        ) from None
+
+
+def threaded_deadlock_reproducer(operation, nworkers, niters, stall):
+    import faulthandler
+    import os
+    import sys
+    import threading
+    import time
+
+    progress = [0] * nworkers
+    errors = []
+    barrier = threading.Barrier(nworkers)
+
+    def worker(idx):
+        try:
+            barrier.wait()
+            for _ in range(niters):
+                operation(idx)
+                progress[idx] += 1
+        except BaseException as exc:
+            errors.append(exc)
+            raise
+
+    workers = [threading.Thread(target=worker, args=(i,), daemon=True)
+               for i in range(nworkers)]
+    for t in workers:
+        t.start()
+
+    last_total, last_change = 0, time.monotonic()
+    while any(t.is_alive() for t in workers):
+        time.sleep(0.05)
+        if errors:
+            raise AssertionError(f"worker failed: {errors[0]!r}") from errors[0]
+        total = sum(progress)
+        now = time.monotonic()
+        if total != last_total:
+            last_total, last_change = total, now
+        elif now - last_change > stall:
+            # dump the wedged threads' tracebacks, then os._exit to avoid a
+            # shutdown hang on the daemon threads.
+            sys.stderr.write("Probably deadlocked!\n")
+            faulthandler.dump_traceback()
+            sys.stderr.flush()
+            os._exit(1)
+    if errors:
+        raise AssertionError(f"worker failed: {errors[0]!r}") from errors[0]
+
+
+def allocator_lock_order_workload(case_):
+    import numpy as np
+
+    N = 1_000
+    NWORKERS = 8
+    NITERS = 1000
+    STALL = 2.0
+
+    if case_ == "two-allocator":
+        a = np.array(["alpha"] * N, dtype="T")
+        b = np.array(["bravo"] * N, dtype="T")
+
+        def operation(idx):
+            if idx % 2 == 0:
+                np.less(a, b)   # locks alloc(a) then alloc(b)
+            else:
+                np.less(b, a)   # locks alloc(b) then alloc(a)
+
+    elif case_ == "three-allocator":
+        a = np.array(["alpha"] * N, dtype="T")
+        b = np.array(["bravo"] * N, dtype="T")
+        c = np.array(["charlie"] * N, dtype="T")
+
+        def operation(idx):
+            order = idx % 3
+            if order == 0:
+                np.maximum(a, b, out=c)   # locks alloc(a), alloc(b), alloc(c)
+            elif order == 1:
+                np.maximum(b, c, out=a)   # locks alloc(b), alloc(c), alloc(a)
+            else:
+                np.maximum(c, a, out=b)   # locks alloc(c), alloc(a), alloc(b)
+
+    elif case_ == "four-allocator":
+        from numpy._core.umath import _replace
+
+        a = np.array(["a"] * N, dtype="T")
+        b = np.array(["b"] * N, dtype="T")
+        c = np.array(["c"] * N, dtype="T")
+        d = np.array(["d"] * N, dtype="T")
+        counts = np.ones(N, dtype=np.int64)
+
+        def operation(idx):
+            order = idx % 4
+            if order == 0:
+                _replace(a, b, c, counts, out=d)
+            elif order == 1:
+                _replace(b, c, d, counts, out=a)
+            elif order == 2:
+                _replace(c, d, a, counts, out=b)
+            else:
+                _replace(d, a, b, counts, out=c)
+
+    elif case_ == "duplicate-allocator":
+        from numpy._core.umath import _replace
+
+        a = np.array(["same"] * N, dtype="T")
+        b = np.array(["other"] * N, dtype="T")
+        c = np.array(["out"] * N, dtype="T")
+        counts = np.ones(N, dtype=np.int64)
+
+        def operation(idx):
+            if idx % 2 == 0:
+                np.maximum(a, a, out=b)
+            else:
+                _replace(a, a, b, counts, out=c)
+
+    else:
+        raise ValueError(f"unknown allocator deadlock case: {case_}")
+
+    threaded_deadlock_reproducer(
+        operation, NWORKERS, NITERS, stall=STALL,
+    )
+
+
+def test_setitem_reentrant_no_deadlock():
+    def workload():
+        import numpy as np
+
+        arr = np.empty(2, dtype="T")
+
+        class Reenter:
+            def __str__(self):
+                # re-enters stringdtype_setitem and re-acquires the allocator
+                arr[1] = "inner"
+                return "outer"
+
+        arr[0] = Reenter()
+        assert arr[0] == "outer"
+        assert arr[1] == "inner"
+
+    assert_no_deadlock(
+        workload,
+        reason="re-entrant allocator acquire in stringdtype_setitem",
+    )
+
+
+@pytest.mark.parametrize(
+    "case_",
+    ["two-allocator", "three-allocator", "four-allocator",
+     "duplicate-allocator"],
+)
+def test_concurrent_allocator_acquire_no_deadlock(case_):
+    # NpyString_acquire_allocators must lock distinct allocators in a
+    # canonical order, otherwise deadlocks are possible from ABBA cycles
+    assert_no_deadlock(
+        allocator_lock_order_workload,
+        args=(case_,),
+        helpers=(threaded_deadlock_reproducer,),
+        reason=f"allocator lock-ordering in {case_}",
+    )
+
+
+def unique_deadlock_workload():
+    import numpy as np
+    from numpy._core._multiarray_umath import _unique_hash
+
+    NWORKERS = 8
+    NITERS = 200
+    STALL = 2.0
+
+    # _unique_hash (the engine under np.unique) rather than np.unique itself:
+    # it spends almost all its time in the GIL-released, allocator-locked load
+    # loop, so workers reliably overlap there. A single shared array with many
+    # duplicates concentrates contention on one allocator.
+    data = np.array([f"v{i % 128}" for i in range(50_000)], dtype="T")
+
+    def operation(idx):
+        _unique_hash(data, equal_nan=False)
+
+    threaded_deadlock_reproducer(operation, NWORKERS, NITERS, stall=STALL)
+
+
+def test_concurrent_unique_no_deadlock():
+    # Concurrent unique on a shared array deadlocks the allocator lock against
+    # the GIL unless unique_vstring releases the GIL before locking. Only
+    # reproduces on Python <= 3.12; PyMutex detaches on 3.13+.
+    assert_no_deadlock(
+        unique_deadlock_workload,
+        helpers=(threaded_deadlock_reproducer,),
+        reason="unique allocator lock vs GIL",
+    )

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -892,6 +892,25 @@ def test_float_nan_cast_na_object():
     assert arr[0] == '1.2'
 
 
+def test_string_to_bytes_invalid_ascii_error():
+    # The cast builds this UnicodeEncodeError only after releasing the allocator
+    # lock and copying the offending bytes out of the arena; check the reported
+    # character and position survive that.
+    arr = np.array(["abc", "café", "xy"], dtype="T")
+    with pytest.raises(UnicodeEncodeError) as excinfo:
+        arr.astype("S10")
+    exc = excinfo.value
+    assert exc.encoding == "ascii"
+    assert exc.object == "café"
+    assert exc.start == 3
+    assert exc.end == 4
+    assert exc.reason == "ordinal not in range(128)"
+    assert_array_equal(
+        np.array(["abc", "xy"], dtype="T").astype("S3"),
+        np.array([b"abc", b"xy"], dtype="S3"),
+    )
+
+
 @pytest.mark.parametrize(
     "typename",
     [


### PR DESCRIPTION
Backport of #31682.

I'm working on a design for a new ByteStringDType and have come across some design issues with StringDType. In particular, it turns out that there are a number of places we're susceptible to possible deadlocks with CPython or between StringDType instances.

For `NpyString_acquire_allocators` and `NpyString_release_allocators`, the fix is to sort the mutexes by address before locking. I added tests for ufuncs that need 2, 3, and 4 allocators as well as one that uses a duplicate allocator that all deadlock on `main` and don't with the fixes here.

There are also a few more fixes:

* StringDType setitem was holding an allocator lock while allowing arbitrary Python code to execute. I added a reentrant example in a test that deadlocks right now.
* There are also issues in several casts with lock discipline and not reliably separating sections of code that hole the allocator lock or use the CPython C API.
* Python 3.12 using `PyThread_type_lock` can deadlock with the GIL, so I added a code that checks if the GIL is held before trying to acquire the lock. This is the same deadlock-avoiding behavior as PyMutex.

There are still places that use the C API with the allocator lock held but I'm pretty sure there are no reentrancy issues in those places.

This was all done heavily with AI assistance. Please let me know if you spot anything you think is fishy because of that.