### PR TITLE
BUG: fix `StringDType` coerce flag in binary ufunc promotion (#31861)

### DIFF
--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -248,7 +248,7 @@ binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
 {
     PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
     PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    int out_coerce = descr1->coerce && descr1->coerce;
+    int out_coerce = descr1->coerce && descr2->coerce;
     PyObject *out_na_object = NULL;
 
     if (stringdtype_compatible_na(

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1858,6 +1858,27 @@ def test_coerce_promotion_commutative():
     assert np.promote_types(dt_no_coerce, dt_no_coerce) == dt_no_coerce
 
 
+@pytest.mark.parametrize(
+    "coerce_a, coerce_b",
+    [(True, False), (False, True)],
+)
+def test_add_preserves_coerce_false(coerce_a, coerce_b):
+    # Mixing coerce=True and coerce=False under ufuncs should promote to
+    # coerce=False (same as np.promote_types), so assignment of non-strings
+    # remains strict.
+    a = np.array(["a"], dtype=StringDType(coerce=coerce_a))
+    b = np.array(["b"], dtype=StringDType(coerce=coerce_b))
+
+    c = np.add(a, b)
+    assert c.dtype == StringDType(coerce=False)
+    assert c.dtype.coerce is False
+    assert_array_equal(c, np.array(["ab"], dtype=StringDType(coerce=False)))
+
+    # Same error as a direct StringDType(coerce=False) array.
+    with pytest.raises(ValueError, match="string coercion is disabled"):
+        c[0] = object()
+
+
 def test_repeat(string_array):
     res = string_array.repeat(1000)
     # Create an empty array with expanded dimension, and fill it.  Then,

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1820,10 +1820,13 @@ def test_unset_na_coercion():
                      StringDType(na_object=None)]:
         if op_dtype is None:
             op = "2"
+            expected = StringDType(na_object=None)  # coerce defaults to True
         else:
             op = np.array("2", dtype=op_dtype)
+            expected = StringDType(na_object=None, coerce=op_dtype.coerce)
         res = arr + op
         assert_array_equal(res, ["hello2", "world2"])
+        assert res.dtype == expected
 
     # dtype instances with distinct explicitly set NA objects are incompatible
     for op_dtype in [StringDType(na_object=pd_NA), StringDType(na_object="")]:
@@ -1856,27 +1859,6 @@ def test_coerce_promotion_commutative():
     assert np.promote_types(dt_no_coerce, dt) == dt_no_coerce
     assert np.promote_types(dt, dt) == dt
     assert np.promote_types(dt_no_coerce, dt_no_coerce) == dt_no_coerce
-
-
-@pytest.mark.parametrize(
-    "coerce_a, coerce_b",
-    [(True, False), (False, True)],
-)
-def test_add_preserves_coerce_false(coerce_a, coerce_b):
-    # Mixing coerce=True and coerce=False under ufuncs should promote to
-    # coerce=False (same as np.promote_types), so assignment of non-strings
-    # remains strict.
-    a = np.array(["a"], dtype=StringDType(coerce=coerce_a))
-    b = np.array(["b"], dtype=StringDType(coerce=coerce_b))
-
-    c = np.add(a, b)
-    assert c.dtype == StringDType(coerce=False)
-    assert c.dtype.coerce is False
-    assert_array_equal(c, np.array(["ab"], dtype=StringDType(coerce=False)))
-
-    # Same error as a direct StringDType(coerce=False) array.
-    with pytest.raises(ValueError, match="string coercion is disabled"):
-        c[0] = object()
 
 
 def test_repeat(string_array):


### PR DESCRIPTION
### PR summary

Fixes #31861.

Binary `StringDType` ufuncs resolved output `coerce` with `descr1->coerce && descr1->coerce` instead of combining both operands.

That made results order-dependent (e.g. `np.add` with `coerce=True` then `coerce=False` kept `coerce=True`) and allowed non-string assignment via implicit stringification.

This changes the combination to `descr1->coerce && descr2->coerce`, matching `common_instance` / `np.promote_types`, and adds a small regression test for both operand orders.

### First time committer introduction

I have been using NumPy for some time now. I hit this while working with `StringDType` and `coerce`, and found two places with similar typo bug. I checked and found that one typo in `common_instance` has been fixed yesterday, so wanted to fix the remaining typo in the binary ufunc path.

#### AI Disclosure

I used Grok to help locate the bug in `binary_resolve_descriptors`, draft the regression test, and refine the issue/PR wording. I made and verified the fix with correctness checks, rebuilds and the test suite; final review and PR submission were done by me.