### PR TITLE
PERF: fast-path no-op roll cases

### DIFF
--- a/benchmarks/benchmarks/bench_manipulate.py
+++ b/benchmarks/benchmarks/bench_manipulate.py
@@ -107,5 +107,11 @@ class DimsManipulations(Benchmark):
     def time_roll(self, shape):
         np.roll(self.xarg, 3)
 
+    def time_roll_zero_shift(self, shape):
+        np.roll(self.xarg, 0, axis=0)
+
+    def time_roll_empty_axes(self, shape):
+        np.roll(self.xarg, (), axis=())
+
     def time_reshape(self, shape):
         np.reshape(self.xarg, self.reshaped)

--- a/doc/release/upcoming_changes/31894.performance.rst
+++ b/doc/release/upcoming_changes/31894.performance.rst
@@ -1,0 +1,3 @@
+``np.roll`` is faster for no-op shifts
+--------------------------------------
+``np.roll`` now skips unnecessary work when the requested shift is zero, reducing overhead for no-op roll cases.

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1309,19 +1309,28 @@ def roll(a, shift, axis=None):
         if broadcasted.ndim > 1:
             raise ValueError(
                 "'shift' and 'axis' should be scalars or 1D sequences")
+        if len(axis) == 0:
+            return a
+
         shifts = dict.fromkeys(range(a.ndim), 0)
         for sh, ax in broadcasted:
             shifts[ax] += int(sh)
 
         rolls = [((slice(None), slice(None)),)] * a.ndim
+        roll_needed = False
         for ax, offset in shifts.items():
             offset %= a.shape[ax] or 1  # If `a` is empty, nothing matters.
             if offset:
+                roll_needed = True
                 # (original, result), (original, result)
                 rolls[ax] = ((slice(None, -offset), slice(offset, None)),
                              (slice(-offset, None), slice(None, offset)))
 
         result = empty_like(a)
+        if not roll_needed:
+            result[...] = a
+            return result
+
         for indices in itertools.product(*rolls):
             arr_index, res_index = zip(*indices)
             result[res_index] = a[arr_index]

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -3815,6 +3815,26 @@ class TestRoll:
         x = np.arange(4)
         assert_equal(np.roll(x, 2**100), x)
 
+    @pytest.mark.parametrize("shift, axis", [
+        (0, 0),
+        (3, 1),
+        ((1, -1), (0, 0)),
+    ])
+    def test_roll_noop_returns_copy(self, shift, axis):
+        x = np.arange(6).reshape(2, 3)
+        xr = np.roll(x, shift, axis=axis)
+
+        assert_array_equal(xr, x)
+        assert_(xr is not x)
+        assert_(not np.shares_memory(xr, x))
+
+    @pytest.mark.parametrize("shift", [0, 1, ()])
+    def test_roll_empty_axes_returns_input(self, shift):
+        x = np.arange(6).reshape(2, 3)
+        xr = np.roll(x, shift, axis=())
+
+        assert_(xr is x)
+
 
 class TestRollaxis:
 


### PR DESCRIPTION
### PR summary

Fast-paths two no-op `np.roll` cases:

- return the input directly for `axis=()`
- avoid the generic slice-product roll loop when all normalized shifts are zero, while preserving copy semantics

Addresses gh-12389.

Benchmarks from `spin bench --compare main HEAD -t bench_manipulate.DimsManipulations`:

- `time_roll_empty_axes`: 59-64% faster
- `time_roll_zero_shift`: 16-18% faster

### First time committer introduction

I am a NumPy user/contributor looking at small, focused performance improvements in common array operations. I will handle review discussion and follow-up changes directly.

#### AI Disclosure

LLM / Harness: hybrid.

AI assistance was used to inspect the codebase, run local commands and benchmarks, draft PR text, and help prepare candidate patches. I reviewed the generated suggestions, selected the final changes, and am responsible for the code, submission, and follow-up discussion. Some PR text and candidate code edits were drafted with AI assistance; the final patch and text were reviewed and edited by me.
