### PR TITLE
ENH: Support DLPack for scalars by converting to 0-D array

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -5117,6 +5117,18 @@ class generic(_ArrayOrScalarCommon, Generic[_ItemT_co]):
         /,
     ) -> ScalarT | ndarray[ShapeT, _dtype[ScalarT]]: ...
 
+    #
+    def __dlpack__(
+        self,
+        /,
+        *,
+        stream: int | Any | None = None,
+        max_version: tuple[int, int] | None = None,
+        dl_device: tuple[int, int] | None = None,
+        copy: py_bool | None = None,
+    ) -> CapsuleType: ...
+    def __dlpack_device__(self, /) -> tuple[L[1], L[0]]: ...
+
     @property
     def base(self) -> None: ...
     @property

--- a/numpy/_core/src/common/npy_dlpack.h
+++ b/numpy/_core/src/common/npy_dlpack.h
@@ -26,6 +26,15 @@ array_dlpack_device(PyArrayObject *self, PyObject *NPY_UNUSED(args));
 
 
 NPY_NO_EXPORT PyObject *
+gentype_dlpack(PyObject *self, PyObject *const *args,
+        Py_ssize_t len_args, PyObject *kwnames);
+
+
+NPY_NO_EXPORT PyObject *
+gentype_dlpack_device(PyObject *NPY_UNUSED(self), PyObject *NPY_UNUSED(args));
+
+
+NPY_NO_EXPORT PyObject *
 from_dlpack(PyObject *NPY_UNUSED(self),
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames);
 

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -568,6 +568,27 @@ array_dlpack_device(PyArrayObject *self, PyObject *NPY_UNUSED(args))
     return Py_BuildValue("ii", device.device_type, device.device_id);
 }
 
