### PR TITLE
PERF: Optimize reduction helper fast paths

### DIFF
--- a/doc/release/upcoming_changes/31845.performance.rst
+++ b/doc/release/upcoming_changes/31845.performance.rst
@@ -1,0 +1,6 @@
+Faster reductions on small arrays
+---------------------------------
+``numpy.sum``, ``numpy.prod``, ``numpy.min``, ``numpy.max``, ``numpy.any``,
+and ``numpy.all`` are now faster for small arrays. This reduces the
+Python-level overhead of calling these reductions, which is most noticeable
+when the reduction itself is cheap.

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -64,6 +64,11 @@ def _wrapfunc(obj, method, *args, **kwds):
         return _wrapit(obj, method, *args, **kwds)
 
 
+# The positional-only signature and unrolled _NoValue checks (rather than
+# **kwargs with a dict comprehension) are deliberate: these helpers are on
+# the hot path of every reduction (sum, prod, min, max, any, all), and
+# avoiding the creation and iteration of a temporary kwargs dict measurably
+# reduces call overhead for small arrays.  See gh-31845.
 def _wrapreduction(obj, ufunc, method, axis, dtype, out,
                    keepdims=_NoValue, initial=_NoValue, where=_NoValue, /):
     passkwargs = {}

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -64,8 +64,8 @@ def _wrapfunc(obj, method, *args, **kwds):
         return _wrapit(obj, method, *args, **kwds)
 
 
-def _wrapreduction(obj, ufunc, method, axis, dtype, out, *,
-                   keepdims=_NoValue, initial=_NoValue, where=_NoValue):
+def _wrapreduction(obj, ufunc, method, axis, dtype, out,
+                   keepdims=_NoValue, initial=_NoValue, where=_NoValue, /):
     passkwargs = {}
     if keepdims is not _NoValue:
         passkwargs["keepdims"] = keepdims
@@ -90,8 +90,8 @@ def _wrapreduction(obj, ufunc, method, axis, dtype, out, *,
     return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
 
 
-def _wrapreduction_any_all(obj, ufunc, method, axis, out, *,
-                           keepdims=_NoValue, where=_NoValue):
+def _wrapreduction_any_all(obj, ufunc, method, axis, out,
+                           keepdims=_NoValue, where=_NoValue, /):
     # Same as above function, but dtype is always bool (but never passed on)
     passkwargs = {}
     if keepdims is not _NoValue:
@@ -2497,8 +2497,7 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
         )
 
     return _wrapreduction(
-        a, np.add, 'sum', axis, dtype, out,
-        keepdims=keepdims, initial=initial, where=where
+        a, np.add, 'sum', axis, dtype, out, keepdims, initial, where
     )
 
 
@@ -2611,7 +2610,7 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
 
     """
     return _wrapreduction_any_all(a, np.logical_or, 'any', axis, out,
-                                  keepdims=keepdims, where=where)
+                                  keepdims, where)
 
 
 def _all_dispatcher(a, axis=None, out=None, keepdims=None, *,
@@ -2706,7 +2705,7 @@ def all(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
 
     """
     return _wrapreduction_any_all(a, np.logical_and, 'all', axis, out,
-                                  keepdims=keepdims, where=where)
+                                  keepdims, where)
 
 
 def _cumulative_func(x, func, axis, dtype, out, include_initial):
