### PR TITLE
TYP: fix ``tri{l,u}`` shape-typing for 1d input

### DIFF
--- a/numpy/lib/_twodim_base_impl.pyi
+++ b/numpy/lib/_twodim_base_impl.pyi
@@ -40,6 +40,8 @@ type _Int_co = np.integer | np.bool
 type _Float_co = np.floating | _Int_co
 type _Number_co = np.number | np.bool
 
+type _AtLeast2D = tuple[int, int, *tuple[int, ...]]  # input only
+
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
 # Workaround for mypy's and pyright's lack of compliance with the typing spec for
@@ -192,7 +194,9 @@ def tri(
 
 # keep in sync with `triu`
 @overload
-def tril[ArrayT: np.ndarray](m: ArrayT, k: int = 0) -> ArrayT: ...
+def tril[ArrayT: np.ndarray[_AtLeast2D]](m: ArrayT, k: int = 0) -> ArrayT: ...
+@overload
+def tril[DTypeT: np.dtype](m: np.ndarray[tuple[int], DTypeT], k: int = 0) -> np.ndarray[tuple[int, int], DTypeT]: ...
 @overload
 def tril[ScalarT: np.generic](m: _ArrayLike[ScalarT], k: int = 0) -> NDArray[ScalarT]: ...
 @overload
@@ -200,7 +204,9 @@ def tril(m: ArrayLike, k: int = 0) -> NDArray[Any]: ...
 
 # keep in sync with `tril`
 @overload
-def triu[ArrayT: np.ndarray](m: ArrayT, k: int = 0) -> ArrayT: ...
+def triu[ArrayT: np.ndarray[_AtLeast2D]](m: ArrayT, k: int = 0) -> ArrayT: ...
+@overload
+def triu[DTypeT: np.dtype](m: np.ndarray[tuple[int], DTypeT], k: int = 0) -> np.ndarray[tuple[int, int], DTypeT]: ...
 @overload
 def triu[ScalarT: np.generic](m: _ArrayLike[ScalarT], k: int = 0) -> NDArray[ScalarT]: ...
 @overload

--- a/numpy/typing/tests/data/reveal/twodim_base.pyi
+++ b/numpy/typing/tests/data/reveal/twodim_base.pyi
@@ -5,6 +5,7 @@ import numpy.typing as npt
 
 type _1D = tuple[int]
 type _2D = tuple[int, int]
+type _3D = tuple[int, int, int]
 type _ND = tuple[Any, ...]
 
 type _Indices2D = tuple[
@@ -17,6 +18,7 @@ type _Indices2D = tuple[
 _nd_bool: np.ndarray[_ND, np.dtype[np.bool]]
 _1d_bool: np.ndarray[_1D, np.dtype[np.bool]]
 _2d_bool: np.ndarray[_2D, np.dtype[np.bool]]
+_3d_bool: np.ndarray[_3D, np.dtype[np.bool]]
 _nd_u64: np.ndarray[_ND, np.dtype[np.uint64]]
 _nd_i64: np.ndarray[_ND, np.dtype[np.int64]]
 _nd_f64: np.ndarray[_ND, np.dtype[np.float64]]
@@ -89,12 +91,18 @@ assert_type(np.tril(_nd_bool), np.ndarray[_ND, np.dtype[np.bool]])
 assert_type(np.tril(_to_nd_bool, k=0), np.ndarray)
 assert_type(np.tril(_to_1d_bool, k=0), np.ndarray)
 assert_type(np.tril(_to_2d_bool, k=0), np.ndarray)
+assert_type(np.tril(_1d_bool, k=0), np.ndarray[_2D, np.dtype[np.bool]])
+assert_type(np.tril(_2d_bool, k=0), np.ndarray[_2D, np.dtype[np.bool]])
+assert_type(np.tril(_3d_bool, k=0), np.ndarray[_3D, np.dtype[np.bool]])
 
 # triu
 assert_type(np.triu(_nd_bool), np.ndarray[_ND, np.dtype[np.bool]])
 assert_type(np.triu(_to_nd_bool, k=0), np.ndarray)
 assert_type(np.triu(_to_1d_bool, k=0), np.ndarray)
 assert_type(np.triu(_to_2d_bool, k=0), np.ndarray)
+assert_type(np.triu(_1d_bool, k=0), np.ndarray[_2D, np.dtype[np.bool]])
+assert_type(np.triu(_2d_bool, k=0), np.ndarray[_2D, np.dtype[np.bool]])
+assert_type(np.triu(_3d_bool, k=0), np.ndarray[_3D, np.dtype[np.bool]])
 
 # vander
 assert_type(np.vander(_nd_bool), np.ndarray[_2D, np.dtype[np.int_]])


### PR DESCRIPTION
`np.tril` and `np.triu` return a 2d array for 1d input at runtime, but the stubs returned a 1d array in this case. 

---

Fully written by me (a human, <sup>I think</sup>); bug found by Claude Fable 5 (high) ([here's the full audit for those interested](https://gist.github.com/jorenham/f91ff9ae7453e4fafabaf4c490545404)).