### PR TITLE
TYP: fix specialized ufunc bool/int => float promotions

### DIFF
--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -207,6 +207,10 @@ type _numeric = np.number | np.timedelta64
 type _time = np.datetime64 | np.timedelta64
 type _non_object = _to_number | _time | np.flexible  # np.generic - np.object_
 
+type _as_f64 = np.int64 | np.uint64 | np.int32 | np.uint32
+type _as_f32 = np.int16 | np.uint16
+type _as_f16 = np.int8 | np.uint8 | np.bool
+
 type _ArrayLikeNumericObj = _DualArrayLike[np.dtype[_numeric | np.object_], complex]
 type _ArrayLikeNumericObj_co = _DualArrayLike[np.dtype[_to_numeric | np.object_], complex]
 
@@ -883,23 +887,63 @@ class _ufunc_11_f(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_integer]],
+        x: np.ndarray[ShapeT, np.dtype[_as_f64]],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
     ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+    @overload  # Nd, +f32
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_as_f32]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT, np.dtype[np.float32]]: ...
+    @overload  # Nd, +f16
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_as_f16]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT, np.dtype[np.float16]]: ...
     @overload  # scalar, float | +f64
     def __call__(
         self,
-        x: float | _to_integer,
+        x: float | _as_f64,
         /,
         *,
         out: None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
     ) -> np.float64: ...
+    @overload  # scalar, +f32
+    def __call__(
+        self,
+        x: _as_f32,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.float32: ...
+    @overload  # scalar, +f16
+    def __call__(
+        self,
+        x: _as_f16,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.float16: ...
     @overload  # 1d, +float
     def __call__(
         self,
@@ -1035,23 +1079,63 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.integer | np.bool]],
+        x: np.ndarray[ShapeT, np.dtype[_as_f64]],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
     ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+    @overload  # Nd, +f32
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_as_f32]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT, np.dtype[np.float32]]: ...
+    @overload  # Nd, +f16
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_as_f16]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT, np.dtype[np.float16]]: ...
     @overload  # scalar, float | +f64
     def __call__(
         self,
-        x: float | np.integer | np.bool,
+        x: float | _as_f64,
         /,
         *,
         out: None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
     ) -> np.float64: ...
+    @overload  # scalar, +f32
+    def __call__(
+        self,
+        x: _as_f32,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.float32: ...
+    @overload  # scalar, +f16
+    def __call__(
+        self,
+        x: _as_f16,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.float16: ...
     @overload  # 1d, +float
     def __call__(
         self,
@@ -1187,23 +1271,63 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.integer | np.bool]],
+        x: np.ndarray[ShapeT, np.dtype[_as_f64]],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
     ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+    @overload  # Nd, +f32
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_as_f32]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT, np.dtype[np.float32]]: ...
+    @overload  # Nd, +f16
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_as_f16]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.ndarray[ShapeT, np.dtype[np.float16]]: ...
     @overload  # scalar, float | +f64
     def __call__(
         self,
-        x: float | np.integer | np.bool,
+        x: float | _as_f64,
         /,
         *,
         out: None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
     ) -> np.float64: ...
+    @overload  # scalar, +f32
+    def __call__(
+        self,
+        x: _as_f32,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.float32: ...
+    @overload  # scalar, +f16
+    def __call__(
+        self,
+        x: _as_f16,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs11],
+    ) -> np.float16: ...
     @overload  # 1d, +float
     def __call__(
         self,
@@ -3079,13 +3203,33 @@ class _ufunc_12_frexp(_ufunc_12):  # type: ignore[misc]
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_integer]],
+        x: np.ndarray[ShapeT, np.dtype[_as_f64]],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs12],
     ) -> tuple[np.ndarray[ShapeT, np.dtype[np.float64]], np.ndarray[ShapeT, np.dtype[np.int32]]]: ...
