### PR TITLE
TYP: Fix `np.ma.masked_array` 2.5.0 regression

### DIFF
--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -2848,7 +2848,8 @@ class MaskedConstant(MaskedArray[tuple[()], dtype[float64]]):
 masked: Final[MaskedConstant] = ...
 masked_singleton: Final[MaskedConstant] = ...
 
-type masked_array = MaskedArray
+# this should NOT be a (PEP 695) type alias, see https://github.com/numpy/numpy/issues/31737
+masked_array = MaskedArray
 
 # keep in sync with `MaskedArray.__new__`
 @overload

--- a/numpy/typing/tests/data/pass/ma.py
+++ b/numpy/typing/tests/data/pass/ma.py
@@ -7,8 +7,6 @@ from numpy._typing import _Shape
 
 type MaskedArray[ScalarT: np.generic] = np.ma.MaskedArray[_Shape, np.dtype[ScalarT]]
 
-# mypy: disable-error-code=no-untyped-call
-
 MAR_b: MaskedArray[np.bool] = np.ma.MaskedArray([True])
 MAR_u: MaskedArray[np.uint32] = np.ma.MaskedArray([1], dtype=np.uint32)
 MAR_i: MaskedArray[np.int64] = np.ma.MaskedArray([1])
@@ -196,3 +194,6 @@ MAR_c **= AR_LIKE_u
 MAR_c **= AR_LIKE_i
 MAR_c **= AR_LIKE_f
 MAR_c **= AR_LIKE_c
+
+# https://github.com/numpy/numpy/issues/31737
+np.ma.masked_array([1])


### PR DESCRIPTION
Backport of #31738.

Fixes #31737.

No AI.