### PR TITLE
MNT: remove some obsolete string to bool workarounds

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -534,7 +534,15 @@ def count_nonzero(a, axis=None, *, keepdims=False):
     if axis is None and not keepdims:
         return multiarray.count_nonzero(a)
 
-    a_bool = asanyarray(a, dtype=np.bool)
+    a = asanyarray(a)
+
+    # This is a performance optimization for character dtypes
+    # TODO: this can be removed if the legacy fixed-width string dtypes are ever removed
+    if np.issubdtype(a.dtype, np.character):
+        a_bool = a != a.dtype.type()
+    else:
+        a_bool = a.astype(np.bool, copy=False)
+
     return a_bool.sum(axis=axis, dtype=np.intp, keepdims=keepdims)
 
 

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -535,13 +535,7 @@ def count_nonzero(a, axis=None, *, keepdims=False):
         return multiarray.count_nonzero(a)
 
     a = asanyarray(a)
-
-    # TODO: this works around .astype(bool) not working properly (gh-9847)
-    if np.issubdtype(a.dtype, np.character):
-        a_bool = a != a.dtype.type()
-    else:
-        a_bool = a.astype(np.bool, copy=False)
-
+    a_bool = a.astype(np.bool, copy=False)
     return a_bool.sum(axis=axis, dtype=np.intp, keepdims=keepdims)
 
 

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -534,8 +534,7 @@ def count_nonzero(a, axis=None, *, keepdims=False):
     if axis is None and not keepdims:
         return multiarray.count_nonzero(a)
 
-    a = asanyarray(a)
-    a_bool = a.astype(np.bool, copy=False)
+    a_bool = asanyarray(a, dtype=np.bool)
     return a_bool.sum(axis=axis, dtype=np.intp, keepdims=keepdims)
 
 

--- a/numpy/_core/tests/test_array_coercion.py
+++ b/numpy/_core/tests/test_array_coercion.py
@@ -95,9 +95,7 @@ def scalar_instances(times=True, extended_precision=True, user_dtype=True):
         yield param(np.sqrt(np.clongdouble(2 + 3j)), id="clongdouble")
 
     # Bool:
-    # XFAIL: Bool should be added, but has some bad properties when it
-    # comes to strings, see also gh-9875
-    # yield param(np.bool(0), id="bool")
+    yield param(np.bool(0), id="bool")
 
     # Integers:
     yield param(np.int8(2), id="int8")

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1840,6 +1840,15 @@ class TestNonzero:
                 assert_equal(np.count_nonzero(m),
                              expected, err_msg=err_msg)
 
+    @pytest.mark.parametrize("dtype", ["S5", "U5"])
+    def test_count_nonzero_character_axis(self, dtype):
+        a = np.array([
+            ["", "0", " "],
+            ["1", "", "False"],
+        ], dtype=dtype)
+
+        assert_array_equal(np.count_nonzero(a, axis=1), [2, 2])
+
     def test_count_nonzero_axis_consistent(self):
         # Check that the axis behaviour for valid axes in
         # non-special cases is consistent (and therefore

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -1840,7 +1840,7 @@ class TestNonzero:
                 assert_equal(np.count_nonzero(m),
                              expected, err_msg=err_msg)
 
-    @pytest.mark.parametrize("dtype", ["S5", "U5"])
+    @pytest.mark.parametrize("dtype", ["S5", "U5", "T"])
     def test_count_nonzero_character_axis(self, dtype):
         a = np.array([
             ["", "0", " "],
@@ -1848,6 +1848,8 @@ class TestNonzero:
         ], dtype=dtype)
 
         assert_array_equal(np.count_nonzero(a, axis=1), [2, 2])
+        assert_array_equal(np.count_nonzero(a, axis=0), [1, 1, 2])
+        assert np.count_nonzero(a) == 4
 
     def test_count_nonzero_axis_consistent(self):
         # Check that the axis behaviour for valid axes in


### PR DESCRIPTION
### PR summary
Removes a couple of obsolete string to bool workarounds and updates a comment and adds a tiny bit of testing.

### First time committer introduction
N/A

#### AI Disclosure
No AI
