### PR TITLE
DOC: Correct backcompat sentence and reduce NumPy 2 docs

### DIFF
--- a/doc/source/dev/depending_on_numpy.rst
+++ b/doc/source/dev/depending_on_numpy.rst
@@ -28,11 +28,10 @@ least two releases. For more details, see :ref:`NEP23`.
 
 NumPy provides both a Python API and a C-API. The C-API can be accessed
 directly or through tools like Cython or f2py. If your package uses the
-C-API, it's important to understand NumPy's application binary interface
-(ABI) compatibility: NumPy's ABI is forward compatible but not backward
-compatible. This means that binaries compiled against an older version of
-NumPy will still work with newer versions, but binaries compiled against a
-newer version will not necessarily work with older ones.
+NumPy C-API this will generally be backwards compatible to all relevant older
+NumPy versions and forward compatible within the same major NumPy version.
+For more details, for example if you wish to use API added in newer NumPy versions,
+see :ref:`depending_on_numpy`.
 
 Modules can also be safely built against NumPy 2.0 or later in
 :ref:`CPython's abi3 mode <python:stable-abi>`, which allows
@@ -100,7 +99,8 @@ NumPy 1.25 will, when using defaults, expose a C-API compatible with NumPy
 1.19. (the exact version is set within NumPy-internal header files).
 
 NumPy is also forward compatible for all minor releases, but a major release
