### PR TITLE
TYP: fix ``std``/``var`` output type for complex input

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3201,9 +3201,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
 
     # keep in sync with `ndarray.mean` above
     @override  # type: ignore[override]
-    @overload  # +integer | ~object_
+    @overload  # ~complex128 | +integer | ~object_
     def std(
-        self: NDArray[integer | bool_ | object_],
+        self: NDArray[complex128 | integer | bool_ | object_],
         axis: None = None,
         dtype: None = None,
         out: None = None,
@@ -3214,9 +3214,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         mean: _ArrayLikeNumber_co | _NoValueType = ...,
         correction: float | _NoValueType = ...,
     ) -> float64: ...
-    @overload  # +integer, axis: <given>
+    @overload  # ~complex128 | +integer, axis: <given>
     def std(
-        self: NDArray[integer | bool_],
+        self: NDArray[complex128 | integer | bool_],
         axis: int | tuple[int, ...],
         dtype: None = None,
         out: None = None,
@@ -3227,9 +3227,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         mean: _ArrayLikeNumber_co | _NoValueType = ...,
         correction: float | _NoValueType = ...,
     ) -> NDArray[float64]: ...
-    @overload  # +integer, keepdims=True
+    @overload  # ~complex128 | +integer, keepdims=True
     def std(
-        self: NDArray[integer | bool_],
+        self: NDArray[complex128 | integer | bool_],
         axis: int | tuple[int, ...] | None = None,
         dtype: None = None,
         out: None = None,
@@ -3240,8 +3240,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         mean: _ArrayLikeNumber_co | _NoValueType = ...,
         correction: float | _NoValueType = ...,
     ) -> ndarray[_ShapeT_co, dtype[float64]]: ...
