### PR TITLE
TYP: specialized ``ldexp`` ufunc

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -428,6 +428,7 @@ from numpy._core.umath import (
     isinf,
     isnan,
     isnat,
+    ldexp,
     less,
     less_equal,
     log,
@@ -7627,7 +7628,6 @@ gcd: _UFunc_Nin2_Nout1[L["gcd"], L[11], L[0]]
 heaviside: _UFunc_Nin2_Nout1[L["heaviside"], L[4], None]
 hypot: _UFunc_Nin2_Nout1[L["hypot"], L[5], L[0]]
 lcm: _UFunc_Nin2_Nout1[L["lcm"], L[11], None]
-ldexp: _UFunc_Nin2_Nout1[L["ldexp"], L[8], None]
 left_shift: _UFunc_Nin2_Nout1[L["left_shift"], L[11], None]
 logaddexp2: _UFunc_Nin2_Nout1[L["logaddexp2"], L[4], float]
 logaddexp: _UFunc_Nin2_Nout1[L["logaddexp"], L[4], float]

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -45,7 +45,6 @@ from numpy import (
     heaviside,
     hypot,
     lcm,
-    ldexp,
     left_shift,
     logaddexp,
     logaddexp2,
@@ -4138,6 +4137,353 @@ class _ufunc_21_cmp(_ufunc_21[None]):  # type: ignore[misc]
         out: np.ndarray | None = None,
     ) -> OutT: ...
 
+# efdg, il => efdg
+@type_check_only
+class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
+    # TODO(@jorenham): shape-typing
+
+    @override
+    @overload  # 0d T@floating, 0d
+    def __call__[ScalarT: np.floating](
+        self,
+        x1: ScalarT,
+        x2: _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> ScalarT: ...
+    @overload  # 0d <f64, 0d
+    def __call__[ScalarT: np.floating](
+        self,
+        x1: float | _to_integer,
+        x2: _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.float64: ...
+    @overload  # >0d T@floating, >=0d
+    def __call__[ScalarT: np.floating](
+        self,
+        x1: npt.NDArray[ScalarT] | _NestedSequence[ScalarT],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # >0d <f64, >=0d
+    def __call__(
+        self,
+        x1: npt.NDArray[_to_integer] | _NestedSequence[float | _to_integer],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float64]: ...
+    @overload  # >=0d T@floating, >0d
+    def __call__[ScalarT: np.floating](
+        self,
+        x1: _ArrayLike[ScalarT],
+        x2: npt.NDArray[_to_integer] | _NestedSequence[_IntLike_co],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # >=0d <f64, >0d
+    def __call__(
+        self,
+        x1: _DualArrayLike[np.dtype[_to_integer], float],
+        x2: npt.NDArray[_to_integer] | _NestedSequence[_IntLike_co],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float64]: ...
+    @overload  # >=0d T@floating, >=0d, out=...
+    def __call__[ScalarT: np.floating](
+        self,
+        x1: _ArrayLike[ScalarT],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # >=0d <f64, >=0d, out=...
+    def __call__(
+        self,
+        x1: _DualArrayLike[np.dtype[_to_integer], float],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float64]: ...
+    @overload  # out=<given>
+    def __call__[OutT: np.ndarray](
+        self,
+        x1: _ArrayLikeFloat_co,
+        x2: _ArrayLikeInt_co,
+        /,
+        out: OutT,
+        *,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> OutT: ...
+    @overload  # x1.__array_ufunc__(self, "__call__", x1, x2, ...)
+    def __call__[OtherT, OutT](
+        self,
+        x1: _CanUfuncCall2L[OtherT, OutT],
+        x2: OtherT,
+        /,
+        *,
+        out: object | None = None,
+        dtype: npt.DTypeLike | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> OutT: ...
+    @overload  # x2.__array_ufunc__(self, "__call__", x1, x2, ...)
+    def __call__[OtherT, OutT](
+        self,
+        x1: OtherT,
+        x2: _CanUfuncCall2R[OtherT, OutT],
+        /,
+        *,
+        out: object | None = None,
+        dtype: npt.DTypeLike | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> OutT: ...
+
+    #
+    @override
+    @overload  # 0d T@floating, 0d
+    def outer[ScalarT: np.floating](  # pyrefly:ignore[bad-override]
+        self,
+        x1: ScalarT,
+        x2: _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> ScalarT: ...
+    @overload  # 0d <f64, 0d
+    def outer[ScalarT: np.floating](
+        self,
+        x1: float | _to_integer,
+        x2: _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.float64: ...
+    @overload  # >0d T@floating, >=0d
+    def outer[ScalarT: np.floating](
+        self,
+        x1: npt.NDArray[ScalarT] | _NestedSequence[ScalarT],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # >0d <f64, >=0d
+    def outer(
+        self,
+        x1: npt.NDArray[_to_integer] | _NestedSequence[float | _to_integer],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float64]: ...
+    @overload  # >=0d T@floating, >0d
+    def outer[ScalarT: np.floating](
+        self,
+        x1: _ArrayLike[ScalarT],
+        x2: npt.NDArray[_to_integer] | _NestedSequence[_IntLike_co],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # >=0d <f64, >0d
+    def outer(
+        self,
+        x1: _DualArrayLike[np.dtype[_to_integer], float],
+        x2: npt.NDArray[_to_integer] | _NestedSequence[_IntLike_co],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float64]: ...
+    @overload  # >=0d T@floating, >=0d, out=...
+    def outer[ScalarT: np.floating](
+        self,
+        x1: _ArrayLike[ScalarT],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # >=0d <f64, >=0d, out=...
+    def outer(
+        self,
+        x1: _DualArrayLike[np.dtype[_to_integer], float],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float64]: ...
+    @overload  # out=<given>
+    def outer[OutT: np.ndarray](
+        self,
+        x1: _ArrayLikeFloat_co,
+        x2: _ArrayLikeInt_co,
+        /,
+        out: OutT,
+        *,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> OutT: ...
+    @overload  # x1.__array_ufunc__(self, "outer", x1, x2, ...)
+    def outer[OtherT, OutT](
+        self,
+        x1: _CanUfuncCall2L[OtherT, OutT],
+        x2: OtherT,
+        /,
+        *,
+        out: object | None = None,
+        dtype: npt.DTypeLike | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> OutT: ...
+    @overload  # x2.__array_ufunc__(self, "outer", x1, x2, ...)
+    def outer[OtherT, OutT](
+        self,
+        x1: OtherT,
+        x2: _CanUfuncCall2R[OtherT, OutT],
+        /,
+        *,
+        out: object | None = None,
+        dtype: npt.DTypeLike | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> OutT: ...
+
+    #
+    @override
+    @overload
+    def at(self, a: npt.NDArray[_to_floating], indices: _ArrayLikeInt, b: _ArrayLikeInt_co, /) -> None: ...  # pyrefly:ignore[bad-override]
+    @overload
+    def at[OtherT, IxT, OutT](self, a: _CanUfuncAt2L[OtherT, IxT, OutT], indices: IxT, b: OtherT, /) -> OutT: ...
+    @overload
+    def at[OtherT, IxT, OutT](self, a: OtherT, indices: IxT, b: _CanUfuncAt2R[OtherT, IxT, OutT], /) -> OutT: ...
+
+    #
+    @override
+    @overload  # unknown shape
+    def reduce(  # pyrefly:ignore[bad-override]
+        self,
+        array: _ArrayLikeInt,
+        /,
+        *,
+        axis: int | tuple[int, ...] = 0,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[False] = False,
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[np.float64] | np.float64: ...
+    @overload  # unknown shape, axis=None
+    def reduce(
+        self,
+        array: _ArrayLikeInt,
+        /,
+        *,
+        axis: None,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[False] = False,
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> np.float64: ...
+    @overload  # unknown shape, keepdims=True
+    def reduce(
+        self,
+        array: _ArrayLikeInt,
+        /,
+        *,
+        axis: int | tuple[int, ...] | None = 0,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[True],
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[np.float64]: ...
+    @overload  # unknown shape, out=...
+    def reduce(
+        self,
+        array: _ArrayLikeInt,
+        /,
+        *,
+        axis: int | tuple[int, ...] | None = 0,
+        dtype: None = None,
+        out: EllipsisType,
+        keepdims: bool = False,
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[np.float64]: ...
+    @overload  # out=<given>
+    def reduce[OutT: np.ndarray](
+        self,
+        array: _ArrayLikeInt,
+        /,
+        *,
+        axis: int | tuple[int, ...] | None = 0,
+        dtype: None = None,
+        out: OutT,
+        keepdims: bool = False,
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> OutT: ...
+    @overload  # array.__array_ufunc__(self, "reduce", array, ...)
+    def reduce[OutT](
+        self,
+        array: _CanUfuncReduce[OutT],
+        /,
+        *,
+        axis: int | tuple[int, ...] | None = 0,
+        dtype: npt.DTypeLike | None = None,
+        out: np.ndarray | EllipsisType | None = None,
+        keepdims: bool = False,
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> OutT: ...
+
+    @override
+    def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    @override
+    def accumulate(self, array: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
+
 logical_and: Final[_ufunc_21_logical[Literal[True]]] = ...
 logical_or: Final[_ufunc_21_logical[Literal[False]]] = ...
 logical_xor: Final[_ufunc_21_logical[Literal[False]]] = ...
@@ -4148,6 +4494,8 @@ greater_equal: Final[_ufunc_21_cmp] = ...
 less: Final[_ufunc_21_cmp] = ...
 less_equal: Final[_ufunc_21_cmp] = ...
 not_equal: Final[_ufunc_21_cmp] = ...
+
+ldexp: Final[_ufunc_21_ldexp] = ...
 
 ###
 # re-exports from `_core._multiarray_umath` that are used by `_core._ufunc_config`

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -924,3 +924,51 @@ assert_type(np.less.reduceat(_bool_1d, (0,)), np.ndarray[tuple[int], np.dtype[np
 assert_type(np.less.reduceat(_bool_2d, (0,)), np.ndarray[tuple[int, int], np.dtype[np.bool]])
 assert_type(np.less.reduceat(_py_b_1d, (0,)), npt.NDArray[np.bool])
 assert_type(np.less.reduceat(_py_b_1d, (0,), out=_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+
+# _ufunc_21_ldexp
+# (ldexp)
+
+assert_type(np.ldexp(_py_b_0d, _py_b_0d), np.float64)
+assert_type(np.ldexp(_py_b_1d, _py_b_1d), npt.NDArray[np.float64])
+assert_type(np.ldexp(_py_b_2d, _py_b_2d), npt.NDArray[np.float64])
+assert_type(np.ldexp(_py_i_0d, _py_i_0d), np.float64)
+assert_type(np.ldexp(_py_i_1d, _py_i_1d), npt.NDArray[np.float64])
+assert_type(np.ldexp(_py_i_2d, _py_i_2d), npt.NDArray[np.float64])
+assert_type(np.ldexp(_py_f_0d, _py_i_0d), np.float64)
+assert_type(np.ldexp(_py_f_1d, _py_i_1d), npt.NDArray[np.float64])
+assert_type(np.ldexp(_py_f_2d, _py_i_2d), npt.NDArray[np.float64])
+
+assert_type(np.ldexp(_bool_0d, _bool_0d), np.float64)
+assert_type(np.ldexp(_bool_1d, _bool_1d), npt.NDArray[np.float64])
+assert_type(np.ldexp(_bool_2d, _bool_2d), npt.NDArray[np.float64])
+assert_type(np.ldexp(_bool_nd, _bool_nd), npt.NDArray[np.float64])
+assert_type(np.ldexp(_i16_0d, _i16_0d), np.float64)
+assert_type(np.ldexp(_i16_1d, _i16_1d), npt.NDArray[np.float64])
+assert_type(np.ldexp(_i16_2d, _i16_2d), npt.NDArray[np.float64])
+assert_type(np.ldexp(_i16_nd, _i16_nd), npt.NDArray[np.float64])
+assert_type(np.ldexp(_f32_0d, _i16_0d), np.float32)
+assert_type(np.ldexp(_f32_1d, _i16_1d), npt.NDArray[np.float32])
+assert_type(np.ldexp(_f32_2d, _i16_2d), npt.NDArray[np.float32])
+assert_type(np.ldexp(_f32_nd, _i16_nd), npt.NDArray[np.float32])
+
+assert_type(np.ldexp(_py_i_2d, _py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+
+assert_type(np.ldexp.outer(_py_f_0d, _py_i_0d), np.float64)
+assert_type(np.ldexp.outer(_py_f_1d, _py_i_0d), npt.NDArray[np.float64])
+assert_type(np.ldexp.outer(_py_f_0d, _py_i_1d), npt.NDArray[np.float64])
+assert_type(np.ldexp.outer(_py_f_1d, _py_i_1d), npt.NDArray[np.float64])
+assert_type(np.ldexp.outer(_f32_0d, _py_i_0d), np.float32)
+assert_type(np.ldexp.outer(_f32_1d, _py_i_0d), npt.NDArray[np.float32])
+assert_type(np.ldexp.outer(_f32_0d, _py_i_1d), npt.NDArray[np.float32])
+assert_type(np.ldexp.outer(_f32_1d, _py_i_1d), npt.NDArray[np.float32])
+
+assert_type(np.ldexp.at(_f32_2d, 1, _py_i_1d), None)
+
+assert_type(np.ldexp.reduce(_i16_1d), npt.NDArray[np.float64] | np.float64)
+assert_type(np.ldexp.reduce(_i16_2d), npt.NDArray[np.float64] | np.float64)
+assert_type(np.ldexp.reduce(_i16_1d, axis=None), np.float64)
+assert_type(np.ldexp.reduce(_i16_1d, keepdims=True), npt.NDArray[np.float64])
+assert_type(np.ldexp.reduce(_i16_1d, out=...), npt.NDArray[np.float64])
+assert_type(np.ldexp.reduce(_i16_1d, out=_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
+
+# ldexp doesn't support reduceat / accumulate


### PR DESCRIPTION
Following #31824, this adds the specialized typing stubs for the `np.ldexp` binary ufunc. The nice thing about this one is that the dtype promotions one epend on the first inoput, not the second one, so it's not as complicated to type as the other (all remaining) binary ufuncs.

---

No AI.