### PR TITLE
TYP: reduce ufunc stubs spaghetti using shaped array type aliases

### DIFF
--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -189,10 +189,11 @@ __all__ = [
 
 ###
 
-type _Array0D[ScalarT: np.generic] = np.ndarray[tuple[()], np.dtype[ScalarT]]
-type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
-type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
-type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
+type _Array[ShapeT: _Shape, ScalarT: np.generic] = np.ndarray[ShapeT, np.dtype[ScalarT]]
+type _Array0D[ScalarT: np.generic] = _Array[tuple[()], ScalarT]
+type _Array1D[ScalarT: np.generic] = _Array[tuple[int], ScalarT]
+type _Array2D[ScalarT: np.generic] = _Array[tuple[int, int], ScalarT]
+type _Array3D[ScalarT: np.generic] = _Array[tuple[int, int, int], ScalarT]
 
 type _tuple2[T] = tuple[T, T]
 
@@ -397,13 +398,13 @@ class _ufunc_11_m_b(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, known shape
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_time]],
+        x: _Array[ShapeT, _time],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLikeBool | None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
+    ) -> _Array[ShapeT, np.bool]: ...
     @overload  # scalar
     def __call__(
         self,
@@ -478,7 +479,7 @@ class _ufunc_11_m_b(_ufunc_11):  # type: ignore[misc]
     #
     @override
     @overload
-    def at(self, a: np.ndarray[_Shape, np.dtype[_time]], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
+    def at(self, a: npt.NDArray[_time], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
     @overload
     def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
 
@@ -489,13 +490,13 @@ class _ufunc_11_f_b(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, known shape
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_floating]],
+        x: _Array[ShapeT, _to_floating],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLikeBool | None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
+    ) -> _Array[ShapeT, np.bool]: ...
     @overload  # scalar
     def __call__(
         self,
@@ -570,7 +571,7 @@ class _ufunc_11_f_b(_ufunc_11):  # type: ignore[misc]
     #
     @override
     @overload
-    def at(self, a: np.ndarray[_Shape, np.dtype[np.floating]], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
+    def at(self, a: npt.NDArray[np.floating], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
     @overload
     def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
 
@@ -581,13 +582,13 @@ class _ufunc_11_bifgcm_b(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, known shape
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_number | _time]],
+        x: _Array[ShapeT, _to_number | _time],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLikeBool | None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
+    ) -> _Array[ShapeT, np.bool]: ...
     @overload  # scalar
     def __call__(
         self,
@@ -662,7 +663,7 @@ class _ufunc_11_bifgcm_b(_ufunc_11):  # type: ignore[misc]
     #
     @override
     @overload
-    def at(self, a: np.ndarray[_Shape, np.dtype[_to_number]], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
+    def at(self, a: npt.NDArray[_to_number], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
     @overload
     def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
 
@@ -673,23 +674,23 @@ class _ufunc_11_bifgco_bo(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, known shape
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_number]],
+        x: _Array[ShapeT, _to_number],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLikeBool | None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
+    ) -> _Array[ShapeT, np.bool]: ...
     @overload  # Nd object, known shape
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.object_]],
+        x: _Array[ShapeT, np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLikeBool | None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.object_]]: ...
+    ) -> _Array[ShapeT, np.object_]: ...
     @overload  # scalar
     def __call__(
         self,
@@ -764,7 +765,7 @@ class _ufunc_11_bifgco_bo(_ufunc_11):  # type: ignore[misc]
     #
     @override
     @overload
-    def at(self, a: np.ndarray[_Shape, np.dtype[_to_number | np.object_]], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
+    def at(self, a: npt.NDArray[_to_number | np.object_], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
     @overload
     def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
 
@@ -775,23 +776,23 @@ class _ufunc_11_io(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, known shape
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_integer]],
+        x: _Array[ShapeT, _to_integer],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.uint8]]: ...
+    ) -> _Array[ShapeT, np.uint8]: ...
     @overload  # Nd object, known shape
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.object_]],
+        x: _Array[ShapeT, np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.object_]]: ...
+    ) -> _Array[ShapeT, np.object_]: ...
     @overload  # scalar
     def __call__(
         self,
@@ -866,7 +867,7 @@ class _ufunc_11_io(_ufunc_11):  # type: ignore[misc]
     #
     @override
     @overload
-    def at(self, a: np.ndarray[_Shape, np.dtype[_to_integer]], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
+    def at(self, a: npt.NDArray[_to_integer], indices: _ArrayLikeInt, /) -> None: ...  # pyrefly:ignore[bad-override]
     @overload
     def at[IxT, OutT](self, a: _CanUfuncAt1[IxT, OutT], indices: IxT, /) -> OutT: ...
 
@@ -887,33 +888,33 @@ class _ufunc_11_f(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f64]],
+        x: _Array[ShapeT, _as_f64],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+    ) -> _Array[ShapeT, np.float64]: ...
     @overload  # Nd, +f32
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f32]],
+        x: _Array[ShapeT, _as_f32],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float32]]: ...
+    ) -> _Array[ShapeT, np.float32]: ...
     @overload  # Nd, +f16
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f16]],
+        x: _Array[ShapeT, _as_f16],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float16]]: ...
+    ) -> _Array[ShapeT, np.float16]: ...
     @overload  # scalar, float | +f64
     def __call__(
         self,
@@ -977,23 +978,23 @@ class _ufunc_11_f(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: np.floating](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_floating]],
+        x: _Array[ShapeT, _to_floating],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    ) -> _Array[ShapeT, ScalarT]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_floating]],
+        x: _Array[ShapeT, _to_floating],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT]: ...
+    ) -> _Array[ShapeT, Any]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: np.floating](
         self,
@@ -1079,33 +1080,33 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f64]],
+        x: _Array[ShapeT, _as_f64],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+    ) -> _Array[ShapeT, np.float64]: ...
     @overload  # Nd, +f32
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f32]],
+        x: _Array[ShapeT, _as_f32],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float32]]: ...
+    ) -> _Array[ShapeT, np.float32]: ...
     @overload  # Nd, +f16
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f16]],
+        x: _Array[ShapeT, _as_f16],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float16]]: ...
+    ) -> _Array[ShapeT, np.float16]: ...
     @overload  # scalar, float | +f64
     def __call__(
         self,
@@ -1169,23 +1170,23 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: np.floating](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_floating | np.object_]],
+        x: _Array[ShapeT, _to_floating | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    ) -> _Array[ShapeT, ScalarT]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_floating | np.object_]],
+        x: _Array[ShapeT, _to_floating | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT]: ...
+    ) -> _Array[ShapeT, Any]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: np.floating | np.object_](
         self,
@@ -1205,7 +1206,7 @@ class _ufunc_11_fo(_ufunc_11):  # type: ignore[misc]
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray: ...
+    ) -> npt.NDArray[Any]: ...
     @overload  # ?d, dtype=<known>
     def __call__[ScalarT: np.floating | np.object_](
         self,
@@ -1271,33 +1272,33 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f64]],
+        x: _Array[ShapeT, _as_f64],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+    ) -> _Array[ShapeT, np.float64]: ...
     @overload  # Nd, +f32
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f32]],
+        x: _Array[ShapeT, _as_f32],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float32]]: ...
+    ) -> _Array[ShapeT, np.float32]: ...
     @overload  # Nd, +f16
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f16]],
+        x: _Array[ShapeT, _as_f16],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float16]]: ...
+    ) -> _Array[ShapeT, np.float16]: ...
     @overload  # scalar, float | +f64
     def __call__(
         self,
@@ -1391,23 +1392,23 @@ class _ufunc_11_fco(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: np.inexact](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.number | np.bool | np.object_]],
+        x: _Array[ShapeT, np.number | np.bool | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    ) -> _Array[ShapeT, ScalarT]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.number | np.bool | np.object_]],
+        x: _Array[ShapeT, np.number | np.bool | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT]: ...
+    ) -> _Array[ShapeT, Any]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: np.inexact | np.object_](
         self,
@@ -1493,13 +1494,13 @@ class _ufunc_11_ifco(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, bool->i8
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.bool]],
+        x: _Array[ShapeT, np.bool],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.int8]]: ...
+    ) -> _Array[ShapeT, np.int8]: ...
     @overload  # scalar, bool->i8
     def __call__(
         self,
@@ -1633,23 +1634,23 @@ class _ufunc_11_ifco(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: np.number | np.object_](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_number | np.object_]],
+        x: _Array[ShapeT, _to_number | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    ) -> _Array[ShapeT, ScalarT]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_number | np.object_]],
+        x: _Array[ShapeT, _to_number | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT]: ...
+    ) -> _Array[ShapeT, Any]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: np.number | np.object_](
         self,
@@ -1735,13 +1736,13 @@ class _ufunc_11_ifcmo_ifco(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, timedelta64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.timedelta64]],
+        x: _Array[ShapeT, np.timedelta64],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+    ) -> _Array[ShapeT, np.float64]: ...
     @overload  # scalar, int
     def __call__(
         self,
@@ -1855,23 +1856,23 @@ class _ufunc_11_ifcmo_ifco(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: np.number | np.object_](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_numeric | np.object_]],
+        x: _Array[ShapeT, _numeric | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    ) -> _Array[ShapeT, ScalarT]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_numeric | np.object_]],
+        x: _Array[ShapeT, _numeric | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT]: ...
+    ) -> _Array[ShapeT, Any]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: np.number | np.object_](
         self,
@@ -2057,23 +2058,23 @@ class _ufunc_11_ifcmo(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: _numeric | np.object_](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_numeric | np.object_]],
+        x: _Array[ShapeT, _numeric | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    ) -> _Array[ShapeT, ScalarT]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_numeric | np.object_]],
+        x: _Array[ShapeT, _numeric | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT]: ...
+    ) -> _Array[ShapeT, Any]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: _numeric | np.object_](
         self,
@@ -2249,23 +2250,23 @@ class _ufunc_11_bio(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: _to_integer | np.object_](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_integer | np.object_]],
+        x: _Array[ShapeT, _to_integer | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    ) -> _Array[ShapeT, ScalarT]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_integer | np.object_]],
+        x: _Array[ShapeT, _to_integer | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT]: ...
+    ) -> _Array[ShapeT, Any]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: _to_integer | np.object_](
         self,
@@ -2471,23 +2472,23 @@ class _ufunc_11_bifo(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: _to_floating | np.object_](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_floating | np.object_]],
+        x: _Array[ShapeT, _to_floating | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    ) -> _Array[ShapeT, ScalarT]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_floating | np.object_]],
+        x: _Array[ShapeT, _to_floating | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT]: ...
+    ) -> _Array[ShapeT, Any]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: _to_floating | np.object_](
         self,
@@ -2573,33 +2574,33 @@ class _ufunc_11_bifcmo(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, c128 -> f64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.complex128]],
+        x: _Array[ShapeT, np.complex128],
         /,
         *,
         out: None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float64]]: ...
