### PR TITLE
TYP: fix swapped ``linalg.slogdet`` dtypes of ``sign``/``logabsdet``

### DIFF
--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -196,8 +196,8 @@ class SVDResult(NamedTuple, Generic[_FloatingT_co, _InexactT_co]):
     Vh: NDArray[_InexactT_co]
 
 class SlogdetResult(NamedTuple, Generic[_FloatingOrArrayT_co, _InexactOrArrayT_co]):
-    sign: _FloatingOrArrayT_co
-    logabsdet: _InexactOrArrayT_co
+    sign: _InexactOrArrayT_co
+    logabsdet: _FloatingOrArrayT_co
 
 # keep in sync with `solve`
 @overload  # ~float64, +float64


### PR DESCRIPTION
In short: `linalg.slogdet(...).sign` can be complex and `logabsdet` can only be real, but it was the other way around in the stubs.

---

Fully written by me (a human, <sup>I think</sup>); bug found by Claude Fable 5 (high) ([here's the full audit for those interested](https://gist.github.com/jorenham/f91ff9ae7453e4fafabaf4c490545404)).