### PR TITLE
PERF: fast-path large order diff

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -120,6 +120,20 @@ class Percentile(Benchmark):
         np.percentile(self.o, [25, 75])
 
 
+class Diff(Benchmark):
+    params = [
+        [(10,), (10, 10)],
+        [10, 1000],
+    ]
+    param_names = ["shape", "n"]
+
+    def setup(self, shape, n):
+        self.arr = np.arange(np.prod(shape)).reshape(shape)
+
+    def time_large_n(self, shape, n):
+        np.diff(self.arr, n=n)
+
+
 class Select(Benchmark):
     def setup(self):
         self.d = np.arange(20000)

--- a/doc/release/upcoming_changes/31897.performance.rst
+++ b/doc/release/upcoming_changes/31897.performance.rst
@@ -1,0 +1,3 @@
+``np.diff`` is faster for large ``n`` values
+--------------------------------------------
+``np.diff`` now returns early when ``n`` is at least the input length, avoiding repeated work for empty results.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1528,6 +1528,13 @@ def diff(a, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
     if len(combined) > 1:
         a = np.concatenate(combined, axis)
 
+    op = not_equal if a.dtype == np.bool else subtract
+    if n >= a.shape[axis] and not a.dtype.hasobject:
+        empty = [slice(None)] * nd
+        empty[axis] = slice(0, 0)
+        empty = tuple(empty)
+        return op(a[empty], a[empty])
+
     slice1 = [slice(None)] * nd
     slice2 = [slice(None)] * nd
     slice1[axis] = slice(1, None)
@@ -1535,7 +1542,6 @@ def diff(a, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
     slice1 = tuple(slice1)
     slice2 = tuple(slice2)
 
-    op = not_equal if a.dtype == np.bool else subtract
     for _ in range(n):
         a = op(a[slice1], a[slice2])
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -920,6 +920,36 @@ class TestDiff:
             assert_array_equal(out, exp)
             assert_equal(out.dtype, exp.dtype)
 
+    @pytest.mark.parametrize(
+        "array, expected_dtype",
+        [
+            (np.arange(3, dtype=np.int64), np.dtype(np.int64)),
+            (np.arange(3, dtype=np.uint8), np.dtype(np.uint8)),
+            (np.array([True, False, True]), np.dtype(bool)),
+            (
+                np.arange("1066-10-13", "1066-10-16", dtype="datetime64[D]"),
+                np.dtype("timedelta64[D]"),
+            ),
+        ],
+    )
+    def test_large_n_empty_result_dtype(self, array, expected_dtype):
+        out = diff(array, n=100)
+        assert_array_equal(out, [])
+        assert_equal(out.dtype, expected_dtype)
+
+        out = diff(array.reshape(1, -1), n=100, axis=1)
+        assert_equal(out.shape, (1, 0))
+        assert_equal(out.dtype, expected_dtype)
+
+    def test_large_n_object_subtraction_error(self):
+        class NoSub:
+            def __sub__(self, other):
+                raise TypeError("no subtraction")
+
+        array = np.array([NoSub(), NoSub()], dtype=object)
+        with pytest.raises(TypeError, match="no subtraction"):
+            diff(array, n=100)
+
     def test_subclass(self):
         x = ma.array([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]],
                      mask=[[False, False], [True, False],


### PR DESCRIPTION
### PR summary

Add a fast path for `np.diff` when `n` is at least the effective axis length. In that case the result is empty, so numeric and non-object dtypes can avoid repeated differencing of already-empty arrays. Object arrays keep the existing path so Python-level subtraction behavior is preserved.

ASV quick comparison against `main`:

```
bench_function_base.Diff.time_large_n((10,), 10):       21.0 us -> 16.5 us
bench_function_base.Diff.time_large_n((10, 10), 10):    41.3 us -> 13.9 us
bench_function_base.Diff.time_large_n((10,), 1000):      346 us -> 12.4 us
bench_function_base.Diff.time_large_n((10, 10), 1000):   481 us -> 15.0 us
```

### First time committer introduction

I am a NumPy user/contributor looking at small, focused performance improvements in common array operations. I will handle review discussion and follow-up changes directly.

#### AI Disclosure

LLM / Harness: hybrid.

AI assistance was used to inspect the codebase, run local commands and benchmarks, draft PR text, and help prepare candidate patches. I reviewed the generated suggestions, selected the final changes, and am responsible for the code, submission, and follow-up discussion. Some PR text and candidate code edits were drafted with AI assistance; the final patch and text were reviewed and edited by me.
