### PR TITLE
BUG: Fix segfault in MT19937 by preventing recursive seed lists (#31775)

### DIFF
--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -249,6 +249,18 @@ cdef class SeedlessSeedSequence:
 # We cannot directly subclass a `cdef class` type from an `ABC` in Cython, so
 # we must register it after the fact.
 ISpawnableSeedSequence.register(SeedlessSeedSequence)
+def _has_cycle(obj, visited=None):
+    if visited is None:
+        visited = set()
+    if id(obj) in visited:
+        return True
+    visited.add(id(obj))
+    if isinstance(obj, list):
+        for item in obj:
+            if _has_cycle(item, visited):
+                return True
+        visited.remove(id(obj))
+    return False
 
 
 cdef class SeedSequence:
@@ -300,6 +312,12 @@ cdef class SeedSequence:
 
     def __init__(self, entropy=None, *, spawn_key=(),
                  pool_size=DEFAULT_POOL_SIZE, n_children_spawned=0):
+        
+        # --- OUR FIX ---
+        if isinstance(entropy, list) and _has_cycle(entropy):
+            raise ValueError("Seed (entropy) cannot be a recursive or self-referencing list.")
+        # ---------------
+
         if pool_size < DEFAULT_POOL_SIZE:
             raise ValueError("The size of the entropy pool should be at least "
                              f"{DEFAULT_POOL_SIZE}")

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -142,9 +142,16 @@ def _coerce_to_uint32_array(x):
     else:
         if len(x) == 0:
             return np.array([], dtype=np.uint32)
+        
         # Should be a sequence of interpretable-as-ints. Convert each one to
         # a uint32 array and concatenate.
-        subseqs = [_coerce_to_uint32_array(v) for v in x]
+        subseqs = []
+        for v in x:
+            if hasattr(v, '__len__') and not isinstance(v, str):
+                raise TypeError("SeedSequence does not accept nested sequences.")
+            
+            subseqs.append(_coerce_to_uint32_array(v))
+            
         return np.concatenate(subseqs)
 
 
@@ -249,18 +256,6 @@ cdef class SeedlessSeedSequence:
 # We cannot directly subclass a `cdef class` type from an `ABC` in Cython, so
 # we must register it after the fact.
 ISpawnableSeedSequence.register(SeedlessSeedSequence)
-def _has_cycle(obj, visited=None):
-    if visited is None:
-        visited = set()
-    if id(obj) in visited:
-        return True
-    visited.add(id(obj))
-    if isinstance(obj, list):
-        for item in obj:
-            if _has_cycle(item, visited):
-                return True
-        visited.remove(id(obj))
-    return False
 
 
 cdef class SeedSequence:
@@ -313,10 +308,6 @@ cdef class SeedSequence:
     def __init__(self, entropy=None, *, spawn_key=(),
                  pool_size=DEFAULT_POOL_SIZE, n_children_spawned=0):
         
-        # --- OUR FIX ---
-        if isinstance(entropy, list) and _has_cycle(entropy):
-            raise ValueError("Seed (entropy) cannot be a recursive or self-referencing list.")
-        # ---------------
 
         if pool_size < DEFAULT_POOL_SIZE:
             raise ValueError("The size of the entropy pool should be at least "

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -307,8 +307,6 @@ cdef class SeedSequence:
 
     def __init__(self, entropy=None, *, spawn_key=(),
                  pool_size=DEFAULT_POOL_SIZE, n_children_spawned=0):
-        
-
         if pool_size < DEFAULT_POOL_SIZE:
             raise ValueError("The size of the entropy pool should be at least "
                              f"{DEFAULT_POOL_SIZE}")

--- a/numpy/random/tests/test_seed_sequence.py
+++ b/numpy/random/tests/test_seed_sequence.py
@@ -77,3 +77,20 @@ def test_zero_padding():
         np.not_equal,
         SeedSequence(42, spawn_key=(0,)).generate_state(4),
         expected42)
+def test_seedsequence_rejects_nested_sequence():
+    import pytest  # <-- We just added this line!
+    from numpy.random import SeedSequence
+    
+    # Prevents infinite recursion (Issue #28822) and rejects invalid types (Issue #27380)
+    match_str = "SeedSequence does not accept nested sequences."
+    
+    # Test standard nested lists
+    with pytest.raises(TypeError, match=match_str):
+        SeedSequence([[1, 2], [3, 4]])
+        
+    # Test self-referencing/cyclic lists
+    with pytest.raises(TypeError, match=match_str):
+        cyclic_seed = []
+        cyclic_seed.append(cyclic_seed)
+        SeedSequence(cyclic_seed)    
+        

--- a/numpy/random/tests/test_seed_sequence.py
+++ b/numpy/random/tests/test_seed_sequence.py
@@ -1,6 +1,11 @@
 import numpy as np
 from numpy.random import SeedSequence
-from numpy.testing import assert_array_compare, assert_array_equal, assert_raises, assert_raises_regex
+from numpy.testing import (
+    assert_array_compare,
+    assert_array_equal,
+    assert_raises,
+    assert_raises_regex,
+)
 
 
 def test_reference_data():
@@ -82,17 +87,17 @@ def test_zero_padding():
 def test_seedsequence_rejects_nested_sequence():
     with assert_raises(TypeError):
         SeedSequence(SeedSequence(42))
-    
-    # Prevents infinite recursion (Issue #28822) and rejects invalid types (Issue #27380)
+
+    # Prevents infinite recursion (Issue #28822) and rejects
+    # invalid types (Issue #27380)
     match_str = "SeedSequence does not accept nested sequences."
-    
+
     # Test standard nested lists
     with assert_raises_regex(TypeError, match_str):
         SeedSequence([[1, 2], [3, 4]])
-        
+
     # Test self-referencing/cyclic lists
     with assert_raises_regex(TypeError, match_str):
         cyclic_seed = []
         cyclic_seed.append(cyclic_seed)
-        SeedSequence(cyclic_seed)    
-        
+        SeedSequence(cyclic_seed)

--- a/numpy/random/tests/test_seed_sequence.py
+++ b/numpy/random/tests/test_seed_sequence.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.random import SeedSequence
-from numpy.testing import assert_array_compare, assert_array_equal
+from numpy.testing import assert_array_compare, assert_array_equal, assert_raises, assert_raises_regex
 
 
 def test_reference_data():
@@ -77,19 +77,21 @@ def test_zero_padding():
         np.not_equal,
         SeedSequence(42, spawn_key=(0,)).generate_state(4),
         expected42)
