### PR TITLE
BUG: MaskedArray arithmetic with Python scalars ignores NEP 50 weak-type

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1064,8 +1064,10 @@ class _MaskedBinaryOperation(_MaskedUFunc):
         Execute the call behavior.
 
         """
-        # Get the data, as ndarray
-        (da, db) = (getdata(a), getdata(b))
+        # Get the data, as ndarray. Python scalars are passed through
+        # unchanged so that ufuncs see them as weak types under NEP 50
+        da = a if isinstance(a, (int, float, complex)) else getdata(a)
+        db = b if isinstance(b, (int, float, complex)) else getdata(b)
         # Get the result
         with np.errstate():
             np.seterr(divide='ignore', invalid='ignore')
@@ -7181,9 +7183,9 @@ def power(a, b, third=None):
     ma = getmask(a)
     mb = getmask(b)
     m = mask_or(ma, mb)
-    # Get the rawdata
-    fa = getdata(a)
-    fb = getdata(b)
+    # Get the rawdata, preserving Python scalars for NEP 50 (gh-31868)
+    fa = a if isinstance(a, (int, float, complex)) else getdata(a)
+    fb = b if isinstance(b, (int, float, complex)) else getdata(b)
     # Get the type of the result (so that we preserve subclasses)
     if isinstance(a, MaskedArray):
         basetype = type(a)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2089,6 +2089,31 @@ class TestMaskedArrayArithmetic:
         assert_equal(test.mask, control.mask)
         assert_equal(a.mask, [0, 0, 0, 0, 1])
 
+    def test_scalar_arithmetic_preserves_dtype_nep50(self):
+        # MaskedArray arithmetic with Python scalars should follow NEP 50
+        marr = masked_array([100], dtype=np.int8)
+        arr = np.array([100], dtype=np.int8)
+
+        assert_equal((marr + 50).dtype, np.int8)
+        assert_equal((marr - 50).dtype, np.int8)
+        assert_equal((marr * 2).dtype, np.int8)
+        assert_equal((marr ** 2).dtype, np.int8)
+        assert_equal((marr + 50).dtype, (arr + 50).dtype)
+
+        marr_f = masked_array([1.5], dtype=np.float32)
+        arr_f = np.array([1.5], dtype=np.float32)
+
+        assert_equal((marr_f + 1.0).dtype, np.float32)
+        assert_equal((marr_f * 2.0).dtype, np.float32)
+        assert_equal((marr_f + 1.0).dtype, (arr_f + 1.0).dtype)
+
+        # reversed operand order
+        assert_equal((50 + marr).dtype, np.int8)
+        assert_equal((50 + marr).dtype, (50 + arr).dtype)
+
+        # numpy scalars should still promote (strong types)
+        assert_equal((marr + np.int64(50)).dtype, np.int64)
+
 
 class TestMaskedArrayAttributes:
 


### PR DESCRIPTION
Closes #31868

### Problem

MaskedArray arithmetic with Python scalars produces a different dtype
than the same operation on a plain ndarray:
```python
import numpy as np
import numpy.ma as ma

arr = np.array([100], dtype=np.int8)
masked = ma.masked_array([100], dtype=np.int8)

print((arr + 50).dtype)     # int8  (Expected, respects NEP 50)
print((masked + 50).dtype)  # int64 (Bug)
```

This was due to:
`_MaskedBinaryOperation.__call__` calls `getdata()` on both operands before calling the ufunc. For Python scalars, `getdata()` has no
`._data` to grab, so it falls back to `np.array(50)` which creates a 0-d int64 array. Under NEP 50 that's a "strong" type, so the ufunc
promotes int8 to int64. The standalone `power()` function has the same issue.

### Fix

Skip `getdata()` for Python scalars (`int`, `float`, `complex`) in the two call sites, passing them straight to the ufunc where NEP 50
treats them as weak types.


### Test & Enviornment

Added `test_scalar_arithmetic_preserves_dtype_nep50` covering int8,float32, four operators, reversed operand order, and numpy-scalar promotion.

* **OS:** Darwin 25.5.0 (arm64)
* **Python:** 3.14.0
* **NumPy:** 2.6.0.dev0+git20260706.7e381e7
```bash
$ spin test numpy/ma/tests/test_core.py -- -x -q
...
=========================== short test summary info ===========================
SKIPPED [1] numpy/testing/_private/utils.py:2692: Could not determine available memory...
XFAIL numpy/ma/tests/test_core.py::TestMaskedConstant::test_coercion_unicode - See gh-9750
XFAIL numpy/ma/tests/test_core.py::TestMaskedConstant::test_coercion_bytes - See gh-9750
4170 passed, 1 skipped, 2 xfailed in 2.37s
```

### AI Disclosure

AI was used only to strictly format this PR for maintainer readability and ease I also Used an AI assistant to help trace the call chain from `MaskedArray.__add__` through `_MaskedBinaryOperation.__call__` to
`getdata`, and to confirm the root cause.

The diagnosis, fix, and tests were written and verified manually.