+    @overload  # Nd, +f32
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_as_f32]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs12],
+    ) -> tuple[np.ndarray[ShapeT, np.dtype[np.float32]], np.ndarray[ShapeT, np.dtype[np.int32]]]: ...
+    @overload  # Nd, +f16
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_as_f16]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs12],
+    ) -> tuple[np.ndarray[ShapeT, np.dtype[np.float16]], np.ndarray[ShapeT, np.dtype[np.int32]]]: ...
     @overload  # scalar, known dtype
     def __call__[ScalarT: np.floating](
         self,
@@ -3099,13 +3243,33 @@ class _ufunc_12_frexp(_ufunc_12):  # type: ignore[misc]
     @overload  # scalar, float | +f64
     def __call__(
         self,
-        x: float | _to_integer,
+        x: float | _as_f64,
         /,
         *,
         out: None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs12],
     ) -> tuple[np.float64, np.int32]: ...
+    @overload  # scalar, +f32
+    def __call__(
+        self,
+        x: _as_f32,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs12],
+    ) -> tuple[np.float32, np.int32]: ...
+    @overload  # scalar, +f16
+    def __call__(
+        self,
+        x: _as_f16,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs12],
+    ) -> tuple[np.float16, np.int32]: ...
     @overload  # 1d, +float
     def __call__(
         self,
@@ -3174,23 +3338,63 @@ class _ufunc_12_modf(_ufunc_12):  # type: ignore[misc]
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_integer]],
+        x: np.ndarray[ShapeT, np.dtype[_as_f64]],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs12],
     ) -> _tuple2[np.ndarray[ShapeT, np.dtype[np.float64]]]: ...
+    @overload  # Nd, +f32
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_as_f32]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs12],
+    ) -> _tuple2[np.ndarray[ShapeT, np.dtype[np.float32]]]: ...
+    @overload  # Nd, +f16
+    def __call__[ShapeT: _Shape](
+        self,
+        x: np.ndarray[ShapeT, np.dtype[_as_f16]],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs12],
+    ) -> _tuple2[np.ndarray[ShapeT, np.dtype[np.float16]]]: ...
     @overload  # scalar, float | +f64
     def __call__(
         self,
-        x: float | _to_integer,
+        x: float | _as_f64,
         /,
         *,
         out: None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs12],
     ) -> _tuple2[np.float64]: ...
