### PR TITLE
MAINT: Update Cython version check.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,8 +31,8 @@ elif cc.get_id() == 'msvc'
   endif
   add_project_arguments('/experimental:c11atomics', language: 'c')
 endif
-if not cy.version().version_compare('>=3.0.6')
-  error('NumPy requires Cython >= 3.0.6')
+if not cy.version().version_compare('>=3.1.0')
+  error('NumPy requires Cython >= 3.1.0')
 endif
 
 py = import('python').find_installation(pure: false)


### PR DESCRIPTION
This updates the minimum Cython version to 3.1.0 to match the version in pyproject.toml.

No AI.