### PR TITLE
PERF: skip copyto mask conversion for where=True

### DIFF
--- a/benchmarks/benchmarks/bench_io.py
+++ b/benchmarks/benchmarks/bench_io.py
@@ -60,6 +60,15 @@ class CopyTo(Benchmark):
         np.copyto(self.d, self.e, where=self.im8)
 
 
+class CopyToWhereTrue(Benchmark):
+    def setup(self):
+        self.d = np.ones(8)
+        self.e = self.d.copy()
+
+    def time_copyto(self):
+        np.copyto(self.d, self.e, where=True)
+
+
 class CopyStructured(Benchmark):
     params = [
         [10, 100, 1000],

--- a/doc/release/upcoming_changes/31899.performance.rst
+++ b/doc/release/upcoming_changes/31899.performance.rst
@@ -1,0 +1,3 @@
+``np.copyto`` is faster when ``where=True``
+-------------------------------------------
+``np.copyto`` now skips converting the ``where`` argument to a boolean mask when ``where=True``, reducing overhead in the all-True case.

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -2005,7 +2005,7 @@ array_copyto(PyObject *NPY_UNUSED(ignored),
         Py_DECREF(DType);
     }
 
-    if (wheremask_in != NULL) {
+    if (wheremask_in != NULL && wheremask_in != Py_True) {
         /* Get the boolean where mask */
         PyArray_Descr *descr = PyArray_DescrFromType(NPY_BOOL);
         if (descr == NULL) {


### PR DESCRIPTION
### PR summary

Avoid constructing a 0-D boolean mask when `np.copyto` is called with the exact Python `True` object for `where`, matching the existing ufunc fast path. Other mask-like inputs keep the existing conversion path.

ASV quick compare for `bench_io.CopyToWhereTrue.time_copyto`: `7.04 us -> 1.96 us` (ratio 0.28).

### First time committer introduction

I am a NumPy user/contributor looking at small, focused performance improvements in common array operations. I will handle review discussion and follow-up changes directly.

#### AI Disclosure

LLM / Harness: hybrid.

AI assistance was used to inspect the codebase, run local commands and benchmarks, draft PR text, and help prepare candidate patches. I reviewed the generated suggestions, selected the final changes, and am responsible for the code, submission, and follow-up discussion. Some PR text and candidate code edits were drafted with AI assistance; the final patch and text were reviewed and edited by me.
