### PR TITLE
REL: Prepare for the NumPy 2.5.1 release.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -83,6 +83,7 @@ Abhishek Kumar <abhishek.r.kumar@fujitsu.com>
 Abhishek Kumar <abhishek.r.kumar@fujitsu.com> <142383124+abhishek-iitmadras@users.noreply.github.com>
 Abhishek Tiwari <27881020+Abhi210@users.noreply.github.com>
 Abraham Medina <abhram_medina@yahoo.com>
+Adhyan Gupta <123641130+Adhyansinghgupta@users.noreply.github.com>
 Adrin Jalali <adrin.jalali@gmail.com>
 Akhil Kannan <akhilkannan10a@gmail.com>
 Akhil Kannan <akhilkannan10a@gmail.com> <143798318+Alverok@users.noreply.github.com>

--- a/doc/changelog/2.5.1-changelog.rst
+++ b/doc/changelog/2.5.1-changelog.rst
@@ -1,24 +1,3 @@
-.. currentmodule:: numpy
-
-=========================
-NumPy 2.5.1 Release Notes
-=========================
-
-The NumPy 2.5.1 is a patch release that fixes bugs discovered after the 2.5.0
-release. The most noticeable is the fix is to the numpy datetime cython API
-which should allow downstream to support NumPy versions older than 2.5.
-Preparation for Python 3.15 continues along with typing improvements.
-
-This release supports Python versions 3.12-3.14
-
-
-Changes
-=======
-
-* The minimum supported GCC version has been updated from 9.3.0 to 10.3.0
-
-  (`gh-31843 <https://github.com/numpy/numpy/pull/31843>`__)
-
 
 Contributors
 ============
@@ -36,7 +15,6 @@ names contributed a patch for the first time.
 * Sebastian Berg
 * Ties Jan Hefting +
 * Vineet Kumar
-
 
 Pull requests merged
 ====================

--- a/doc/release/upcoming_changes/31843.change.rst
+++ b/doc/release/upcoming_changes/31843.change.rst
@@ -1,1 +1,0 @@
-* The minimum supported GCC version has been updated from 9.3.0 to 10.3.0


### PR DESCRIPTION
- Create 2.5.1-changelog.rst
- Update 2.5.1-notes.rst
- Update .mailmap

No AI.