+    @overload  # scalar, +f32
+    def __call__(
+        self,
+        x: _as_f32,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs12],
+    ) -> _tuple2[np.float32]: ...
+    @overload  # scalar, +f16
+    def __call__(
+        self,
+        x: _as_f16,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs12],
+    ) -> _tuple2[np.float16]: ...
     @overload  # 1d, +float
     def __call__(
         self,
@@ -4154,10 +4358,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> ScalarT: ...
-    @overload  # 0d <f64, 0d
-    def __call__[ScalarT: np.floating](
+    @overload  # 0d float | +f64, 0d
+    def __call__(
         self,
-        x1: float | _to_integer,
+        x1: float | _as_f64,
         x2: _IntLike_co,
         /,
         *,
@@ -4165,6 +4369,28 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> np.float64: ...
+    @overload  # 0d +f32, 0d
+    def __call__(
+        self,
+        x1: _as_f32,
+        x2: _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.float32: ...
+    @overload  # 0d +f16, 0d
+    def __call__(
+        self,
+        x1: _as_f16,
+        x2: _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.float16: ...
     @overload  # >0d T@floating, >=0d
     def __call__[ScalarT: np.floating](
         self,
@@ -4176,10 +4402,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[ScalarT]: ...
-    @overload  # >0d <f64, >=0d
+    @overload  # >0d +f64, >=0d
     def __call__(
         self,
-        x1: npt.NDArray[_to_integer] | _NestedSequence[float | _to_integer],
+        x1: npt.NDArray[_as_f64] | _NestedSequence[float | _as_f64],
         x2: _ArrayLikeInt_co,
         /,
         *,
@@ -4187,6 +4413,28 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.float64]: ...
+    @overload  # >0d +f32, >=0d
+    def __call__(
+        self,
+        x1: npt.NDArray[_as_f32] | _NestedSequence[_as_f32],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float32]: ...
+    @overload  # >0d +f16, >=0d
+    def __call__(
+        self,
+        x1: npt.NDArray[_as_f16] | _NestedSequence[_as_f16],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float16]: ...
     @overload  # >=0d T@floating, >0d
     def __call__[ScalarT: np.floating](
         self,
@@ -4198,10 +4446,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[ScalarT]: ...
-    @overload  # >=0d <f64, >0d
+    @overload  # >=0d +f64, >0d
     def __call__(
         self,
-        x1: _DualArrayLike[np.dtype[_to_integer], float],
+        x1: _DualArrayLike[np.dtype[_as_f64], float],
         x2: npt.NDArray[_to_integer] | _NestedSequence[_IntLike_co],
         /,
         *,
@@ -4209,6 +4457,28 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.float64]: ...
+    @overload  # >=0d +f32, >0d
+    def __call__(
+        self,
+        x1: _ArrayLike[_as_f32],
+        x2: npt.NDArray[_to_integer] | _NestedSequence[_IntLike_co],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float32]: ...
+    @overload  # >=0d +f32, >0d
+    def __call__(
+        self,
+        x1: _ArrayLike[_as_f16],
+        x2: npt.NDArray[_to_integer] | _NestedSequence[_IntLike_co],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float16]: ...
     @overload  # >=0d T@floating, >=0d, out=...
     def __call__[ScalarT: np.floating](
         self,
@@ -4220,10 +4490,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[ScalarT]: ...
-    @overload  # >=0d <f64, >=0d, out=...
+    @overload  # >=0d +f64, >=0d, out=...
     def __call__(
         self,
-        x1: _DualArrayLike[np.dtype[_to_integer], float],
+        x1: _DualArrayLike[np.dtype[_as_f64], float],
         x2: _ArrayLikeInt_co,
         /,
         *,
@@ -4231,6 +4501,28 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.float64]: ...
+    @overload  # >=0d +f32, >=0d, out=...
+    def __call__(
+        self,
+        x1: _ArrayLike[_as_f32],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float32]: ...
+    @overload  # >=0d +f16, >=0d, out=...
+    def __call__(
+        self,
+        x1: _ArrayLike[_as_f16],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float16]: ...
     @overload  # out=<given>
     def __call__[OutT: np.ndarray](
         self,
@@ -4278,10 +4570,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> ScalarT: ...
-    @overload  # 0d <f64, 0d
-    def outer[ScalarT: np.floating](
+    @overload  # 0d float | +f64, 0d
+    def outer(
         self,
-        x1: float | _to_integer,
+        x1: float | _as_f64,
         x2: _IntLike_co,
         /,
         *,
@@ -4289,6 +4581,28 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> np.float64: ...
+    @overload  # 0d +f32, 0d
+    def outer(
+        self,
+        x1: _as_f32,
+        x2: _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.float32: ...
+    @overload  # 0d +f16, 0d
+    def outer(
+        self,
+        x1: _as_f16,
+        x2: _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.float16: ...
     @overload  # >0d T@floating, >=0d
     def outer[ScalarT: np.floating](
         self,
@@ -4300,10 +4614,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[ScalarT]: ...
-    @overload  # >0d <f64, >=0d
+    @overload  # >0d +f64, >=0d
     def outer(
         self,
-        x1: npt.NDArray[_to_integer] | _NestedSequence[float | _to_integer],
+        x1: npt.NDArray[_as_f64] | _NestedSequence[float | _as_f64],
         x2: _ArrayLikeInt_co,
         /,
         *,
@@ -4311,6 +4625,28 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.float64]: ...
+    @overload  # >0d +f32, >=0d
+    def outer(
+        self,
+        x1: npt.NDArray[_as_f32] | _NestedSequence[_as_f32],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float32]: ...
+    @overload  # >0d +f16, >=0d
+    def outer(
+        self,
+        x1: npt.NDArray[_as_f16] | _NestedSequence[_as_f16],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float16]: ...
     @overload  # >=0d T@floating, >0d
     def outer[ScalarT: np.floating](
         self,
@@ -4322,10 +4658,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[ScalarT]: ...
-    @overload  # >=0d <f64, >0d
+    @overload  # >=0d +f64, >0d
     def outer(
         self,
-        x1: _DualArrayLike[np.dtype[_to_integer], float],
+        x1: _DualArrayLike[np.dtype[_as_f64], float],
         x2: npt.NDArray[_to_integer] | _NestedSequence[_IntLike_co],
         /,
         *,
@@ -4333,6 +4669,28 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.float64]: ...
+    @overload  # >=0d +f32, >0d
+    def outer(
+        self,
+        x1: _ArrayLike[_as_f32],
+        x2: npt.NDArray[_to_integer] | _NestedSequence[_IntLike_co],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float32]: ...
+    @overload  # >=0d +f16, >0d
+    def outer(
+        self,
+        x1: _ArrayLike[_as_f16],
+        x2: npt.NDArray[_to_integer] | _NestedSequence[_IntLike_co],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float16]: ...
     @overload  # >=0d T@floating, >=0d, out=...
     def outer[ScalarT: np.floating](
         self,
@@ -4344,10 +4702,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[ScalarT]: ...
-    @overload  # >=0d <f64, >=0d, out=...
+    @overload  # >=0d +f64, >=0d, out=...
     def outer(
         self,
-        x1: _DualArrayLike[np.dtype[_to_integer], float],
+        x1: _DualArrayLike[np.dtype[_as_f64], float],
         x2: _ArrayLikeInt_co,
         /,
         *,
@@ -4355,6 +4713,28 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.float64]: ...
+    @overload  # >=0d +f32, >=0d, out=...
+    def outer(
+        self,
+        x1: _ArrayLike[_as_f32],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float32]: ...
+    @overload  # >=0d +f16, >=0d, out=...
+    def outer(
+        self,
+        x1: _ArrayLike[_as_f16],
+        x2: _ArrayLikeInt_co,
+        /,
+        *,
+        out: EllipsisType,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.float16]: ...
     @overload  # out=<given>
     def outer[OutT: np.ndarray](
         self,
@@ -4400,10 +4780,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
 
     #
     @override
-    @overload  # unknown shape
+    @overload  # unknown shape, +f64
     def reduce(  # pyrefly:ignore[bad-override]
         self,
-        array: _ArrayLikeInt,
+        array: _DualArrayLike[np.dtype[_as_f64], float],
         /,
         *,
         axis: int | tuple[int, ...] = 0,
@@ -4413,10 +4793,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         initial: bool | np.bool = ...,
         where: _ArrayLikeBool_co = True,
     ) -> npt.NDArray[np.float64] | np.float64: ...
-    @overload  # unknown shape, axis=None
+    @overload  # unknown shape, +f64, axis=None
     def reduce(
         self,
-        array: _ArrayLikeInt,
+        array: _DualArrayLike[np.dtype[_as_f64], float],
         /,
         *,
         axis: None,
@@ -4426,10 +4806,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         initial: bool | np.bool = ...,
         where: _ArrayLikeBool_co = True,
     ) -> np.float64: ...
-    @overload  # unknown shape, keepdims=True
+    @overload  # unknown shape, +f64, keepdims=True
     def reduce(
         self,
-        array: _ArrayLikeInt,
+        array: _DualArrayLike[np.dtype[_as_f64], float],
         /,
         *,
         axis: int | tuple[int, ...] | None = 0,
@@ -4439,10 +4819,10 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         initial: bool | np.bool = ...,
         where: _ArrayLikeBool_co = True,
     ) -> npt.NDArray[np.float64]: ...
-    @overload  # unknown shape, out=...
+    @overload  # unknown shape, +f64, out=...
     def reduce(
         self,
-        array: _ArrayLikeInt,
+        array: _DualArrayLike[np.dtype[_as_f64], float],
         /,
         *,
         axis: int | tuple[int, ...] | None = 0,
@@ -4452,6 +4832,110 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
         initial: bool | np.bool = ...,
         where: _ArrayLikeBool_co = True,
     ) -> npt.NDArray[np.float64]: ...
+    @overload  # unknown shape, +f32
+    def reduce(
+        self,
+        array: _ArrayLike[_as_f32],
+        /,
+        *,
+        axis: int | tuple[int, ...] = 0,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[False] = False,
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[np.float32] | np.float32: ...
+    @overload  # unknown shape, +f32, axis=None
+    def reduce(
+        self,
+        array: _ArrayLike[_as_f32],
+        /,
+        *,
+        axis: None,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[False] = False,
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> np.float32: ...
+    @overload  # unknown shape, +f32, keepdims=True
+    def reduce(
+        self,
+        array: _ArrayLike[_as_f32],
+        /,
+        *,
+        axis: int | tuple[int, ...] | None = 0,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[True],
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[np.float32]: ...
+    @overload  # unknown shape, +f32, out=...
+    def reduce(
+        self,
+        array: _ArrayLike[_as_f32],
+        /,
+        *,
+        axis: int | tuple[int, ...] | None = 0,
+        dtype: None = None,
+        out: EllipsisType,
+        keepdims: bool = False,
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[np.float32]: ...
+    @overload  # unknown shape, +f16
+    def reduce(
+        self,
+        array: _ArrayLike[_as_f16],
+        /,
+        *,
+        axis: int | tuple[int, ...] = 0,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[False] = False,
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[np.float16] | np.float16: ...
+    @overload  # unknown shape, +f16, axis=None
+    def reduce(
+        self,
+        array: _ArrayLike[_as_f16],
+        /,
+        *,
+        axis: None,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[False] = False,
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> np.float16: ...
+    @overload  # unknown shape, +f16, keepdims=True
+    def reduce(
+        self,
+        array: _ArrayLike[_as_f16],
+        /,
+        *,
+        axis: int | tuple[int, ...] | None = 0,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[True],
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[np.float16]: ...
+    @overload  # unknown shape, +f16, out=...
+    def reduce(
+        self,
+        array: _ArrayLike[_as_f16],
+        /,
+        *,
+        axis: int | tuple[int, ...] | None = 0,
+        dtype: None = None,
+        out: EllipsisType,
+        keepdims: bool = False,
+        initial: bool | np.bool = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[np.float16]: ...
     @overload  # out=<given>
     def reduce[OutT: np.ndarray](
         self,

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -129,6 +129,10 @@ _i16_0d: np.int16
 _i16_1d: np.ndarray[tuple[int], np.dtype[np.int16]]
 _i16_2d: np.ndarray[tuple[int, int], np.dtype[np.int16]]
 _i16_nd: npt.NDArray[np.int16]
+_i32_0d: np.int32
+_i32_1d: np.ndarray[tuple[int], np.dtype[np.int32]]
+_i32_2d: np.ndarray[tuple[int, int], np.dtype[np.int32]]
+_i32_nd: npt.NDArray[np.int32]
 _f32_0d: np.float32
 _f32_1d: np.ndarray[tuple[int], np.dtype[np.float32]]
 _f32_2d: np.ndarray[tuple[int, int], np.dtype[np.float32]]
@@ -299,10 +303,18 @@ assert_type(np.spacing(_py_f_0d), np.float64)
 assert_type(np.spacing(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
 assert_type(np.spacing(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
 
-assert_type(np.spacing(_i16_0d), np.float64)
-assert_type(np.spacing(_i16_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.spacing(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
-assert_type(np.spacing(_i16_nd), npt.NDArray[np.float64])
+assert_type(np.spacing(_bool_0d), np.float16)
+assert_type(np.spacing(_bool_1d), np.ndarray[tuple[int], np.dtype[np.float16]])
+assert_type(np.spacing(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.float16]])
+assert_type(np.spacing(_bool_nd), npt.NDArray[np.float16])
+assert_type(np.spacing(_i16_0d), np.float32)
+assert_type(np.spacing(_i16_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.spacing(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.spacing(_i16_nd), npt.NDArray[np.float32])
+assert_type(np.spacing(_i32_0d), np.float64)
+assert_type(np.spacing(_i32_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.spacing(_i32_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.spacing(_i32_nd), npt.NDArray[np.float64])
 assert_type(np.spacing(_f32_0d), np.float32)
 assert_type(np.spacing(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
 assert_type(np.spacing(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
@@ -328,10 +340,18 @@ assert_type(np.cbrt(_py_f_0d), np.float64)
 assert_type(np.cbrt(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
 assert_type(np.cbrt(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
 
-assert_type(np.cbrt(_i16_0d), np.float64)
-assert_type(np.cbrt(_i16_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.cbrt(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
-assert_type(np.cbrt(_i16_nd), npt.NDArray[np.float64])
+assert_type(np.cbrt(_bool_0d), np.float16)
+assert_type(np.cbrt(_bool_1d), np.ndarray[tuple[int], np.dtype[np.float16]])
+assert_type(np.cbrt(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.float16]])
+assert_type(np.cbrt(_bool_nd), npt.NDArray[np.float16])
+assert_type(np.cbrt(_i16_0d), np.float32)
+assert_type(np.cbrt(_i16_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.cbrt(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.cbrt(_i16_nd), npt.NDArray[np.float32])
+assert_type(np.cbrt(_i32_0d), np.float64)
+assert_type(np.cbrt(_i32_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.cbrt(_i32_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.cbrt(_i32_nd), npt.NDArray[np.float64])
 assert_type(np.cbrt(_f32_0d), np.float32)
 assert_type(np.cbrt(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
 assert_type(np.cbrt(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
@@ -362,10 +382,14 @@ assert_type(np.sin(_py_c_0d), np.complex128 | Any)  # `complex` overlaps with `f
 assert_type(np.sin(_py_c_1d), np.ndarray[tuple[int], np.dtype[np.complex128]])
 assert_type(np.sin(_py_c_2d), np.ndarray[tuple[int, int], np.dtype[np.complex128]])
 
-assert_type(np.sin(_i16_0d), np.float64)
-assert_type(np.sin(_i16_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.sin(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
-assert_type(np.sin(_i16_nd), npt.NDArray[np.float64])
+assert_type(np.sin(_i16_0d), np.float32)
+assert_type(np.sin(_i16_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.sin(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.sin(_i16_nd), npt.NDArray[np.float32])
+assert_type(np.sin(_i32_0d), np.float64)
+assert_type(np.sin(_i32_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.sin(_i32_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.sin(_i32_nd), npt.NDArray[np.float64])
 assert_type(np.sin(_f32_0d), np.float32)
 assert_type(np.sin(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
 assert_type(np.sin(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
@@ -694,22 +718,54 @@ assert_type(
     ],
 )
 
-assert_type(np.frexp(_i16_0d), tuple[np.float64, np.int32])
+assert_type(np.frexp(_bool_0d), tuple[np.float16, np.int32])
+assert_type(
+    np.frexp(_bool_1d),
+    tuple[
+        np.ndarray[tuple[int], np.dtype[np.float16]],
+        np.ndarray[tuple[int], np.dtype[np.int32]],
+    ],
+)
+assert_type(
+    np.frexp(_bool_2d),
+    tuple[
+        np.ndarray[tuple[int, int], np.dtype[np.float16]],
+        np.ndarray[tuple[int, int], np.dtype[np.int32]],
+    ],
+)
+assert_type(np.frexp(_bool_nd), tuple[npt.NDArray[np.float16], npt.NDArray[np.int32]])
+assert_type(np.frexp(_i16_0d), tuple[np.float32, np.int32])
 assert_type(
     np.frexp(_i16_1d),
     tuple[
-        np.ndarray[tuple[int], np.dtype[np.float64]],
+        np.ndarray[tuple[int], np.dtype[np.float32]],
         np.ndarray[tuple[int], np.dtype[np.int32]],
     ],
 )
 assert_type(
     np.frexp(_i16_2d),
     tuple[
+        np.ndarray[tuple[int, int], np.dtype[np.float32]],
+        np.ndarray[tuple[int, int], np.dtype[np.int32]],
+    ],
+)
+assert_type(np.frexp(_i16_nd), tuple[npt.NDArray[np.float32], npt.NDArray[np.int32]])
+assert_type(np.frexp(_i32_0d), tuple[np.float64, np.int32])
+assert_type(
+    np.frexp(_i32_1d),
+    tuple[
+        np.ndarray[tuple[int], np.dtype[np.float64]],
+        np.ndarray[tuple[int], np.dtype[np.int32]],
+    ],
+)
+assert_type(
+    np.frexp(_i32_2d),
+    tuple[
         np.ndarray[tuple[int, int], np.dtype[np.float64]],
         np.ndarray[tuple[int, int], np.dtype[np.int32]],
     ],
 )
-assert_type(np.frexp(_i16_nd), tuple[npt.NDArray[np.float64], npt.NDArray[np.int32]])
+assert_type(np.frexp(_i32_nd), tuple[npt.NDArray[np.float64], npt.NDArray[np.int32]])
 assert_type(np.frexp(_f32_0d), tuple[np.float32, np.int32])
 assert_type(
     np.frexp(_f32_1d),
@@ -746,10 +802,18 @@ assert_type(np.modf(_py_f_0d), _tuple2[np.float64])
 assert_type(np.modf(_py_f_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float64]]])
 assert_type(np.modf(_py_f_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float64]]])
 
-assert_type(np.modf(_i16_0d), _tuple2[np.float64])
-assert_type(np.modf(_i16_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float64]]])
-assert_type(np.modf(_i16_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float64]]])
-assert_type(np.modf(_i16_nd), _tuple2[npt.NDArray[np.float64]])
+assert_type(np.modf(_bool_0d), _tuple2[np.float16])
+assert_type(np.modf(_bool_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float16]]])
+assert_type(np.modf(_bool_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float16]]])
+assert_type(np.modf(_bool_nd), _tuple2[npt.NDArray[np.float16]])
+assert_type(np.modf(_i16_0d), _tuple2[np.float32])
+assert_type(np.modf(_i16_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float32]]])
+assert_type(np.modf(_i16_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float32]]])
+assert_type(np.modf(_i16_nd), _tuple2[npt.NDArray[np.float32]])
+assert_type(np.modf(_i32_0d), _tuple2[np.float64])
+assert_type(np.modf(_i32_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float64]]])
+assert_type(np.modf(_i32_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float64]]])
+assert_type(np.modf(_i32_nd), _tuple2[npt.NDArray[np.float64]])
 assert_type(np.modf(_f32_0d), _tuple2[np.float32])
 assert_type(np.modf(_f32_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float32]]])
 assert_type(np.modf(_f32_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float32]]])
@@ -938,14 +1002,18 @@ assert_type(np.ldexp(_py_f_0d, _py_i_0d), np.float64)
 assert_type(np.ldexp(_py_f_1d, _py_i_1d), npt.NDArray[np.float64])
 assert_type(np.ldexp(_py_f_2d, _py_i_2d), npt.NDArray[np.float64])
 
-assert_type(np.ldexp(_bool_0d, _bool_0d), np.float64)
-assert_type(np.ldexp(_bool_1d, _bool_1d), npt.NDArray[np.float64])
-assert_type(np.ldexp(_bool_2d, _bool_2d), npt.NDArray[np.float64])
-assert_type(np.ldexp(_bool_nd, _bool_nd), npt.NDArray[np.float64])
-assert_type(np.ldexp(_i16_0d, _i16_0d), np.float64)
-assert_type(np.ldexp(_i16_1d, _i16_1d), npt.NDArray[np.float64])
-assert_type(np.ldexp(_i16_2d, _i16_2d), npt.NDArray[np.float64])
-assert_type(np.ldexp(_i16_nd, _i16_nd), npt.NDArray[np.float64])
+assert_type(np.ldexp(_bool_0d, _bool_0d), np.float16)
+assert_type(np.ldexp(_bool_1d, _bool_1d), npt.NDArray[np.float16])
+assert_type(np.ldexp(_bool_2d, _bool_2d), npt.NDArray[np.float16])
+assert_type(np.ldexp(_bool_nd, _bool_nd), npt.NDArray[np.float16])
+assert_type(np.ldexp(_i16_0d, _i16_0d), np.float32)
+assert_type(np.ldexp(_i16_1d, _i16_1d), npt.NDArray[np.float32])
+assert_type(np.ldexp(_i16_2d, _i16_2d), npt.NDArray[np.float32])
+assert_type(np.ldexp(_i16_nd, _i16_nd), npt.NDArray[np.float32])
+assert_type(np.ldexp(_i32_0d, _i32_0d), np.float64)
+assert_type(np.ldexp(_i32_1d, _i32_1d), npt.NDArray[np.float64])
+assert_type(np.ldexp(_i32_2d, _i32_2d), npt.NDArray[np.float64])
+assert_type(np.ldexp(_i32_nd, _i32_nd), npt.NDArray[np.float64])
 assert_type(np.ldexp(_f32_0d, _i16_0d), np.float32)
 assert_type(np.ldexp(_f32_1d, _i16_1d), npt.NDArray[np.float32])
 assert_type(np.ldexp(_f32_2d, _i16_2d), npt.NDArray[np.float32])
@@ -964,11 +1032,21 @@ assert_type(np.ldexp.outer(_f32_1d, _py_i_1d), npt.NDArray[np.float32])
 
 assert_type(np.ldexp.at(_f32_2d, 1, _py_i_1d), None)
 
-assert_type(np.ldexp.reduce(_i16_1d), npt.NDArray[np.float64] | np.float64)
-assert_type(np.ldexp.reduce(_i16_2d), npt.NDArray[np.float64] | np.float64)
-assert_type(np.ldexp.reduce(_i16_1d, axis=None), np.float64)
-assert_type(np.ldexp.reduce(_i16_1d, keepdims=True), npt.NDArray[np.float64])
-assert_type(np.ldexp.reduce(_i16_1d, out=...), npt.NDArray[np.float64])
-assert_type(np.ldexp.reduce(_i16_1d, out=_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.ldexp.reduce(_bool_1d), npt.NDArray[np.float16] | np.float16)
+assert_type(np.ldexp.reduce(_bool_2d), npt.NDArray[np.float16] | np.float16)
+assert_type(np.ldexp.reduce(_bool_1d, axis=None), np.float16)
+assert_type(np.ldexp.reduce(_bool_1d, keepdims=True), npt.NDArray[np.float16])
+assert_type(np.ldexp.reduce(_bool_1d, out=...), npt.NDArray[np.float16])
+assert_type(np.ldexp.reduce(_i16_1d), npt.NDArray[np.float32] | np.float32)
+assert_type(np.ldexp.reduce(_i16_2d), npt.NDArray[np.float32] | np.float32)
+assert_type(np.ldexp.reduce(_i16_1d, axis=None), np.float32)
+assert_type(np.ldexp.reduce(_i16_1d, keepdims=True), npt.NDArray[np.float32])
+assert_type(np.ldexp.reduce(_i16_1d, out=...), npt.NDArray[np.float32])
+assert_type(np.ldexp.reduce(_i32_1d), npt.NDArray[np.float64] | np.float64)
+assert_type(np.ldexp.reduce(_i32_2d), npt.NDArray[np.float64] | np.float64)
+assert_type(np.ldexp.reduce(_i32_1d, axis=None), np.float64)
+assert_type(np.ldexp.reduce(_i32_1d, keepdims=True), npt.NDArray[np.float64])
+assert_type(np.ldexp.reduce(_i32_1d, out=...), npt.NDArray[np.float64])
+assert_type(np.ldexp.reduce(_i32_1d, out=_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
 
 # ldexp doesn't support reduceat / accumulate


### PR DESCRIPTION
Previously, all ``integer`` and ``bool`` inputs were promoted to ``float64`` in the speciailzed float ufuncs. But in reality, `bool`/`[u]int8` promotes to `float16`, and `[u]int16` promotes to `float32`. 

```
In [1]: np.spacing(np.True_)
Out[1]: np.float16(0.000977)

In [2]: np.spacing(np.int8(1))
Out[2]: np.float16(0.000977)

In [3]: np.spacing(np.int16(1))
Out[3]: np.float32(1.1920929e-07)

In [4]: np.spacing(np.int32(1))
Out[4]: np.float64(2.220446049250313e-16)

In [5]: np.spacing(np.int64(1))
Out[5]: np.float64(2.220446049250313e-16)
```

The solution is, as per usual, to add even more overloads ( :tada: ), special-casing these three promotion rule classes.

---

No AI (although I indirectly realized that this was an issue because of https://github.com/scipy/scipy-stubs/issues/1823, so I suppose that indirectly Fable 5 helped me discover this issue).