+    ) -> _Array[ShapeT, np.float64]: ...
     @overload  # Nd, c64 -> f32
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.complex64]],
+        x: _Array[ShapeT, np.complex64],
         /,
         *,
         out: None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.float32]]: ...
+    ) -> _Array[ShapeT, np.float32]: ...
     @overload  # Nd, c160 -> f80
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[np.clongdouble]],
+        x: _Array[ShapeT, np.clongdouble],
         /,
         *,
         out: None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.longdouble]]: ...
+    ) -> _Array[ShapeT, np.longdouble]: ...
     @overload  # scalar, c128 -> f64
     def __call__(
         self,
@@ -2753,23 +2754,23 @@ class _ufunc_11_bifcmo(_ufunc_11):  # type: ignore[misc]
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: _to_floating | np.timedelta64 | np.object_](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_numeric]],
+        x: _Array[ShapeT, _to_numeric],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+    ) -> _Array[ShapeT, ScalarT]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_numeric | np.object_]],
+        x: _Array[ShapeT, _to_numeric | np.object_],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT]: ...
+    ) -> _Array[ShapeT, Any]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: _to_floating | np.object_](
         self,
@@ -2851,7 +2852,7 @@ class _ufunc_11_ut_b(_ufunc_11[Literal[False]]):  # type: ignore[misc]
         out: EllipsisType | None = None,
         dtype: _DTypeLikeBool | None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
+    ) -> _Array[ShapeT, np.bool]: ...
     @overload  # scalar
     def __call__(
         self,
@@ -2943,7 +2944,7 @@ class _ufunc_11_sut_b(_ufunc_11[Literal[False]]):  # type: ignore[misc]
         out: EllipsisType | None = None,
         dtype: _DTypeLikeBool | None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
+    ) -> _Array[ShapeT, np.bool]: ...
     @overload  # scalar
     def __call__(
         self,
@@ -3035,7 +3036,7 @@ class _ufunc_11_sut_i(_ufunc_11[Literal[0]]):  # type: ignore[misc]
         out: EllipsisType | None = None,
         dtype: _DTypeLikeBool | None = None,
         **kwargs: Unpack[_Kwargs11],
-    ) -> np.ndarray[ShapeT, np.dtype[np.int_]]: ...
+    ) -> _Array[ShapeT, np.int_]: ...
     @overload  # scalar
     def __call__(
         self,
@@ -3199,37 +3200,37 @@ class _ufunc_12_frexp(_ufunc_12):  # type: ignore[misc]
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs12],
-    ) -> tuple[np.ndarray[ShapeT, DTypeT], np.ndarray[ShapeT, np.dtype[np.int32]]]: ...
+    ) -> tuple[np.ndarray[ShapeT, DTypeT], _Array[ShapeT, np.int32]]: ...
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f64]],
+        x: _Array[ShapeT, _as_f64],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs12],
-    ) -> tuple[np.ndarray[ShapeT, np.dtype[np.float64]], np.ndarray[ShapeT, np.dtype[np.int32]]]: ...
+    ) -> tuple[_Array[ShapeT, np.float64], _Array[ShapeT, np.int32]]: ...
     @overload  # Nd, +f32
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f32]],
+        x: _Array[ShapeT, _as_f32],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs12],
-    ) -> tuple[np.ndarray[ShapeT, np.dtype[np.float32]], np.ndarray[ShapeT, np.dtype[np.int32]]]: ...
+    ) -> tuple[_Array[ShapeT, np.float32], _Array[ShapeT, np.int32]]: ...
     @overload  # Nd, +f16
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f16]],
+        x: _Array[ShapeT, _as_f16],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs12],
-    ) -> tuple[np.ndarray[ShapeT, np.dtype[np.float16]], np.ndarray[ShapeT, np.dtype[np.int32]]]: ...
+    ) -> tuple[_Array[ShapeT, np.float16], _Array[ShapeT, np.int32]]: ...
     @overload  # scalar, known dtype
     def __call__[ScalarT: np.floating](
         self,
@@ -3338,33 +3339,33 @@ class _ufunc_12_modf(_ufunc_12):  # type: ignore[misc]
     @overload  # Nd, +f64
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f64]],
+        x: _Array[ShapeT, _as_f64],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs12],
-    ) -> _tuple2[np.ndarray[ShapeT, np.dtype[np.float64]]]: ...
+    ) -> _tuple2[_Array[ShapeT, np.float64]]: ...
     @overload  # Nd, +f32
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f32]],
+        x: _Array[ShapeT, _as_f32],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs12],
-    ) -> _tuple2[np.ndarray[ShapeT, np.dtype[np.float32]]]: ...
+    ) -> _tuple2[_Array[ShapeT, np.float32]]: ...
     @overload  # Nd, +f16
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_as_f16]],
+        x: _Array[ShapeT, _as_f16],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: None = None,
         **kwargs: Unpack[_Kwargs12],
-    ) -> _tuple2[np.ndarray[ShapeT, np.dtype[np.float16]]]: ...
+    ) -> _tuple2[_Array[ShapeT, np.float16]]: ...
     @overload  # scalar, float | +f64
     def __call__(
         self,
@@ -3428,23 +3429,23 @@ class _ufunc_12_modf(_ufunc_12):  # type: ignore[misc]
     @overload  # Nd, dtype=<known>
     def __call__[ShapeT: _Shape, ScalarT: np.floating](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_floating]],
+        x: _Array[ShapeT, _to_floating],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: _DTypeLike[ScalarT],
         **kwargs: Unpack[_Kwargs12],
