### PR TITLE
CI: fix hangs on MacOS ASan CI

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -33,7 +33,7 @@ jobs:
   clang_ASAN_UBSAN:
     # To enable this workflow on a fork, comment out:
     if: github.repository == 'numpy/numpy'
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -54,8 +54,8 @@ jobs:
         pyenv --version
     - name: Set up LLVM
       run: |
-        brew install llvm@20
-        LLVM_PREFIX=$(brew --prefix llvm@20)
+        brew install llvm
+        LLVM_PREFIX=$(brew --prefix llvm)
         echo CC="$LLVM_PREFIX/bin/clang" >> $GITHUB_ENV
         echo CXX="$LLVM_PREFIX/bin/clang++" >> $GITHUB_ENV
         echo LDFLAGS="-L$LLVM_PREFIX/lib" >> $GITHUB_ENV

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -42,7 +42,7 @@ jobs:
         persist-credentials: false
     - name: Set up pyenv
       run: |
-        git clone --branch v2.6.25 --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
+        git clone --branch v2.7.3 --depth 1 https://github.com/pyenv/pyenv.git "$HOME/.pyenv"
         PYENV_ROOT="$HOME/.pyenv"
         PYENV_BIN="$PYENV_ROOT/bin"
         PYENV_SHIMS="$PYENV_ROOT/shims"
@@ -62,7 +62,7 @@ jobs:
         echo CPPFLAGS="-I$LLVM_PREFIX/include" >> $GITHUB_ENV
     - name: Build Python with address sanitizer
       run: |
-        CONFIGURE_OPTS="--with-address-sanitizer" pyenv install 3.14
+        CONFIGURE_OPTS="--with-address-sanitizer" pyenv install -v 3.14
         pyenv global 3.14
     - name: Install dependencies
       run: |


### PR DESCRIPTION
### PR summary
This should (hopefully) fix hangs seen on the UBSan CI lately.

This is happening because of the phased rollout of macos-26 images: https://github.com/actions/runner-images/issues/14167

I'm pretty sure the problem is that LLVM 20 doesn't support macos-26. Let's see!

#### AI Disclosure
No AI use.
