### PR TITLE
BUG: reject out-of-bounds indices in np.insert multi-element obj path

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5562,6 +5562,10 @@ def insert(arr, obj, values, axis=None):
         # Can safely cast the empty list to intp
         indices = indices.astype(intp)
 
+    if indices.size and (indices.min() < -N or indices.max() > N):
+        bad = indices[(indices < -N) | (indices > N)][0]
+        raise IndexError(f"index {bad} is out of bounds for axis {axis} "
+                         f"with size {N}")
     indices[indices < 0] += N
 
     numnew = len(indices)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -703,6 +703,13 @@ class TestInsert:
         with pytest.raises(IndexError, match='out of bounds'):
             np.insert([0, 1, 2], [idx], [3, 4])
 
+    @pytest.mark.parametrize('bad', [6, -6])
+    def test_index_out_of_bounds_multi(self, bad):
+        # A multi-element obj must reject out-of-bounds indices, matching the
+        # scalar/single-element path (gh-31777).
+        with pytest.raises(IndexError, match='out of bounds'):
+            np.insert(np.arange(5), [bad, 0], [9, 8])
+
 
 class TestAmax:
 


### PR DESCRIPTION
## Summary

Fixes #31777.

`np.insert` validates out-of-bounds indices only when `obj` is scalar or a single element. The multi-element path (`indices.size > 1`) runs `indices[indices < 0] += N` with no bounds check, so an out-of-range index is silently accepted instead of raising.

Example, `a = np.arange(5)` (size 5):

```
>>> np.insert(a, [-6, 0], [9, 8])
array([0, 8, 1, 2, 3, 4, 9])   # -6 silently treated as "end"
```

The scalar path and `np.delete` both raise `IndexError` for the same input. `insert` differs only because the multi-element branch indexes into `old_mask` (size `N + numnew`), where a negative wrap never trips an error.

This adds the same `[-N, N]` bounds check the scalar branch uses and reports the offending index. Positive out-of-bounds indices in this path were silently accepted too, and now raise, matching the scalar behavior.

## Changes

- `numpy/lib/_function_base_impl.py`: validate indices in the multi-element `insert` path before wrapping negatives.
- `numpy/lib/tests/test_function_base.py`: add `test_index_out_of_bounds_multi`, mirroring the existing single-element test.

## Testing

`pytest numpy/lib/tests/test_function_base.py -k TestInsert`
