### PR TITLE
ENH: implement `np.unwrap` as a generalized ufunc

### DIFF
--- a/doc/release/upcoming_changes/9959.change.rst
+++ b/doc/release/upcoming_changes/9959.change.rst
@@ -1,0 +1,10 @@
+``numpy.unwrap`` behavior changes for edge cases
+-------------------------------------------------
+An explicitly typed ``discont`` argument passed to `numpy.unwrap` wider than the
+result dtype is now compared at the result dtype rather than promoting. This may
+change the result of `numpy.unwrap` by ~1 ULP.
+
+Calling `numpy.unwrap` with an unsigned integer ``period`` that cannot represent
+the values needed internally now raises a `TypeError` ("no loop found" ufunc
+error, reporting the mismatched dtypes) instead of the ``OverflowError``
+raised by the previous Python implementation.

--- a/doc/release/upcoming_changes/9959.improvement.rst
+++ b/doc/release/upcoming_changes/9959.improvement.rst
@@ -4,4 +4,6 @@ The core of ``numpy.unwrap`` is now a generalized ufunc in C++ (signature ``(n),
 covering the floating point and signed integer dtypes while performing the operation
 in a single pass without the intermediate arrays the previous Python implementation
 had to allocate. As a result, ``numpy.unwrap`` now preserves the ``ndarray`` subclasses
-rather than always returning a base ``ndarray``.
+rather than always returning a base ``ndarray`` in all cases except masked arrays.
+For masked arrays and their subclasses, the current unwrap algorithm is ill-defined
+so it unmasks the maskedarray and performs the operation on an ndarray instead.

--- a/doc/release/upcoming_changes/9959.improvement.rst
+++ b/doc/release/upcoming_changes/9959.improvement.rst
@@ -1,0 +1,8 @@
+``numpy.unwrap`` is now implement as a generalized ufunc and preserves array subclasses
+---------------------------------------------------------------------------------------
+The core of ``numpy.unwrap`` is now a generalized ufunc in C (signature ``(n),(),()->(n)``)
+covering floating point, signed integer, and object dtypes while performing the operation
+in a single pass without allocating intermediate arrays the previous Python implementation
+had to allocate. As a result, ``numpy.unwrap`` now dispatches through ``__array_ufunc__``
+and preserves the ``ndarray`` subclasses rather than always returning a base ``ndarray``.
+

--- a/doc/release/upcoming_changes/9959.improvement.rst
+++ b/doc/release/upcoming_changes/9959.improvement.rst
@@ -1,7 +1,7 @@
-``numpy.unwrap`` is now implement as a generalized ufunc and preserves array subclasses
----------------------------------------------------------------------------------------
+``numpy.unwrap`` is now implemented as a generalized ufunc and preserves array subclasses
+-----------------------------------------------------------------------------------------
 The core of ``numpy.unwrap`` is now a generalized ufunc in C++ (signature ``(n),(),()->(n)``)
-covering floating point, signed integer, and object dtypes while performing the operation
-in a single pass without allocating intermediate arrays the previous Python implementation
+covering the floating point and signed integer dtypes while performing the operation
+in a single pass without the intermediate arrays the previous Python implementation
 had to allocate. As a result, ``numpy.unwrap`` now preserves the ``ndarray`` subclasses
 rather than always returning a base ``ndarray``.

--- a/doc/release/upcoming_changes/9959.improvement.rst
+++ b/doc/release/upcoming_changes/9959.improvement.rst
@@ -1,6 +1,6 @@
 ``numpy.unwrap`` is now implement as a generalized ufunc and preserves array subclasses
 ---------------------------------------------------------------------------------------
-The core of ``numpy.unwrap`` is now a generalized ufunc in C (signature ``(n),(),()->(n)``)
+The core of ``numpy.unwrap`` is now a generalized ufunc in C++ (signature ``(n),(),()->(n)``)
 covering floating point, signed integer, and object dtypes while performing the operation
 in a single pass without allocating intermediate arrays the previous Python implementation
 had to allocate. As a result, ``numpy.unwrap`` now preserves the ``ndarray`` subclasses

--- a/doc/release/upcoming_changes/9959.improvement.rst
+++ b/doc/release/upcoming_changes/9959.improvement.rst
@@ -3,6 +3,5 @@
 The core of ``numpy.unwrap`` is now a generalized ufunc in C (signature ``(n),(),()->(n)``)
 covering floating point, signed integer, and object dtypes while performing the operation
 in a single pass without allocating intermediate arrays the previous Python implementation
-had to allocate. As a result, ``numpy.unwrap`` now dispatches through ``__array_ufunc__``
-and preserves the ``ndarray`` subclasses rather than always returning a base ``ndarray``.
-
+had to allocate. As a result, ``numpy.unwrap`` now preserves the ``ndarray`` subclasses
+rather than always returning a base ``ndarray``.

--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -1206,6 +1206,12 @@ defdict = {
           TD(O),
           signature='(n),(n,m)->(m)',
           ),
+'_unwrap':
+    Ufunc(3, 1, None,
+          docstrings.get('numpy._core.umath._unwrap'),
+          None,
+          signature='(n),(),()->(n)',
+          ),
 # Real and imag ufunc helpers (loops added later):
 'real':
     Ufunc(1, 1, None,

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -3294,6 +3294,28 @@ add_newdoc('numpy._core.umath', '_ones_like',
 
     """)
 
+add_newdoc('numpy._core.umath', '_unwrap',
+    """
+    _unwrap(p, discont, period)
+
+    Generalized ufunc backing `numpy.unwrap`, with signature
+    ``(n),(),()->(n)``.
+
+    For each 1-D slice ``p`` along the core dimension, unwrap the values by
+    changing elements whose absolute difference from their predecessor exceeds
+    ``max(discont, period/2)`` to their `period`-complementary values, in a
+    single pass with no temporaries.  `discont` and `period` are scalars and
+    are expected to already share the common dtype of `p`; the public
+    `numpy.unwrap` wrapper fills their defaults, resolves that dtype and casts
+    them.  Loops are provided for the half, single, double and extended
+    floating-point dtypes, the signed integer dtypes and object.
+
+    See Also
+    --------
+    unwrap
+
+    """)
+
 add_newdoc('numpy._core.umath', 'power',
     """
     First array elements raised to powers from second array, element-wise.

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -3303,12 +3303,10 @@ add_newdoc('numpy._core.umath', '_unwrap',
 
     For each 1-D slice ``p`` along the core dimension, unwrap the values by
     changing elements whose absolute difference from their predecessor exceeds
-    ``max(discont, period/2)`` to their `period`-complementary values, in a
-    single pass with no temporaries.  `discont` and `period` are scalars and
-    are expected to already share the common dtype of `p`; the public
-    `numpy.unwrap` wrapper fills their defaults, resolves that dtype and casts
-    them.  Loops are provided for the half, single, double and extended
-    floating-point dtypes, the signed integer dtypes and object.
+    ``max(discont, period/2)`` to their `period`-complementary values.
+    `discont` and `period` are scalars that are expected to already share the
+    common dtype of `p`. The public `numpy.unwrap` wrapper fills their
+    defaults, resolves that dtype and casts them.
 
     See Also
     --------

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -3304,9 +3304,9 @@ add_newdoc('numpy._core.umath', '_unwrap',
     For each 1-D slice ``p`` along the core dimension, unwrap the values by
     changing elements whose absolute difference from their predecessor exceeds
     ``max(discont, period/2)`` to their `period`-complementary values.
-    `discont` and `period` are scalars that are expected to already share the
-    common dtype of `p`. The public `numpy.unwrap` wrapper fills their
-    defaults, resolves that dtype and casts them.
+    `period` is expected to already share `p`'s dtype, and `discont` its own
+    matching dtype. The public `numpy.unwrap` wrapper fills their defaults
+    and resolves and casts both before calling this.
 
     See Also
     --------

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -1280,6 +1280,8 @@ src_umath = umath_gen_headers + [
   src_file.process('src/umath/loops.c.src'),
   src_file.process('src/umath/matmul.c.src'),
   src_file.process('src/umath/matmul.h.src'),
+  'src/umath/unwrap.cpp',
+  'src/umath/unwrap.h',
   'src/umath/ufunc_type_resolution.c',
   'src/umath/clip.cpp',
   'src/umath/clip.h',

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -32,6 +32,7 @@
 #include "stringdtype_ufuncs.h"
 #include "special_integer_comparisons.h"
 #include "real_imag_ufuncs.h"
+#include "unwrap.h"
 #include "extobj.h"  /* for _extobject_contextvar exposure */
 #include "ufunc_type_resolution.h"
 
@@ -270,6 +271,10 @@ int initumath(PyObject *m)
         return -1;
     }
     Py_DECREF(s);
+
+    if (init_unwrap_ufunc(d) < 0 ) {
+        return -1;
+    }
 
     if (init_string_ufuncs(d) < 0) {
         return -1;

--- a/numpy/_core/src/umath/unwrap.cpp
+++ b/numpy/_core/src/umath/unwrap.cpp
@@ -86,19 +86,17 @@ floor_mod(T a, T b)
 }
 
 /*
- * One loop per real dtype. T is the storage/compute type; discont is read
- * as npy_longdouble only for the longdouble loop, npy_double otherwise.
- * npy_half has no native arithmetic, so it gets its own loop below.
+ * One loop per (T, D) pair. T is the storage/compute type; D is discont's
+ * type, either T itself (NEP 50 weak-scalar match) or a wider float type
+ * for explicitly-typed/cross-kind discont. npy_half has no native
+ * arithmetic, so it gets its own loop below.
  */
-template <typename T>
+template <typename T, typename D>
 static int
 unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
             npy_intp const dimensions[], npy_intp const strides[],
             NpyAuxData *NPY_UNUSED(auxdata))
 {
-    using D = std::conditional_t<std::is_same_v<T, npy_longdouble>,
-                                  npy_longdouble, npy_double>;
-
     npy_intp n_outer = dimensions[0];
     npy_intp n = dimensions[1];
     if (n == 0) {
@@ -162,6 +160,7 @@ unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 static inline float h2f(npy_half h) { return npy_half_to_float(h); }
 static inline npy_half f2h(float f) { return npy_float_to_half(f); }
 
+template <typename D>
 static int
 unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
                  npy_intp const dimensions[], npy_intp const strides[],
@@ -181,7 +180,15 @@ unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 
     for (npy_intp k = 0; k < n_outer; k++,
             p_o += s_p, disc_o += s_disc, per_o += s_per, out_o += s_out) {
-        npy_double discont = *(const npy_double *)disc_o;
+        /* npy_half discont is read through h2f, matching the NEP 50 weak-
+         * scalar case where discont is compared at half precision */
+        double discont;
+        if constexpr (std::is_same_v<D, npy_half>) {
+            discont = h2f(*(const npy_half *)disc_o);
+        }
+        else {
+            discont = *(const D *)disc_o;
+        }
         npy_half period = *(const npy_half *)per_o;
         npy_half interval_high = f2h(h2f(period) / 2.0f);
         npy_half interval_low = f2h(-h2f(interval_high));
@@ -218,7 +225,7 @@ unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 
 static int
 add_unwrap_loop(PyObject *ufunc, int typenum,
-                PyArrayMethod_StridedLoop *loop, int discont_typenum = NPY_DOUBLE)
+                PyArrayMethod_StridedLoop *loop, int discont_typenum)
 {
     PyArray_DTypeMeta *dt = PyArray_DTypeFromTypeNum(typenum);
     if (dt == NULL) {
@@ -272,28 +279,37 @@ init_unwrap_ufunc(PyObject *umath)
     struct Loop {
         int typenum;
         PyArrayMethod_StridedLoop *loop;
+        int discont_typenum;
     };
 
+    /*
+     * float dtypes get two loops: discont at native precision (the NEP 50
+     * weak-scalar case, where the python wrapper matches discont to p's
+     * dtype) and at wider precision (explicitly-typed/cross-kind discont).
+     * Integer dtypes only get the wider loop -- NEP 50 native-int discont
+     * is not implemented, so the wrapper always widens for those.
+     */
     Loop loops[] = {
-        {NPY_HALF, unwrap_half_loop},
-        {NPY_FLOAT, unwrap_loop<npy_float>},
-        {NPY_DOUBLE, unwrap_loop<npy_double>},
-        {NPY_LONGDOUBLE, unwrap_loop<npy_longdouble>},
-        {NPY_BYTE, unwrap_loop<npy_byte>},
-        {NPY_SHORT, unwrap_loop<npy_short>},
-        {NPY_INT, unwrap_loop<npy_int>},
-        {NPY_LONG, unwrap_loop<npy_long>},
-        {NPY_LONGLONG, unwrap_loop<npy_longlong>},
+        {NPY_HALF, unwrap_half_loop<npy_half>, NPY_HALF},
+        {NPY_HALF, unwrap_half_loop<npy_double>, NPY_DOUBLE},
+        {NPY_FLOAT, unwrap_loop<npy_float, npy_float>, NPY_FLOAT},
+        {NPY_FLOAT, unwrap_loop<npy_float, npy_double>, NPY_DOUBLE},
+        {NPY_DOUBLE, unwrap_loop<npy_double, npy_double>, NPY_DOUBLE},
+        {NPY_LONGDOUBLE, unwrap_loop<npy_longdouble, npy_longdouble>,
+         NPY_LONGDOUBLE},
+        {NPY_BYTE, unwrap_loop<npy_byte, npy_double>, NPY_DOUBLE},
+        {NPY_SHORT, unwrap_loop<npy_short, npy_double>, NPY_DOUBLE},
+        {NPY_INT, unwrap_loop<npy_int, npy_double>, NPY_DOUBLE},
+        {NPY_LONG, unwrap_loop<npy_long, npy_double>, NPY_DOUBLE},
+        {NPY_LONGLONG, unwrap_loop<npy_longlong, npy_double>, NPY_DOUBLE},
         /* object dtype falls back to the python implementation instead */
         // {NPY_OBJECT, object_unwrap_loop},
     };
 
     int res = 0;
     for (const auto& entry : loops) {
-        int discont_typenum = entry.typenum == NPY_LONGDOUBLE
-                ? NPY_LONGDOUBLE : NPY_DOUBLE;
         if (add_unwrap_loop(ufunc, entry.typenum, entry.loop,
-                             discont_typenum) < 0) {
+                             entry.discont_typenum) < 0) {
             res = -1;
             break;
         }

--- a/numpy/_core/src/umath/unwrap.cpp
+++ b/numpy/_core/src/umath/unwrap.cpp
@@ -1,0 +1,293 @@
+/**
+ * This module provides the inner loops for the unwrap ufunc
+ */
+
+#define _UMATHMODULE
+#define _MULTIARRAYMODULE
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <type_traits>
+
+#include "numpy/halffloat.h"
+#include "numpy/ndarraytypes.h"
+#include "numpy/npy_common.h"
+#include "numpy/npy_math.h"
+#include "numpy/utils.h"
+#include "array_method.h"
+#include "dispatching.h"
+#include "dtypemeta.h"
+
+#include "unwrap.h"
+
+
+/*
+ * `unwrap` is a scan (each output depends on the running phase correction of
+ * the whole prefix along the core axis), so it cannot be a plain element-wise
+ * ufunc.  Each loop performs the diff / modular-wrap / cumulative-correction in
+ * a single pass over the core dimension, without allocating any temporaries.
+ *
+ * The operands are, in order, the values `p` (core `(n)`), the scalars
+ * `discont` and `period`, and the output (core `(n)`).  The Python wrapper in
+ * numpy/lib/_function_base_impl.py fills the `discont`/`period` defaults,
+ * resolves the common dtype and casts the scalars to it (rounding `discont` up
+ * for integer dtypes so that the `|dd| < discont` threshold keeps its meaning).
+ *
+ * gufunc strided-loop layout for signature (n),(),()->(n):
+ *   dimensions[0]      outer (broadcast) loop count
+ *   dimensions[1]      core length n
+ *   strides[0..3]      outer strides for p, discont, period, out
+ *   strides[4]         core stride of p
+ *   strides[5]         core stride of out
+ */
+
+/*
+ * floor-modulo matching numpy's `mod`, picked by overload on the npy floating
+ * types.  The long double overload is only defined when it is a distinct type
+ * from double (otherwise the double overload already covers npy_longdouble).
+ */
+static inline npy_float
+floor_mod(npy_float a, npy_float b)
+{
+    npy_float m;
+    npy_divmodf(a, b, &m);
+    return m;
+}
+static inline npy_double
+floor_mod(npy_double a, npy_double b)
+{
+    npy_double m;
+    npy_divmod(a, b, &m);
+    return m;
+}
+#if NPY_SIZEOF_LONGDOUBLE != NPY_SIZEOF_DOUBLE
+static inline npy_longdouble
+floor_mod(npy_longdouble a, npy_longdouble b)
+{
+    npy_longdouble m;
+    npy_divmodl(a, b, &m);
+    return m;
+}
+#endif
+
+/*
+ * One strided loop per real dtype.  `T` is both the storage and the compute
+ * type; the integer vs. floating-point parts of the algorithm (floor division
+ * for the interval, the even-period boundary, integer floor-modulo) select with
+ * `if constexpr` on `T`.  `discont` is only a threshold (never part of the wrap
+ * arithmetic), so it is always a plain double operand -- it keeps its value
+ * exactly and never drags the result dtype (e.g. integer input stays integer).
+ *
+ * `npy_half` has no native arithmetic, so it gets its own loop below that
+ * computes in float; every other real dtype uses this template.
+ */
+template <typename T>
+static int
+unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
+            npy_intp const dimensions[], npy_intp const strides[],
+            NpyAuxData *NPY_UNUSED(auxdata))
+{
+    npy_intp n_outer = dimensions[0];
+    npy_intp n = dimensions[1];
+    npy_intp s_p = strides[0], s_disc = strides[1];
+    npy_intp s_per = strides[2], s_out = strides[3];
+    npy_intp ip_step = strides[4];
+    npy_intp op_step = strides[5];
+
+    char *p_o = data[0], *disc_o = data[1], *per_o = data[2], *out_o = data[3];
+
+    for (npy_intp k = 0; k < n_outer; k++,
+            p_o += s_p, disc_o += s_disc, per_o += s_per, out_o += s_out) {
+        if (n <= 0) {
+            continue;
+        }
+        npy_double discont = *(const npy_double *)disc_o;
+        T period = *(const T *)per_o;
+        /* floor division for ints, exact half for floats */
+        T interval_high = period / 2;
+        T interval_low = -interval_high;
+        bool boundary_ambiguous;
+        if constexpr (std::is_integral_v<T>) {
+            /* only an even period has a representable +/-period/2 boundary */
+            boundary_ambiguous = (period % 2) == 0;
+        }
+        else {
+            boundary_ambiguous = true;
+        }
+
+        const char *ip = p_o;
+        char *op = out_o;
+        T prev = *(const T *)ip;
+        *(T *)op = prev;
+        T cum = 0;
+        for (npy_intp i = 1; i < n; i++) {
+            ip += ip_step;
+            op += op_step;
+            T cur = *(const T *)ip;
+            T dd = cur - prev;
+            T ddmod;
+            if constexpr (std::is_integral_v<T>) {
+                /* floor-modulo into [0, period); period > 0 so a single fixup */
+                T m = (T)((dd - interval_low) % period);
+                if (m < 0) {
+                    m += period;
+                }
+                ddmod = m + interval_low;
+            }
+            else {
+                ddmod = floor_mod(dd - interval_low, period) + interval_low;
+            }
+            if (boundary_ambiguous && ddmod == interval_low && dd > 0) {
+                ddmod = interval_high;
+            }
+            T corr = ddmod - dd;
+            T adiff = dd < 0 ? (T)-dd : dd;
+            if (adiff < discont) {
+                corr = 0;
+            }
+            cum += corr;
+            *(T *)op = (T)(cur + cum);
+            prev = cur;
+        }
+    }
+    return 0;
+}
+
+/* Half is stored as npy_half but has no native arithmetic, so it loads/stores
+ * npy_half and does the whole scan in float. */
+static int
+unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
+                 npy_intp const dimensions[], npy_intp const strides[],
+                 NpyAuxData *NPY_UNUSED(auxdata))
+{
+    npy_intp n_outer = dimensions[0];
+    npy_intp n = dimensions[1];
+    npy_intp s_p = strides[0], s_disc = strides[1];
+    npy_intp s_per = strides[2], s_out = strides[3];
+    npy_intp ip_step = strides[4];
+    npy_intp op_step = strides[5];
+
+    char *p_o = data[0], *disc_o = data[1], *per_o = data[2], *out_o = data[3];
+
+    for (npy_intp k = 0; k < n_outer; k++,
+            p_o += s_p, disc_o += s_disc, per_o += s_per, out_o += s_out) {
+        if (n <= 0) {
+            continue;
+        }
+        npy_double discont = *(const npy_double *)disc_o;
+        float period = npy_half_to_float(*(const npy_half *)per_o);
+        float interval_high = period / 2;
+        float interval_low = -interval_high;
+
+        const char *ip = p_o;
+        char *op = out_o;
+        float prev = npy_half_to_float(*(const npy_half *)ip);
+        *(npy_half *)op = npy_float_to_half(prev);
+        float cum = 0;
+        for (npy_intp i = 1; i < n; i++) {
+            ip += ip_step;
+            op += op_step;
+            float cur = npy_half_to_float(*(const npy_half *)ip);
+            float dd = cur - prev;
+            float ddmod = floor_mod(dd - interval_low, period) + interval_low;
+            if (ddmod == interval_low && dd > 0) {
+                ddmod = interval_high;
+            }
+            float corr = ddmod - dd;
+            float adiff = dd < 0 ? -dd : dd;
+            if (adiff < discont) {
+                corr = 0;
+            }
+            cum += corr;
+            *(npy_half *)op = npy_float_to_half(cur + cum);
+            prev = cur;
+        }
+    }
+    return 0;
+}
+
+
+static int
+add_unwrap_loop(PyObject *ufunc, int typenum,
+                PyArrayMethod_StridedLoop *loop)
+{
+    PyArray_DTypeMeta *dt = PyArray_DTypeFromTypeNum(typenum);
+    if (dt == NULL) {
+        return -1;
+    }
+    PyArray_DTypeMeta *dbl = PyArray_DTypeFromTypeNum(NPY_DOUBLE);
+    if (dbl == NULL) {
+        Py_DECREF(dt);
+        return -1;
+    }
+    /* p, out and period share the loop dtype; discont is always double. */
+    PyArray_DTypeMeta *dtypes[4] = {dt, dbl, dt, dt};
+    PyType_Slot slots[] = {
+        {NPY_METH_strided_loop, (void *)loop},
+        {0, NULL}
+    };
+
+    PyArrayMethod_Spec spec = {};
+    spec.name = "unwrap_loop";
+    spec.nin = 3;
+    spec.nout = 1;
+    spec.casting = NPY_NO_CASTING;
+    spec.flags = (NPY_ARRAYMETHOD_FLAGS)0;
+    spec.dtypes = dtypes;
+    spec.slots = slots;
+
+    if (PyUFunc_AddLoopFromSpec_int(ufunc, &spec, 1)) {
+        Py_DECREF(dt);
+        Py_DECREF(dbl);
+        return -1;
+    }
+    Py_DECREF(dbl);
+
+    Py_DECREF(dt);
+    return 0;
+}
+
+NPY_NO_EXPORT int
+init_unwrap_ufunc(PyObject *umath)
+{
+    PyObject *name = PyUnicode_FromString("_unwrap");
+    if (name == NULL) {
+        return -1;
+    }
+    PyObject *ufunc = PyObject_GetItem(umath, name);
+    Py_DECREF(name);
+    if (ufunc == NULL) {
+        return -1;
+    }
+
+    struct Loop {
+        int typenum;
+        PyArrayMethod_StridedLoop *loop;
+    };
+
+    Loop loops[] = {
+        {NPY_HALF, unwrap_half_loop},
+        {NPY_FLOAT, unwrap_loop<npy_float>},
+        {NPY_DOUBLE, unwrap_loop<npy_double>},
+        {NPY_LONGDOUBLE, unwrap_loop<npy_longdouble>},
+        {NPY_BYTE, unwrap_loop<npy_byte>},
+        {NPY_SHORT, unwrap_loop<npy_short>},
+        {NPY_INT, unwrap_loop<npy_int>},
+        {NPY_LONG, unwrap_loop<npy_long>},
+        {NPY_LONGLONG, unwrap_loop<npy_longlong>},
+        // {NPY_OBJECT, object_unwrap_loop},
+    };
+
+    int res = 0;
+    for (const auto& entry : loops) {
+        if (add_unwrap_loop(ufunc, entry.typenum, entry.loop) < 0) {
+            res = -1;
+            break;
+        }
+    }
+
+    Py_DECREF(ufunc);
+    return res;
+}

--- a/numpy/_core/src/umath/unwrap.cpp
+++ b/numpy/_core/src/umath/unwrap.cpp
@@ -9,6 +9,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#include <limits>
 #include <type_traits>
 
 #include "numpy/halffloat.h"
@@ -32,8 +33,7 @@
  * The operands are, in order, the values `p` (core `(n)`), the scalars
  * `discont` and `period`, and the output (core `(n)`).  The Python wrapper in
  * numpy/lib/_function_base_impl.py fills the `discont`/`period` defaults,
- * resolves the common dtype and casts the scalars to it (rounding `discont` up
- * for integer dtypes so that the `|dd| < discont` threshold keeps its meaning).
+ * resolves the common dtype and casts the scalars to it.
  *
  * gufunc strided-loop layout for signature (n),(),()->(n):
  *   dimensions[0]      outer (broadcast) loop count
@@ -43,63 +43,46 @@
  *   strides[5]         core stride of out
  */
 
-/*
- * floor-modulo matching numpy's `mod`, picked by overload on the npy floating
- * types.  The long double overload is only defined when it is a distinct type
- * from double (otherwise the double overload already covers npy_longdouble).
- */
+/* floor-modulo matching numpy's `mod`, same as @TYPE@_remainder in loops.c.src */
 static inline npy_float
 floor_mod(npy_float a, npy_float b)
 {
-    npy_float m;
-    npy_divmodf(a, b, &m);
-    return m;
+    return npy_remainderf(a, b);
 }
 static inline npy_double
 floor_mod(npy_double a, npy_double b)
 {
-    npy_double m;
-    npy_divmod(a, b, &m);
-    return m;
+    return npy_remainder(a, b);
 }
 #if NPY_SIZEOF_LONGDOUBLE != NPY_SIZEOF_DOUBLE
 static inline npy_longdouble
 floor_mod(npy_longdouble a, npy_longdouble b)
 {
-    npy_longdouble m;
-    npy_divmodl(a, b, &m);
-    return m;
+    return npy_remainderl(a, b);
 }
 #endif
-/*
- * integer floor-modulo into [0, b).
- * if b == 0, returns 0 and sets the floating-point divide-by-zero flag
- */
+
+/* no integer npy_remainder to call; mirrors @TYPE@_remainder in
+ * loops_modulo.dispatch.c.src, including the T_MIN / -1 guard */
 template <typename T>
 static inline std::enable_if_t<std::is_integral_v<T>, T>
 floor_mod(T a, T b)
 {
-    if (b == 0) {
+    if (b == 0 || (a == std::numeric_limits<T>::min() && b == -1)) {
         npy_set_floatstatus_divbyzero();
         return 0;
     }
-    T m = a % b;
-    if (m < 0) {
-        m += b;
+    T rem = a % b;
+    if ((a > 0) == (b > 0) || rem == 0) {
+        return rem;
     }
-    return m;
+    return rem + b;
 }
 
 /*
- * One strided loop per real dtype.  `T` is both the storage and the compute
- * type; the integer vs. floating-point parts of the algorithm (floor division
- * for the interval, the even-period boundary, integer floor-modulo) select with
- * `if constexpr` on `T`.  `discont` is only a threshold (never part of the wrap
- * arithmetic), so it is always a plain double operand -- it keeps its value
- * exactly and never drags the result dtype (e.g. integer input stays integer).
- *
- * `npy_half` has no native arithmetic, so it gets its own loop below that
- * computes in float; every other real dtype uses this template.
+ * One loop per real dtype. T is the storage/compute type; discont is read
+ * as npy_longdouble only for the longdouble loop, npy_double otherwise.
+ * npy_half has no native arithmetic, so it gets its own loop below.
  */
 template <typename T>
 static int
@@ -107,6 +90,9 @@ unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
             npy_intp const dimensions[], npy_intp const strides[],
             NpyAuxData *NPY_UNUSED(auxdata))
 {
+    using D = std::conditional_t<std::is_same_v<T, npy_longdouble>,
+                                  npy_longdouble, npy_double>;
+
     npy_intp n_outer = dimensions[0];
     npy_intp n = dimensions[1];
     npy_intp s_p = strides[0], s_disc = strides[1];
@@ -121,19 +107,21 @@ unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
         if (n <= 0) {
             continue;
         }
-        npy_double discont = *(const npy_double *)disc_o;
+        D discont = *(const D *)disc_o;
         T period = *(const T *)per_o;
-        /* floor division for ints, exact half for floats */
-        T interval_high = period / 2;
-        T interval_low = -interval_high;
+        T interval_high;
         bool boundary_ambiguous;
         if constexpr (std::is_integral_v<T>) {
-            /* only an even period has a representable +/-period/2 boundary */
-            boundary_ambiguous = (period % 2) == 0;
+            /* floor((period)/2), matching python's `divmod(period, 2)` */
+            T rem = floor_mod(period, (T)2);
+            interval_high = (period - rem) / 2;
+            boundary_ambiguous = (rem == 0);
         }
         else {
+            interval_high = period / 2;
             boundary_ambiguous = true;
         }
+        T interval_low = -interval_high;
 
         const char *ip = p_o;
         char *op = out_o;
@@ -145,14 +133,13 @@ unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
             op += op_step;
             T cur = *(const T *)ip;
             T dd = cur - prev;
-            /* wrap the raw diff into [interval_low, interval_low + period);
-             * floor_mod dispatches to the integer or floating overload on T. */
+            /* wrap the raw diff into [interval_low, interval_low + period) */
             T ddmod = (T)(floor_mod((T)(dd - interval_low), period) + interval_low);
             if (boundary_ambiguous && ddmod == interval_low && dd > 0) {
                 ddmod = interval_high;
             }
             T corr = ddmod - dd;
-            T adiff = dd < 0 ? (T)-dd : dd;
+            D adiff = (D)(dd < 0 ? (T)-dd : dd);
             if (adiff < discont) {
                 corr = 0;
             }
@@ -164,8 +151,11 @@ unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
     return 0;
 }
 
-/* Half is stored as npy_half but has no native arithmetic, so it loads/stores
- * npy_half and does the whole scan in float. */
+/* rounds to half after every step, like numpy's own HALF_remainder loop,
+ * instead of only at the end -- that changes the result */
+static inline float h2f(npy_half h) { return npy_half_to_float(h); }
+static inline npy_half f2h(float f) { return npy_float_to_half(f); }
+
 static int
 unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
                  npy_intp const dimensions[], npy_intp const strides[],
@@ -186,31 +176,33 @@ unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
             continue;
         }
         npy_double discont = *(const npy_double *)disc_o;
-        float period = npy_half_to_float(*(const npy_half *)per_o);
-        float interval_high = period / 2;
-        float interval_low = -interval_high;
+        npy_half period = *(const npy_half *)per_o;
+        npy_half interval_high = f2h(h2f(period) / 2.0f);
+        npy_half interval_low = f2h(-h2f(interval_high));
 
         const char *ip = p_o;
         char *op = out_o;
-        float prev = npy_half_to_float(*(const npy_half *)ip);
-        *(npy_half *)op = npy_float_to_half(prev);
-        float cum = 0;
+        npy_half prev = *(const npy_half *)ip;
+        *(npy_half *)op = prev;
+        npy_half cum = f2h(0.0f);
         for (npy_intp i = 1; i < n; i++) {
             ip += ip_step;
             op += op_step;
-            float cur = npy_half_to_float(*(const npy_half *)ip);
-            float dd = cur - prev;
-            float ddmod = floor_mod(dd - interval_low, period) + interval_low;
-            if (ddmod == interval_low && dd > 0) {
+            npy_half cur = *(const npy_half *)ip;
+            npy_half dd = f2h(h2f(cur) - h2f(prev));
+            npy_half t1 = f2h(h2f(dd) - h2f(interval_low));
+            npy_half t2 = f2h(floor_mod(h2f(t1), h2f(period)));
+            npy_half ddmod = f2h(h2f(t2) + h2f(interval_low));
+            if (ddmod == interval_low && h2f(dd) > 0) {
                 ddmod = interval_high;
             }
-            float corr = ddmod - dd;
-            float adiff = dd < 0 ? -dd : dd;
+            npy_half corr = f2h(h2f(ddmod) - h2f(dd));
+            double adiff = h2f(dd) < 0 ? -(double)h2f(dd) : (double)h2f(dd);
             if (adiff < discont) {
-                corr = 0;
+                corr = f2h(0.0f);
             }
-            cum += corr;
-            *(npy_half *)op = npy_float_to_half(cur + cum);
+            cum = f2h(h2f(cum) + h2f(corr));
+            *(npy_half *)op = f2h(h2f(cur) + h2f(cum));
             prev = cur;
         }
     }
@@ -220,19 +212,19 @@ unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 
 static int
 add_unwrap_loop(PyObject *ufunc, int typenum,
-                PyArrayMethod_StridedLoop *loop)
+                PyArrayMethod_StridedLoop *loop, int discont_typenum = NPY_DOUBLE)
 {
     PyArray_DTypeMeta *dt = PyArray_DTypeFromTypeNum(typenum);
     if (dt == NULL) {
         return -1;
     }
-    PyArray_DTypeMeta *dbl = PyArray_DTypeFromTypeNum(NPY_DOUBLE);
-    if (dbl == NULL) {
+    PyArray_DTypeMeta *disc_dt = PyArray_DTypeFromTypeNum(discont_typenum);
+    if (disc_dt == NULL) {
         Py_DECREF(dt);
         return -1;
     }
-    /* p, out and period share the loop dtype; discont is always double. */
-    PyArray_DTypeMeta *dtypes[4] = {dt, dbl, dt, dt};
+    /* p, out and period share the loop dtype; discont has its own dtype. */
+    PyArray_DTypeMeta *dtypes[4] = {dt, disc_dt, dt, dt};
     PyType_Slot slots[] = {
         {NPY_METH_strided_loop, (void *)loop},
         {0, NULL}
@@ -249,10 +241,10 @@ add_unwrap_loop(PyObject *ufunc, int typenum,
 
     if (PyUFunc_AddLoopFromSpec_int(ufunc, &spec, 1)) {
         Py_DECREF(dt);
-        Py_DECREF(dbl);
+        Py_DECREF(disc_dt);
         return -1;
     }
-    Py_DECREF(dbl);
+    Py_DECREF(disc_dt);
 
     Py_DECREF(dt);
     return 0;
@@ -286,16 +278,16 @@ init_unwrap_ufunc(PyObject *umath)
         {NPY_INT, unwrap_loop<npy_int>},
         {NPY_LONG, unwrap_loop<npy_long>},
         {NPY_LONGLONG, unwrap_loop<npy_longlong>},
-        /*
-         * We could implement a gufunc loop for object dtype
-         * but it's not worth the burden of all the extra c++ code.
-        */
+        /* object dtype falls back to the python implementation instead */
         // {NPY_OBJECT, object_unwrap_loop},
     };
 
     int res = 0;
     for (const auto& entry : loops) {
-        if (add_unwrap_loop(ufunc, entry.typenum, entry.loop) < 0) {
+        int discont_typenum = entry.typenum == NPY_LONGDOUBLE
+                ? NPY_LONGDOUBLE : NPY_DOUBLE;
+        if (add_unwrap_loop(ufunc, entry.typenum, entry.loop,
+                             discont_typenum) < 0) {
             res = -1;
             break;
         }

--- a/numpy/_core/src/umath/unwrap.cpp
+++ b/numpy/_core/src/umath/unwrap.cpp
@@ -277,6 +277,10 @@ init_unwrap_ufunc(PyObject *umath)
         {NPY_INT, unwrap_loop<npy_int>},
         {NPY_LONG, unwrap_loop<npy_long>},
         {NPY_LONGLONG, unwrap_loop<npy_longlong>},
+        /*
+         * We could implement a gufunc loop for object dtype
+         * but it's not worth the burden of all the extra c++ code.
+        */
         // {NPY_OBJECT, object_unwrap_loop},
     };
 

--- a/numpy/_core/src/umath/unwrap.cpp
+++ b/numpy/_core/src/umath/unwrap.cpp
@@ -71,6 +71,17 @@ floor_mod(npy_longdouble a, npy_longdouble b)
     return m;
 }
 #endif
+/* integer floor-modulo into [0, b); the caller guarantees b > 0. */
+template <typename T>
+static inline std::enable_if_t<std::is_integral_v<T>, T>
+floor_mod(T a, T b)
+{
+    T m = a % b;
+    if (m < 0) {
+        m += b;
+    }
+    return m;
+}
 
 /*
  * One strided loop per real dtype.  `T` is both the storage and the compute
@@ -127,18 +138,9 @@ unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
             op += op_step;
             T cur = *(const T *)ip;
             T dd = cur - prev;
-            T ddmod;
-            if constexpr (std::is_integral_v<T>) {
-                /* floor-modulo into [0, period); period > 0 so a single fixup */
-                T m = (T)((dd - interval_low) % period);
-                if (m < 0) {
-                    m += period;
-                }
-                ddmod = m + interval_low;
-            }
-            else {
-                ddmod = floor_mod(dd - interval_low, period) + interval_low;
-            }
+            /* wrap the raw diff into [interval_low, interval_low + period);
+             * floor_mod dispatches to the integer or floating overload on T. */
+            T ddmod = (T)(floor_mod((T)(dd - interval_low), period) + interval_low);
             if (boundary_ambiguous && ddmod == interval_low && dd > 0) {
                 ddmod = interval_high;
             }

--- a/numpy/_core/src/umath/unwrap.cpp
+++ b/numpy/_core/src/umath/unwrap.cpp
@@ -9,7 +9,6 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-#include <limits>
 #include <type_traits>
 
 #include "numpy/halffloat.h"
@@ -63,9 +62,11 @@ floor_mod(npy_longdouble a, npy_longdouble b)
 #endif
 
 /* no integer npy_remainder to call; mirrors @TYPE@_remainder in
- * loops_modulo.dispatch.c.src, including the T_MIN / -1 guard */
+ * loops_modulo.dispatch.c.src, including the T_MIN / -1 guard (which sets
+ * no floating point status there either -- only the quotient overflows,
+ * and this only ever computes the remainder) */
 template <typename T>
-static inline std::enable_if_t<std::is_integral_v<T>, T>
+static inline std::enable_if_t<std::is_integral_v<T> && std::is_signed_v<T>, T>
 floor_mod(T a, T b)
 {
     if (b == 0) {
@@ -73,9 +74,6 @@ floor_mod(T a, T b)
         return 0;
     }
     if (b == -1) {
-        if (a == std::numeric_limits<T>::min()) {
-            npy_set_floatstatus_divbyzero();
-        }
         return 0;
     }
     T rem = a % b;
@@ -86,17 +84,18 @@ floor_mod(T a, T b)
 }
 
 /*
- * One loop per (T, D) pair. T is the storage/compute type; D is discont's
- * type, either T itself (NEP 50 weak-scalar match) or a wider float type
- * for explicitly-typed/cross-kind discont. npy_half has no native
- * arithmetic, so it gets its own loop below.
+ * One loop per real dtype. T is the storage/compute type; discont is read
+ * as T itself for the float dtypes, npy_double for the integer ones.
+ * npy_half has no native arithmetic, so it gets its own loop below.
  */
-template <typename T, typename D>
+template <typename T>
 static int
 unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
             npy_intp const dimensions[], npy_intp const strides[],
             NpyAuxData *NPY_UNUSED(auxdata))
 {
+    using D = std::conditional_t<std::is_floating_point_v<T>, T, npy_double>;
+
     npy_intp n_outer = dimensions[0];
     npy_intp n = dimensions[1];
     if (n == 0) {
@@ -160,7 +159,6 @@ unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 static inline float h2f(npy_half h) { return npy_half_to_float(h); }
 static inline npy_half f2h(float f) { return npy_float_to_half(f); }
 
-template <typename D>
 static int
 unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
                  npy_intp const dimensions[], npy_intp const strides[],
@@ -180,15 +178,7 @@ unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 
     for (npy_intp k = 0; k < n_outer; k++,
             p_o += s_p, disc_o += s_disc, per_o += s_per, out_o += s_out) {
-        /* npy_half discont is read through h2f, matching the NEP 50 weak-
-         * scalar case where discont is compared at half precision */
-        double discont;
-        if constexpr (std::is_same_v<D, npy_half>) {
-            discont = h2f(*(const npy_half *)disc_o);
-        }
-        else {
-            discont = *(const D *)disc_o;
-        }
+        double discont = h2f(*(const npy_half *)disc_o);
         npy_half period = *(const npy_half *)per_o;
         npy_half interval_high = f2h(h2f(period) / 2.0f);
         npy_half interval_low = f2h(-h2f(interval_high));
@@ -224,13 +214,15 @@ unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 
 
 static int
-add_unwrap_loop(PyObject *ufunc, int typenum,
-                PyArrayMethod_StridedLoop *loop, int discont_typenum)
+add_unwrap_loop(PyObject *ufunc, int typenum, PyArrayMethod_StridedLoop *loop)
 {
     PyArray_DTypeMeta *dt = PyArray_DTypeFromTypeNum(typenum);
     if (dt == NULL) {
         return -1;
     }
+    /* discont is read at typenum's own precision for float dtypes, double
+     * for the integer ones -- matches unwrap_loop's own D derivation */
+    int discont_typenum = PyTypeNum_ISFLOAT(typenum) ? typenum : NPY_DOUBLE;
     PyArray_DTypeMeta *disc_dt = PyArray_DTypeFromTypeNum(discont_typenum);
     if (disc_dt == NULL) {
         Py_DECREF(dt);
@@ -274,36 +266,24 @@ init_unwrap_ufunc(PyObject *umath)
     struct Loop {
         int typenum;
         PyArrayMethod_StridedLoop *loop;
-        int discont_typenum;
     };
 
-    /*
-     * float dtypes get two loops: discont at native precision (the NEP 50
-     * weak-scalar case, where the python wrapper matches discont to p's
-     * dtype) and at wider precision (explicitly-typed/cross-kind discont).
-     * Integer dtypes only get the wider loop -- NEP 50 native-int discont
-     * is not implemented, so the wrapper always widens for those.
-     */
     Loop loops[] = {
-        {NPY_HALF, unwrap_half_loop<npy_half>, NPY_HALF},
-        {NPY_HALF, unwrap_half_loop<npy_double>, NPY_DOUBLE},
-        {NPY_FLOAT, unwrap_loop<npy_float, npy_float>, NPY_FLOAT},
-        {NPY_FLOAT, unwrap_loop<npy_float, npy_double>, NPY_DOUBLE},
-        {NPY_DOUBLE, unwrap_loop<npy_double, npy_double>, NPY_DOUBLE},
-        {NPY_LONGDOUBLE, unwrap_loop<npy_longdouble, npy_longdouble>,
-         NPY_LONGDOUBLE},
-        {NPY_BYTE, unwrap_loop<npy_byte, npy_double>, NPY_DOUBLE},
-        {NPY_SHORT, unwrap_loop<npy_short, npy_double>, NPY_DOUBLE},
-        {NPY_INT, unwrap_loop<npy_int, npy_double>, NPY_DOUBLE},
-        {NPY_LONG, unwrap_loop<npy_long, npy_double>, NPY_DOUBLE},
-        {NPY_LONGLONG, unwrap_loop<npy_longlong, npy_double>, NPY_DOUBLE},
+        {NPY_HALF, unwrap_half_loop},
+        {NPY_FLOAT, unwrap_loop<npy_float>},
+        {NPY_DOUBLE, unwrap_loop<npy_double>},
+        {NPY_LONGDOUBLE, unwrap_loop<npy_longdouble>},
+        {NPY_BYTE, unwrap_loop<npy_byte>},
+        {NPY_SHORT, unwrap_loop<npy_short>},
+        {NPY_INT, unwrap_loop<npy_int>},
+        {NPY_LONG, unwrap_loop<npy_long>},
+        {NPY_LONGLONG, unwrap_loop<npy_longlong>},
         /* object dtype falls back to the python implementation instead */
         // {NPY_OBJECT, object_unwrap_loop},
     };
 
     for (const auto& entry : loops) {
-        if (add_unwrap_loop(ufunc, entry.typenum, entry.loop,
-                             entry.discont_typenum) < 0) {
+        if (add_unwrap_loop(ufunc, entry.typenum, entry.loop) < 0) {
             Py_DECREF(ufunc);
             return -1;
         }

--- a/numpy/_core/src/umath/unwrap.cpp
+++ b/numpy/_core/src/umath/unwrap.cpp
@@ -61,10 +61,10 @@ floor_mod(npy_longdouble a, npy_longdouble b)
 }
 #endif
 
-/* no integer npy_remainder to call; mirrors @TYPE@_remainder in
- * loops_modulo.dispatch.c.src, including the T_MIN / -1 guard (which sets
- * no floating point status there either -- only the quotient overflows,
- * and this only ever computes the remainder) */
+/* no integer npy_remainder to call, so mirror @TYPE@_remainder in
+ * loops_modulo.dispatch.c.src, including the T_MIN / -1 guard. that guard
+ * doesn't set a floating point status there either, since only the
+ * quotient overflows and this only ever computes the remainder */
 template <typename T>
 static inline std::enable_if_t<std::is_integral_v<T> && std::is_signed_v<T>, T>
 floor_mod(T a, T b)
@@ -84,8 +84,8 @@ floor_mod(T a, T b)
 }
 
 /*
- * One loop per real dtype. T is the storage/compute type; discont is read
- * as T itself for the float dtypes, npy_double for the integer ones.
+ * One loop per real dtype. T is the storage/compute type, and discont is
+ * read as T itself for the float dtypes, npy_double for the integer ones.
  * npy_half has no native arithmetic, so it gets its own loop below.
  */
 template <typename T>
@@ -154,8 +154,8 @@ unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
     return 0;
 }
 
-/* rounds to half after every step, like numpy's own HALF_remainder loop,
- * instead of only at the end -- that changes the result */
+/* rounds to half after every step, like numpy's own HALF_remainder loop.
+ * rounding only at the end instead would change the result */
 static inline float h2f(npy_half h) { return npy_half_to_float(h); }
 static inline npy_half f2h(float f) { return npy_float_to_half(f); }
 
@@ -220,15 +220,15 @@ add_unwrap_loop(PyObject *ufunc, int typenum, PyArrayMethod_StridedLoop *loop)
     if (dt == NULL) {
         return -1;
     }
-    /* discont is read at typenum's own precision for float dtypes, double
-     * for the integer ones -- matches unwrap_loop's own D derivation */
+    /* discont is read at typenum's own precision for float dtypes and at
+     * double for the integer ones, matching unwrap_loop's own D derivation */
     int discont_typenum = PyTypeNum_ISFLOAT(typenum) ? typenum : NPY_DOUBLE;
     PyArray_DTypeMeta *disc_dt = PyArray_DTypeFromTypeNum(discont_typenum);
     if (disc_dt == NULL) {
         Py_DECREF(dt);
         return -1;
     }
-    /* p, out and period share the loop dtype; discont has its own dtype. */
+    /* p, out and period share the loop dtype, discont has its own */
     PyArray_DTypeMeta *dtypes[4] = {dt, disc_dt, dt, dt};
     PyType_Slot slots[] = {
         {NPY_METH_strided_loop, (void *)loop},

--- a/numpy/_core/src/umath/unwrap.cpp
+++ b/numpy/_core/src/umath/unwrap.cpp
@@ -71,11 +71,18 @@ floor_mod(npy_longdouble a, npy_longdouble b)
     return m;
 }
 #endif
-/* integer floor-modulo into [0, b); the caller guarantees b > 0. */
+/*
+ * integer floor-modulo into [0, b).
+ * if b == 0, returns 0 and sets the floating-point divide-by-zero flag
+ */
 template <typename T>
 static inline std::enable_if_t<std::is_integral_v<T>, T>
 floor_mod(T a, T b)
 {
+    if (b == 0) {
+        npy_set_floatstatus_divbyzero();
+        return 0;
+    }
     T m = a % b;
     if (m < 0) {
         m += b;

--- a/numpy/_core/src/umath/unwrap.cpp
+++ b/numpy/_core/src/umath/unwrap.cpp
@@ -68,8 +68,14 @@ template <typename T>
 static inline std::enable_if_t<std::is_integral_v<T>, T>
 floor_mod(T a, T b)
 {
-    if (b == 0 || (a == std::numeric_limits<T>::min() && b == -1)) {
+    if (b == 0) {
         npy_set_floatstatus_divbyzero();
+        return 0;
+    }
+    if (b == -1) {
+        if (a == std::numeric_limits<T>::min()) {
+            npy_set_floatstatus_divbyzero();
+        }
         return 0;
     }
     T rem = a % b;

--- a/numpy/_core/src/umath/unwrap.cpp
+++ b/numpy/_core/src/umath/unwrap.cpp
@@ -101,6 +101,9 @@ unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 
     npy_intp n_outer = dimensions[0];
     npy_intp n = dimensions[1];
+    if (n == 0) {
+        return 0;
+    }
     npy_intp s_p = strides[0], s_disc = strides[1];
     npy_intp s_per = strides[2], s_out = strides[3];
     npy_intp ip_step = strides[4];
@@ -110,9 +113,6 @@ unwrap_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 
     for (npy_intp k = 0; k < n_outer; k++,
             p_o += s_p, disc_o += s_disc, per_o += s_per, out_o += s_out) {
-        if (n <= 0) {
-            continue;
-        }
         D discont = *(const D *)disc_o;
         T period = *(const T *)per_o;
         T interval_high;
@@ -169,6 +169,9 @@ unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 {
     npy_intp n_outer = dimensions[0];
     npy_intp n = dimensions[1];
+    if (n == 0) {
+        return 0;
+    }
     npy_intp s_p = strides[0], s_disc = strides[1];
     npy_intp s_per = strides[2], s_out = strides[3];
     npy_intp ip_step = strides[4];
@@ -178,9 +181,6 @@ unwrap_half_loop(PyArrayMethod_Context *NPY_UNUSED(context), char *const data[],
 
     for (npy_intp k = 0; k < n_outer; k++,
             p_o += s_p, disc_o += s_disc, per_o += s_per, out_o += s_out) {
-        if (n <= 0) {
-            continue;
-        }
         npy_double discont = *(const npy_double *)disc_o;
         npy_half period = *(const npy_half *)per_o;
         npy_half interval_high = f2h(h2f(period) / 2.0f);

--- a/numpy/_core/src/umath/unwrap.cpp
+++ b/numpy/_core/src/umath/unwrap.cpp
@@ -252,15 +252,10 @@ add_unwrap_loop(PyObject *ufunc, int typenum,
     spec.dtypes = dtypes;
     spec.slots = slots;
 
-    if (PyUFunc_AddLoopFromSpec_int(ufunc, &spec, 1)) {
-        Py_DECREF(dt);
-        Py_DECREF(disc_dt);
-        return -1;
-    }
-    Py_DECREF(disc_dt);
-
+    int ret = PyUFunc_AddLoopFromSpec_int(ufunc, &spec, 1);
     Py_DECREF(dt);
-    return 0;
+    Py_DECREF(disc_dt);
+    return ret;
 }
 
 NPY_NO_EXPORT int
@@ -306,15 +301,14 @@ init_unwrap_ufunc(PyObject *umath)
         // {NPY_OBJECT, object_unwrap_loop},
     };
 
-    int res = 0;
     for (const auto& entry : loops) {
         if (add_unwrap_loop(ufunc, entry.typenum, entry.loop,
                              entry.discont_typenum) < 0) {
-            res = -1;
-            break;
+            Py_DECREF(ufunc);
+            return -1;
         }
     }
 
     Py_DECREF(ufunc);
-    return res;
+    return 0;
 }

--- a/numpy/_core/src/umath/unwrap.h
+++ b/numpy/_core/src/umath/unwrap.h
@@ -13,4 +13,3 @@ init_unwrap_ufunc(PyObject *umath);
 #endif
 
 #endif  /* _NPY_CORE_SRC_UMATH_UNWRAP_H_ */
-

--- a/numpy/_core/src/umath/unwrap.h
+++ b/numpy/_core/src/umath/unwrap.h
@@ -1,0 +1,16 @@
+#ifndef _NPY_CORE_SRC_UMATH_UNWRAP_H_
+#define _NPY_CORE_SRC_UMATH_UNWRAP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NPY_NO_EXPORT int
+init_unwrap_ufunc(PyObject *umath);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* _NPY_CORE_SRC_UMATH_UNWRAP_H_ */
+

--- a/numpy/_core/umath.py
+++ b/numpy/_core/umath.py
@@ -38,6 +38,7 @@ from ._multiarray_umath import (
     _slice,
     _strip_chars,
     _strip_whitespace,
+    _unwrap,
     _zfill,
 )
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1868,11 +1868,10 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
         # TODO: one could potentially implement a mask aware unwrap function
         # we now remove the mask and rewrap the result into a masked array
         # to preserve the ndarray subclass type
-        fill_value = p.fill_value
         unmasked = unwrap(np.asarray(p), discont=discont, axis=axis, period=period)
         result = unmasked.view(type(p))
         result.mask = False
-        result.fill_value = fill_value
+        result.fill_value = p.fill_value
         return result
     p = asanyarray(p)
     if discont is None:

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1764,7 +1764,7 @@ def _unwrap_fallback(p, discont, period, axis):
         # `ddmod[mask] == -period/2`. correct these such that
         # `ddmod[mask] == sign(dd[mask])*period/2`.
         _nx.copyto(ddmod, interval_high,
-                where=(ddmod == interval_low) & (dd > 0))
+                   where=(ddmod == interval_low) & (dd > 0))
     ph_correct = ddmod - dd
     _nx.copyto(ph_correct, 0, where=abs(dd) < discont)
     up = asanyarray(p, dtype=dtype, copy=True)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1866,13 +1866,9 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     """
     if np.ma.isMaskedArray(p):
         # TODO: one could potentially implement a mask aware unwrap function
-        # we now remove the mask and rewrap the result into a masked array
-        # to preserve the ndarray subclass type
-        unmasked = unwrap(np.asarray(p), discont=discont, axis=axis, period=period)
-        result = unmasked.view(type(p))
-        result.mask = False
-        result.fill_value = p.fill_value
-        return result
+        # we now remove the mask and do the unwrapping on the unmasked array
+        # and return back an ndarray
+        return unwrap(np.asarray(p), discont=discont, axis=axis, period=period)
     p = asanyarray(p)
     if discont is None:
         discont = period / 2

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1841,7 +1841,13 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     if discont is None:
         discont = period / 2
     dtype = np.result_type(p, period)
-    if p.dtype == object or dtype.isbuiltin != 1:
+    try:
+        return _unwrap(p, discont, period,
+                       signature=(type(dtype), np.float64, type(dtype), type(dtype)),
+                       axis=axis)
+    except np._core._exceptions._UFuncNoLoopError:
+        if dtype.isbuiltin == 1 and p.dtype != object:
+            raise
         nd = p.ndim
         dd = diff(p, axis=axis)
         slice1 = [slice(None, None)] * nd     # full slices
@@ -1866,8 +1872,6 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
         up = asanyarray(p, dtype=dtype, copy=True)
         up[slice1] = p[slice1] + ph_correct.cumsum(axis)
         return up
-    return _unwrap(p, discont, period,
-                   signature=(dtype, np.float64, dtype, dtype), axis=axis)
 
 
 def _sort_complex(a):

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1873,6 +1873,9 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
                        signature=(type(dtype), np.float64, type(dtype), type(dtype)),
                        axis=axis)
     except np._core._exceptions._UFuncNoLoopError:
+        # We could implement a gufunc loop for object dtype
+        # but it's not worth the burden of all the extra c++ code.
+        # We let object dtype go through the fallback.
         if dtype.isbuiltin == 1 and p.dtype != object:
             raise
         return _unwrap_fallback(p, discont, period, axis)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1874,7 +1874,9 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
         discont = period / 2
     try:
         dtype = np.result_type(p, period)
-        discont_type = type(dtype) if _nx.issubdtype(dtype, _nx.floating) else np.float64
+        discont_type = (
+            type(dtype) if _nx.issubdtype(dtype, _nx.floating) else np.float64
+        )
         return _unwrap(p, discont, period,
                        signature=(type(dtype), discont_type, type(dtype), type(dtype)),
                        axis=axis)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1863,7 +1863,7 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
                     where=(ddmod == interval_low) & (dd > 0))
         ph_correct = ddmod - dd
         _nx.copyto(ph_correct, 0, where=abs(dd) < discont)
-        up = array(p, copy=True, dtype=dtype)
+        up = asanyarray(p, dtype=dtype, copy=True)
         up[slice1] = p[slice1] + ph_correct.cumsum(axis)
         return up
     return _unwrap(p, discont, period,

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1872,15 +1872,9 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     p = asanyarray(p)
     if discont is None:
         discont = period / 2
-    dtype = np.result_type(p, period)
-    # match NEP 50: a discont that would collapse to dtype anyway (the
-    # weak-scalar or same-dtype case) is compared at that native precision;
-    # anything wider (explicit stronger scalar, or cross-kind on an integer
-    # dtype) is compared at >=double
-    discont_type = np.longdouble if dtype.type is np.longdouble else np.float64
-    if _nx.issubdtype(dtype, _nx.floating) and np.result_type(dtype, discont) == dtype:
-        discont_type = dtype.type
     try:
+        dtype = np.result_type(p, period)
+        discont_type = type(dtype) if _nx.issubdtype(dtype, _nx.floating) else np.float64
         return _unwrap(p, discont, period,
                        signature=(type(dtype), discont_type, type(dtype), type(dtype)),
                        axis=axis)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1864,17 +1864,19 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     >>> plt.legend(framealpha=1, shadow=True)
     >>> plt.show()
     """
-    p = asanyarray(p)
-    if discont is None:
-        discont = period / 2
     if np.ma.isMaskedArray(p):
         # TODO: one could potentially implement a mask aware unwrap function
+        # we now remove the mask and rewrap the result into a masked array
+        # to preserve the ndarray subclass type
         fill_value = p.fill_value
-        unmasked = _unwrap_fallback(asarray(p), discont, period, axis)
+        unmasked = unwrap(np.asarray(p), discont=discont, axis=axis, period=period)
         result = unmasked.view(type(p))
         result.mask = False
         result.fill_value = fill_value
         return result
+    p = asanyarray(p)
+    if discont is None:
+        discont = period / 2
     dtype = np.result_type(p, period)
     discont_type = np.longdouble if dtype.type is np.longdouble else np.float64
     try:

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1867,6 +1867,10 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     p = asanyarray(p)
     if discont is None:
         discont = period / 2
+    if np.ma.isMaskedArray(p):
+        # the gufunc's C loop has no concept of masking and would compute
+        # straight through masked values; the fallback's ops are mask-aware
+        return _unwrap_fallback(p, discont, period, axis)
     dtype = np.result_type(p, period)
     discont_type = (np.longdouble if type(dtype) is np.dtypes.LongDoubleDType
                      else np.float64)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1873,7 +1873,13 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     if discont is None:
         discont = period / 2
     dtype = np.result_type(p, period)
+    # match NEP 50: a discont that would collapse to dtype anyway (the
+    # weak-scalar or same-dtype case) is compared at that native precision;
+    # anything wider (explicit stronger scalar, or cross-kind on an integer
+    # dtype) is compared at >=double
     discont_type = np.longdouble if dtype.type is np.longdouble else np.float64
+    if _nx.issubdtype(dtype, _nx.floating) and np.result_type(dtype, discont) == dtype:
+        discont_type = dtype.type
     try:
         return _unwrap(p, discont, period,
                        signature=(type(dtype), discont_type, type(dtype), type(dtype)),

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1853,6 +1853,7 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
         slice1 = [slice(None, None)] * nd     # full slices
         slice1[axis] = slice(1, None)
         slice1 = tuple(slice1)
+        dtype = np.result_type(dd, period)
         if _nx.issubdtype(dtype, _nx.integer):
             interval_high, rem = divmod(period, 2)
             boundary_ambiguous = rem == 0

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1744,6 +1744,33 @@ def angle(z, deg=False):
         a *= 180 / pi
     return a
 
+def _unwrap_fallback(p, discont, period, axis):
+    nd = p.ndim
+    dd = diff(p, axis=axis)
+    slice1 = [slice(None, None)] * nd     # full slices
+    slice1[axis] = slice(1, None)
+    slice1 = tuple(slice1)
+    dtype = np.result_type(dd, period)
+    if _nx.issubdtype(dtype, _nx.integer):
+        interval_high, rem = divmod(period, 2)
+        boundary_ambiguous = rem == 0
+    else:
+        interval_high = period / 2
+        boundary_ambiguous = True
+    interval_low = -interval_high
+    ddmod = mod(dd - interval_low, period) + interval_low
+    if boundary_ambiguous:
+        # for `mask = (abs(dd) == period/2)`, the above line made
+        # `ddmod[mask] == -period/2`. correct these such that
+        # `ddmod[mask] == sign(dd[mask])*period/2`.
+        _nx.copyto(ddmod, interval_high,
+                where=(ddmod == interval_low) & (dd > 0))
+    ph_correct = ddmod - dd
+    _nx.copyto(ph_correct, 0, where=abs(dd) < discont)
+    up = asanyarray(p, dtype=dtype, copy=True)
+    up[slice1] = p[slice1] + ph_correct.cumsum(axis)
+    return up
+
 
 def _unwrap_dispatcher(p, discont=None, axis=None, *, period=None):
     return (p,)
@@ -1848,31 +1875,7 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     except np._core._exceptions._UFuncNoLoopError:
         if dtype.isbuiltin == 1 and p.dtype != object:
             raise
-        nd = p.ndim
-        dd = diff(p, axis=axis)
-        slice1 = [slice(None, None)] * nd     # full slices
-        slice1[axis] = slice(1, None)
-        slice1 = tuple(slice1)
-        dtype = np.result_type(dd, period)
-        if _nx.issubdtype(dtype, _nx.integer):
-            interval_high, rem = divmod(period, 2)
-            boundary_ambiguous = rem == 0
-        else:
-            interval_high = period / 2
-            boundary_ambiguous = True
-        interval_low = -interval_high
-        ddmod = mod(dd - interval_low, period) + interval_low
-        if boundary_ambiguous:
-            # for `mask = (abs(dd) == period/2)`, the above line made
-            # `ddmod[mask] == -period/2`. correct these such that
-            # `ddmod[mask] == sign(dd[mask])*period/2`.
-            _nx.copyto(ddmod, interval_high,
-                    where=(ddmod == interval_low) & (dd > 0))
-        ph_correct = ddmod - dd
-        _nx.copyto(ph_correct, 0, where=abs(dd) < discont)
-        up = asanyarray(p, dtype=dtype, copy=True)
-        up[slice1] = p[slice1] + ph_correct.cumsum(axis)
-        return up
+        return _unwrap_fallback(p, discont, period, axis)
 
 
 def _sort_complex(a):

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1841,7 +1841,7 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     if discont is None:
         discont = period / 2
     dtype = np.result_type(p, period)
-    if p.dtype == object:
+    if p.dtype == object or dtype.isbuiltin != 1:
         nd = p.ndim
         dd = diff(p, axis=axis)
         slice1 = [slice(None, None)] * nd     # full slices

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1810,10 +1810,10 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     Returns
     -------
     out : ndarray
-        Output array. Its dtype is ``numpy.result_type(p, period)``; in
-        particular an integer array unwrapped with an integer `period` keeps
-        its integer dtype, while any float `period` (including the default
-        ``2 pi``) produces a floating-point result.
+        Output array. Its dtype is ``numpy.result_type(p, period)``.
+        In particular an integer array unwrapped with an integer `period`
+        keeps its integer dtype, while any float `period` (including the
+        default ``2 pi``) produces a floating-point result.
 
     See Also
     --------
@@ -1879,13 +1879,13 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
                        signature=(type(dtype), discont_type, type(dtype), type(dtype)),
                        axis=axis)
     except np._core._exceptions._UFuncNoLoopError:
-        # object and user DTypes fall back; check p.dtype, not the promoted
+        # object and user DTypes fall back. check p.dtype, not the promoted
         # dtype, since a user DType can promote through a builtin
         if p.dtype.isbuiltin == 1 and p.dtype != object:
             raise
         return _unwrap_fallback(p, discont, period, axis)
     except TypeError:
-        # p's __array_ufunc__ declined the private _unwrap gufunc; the
+        # p's __array_ufunc__ declined the private _unwrap gufunc. the
         # fallback only uses public ufuncs, which it may still implement
         return _unwrap_fallback(p, discont, period, axis)
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1872,8 +1872,7 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
         # straight through masked values; the fallback's ops are mask-aware
         return _unwrap_fallback(p, discont, period, axis)
     dtype = np.result_type(p, period)
-    discont_type = (np.longdouble if type(dtype) is np.dtypes.LongDoubleDType
-                     else np.float64)
+    discont_type = np.longdouble if dtype.type is np.longdouble else np.float64
     try:
         return _unwrap(p, discont, period,
                        signature=(type(dtype), discont_type, type(dtype), type(dtype)),

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1868,9 +1868,13 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     if discont is None:
         discont = period / 2
     if np.ma.isMaskedArray(p):
-        # the gufunc's C loop has no concept of masking and would compute
-        # straight through masked values; the fallback's ops are mask-aware
-        return _unwrap_fallback(p, discont, period, axis)
+        # TODO: one could potentially implement a mask aware unwrap function
+        fill_value = p.fill_value
+        unmasked = _unwrap_fallback(asarray(p), discont, period, axis)
+        result = unmasked.view(type(p))
+        result.mask = False
+        result.fill_value = fill_value
+        return result
     dtype = np.result_type(p, period)
     discont_type = np.longdouble if dtype.type is np.longdouble else np.float64
     try:

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -38,6 +38,7 @@ from numpy._core.numeric import (
 )
 from numpy._core.numerictypes import typecodes
 from numpy._core.umath import (
+    _unwrap,
     add,
     arctan2,
     cos,
@@ -1773,7 +1774,7 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
         larger than ``period/2``.
     axis : int, optional
         Axis along which unwrap will operate, default is the last axis.
-    period : float, optional
+    period : float or int, optional
         Size of the range over which the input wraps. By default, it is
         ``2 pi``.
 
@@ -1782,7 +1783,10 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     Returns
     -------
     out : ndarray
-        Output array.
+        Output array. Its dtype is ``numpy.result_type(p, period)``; in
+        particular an integer array unwrapped with an integer `period` keeps
+        its integer dtype, while any float `period` (including the default
+        ``2 pi``) produces a floating-point result.
 
     See Also
     --------
@@ -1833,34 +1837,37 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     >>> plt.legend(framealpha=1, shadow=True)
     >>> plt.show()
     """
-    p = asarray(p)
-    nd = p.ndim
-    dd = diff(p, axis=axis)
+    p = asanyarray(p)
     if discont is None:
         discont = period / 2
-    slice1 = [slice(None, None)] * nd     # full slices
-    slice1[axis] = slice(1, None)
-    slice1 = tuple(slice1)
-    dtype = np.result_type(dd, period)
-    if _nx.issubdtype(dtype, _nx.integer):
-        interval_high, rem = divmod(period, 2)
-        boundary_ambiguous = rem == 0
-    else:
-        interval_high = period / 2
-        boundary_ambiguous = True
-    interval_low = -interval_high
-    ddmod = mod(dd - interval_low, period) + interval_low
-    if boundary_ambiguous:
-        # for `mask = (abs(dd) == period/2)`, the above line made
-        # `ddmod[mask] == -period/2`. correct these such that
-        # `ddmod[mask] == sign(dd[mask])*period/2`.
-        _nx.copyto(ddmod, interval_high,
-                   where=(ddmod == interval_low) & (dd > 0))
-    ph_correct = ddmod - dd
-    _nx.copyto(ph_correct, 0, where=abs(dd) < discont)
-    up = array(p, copy=True, dtype=dtype)
-    up[slice1] = p[slice1] + ph_correct.cumsum(axis)
-    return up
+    dtype = np.result_type(p, period)
+    if p.dtype == object:
+        nd = p.ndim
+        dd = diff(p, axis=axis)
+        slice1 = [slice(None, None)] * nd     # full slices
+        slice1[axis] = slice(1, None)
+        slice1 = tuple(slice1)
+        if _nx.issubdtype(dtype, _nx.integer):
+            interval_high, rem = divmod(period, 2)
+            boundary_ambiguous = rem == 0
+        else:
+            interval_high = period / 2
+            boundary_ambiguous = True
+        interval_low = -interval_high
+        ddmod = mod(dd - interval_low, period) + interval_low
+        if boundary_ambiguous:
+            # for `mask = (abs(dd) == period/2)`, the above line made
+            # `ddmod[mask] == -period/2`. correct these such that
+            # `ddmod[mask] == sign(dd[mask])*period/2`.
+            _nx.copyto(ddmod, interval_high,
+                    where=(ddmod == interval_low) & (dd > 0))
+        ph_correct = ddmod - dd
+        _nx.copyto(ph_correct, 0, where=abs(dd) < discont)
+        up = array(p, copy=True, dtype=dtype)
+        up[slice1] = p[slice1] + ph_correct.cumsum(axis)
+        return up
+    return _unwrap(p, discont, period,
+                   signature=(dtype, np.float64, dtype, dtype), axis=axis)
 
 
 def _sort_complex(a):

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1868,16 +1868,21 @@ def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     if discont is None:
         discont = period / 2
     dtype = np.result_type(p, period)
+    discont_type = (np.longdouble if type(dtype) is np.dtypes.LongDoubleDType
+                     else np.float64)
     try:
         return _unwrap(p, discont, period,
-                       signature=(type(dtype), np.float64, type(dtype), type(dtype)),
+                       signature=(type(dtype), discont_type, type(dtype), type(dtype)),
                        axis=axis)
     except np._core._exceptions._UFuncNoLoopError:
-        # We could implement a gufunc loop for object dtype
-        # but it's not worth the burden of all the extra c++ code.
-        # We let object dtype go through the fallback.
-        if dtype.isbuiltin == 1 and p.dtype != object:
+        # object and user DTypes fall back; check p.dtype, not the promoted
+        # dtype, since a user DType can promote through a builtin
+        if p.dtype.isbuiltin == 1 and p.dtype != object:
             raise
+        return _unwrap_fallback(p, discont, period, axis)
+    except TypeError:
+        # p's __array_ufunc__ declined the private _unwrap gufunc; the
+        # fallback only uses public ufuncs, which it may still implement
         return _unwrap_fallback(p, discont, period, axis)
 
 

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -886,6 +886,14 @@ def unwrap[ArrayT: NDArray[np.floating | np.object_]](
     *,
     period: float = ...,  # = τ
 ) -> ArrayT: ...
+@overload  # integer array + integer period keeps the integer dtype
+def unwrap[ArrayT: NDArray[np.integer]](
+    p: ArrayT,
+    discont: float | None = None,
+    axis: int = -1,
+    *,
+    period: int,
+) -> ArrayT: ...
 @overload  # known shape, float64
 def unwrap[ShapeT: _Shape](
     p: _Array[ShapeT, _float64_co],

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -884,7 +884,7 @@ def unwrap[ArrayT: NDArray[np.floating | np.object_]](
     discont: float | None = None,
     axis: int = -1,
     *,
-    period: float = ...,  # = τ
+    period: float | int = ...,  # = τ
 ) -> ArrayT: ...
 @overload  # integer array + integer period keeps the integer dtype
 def unwrap[ArrayT: NDArray[np.integer]](

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2475,11 +2475,9 @@ class TestUnwrap:
         p = np.ma.MaskedArray([0., 1., 2., 2 + 2 * np.pi, 3 + 2 * np.pi],
                               mask=[False, False, True, False, False])
         out = unwrap(p)
-        assert isinstance(out, np.ma.MaskedArray)
+        assert isinstance(out, np.ndarray)
         expected = self._reference_unwrap(np.asarray(p))
-        expected = np.ma.array(expected, mask=False, fill_value=p.fill_value)
-        assert_array_equal(out.mask, expected.mask)
-        assert_array_equal(out.data, expected.data)
+        assert_array_equal(out, expected)
 
     def test_array_ufunc_no_override_raises(self):
         class MyArray(np.ndarray):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2476,7 +2476,7 @@ class TestUnwrap:
                               mask=[False, False, True, False, False])
         out = unwrap(p)
         assert isinstance(out, np.ma.MaskedArray)
-        expected = nfb._unwrap_fallback(np.asarray(p), np.pi, 2 * np.pi, -1)
+        expected = self._reference_unwrap(np.asarray(p))
         expected = np.ma.array(expected, mask=False, fill_value=p.fill_value)
         assert_array_equal(out.mask, expected.mask)
         assert_array_equal(out.data, expected.data)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2478,6 +2478,15 @@ class TestUnwrap:
         discont = 3 + 1e-4
         assert_array_equal(unwrap(p, discont=discont, period=period), [0, -1])
 
+    def test_discont_explicit_wider_truncates_to_dtype(self):
+        # an explicitly typed discont wider than the result dtype is
+        # compared at the result dtype rather than promoting (see release
+        # notes); 3 + 1e-8 rounds down to exactly 3.0 in float32
+        p = np.array([0, 3], dtype=np.float32)
+        period = 4
+        discont = np.float64(3) + 1e-8
+        assert_array_equal(unwrap(p, discont=discont, period=period), [0, -1])
+
     def test_masked_array(self):
         # for masked arrays, we'd need a masked aware np.ma.unwrap implementation
         # the operation currently unmasks the masked array into an ndarray

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2237,6 +2237,30 @@ class TestDigitize:
 
 class TestUnwrap:
 
+    @staticmethod
+    def _reference_unwrap(p, discont=None, period=2 * np.pi):
+        # the documented algorithm, spelled out with plain numpy ops
+        p = np.asarray(p)
+        dtype = np.result_type(p, period)
+        if discont is None:
+            discont = period / 2
+        dd = np.diff(p.astype(dtype))
+        if np.issubdtype(dtype, np.integer):
+            interval_high, rem = divmod(period, 2)
+            boundary_ambiguous = rem == 0
+        else:
+            interval_high = period / 2
+            boundary_ambiguous = True
+        interval_low = -interval_high
+        ddmod = np.mod(dd - interval_low, period) + interval_low
+        if boundary_ambiguous:
+            np.copyto(ddmod, interval_high, where=(ddmod == interval_low) & (dd > 0))
+        ph_correct = ddmod - dd
+        np.copyto(ph_correct, 0, where=np.abs(dd) < discont)
+        out = p.astype(dtype).copy()
+        out[1:] = p[1:].astype(dtype) + ph_correct.cumsum()
+        return out
+
     def test_simple(self):
         # check that unwrap removes jumps greater that 2*pi
         assert_array_equal(unwrap([1, 1 + 2 * np.pi]), [1, 1])
@@ -2343,19 +2367,147 @@ class TestUnwrap:
         with pytest.raises(np.exceptions.DTypePromotionError):
             unwrap(np.arange(5).astype(dtype))
 
-    @pytest.mark.parametrize(
-        "dtype, expected",
-        [(np.int64, [1, 1, 1]), (np.float64, [1, np.nan, np.nan])],
-    )
-    def test_period_zero(self, dtype, expected):
-        p = np.array([1, 2, 3], dtype=dtype)
+    def test_period_zero_int(self):
+        # matches np.mod's own int-division-by-zero warning
+        p = np.array([1, 2, 3], dtype=np.int64)
         if IS_WASM:
             with np.errstate(divide="ignore", invalid="ignore"):
                 result = unwrap(p, period=0)
         else:
             with pytest.warns(RuntimeWarning):
                 result = unwrap(p, period=0)
-        assert_array_equal(result, np.array(expected, dtype=result.dtype))
+        assert_array_equal(result, [1, 1, 1])
+
+    def test_period_zero_float(self):
+        # np.mod doesn't warn on float division by zero, only int does
+        p = np.array([1, 2, 3], dtype=np.float64)
+        result = unwrap(p, period=0)
+        assert_array_equal(result, [1, np.nan, np.nan])
+
+    def test_negative_period(self):
+        p = np.array([0, 3, 6, 1, 4], dtype=np.int64)
+        assert_array_equal(unwrap(p, period=-8), [0, 3, 6, 9, 12])
+
+    @hypothesis.given(
+            arr=arrays(dtype=np.int32,
+                       shape=st.integers(min_value=1, max_value=50),
+                       elements=st.integers(min_value=-1000, max_value=1000)),
+            period=st.integers(min_value=-50, max_value=50).filter(bool))
+    def test_int_matches_reference_hypo(self, arr, period):
+        assert_array_equal(unwrap(arr, period=period),
+                           self._reference_unwrap(arr, period=period))
+
+    @hypothesis.given(
+            arr=arrays(dtype=np.float64,
+                       shape=st.integers(min_value=1, max_value=50),
+                       elements=st.floats(allow_infinity=False, allow_nan=False,
+                                          min_value=-1e6, max_value=1e6)))
+    def test_float_matches_reference_hypo(self, arr):
+        assert_allclose(unwrap(arr), self._reference_unwrap(arr))
+
+    def test_float16_random(self):
+        rng = np.random.default_rng(0)
+        for period in [2 * np.pi, 1.0, 10.0]:
+            p = rng.uniform(-3 * period, 3 * period, size=50).astype(np.float16)
+            got = unwrap(p, period=np.float16(period))
+            exp = self._reference_unwrap(p, period=np.float16(period))
+            # exact bit comparison: pins the per-op half-precision rounding
+            assert_array_equal(got.view(np.uint16), exp.view(np.uint16))
+
+    @pytest.mark.parametrize("dtype", [np.int8, np.int16, np.int32, np.int64])
+    def test_signed_extrema(self, dtype):
+        lo, hi = np.iinfo(dtype).min, np.iinfo(dtype).max
+        p = np.array([hi, lo, hi, lo], dtype=dtype)
+        assert_array_equal(unwrap(p, period=4), self._reference_unwrap(p, period=4))
+
+    @pytest.mark.parametrize("dtype", [np.int8, np.int16, np.int32, np.int64])
+    def test_int_min_period_minus_one(self, dtype):
+        # T_MIN % -1 is the one case that's UB in C++ if not guarded
+        lo = np.iinfo(dtype).min
+        p = np.array([lo, lo + 1, lo + 2], dtype=dtype)
+        assert_array_equal(unwrap(p, period=-1), self._reference_unwrap(p, period=-1))
+
+    def test_longdouble_discont_precision(self):
+        if np.finfo(np.longdouble).eps >= np.finfo(np.float64).eps:
+            pytest.skip("long double has no extra precision on this platform")
+        p = np.array([0, 5], dtype=np.longdouble)
+        period = np.longdouble(100)
+        # only representable with more than float64 precision
+        discont = np.longdouble(5) + np.longdouble(2) ** -80
+        assert_array_equal(unwrap(p, discont=discont, period=period), [0, 5])
+        truncated = np.float64(discont)
+        assert unwrap(p, discont=truncated, period=period)[1] != 5
+
+    def test_non_native_byteorder(self):
+        p = np.array([0, 1, 2, -1, 0], dtype=np.int32)
+        swapped = p.astype(p.dtype.newbyteorder())
+        assert_array_equal(unwrap(swapped, period=4), unwrap(p, period=4))
+
+    def test_custom_dtype(self):
+        # quaddtype <= 1.0.0 corrupts unrelated dtype promotions for the
+        # rest of the process on *import*, so check the version via package
+        # metadata (doesn't import it) before importing (see
+        # test_arrayprint.py for the same guard)
+        from importlib.metadata import version
+        try:
+            quaddtype_version = version("numpy_quaddtype")
+        except Exception:
+            pytest.skip("numpy_quaddtype not installed")
+        from numpy._utils import _pep440
+        if _pep440.Version(quaddtype_version) <= _pep440.Version("1.0.0"):
+            pytest.skip("critical bug in quaddtype during import")
+
+        quaddtype = pytest.importorskip("numpy_quaddtype")
+        p = np.array([quaddtype.QuadPrecision(v) for v in (0, 1, 2)],
+                     dtype=quaddtype.QuadPrecDType())
+        result = unwrap(p, period=4)
+        assert result.dtype == quaddtype.QuadPrecision
+        assert_array_equal(result, [0, 1, 2])
+
+    def test_array_ufunc_no_override_raises(self):
+        class MyArray(np.ndarray):
+            def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+                return NotImplemented
+
+        p = np.array([0., 1., 2., 2 + 2 * np.pi]).view(MyArray)
+        with pytest.raises(TypeError):
+            unwrap(p)
+
+    def test_array_ufunc_override_forwards(self):
+        class MyArray(np.ndarray):
+            calls = []
+
+            def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+                type(self).calls.append(ufunc.__name__)
+                inputs = tuple(x.view(np.ndarray) if isinstance(x, MyArray) else x
+                               for x in inputs)
+                out = super().__array_ufunc__(ufunc, method, *inputs, **kwargs)
+                return out.view(MyArray) if isinstance(out, np.ndarray) else out
+
+        p = np.array([0., 1., 2., 2 + 2 * np.pi]).view(MyArray)
+        out = unwrap(p)
+        assert isinstance(out, MyArray)
+        assert_array_equal(np.asarray(out), unwrap(np.asarray(p)))
+        assert "_unwrap" in MyArray.calls
+
+    def test_array_ufunc_partial_override_falls_back(self):
+        # doesn't know about the private _unwrap gufunc, but does implement
+        # the public ufuncs the python fallback uses
+        public = {"subtract", "remainder", "add", "equal", "greater",
+                  "bitwise_and", "absolute", "less"}
+
+        class MyArray(np.ndarray):
+            def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+                if ufunc.__name__ not in public:
+                    return NotImplemented
+                inputs = tuple(x.view(np.ndarray) if isinstance(x, MyArray) else x
+                               for x in inputs)
+                out = super().__array_ufunc__(ufunc, method, *inputs, **kwargs)
+                return out.view(MyArray) if isinstance(out, np.ndarray) else out
+
+        p = np.array([0., 1., 2., 2 + 2 * np.pi]).view(MyArray)
+        out = unwrap(p)
+        assert_array_equal(np.asarray(out), unwrap(np.asarray(p)))
 
 
 @pytest.mark.parametrize(

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2288,7 +2288,8 @@ class TestUnwrap:
     @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int8, np.int32,
                                        np.int64, object])
     def test_dtype_preserved(self, dtype):
-        # integer array + integer period keeps the integer dtype; float stays
+        # p keeps its own dtype here for every dtype tested, since period=4
+        # is an integer and never forces a float result
         p = np.array([0, 1, 2, -1, 0], dtype=dtype)
         out = unwrap(p, period=4)
         assert out.dtype == dtype
@@ -2312,8 +2313,8 @@ class TestUnwrap:
         assert_array_equal(np.asarray(out), unwrap(np.asarray(p)))
 
     def test_object_matches_float(self):
-        # object arrays go through the Python fall-back; result matches the
-        # float computation, stays object, and preserves subclasses
+        # object arrays go through the python fallback. the result matches
+        # the float computation, stays object dtype, and preserves subclasses
         base = np.array([0., 1., 2., 2 + 2 * np.pi, 3 + 2 * np.pi, 3.1, 3.2])
         obj = base.astype(object)
         out = unwrap(obj)
@@ -2323,8 +2324,8 @@ class TestUnwrap:
         assert_array_equal(unwrap(obj, discont=10).astype(float), base)
 
     def test_object_boundary_and_fraction(self):
-        # exact +period/2 upward jump exercises the boundary correction; the
-        # values stay exact Python objects (Fractions)
+        # exact +period/2 upward jump exercises the boundary correction,
+        # and the values stay exact python objects (Fractions)
         p = np.array([Fraction(0), Fraction(2), Fraction(4), Fraction(1),
                       Fraction(0)], dtype=object)
         out = unwrap(p, period=4)
@@ -2470,9 +2471,9 @@ class TestUnwrap:
 
     def test_discont_weak_scalar_narrow_dtype(self):
         # a bare python float discont is a weak scalar (NEP 50), so main
-        # downcasts it to p's dtype before comparing; here that downcast
-        # rounds 3.0001 down to exactly 3.0, so the diff of 3 is no longer
-        # judged smaller than discont and does get corrected
+        # downcasts it to p's dtype before comparing. that downcast rounds
+        # 3.0001 down to exactly 3.0, so the diff of 3 no longer looks
+        # smaller than discont and gets corrected
         p = np.array([0, 3], dtype=np.float16)
         period = 4
         discont = 3 + 1e-4
@@ -2480,8 +2481,8 @@ class TestUnwrap:
 
     def test_discont_explicit_wider_truncates_to_dtype(self):
         # an explicitly typed discont wider than the result dtype is
-        # compared at the result dtype rather than promoting (see release
-        # notes); 3 + 1e-8 rounds down to exactly 3.0 in float32
+        # compared at the result dtype rather than promoting, see the
+        # release notes. 3 + 1e-8 rounds down to exactly 3.0 in float32
         p = np.array([0, 3], dtype=np.float32)
         period = 4
         discont = np.float64(3) + 1e-8

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2319,22 +2319,29 @@ class TestUnwrap:
         assert_array_equal(unwrap(np.zeros(0)), np.zeros(0))
         assert_array_equal(unwrap(np.array([3.5])), np.array([3.5]))
 
-    @pytest.mark.parametrize("dtype", [np.complex128, "O"])
-    def test_complex_raises(self, dtype):
-        p = np.arange(5, dtype=np.complex128).astype(dtype)
-        assert_raises(TypeError, unwrap, p)
+    def test_complex_raises(self):
+        p = np.arange(5, dtype=np.complex128)
+        with pytest.raises(np._core._exceptions._UFuncNoLoopError):
+            unwrap(p)
+
+    def test_complex_object_dtype_raises(self):
+        p = np.arange(5, dtype=np.complex128).astype(object)
+        with pytest.raises(TypeError, match="unsupported operand type"):
+            unwrap(p)
 
     @pytest.mark.parametrize("dtype", [np.uint8, np.uint32, np.uint64])
     def test_unsigned_integer_period_raises(self, dtype):
         # unsigned + integer period needs the negative bound ``-period // 2``,
         # which is out of range for the unsigned dtype
         p = np.array([0, 3, 6, 1, 4], dtype=dtype)
-        assert_raises((OverflowError, TypeError), unwrap, p, period=8)
+        with pytest.raises(np._core._exceptions._UFuncNoLoopError):
+            unwrap(p, period=8)
 
     @pytest.mark.parametrize("dtype", ["datetime64[D]", "timedelta64[D]"])
     def test_temporal_raises(self, dtype):
         # datetime/timedelta have no meaningful modular wrap
-        assert_raises(TypeError, unwrap, np.arange(5).astype(dtype))
+        with pytest.raises(np.exceptions.DTypePromotionError):
+            unwrap(np.arange(5).astype(dtype))
 
 
 @pytest.mark.parametrize(

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2430,13 +2430,16 @@ class TestUnwrap:
     def test_longdouble_discont_precision(self):
         if np.finfo(np.longdouble).eps >= np.finfo(np.float64).eps:
             pytest.skip("long double has no extra precision on this platform")
+        # period=8 puts the delta (5) past the wrap boundary (+-4), so
+        # whether discont suppresses the correction actually depends on
+        # its precision
         p = np.array([0, 5], dtype=np.longdouble)
-        period = np.longdouble(100)
+        period = np.longdouble(8)
         # only representable with more than float64 precision
         discont = np.longdouble(5) + np.longdouble(2) ** -80
         assert_array_equal(unwrap(p, discont=discont, period=period), [0, 5])
         truncated = np.float64(discont)
-        assert unwrap(p, discont=truncated, period=period)[1] != 5
+        assert_array_equal(unwrap(p, discont=truncated, period=period), [0, -3])
 
     def test_non_native_byteorder(self):
         p = np.array([0, 1, 2, -1, 0], dtype=np.int32)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2479,9 +2479,9 @@ class TestUnwrap:
         assert_array_equal(unwrap(p, discont=discont, period=period), [0, -1])
 
     def test_masked_array(self):
-        # the gufunc's C loop can't propagate masking through the scan the
-        # way the fallback's mask-aware ops do, so this must match the
-        # fallback exactly, not just "look reasonable"
+        # for masked arrays, we'd need a masked aware np.ma.unwrap implementation
+        # the operation currently unmasks the masked array into an ndarray
+        # and runs the operation on that, completely ignoring the mask
         p = np.ma.MaskedArray([0., 1., 2., 2 + 2 * np.pi, 3 + 2 * np.pi],
                               mask=[False, False, True, False, False])
         out = unwrap(p)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2454,6 +2454,20 @@ class TestUnwrap:
         assert result.dtype == quaddtype.QuadPrecision
         assert_array_equal(result, [0, 1, 2])
 
+    def test_longdouble_discont_precision(self):
+        if np.finfo(np.longdouble).eps >= np.finfo(np.float64).eps:
+            pytest.skip("long double has no extra precision on this platform")
+        # period=8 puts the delta (5) past the wrap boundary (+-4), so
+        # whether discont suppresses the correction actually depends on
+        # its precision
+        p = np.array([0, 5], dtype=np.longdouble)
+        period = np.longdouble(8)
+        # only representable with more than float64 precision
+        discont = np.longdouble(5) + np.longdouble(2) ** -56
+        assert_array_equal(unwrap(p, discont=discont, period=period), [0, 5])
+        truncated = np.float64(discont)
+        assert_array_equal(unwrap(p, discont=truncated, period=period), [0, -3])
+
     def test_masked_array(self):
         # the gufunc's C loop can't propagate masking through the scan the
         # way the fallback's mask-aware ops do, so this must match the

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2261,6 +2261,81 @@ class TestUnwrap:
         assert_array_equal(sm_discont, [0, 75, 150, 225, 300, 430])
         assert sm_discont.dtype == wrap_uneven.dtype
 
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int8, np.int32,
+                                       np.int64, object])
+    def test_dtype_preserved(self, dtype):
+        # integer array + integer period keeps the integer dtype; float stays
+        p = np.array([0, 1, 2, -1, 0], dtype=dtype)
+        out = unwrap(p, period=4)
+        assert out.dtype == dtype
+        assert_array_equal(out, [0, 1, 2, 3, 4])
+
+    @pytest.mark.parametrize("dtype", [np.int8, np.int32, np.int64])
+    def test_int_float_period_promotes(self, dtype):
+        # a float period turns an integer array into a float64 result
+        out = unwrap(np.array([0, 1, 2, -1, 0], dtype=dtype), period=2 * np.pi)
+        assert out.dtype == np.float64
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64, np.int8, np.int32,
+                                       np.int64, np.bool_, object])
+    def test_subclass_preserved(self, dtype):
+        class MyArray(np.ndarray):
+            pass
+        p = np.array([0, 1, 2, -1, 0], dtype=dtype).view(MyArray)
+        out = unwrap(p)
+        assert isinstance(out, MyArray)
+        # same code path with/without the subclass, so results are exactly equal
+        assert_array_equal(np.asarray(out), unwrap(np.asarray(p)))
+
+    def test_object_matches_float(self):
+        # object arrays go through the Python fall-back; result matches the
+        # float computation, stays object, and preserves subclasses
+        base = np.array([0., 1., 2., 2 + 2 * np.pi, 3 + 2 * np.pi, 3.1, 3.2])
+        obj = base.astype(object)
+        out = unwrap(obj)
+        assert out.dtype == object
+        assert_allclose(out.astype(float), unwrap(base))
+        # custom discont on the object path leaves sub-discont jumps untouched
+        assert_array_equal(unwrap(obj, discont=10).astype(float), base)
+
+    def test_object_boundary_and_fraction(self):
+        # exact +period/2 upward jump exercises the boundary correction; the
+        # values stay exact Python objects (Fractions)
+        p = np.array([Fraction(0), Fraction(2), Fraction(4), Fraction(1),
+                      Fraction(0)], dtype=object)
+        out = unwrap(p, period=4)
+        assert out.dtype == object
+        assert_array_equal(out.astype(float),
+                           unwrap(np.array([0., 2., 4., 1., 0.]), period=4))
+
+    def test_object_2d_axis(self):
+        base = np.linspace(0, 20 * np.pi, 24).reshape(4, 6)
+        obj = base.astype(object)
+        for axis in (0, 1):
+            assert_allclose(unwrap(obj, axis=axis).astype(float),
+                            unwrap(base, axis=axis))
+
+    def test_empty_and_single(self):
+        assert_array_equal(unwrap(np.zeros(0)), np.zeros(0))
+        assert_array_equal(unwrap(np.array([3.5])), np.array([3.5]))
+
+    @pytest.mark.parametrize("dtype", [np.complex128, "O"])
+    def test_complex_raises(self, dtype):
+        p = np.arange(5, dtype=np.complex128).astype(dtype)
+        assert_raises(TypeError, unwrap, p)
+
+    @pytest.mark.parametrize("dtype", [np.uint8, np.uint32, np.uint64])
+    def test_unsigned_integer_period_raises(self, dtype):
+        # unsigned + integer period needs the negative bound ``-period // 2``,
+        # which is out of range for the unsigned dtype
+        p = np.array([0, 3, 6, 1, 4], dtype=dtype)
+        assert_raises((OverflowError, TypeError), unwrap, p, period=8)
+
+    @pytest.mark.parametrize("dtype", ["datetime64[D]", "timedelta64[D]"])
+    def test_temporal_raises(self, dtype):
+        # datetime/timedelta have no meaningful modular wrap
+        assert_raises(TypeError, unwrap, np.arange(5).astype(dtype))
+
 
 @pytest.mark.parametrize(
     "dtype", "O" + np.typecodes["AllInteger"] + np.typecodes["Float"]

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2343,6 +2343,16 @@ class TestUnwrap:
         with pytest.raises(np.exceptions.DTypePromotionError):
             unwrap(np.arange(5).astype(dtype))
 
+    @pytest.mark.parametrize(
+        "dtype, expected",
+        [(np.int64, [1, 1, 1]), (np.float64, [1, np.nan, np.nan])],
+    )
+    def test_period_zero(self, dtype, expected):
+        p = np.array([1, 2, 3], dtype=dtype)
+        with pytest.warns(RuntimeWarning):
+            result = unwrap(p, period=0)
+        assert_array_equal(result, np.array(expected, dtype=result.dtype))
+
 
 @pytest.mark.parametrize(
     "dtype", "O" + np.typecodes["AllInteger"] + np.typecodes["Float"]

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2349,8 +2349,12 @@ class TestUnwrap:
     )
     def test_period_zero(self, dtype, expected):
         p = np.array([1, 2, 3], dtype=dtype)
-        with pytest.warns(RuntimeWarning):
-            result = unwrap(p, period=0)
+        if IS_WASM:
+            with np.errstate(divide="ignore", invalid="ignore"):
+                result = unwrap(p, period=0)
+        else:
+            with pytest.warns(RuntimeWarning):
+                result = unwrap(p, period=0)
         assert_array_equal(result, np.array(expected, dtype=result.dtype))
 
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2476,7 +2476,8 @@ class TestUnwrap:
                               mask=[False, False, True, False, False])
         out = unwrap(p)
         assert isinstance(out, np.ma.MaskedArray)
-        expected = nfb._unwrap_fallback(p, np.pi, 2 * np.pi, -1)
+        expected = nfb._unwrap_fallback(np.asarray(p), np.pi, 2 * np.pi, -1)
+        expected = np.ma.array(expected, mask=False, fill_value=p.fill_value)
         assert_array_equal(out.mask, expected.mask)
         assert_array_equal(out.data, expected.data)
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2464,6 +2464,18 @@ class TestUnwrap:
         assert result.dtype == quaddtype.QuadPrecision
         assert_array_equal(result, [0, 1, 2])
 
+    def test_masked_array(self):
+        # the gufunc's C loop can't propagate masking through the scan the
+        # way the fallback's mask-aware ops do, so this must match the
+        # fallback exactly, not just "look reasonable"
+        p = np.ma.MaskedArray([0., 1., 2., 2 + 2 * np.pi, 3 + 2 * np.pi],
+                              mask=[False, False, True, False, False])
+        out = unwrap(p)
+        assert isinstance(out, np.ma.MaskedArray)
+        expected = nfb._unwrap_fallback(p, np.pi, 2 * np.pi, -1)
+        assert_array_equal(out.mask, expected.mask)
+        assert_array_equal(out.data, expected.data)
+
     def test_array_ufunc_no_override_raises(self):
         class MyArray(np.ndarray):
             def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2379,9 +2379,10 @@ class TestUnwrap:
         assert_array_equal(result, [1, 1, 1])
 
     def test_period_zero_float(self):
-        # np.mod doesn't warn on float division by zero, only int does
+        # whether float division by zero warns is platform-dependent
         p = np.array([1, 2, 3], dtype=np.float64)
-        result = unwrap(p, period=0)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            result = unwrap(p, period=0)
         assert_array_equal(result, [1, np.nan, np.nan])
 
     def test_negative_period(self):
@@ -2426,20 +2427,6 @@ class TestUnwrap:
         lo = np.iinfo(dtype).min
         p = np.array([lo, lo + 1, lo + 2], dtype=dtype)
         assert_array_equal(unwrap(p, period=-1), self._reference_unwrap(p, period=-1))
-
-    def test_longdouble_discont_precision(self):
-        if np.finfo(np.longdouble).eps >= np.finfo(np.float64).eps:
-            pytest.skip("long double has no extra precision on this platform")
-        # period=8 puts the delta (5) past the wrap boundary (+-4), so
-        # whether discont suppresses the correction actually depends on
-        # its precision
-        p = np.array([0, 5], dtype=np.longdouble)
-        period = np.longdouble(8)
-        # only representable with more than float64 precision
-        discont = np.longdouble(5) + np.longdouble(2) ** -80
-        assert_array_equal(unwrap(p, discont=discont, period=period), [0, 5])
-        truncated = np.float64(discont)
-        assert_array_equal(unwrap(p, discont=truncated, period=period), [0, -3])
 
     def test_non_native_byteorder(self):
         p = np.array([0, 1, 2, -1, 0], dtype=np.int32)

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2468,6 +2468,16 @@ class TestUnwrap:
         truncated = np.float64(discont)
         assert_array_equal(unwrap(p, discont=truncated, period=period), [0, -3])
 
+    def test_discont_weak_scalar_narrow_dtype(self):
+        # a bare python float discont is a weak scalar (NEP 50), so main
+        # downcasts it to p's dtype before comparing; here that downcast
+        # rounds 3.0001 down to exactly 3.0, so the diff of 3 is no longer
+        # judged smaller than discont and does get corrected
+        p = np.array([0, 3], dtype=np.float16)
+        period = 4
+        discont = 3 + 1e-4
+        assert_array_equal(unwrap(p, discont=discont, period=period), [0, -1])
+
     def test_masked_array(self):
         # the gufunc's C loop can't propagate masking through the scan the
         # way the fallback's mask-aware ops do, so this must match the

--- a/numpy/typing/tests/data/reveal/lib_function_base.pyi
+++ b/numpy/typing/tests/data/reveal/lib_function_base.pyi
@@ -209,6 +209,8 @@ assert_type(np.unwrap(AR_f8_3d), np.ndarray[tuple[int, int, int], np.dtype[np.fl
 assert_type(np.unwrap(AR_LIKE_b), np.ndarray[tuple[int], np.dtype[np.float64]])
 assert_type(np.unwrap(AR_LIKE_i8), np.ndarray[tuple[int], np.dtype[np.float64]])
 assert_type(np.unwrap(AR_LIKE_f8), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.unwrap(AR_i8, period=4), npt.NDArray[np.int64])
+assert_type(np.unwrap(AR_i8), npt.NDArray[np.float64])
 
 # sort_complex
 assert_type(np.sort_complex(AR_u1), npt.NDArray[np.complex64])


### PR DESCRIPTION
### PR summary
Closes https://github.com/numpy/numpy/issues/9959

This PR implements `np.unwrap` as a generalized ufunc. We have to preserve the python wrapper to keep the API intact.
While making this PR I also found that unwrap had a docstring and typing issue. It's period argument can be an integer too and when both the input array and period are integers, the output dtype is also an integer. This was already shown in the docstring examples but not reflected in the types and typing stubs. I fixed both here.

The core of unwrap is now a generalized ufunc in C++ (signature ``(n),(),()->(n)``). The loop is implemented with discont argument always being a double as the function asks for it to be a python float.
As a result, unwrap now preserves the ndarray subclasses rather than always returning a base ndarray which is what the issue wanted at the time.

I chose not to add an object dtype C++ loop here as that is way too complicated for what it offers because I assume there is very little use of unwrap for object dtypes. We fall back to the old python implementation for object dtypes. I vibe coded an object dtype loop and it's 2x faster than the fallback on my machine but I think it's not worth having this complicated C++ code for this.

For integer/float dtypes, I see a nice 2x - 3x speed improvement on my machine from limited benchmarking and memory should be improved too as the fused loop avoids copies.

As unwrap had very limited testing, I added tests here that all pass on `main` except the `test_subclass_preserved` of course because until now unwrap did not preserve ndarray subclasses.

#### AI Disclosure
AI tools were used to help me translate the python implementation algorithm into the C++ loop. The documenting comments above the loop were also written by AI after I asked it (but I don't know if those are useful and can be removed).