-will require recompilation (see NumPy 2.0-specific advice further down).
+is expected to require recompilation (see NumPy 2.0-specific advice further down).\
+[#major-transition]_
 
 The default behavior can be customized for example by adding::
 
@@ -109,7 +109,7 @@ The default behavior can be customized for example by adding::
 before including any NumPy headers (or the equivalent ``-D`` compiler flag) in
 every extension module that requires the NumPy C-API.
 This is mainly useful if you need to use newly added API at the cost of not
-being compatible with older versions.
+being compatible with older versions.\ [#future-api]_
 
 If for some reason you wish to compile for the currently installed NumPy
 version by default you can add::
@@ -132,6 +132,21 @@ For conda-forge packages, please see
 for instructions on how to declare a dependency on ``numpy`` when using the C
 API.
 
+.. [#major-transition] Improving on the NumPy 2 transition, if a NumPy 3.0
+    release happens we may release NumPy 2.x versions that can compile modules
+    compatible with NumPy 3.0 when deprecated APIs are disabled.
+
+.. [#future-api] We do not provide a mechanism to compile a single extension
+    module that is compatible with old NumPy versions but uses new NumPy API
+    when running with a newer NumPy version.
+    This can be achieved via ``PyArray_RUNTIME_VERSION`` and manually
+    backported API although it means that you may not recieve fixes in NumPy
+    headers. We advise to only backport when ``NPY_FEATURE_VERSION`` is
+    smaller than the given API so that you recieve fixes when it is.
+    (Eventually, this will happen and, even without bugs, at that point your
+    definitions could become incorrect.)
+
+
 
 Runtime dependency & version ranges
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -150,19 +165,19 @@ That said, if you are (a) a project that is guaranteed to release
 frequently, (b) use a large part of NumPy's API surface, and (c) is
 worried that changes in NumPy may break your code, you can set an
 upper bound of ``<MAJOR.MINOR + N`` with N no less than 3, and
-``MAJOR.MINOR`` being the current release of NumPy [*]_. If you use the NumPy
+``MAJOR.MINOR`` being the current release of NumPy.\ [#N]_ If you use the NumPy
 C-API (directly or via Cython), you can also pin the current major
 version to prevent ABI breakage. Note that setting an upper bound on
 NumPy may `affect the ability of your library to be installed
 alongside other, newer packages
 <https://iscinumpy.dev/post/bound-version-constraints/>`__.
 
-.. [*] The reason for setting ``N=3`` is that NumPy will, on the
-       rare occasion where it makes breaking changes, raise warnings
-       for at least two releases. (NumPy releases about once every six
-       months, so this translates to a window of at least a year;
-       hence the subsequent requirement that your project releases at
-       least on that cadence.)
+.. [#N] The reason for setting ``N=3`` is that NumPy will, on the
+    rare occasion where it makes breaking changes, raise warnings
+    for at least two releases. (NumPy releases about once every six
+    months, so this translates to a window of at least a year;
+    hence the subsequent requirement that your project releases at
+    least on that cadence.)
 
 .. note::
 

--- a/doc/source/dev/depending_on_numpy.rst
+++ b/doc/source/dev/depending_on_numpy.rst
@@ -201,8 +201,9 @@ NumPy 2.0 ABI handling
 NumPy 2.0 changed the C ABI. The important rule for binary wheels is:
 
 1. Wheels built against NumPy 1.xx **will not work** with NumPy 2.0 or later.
-2. Wheels built against NumPy 2.x **will work** with NumPy 1.xx at runtime
-   (within the exposed feature subset).
+2. Wheels built against NumPy 2.x **will work** with NumPy 1.xx at runtime.
+   How old NumPy versions are supported can be customized with ``NPY_TARGET_VERSION``,
+   see :ref:`depending_on_numpy`.
 
 If your package uses the NumPy C-API (directly or via Cython), you need to
 rebuild and release wheels compiled against NumPy 2.x. Pure Python packages

--- a/doc/source/dev/depending_on_numpy.rst
+++ b/doc/source/dev/depending_on_numpy.rst
@@ -23,20 +23,20 @@ contain any new features or deprecations.
 
 It is important to know that NumPy, like Python itself and most other
 well known scientific Python projects, does **not** use semantic versioning.
-Instead, backwards incompatible API changes require deprecation warnings for at
+Instead, backward incompatible API changes require deprecation warnings for at
 least two releases. For more details, see :ref:`NEP23`.
 
 NumPy provides both a Python API and a C-API. The C-API can be accessed
 directly or through tools like Cython or f2py. If your package uses the
-NumPy C-API this will generally be backwards compatible to all relevant older
+NumPy C-API, it will generally be backward compatible with all relevant older
 NumPy versions and forward compatible within the same major NumPy version.
-For more details, for example if you wish to use API added in newer NumPy versions,
-see :ref:`depending_on_numpy`.
+For more details, for example if you wish to use API added in newer NumPy
+versions, see :ref:`depending_on_numpy`.
 
 Modules can also be safely built against NumPy 2.0 or later in
 :ref:`CPython's abi3 mode <python:stable-abi>`, which allows
 building against a single (minimum-supported) version of Python but be
-forward compatible higher versions in the same series (e.g., ``3.x``).
+forward compatible with higher versions in the same series (e.g., ``3.x``).
 This can greatly reduce the number of wheels that need to be built and
 distributed. For more information and examples, see the
 `cibuildwheel docs <https://cibuildwheel.pypa.io/en/stable/faq/#abi3>`__.
@@ -78,7 +78,7 @@ Build-time dependency
 
 .. note::
 
-    Before NumPy 1.25, the NumPy C-API was *not* exposed in a backwards
+    Before NumPy 1.25, the NumPy C-API was *not* exposed in a backward
     compatible way by default. This means that when compiling with a NumPy
     version earlier than 1.25 you have to compile with the oldest version you
     wish to support. This can be done by using
@@ -99,7 +99,7 @@ NumPy 1.25 will, when using defaults, expose a C-API compatible with NumPy
 1.19. (the exact version is set within NumPy-internal header files).
 
 NumPy is also forward compatible for all minor releases, but a major release
-is expected to require recompilation (see NumPy 2.0-specific advice further down).\
+is expected to require recompilation (see :ref:`numpy-2-abi-handling` further down).\
 [#major-transition]_
 
 The default behavior can be customized for example by adding::
@@ -133,18 +133,20 @@ for instructions on how to declare a dependency on ``numpy`` when using the C
 API.
 
 .. [#major-transition] Improving on the NumPy 2 transition, if a NumPy 3.0
-    release happens we may release NumPy 2.x versions that can compile modules
-    compatible with NumPy 3.0 when deprecated APIs are disabled.
+    release happens, we may release NumPy 2.x versions that can compile
+    modules that are compatible with NumPy 3.0 when deprecated APIs are
+    disabled.
 
 .. [#future-api] We do not provide a mechanism to compile a single extension
     module that is compatible with old NumPy versions but uses new NumPy API
     when running with a newer NumPy version.
     This can be achieved via ``PyArray_RUNTIME_VERSION`` and manually
-    backported API although it means that you may not recieve fixes in NumPy
-    headers. We advise to only backport when ``NPY_FEATURE_VERSION`` is
-    smaller than the given API so that you recieve fixes when it is.
-    (Eventually, this will happen and, even without bugs, at that point your
-    definitions could become incorrect.)
+    backported API, although you may not receive fixes from NumPy headers when
+    using a backport. We recommend only backporting when
+    ``NPY_FEATURE_VERSION`` is lower than the version at which the API was
+    introduced. That way you pick up official header definitions and fixes
+    once they are available. Even without bugs, future NumPy versions could
+    introduce incompatible changes eventually.
 
 
 
@@ -193,68 +195,32 @@ alongside other, newer packages
 
 .. _numpy-2-abi-handling:
 
-NumPy 2.0-specific advice
-~~~~~~~~~~~~~~~~~~~~~~~~~
+NumPy 2.0 ABI handling
+~~~~~~~~~~~~~~~~~~~~~~
 
-NumPy 2.0 is an ABI-breaking release, however it does contain support for
-building wheels that work on both 2.0 and 1.xx releases. It's important to understand that:
+NumPy 2.0 changed the C ABI. The important rule for binary wheels is:
 
-1. When you build wheels for your package using a NumPy 1.xx version at build
-   time, those **will not work** with NumPy 2.0.
-2. When you build wheels for your package using a NumPy 2.x version at build
-   time, those **will work** with NumPy 1.xx.
+1. Wheels built against NumPy 1.xx **will not work** with NumPy 2.0 or later.
+2. Wheels built against NumPy 2.x **will work** with NumPy 1.xx at runtime
+   (within the exposed feature subset).
 
-The first time the NumPy ABI for 2.0 is guaranteed to be stable will be the
-release of the first release candidate for 2.0 (i.e., 2.0.0rc1). Our advice for
-handling your dependency on NumPy is as follows:
+If your package uses the NumPy C-API (directly or via Cython), you need to
+rebuild and release wheels compiled against NumPy 2.x. Pure Python packages
+may also need code updates; see :ref:`numpy-2-migration-guide`.
 
-1. In the main (development) branch of your package, do not add any constraints.
-2. If you rely on the NumPy C-API (e.g. via direct use in C/C++, or via Cython
-   code that uses NumPy), add a ``numpy<2.0`` requirement in your
-   package's dependency metadata for releases / in release branches. Do this
-   until numpy ``2.0.0rc1`` is released and you can target that.
-   *Rationale: the NumPy C ABI will change in 2.0, so any compiled extension
-   modules that rely on NumPy will break; they need to be recompiled.*
-3. If you rely on a large API surface from NumPy's Python API, also consider
-   adding the same ``numpy<2.0`` requirement to your metadata until you are
-   sure your code is updated for changes in 2.0 (i.e., when you've tested
-   things work against ``2.0.0rc1``).
-   *Rationale: we will do a significant API cleanup, with many aliases and
-   deprecated/non-recommended objects being removed (see, e.g.,*
-   :ref:`numpy-2-migration-guide` *and* :ref:`NEP52`), *so unless you only use
-   modern/recommended functions and objects, your code is likely to require at
-   least some adjustments.*
-4. Plan to do a release of your own packages which depend on ``numpy`` shortly
-   after the first NumPy 2.0 release candidate is released (probably around 1
-   Feb 2024).
-   *Rationale: at that point, you can release packages that will work with both
-   2.0 and 1.X, and hence your own end users will not be seeing much/any
-   disruption (you want* ``pip install mypackage`` *to continue working on the
-   day NumPy 2.0 is released).*
-5. Once ``2.0.0rc1`` is available, you can adjust your metadata in
-   ``pyproject.toml`` in the way outlined below.
+There are two common cases:
 
-There are two cases: you need to keep compatibility with numpy 1.xx while also
-supporting 2.0, or you are able to drop numpy 1.xx support for new releases of
-your package and support >=2.0 only. The latter is simpler, but may be more
-restrictive for your users. In that case, simply add ``numpy>=2.0`` (or
-``numpy>=2.0.0rc1``) to your build and runtime requirements and you're good to
-go. We'll focus on the "keep compatibility with 1.xx and 2.x" now, which is a
-little more involved.
+**Keep compatibility with NumPy 1.xx and 2.x**
 
-*Example for a package using the NumPy C-API (via C/Cython/etc.) which wants to support
-NumPy 1.23.5 and up*:
+Build against NumPy 2.x, but keep a lower runtime bound. For example, to
+support NumPy 1.23.5 and up:
 
 .. code:: ini
 
     [build-system]
     build-backend = ...
     requires = [
-        # Note for packagers: this constraint is specific to wheels
-        # for PyPI; it is also supported to build against 1.xx still.
-        # If you do so, please ensure to include a `numpy<2.0`
-        # runtime requirement for those binary packages.
-        "numpy>=2.0.0rc1",
+        "numpy>=2.0",
         ...
     ]
 
@@ -263,22 +229,38 @@ NumPy 1.23.5 and up*:
         "numpy>=1.23.5",
     ]
 
-We recommend that you have at least one CI job which builds/installs via a wheel,
-and then runs tests against the oldest numpy version that the package supports.
-For example:
+**Support NumPy 2.x only**
+
+This is simpler, but more restrictive for your users:
+
+.. code:: ini
+
+    [build-system]
+    build-backend = ...
+    requires = [
+        "numpy>=2.0",
+        ...
+    ]
+
+    [project]
+    dependencies = [
+        "numpy>=2.0",
+    ]
+
+We recommend at least one CI job that builds a wheel and then tests it against
+the oldest NumPy version you support. For example:
 
 .. code:: yaml
 
-    - name: Build wheel via wheel, then install it
+    - name: Build wheel, then install it
       run: |
-        python -m build  # This will pull in numpy 2.0 in an isolated env
+        python -m build
         python -m pip install dist/*.whl
 
-    - name: Test against oldest supported numpy version
+    - name: Test against oldest supported NumPy version
       run: |
         python -m pip install numpy==1.23.5
         # now run test suite
 
-The above only works once NumPy 2.0 is available on PyPI. If you want to test
-against a NumPy 2.0-dev wheel, you have to use a numpy nightly build (see
-:ref:`this section <testing-prereleases>` higher up) or build numpy from source.
+To test against unreleased NumPy versions, use a nightly build (see
+:ref:`this section <testing-prereleases>`) or build NumPy from source.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -4301,40 +4301,33 @@ the C-API is needed then some additional steps must be taken.
 Checking the API Version
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Because python extensions are not used in the same way as usual libraries on
-most platforms, some errors cannot be automatically detected at build time or
-even runtime. For example, if you build an extension using a function available
-only for numpy >= 1.3.0, and you import the extension later with numpy 1.2, you
-will not get an import error (but almost certainly a segmentation fault when
-calling the function). That's why several functions are provided to check for
-numpy versions. The macros :c:data:`NPY_VERSION`  and
-:c:data:`NPY_FEATURE_VERSION` corresponds to the numpy version used to build the
-extension, whereas the versions returned by the functions
-:c:func:`PyArray_GetNDArrayCVersion` and :c:func:`PyArray_GetNDArrayCFeatureVersion`
-corresponds to the runtime numpy's version.
+The following definitions allow checking the NumPy compile time version,
+enabled C-API feature version and runtime version.
 
-The rules for ABI and API compatibilities can be summarized as follows:
+ABI and C-API compatibility are automatically checked when calling
+:c:func:`PyArray_ImportNumPyAPI` or :c:func:`import_array` and an error
+will be raised when these are incompatible with the NumPy runtime.
+User code should generally **not** check these manually.
 
-* Whenever :c:data:`NPY_VERSION` != ``PyArray_GetNDArrayCVersion()``, the
-  extension has to be recompiled (ABI incompatibility).
-* :c:data:`NPY_VERSION` == ``PyArray_GetNDArrayCVersion()`` and
-  :c:data:`NPY_FEATURE_VERSION` <= ``PyArray_GetNDArrayCFeatureVersion()`` means
-  backward compatible changes.
-
-ABI incompatibility is automatically detected in every numpy's version. API
-incompatibility detection was added in numpy 1.4.0. If you want to supported
-many different numpy versions with one extension binary, you have to build your
-extension with the lowest :c:data:`NPY_FEATURE_VERSION` as possible.
+For details about NumPy C-API compatibility see
+:ref:`for-downstream-package-authors`.
 
 .. c:macro:: NPY_VERSION
 
-    The current version of the ndarray object (check to see if this
-    variable is defined to guarantee the ``numpy/arrayobject.h`` header is
-    being used).
+    The ABI version of the NumPy headers at compile time.
 
 .. c:macro:: NPY_FEATURE_VERSION
 
-    The current version of the C-API.
+    The version of the NumPy C-API the compilation targets.
+    Setting ``NPY_TARGET_VERSION`` may modify this value to make newer
+    NumPy API features available or, in principle, to be compatible with
+    older NumPy versions.
+
+.. c:data:: PyArray_RUNTIME_VERSION
+
+    After the C-API has been imported ``PyArray_RUNTIME_VERSION`` is set to
+    the current runtime C-API version. ``PyArray_RUNTIME_VERSION`` is
+    mainly used when necessary to support both old and new NumPy versions.
 
 .. c:function:: unsigned int PyArray_GetNDArrayCVersion(void)
 

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -4323,7 +4323,7 @@ For details about NumPy C-API compatibility see
     NumPy API features available or, in principle, to be compatible with
     older NumPy versions.
 
-.. c:data:: PyArray_RUNTIME_VERSION
+.. c:macro:: PyArray_RUNTIME_VERSION
 
     After the C-API has been imported ``PyArray_RUNTIME_VERSION`` is set to
     the current runtime C-API version. ``PyArray_RUNTIME_VERSION`` is


### PR DESCRIPTION
We forgot to delete an early sentence claiming no backwards compatibility for NumPy headers.

I also added two footnotes that are admittedly a bit long but:
1. I think when a NumPy 3 happens, we should improve so that there are 2.x releases that already generate runtime code that is compatible with 3.x.
   I.e. whatever we change it is always API _removals_ that drive things (even if removals via replacements). A 2.x version _can_ be compatible easily, so long users would set a "don't use deprecated API" define.
2. I don't hesitate to vendor "future" NumPy API in downstream (e.g. `ml_dtypes`).  I think it is a pragmatic thing to do so long it is only done for old versions and guarded via `NPY_FEATURE_VERSION`.

Looking at this, I realized that the "version API" C-API docs are outdated and also the NumPy 2 transition only interesting in how to set the build vs. runtime version.
That could probably be re-organized a bit more, but it seemed OK to me.

(Used a bit of AI to get started on cleaning out some of the old code, it also wanted "backward" rather than "backwards", so...)