+
+
 def test_seedsequence_rejects_nested_sequence():
-    import pytest  # <-- We just added this line!
-    from numpy.random import SeedSequence
+    with assert_raises(TypeError):
+        SeedSequence(SeedSequence(42))
     
     # Prevents infinite recursion (Issue #28822) and rejects invalid types (Issue #27380)
     match_str = "SeedSequence does not accept nested sequences."
     
     # Test standard nested lists
-    with pytest.raises(TypeError, match=match_str):
+    with assert_raises_regex(TypeError, match_str):
         SeedSequence([[1, 2], [3, 4]])
         
     # Test self-referencing/cyclic lists
-    with pytest.raises(TypeError, match=match_str):
+    with assert_raises_regex(TypeError, match_str):
         cyclic_seed = []
         cyclic_seed.append(cyclic_seed)
         SeedSequence(cyclic_seed)    


### PR DESCRIPTION
Backport of #31775.

PR summary
This PR fixes a Segmentation Fault (stack overflow) that occurs when initialising MT19937 with a recursive or self-referencing list.
Previously, passing a cyclic list (e.g., x = []; x.append(x)) into the generator caused an infinite loop in the Cython unpacking logic, leading to a hard crash.
I added a _has_cycle helper function in bit_generator.pyx to detect self-referencing sequences early. If a cycle is detected, the SeedSequence initialisation now safely raises a ValueError instead of segfaulting.

Closes #28822 
First-time committer introduction
Hi everyone! I am a newer contributor looking to dive deep into the Python data science stack. I wanted my first major contribution to be on the systems level rather than just documentation, so hunting down a C/Cython memory bug seemed like a great challenge. I'm excited to learn more from the maintainers here!

AI Disclosure
I used an AI assistant (Google Gemini) strictly as a pair-programming tool to help navigate the Meson/Spin build system and to draft the initial logic for the _has_cycle helper function. I manually compiled the environment, reproduced the bug, and verified the fix locally.

### Verification
Here is the local terminal output proving the fix. Instead of a Segmentation Fault, it now safely catches the cycle and throws the expected exception:

```bash
Testing MT19937...
Traceback (most recent call last):
  File "/workspaces/numpy/../test_bug.py", line 5, in <module>
    MT19937(x)
  File "numpy/random/_mt19937.pyx", line 131, in numpy.random._mt19937.MT19937.__init__
    BitGenerator.__init__(self, seed)
  File "numpy/random/bit_generator.pyx", line 559, in numpy.random.bit_generator.BitGenerator.__init__
    seed = SeedSequence(seed)
  File "numpy/random/bit_generator.pyx", line 318, in numpy.random.bit_generator.SeedSequence.__init__
    raise ValueError("Seed (entropy) cannot be a recursive or self-referencing list.")
ValueError: Seed (entropy) cannot be a recursive or self-referencing list.
