### PR TITLE
DOC: clarify copy semantics of BitGenerator state

### DIFF
--- a/doc/source/reference/random/bit_generators/index.rst
+++ b/doc/source/reference/random/bit_generators/index.rst
@@ -160,6 +160,47 @@ by a tuple of elements. Here we use a base entropy value and an integer
 Note that the sequences produced by the latter method will be distinct from
 those constructed via `~SeedSequence.spawn`.
 
+.. _random-bit-generator-state:
+
+Saving and restoring state
+--------------------------
+
+All BitGenerators expose a ``state`` property that can be used to capture
+the current PRNG state and restore it later::
+
+    state = bit_generator.state
+    values_before = generator.random(5)
+    bit_generator.state = state
+    values_again = generator.random(5)
+    assert (values_before == values_again).all()
+
+The ``state`` getter returns a **snapshot** of the internal PRNG state. Each
+access returns a new ``dict``; continuing to draw random numbers from the
+generator does **not** update a previously retrieved state object.
+
+Setting ``bit_generator.state`` copies the values from the provided ``dict``
+into the internal PRNG state. Assigning a previously saved state dict always
+restores that saved state, even if it is the same Python object that was
+returned by an earlier call to the getter.
+
+No additional copy is required to save and restore state within the same
+session, provided the saved state dict (and any arrays it contains) is not
+modified. Some BitGenerators (``MT19937``, ``Philox``, and ``SFC64``) include
+NumPy arrays in the state dict. These arrays are copies of the internal state,
+not views, but in-place modifications to the saved arrays will change the
+saved checkpoint. Use :func:`copy.deepcopy` if you need to modify a state dict
+without affecting a saved checkpoint.
+
+``PCG64`` and ``PCG64DXSM`` store their core state using Python integers and
+so their snapshots contain only immutable values.
+
+For legacy :class:`~RandomState`, use :meth:`~RandomState.get_state` and
+:meth:`~RandomState.set_state` rather than the underlying
+``RandomState.bit_generator.state``. ``RandomState`` adds extra state needed
+for some distributions (for example, Box-Muller normals). The same snapshot
+semantics apply: the returned state is independent of subsequent draws until
+it is restored with :meth:`~RandomState.set_state`.
+
 
 .. autosummary::
     :toctree: generated/

--- a/doc/source/reference/random/legacy.rst
+++ b/doc/source/reference/random/legacy.rst
@@ -17,6 +17,8 @@ to the state which is required when using Box-Muller normals since these
 are produced in pairs. It is important to use
 `RandomState.get_state`, and not the underlying bit generators
 `state`, when accessing the state so that these extra values are saved.
+See :ref:`random-bit-generator-state` for a general discussion of state
+copy semantics.
 
 Although we provide the `MT19937` BitGenerator for use independent of
 `RandomState`, note that its default seeding uses `SeedSequence`

--- a/numpy/random/_mt19937.pyx
+++ b/numpy/random/_mt19937.pyx
@@ -264,6 +264,14 @@ cdef class MT19937(BitGenerator):
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        The getter returns a snapshot of the internal state. Subsequent
+        random draws do not modify a previously retrieved state object.
+        Assigning a saved state restores the PRNG from that snapshot.
+        See :ref:`random-bit-generator-state` for copy semantics and
+        guidance on when :func:`copy.deepcopy` may be needed.
         """
         key = np.zeros(624, dtype=np.uint32)
         for i in range(624):

--- a/numpy/random/_pcg64.pyx
+++ b/numpy/random/_pcg64.pyx
@@ -199,6 +199,14 @@ cdef class PCG64(BitGenerator):
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        The getter returns a snapshot of the internal state. Subsequent
+        random draws do not modify a previously retrieved state object.
+        Assigning a saved state restores the PRNG from that snapshot.
+        See :ref:`random-bit-generator-state` for copy semantics and
+        guidance on when :func:`copy.deepcopy` may be needed.
         """
         cdef np.ndarray state_vec
         cdef int has_uint32
