### PR TITLE
TYP: fix unit-dependent ``timedelta64``/``datetime64`` overloads

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1016,7 +1016,7 @@ type _TimeUnit = L[_NativeTimeUnit, _IntTimeUnit]
 type _NativeTD64Unit = L[_DayUnit, _NativeTimeUnit]
 type _IntTD64Unit = L[_MonthUnit, _IntTimeUnit]
 type _TD64Unit = L[_DateUnit, _TimeUnit]
-type _TimeUnitSpec[UnitT: _TD64Unit] = _TD64Unit | tuple[_TD64Unit, SupportsIndex]
+type _TimeUnitSpec[UnitT: _TD64Unit] = UnitT | tuple[UnitT, SupportsIndex]
 
 ### TypedDict's (for internal use only)
 
@@ -7334,11 +7334,11 @@ class datetime64(_RealMixin, generic[_DT64ItemT_co], Generic[_DT64ItemT_co]):
     @overload
     def __new__(cls, value: int | bytes | str | dt.date, format: _TimeUnitSpec[_IntTimeUnit], /) -> datetime64[int]: ...
     @overload
-    def __new__(  # type: ignore[overload-cannot-match]
+    def __new__(
         cls, value: int | bytes | str | dt.date, format: _TimeUnitSpec[_NativeTimeUnit], /
     ) -> datetime64[dt.datetime]: ...
     @overload
-    def __new__(cls, value: int | bytes | str | dt.date, format: _TimeUnitSpec[_DateUnit], /) -> datetime64[dt.date]: ...  # type: ignore[overload-cannot-match]
+    def __new__(cls, value: int | bytes | str | dt.date, format: _TimeUnitSpec[_DateUnit], /) -> datetime64[dt.date]: ...
     @overload
     def __new__(cls, value: bytes | str | dt.date | None, format: _TimeUnitSpec[_TD64Unit] = ..., /) -> Self: ...
 


### PR DESCRIPTION
The `_TimeUnitSpec` type alias type parameter was unused, leading to incorrect inference for the ``timedelta64`` and ``datetime64`` constructors:

```
reveal_type(np.timedelta64(5, 'D').item())          # int
reveal_type(np.datetime64('2021-01-01', 's').item())  # int
reveal_type(np.datetime64(dt.date(2021, 1, 1), 'ns').item())  # date
int(np.timedelta64(5, 'D'))                          # accepted by checkers
```

Clearly, these are all wrong.

Luckily it's a pretty trivial fix.

---

Claude Fable 5 (high) discovered this bug. but no AI used for the fix.