### PR TITLE
BLD: set minimum required gcc version to 10.3

### DIFF
--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -89,19 +89,11 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Install GCC9/10
+    - name: Install GCC10
       run: |
         echo "deb http://archive.ubuntu.com/ubuntu focal main universe" | sudo tee /etc/apt/sources.list.d/focal.list
         sudo apt update
-        sudo apt install -y g++-9 g++-10
-
-    - name: Enable gcc-9
-      run: |
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 1
-
-    - uses: ./.github/meson_actions
-      name: Build/Test against gcc-9
+        sudo apt install -y g++-10
 
     - name: Enable gcc-10
       run: |

--- a/doc/release/upcoming_changes/31843.change.rst
+++ b/doc/release/upcoming_changes/31843.change.rst
@@ -1,0 +1,1 @@
+* The minimum supported GCC version has been updated from 9.3.0 to 10.3.0

--- a/meson.build
+++ b/meson.build
@@ -21,8 +21,8 @@ cy = meson.get_compiler('cython')
 
 # Check compiler is recent enough (see the SciPy Toolchain Roadmap for details)
 if cc.get_id() == 'gcc'
-  if not cc.version().version_compare('>=9.3')
-    error('NumPy requires GCC >= 9.3')
+  if not cc.version().version_compare('>=10.3')
+    error('NumPy requires GCC >= 10.3')
   endif
 elif cc.get_id() == 'msvc'
   if not cc.version().version_compare('>=19.35')


### PR DESCRIPTION
### PR summary

Fixes #31828, see that issue for details.

#### AI Disclosure

No AI use.