-    @overload  # ~inexact | timedelta64
-    def std[ScalarT: inexact | timedelta64](
+    @overload  # ~floating | timedelta64
+    def std[ScalarT: floating | timedelta64](
         self: NDArray[ScalarT],
         axis: None = None,
         dtype: None = None,
@@ -3253,8 +3253,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         mean: _ArrayLikeNumber_co | _NoValueType = ...,
         correction: float | _NoValueType = ...,
     ) -> ScalarT: ...
-    @overload  # ~inexact | timedelta64, axis: <given>
-    def std[ScalarT: inexact | timedelta64 | object_](
+    @overload  # ~floating | timedelta64, axis: <given>
+    def std[ScalarT: floating | timedelta64 | object_](
         self: NDArray[ScalarT],
         axis: int | tuple[int, ...],
         dtype: None = None,
@@ -3266,8 +3266,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         mean: _ArrayLikeNumber_co | _NoValueType = ...,
         correction: float | _NoValueType = ...,
     ) -> NDArray[ScalarT]: ...
-    @overload  # ~inexact | timedelta64 | object_, keepdims=True
-    def std[ArrayT: NDArray[inexact | timedelta64 | object_]](
+    @overload  # ~floating | timedelta64 | object_, keepdims=True
+    def std[ArrayT: NDArray[floating | timedelta64 | object_]](
         self: ArrayT,
         axis: int | tuple[int, ...] | None = None,
         dtype: None = None,
@@ -3386,9 +3386,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
 
     # keep in sync with `ndarray.std` above
     @override  # type: ignore[override]
-    @overload  # +integer | ~object_
+    @overload  # ~complex128 | +integer | ~object_
     def var(
-        self: NDArray[integer | bool_ | object_],
+        self: NDArray[complex128 | integer | bool_ | object_],
         axis: None = None,
         dtype: None = None,
         out: None = None,
@@ -3399,9 +3399,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         mean: _ArrayLikeNumber_co | _NoValueType = ...,
         correction: float | _NoValueType = ...,
     ) -> float64: ...
-    @overload  # +integer, axis: <given>
+    @overload  # ~complex128 | +integer, axis: <given>
     def var(
-        self: NDArray[integer | bool_],
+        self: NDArray[complex128 | integer | bool_],
         axis: int | tuple[int, ...],
         dtype: None = None,
         out: None = None,
@@ -3412,9 +3412,9 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         mean: _ArrayLikeNumber_co | _NoValueType = ...,
         correction: float | _NoValueType = ...,
     ) -> NDArray[float64]: ...
-    @overload  # +integer, keepdims=True
+    @overload  # ~complex128 | +integer, keepdims=True
     def var(
-        self: NDArray[integer | bool_],
+        self: NDArray[complex128 | integer | bool_],
         axis: int | tuple[int, ...] | None = None,
         dtype: None = None,
         out: None = None,
@@ -3425,8 +3425,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         mean: _ArrayLikeNumber_co | _NoValueType = ...,
         correction: float | _NoValueType = ...,
     ) -> ndarray[_ShapeT_co, dtype[float64]]: ...
-    @overload  # ~inexact | timedelta64
-    def var[ScalarT: inexact | timedelta64](
+    @overload  # ~floating | timedelta64
+    def var[ScalarT: floating | timedelta64](
         self: NDArray[ScalarT],
         axis: None = None,
         dtype: None = None,
@@ -3438,8 +3438,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         mean: _ArrayLikeNumber_co | _NoValueType = ...,
         correction: float | _NoValueType = ...,
     ) -> ScalarT: ...
-    @overload  # ~inexact | timedelta64, axis: <given>
-    def var[ScalarT: inexact | timedelta64 | object_](
+    @overload  # ~floating | timedelta64, axis: <given>
+    def var[ScalarT: floating | timedelta64 | object_](
         self: NDArray[ScalarT],
         axis: int | tuple[int, ...],
         dtype: None = None,
@@ -3451,8 +3451,8 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         mean: _ArrayLikeNumber_co | _NoValueType = ...,
         correction: float | _NoValueType = ...,
     ) -> NDArray[ScalarT]: ...
-    @overload  # ~inexact | timedelta64 | object_, keepdims=True
-    def var[ArrayT: NDArray[inexact | timedelta64 | object_]](
+    @overload  # ~floating | timedelta64 | object_, keepdims=True
+    def var[ArrayT: NDArray[floating | timedelta64 | object_]](
         self: ArrayT,
         axis: int | tuple[int, ...] | None = None,
         dtype: None = None,

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -2759,10 +2759,10 @@ def mean(
     where: _ArrayLikeBool_co | _NoValueType = ...,
 ) -> NDArray[Any]: ...
 
-# keep in sync with `mean` above
-@overload  # +integer | ~object_ | +builtins.float
+#
+@overload  # ~complex128 | +integer | ~object_ | +builtins.float
 def std(
-    a: _DualArrayLike[np.dtype[np.integer | np.bool | np.object_], float],
+    a: _DualArrayLike[np.dtype[np.complex128 | np.integer | np.bool | np.object_], complex],
     axis: None = None,
     dtype: None = None,
     out: None = None,
@@ -2773,9 +2773,9 @@ def std(
     mean: _ArrayLikeFloat_co | _NoValueType = ...,
     correction: float | _NoValueType = ...,
 ) -> np.float64: ...
-@overload  # +integer | +builtins.float, axis: <given>
+@overload  # ~complex128 | +integer | +builtins.float, axis: <given>
 def std(
-    a: _DualArrayLike[np.dtype[np.integer | np.bool], float],
+    a: _DualArrayLike[np.dtype[np.complex128 | np.integer | np.bool], complex],
     axis: int | tuple[int, ...],
     dtype: None = None,
     out: None = None,
@@ -2788,7 +2788,7 @@ def std(
 ) -> NDArray[np.float64]: ...
 @overload  # +integer, keepdims=True
 def std[ShapeT: _Shape](
-    a: np.ndarray[ShapeT, np.dtype[np.integer | np.bool]],
+    a: np.ndarray[ShapeT, np.dtype[np.complex128 | np.integer | np.bool]],
     axis: int | tuple[int, ...] | None = None,
     dtype: None = None,
     out: None = None,
@@ -2799,21 +2799,8 @@ def std[ShapeT: _Shape](
     mean: _ArrayLikeComplex_co | _NoValueType = ...,
     correction: float | _NoValueType = ...,
 ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
-@overload  # ~complex  (`list` ensures invariance to avoid overlap with the previous overload)
-def std(
-    a: _NestedSequence[list[complex]] | list[complex],
-    axis: None = None,
-    dtype: None = None,
-    out: None = None,
-    ddof: float = 0,
-    keepdims: Literal[False] | _NoValueType = ...,
-    *,
-    where: _ArrayLikeBool_co | _NoValueType = ...,
-    mean: _ArrayLikeComplex_co | _NoValueType = ...,
-    correction: float | _NoValueType = ...,
-) -> np.complex128: ...
-@overload  # ~inexact | timedelta64
-def std[ScalarT: np.inexact | np.timedelta64](
+@overload  # ~floating | timedelta64
+def std[ScalarT: np.floating | np.timedelta64](
     a: _ArrayLike[ScalarT],
     axis: None = None,
     dtype: None = None,
@@ -2825,8 +2812,8 @@ def std[ScalarT: np.inexact | np.timedelta64](
     mean: _ArrayLikeComplex_co | _NoValueType = ...,
     correction: float | _NoValueType = ...,
 ) -> ScalarT: ...
-@overload  # ~inexact | timedelta64 | object_, axis: <given>
-def std[ScalarT: np.inexact | np.timedelta64 | np.object_](
+@overload  # ~floating | timedelta64 | object_, axis: <given>
+def std[ScalarT: np.floating | np.timedelta64 | np.object_](
     a: _ArrayLike[ScalarT],
     axis: int | tuple[int, ...],
     dtype: None = None,
@@ -2838,8 +2825,8 @@ def std[ScalarT: np.inexact | np.timedelta64 | np.object_](
     mean: _ArrayLikeComplex_co | _NoValueType = ...,
     correction: float | _NoValueType = ...,
 ) -> NDArray[ScalarT]: ...
-@overload  # ~inexact | timedelta64 | object_, keepdims=True
-def std[ArrayT: NDArray[np.inexact | np.timedelta64 | np.object_]](
+@overload  # ~floating | timedelta64 | object_, keepdims=True
+def std[ArrayT: NDArray[np.floating | np.timedelta64 | np.object_]](
     a: ArrayT,
     axis: int | tuple[int, ...] | None = None,
     dtype: None = None,
@@ -2970,9 +2957,9 @@ def std(
 ) -> NDArray[Any]: ...
 
 # keep in sync with `std` above
-@overload  # +integer | ~object_ | +builtins.float
+@overload  # ~complex128 | +integer | ~object_ | +builtins.float
 def var(
-    a: _DualArrayLike[np.dtype[np.integer | np.bool | np.object_], float],
+    a: _DualArrayLike[np.dtype[np.complex128 | np.integer | np.bool | np.object_], complex],
     axis: None = None,
     dtype: None = None,
     out: None = None,
@@ -2983,9 +2970,9 @@ def var(
     mean: _ArrayLikeFloat_co | _NoValueType = ...,
     correction: float | _NoValueType = ...,
 ) -> np.float64: ...
-@overload  # +integer | +builtins.float, axis: <given>
+@overload  # ~complex128 | +integer | +builtins.float, axis: <given>
 def var(
-    a: _DualArrayLike[np.dtype[np.integer | np.bool], float],
+    a: _DualArrayLike[np.dtype[np.complex128 | np.integer | np.bool], complex],
     axis: int | tuple[int, ...],
     dtype: None = None,
     out: None = None,
@@ -2998,7 +2985,7 @@ def var(
 ) -> NDArray[np.float64]: ...
 @overload  # +integer, keepdims=True
 def var[ShapeT: _Shape](
-    a: np.ndarray[ShapeT, np.dtype[np.integer | np.bool]],
+    a: np.ndarray[ShapeT, np.dtype[np.complex128 | np.integer | np.bool]],
     axis: int | tuple[int, ...] | None = None,
     dtype: None = None,
     out: None = None,
@@ -3009,21 +2996,8 @@ def var[ShapeT: _Shape](
     mean: _ArrayLikeComplex_co | _NoValueType = ...,
     correction: float | _NoValueType = ...,
 ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
-@overload  # ~complex  (`list` ensures invariance to avoid overlap with the previous overload)
-def var(
-    a: _NestedSequence[list[complex]] | list[complex],
-    axis: None = None,
-    dtype: None = None,
-    out: None = None,
-    ddof: float = 0,
-    keepdims: Literal[False] | _NoValueType = ...,
-    *,
-    where: _ArrayLikeBool_co | _NoValueType = ...,
-    mean: _ArrayLikeComplex_co | _NoValueType = ...,
-    correction: float | _NoValueType = ...,
-) -> np.complex128: ...
-@overload  # ~inexact | timedelta64
-def var[ScalarT: np.inexact | np.timedelta64](
+@overload  # ~floating | timedelta64
+def var[ScalarT: np.floating | np.timedelta64](
     a: _ArrayLike[ScalarT],
     axis: None = None,
     dtype: None = None,
@@ -3035,8 +3009,8 @@ def var[ScalarT: np.inexact | np.timedelta64](
     mean: _ArrayLikeComplex_co | _NoValueType = ...,
     correction: float | _NoValueType = ...,
 ) -> ScalarT: ...
-@overload  # ~inexact | timedelta64 | object_, axis: <given>
-def var[ScalarT: np.inexact | np.timedelta64 | np.object_](
+@overload  # ~floating | timedelta64 | object_, axis: <given>
+def var[ScalarT: np.floating | np.timedelta64 | np.object_](
     a: _ArrayLike[ScalarT],
     axis: int | tuple[int, ...],
     dtype: None = None,
@@ -3048,8 +3022,8 @@ def var[ScalarT: np.inexact | np.timedelta64 | np.object_](
     mean: _ArrayLikeComplex_co | _NoValueType = ...,
     correction: float | _NoValueType = ...,
 ) -> NDArray[ScalarT]: ...
-@overload  # ~inexact | timedelta64 | object_, keepdims=True
-def var[ArrayT: NDArray[np.inexact | np.timedelta64 | np.object_]](
+@overload  # ~floating | timedelta64 | object_, keepdims=True
+def var[ArrayT: NDArray[np.floating | np.timedelta64 | np.object_]](
     a: ArrayT,
     axis: int | tuple[int, ...] | None = None,
     dtype: None = None,

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -13,6 +13,7 @@ AR_f4: npt.NDArray[np.float32]
 AR_f4_1d: np.ndarray[tuple[int], np.dtype[np.float32]]
 AR_f4_2d: np.ndarray[tuple[int, int], np.dtype[np.float32]]
 AR_f4_3d: np.ndarray[tuple[int, int, int], np.dtype[np.float32]]
+AR_c8: npt.NDArray[np.complex64]
 AR_c16: npt.NDArray[np.complex128]
 AR_i1: npt.NDArray[np.int8]
 AR_u8: npt.NDArray[np.uint64]
@@ -502,7 +503,12 @@ assert_type(np.std(AR_i8, axis=0), npt.NDArray[np.float64])
 assert_type(np.std(AR_i8, keepdims=True), npt.NDArray[np.float64])
 assert_type(np.std(AR_i8, axis=0, keepdims=True), npt.NDArray[np.float64])
 assert_type(np.std(AR_f4), np.float32)
-assert_type(np.std(AR_c16), np.complex128)
+assert_type(np.std(AR_c8), Any)
+assert_type(np.std(AR_c8, axis=0), npt.NDArray[Any])
+assert_type(np.std(AR_c8, keepdims=True), npt.NDArray[Any])
+assert_type(np.std(AR_c16), np.float64)
+assert_type(np.std(AR_c16, axis=0), npt.NDArray[np.float64])
+assert_type(np.std(AR_c16, keepdims=True), npt.NDArray[np.float64])
 assert_type(np.std(AR_O), np.float64)
 assert_type(np.std(AR_O, axis=0), npt.NDArray[np.object_])
 assert_type(np.std(AR_O, keepdims=True), npt.NDArray[np.object_])
@@ -533,7 +539,12 @@ assert_type(np.var(AR_i8, axis=0), npt.NDArray[np.float64])
 assert_type(np.var(AR_i8, keepdims=True), npt.NDArray[np.float64])
 assert_type(np.var(AR_i8, axis=0, keepdims=True), npt.NDArray[np.float64])
 assert_type(np.var(AR_f4), np.float32)
-assert_type(np.var(AR_c16), np.complex128)
+assert_type(np.var(AR_c8), Any)
+assert_type(np.var(AR_c8, axis=0), npt.NDArray[Any])
+assert_type(np.var(AR_c8, keepdims=True), npt.NDArray[Any])
+assert_type(np.var(AR_c16), np.float64)
+assert_type(np.var(AR_c16, axis=0), npt.NDArray[np.float64])
+assert_type(np.var(AR_c16, keepdims=True), npt.NDArray[np.float64])
 assert_type(np.var(AR_O), np.float64)
 assert_type(np.var(AR_O, axis=0), npt.NDArray[np.object_])
 assert_type(np.var(AR_O, keepdims=True), npt.NDArray[np.object_])

--- a/numpy/typing/tests/data/reveal/ndarray_misc.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.pyi
@@ -32,6 +32,7 @@ AR_f8: npt.NDArray[np.float64]
 AR_i8: npt.NDArray[np.int64]
 AR_u1: npt.NDArray[np.uint8]
 AR_c8: npt.NDArray[np.complex64]
+AR_c16: npt.NDArray[np.complex128]
 AR_m: npt.NDArray[np.timedelta64]
 AR_U: npt.NDArray[np.str_]
 AR_V: npt.NDArray[np.void]
@@ -236,12 +237,16 @@ assert_type(AR_f8_2d.mean(dtype=np.float32, axis=0), npt.NDArray[np.float32])
 assert_type(AR_f8_2d.mean(dtype=np.float32, keepdims=True), np.ndarray[tuple[int, int], np.dtype[np.float32]])
 assert_type(AR_f8_2d.mean(dtype=np.float32, axis=0, keepdims=True), np.ndarray[tuple[int, int], np.dtype[np.float32]])
 
-# same as above
+# as above, but returns floating for complexfloating input
 assert_type(f8.std(), Any)
 assert_type(AR_f8.std(), np.float64)
 assert_type(AR_f8.std(keepdims=True), npt.NDArray[np.float64])
 assert_type(AR_f8.std(axis=0), npt.NDArray[np.float64])
 assert_type(AR_f8.std(axis=0, keepdims=True), npt.NDArray[np.float64])
+assert_type(AR_c16.std(), np.float64)
+assert_type(AR_c16.std(keepdims=True), npt.NDArray[np.float64])
+assert_type(AR_c16.std(axis=0), npt.NDArray[np.float64])
+assert_type(AR_c16.std(axis=0, keepdims=True), npt.NDArray[np.float64])
 assert_type(AR_f8.std(dtype=np.float32), np.float32)
 assert_type(AR_f8.std(dtype=np.float32, axis=0), npt.NDArray[np.float32])
 assert_type(AR_f8.std(dtype=np.float32, keepdims=True), npt.NDArray[np.float32])
@@ -262,6 +267,10 @@ assert_type(AR_f8.var(), np.float64)
 assert_type(AR_f8.var(keepdims=True), npt.NDArray[np.float64])
 assert_type(AR_f8.var(axis=0), npt.NDArray[np.float64])
 assert_type(AR_f8.var(axis=0, keepdims=True), npt.NDArray[np.float64])
+assert_type(AR_c16.var(), np.float64)
+assert_type(AR_c16.var(keepdims=True), npt.NDArray[np.float64])
+assert_type(AR_c16.var(axis=0), npt.NDArray[np.float64])
+assert_type(AR_c16.var(axis=0, keepdims=True), npt.NDArray[np.float64])
 assert_type(AR_f8.var(dtype=np.float32), np.float32)
 assert_type(AR_f8.var(dtype=np.float32, axis=0), npt.NDArray[np.float32])
 assert_type(AR_f8.var(dtype=np.float32, keepdims=True), npt.NDArray[np.float32])


### PR DESCRIPTION
The `np.std`/`np.var` functions and `ndarray.std`/`ndarray.var` methods incorrectly returned complex dtypes for complex input. Because at runtime that would result in real output:

```
In [1]: c = np.array([1j, 1])

In [2]: np.std(c)
Out[2]: np.float64(0.7071067811865476)

In [3]: c.std()
Out[3]: np.float64(0.7071067811865476)
```

Miraculously, the fix didn't require adding new overloads this time. It even got rid of two!

---

Fully written by me (a human, <sup>I think</sup>); bug found by Claude Fable 5 (high) ([here's the full audit for those interested](https://gist.github.com/jorenham/f91ff9ae7453e4fafabaf4c490545404)).