-    ) -> _tuple2[np.ndarray[ShapeT, np.dtype[ScalarT]]]: ...
+    ) -> _tuple2[_Array[ShapeT, ScalarT]]: ...
     @overload  # Nd, dtype=<unknown>
     def __call__[ShapeT: _Shape](
         self,
-        x: np.ndarray[ShapeT, np.dtype[_to_floating]],
+        x: _Array[ShapeT, _to_floating],
         /,
         *,
         out: EllipsisType | None = None,
         dtype: npt.DTypeLike,
         **kwargs: Unpack[_Kwargs12],
-    ) -> _tuple2[np.ndarray[ShapeT]]: ...
+    ) -> _tuple2[_Array[ShapeT, Any]]: ...
     @overload  # Nd, dtype=<known>
     def __call__[ScalarT: np.floating](
         self,
@@ -3893,18 +3894,18 @@ class _ufunc_21_logical[IdT: bool](_ufunc_21[IdT]):  # type: ignore[misc]
         axis: int = 0,
         dtype: _DTypeLikeBool | None = None,
         out: None = None,
-    ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
+    ) -> _Array[ShapeT, np.bool]: ...
     @overload  # known shape, object_
     def reduceat[ShapeT: _Shape](  # pyrefly:ignore[bad-override]
         self,
-        array: np.ndarray[ShapeT, np.dtype[np.object_]],
+        array: _Array[ShapeT, np.object_],
         /,
         indices: tuple[int, ...],
         *,
         axis: int = 0,
         dtype: _DTypeLikeObject | None = None,
         out: None = None,
-    ) -> np.ndarray[ShapeT, np.dtype[np.object_]]: ...
+    ) -> _Array[ShapeT, np.object_]: ...
     @overload  # unknown shape
     def reduceat(
         self,
@@ -3950,17 +3951,17 @@ class _ufunc_21_logical[IdT: bool](_ufunc_21[IdT]):  # type: ignore[misc]
         axis: int = 0,
         dtype: _DTypeLikeBool | None = None,
         out: None = None,
-    ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
+    ) -> _Array[ShapeT, np.bool]: ...
     @overload  # known shape, OBJECT_
     def accumulate[ShapeT: _Shape](
         self,
-        array: np.ndarray[ShapeT, np.dtype[np.object_]],
+        array: _Array[ShapeT, np.object_],
         /,
         *,
         axis: int = 0,
         dtype: _DTypeLikeObject | None = None,
         out: None = None,
-    ) -> np.ndarray[ShapeT, np.dtype[np.object_]]: ...
+    ) -> _Array[ShapeT, np.object_]: ...
     @overload  # unknown shape
     def accumulate(
         self,
@@ -4256,14 +4257,14 @@ class _ufunc_21_cmp(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # known shape
     def reduceat[ShapeT: _Shape](  # pyrefly:ignore[bad-override]
         self,
-        array: np.ndarray[ShapeT, np.dtype[np.bool]],
+        array: _Array[ShapeT, np.bool],
         /,
         indices: tuple[int, ...],
         *,
         axis: int = 0,
         dtype: _DTypeLikeBool | None = None,
         out: None = None,
-    ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
+    ) -> _Array[ShapeT, np.bool]: ...
     @overload  # unknown shape
     def reduceat(
         self,
@@ -4303,13 +4304,13 @@ class _ufunc_21_cmp(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # known shape
     def accumulate[ShapeT: _Shape](  # pyrefly:ignore[bad-override]
         self,
-        array: np.ndarray[ShapeT, np.dtype[np.bool]],
+        array: _Array[ShapeT, np.bool],
         /,
         *,
         axis: int = 0,
         dtype: _DTypeLikeBool | None = None,
         out: None = None,
-    ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
+    ) -> _Array[ShapeT, np.bool]: ...
     @overload  # unknown shape
     def accumulate(
         self,

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -104,6 +104,9 @@ def test_matmul_at_invalid() -> None:
 
 ###
 
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
+
 _py_b_0d: bool
 _py_b_1d: list[bool]
 _py_b_2d: list[list[bool]]
@@ -118,722 +121,638 @@ _py_c_1d: list[complex]
 _py_c_2d: list[list[complex]]
 
 _bool_0d: np.bool
-_bool_1d: np.ndarray[tuple[int], np.dtype[np.bool]]
-_bool_2d: np.ndarray[tuple[int, int], np.dtype[np.bool]]
+_bool_1d: _Array1D[np.bool]
+_bool_2d: _Array2D[np.bool]
 _bool_nd: npt.NDArray[np.bool]
 _u8_0d: np.uint8
-_u8_1d: np.ndarray[tuple[int], np.dtype[np.uint8]]
-_u8_2d: np.ndarray[tuple[int, int], np.dtype[np.uint8]]
+_u8_1d: _Array1D[np.uint8]
+_u8_2d: _Array2D[np.uint8]
 _u8_nd: npt.NDArray[np.uint8]
 _i16_0d: np.int16
-_i16_1d: np.ndarray[tuple[int], np.dtype[np.int16]]
-_i16_2d: np.ndarray[tuple[int, int], np.dtype[np.int16]]
+_i16_1d: _Array1D[np.int16]
+_i16_2d: _Array2D[np.int16]
 _i16_nd: npt.NDArray[np.int16]
 _i32_0d: np.int32
-_i32_1d: np.ndarray[tuple[int], np.dtype[np.int32]]
-_i32_2d: np.ndarray[tuple[int, int], np.dtype[np.int32]]
+_i32_1d: _Array1D[np.int32]
+_i32_2d: _Array2D[np.int32]
 _i32_nd: npt.NDArray[np.int32]
 _f32_0d: np.float32
-_f32_1d: np.ndarray[tuple[int], np.dtype[np.float32]]
-_f32_2d: np.ndarray[tuple[int, int], np.dtype[np.float32]]
+_f32_1d: _Array1D[np.float32]
+_f32_2d: _Array2D[np.float32]
 _f32_nd: npt.NDArray[np.float32]
 _c64_0d: np.complex64
-_c64_1d: np.ndarray[tuple[int], np.dtype[np.complex64]]
-_c64_2d: np.ndarray[tuple[int, int], np.dtype[np.complex64]]
+_c64_1d: _Array1D[np.complex64]
+_c64_2d: _Array2D[np.complex64]
 _c64_nd: npt.NDArray[np.complex64]
 _dt_ns_0d: np.datetime64[int]
-_dt_ns_1d: np.ndarray[tuple[int], np.dtype[np.datetime64[int]]]
-_dt_ns_2d: np.ndarray[tuple[int, int], np.dtype[np.datetime64[int]]]
+_dt_ns_1d: _Array1D[np.datetime64[int]]
+_dt_ns_2d: _Array2D[np.datetime64[int]]
 _dt_ns_nd: npt.NDArray[np.datetime64[int]]
 _td_ns_0d: np.timedelta64[int]
-_td_ns_1d: np.ndarray[tuple[int], np.dtype[np.timedelta64[int]]]
-_td_ns_2d: np.ndarray[tuple[int, int], np.dtype[np.timedelta64[int]]]
+_td_ns_1d: _Array1D[np.timedelta64[int]]
+_td_ns_2d: _Array2D[np.timedelta64[int]]
 _td_ns_nd: npt.NDArray[np.timedelta64[int]]
-_obj_1d: np.ndarray[tuple[int], np.dtype[np.object_]]
-_obj_2d: np.ndarray[tuple[int, int], np.dtype[np.object_]]
+_obj_1d: _Array1D[np.object_]
+_obj_2d: _Array2D[np.object_]
 _obj_nd: npt.NDArray[np.object_]
 
 # _ufunc_11_m_b
 # (isnat)
 
 assert_type(np.isnat(_dt_ns_0d), np.bool)
-assert_type(np.isnat(_dt_ns_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isnat(_dt_ns_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isnat(_dt_ns_1d), _Array1D[np.bool])
+assert_type(np.isnat(_dt_ns_2d), _Array2D[np.bool])
 assert_type(np.isnat(_dt_ns_nd), npt.NDArray[np.bool])
 assert_type(np.isnat(_td_ns_0d), np.bool)
-assert_type(np.isnat(_td_ns_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isnat(_td_ns_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isnat(_td_ns_1d), _Array1D[np.bool])
+assert_type(np.isnat(_td_ns_2d), _Array2D[np.bool])
 assert_type(np.isnat(_td_ns_nd), npt.NDArray[np.bool])
 
-assert_type(np.isnat(_dt_ns_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.isnat(_dt_ns_2d, out=_f32_2d), _Array2D[np.float32])
 
 # _ufunc_11_f_b
 # (signbit)
 
 assert_type(np.signbit(_py_b_0d), np.bool)
-assert_type(np.signbit(_py_b_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.signbit(_py_b_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.signbit(_py_b_1d), _Array1D[np.bool])
+assert_type(np.signbit(_py_b_2d), _Array2D[np.bool])
 assert_type(np.signbit(_py_i_0d), np.bool)
-assert_type(np.signbit(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.signbit(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.signbit(_py_i_1d), _Array1D[np.bool])
+assert_type(np.signbit(_py_i_2d), _Array2D[np.bool])
 assert_type(np.signbit(_py_f_0d), np.bool)
-assert_type(np.signbit(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.signbit(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.signbit(_py_f_1d), _Array1D[np.bool])
+assert_type(np.signbit(_py_f_2d), _Array2D[np.bool])
 
 assert_type(np.signbit(_i16_0d), np.bool)
-assert_type(np.signbit(_i16_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.signbit(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.signbit(_i16_1d), _Array1D[np.bool])
+assert_type(np.signbit(_i16_2d), _Array2D[np.bool])
 assert_type(np.signbit(_i16_nd), npt.NDArray[np.bool])
 assert_type(np.signbit(_f32_0d), np.bool)
-assert_type(np.signbit(_f32_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.signbit(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.signbit(_f32_1d), _Array1D[np.bool])
+assert_type(np.signbit(_f32_2d), _Array2D[np.bool])
 assert_type(np.signbit(_f32_nd), npt.NDArray[np.bool])
 
-assert_type(np.signbit(_py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.signbit(_py_i_2d, out=_f32_2d), _Array2D[np.float32])
 
 # _ufunc_11_bifgco_bo
 # (logical_not)
 
 assert_type(np.logical_not(_py_b_0d), np.bool)
-assert_type(np.logical_not(_py_b_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.logical_not(_py_b_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.logical_not(_py_b_1d), _Array1D[np.bool])
+assert_type(np.logical_not(_py_b_2d), _Array2D[np.bool])
 assert_type(np.logical_not(_py_i_0d), np.bool)
-assert_type(np.logical_not(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.logical_not(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.logical_not(_py_i_1d), _Array1D[np.bool])
+assert_type(np.logical_not(_py_i_2d), _Array2D[np.bool])
 assert_type(np.logical_not(_py_f_0d), np.bool)
-assert_type(np.logical_not(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.logical_not(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.logical_not(_py_f_1d), _Array1D[np.bool])
+assert_type(np.logical_not(_py_f_2d), _Array2D[np.bool])
 assert_type(np.logical_not(_py_c_0d), np.bool)
-assert_type(np.logical_not(_py_c_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.logical_not(_py_c_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.logical_not(_py_c_1d), _Array1D[np.bool])
+assert_type(np.logical_not(_py_c_2d), _Array2D[np.bool])
 
 assert_type(np.logical_not(_bool_0d), np.bool)
-assert_type(np.logical_not(_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.logical_not(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.logical_not(_bool_1d), _Array1D[np.bool])
+assert_type(np.logical_not(_bool_2d), _Array2D[np.bool])
 assert_type(np.logical_not(_bool_nd), npt.NDArray[np.bool])
 assert_type(np.logical_not(_i16_0d), np.bool)
-assert_type(np.logical_not(_i16_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.logical_not(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.logical_not(_i16_1d), _Array1D[np.bool])
+assert_type(np.logical_not(_i16_2d), _Array2D[np.bool])
 assert_type(np.logical_not(_i16_nd), npt.NDArray[np.bool])
 assert_type(np.logical_not(_f32_0d), np.bool)
-assert_type(np.logical_not(_f32_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.logical_not(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.logical_not(_f32_1d), _Array1D[np.bool])
+assert_type(np.logical_not(_f32_2d), _Array2D[np.bool])
 assert_type(np.logical_not(_f32_nd), npt.NDArray[np.bool])
 assert_type(np.logical_not(_c64_0d), np.bool)
-assert_type(np.logical_not(_c64_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.logical_not(_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.logical_not(_c64_1d), _Array1D[np.bool])
+assert_type(np.logical_not(_c64_2d), _Array2D[np.bool])
 assert_type(np.logical_not(_c64_nd), npt.NDArray[np.bool])
-assert_type(np.logical_not(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
-assert_type(np.logical_not(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.logical_not(_obj_1d), _Array1D[np.object_])
+assert_type(np.logical_not(_obj_2d), _Array2D[np.object_])
 assert_type(np.logical_not(_obj_nd), npt.NDArray[np.object_])
 
-assert_type(np.logical_not(_py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.logical_not(_py_i_2d, out=_f32_2d), _Array2D[np.float32])
 
 # _ufunc_11_bifgcm_b
 # (isfinite, isinf, isnan)
 
 assert_type(np.isinf(_py_b_0d), np.bool)
-assert_type(np.isinf(_py_b_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isinf(_py_b_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isinf(_py_b_1d), _Array1D[np.bool])
+assert_type(np.isinf(_py_b_2d), _Array2D[np.bool])
 assert_type(np.isinf(_py_i_0d), np.bool)
-assert_type(np.isinf(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isinf(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isinf(_py_i_1d), _Array1D[np.bool])
+assert_type(np.isinf(_py_i_2d), _Array2D[np.bool])
 assert_type(np.isinf(_py_f_0d), np.bool)
-assert_type(np.isinf(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isinf(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isinf(_py_f_1d), _Array1D[np.bool])
+assert_type(np.isinf(_py_f_2d), _Array2D[np.bool])
 assert_type(np.isinf(_py_c_0d), np.bool)
-assert_type(np.isinf(_py_c_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isinf(_py_c_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isinf(_py_c_1d), _Array1D[np.bool])
+assert_type(np.isinf(_py_c_2d), _Array2D[np.bool])
 
 assert_type(np.isinf(_bool_0d), np.bool)
-assert_type(np.isinf(_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isinf(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isinf(_bool_1d), _Array1D[np.bool])
+assert_type(np.isinf(_bool_2d), _Array2D[np.bool])
 assert_type(np.isinf(_bool_nd), npt.NDArray[np.bool])
 assert_type(np.isinf(_i16_0d), np.bool)
-assert_type(np.isinf(_i16_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isinf(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isinf(_i16_1d), _Array1D[np.bool])
+assert_type(np.isinf(_i16_2d), _Array2D[np.bool])
 assert_type(np.isinf(_i16_nd), npt.NDArray[np.bool])
 assert_type(np.isinf(_f32_0d), np.bool)
-assert_type(np.isinf(_f32_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isinf(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isinf(_f32_1d), _Array1D[np.bool])
+assert_type(np.isinf(_f32_2d), _Array2D[np.bool])
 assert_type(np.isinf(_f32_nd), npt.NDArray[np.bool])
 assert_type(np.isinf(_c64_0d), np.bool)
-assert_type(np.isinf(_c64_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isinf(_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isinf(_c64_1d), _Array1D[np.bool])
+assert_type(np.isinf(_c64_2d), _Array2D[np.bool])
 assert_type(np.isinf(_c64_nd), npt.NDArray[np.bool])
 assert_type(np.isinf(_dt_ns_0d), np.bool)
-assert_type(np.isinf(_dt_ns_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isinf(_dt_ns_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isinf(_dt_ns_1d), _Array1D[np.bool])
+assert_type(np.isinf(_dt_ns_2d), _Array2D[np.bool])
 assert_type(np.isinf(_dt_ns_nd), npt.NDArray[np.bool])
 assert_type(np.isinf(_td_ns_0d), np.bool)
-assert_type(np.isinf(_td_ns_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.isinf(_td_ns_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isinf(_td_ns_1d), _Array1D[np.bool])
+assert_type(np.isinf(_td_ns_2d), _Array2D[np.bool])
 assert_type(np.isinf(_td_ns_nd), npt.NDArray[np.bool])
 
-assert_type(np.isinf(_py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.isinf(_py_i_2d, out=_f32_2d), _Array2D[np.float32])
 
 # _ufunc_11_io
 # (bitwise_count)
 
 assert_type(np.bitwise_count(_py_b_0d), np.uint8)
-assert_type(np.bitwise_count(_py_b_1d), np.ndarray[tuple[int], np.dtype[np.uint8]])
-assert_type(np.bitwise_count(_py_b_2d), np.ndarray[tuple[int, int], np.dtype[np.uint8]])
+assert_type(np.bitwise_count(_py_b_1d), _Array1D[np.uint8])
+assert_type(np.bitwise_count(_py_b_2d), _Array2D[np.uint8])
 assert_type(np.bitwise_count(_py_i_0d), np.uint8)
-assert_type(np.bitwise_count(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.uint8]])
-assert_type(np.bitwise_count(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.uint8]])
+assert_type(np.bitwise_count(_py_i_1d), _Array1D[np.uint8])
+assert_type(np.bitwise_count(_py_i_2d), _Array2D[np.uint8])
 
 assert_type(np.bitwise_count(_bool_0d), np.uint8)
-assert_type(np.bitwise_count(_bool_1d), np.ndarray[tuple[int], np.dtype[np.uint8]])
-assert_type(np.bitwise_count(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.uint8]])
+assert_type(np.bitwise_count(_bool_1d), _Array1D[np.uint8])
+assert_type(np.bitwise_count(_bool_2d), _Array2D[np.uint8])
 assert_type(np.bitwise_count(_bool_nd), npt.NDArray[np.uint8])
 assert_type(np.bitwise_count(_i16_0d), np.uint8)
-assert_type(np.bitwise_count(_i16_1d), np.ndarray[tuple[int], np.dtype[np.uint8]])
-assert_type(np.bitwise_count(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.uint8]])
+assert_type(np.bitwise_count(_i16_1d), _Array1D[np.uint8])
+assert_type(np.bitwise_count(_i16_2d), _Array2D[np.uint8])
 assert_type(np.bitwise_count(_i16_nd), npt.NDArray[np.uint8])
 
-assert_type(np.bitwise_count(_py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.bitwise_count(_py_i_2d, out=_f32_2d), _Array2D[np.float32])
 
 # _ufunc_11_f
 # (spacing)
 
 assert_type(np.spacing(_py_i_0d), np.float64)
-assert_type(np.spacing(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.spacing(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.spacing(_py_i_1d), _Array1D[np.float64])
+assert_type(np.spacing(_py_i_2d), _Array2D[np.float64])
 assert_type(np.spacing(_py_f_0d), np.float64)
-assert_type(np.spacing(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.spacing(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.spacing(_py_f_1d), _Array1D[np.float64])
+assert_type(np.spacing(_py_f_2d), _Array2D[np.float64])
 
 assert_type(np.spacing(_bool_0d), np.float16)
-assert_type(np.spacing(_bool_1d), np.ndarray[tuple[int], np.dtype[np.float16]])
-assert_type(np.spacing(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.float16]])
+assert_type(np.spacing(_bool_1d), _Array1D[np.float16])
+assert_type(np.spacing(_bool_2d), _Array2D[np.float16])
 assert_type(np.spacing(_bool_nd), npt.NDArray[np.float16])
 assert_type(np.spacing(_i16_0d), np.float32)
-assert_type(np.spacing(_i16_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.spacing(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.spacing(_i16_1d), _Array1D[np.float32])
+assert_type(np.spacing(_i16_2d), _Array2D[np.float32])
 assert_type(np.spacing(_i16_nd), npt.NDArray[np.float32])
 assert_type(np.spacing(_i32_0d), np.float64)
-assert_type(np.spacing(_i32_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.spacing(_i32_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.spacing(_i32_1d), _Array1D[np.float64])
+assert_type(np.spacing(_i32_2d), _Array2D[np.float64])
 assert_type(np.spacing(_i32_nd), npt.NDArray[np.float64])
 assert_type(np.spacing(_f32_0d), np.float32)
-assert_type(np.spacing(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.spacing(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.spacing(_f32_1d), _Array1D[np.float32])
+assert_type(np.spacing(_f32_2d), _Array2D[np.float32])
 assert_type(np.spacing(_f32_nd), npt.NDArray[np.float32])
 
 assert_type(np.spacing(_py_i_0d, dtype=np.float32), np.float32)
 assert_type(np.spacing(_py_i_1d, dtype=np.float32), npt.NDArray[np.float32])
-assert_type(np.spacing(_i16_2d, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.spacing(_i16_2d, dtype=np.float32), _Array2D[np.float32])
 
 assert_type(np.spacing(_py_i_0d, dtype="f4"), Any)
 assert_type(np.spacing(_py_i_1d, dtype="f4"), np.ndarray)
 assert_type(np.spacing(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
 
-assert_type(np.spacing(_py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.spacing(_py_i_2d, out=_f32_2d), _Array2D[np.float32])
 
 # _ufunc_11_fo
 # (cbrt, deg2rad, degrees, fabs, rad2deg, radians)
 
 assert_type(np.cbrt(_py_i_0d), np.float64)
-assert_type(np.cbrt(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.cbrt(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.cbrt(_py_i_1d), _Array1D[np.float64])
+assert_type(np.cbrt(_py_i_2d), _Array2D[np.float64])
 assert_type(np.cbrt(_py_f_0d), np.float64)
-assert_type(np.cbrt(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.cbrt(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.cbrt(_py_f_1d), _Array1D[np.float64])
+assert_type(np.cbrt(_py_f_2d), _Array2D[np.float64])
 
 assert_type(np.cbrt(_bool_0d), np.float16)
-assert_type(np.cbrt(_bool_1d), np.ndarray[tuple[int], np.dtype[np.float16]])
-assert_type(np.cbrt(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.float16]])
+assert_type(np.cbrt(_bool_1d), _Array1D[np.float16])
+assert_type(np.cbrt(_bool_2d), _Array2D[np.float16])
 assert_type(np.cbrt(_bool_nd), npt.NDArray[np.float16])
 assert_type(np.cbrt(_i16_0d), np.float32)
-assert_type(np.cbrt(_i16_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.cbrt(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.cbrt(_i16_1d), _Array1D[np.float32])
+assert_type(np.cbrt(_i16_2d), _Array2D[np.float32])
 assert_type(np.cbrt(_i16_nd), npt.NDArray[np.float32])
 assert_type(np.cbrt(_i32_0d), np.float64)
-assert_type(np.cbrt(_i32_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.cbrt(_i32_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.cbrt(_i32_1d), _Array1D[np.float64])
+assert_type(np.cbrt(_i32_2d), _Array2D[np.float64])
 assert_type(np.cbrt(_i32_nd), npt.NDArray[np.float64])
 assert_type(np.cbrt(_f32_0d), np.float32)
-assert_type(np.cbrt(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.cbrt(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.cbrt(_f32_1d), _Array1D[np.float32])
+assert_type(np.cbrt(_f32_2d), _Array2D[np.float32])
 assert_type(np.cbrt(_f32_nd), npt.NDArray[np.float32])
-assert_type(np.cbrt(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
-assert_type(np.cbrt(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.cbrt(_obj_1d), _Array1D[np.object_])
+assert_type(np.cbrt(_obj_2d), _Array2D[np.object_])
 assert_type(np.cbrt(_obj_nd), npt.NDArray[np.object_])
 
 assert_type(np.cbrt(_py_i_0d, dtype=np.float32), np.float32)
 assert_type(np.cbrt(_py_i_1d, dtype=np.float32), npt.NDArray[np.float32])
-assert_type(np.cbrt(_i16_2d, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.cbrt(_i16_2d, dtype=np.float32), _Array2D[np.float32])
 
 assert_type(np.cbrt(_py_i_0d, dtype="f4"), Any)
 assert_type(np.cbrt(_py_i_1d, dtype="f4"), np.ndarray)
 assert_type(np.cbrt(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
 
-assert_type(np.cbrt(_py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.cbrt(_py_i_2d, out=_f32_2d), _Array2D[np.float32])
 
 # _ufunc_11_fco
 
 assert_type(np.sin(_py_i_0d), np.float64)
-assert_type(np.sin(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.sin(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.sin(_py_i_1d), _Array1D[np.float64])
+assert_type(np.sin(_py_i_2d), _Array2D[np.float64])
 assert_type(np.sin(_py_f_0d), np.float64)
-assert_type(np.sin(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.sin(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.sin(_py_f_1d), _Array1D[np.float64])
+assert_type(np.sin(_py_f_2d), _Array2D[np.float64])
 assert_type(np.sin(_py_c_0d), np.complex128 | Any)  # `complex` overlaps with `float`, hence the `Any`
-assert_type(np.sin(_py_c_1d), np.ndarray[tuple[int], np.dtype[np.complex128]])
-assert_type(np.sin(_py_c_2d), np.ndarray[tuple[int, int], np.dtype[np.complex128]])
+assert_type(np.sin(_py_c_1d), _Array1D[np.complex128])
+assert_type(np.sin(_py_c_2d), _Array2D[np.complex128])
 
 assert_type(np.sin(_i16_0d), np.float32)
-assert_type(np.sin(_i16_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.sin(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.sin(_i16_1d), _Array1D[np.float32])
+assert_type(np.sin(_i16_2d), _Array2D[np.float32])
 assert_type(np.sin(_i16_nd), npt.NDArray[np.float32])
 assert_type(np.sin(_i32_0d), np.float64)
-assert_type(np.sin(_i32_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.sin(_i32_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.sin(_i32_1d), _Array1D[np.float64])
+assert_type(np.sin(_i32_2d), _Array2D[np.float64])
 assert_type(np.sin(_i32_nd), npt.NDArray[np.float64])
 assert_type(np.sin(_f32_0d), np.float32)
-assert_type(np.sin(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.sin(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.sin(_f32_1d), _Array1D[np.float32])
+assert_type(np.sin(_f32_2d), _Array2D[np.float32])
 assert_type(np.sin(_f32_nd), npt.NDArray[np.float32])
 assert_type(np.sin(_c64_0d), np.complex64)
-assert_type(np.sin(_c64_1d), np.ndarray[tuple[int], np.dtype[np.complex64]])
-assert_type(np.sin(_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+assert_type(np.sin(_c64_1d), _Array1D[np.complex64])
+assert_type(np.sin(_c64_2d), _Array2D[np.complex64])
 assert_type(np.sin(_c64_nd), npt.NDArray[np.complex64])
-assert_type(np.sin(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
-assert_type(np.sin(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.sin(_obj_1d), _Array1D[np.object_])
+assert_type(np.sin(_obj_2d), _Array2D[np.object_])
 assert_type(np.sin(_obj_nd), npt.NDArray[np.object_])
 
 assert_type(np.sin(_py_i_0d, dtype=np.float32), np.float32)
 assert_type(np.sin(_py_i_1d, dtype=np.float32), npt.NDArray[np.float32])
-assert_type(np.sin(_i16_2d, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.sin(_i16_2d, dtype=np.float32), _Array2D[np.float32])
 
 assert_type(np.sin(_py_i_0d, dtype="f4"), Any)
 assert_type(np.sin(_py_i_1d, dtype="f4"), np.ndarray)
 assert_type(np.sin(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
 
-assert_type(np.sin(_py_i_2d, out=_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+assert_type(np.sin(_py_i_2d, out=_c64_2d), _Array2D[np.complex64])
 
 # _ufunc_11_ifco
 # (conj[ugate], reciprocal, square)
 
 assert_type(np.square(_py_b_0d), np.int8)
-assert_type(np.square(_py_b_1d), np.ndarray[tuple[int], np.dtype[np.int8]])
-assert_type(np.square(_py_b_2d), np.ndarray[tuple[int, int], np.dtype[np.int8]])
+assert_type(np.square(_py_b_1d), _Array1D[np.int8])
+assert_type(np.square(_py_b_2d), _Array2D[np.int8])
 assert_type(np.square(_py_i_0d), np.int_ | Any)  # `int` overlaps with `bool`
-assert_type(np.square(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.int_]])
-assert_type(np.square(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.int_]])
+assert_type(np.square(_py_i_1d), _Array1D[np.int_])
+assert_type(np.square(_py_i_2d), _Array2D[np.int_])
 assert_type(np.square(_py_f_0d), np.float64 | Any)  # `complex` overlaps with `int`
-assert_type(np.square(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.square(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.square(_py_f_1d), _Array1D[np.float64])
+assert_type(np.square(_py_f_2d), _Array2D[np.float64])
 assert_type(np.square(_py_c_0d), np.complex128 | Any)  # `complex` overlaps with `float`
-assert_type(np.square(_py_c_1d), np.ndarray[tuple[int], np.dtype[np.complex128]])
-assert_type(np.square(_py_c_2d), np.ndarray[tuple[int, int], np.dtype[np.complex128]])
+assert_type(np.square(_py_c_1d), _Array1D[np.complex128])
+assert_type(np.square(_py_c_2d), _Array2D[np.complex128])
 
 assert_type(np.square(_bool_0d), np.int8)
-assert_type(np.square(_bool_1d), np.ndarray[tuple[int], np.dtype[np.int8]])
-assert_type(np.square(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.int8]])
+assert_type(np.square(_bool_1d), _Array1D[np.int8])
+assert_type(np.square(_bool_2d), _Array2D[np.int8])
 assert_type(np.square(_bool_nd), npt.NDArray[np.int8])
 assert_type(np.square(_i16_0d), np.int16)
-assert_type(np.square(_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
-assert_type(np.square(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.int16]])
+assert_type(np.square(_i16_1d), _Array1D[np.int16])
+assert_type(np.square(_i16_2d), _Array2D[np.int16])
 assert_type(np.square(_i16_nd), npt.NDArray[np.int16])
 assert_type(np.square(_f32_0d), np.float32)
-assert_type(np.square(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.square(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.square(_f32_1d), _Array1D[np.float32])
+assert_type(np.square(_f32_2d), _Array2D[np.float32])
 assert_type(np.square(_f32_nd), npt.NDArray[np.float32])
 assert_type(np.square(_c64_0d), np.complex64)
-assert_type(np.square(_c64_1d), np.ndarray[tuple[int], np.dtype[np.complex64]])
-assert_type(np.square(_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+assert_type(np.square(_c64_1d), _Array1D[np.complex64])
+assert_type(np.square(_c64_2d), _Array2D[np.complex64])
 assert_type(np.square(_c64_nd), npt.NDArray[np.complex64])
-assert_type(np.square(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
-assert_type(np.square(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.square(_obj_1d), _Array1D[np.object_])
+assert_type(np.square(_obj_2d), _Array2D[np.object_])
 assert_type(np.square(_obj_nd), npt.NDArray[np.object_])
 
 assert_type(np.square(_py_b_0d, dtype=np.float32), np.float32)
 assert_type(np.square(_py_i_1d, dtype=np.float32), npt.NDArray[np.float32])
-assert_type(np.square(_i16_2d, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.square(_i16_2d, dtype=np.float32), _Array2D[np.float32])
 
 assert_type(np.square(_py_b_0d, dtype="f4"), Any)
 assert_type(np.square(_py_i_1d, dtype="f4"), np.ndarray)
 assert_type(np.square(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
 
-assert_type(np.square(_py_b_0d, out=_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
-assert_type(np.square(_py_i_1d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
-assert_type(np.square(_py_f_2d, out=_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+assert_type(np.square(_py_b_0d, out=_i16_1d), _Array1D[np.int16])
+assert_type(np.square(_py_i_1d, out=_f32_2d), _Array2D[np.float32])
+assert_type(np.square(_py_f_2d, out=_c64_2d), _Array2D[np.complex64])
 
 # _ufunc_11_ifcmo_ifco
 # (sign)
 
 assert_type(np.sign(_py_i_0d), np.int_)
-assert_type(np.sign(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.int_]])
-assert_type(np.sign(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.int_]])
+assert_type(np.sign(_py_i_1d), _Array1D[np.int_])
+assert_type(np.sign(_py_i_2d), _Array2D[np.int_])
 assert_type(np.sign(_py_f_0d), np.float64 | Any)  # `complex` overlaps with `int`
-assert_type(np.sign(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.sign(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.sign(_py_f_1d), _Array1D[np.float64])
+assert_type(np.sign(_py_f_2d), _Array2D[np.float64])
 assert_type(np.sign(_py_c_0d), np.complex128 | Any)  # `complex` overlaps with `float`
-assert_type(np.sign(_py_c_1d), np.ndarray[tuple[int], np.dtype[np.complex128]])
-assert_type(np.sign(_py_c_2d), np.ndarray[tuple[int, int], np.dtype[np.complex128]])
+assert_type(np.sign(_py_c_1d), _Array1D[np.complex128])
+assert_type(np.sign(_py_c_2d), _Array2D[np.complex128])
 
 assert_type(np.sign(_i16_0d), np.int16)
-assert_type(np.sign(_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
-assert_type(np.sign(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.int16]])
+assert_type(np.sign(_i16_1d), _Array1D[np.int16])
+assert_type(np.sign(_i16_2d), _Array2D[np.int16])
 assert_type(np.sign(_i16_nd), npt.NDArray[np.int16])
 assert_type(np.sign(_f32_0d), np.float32)
-assert_type(np.sign(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.sign(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.sign(_f32_1d), _Array1D[np.float32])
+assert_type(np.sign(_f32_2d), _Array2D[np.float32])
 assert_type(np.sign(_f32_nd), npt.NDArray[np.float32])
 assert_type(np.sign(_c64_0d), np.complex64)
-assert_type(np.sign(_c64_1d), np.ndarray[tuple[int], np.dtype[np.complex64]])
-assert_type(np.sign(_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+assert_type(np.sign(_c64_1d), _Array1D[np.complex64])
+assert_type(np.sign(_c64_2d), _Array2D[np.complex64])
 assert_type(np.sign(_c64_nd), npt.NDArray[np.complex64])
 assert_type(np.sign(_td_ns_0d), np.float64)
-assert_type(np.sign(_td_ns_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.sign(_td_ns_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.sign(_td_ns_1d), _Array1D[np.float64])
+assert_type(np.sign(_td_ns_2d), _Array2D[np.float64])
 assert_type(np.sign(_td_ns_nd), npt.NDArray[np.float64])
-assert_type(np.sign(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
-assert_type(np.sign(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.sign(_obj_1d), _Array1D[np.object_])
+assert_type(np.sign(_obj_2d), _Array2D[np.object_])
 assert_type(np.sign(_obj_nd), npt.NDArray[np.object_])
 
 assert_type(np.sign(_py_i_0d, dtype=np.float32), np.float32)
 assert_type(np.sign(_py_f_1d, dtype=np.float32), npt.NDArray[np.float32])
-assert_type(np.sign(_i16_2d, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.sign(_i16_2d, dtype=np.float32), _Array2D[np.float32])
 
 assert_type(np.sign(_py_i_0d, dtype="f4"), Any)
 assert_type(np.sign(_py_f_1d, dtype="f4"), np.ndarray)
 assert_type(np.sign(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
 
-assert_type(np.sign(_py_i_0d, out=_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
-assert_type(np.sign(_py_f_1d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
-assert_type(np.sign(_py_c_2d, out=_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+assert_type(np.sign(_py_i_0d, out=_i16_1d), _Array1D[np.int16])
+assert_type(np.sign(_py_f_1d, out=_f32_2d), _Array2D[np.float32])
+assert_type(np.sign(_py_c_2d, out=_c64_2d), _Array2D[np.complex64])
 
 # _ufunc_11_ifcmo
 # (positive, negative)
 
 assert_type(np.negative(_py_i_0d), np.int_)
-assert_type(np.negative(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.int_]])
-assert_type(np.negative(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.int_]])
+assert_type(np.negative(_py_i_1d), _Array1D[np.int_])
+assert_type(np.negative(_py_i_2d), _Array2D[np.int_])
 assert_type(np.negative(_py_f_0d), np.float64 | Any)  # `complex` overlaps with `int`
-assert_type(np.negative(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.negative(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.negative(_py_f_1d), _Array1D[np.float64])
+assert_type(np.negative(_py_f_2d), _Array2D[np.float64])
 assert_type(np.negative(_py_c_0d), np.complex128 | Any)  # `complex` overlaps with `float`
-assert_type(np.negative(_py_c_1d), np.ndarray[tuple[int], np.dtype[np.complex128]])
-assert_type(np.negative(_py_c_2d), np.ndarray[tuple[int, int], np.dtype[np.complex128]])
+assert_type(np.negative(_py_c_1d), _Array1D[np.complex128])
+assert_type(np.negative(_py_c_2d), _Array2D[np.complex128])
 
 assert_type(np.negative(_i16_0d), np.int16)
-assert_type(np.negative(_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
-assert_type(np.negative(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.int16]])
+assert_type(np.negative(_i16_1d), _Array1D[np.int16])
+assert_type(np.negative(_i16_2d), _Array2D[np.int16])
 assert_type(np.negative(_i16_nd), npt.NDArray[np.int16])
 assert_type(np.negative(_f32_0d), np.float32)
-assert_type(np.negative(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.negative(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.negative(_f32_1d), _Array1D[np.float32])
+assert_type(np.negative(_f32_2d), _Array2D[np.float32])
 assert_type(np.negative(_f32_nd), npt.NDArray[np.float32])
 assert_type(np.negative(_c64_0d), np.complex64)
-assert_type(np.negative(_c64_1d), np.ndarray[tuple[int], np.dtype[np.complex64]])
-assert_type(np.negative(_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+assert_type(np.negative(_c64_1d), _Array1D[np.complex64])
+assert_type(np.negative(_c64_2d), _Array2D[np.complex64])
 assert_type(np.negative(_c64_nd), npt.NDArray[np.complex64])
 assert_type(np.negative(_td_ns_0d), np.timedelta64[int])
-assert_type(np.negative(_td_ns_1d), np.ndarray[tuple[int], np.dtype[np.timedelta64[int]]])
-assert_type(np.negative(_td_ns_2d), np.ndarray[tuple[int, int], np.dtype[np.timedelta64[int]]])
+assert_type(np.negative(_td_ns_1d), _Array1D[np.timedelta64[int]])
+assert_type(np.negative(_td_ns_2d), _Array2D[np.timedelta64[int]])
 assert_type(np.negative(_td_ns_nd), npt.NDArray[np.timedelta64[int]])
-assert_type(np.negative(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
-assert_type(np.negative(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.negative(_obj_1d), _Array1D[np.object_])
+assert_type(np.negative(_obj_2d), _Array2D[np.object_])
 assert_type(np.negative(_obj_nd), npt.NDArray[np.object_])
 
 assert_type(np.negative(_py_i_0d, dtype=np.float32), np.float32)
 assert_type(np.negative(_py_f_1d, dtype=np.float32), npt.NDArray[np.float32])
-assert_type(np.negative(_i16_2d, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.negative(_i16_2d, dtype=np.float32), _Array2D[np.float32])
 
 assert_type(np.negative(_py_i_0d, dtype="f4"), Any)
 assert_type(np.negative(_py_f_1d, dtype="f4"), np.ndarray)
 assert_type(np.negative(_i16_2d, dtype="f4"), np.ndarray[tuple[int, int]])
 
-assert_type(np.negative(_py_i_0d, out=_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
-assert_type(np.negative(_py_f_1d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
-assert_type(np.negative(_py_c_2d, out=_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.complex64]])
+assert_type(np.negative(_py_i_0d, out=_i16_1d), _Array1D[np.int16])
+assert_type(np.negative(_py_f_1d, out=_f32_2d), _Array2D[np.float32])
+assert_type(np.negative(_py_c_2d, out=_c64_2d), _Array2D[np.complex64])
 
 # _ufunc_11_bio
 # (invert)
 
 assert_type(np.invert(_py_b_0d), np.bool)
-assert_type(np.invert(_py_b_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.invert(_py_b_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.invert(_py_b_1d), _Array1D[np.bool])
+assert_type(np.invert(_py_b_2d), _Array2D[np.bool])
 assert_type(np.invert(_py_i_0d), np.int_ | Any)
-assert_type(np.invert(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.int_]])
-assert_type(np.invert(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.int_]])
+assert_type(np.invert(_py_i_1d), _Array1D[np.int_])
+assert_type(np.invert(_py_i_2d), _Array2D[np.int_])
 
 assert_type(np.invert(_bool_0d), np.bool)
-assert_type(np.invert(_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.invert(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.invert(_bool_1d), _Array1D[np.bool])
+assert_type(np.invert(_bool_2d), _Array2D[np.bool])
 assert_type(np.invert(_bool_nd), npt.NDArray[np.bool])
 assert_type(np.invert(_u8_0d), np.uint8)
-assert_type(np.invert(_u8_1d), np.ndarray[tuple[int], np.dtype[np.uint8]])
-assert_type(np.invert(_u8_2d), np.ndarray[tuple[int, int], np.dtype[np.uint8]])
+assert_type(np.invert(_u8_1d), _Array1D[np.uint8])
+assert_type(np.invert(_u8_2d), _Array2D[np.uint8])
 assert_type(np.invert(_u8_nd), npt.NDArray[np.uint8])
 assert_type(np.invert(_i16_0d), np.int16)
-assert_type(np.invert(_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
-assert_type(np.invert(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.int16]])
+assert_type(np.invert(_i16_1d), _Array1D[np.int16])
+assert_type(np.invert(_i16_2d), _Array2D[np.int16])
 assert_type(np.invert(_i16_nd), npt.NDArray[np.int16])
-assert_type(np.invert(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
-assert_type(np.invert(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.invert(_obj_1d), _Array1D[np.object_])
+assert_type(np.invert(_obj_2d), _Array2D[np.object_])
 assert_type(np.invert(_obj_nd), npt.NDArray[np.object_])
 
 assert_type(np.invert(_py_b_0d, dtype=np.uint8), np.uint8)
 assert_type(np.invert(_py_i_1d, dtype=np.int16), npt.NDArray[np.int16])
-assert_type(np.invert(_u8_2d, dtype=np.bool), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.invert(_u8_2d, dtype=np.bool), _Array2D[np.bool])
 
 assert_type(np.invert(_py_b_0d, dtype="i4"), Any)
 assert_type(np.invert(_py_i_1d, dtype="i4"), np.ndarray)
 assert_type(np.invert(_u8_2d, dtype="i4"), np.ndarray[tuple[int, int]])
 
-assert_type(np.invert(_py_b_1d, out=_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
+assert_type(np.invert(_py_b_1d, out=_i16_1d), _Array1D[np.int16])
 
 # _ufunc_11_bifo
 # (ceil, floor, trunc)
 
 assert_type(np.ceil(_py_b_0d), np.bool)
-assert_type(np.ceil(_py_b_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.ceil(_py_b_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.ceil(_py_b_1d), _Array1D[np.bool])
+assert_type(np.ceil(_py_b_2d), _Array2D[np.bool])
 assert_type(np.ceil(_py_i_0d), np.int_ | Any)
-assert_type(np.ceil(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.int_]])
-assert_type(np.ceil(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.int_]])
+assert_type(np.ceil(_py_i_1d), _Array1D[np.int_])
+assert_type(np.ceil(_py_i_2d), _Array2D[np.int_])
 assert_type(np.ceil(_py_f_0d), np.float64 | Any)
-assert_type(np.ceil(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.ceil(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.ceil(_py_f_1d), _Array1D[np.float64])
+assert_type(np.ceil(_py_f_2d), _Array2D[np.float64])
 
 assert_type(np.ceil(_bool_0d), np.bool)
-assert_type(np.ceil(_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.ceil(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.ceil(_bool_1d), _Array1D[np.bool])
+assert_type(np.ceil(_bool_2d), _Array2D[np.bool])
 assert_type(np.ceil(_bool_nd), npt.NDArray[np.bool])
 assert_type(np.ceil(_u8_0d), np.uint8)
-assert_type(np.ceil(_u8_1d), np.ndarray[tuple[int], np.dtype[np.uint8]])
-assert_type(np.ceil(_u8_2d), np.ndarray[tuple[int, int], np.dtype[np.uint8]])
+assert_type(np.ceil(_u8_1d), _Array1D[np.uint8])
+assert_type(np.ceil(_u8_2d), _Array2D[np.uint8])
 assert_type(np.ceil(_u8_nd), npt.NDArray[np.uint8])
 assert_type(np.ceil(_i16_0d), np.int16)
-assert_type(np.ceil(_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
-assert_type(np.ceil(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.int16]])
+assert_type(np.ceil(_i16_1d), _Array1D[np.int16])
+assert_type(np.ceil(_i16_2d), _Array2D[np.int16])
 assert_type(np.ceil(_i16_nd), npt.NDArray[np.int16])
 assert_type(np.ceil(_f32_0d), np.float32)
-assert_type(np.ceil(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.ceil(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.ceil(_f32_1d), _Array1D[np.float32])
+assert_type(np.ceil(_f32_2d), _Array2D[np.float32])
 assert_type(np.ceil(_f32_nd), npt.NDArray[np.float32])
-assert_type(np.ceil(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
-assert_type(np.ceil(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.ceil(_obj_1d), _Array1D[np.object_])
+assert_type(np.ceil(_obj_2d), _Array2D[np.object_])
 assert_type(np.ceil(_obj_nd), npt.NDArray[np.object_])
 
 assert_type(np.ceil(_py_b_0d, dtype=np.uint8), np.uint8)
 assert_type(np.ceil(_py_i_1d, dtype=np.float32), npt.NDArray[np.float32])
-assert_type(np.ceil(_u8_2d, dtype=np.bool), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.ceil(_u8_2d, dtype=np.bool), _Array2D[np.bool])
 
 assert_type(np.ceil(_py_b_0d, dtype="f4"), Any)
 assert_type(np.ceil(_py_i_1d, dtype="f4"), np.ndarray)
 assert_type(np.ceil(_u8_2d, dtype="f4"), np.ndarray[tuple[int, int]])
 
-assert_type(np.ceil(_py_b_1d, out=_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
-assert_type(np.ceil(_py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.ceil(_py_b_1d, out=_i16_1d), _Array1D[np.int16])
+assert_type(np.ceil(_py_i_2d, out=_f32_2d), _Array2D[np.float32])
 
 # _ufunc_11_bifcmo
 # (abs[olute])
 
 assert_type(np.abs(_py_b_0d), np.bool)
-assert_type(np.abs(_py_b_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.abs(_py_b_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.abs(_py_b_1d), _Array1D[np.bool])
+assert_type(np.abs(_py_b_2d), _Array2D[np.bool])
 assert_type(np.abs(_py_i_0d), np.int_ | Any)
-assert_type(np.abs(_py_i_1d), np.ndarray[tuple[int], np.dtype[np.int_]])
-assert_type(np.abs(_py_i_2d), np.ndarray[tuple[int, int], np.dtype[np.int_]])
+assert_type(np.abs(_py_i_1d), _Array1D[np.int_])
+assert_type(np.abs(_py_i_2d), _Array2D[np.int_])
 assert_type(np.abs(_py_f_0d), np.float64 | Any)
-assert_type(np.abs(_py_f_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.abs(_py_f_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.abs(_py_f_1d), _Array1D[np.float64])
+assert_type(np.abs(_py_f_2d), _Array2D[np.float64])
 assert_type(np.abs(_py_c_0d), np.float64 | Any)
-assert_type(np.abs(_py_c_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.abs(_py_c_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.abs(_py_c_1d), _Array1D[np.float64])
+assert_type(np.abs(_py_c_2d), _Array2D[np.float64])
 
 assert_type(np.abs(_bool_0d), np.bool)
-assert_type(np.abs(_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.abs(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.abs(_bool_1d), _Array1D[np.bool])
+assert_type(np.abs(_bool_2d), _Array2D[np.bool])
 assert_type(np.abs(_bool_nd), npt.NDArray[np.bool])
 assert_type(np.abs(_u8_0d), np.uint8)
-assert_type(np.abs(_u8_1d), np.ndarray[tuple[int], np.dtype[np.uint8]])
-assert_type(np.abs(_u8_2d), np.ndarray[tuple[int, int], np.dtype[np.uint8]])
+assert_type(np.abs(_u8_1d), _Array1D[np.uint8])
+assert_type(np.abs(_u8_2d), _Array2D[np.uint8])
 assert_type(np.abs(_u8_nd), npt.NDArray[np.uint8])
 assert_type(np.abs(_i16_0d), np.int16)
-assert_type(np.abs(_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
-assert_type(np.abs(_i16_2d), np.ndarray[tuple[int, int], np.dtype[np.int16]])
+assert_type(np.abs(_i16_1d), _Array1D[np.int16])
+assert_type(np.abs(_i16_2d), _Array2D[np.int16])
 assert_type(np.abs(_i16_nd), npt.NDArray[np.int16])
 assert_type(np.abs(_f32_0d), np.float32)
-assert_type(np.abs(_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.abs(_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.abs(_f32_1d), _Array1D[np.float32])
+assert_type(np.abs(_f32_2d), _Array2D[np.float32])
 assert_type(np.abs(_f32_nd), npt.NDArray[np.float32])
 assert_type(np.abs(_c64_0d), np.float32)
-assert_type(np.abs(_c64_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
-assert_type(np.abs(_c64_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.abs(_c64_1d), _Array1D[np.float32])
+assert_type(np.abs(_c64_2d), _Array2D[np.float32])
 assert_type(np.abs(_c64_nd), npt.NDArray[np.float32])
 assert_type(np.abs(_td_ns_0d), np.timedelta64[int])
-assert_type(np.abs(_td_ns_1d), np.ndarray[tuple[int], np.dtype[np.timedelta64[int]]])
-assert_type(np.abs(_td_ns_2d), np.ndarray[tuple[int, int], np.dtype[np.timedelta64[int]]])
+assert_type(np.abs(_td_ns_1d), _Array1D[np.timedelta64[int]])
+assert_type(np.abs(_td_ns_2d), _Array2D[np.timedelta64[int]])
 assert_type(np.abs(_td_ns_nd), npt.NDArray[np.timedelta64[int]])
-assert_type(np.abs(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
-assert_type(np.abs(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.abs(_obj_1d), _Array1D[np.object_])
+assert_type(np.abs(_obj_2d), _Array2D[np.object_])
 assert_type(np.abs(_obj_nd), npt.NDArray[np.object_])
 
 assert_type(np.abs(_py_b_0d, dtype=np.uint8), np.uint8)
 assert_type(np.abs(_py_c_1d, dtype=np.float32), npt.NDArray[np.float32])
-assert_type(np.abs(_u8_2d, dtype=np.bool), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.abs(_u8_2d, dtype=np.bool), _Array2D[np.bool])
 
 assert_type(np.abs(_py_b_0d, dtype="f4"), Any)
 assert_type(np.abs(_py_i_1d, dtype="f4"), np.ndarray)
 assert_type(np.abs(_u8_2d, dtype="f4"), np.ndarray[tuple[int, int]])
 
-assert_type(np.abs(_py_b_1d, out=_i16_1d), np.ndarray[tuple[int], np.dtype[np.int16]])
-assert_type(np.abs(_py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.abs(_py_b_1d, out=_i16_1d), _Array1D[np.int16])
+assert_type(np.abs(_py_i_2d, out=_f32_2d), _Array2D[np.float32])
 
 # _ufunc_12_frexp
 
 assert_type(np.frexp(_py_i_0d), tuple[np.float64, np.int32])
-assert_type(
-    np.frexp(_py_i_1d),
-    tuple[
-        np.ndarray[tuple[int], np.dtype[np.float64]],
-        np.ndarray[tuple[int], np.dtype[np.int32]],
-    ],
-)
-assert_type(
-    np.frexp(_py_i_2d),
-    tuple[
-        np.ndarray[tuple[int, int], np.dtype[np.float64]],
-        np.ndarray[tuple[int, int], np.dtype[np.int32]],
-    ],
-)
+assert_type(np.frexp(_py_i_1d), tuple[_Array1D[np.float64], _Array1D[np.int32]])
+assert_type(np.frexp(_py_i_2d), tuple[_Array2D[np.float64], _Array2D[np.int32]])
 assert_type(np.frexp(_py_f_0d), tuple[np.float64, np.int32])
-assert_type(
-    np.frexp(_py_f_1d),
-    tuple[
-        np.ndarray[tuple[int], np.dtype[np.float64]],
-        np.ndarray[tuple[int], np.dtype[np.int32]],
-    ],
-)
-assert_type(
-    np.frexp(_py_f_2d),
-    tuple[
-        np.ndarray[tuple[int, int], np.dtype[np.float64]],
-        np.ndarray[tuple[int, int], np.dtype[np.int32]],
-    ],
-)
+assert_type(np.frexp(_py_f_1d), tuple[_Array1D[np.float64], _Array1D[np.int32]])
+assert_type(np.frexp(_py_f_2d), tuple[_Array2D[np.float64], _Array2D[np.int32]])
 
 assert_type(np.frexp(_bool_0d), tuple[np.float16, np.int32])
-assert_type(
-    np.frexp(_bool_1d),
-    tuple[
-        np.ndarray[tuple[int], np.dtype[np.float16]],
-        np.ndarray[tuple[int], np.dtype[np.int32]],
-    ],
-)
-assert_type(
-    np.frexp(_bool_2d),
-    tuple[
-        np.ndarray[tuple[int, int], np.dtype[np.float16]],
-        np.ndarray[tuple[int, int], np.dtype[np.int32]],
-    ],
-)
+assert_type(np.frexp(_bool_1d), tuple[_Array1D[np.float16], _Array1D[np.int32]])
+assert_type(np.frexp(_bool_2d), tuple[_Array2D[np.float16], _Array2D[np.int32]])
 assert_type(np.frexp(_bool_nd), tuple[npt.NDArray[np.float16], npt.NDArray[np.int32]])
 assert_type(np.frexp(_i16_0d), tuple[np.float32, np.int32])
-assert_type(
-    np.frexp(_i16_1d),
-    tuple[
-        np.ndarray[tuple[int], np.dtype[np.float32]],
-        np.ndarray[tuple[int], np.dtype[np.int32]],
-    ],
-)
-assert_type(
-    np.frexp(_i16_2d),
-    tuple[
-        np.ndarray[tuple[int, int], np.dtype[np.float32]],
-        np.ndarray[tuple[int, int], np.dtype[np.int32]],
-    ],
-)
+assert_type(np.frexp(_i16_1d), tuple[_Array1D[np.float32], _Array1D[np.int32]])
+assert_type(np.frexp(_i16_2d), tuple[_Array2D[np.float32], _Array2D[np.int32]])
 assert_type(np.frexp(_i16_nd), tuple[npt.NDArray[np.float32], npt.NDArray[np.int32]])
 assert_type(np.frexp(_i32_0d), tuple[np.float64, np.int32])
-assert_type(
-    np.frexp(_i32_1d),
-    tuple[
-        np.ndarray[tuple[int], np.dtype[np.float64]],
-        np.ndarray[tuple[int], np.dtype[np.int32]],
-    ],
-)
-assert_type(
-    np.frexp(_i32_2d),
-    tuple[
-        np.ndarray[tuple[int, int], np.dtype[np.float64]],
-        np.ndarray[tuple[int, int], np.dtype[np.int32]],
-    ],
-)
+assert_type(np.frexp(_i32_1d), tuple[_Array1D[np.float64], _Array1D[np.int32]])
+assert_type(np.frexp(_i32_2d), tuple[_Array2D[np.float64], _Array2D[np.int32]])
 assert_type(np.frexp(_i32_nd), tuple[npt.NDArray[np.float64], npt.NDArray[np.int32]])
 assert_type(np.frexp(_f32_0d), tuple[np.float32, np.int32])
-assert_type(
-    np.frexp(_f32_1d),
-    tuple[
-        np.ndarray[tuple[int], np.dtype[np.float32]],
-        np.ndarray[tuple[int], np.dtype[np.int32]],
-    ],
-)
-assert_type(
-    np.frexp(_f32_2d),
-    tuple[
-        np.ndarray[tuple[int, int], np.dtype[np.float32]],
-        np.ndarray[tuple[int, int], np.dtype[np.int32]],
-    ],
-)
+assert_type(np.frexp(_f32_1d), tuple[_Array1D[np.float32], _Array1D[np.int32]])
+assert_type(np.frexp(_f32_2d), tuple[_Array2D[np.float32], _Array2D[np.int32]])
 assert_type(np.frexp(_f32_nd), tuple[npt.NDArray[np.float32], npt.NDArray[np.int32]])
 
-assert_type(
-    np.frexp(_py_i_2d, out=(_f32_2d, _i16_2d)),
-    tuple[
-        np.ndarray[tuple[int, int], np.dtype[np.float32]],
-        np.ndarray[tuple[int, int], np.dtype[np.int16]],
-    ]
-)
+assert_type(np.frexp(_py_i_2d, out=(_f32_2d, _i16_2d)), tuple[_Array2D[np.float32], _Array2D[np.int16]])
 
 # _ufunc_12_modf
 
 type _tuple2[T] = tuple[T, T]
 
 assert_type(np.modf(_py_i_0d), _tuple2[np.float64])
-assert_type(np.modf(_py_i_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float64]]])
-assert_type(np.modf(_py_i_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float64]]])
+assert_type(np.modf(_py_i_1d), _tuple2[_Array1D[np.float64]])
+assert_type(np.modf(_py_i_2d), _tuple2[_Array2D[np.float64]])
 assert_type(np.modf(_py_f_0d), _tuple2[np.float64])
-assert_type(np.modf(_py_f_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float64]]])
-assert_type(np.modf(_py_f_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float64]]])
+assert_type(np.modf(_py_f_1d), _tuple2[_Array1D[np.float64]])
+assert_type(np.modf(_py_f_2d), _tuple2[_Array2D[np.float64]])
 
 assert_type(np.modf(_bool_0d), _tuple2[np.float16])
-assert_type(np.modf(_bool_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float16]]])
-assert_type(np.modf(_bool_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float16]]])
+assert_type(np.modf(_bool_1d), _tuple2[_Array1D[np.float16]])
+assert_type(np.modf(_bool_2d), _tuple2[_Array2D[np.float16]])
 assert_type(np.modf(_bool_nd), _tuple2[npt.NDArray[np.float16]])
 assert_type(np.modf(_i16_0d), _tuple2[np.float32])
-assert_type(np.modf(_i16_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float32]]])
-assert_type(np.modf(_i16_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float32]]])
+assert_type(np.modf(_i16_1d), _tuple2[_Array1D[np.float32]])
+assert_type(np.modf(_i16_2d), _tuple2[_Array2D[np.float32]])
 assert_type(np.modf(_i16_nd), _tuple2[npt.NDArray[np.float32]])
 assert_type(np.modf(_i32_0d), _tuple2[np.float64])
-assert_type(np.modf(_i32_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float64]]])
-assert_type(np.modf(_i32_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float64]]])
+assert_type(np.modf(_i32_1d), _tuple2[_Array1D[np.float64]])
+assert_type(np.modf(_i32_2d), _tuple2[_Array2D[np.float64]])
 assert_type(np.modf(_i32_nd), _tuple2[npt.NDArray[np.float64]])
 assert_type(np.modf(_f32_0d), _tuple2[np.float32])
-assert_type(np.modf(_f32_1d), _tuple2[np.ndarray[tuple[int], np.dtype[np.float32]]])
-assert_type(np.modf(_f32_2d), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float32]]])
+assert_type(np.modf(_f32_1d), _tuple2[_Array1D[np.float32]])
+assert_type(np.modf(_f32_2d), _tuple2[_Array2D[np.float32]])
 assert_type(np.modf(_f32_nd), _tuple2[npt.NDArray[np.float32]])
 
 assert_type(np.modf(_py_i_0d, dtype=np.float32), _tuple2[np.float32])
 assert_type(np.modf(_py_i_1d, dtype=np.float32), _tuple2[npt.NDArray[np.float32]])
-assert_type(np.modf(_i16_2d, dtype=np.float32), _tuple2[np.ndarray[tuple[int, int], np.dtype[np.float32]]])
+assert_type(np.modf(_i16_2d, dtype=np.float32), _tuple2[_Array2D[np.float32]])
 
 assert_type(np.modf(_py_i_0d, dtype="f4"), _tuple2[Any])
 assert_type(np.modf(_py_i_1d, dtype="f4"), _tuple2[np.ndarray])
 assert_type(np.modf(_i16_2d, dtype="f4"), _tuple2[np.ndarray[tuple[int, int]]])
 
-assert_type(
-    np.modf(_py_i_2d, out=(_f32_2d, _i16_2d)),
-    tuple[
-        np.ndarray[tuple[int, int], np.dtype[np.float32]],
-        np.ndarray[tuple[int, int], np.dtype[np.int16]],
-    ]
-)
+assert_type(np.modf(_py_i_2d, out=(_f32_2d, _i16_2d)), tuple[_Array2D[np.float32], _Array2D[np.int16]])
 
 # _ufunc_21_logical
 # (logical_and, logical_or, logical_xor)
@@ -880,7 +799,7 @@ assert_type(np.logical_or(_obj_nd, _bool_nd), npt.NDArray[np.object_])
 assert_type(np.logical_or(_bool_nd, _obj_nd), npt.NDArray[np.object_])
 assert_type(np.logical_or(_obj_nd, _obj_nd), npt.NDArray[np.object_])
 
-assert_type(np.logical_or(_py_i_2d, _py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.logical_or(_py_i_2d, _py_i_2d, out=_f32_2d), _Array2D[np.float32])
 
 assert_type(np.logical_or.outer(_f32_0d, _c64_0d), np.bool)
 assert_type(np.logical_or.outer(_f32_1d, _c64_0d), npt.NDArray[np.bool])
@@ -895,32 +814,32 @@ assert_type(np.logical_or.outer(object(), object()), Any)
 assert_type(np.logical_or.at(_c64_2d, 1, _py_c_1d), None)
 assert_type(np.logical_or.at(_obj_2d, 1, _obj_1d), None)
 
-assert_type(np.logical_or.accumulate(_dt_ns_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.logical_or.accumulate(_dt_ns_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
-assert_type(np.logical_or.accumulate(_obj_1d), np.ndarray[tuple[int], np.dtype[np.object_]])
-assert_type(np.logical_or.accumulate(_obj_2d), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.logical_or.accumulate(_dt_ns_1d), _Array1D[np.bool])
+assert_type(np.logical_or.accumulate(_dt_ns_2d), _Array2D[np.bool])
+assert_type(np.logical_or.accumulate(_obj_1d), _Array1D[np.object_])
+assert_type(np.logical_or.accumulate(_obj_2d), _Array2D[np.object_])
 assert_type(np.logical_or.accumulate(_py_f_1d), npt.NDArray[np.bool])
-assert_type(np.logical_or.accumulate(_py_f_1d, out=_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.logical_or.accumulate(_py_f_1d, out=_bool_1d), _Array1D[np.bool])
 
 assert_type(np.logical_or.reduce(_i16_1d), npt.NDArray[np.bool] | Any)
 assert_type(np.logical_or.reduce(_i16_2d), npt.NDArray[np.bool] | Any)
 assert_type(np.logical_or.reduce(_i16_1d, axis=None), np.bool)
 assert_type(np.logical_or.reduce(_i16_1d, keepdims=True), npt.NDArray[np.bool])
 assert_type(np.logical_or.reduce(_i16_1d, out=...), npt.NDArray[np.bool])
-assert_type(np.logical_or.reduce(_i16_1d, out=_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.logical_or.reduce(_i16_1d, out=_bool_1d), _Array1D[np.bool])
 assert_type(np.logical_or.reduce(_obj_1d), npt.NDArray[np.object_] | Any)
 assert_type(np.logical_or.reduce(_obj_2d), npt.NDArray[np.object_] | Any)
 assert_type(np.logical_or.reduce(_obj_1d, axis=None), Any)
 assert_type(np.logical_or.reduce(_obj_1d, keepdims=True), npt.NDArray[np.object_])
 assert_type(np.logical_or.reduce(_obj_1d, out=...), npt.NDArray[np.object_])
-assert_type(np.logical_or.reduce(_obj_1d, out=_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.logical_or.reduce(_obj_1d, out=_bool_1d), _Array1D[np.bool])
 
-assert_type(np.logical_or.reduceat(_td_ns_1d, (0,)), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.logical_or.reduceat(_td_ns_2d, (0,)), np.ndarray[tuple[int, int], np.dtype[np.bool]])
-assert_type(np.logical_or.reduceat(_obj_1d, (0,)), np.ndarray[tuple[int], np.dtype[np.object_]])
-assert_type(np.logical_or.reduceat(_obj_2d, (0,)), np.ndarray[tuple[int, int], np.dtype[np.object_]])
+assert_type(np.logical_or.reduceat(_td_ns_1d, (0,)), _Array1D[np.bool])
+assert_type(np.logical_or.reduceat(_td_ns_2d, (0,)), _Array2D[np.bool])
+assert_type(np.logical_or.reduceat(_obj_1d, (0,)), _Array1D[np.object_])
+assert_type(np.logical_or.reduceat(_obj_2d, (0,)), _Array2D[np.object_])
 assert_type(np.logical_or.reduceat(_py_c_1d, (0,)), npt.NDArray[np.bool])
-assert_type(np.logical_or.reduceat(_py_c_1d, (0,), out=_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.logical_or.reduceat(_py_c_1d, (0,), out=_bool_1d), _Array1D[np.bool])
 
 # _ufunc_21_cmp
 # (equal, greater, greater_equal, less, less_equal, not_equal)
@@ -963,7 +882,7 @@ assert_type(np.less(_td_ns_1d, _td_ns_1d), npt.NDArray[np.bool])
 assert_type(np.less(_td_ns_2d, _td_ns_2d), npt.NDArray[np.bool])
 assert_type(np.less(_td_ns_nd, _td_ns_nd), npt.NDArray[np.bool])
 
-assert_type(np.less(_py_i_2d, _py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.less(_py_i_2d, _py_i_2d, out=_f32_2d), _Array2D[np.float32])
 
 assert_type(np.less.outer(_py_c_0d, _py_c_0d), np.bool)
 assert_type(np.less.outer(_py_c_1d, _py_c_0d), npt.NDArray[np.bool])
@@ -972,22 +891,22 @@ assert_type(np.less.outer(_py_c_1d, _py_c_1d), npt.NDArray[np.bool])
 
 assert_type(np.less.at(_c64_1d, 1, _py_c_1d), None)
 
-assert_type(np.less.accumulate(_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.less.accumulate(_bool_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.less.accumulate(_bool_1d), _Array1D[np.bool])
+assert_type(np.less.accumulate(_bool_2d), _Array2D[np.bool])
 assert_type(np.less.accumulate(_py_b_1d), npt.NDArray[np.bool])
-assert_type(np.less.accumulate(_py_b_1d, out=_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.less.accumulate(_py_b_1d, out=_bool_1d), _Array1D[np.bool])
 
 assert_type(np.less.reduce(_bool_1d), npt.NDArray[np.bool] | np.bool)
 assert_type(np.less.reduce(_bool_2d), npt.NDArray[np.bool] | np.bool)
 assert_type(np.less.reduce(_bool_1d, axis=None), np.bool)
 assert_type(np.less.reduce(_bool_1d, keepdims=True), npt.NDArray[np.bool])
 assert_type(np.less.reduce(_bool_1d, out=...), npt.NDArray[np.bool])
-assert_type(np.less.reduce(_bool_1d, out=_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.less.reduce(_bool_1d, out=_bool_1d), _Array1D[np.bool])
 
-assert_type(np.less.reduceat(_bool_1d, (0,)), np.ndarray[tuple[int], np.dtype[np.bool]])
-assert_type(np.less.reduceat(_bool_2d, (0,)), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.less.reduceat(_bool_1d, (0,)), _Array1D[np.bool])
+assert_type(np.less.reduceat(_bool_2d, (0,)), _Array2D[np.bool])
 assert_type(np.less.reduceat(_py_b_1d, (0,)), npt.NDArray[np.bool])
-assert_type(np.less.reduceat(_py_b_1d, (0,), out=_bool_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.less.reduceat(_py_b_1d, (0,), out=_bool_1d), _Array1D[np.bool])
 
 # _ufunc_21_ldexp
 # (ldexp)
@@ -1019,7 +938,7 @@ assert_type(np.ldexp(_f32_1d, _i16_1d), npt.NDArray[np.float32])
 assert_type(np.ldexp(_f32_2d, _i16_2d), npt.NDArray[np.float32])
 assert_type(np.ldexp(_f32_nd, _i16_nd), npt.NDArray[np.float32])
 
-assert_type(np.ldexp(_py_i_2d, _py_i_2d, out=_f32_2d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.ldexp(_py_i_2d, _py_i_2d, out=_f32_2d), _Array2D[np.float32])
 
 assert_type(np.ldexp.outer(_py_f_0d, _py_i_0d), np.float64)
 assert_type(np.ldexp.outer(_py_f_1d, _py_i_0d), npt.NDArray[np.float64])
@@ -1047,6 +966,6 @@ assert_type(np.ldexp.reduce(_i32_2d), npt.NDArray[np.float64] | np.float64)
 assert_type(np.ldexp.reduce(_i32_1d, axis=None), np.float64)
 assert_type(np.ldexp.reduce(_i32_1d, keepdims=True), npt.NDArray[np.float64])
 assert_type(np.ldexp.reduce(_i32_1d, out=...), npt.NDArray[np.float64])
-assert_type(np.ldexp.reduce(_i32_1d, out=_f32_1d), np.ndarray[tuple[int], np.dtype[np.float32]])
+assert_type(np.ldexp.reduce(_i32_1d, out=_f32_1d), _Array1D[np.float32])
 
 # ldexp doesn't support reduceat / accumulate


### PR DESCRIPTION
There was a lot of duplication in the shaped array type declarations in the ufuncs stubs and type-tests, so I introduced some type-aliases to clean that up.

---

No AI.