### PR TITLE
PERF: fast-path empty insert indices

### DIFF
--- a/benchmarks/benchmarks/bench_function_base.py
+++ b/benchmarks/benchmarks/bench_function_base.py
@@ -73,6 +73,25 @@ class Mean(Benchmark):
         np.mean(self.array, axis=1)
 
 
+class Insert(Benchmark):
+    params = [
+        [(1000,), (100, 100)],
+        [None, 0],
+        ["list", "array"],
+    ]
+    param_names = ["shape", "axis", "indexer_type"]
+
+    def setup(self, shape, axis, indexer_type):
+        self.arr = np.arange(np.prod(shape)).reshape(shape)
+        if indexer_type == "list":
+            self.empty_indices = []
+        else:
+            self.empty_indices = np.array([], dtype=np.intp)
+
+    def time_empty_indices(self, shape, axis, indexer_type):
+        np.insert(self.arr, self.empty_indices, 9, axis=axis)
+
+
 class Median(Benchmark):
     def setup(self):
         self.e = np.arange(10000, dtype=np.float32)

--- a/doc/release/upcoming_changes/31898.performance.rst
+++ b/doc/release/upcoming_changes/31898.performance.rst
@@ -1,0 +1,3 @@
+``np.insert`` is faster for empty indices
+-----------------------------------------
+``np.insert`` now skips the general insertion machinery when the index array is empty, reducing overhead for no-op inserts.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -5562,6 +5562,12 @@ def insert(arr, obj, values, axis=None):
         # Can safely cast the empty list to intp
         indices = indices.astype(intp)
 
+    if indices.size == 0 and indices.dtype.kind in "ui":
+        new = arr.copy(order=arrorder)
+        slobj[axis] = indices
+        new[tuple(slobj)] = values
+        return conv.wrap(new, to_scalar=False)
+
     if indices.size > 0:
         min_idx = indices.min()
         max_idx = indices.max()

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -698,6 +698,19 @@ class TestInsert:
         with pytest.raises(IndexError):
             np.insert([0, 1, 2], np.array([], dtype=float), [])
 
+    @pytest.mark.parametrize("indexer", [[], np.array([], dtype=np.intp)])
+    def test_empty_integer_index_returns_copy(self, indexer):
+        a = np.arange(6).reshape(2, 3)
+        res = insert(a, indexer, 9, axis=1)
+
+        assert_array_equal(res, a)
+        assert_(res is not a)
+        assert_(not np.shares_memory(res, a))
+
+    def test_empty_integer_index_validates_values(self):
+        with pytest.raises(ValueError, match="shape mismatch"):
+            insert(np.arange(3), [], [[1, 2, 3]])
+
     @pytest.mark.parametrize('idx,values', [
         ([4], [3, 4]),
         ([-4], [3, 4]),


### PR DESCRIPTION
### PR summary

Add a fast path for `np.insert` with empty integer insertion indices. The result is still a copy, and the path keeps the existing empty-assignment step so `values` validation behavior is preserved.

ASV quick comparison against `main`:

```
bench_function_base.Insert.time_empty_indices((100, 100), 0, list):     50.8 us -> 39.9 us
bench_function_base.Insert.time_empty_indices((100, 100), None, array): 45.4 us -> 24.7 us
bench_function_base.Insert.time_empty_indices((1000,), 0, list):        39.7 us -> 19.3 us
bench_function_base.Insert.time_empty_indices((1000,), 0, array):       37.2 us -> 17.4 us
bench_function_base.Insert.time_empty_indices((1000,), None, array):    37.5 us -> 17.0 us
bench_function_base.Insert.time_empty_indices((100, 100), None, list):  52.5 us -> 22.0 us
bench_function_base.Insert.time_empty_indices((100, 100), 0, array):    64.3 us -> 22.7 us
bench_function_base.Insert.time_empty_indices((1000,), None, list):     92.4 us -> 30.4 us
```

### First time committer introduction

I am a NumPy user/contributor looking at small, focused performance improvements in common array operations. I will handle review discussion and follow-up changes directly.

#### AI Disclosure

LLM / Harness: hybrid.

AI assistance was used to inspect the codebase, run local commands and benchmarks, draft PR text, and help prepare candidate patches. I reviewed the generated suggestions, selected the final changes, and am responsible for the code, submission, and follow-up discussion. Some PR text and candidate code edits were drafted with AI assistance; the final patch and text were reviewed and edited by me.