@@ -433,6 +441,14 @@ cdef class PCG64DXSM(BitGenerator):
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        The getter returns a snapshot of the internal state. Subsequent
+        random draws do not modify a previously retrieved state object.
+        Assigning a saved state restores the PRNG from that snapshot.
+        See :ref:`random-bit-generator-state` for copy semantics and
+        guidance on when :func:`copy.deepcopy` may be needed.
         """
         cdef np.ndarray state_vec
         cdef int has_uint32

--- a/numpy/random/_philox.pyx
+++ b/numpy/random/_philox.pyx
@@ -211,6 +211,14 @@ cdef class Philox(BitGenerator):
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        The getter returns a snapshot of the internal state. Subsequent
+        random draws do not modify a previously retrieved state object.
+        Assigning a saved state restores the PRNG from that snapshot.
+        See :ref:`random-bit-generator-state` for copy semantics and
+        guidance on when :func:`copy.deepcopy` may be needed.
         """
         ctr = np.empty(4, dtype=np.uint64)
         key = np.empty(2, dtype=np.uint64)

--- a/numpy/random/_sfc64.pyx
+++ b/numpy/random/_sfc64.pyx
@@ -112,6 +112,14 @@ cdef class SFC64(BitGenerator):
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        The getter returns a snapshot of the internal state. Subsequent
+        random draws do not modify a previously retrieved state object.
+        Assigning a saved state restores the PRNG from that snapshot.
+        See :ref:`random-bit-generator-state` for copy semantics and
+        guidance on when :func:`copy.deepcopy` may be needed.
         """
         cdef np.ndarray state_vec
         cdef int has_uint32

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -584,6 +584,14 @@ cdef class BitGenerator:
         state : dict
             Dictionary containing the information required to describe the
             state of the PRNG
+
+        Notes
+        -----
+        The getter returns a snapshot of the internal state. Subsequent
+        random draws do not modify a previously retrieved state object.
+        Assigning a saved state restores the PRNG from that snapshot.
+        See :ref:`random-bit-generator-state` for copy semantics and
+        guidance on when :func:`copy.deepcopy` may be needed.
         """
         raise NotImplementedError('Not implemented in base BitGenerator')
 

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -295,6 +295,12 @@ cdef class RandomState:
         random distributions in NumPy. If the internal state is manually altered,
         the user should know exactly what he/she is doing.
 
+        The returned state is a snapshot that is not updated by subsequent
+        draws. See :ref:`random-bit-generator-state` for copy semantics when
+        saving and restoring state. When using legacy ``RandomState``, prefer
+        these methods over ``RandomState.bit_generator.state`` so that extra
+        state required by some distributions is included.
+
         """
         st = self._bit_generator.state
         if st['bit_generator'] != 'MT19937' and legacy:
@@ -354,6 +360,10 @@ cdef class RandomState:
         `set_state` and `get_state` are not needed to work with any of the
         random distributions in NumPy. If the internal state is manually altered,
         the user should know exactly what he/she is doing.
+
+        Assigning a saved state restores the generator from that snapshot.
+        See :ref:`random-bit-generator-state` for copy semantics when saving
+        and restoring state.
 
         For backwards compatibility, the form (str, array of 624 uints, int) is
         also accepted although it is missing some information about the cached


### PR DESCRIPTION
## Summary

Clarifies the copy semantics of `BitGenerator.state` in response to #22337.

- Adds a new **"Saving and restoring state"** section to the BitGenerators docs explaining that `.state` returns a **snapshot**, not a live view of the internal PRNG state
- Documents that subsequent random draws do **not** modify a previously saved state object, so no extra copy is needed for normal save/restore within a session
- Notes when `copy.deepcopy` may be needed (for BitGenerators whose state dict contains NumPy arrays: `MT19937`, `Philox`, `SFC64`)
- Adds `Notes` sections to the `state` docstrings for all BitGenerators (`BitGenerator`, `PCG64`, `PCG64DXSM`, `MT19937`, `Philox`, `SFC64`)
- Updates `RandomState.get_state` / `set_state` docs and adds a cross-link from the legacy random docs

Fixes #22337

## Test plan

- [x] Built docs locally with `spin docs` and verified the new "Saving and restoring state" section renders correctly
- [x] Verified cross-references from `PCG64.state` and other BitGenerator pages link to the new section
- [x] Confirmed no code logic was changed — documentation only