### PR TITLE
TYP: fix ``random.Generator.choice`` output type for int sequences

### DIFF
--- a/numpy/random/_generator.pyi
+++ b/numpy/random/_generator.pyi
@@ -688,17 +688,28 @@ class Generator:
     def permuted[ArrayT: np.ndarray](self, /, x: ArrayLike, *, axis: int | None = None, out: ArrayT) -> ArrayT: ...
 
     #
-    @overload  # >=0d int, size=None (default)
+    @overload  # 0d int, size=None (default)
     def choice(
         self,
         /,
-        a: int | _NestedSequence[int],
+        a: int,
         size: None = None,
         replace: bool = True,
         p: _ArrayLikeFloat_co | None = None,
         axis: int = 0,
         shuffle: bool = True,
     ) -> int: ...
+    @overload  # >0d int, size=None (default)
+    def choice(
+        self,
+        /,
+        a: _NestedSequence[int],
+        size: None = None,
+        replace: bool = True,
+        p: _ArrayLikeFloat_co | None = None,
+        axis: int = 0,
+        shuffle: bool = True,
+    ) -> np.int_: ...
     @overload  # >=0d known, size=None (default)
     def choice[ScalarT: np.generic](
         self,

--- a/numpy/typing/tests/data/reveal/random.pyi
+++ b/numpy/typing/tests/data/reveal/random.pyi
@@ -700,6 +700,7 @@ assert_type(def_gen.bit_generator, np.random.BitGenerator)
 assert_type(def_gen.bytes(2), bytes)
 
 assert_type(def_gen.choice(5), int)
+assert_type(def_gen.choice([1, 2]), np.int_)
 assert_type(def_gen.choice(5, 3), npt.NDArray[np.int64])
 assert_type(def_gen.choice(5, 3, replace=True), npt.NDArray[np.int64])
 assert_type(def_gen.choice(5, 3, p=[1 / 5] * 5), npt.NDArray[np.int64])


### PR DESCRIPTION
Both these cases were typed as `int` in the stubs:

```pycon
In [1]: rng.choice(3)
Out[1]: 0

In [2]: rng.choice([1,2,3])
Out[2]: np.int64(1)
```

The second (`rng.choice([1,2,3])`) case was wrong, and is now correctly annotated to return `np.int_` in the stubs as well.

This matters because `int` and `np.int_` are incompatible types.

---

Fully written by me (a human, <sup>I think</sup>); bug found by Claude Fable 5 (high) ([here's the full audit for those interested](https://gist.github.com/jorenham/f91ff9ae7453e4fafabaf4c490545404)).