@@ -3195,7 +3194,7 @@ def max(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     5
     """
     return _wrapreduction(a, np.maximum, 'max', axis, None, out,
-                          keepdims=keepdims, initial=initial, where=where)
+                          keepdims, initial, where)
 
 
 @array_function_dispatch(_max_dispatcher)
@@ -3212,7 +3211,7 @@ def amax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     ndarray.max : equivalent method
     """
     return _wrapreduction(a, np.maximum, 'max', axis, None, out,
-                          keepdims=keepdims, initial=initial, where=where)
+                          keepdims, initial, where)
 
 
 def _min_dispatcher(a, axis=None, out=None, keepdims=None, initial=None,
@@ -3333,7 +3332,7 @@ def min(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     6
     """
     return _wrapreduction(a, np.minimum, 'min', axis, None, out,
-                          keepdims=keepdims, initial=initial, where=where)
+                          keepdims, initial, where)
 
 
 @array_function_dispatch(_min_dispatcher)
@@ -3350,7 +3349,7 @@ def amin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     ndarray.min : equivalent method
     """
     return _wrapreduction(a, np.minimum, 'min', axis, None, out,
-                          keepdims=keepdims, initial=initial, where=where)
+                          keepdims, initial, where)
 
 
 def _prod_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
@@ -3476,7 +3475,7 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     10
     """
     return _wrapreduction(a, np.multiply, 'prod', axis, dtype, out,
-                          keepdims=keepdims, initial=initial, where=where)
+                          keepdims, initial, where)
 
 
 def _cumprod_dispatcher(a, axis=None, dtype=None, out=None):

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -66,16 +66,13 @@ def _wrapfunc(obj, method, *args, **kwds):
 
 def _wrapreduction(obj, ufunc, method, axis, dtype, out, *,
                    keepdims=_NoValue, initial=_NoValue, where=_NoValue):
-    if keepdims is _NoValue and initial is _NoValue and where is _NoValue:
-        passkwargs = None
-    else:
-        passkwargs = {}
-        if keepdims is not _NoValue:
-            passkwargs["keepdims"] = keepdims
-        if initial is not _NoValue:
-            passkwargs["initial"] = initial
-        if where is not _NoValue:
-            passkwargs["where"] = where
+    passkwargs = {}
+    if keepdims is not _NoValue:
+        passkwargs["keepdims"] = keepdims
+    if initial is not _NoValue:
+        passkwargs["initial"] = initial
+    if where is not _NoValue:
+        passkwargs["where"] = where
 
     if type(obj) is not mu.ndarray:
         try:
@@ -86,31 +83,21 @@ def _wrapreduction(obj, ufunc, method, axis, dtype, out, *,
             # This branch is needed for reductions like any which don't
             # support a dtype.
             if dtype is not None:
-                if passkwargs is None:
-                    return reduction(axis=axis, dtype=dtype, out=out)
-                return reduction(axis=axis, dtype=dtype, out=out,
-                                 **passkwargs)
+                return reduction(axis=axis, dtype=dtype, out=out, **passkwargs)
             else:
-                if passkwargs is None:
-                    return reduction(axis=axis, out=out)
                 return reduction(axis=axis, out=out, **passkwargs)
 
-    if passkwargs is None:
-        return ufunc.reduce(obj, axis, dtype, out)
     return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
 
 
 def _wrapreduction_any_all(obj, ufunc, method, axis, out, *,
                            keepdims=_NoValue, where=_NoValue):
     # Same as above function, but dtype is always bool (but never passed on)
-    if keepdims is _NoValue and where is _NoValue:
-        passkwargs = None
-    else:
-        passkwargs = {}
-        if keepdims is not _NoValue:
-            passkwargs["keepdims"] = keepdims
-        if where is not _NoValue:
-            passkwargs["where"] = where
+    passkwargs = {}
+    if keepdims is not _NoValue:
+        passkwargs["keepdims"] = keepdims
+    if where is not _NoValue:
+        passkwargs["where"] = where
 
     if type(obj) is not mu.ndarray:
         try:
@@ -118,12 +105,8 @@ def _wrapreduction_any_all(obj, ufunc, method, axis, out, *,
         except AttributeError:
             pass
         else:
-            if passkwargs is None:
-                return reduction(axis=axis, out=out)
             return reduction(axis=axis, out=out, **passkwargs)
 
-    if passkwargs is None:
-        return ufunc.reduce(obj, axis, bool, out)
     return ufunc.reduce(obj, axis, bool, out, **passkwargs)
 
 

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -29,6 +29,7 @@ __all__ = [
 _gentype = types.GeneratorType
 # save away Python sum
 _sum_ = sum
+_NoValue = np._NoValue
 
 array_function_dispatch = functools.partial(
     overrides.array_function_dispatch, module='numpy')
@@ -63,9 +64,18 @@ def _wrapfunc(obj, method, *args, **kwds):
         return _wrapit(obj, method, *args, **kwds)
 
 
-def _wrapreduction(obj, ufunc, method, axis, dtype, out, **kwargs):
-    passkwargs = {k: v for k, v in kwargs.items()
-                  if v is not np._NoValue}
+def _wrapreduction(obj, ufunc, method, axis, dtype, out, *,
+                   keepdims=_NoValue, initial=_NoValue, where=_NoValue):
+    if keepdims is _NoValue and initial is _NoValue and where is _NoValue:
+        passkwargs = None
+    else:
+        passkwargs = {}
+        if keepdims is not _NoValue:
+            passkwargs["keepdims"] = keepdims
+        if initial is not _NoValue:
+            passkwargs["initial"] = initial
+        if where is not _NoValue:
+            passkwargs["where"] = where
 
     if type(obj) is not mu.ndarray:
         try:
@@ -76,17 +86,31 @@ def _wrapreduction(obj, ufunc, method, axis, dtype, out, **kwargs):
             # This branch is needed for reductions like any which don't
             # support a dtype.
             if dtype is not None:
-                return reduction(axis=axis, dtype=dtype, out=out, **passkwargs)
+                if passkwargs is None:
+                    return reduction(axis=axis, dtype=dtype, out=out)
+                return reduction(axis=axis, dtype=dtype, out=out,
+                                 **passkwargs)
             else:
+                if passkwargs is None:
+                    return reduction(axis=axis, out=out)
                 return reduction(axis=axis, out=out, **passkwargs)
 
+    if passkwargs is None:
+        return ufunc.reduce(obj, axis, dtype, out)
     return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
 
 
-def _wrapreduction_any_all(obj, ufunc, method, axis, out, **kwargs):
+def _wrapreduction_any_all(obj, ufunc, method, axis, out, *,
+                           keepdims=_NoValue, where=_NoValue):
     # Same as above function, but dtype is always bool (but never passed on)
-    passkwargs = {k: v for k, v in kwargs.items()
-                  if v is not np._NoValue}
+    if keepdims is _NoValue and where is _NoValue:
+        passkwargs = None
+    else:
+        passkwargs = {}
+        if keepdims is not _NoValue:
+            passkwargs["keepdims"] = keepdims
+        if where is not _NoValue:
+            passkwargs["where"] = where
 
     if type(obj) is not mu.ndarray:
         try:
@@ -94,8 +118,12 @@ def _wrapreduction_any_all(obj, ufunc, method, axis, out, **kwargs):
         except AttributeError:
             pass
         else:
+            if passkwargs is None:
+                return reduction(axis=axis, out=out)
             return reduction(axis=axis, out=out, **passkwargs)
 
+    if passkwargs is None:
+        return ufunc.reduce(obj, axis, bool, out)
     return ufunc.reduce(obj, axis, bool, out, **passkwargs)
 
 

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1469,11 +1469,9 @@ def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
     # Optimization to speed-up the most common cases.
     if not isinstance(axis, (tuple, list)):
         try:
-            axis = operator.index(axis)
+            axis = [operator.index(axis)]
         except TypeError:
             pass
-        else:
-            return (normalize_axis_index(axis, ndim, argname),)
     # Going via an iterator directly is slower than via list comprehension.
     axis = tuple(normalize_axis_index(ax, ndim, argname) for ax in axis)
     if not allow_duplicate and len(set(axis)) != len(axis):

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1469,9 +1469,11 @@ def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
     # Optimization to speed-up the most common cases.
     if not isinstance(axis, (tuple, list)):
         try:
-            axis = [operator.index(axis)]
+            axis = operator.index(axis)
         except TypeError:
             pass
+        else:
+            return (normalize_axis_index(axis, ndim, argname),)
     # Going via an iterator directly is slower than via list comprehension.
     axis = tuple(normalize_axis_index(ax, ndim, argname) for ax in axis)
     if not allow_duplicate and len(set(axis)) != len(axis):


### PR DESCRIPTION
### PR summary

This PR optimizes a common Python-level fast path used by NumPy reductions.

The change makes `_wrapreduction` and `_wrapreduction_any_all` take their known optional reduction arguments explicitly and positionally instead of collecting them through internal `**kwargs`. This avoids creating and iterating over a generic keyword dict in these private helpers while preserving the existing forwarding behavior for explicit `keepdims`, `initial`, and `where` values.

The PR is intentionally scoped to this internal reduction-wrapper cleanup only. The separate `normalize_axis_tuple` fast path and the extra empty-`passkwargs` direct-call fast path were removed to keep the patch smaller and easier to review.

ASV results for the affected in-tree reduction benchmarks:

```bash
spin bench --compare upstream/main HEAD \
  -t bench_reduce.SmallReduction \
  -t bench_reduce.StatsReductions.time_min \
  -t bench_reduce.StatsReductions.time_max \
  -t bench_reduce.StatsReductions.time_prod
```

reported `PERFORMANCE INCREASED`.

Representative rows from the focused run:

- `bench_reduce.SmallReduction.time_sum(4)`: `802±40ns -> 530±10ns`, ratio `0.66`
- `bench_reduce.SmallReduction.time_any(100)`: `735±20ns -> 478±20ns`, ratio `0.65`
- `bench_reduce.SmallReduction2D.time_sum_axis_1`: `1.06±0.01μs -> 761±10ns`, ratio `0.72`
- `bench_reduce.StatsReductions.time_prod("int64")`: `816±9ns -> 519±8ns`, ratio `0.64`
- `bench_reduce.StatsReductions.time_min("uint64")`: `781±30ns -> 506±8ns`, ratio `0.65`
- `bench_reduce.StatsReductions.time_max("float64")`: `800±20ns -> 500±6ns`, ratio `0.62`

### First time committer introduction

I am interested in NumPy performance work.

#### AI Disclosure

AI tools were used in preparing this PR.

Codex was used to run local tests and benchmarks, and help prepare draft PR text. A private tool was used to locate the issue, the code was reviewed by me before submission, and I am responsible for the final patch.