+// for scalar __dlpack__ we create a 0-dim array and call the array version
+NPY_NO_EXPORT PyObject *
+gentype_dlpack(PyObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+{
+    PyObject *array = PyArray_FromScalar(self, NULL);
+    if (array == NULL) {
+        return NULL;
+    }
+
+    PyObject *result = array_dlpack((PyArrayObject *)array, args, len_args, kwnames);
+    Py_DECREF(array);
+    return result;
+}
+
+NPY_NO_EXPORT PyObject *
+gentype_dlpack_device(PyObject *NPY_UNUSED(self), PyObject *NPY_UNUSED(args))
+{
+    return Py_BuildValue("ii", kDLCPU, 0);
+}
+
 NPY_NO_EXPORT PyObject *
 from_dlpack(PyObject *NPY_UNUSED(self),
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -482,7 +482,7 @@ device_converter(PyObject *obj, DLDevice *result_device)
 
 
 NPY_NO_EXPORT PyObject *
-array_dlpack_impl(PyArrayObject *self,
+array_dlpack_int(PyArrayObject *self,
     PyObject *stream, PyObject *max_version, DLDevice *result_device,
     NPY_COPYMODE copy_mode)
 {
@@ -564,7 +564,7 @@ array_dlpack(PyArrayObject *self,
         return NULL;
     }
 
-    return array_dlpack_impl(self,
+    return array_dlpack_int(self,
         stream, max_version, &result_device, copy_mode);
 }
 
@@ -615,7 +615,7 @@ gentype_dlpack(PyObject *self,
         return NULL;
     }
 
-    PyObject *result = array_dlpack_impl((PyArrayObject *)array,
+    PyObject *result = array_dlpack_int((PyArrayObject *)array,
         stream, max_version, &result_device, NPY_COPY_IF_NEEDED);
     Py_DECREF(array);
     return result;

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -482,28 +482,11 @@ device_converter(PyObject *obj, DLDevice *result_device)
 
 
 NPY_NO_EXPORT PyObject *
-array_dlpack(PyArrayObject *self,
-        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+array_dlpack_impl(PyArrayObject *self,
+    PyObject *stream, PyObject *max_version, DLDevice *result_device,
+    NPY_COPYMODE copy_mode)
 {
-    PyObject *stream = Py_None;
-    PyObject *max_version = Py_None;
-    NPY_COPYMODE copy_mode = NPY_COPY_IF_NEEDED;
     long major_version = 0;
-    /* We allow the user to request a result device in principle. */
-    DLDevice result_device = array_get_dl_device(self);
-    if (PyErr_Occurred()) {
-        return NULL;
-    }
-
-    NPY_PREPARE_ARGPARSER;
-    if (npy_parse_arguments("__dlpack__", args, len_args, kwnames,
-            {"$stream", NULL, &stream},
-            {"$max_version", NULL, &max_version},
-            {"$dl_device", &device_converter, &result_device},
-            {"$copy", &PyArray_CopyConverter, &copy_mode})) {
-        return NULL;
-    }
-
     if (max_version != Py_None) {
         if (!PyTuple_Check(max_version) || PyTuple_GET_SIZE(max_version) != 2) {
             PyErr_SetString(PyExc_TypeError,
@@ -551,11 +534,38 @@ array_dlpack(PyArrayObject *self,
      * can then be removed again.
      */
     PyObject *res = create_dlpack_capsule(
-            self, major_version >= 1, &result_device,
+            self, major_version >= 1, result_device,
             copy_mode == NPY_COPY_ALWAYS);
     Py_DECREF(self);
 
     return res;
+}
+
+NPY_NO_EXPORT PyObject *
+array_dlpack(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+{
+    PyObject *stream = Py_None;
+    PyObject *max_version = Py_None;
+    NPY_COPYMODE copy_mode = NPY_COPY_IF_NEEDED;
+
+    /* We allow the user to request a result device in principle. */
+    DLDevice result_device = array_get_dl_device(self);
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+
+    NPY_PREPARE_ARGPARSER;
+    if (npy_parse_arguments("__dlpack__", args, len_args, kwnames,
+            {"$stream", NULL, &stream},
+            {"$max_version", NULL, &max_version},
+            {"$dl_device", &device_converter, &result_device},
+            {"$copy", &PyArray_CopyConverter, &copy_mode})) {
+        return NULL;
+    }
+
+    return array_dlpack_impl(self,
+        stream, max_version, &result_device, copy_mode);
 }
 
 NPY_NO_EXPORT PyObject *
@@ -573,12 +583,40 @@ NPY_NO_EXPORT PyObject *
 gentype_dlpack(PyObject *self,
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
+    PyObject *stream = Py_None;
+    PyObject *max_version = Py_None;
+    NPY_COPYMODE copy_mode = NPY_COPY_IF_NEEDED;
+    DLDevice result_device = {kDLCPU, 0};
+
+    NPY_PREPARE_ARGPARSER;
+    if (npy_parse_arguments("__dlpack__", args, len_args, kwnames,
+            {"$stream", NULL, &stream},
+            {"$max_version", NULL, &max_version},
+            {"$dl_device", &device_converter, &result_device},
+            {"$copy", &PyArray_CopyConverter, &copy_mode})) {
+        return NULL;
+    }
+    if (result_device.device_type != kDLCPU ||
+        result_device.device_id != 0) {
+        PyErr_SetString(PyExc_BufferError,
+            "Cannot export a scalar to DLPack on a non-CPU device.");
+        return NULL;
+    }
+    // scalars cannot be viewed, so reject copy=False otherwise
+    // pass copy=None to the array version
+    if (copy_mode == NPY_COPY_NEVER) {
+        PyErr_SetString(PyExc_BufferError,
+            "Cannot export a scalar to DLPack with copy=False.");
+        return NULL;
+    }
+
     PyObject *array = PyArray_FromScalar(self, NULL);
     if (array == NULL) {
         return NULL;
     }
 
-    PyObject *result = array_dlpack((PyArrayObject *)array, args, len_args, kwnames);
+    PyObject *result = array_dlpack_impl((PyArrayObject *)array,
+        stream, max_version, &result_device, NPY_COPY_IF_NEEDED);
     Py_DECREF(array);
     return result;
 }

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -596,12 +596,6 @@ gentype_dlpack(PyObject *self,
             {"$copy", &PyArray_CopyConverter, &copy_mode})) {
         return NULL;
     }
-    if (result_device.device_type != kDLCPU ||
-        result_device.device_id != 0) {
-        PyErr_SetString(PyExc_BufferError,
-            "Cannot export a scalar to DLPack on a non-CPU device.");
-        return NULL;
-    }
     // scalars cannot be viewed, so reject copy=False otherwise
     // pass copy=None to the array version
     if (copy_mode == NPY_COPY_NEVER) {

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -36,6 +36,7 @@
 #include "dragon4.h"
 #include "npy_longdouble.h"
 #include "npy_buffer.h"
+#include "npy_dlpack.h"
 #include "npy_static_data.h"
 #include "multiarraymodule.h"
 #include "array_api_standard.h"
@@ -2830,6 +2831,14 @@ static PyMethodDef gentype_methods[] = {
     {"setflags",
         (PyCFunction)gentype_setflags,
         METH_VARARGS | METH_KEYWORDS, NULL},
+
+    /* For data interchange between libraries */
+    {"__dlpack__",
+        (PyCFunction)gentype_dlpack,
+        METH_FASTCALL | METH_KEYWORDS, NULL},
+    {"__dlpack_device__",
+        (PyCFunction)gentype_dlpack_device,
+        METH_NOARGS, NULL},
 
     /* For Array API compatibility */
     {"__array_namespace__",

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -276,6 +276,12 @@ class TestScalarDLPack:
         x = np.float64(2)
         assert x.__dlpack_device__() == (1, 0)
 
+    def test_dlpack_cannot_view(self):
+        x = np.float64(2)
+
+        with pytest.raises(BufferError, match="copy=False"):
+            np.from_dlpack(x, copy=False)
+
     @pytest.mark.parametrize("dtype", [np.str_, np.datetime64])
     def test_invalid_dtype(self, dtype):
         x = dtype('2021-05-27')

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -260,3 +260,33 @@ class TestRegisterDlpackDtype:
         arr.__dlpack__()  # passes
         with pytest.raises(BufferError):
             np.from_dlpack(arr)  # doesn't round-trip
+
+
+class TestScalarDLPack:
+    @pytest.mark.parametrize("dtype", [np.bool, np.float64, np.complex128])
+    def test_dlpack(self, dtype):
+        x = np.from_dlpack(dtype(2))
+        expected = np.array(2, dtype=dtype)
+
+        assert x.dtype == expected.dtype
+        assert x.shape == ()
+        assert_array_equal(x, expected)
+
+    def test_dlpack_device(self):
+        x = np.float64(2)
+        assert x.__dlpack_device__() == (1, 0)
+
+    @pytest.mark.parametrize("dtype", [np.str_, np.datetime64])
+    def test_invalid_dtype(self, dtype):
+        x = dtype('2021-05-27')
+
+        with pytest.raises(BufferError):
+            np.from_dlpack(x)
+
+    def test_independent_copy(self):
+        x = np.bool_(True)
+        y1 = np.from_dlpack(x)
+        y2 = np.from_dlpack(x)
+        y1[...] = False
+        assert bool(y2) == True
+        assert bool(x) == True  # singleton must be untouched


### PR DESCRIPTION
Closes #27137 by adding `__dlpack__` and `__dlpack_device__` methods to NumPy scalars. `scalar.__dlpack__` currently delegates to `ndarray.__dlpack__` by converting the scalar to a 0-D array. This is a very minimal solution - a copy is fairly natural in this context, so this workaround seemed natural as well. ping @seberg - thanks!

I have to check if we can add additional handling for the `copy=` kwarg - that seemed to be the main case where the array and scalar implementations might diverge in practice (we are _always_ copying). Perhaps with certain conditions we can add validation for `copy`. I also have to check if I missed some other nuances within the arguments, and needs a release note, but otherwise, this is ready for review!

#### AI Disclosure
I used an agent to search for DLPack's implementation in more detail, to check for errors in my code, and to write a few tests (the `independent_copy` one, mainly).