### PR TITLE
BUG: fix several bugs in StringDType operations (#31846)

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -147,6 +147,9 @@ string_to_string_resolve_descriptors(PyObject *NPY_UNUSED(self),
 {
     if (given_descrs[1] == NULL) {
         loop_descrs[1] = stringdtype_finalize_descr(given_descrs[0]);
+        if (loop_descrs[1] == NULL) {
+            return (NPY_CASTING)-1;
+        }
     }
     else {
         Py_INCREF(given_descrs[1]);
@@ -852,9 +855,13 @@ make_type2s_name(NPY_TYPES typenum) {
     size_t nlen = strlen(type_name);
 
     const char suffix[] = "_to_StringDType";
-    size_t slen = sizeof(prefix)/sizeof(char) - 1;
+    size_t slen = sizeof(suffix)/sizeof(char) - 1;
 
     char *buf = (char *)PyMem_RawCalloc(sizeof(char), plen + nlen + slen + 1);
+    if (buf == NULL) {
+        npy_gil_error(PyExc_MemoryError, "Failed allocate memory for cast");
+        return NULL;
+    }
 
     // memcpy instead of strcpy/strncat to avoid stringop-truncation warning,
     // since we are not including the trailing null character
@@ -1873,7 +1880,7 @@ void_to_string(PyArrayMethod_Context *context, char *const data[],
     npy_intp out_stride = strides[1];
 
     while(N--) {
-        size_t out_num_bytes = utf8_buffer_size(in, max_in_size);
+        Py_ssize_t out_num_bytes = utf8_buffer_size(in, max_in_size);
         if (out_num_bytes < 0) {
             npy_gil_error(PyExc_TypeError,
                           "Invalid UTF-8 bytes found, cannot convert to UTF-8");
@@ -1881,7 +1888,7 @@ void_to_string(PyArrayMethod_Context *context, char *const data[],
         }
         npy_static_string out_ss = {0, NULL};
         if (load_new_string((npy_packed_static_string *)out,
-                            &out_ss, out_num_bytes, allocator,
+                            &out_ss, (size_t)out_num_bytes, allocator,
                             "void to string cast") == -1) {
             goto fail;
         }

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -230,7 +230,7 @@ common_instance(PyArray_StringDTypeObject *dtype1, PyArray_StringDTypeObject *dt
     }
 
     return (PyArray_StringDTypeObject *)new_stringdtype_instance(
-            out_na_object, dtype1->coerce && dtype1->coerce);
+            out_na_object, dtype1->coerce && dtype2->coerce);
 }
 
 /*
@@ -265,6 +265,13 @@ as_pystring(PyObject *scalar, int coerce)
     if (scalar_type == &PyUnicode_Type) {
         Py_INCREF(scalar);
         return scalar;
+    }
+    // str subclasses (e.g. np.str_) are string data even when coercion is
+    // disabled; convert to an exact str, preserving embedded and trailing
+    // nulls that a round-trip through a fixed-width unicode descriptor
+    // would strip
+    if (PyUnicode_Check(scalar)) {
+        return PyUnicode_FromObject(scalar);
     }
     if (coerce == 0) {
         PyErr_SetString(PyExc_ValueError,
@@ -635,6 +642,11 @@ stringdtype_is_known_scalar_type(PyArray_DTypeMeta *cls,
     {
         return 1;
     }
+    // otherwise np.str_ discovers its fixed-width 'U' descriptor, whose
+    // cast into StringDType strips trailing NULs setitem would preserve
+    else if (pytype == &PyUnicodeArrType_Type) {
+        return 1;
+    }
     return 0;
 }
 
@@ -654,6 +666,9 @@ stringdtype_finalize_descr(PyArray_Descr *dtype)
     NpyString_release_allocator(allocator);
     PyArray_StringDTypeObject *ret = (PyArray_StringDTypeObject *)new_stringdtype_instance(
             sdtype->na_object, sdtype->coerce);
+    if (ret == NULL) {
+        return NULL;
+    }
     ret->array_owned = 1;
     return (PyArray_Descr *)ret;
 }

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -144,6 +144,35 @@ def test_create_with_na(dtype):
     assert arr[1] is dtype.na_object
 
 
+def test_create_with_failing_na_comparison():
+    # An error raised while re-creating an array-owned descriptor used to
+    # crash with a NULL dereference in stringdtype_finalize_descr instead
+    # of propagating.
+    class Flaky:
+        def __init__(self):
+            self.calls = 0
+
+        def __eq__(self, other):
+            return self is other
+
+        def __ne__(self, other):
+            self.calls += 1
+            if self.calls > 1:
+                raise RuntimeError("boom")
+            return False
+
+        def __hash__(self):
+            return 0
+
+    dt = StringDType(na_object=Flaky())
+    # the first array takes ownership of the descriptor
+    np.array(["x"], dtype=dt)
+    # the second array creation re-creates the descriptor, re-running the
+    # na object classification, which fails
+    with pytest.raises(RuntimeError, match="boom"):
+        np.array(["y"], dtype=dt)
+
+
 @pytest.mark.parametrize("i", list(range(5)))
 def test_set_replace_na(i):
     # Test strings of various lengths can be set to NaN and then replaced.
@@ -166,6 +195,18 @@ def test_null_roundtripping():
     arr = np.array(data, dtype="T")
     assert data[0] == arr[0]
     assert data[1] == arr[1]
+
+
+@pytest.mark.parametrize("coerce", [True, False])
+def test_np_str_trailing_nul_preserved(coerce):
+    dtype = StringDType(coerce=coerce)
+    value = np.str_("q\x00")
+    arr = np.empty(1, dtype=dtype)
+    arr[0] = value
+    assert arr[0] == "q\x00"
+    arr[0:1] = [value]
+    assert arr[0] == "q\x00"
+    assert np.array([value], dtype=dtype)[0] == "q\x00"
 
 
 @pytest.mark.parametrize(
@@ -309,6 +350,17 @@ def test_self_casts(dtype, dtype2, strings):
                 arr[:-1] == newarr[:-1]
             return
     assert_array_equal(arr[:-1], newarr[:-1])
+
+
+def test_cast_method_names():
+    get_castingimpl = np._core._multiarray_umath._get_castingimpl
+    string_DT = type(StringDType())
+    for other_DT, name in [(np.dtypes.BoolDType, "bool"),
+                           (np.dtypes.Float64DType, "double")]:
+        to_string = get_castingimpl(other_DT, string_DT)
+        assert f"cast_{name}_to_StringDType" in repr(to_string)
+        from_string = get_castingimpl(string_DT, other_DT)
+        assert f"cast_StringDType_to_{name}" in repr(from_string)
 
 
 @pytest.mark.parametrize(
@@ -909,6 +961,15 @@ def test_string_to_bytes_invalid_ascii_error():
         np.array(["abc", "xy"], dtype="T").astype("S3"),
         np.array([b"abc", b"xy"], dtype="S3"),
     )
+
+
+def test_void_to_string_invalid_utf8_error():
+    # invalid UTF-8 in a void buffer used to surface as a confusing
+    # MemoryError because the error return of utf8_buffer_size was
+    # stored in an unsigned variable
+    varr = np.array([b"\xff\xff\xff\xff"], dtype="V4")
+    with pytest.raises(TypeError, match="Invalid UTF-8"):
+        varr.astype(StringDType())
 
 
 @pytest.mark.parametrize(
@@ -1784,6 +1845,17 @@ def test_unset_na_coercion():
         op = np.array(inp, dtype=op_dtype)
         with pytest.raises(TypeError):
             arr == op
+
+
+def test_coerce_promotion_commutative():
+    # promoting a coerce=False instance with a coerce=True instance
+    # used to depend on the argument order
+    dt = StringDType()
+    dt_no_coerce = StringDType(coerce=False)
+    assert np.promote_types(dt, dt_no_coerce) == dt_no_coerce
+    assert np.promote_types(dt_no_coerce, dt) == dt_no_coerce
+    assert np.promote_types(dt, dt) == dt
+    assert np.promote_types(dt_no_coerce, dt_no_coerce) == dt_no_coerce
 
 
 def test_repeat(string_array):


### PR DESCRIPTION
Backport of #31846.

### PR summary

Fixes several miscellaneous bugs in StringDType internals. Batching them because I found them in the same AI scan while working on ByteStringDType.

IMO these are all pretty self-explanatory with the tests but let me know if you have any questions.


#### AI Disclosure
an AI identified these bugs
