### PR TITLE
PERF: fast-path empty delete indices

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -134,6 +134,21 @@ class Select(Benchmark):
         np.select(self.cond_large, ([self.d, self.e] * 10))
 
 
+class Delete(Benchmark):
+    params = [
+        [(1000,), (100, 100)],
+        [None, 0],
+    ]
+    param_names = ["shape", "axis"]
+
+    def setup(self, shape, axis):
+        self.arr = np.arange(np.prod(shape)).reshape(shape)
+        self.empty_indices = []
+
+    def time_empty_indices(self, shape, axis):
+        np.delete(self.arr, self.empty_indices, axis=axis)
+
+
 def memoize(f):
     _memoized = {}
 

--- a/doc/release/upcoming_changes/31895.performance.rst
+++ b/doc/release/upcoming_changes/31895.performance.rst
@@ -1,0 +1,3 @@
+``np.delete`` is faster for empty indices
+-----------------------------------------
+``np.delete`` now skips unnecessary work when the indices to remove are empty, reducing overhead for no-op deletions.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5353,6 +5353,8 @@ def delete(arr, obj, axis=None):
         # is really too generic:
         if obj.size == 0 and not isinstance(_obj, np.ndarray):
             obj = obj.astype(intp)
+        if obj.size == 0 and obj.dtype.kind in "ui":
+            return conv.wrap(arr.copy(order=arrorder), to_scalar=False)
         elif obj.size == 1 and obj.dtype.kind in "ui":
             # For a size 1 integer array we can use the single-value path
             # (most dtypes, except boolean, should just fail later).

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1075,6 +1075,15 @@ class TestDelete:
         with pytest.raises(IndexError):
             np.delete([0, 1, 2], np.array([], dtype=float))
 
+    @pytest.mark.parametrize("indexer", [[], np.array([], dtype=np.intp)])
+    def test_empty_integer_index_returns_copy(self, indexer):
+        a = np.arange(6).reshape(2, 3)
+        res = delete(a, indexer, axis=1)
+
+        assert_array_equal(res, a)
+        assert_(res is not a)
+        assert_(not np.shares_memory(res, a))
+
     @pytest.mark.parametrize("indexer", [np.array([1]), [1]])
     def test_single_item_array(self, indexer):
         a, nd_a = self._create_arrays()


### PR DESCRIPTION
### PR summary

Add a fast path for `np.delete` when given an empty integer indexer. The result is still a copy, matching the existing `delete` contract, but avoids allocating and applying a full boolean keep mask.

ASV quick comparison against `main`:

```
bench_function_base.Delete.time_empty_indices((100, 100), None): 29.0 us -> 24.6 us
bench_function_base.Delete.time_empty_indices((100, 100), 0):    34.6 us -> 28.5 us
bench_function_base.Delete.time_empty_indices((1000,), 0):       29.8 us -> 20.5 us
bench_function_base.Delete.time_empty_indices((1000,), None):    45.0 us -> 31.3 us
```

### First time committer introduction

I am a NumPy user/contributor looking at small, focused performance improvements in common array operations. I will handle review discussion and follow-up changes directly.

#### AI Disclosure

LLM / Harness: hybrid.

AI assistance was used to inspect the codebase, run local commands and benchmarks, draft PR text, and help prepare candidate patches. I reviewed the generated suggestions, selected the final changes, and am responsible for the code, submission, and follow-up discussion. Some PR text and candidate code edits were drafted with AI assistance; the final patch and text were reviewed and edited by me.
