### PR TITLE
BUG: fix CPU feature env diagnostic buffer overruns

### DIFF
--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -308,8 +308,11 @@ npy__cpu_check_env(int disable, const char *env) {
         int feature_id = npy__cpu_dispatch_fid(feature);
         if (feature_id == 0) {
             int flen = strlen(feature);
+            if (nexist_cur != nexist) {
+                *nexist_cur++ = ' ';
+            }
             memcpy(nexist_cur, feature, flen);
-            nexist_cur[flen] = ' '; nexist_cur += flen + 1;
+            nexist_cur += flen;
             goto next;
         }
         // check if the feature supported by the running machine
@@ -335,7 +338,6 @@ npy__cpu_check_env(int disable, const char *env) {
 
     *nexist_cur = '\0';
     if (nexist[0] != '\0') {
-        *(nexist_cur-1) = '\0'; // trim the last space
         if (PyErr_WarnFormat(PyExc_ImportWarning, 1,
             "%sYou cannot %s CPU features (%s), since "
             "they are not part of the dispatched optimizations\n"

--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -274,8 +274,8 @@ npy__cpu_check_env(int disable, const char *env) {
     size_t var_len = strlen(env) + 1;
     if (var_len > NPY__MAX_VAR_LEN) {
         PyErr_Format(PyExc_RuntimeError,
-            "Length of environment variable '%s' is %d, only %d accepted",
-            env_name, var_len, NPY__MAX_VAR_LEN
+            "Length of environment variable '%s' is %zu, only %zu accepted",
+            env_name, var_len, (size_t)NPY__MAX_VAR_LEN
         );
         return -1;
     }

--- a/numpy/_core/src/common/npy_cpu_features.c
+++ b/numpy/_core/src/common/npy_cpu_features.c
@@ -285,7 +285,7 @@ npy__cpu_check_env(int disable, const char *env) {
     char nexist[NPY__MAX_VAR_LEN];
     char *nexist_cur = &nexist[0];
 
-    char notsupp[sizeof(NPY_WITH_CPU_DISPATCH) + 1];
+    char notsupp[NPY__MAX_VAR_LEN];
     char *notsupp_cur = &notsupp[0];
 
     //comma and space including (htab, vtab, CR, LF, FF)
@@ -318,8 +318,11 @@ npy__cpu_check_env(int disable, const char *env) {
         // check if the feature supported by the running machine
         if (!npy__cpu_have[feature_id]) {
             int flen = strlen(feature);
+            if (notsupp_cur != notsupp) {
+                *notsupp_cur++ = ' ';
+            }
             memcpy(notsupp_cur, feature, flen);
-            notsupp_cur[flen] = ' '; notsupp_cur += flen + 1;
+            notsupp_cur += flen;
             goto next;
         }
         // Finally we can disable or mark for enabling
@@ -356,7 +359,6 @@ npy__cpu_check_env(int disable, const char *env) {
 
     *notsupp_cur = '\0';
     if (notsupp[0] != '\0') {
-        *(notsupp_cur-1) = '\0'; // trim the last space
         if (!disable){
             PyErr_Format(PyExc_RuntimeError, NOTSUPP_BODY);
             return -1;

--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -281,6 +281,23 @@ if __name__ == "__main__":
             "`__cpu_dispatch__` is non-empty"
         )
     )
+    @pytest.mark.parametrize("action", ["ENABLE", "DISABLE"])
+    def test_max_length_nonexistent_feature(self, action):
+        """
+        Test that the maximum accepted environment variable length can be
+        processed even if the whole value is an invalid feature name.
+        """
+        MAX_VAR_LENGTH = 1024
+        self.env[f'NPY_{action}_CPU_FEATURES'] = "t" * (MAX_VAR_LENGTH - 1)
+        self._run()
+
+    @pytest.mark.skipif(
+        not __cpu_dispatch__,
+        reason=(
+            "NPY_*_CPU_FEATURES only parsed if "
+            "`__cpu_dispatch__` is non-empty"
+        )
+    )
     def test_impossible_feature_disable(self):
         """
         Test that a RuntimeError is thrown if an impossible feature-disabling

--- a/numpy/_core/tests/test_cpu_features.py
+++ b/numpy/_core/tests/test_cpu_features.py
@@ -352,6 +352,28 @@ if __name__ == "__main__":
             )
             self._expect_error(msg, err_type)
 
+    @pytest.mark.parametrize("action", ["ENABLE", "DISABLE"])
+    def test_repeated_unavailable_feature(self, action):
+        """
+        Test that repeated unavailable features can be processed without
+        overflowing the diagnostic buffer.
+        """
+        if self.UNAVAILABLE_FEAT is None:
+            pytest.skip("There are no unavailable features to test with")
+
+        bad_feature = self.UNAVAILABLE_FEAT
+        feature_repeats = 1024 // (len(bad_feature) + 1)
+        self.env[f'NPY_{action}_CPU_FEATURES'] = ",".join(
+            [bad_feature] * feature_repeats
+        )
+
+        if action == "ENABLE":
+            msg = "You cannot enable CPU features"
+            err_type = "RuntimeError"
+            self._expect_error(msg, err_type)
+        else:
+            self._run()
+
 
 is_linux = sys.platform.startswith('linux')
 is_cygwin = sys.platform.startswith('cygwin')


### PR DESCRIPTION
### PR summary

This is a follow up to gh-30877.

I've had on the back on my mind to verify and check some other issues I saw in the file and finally managed to get to it.

The original PR fixed a buffer overrun in CPU baseline validation. This PR fixes two similar issues in `npy__cpu_check_env`.

The two issues fixed:

- nonexistent features: an accepted maximum-length environment variable value could write the terminating NUL one byte past the `nexist` stack buffer
- unsupported dispatched features: repeated unsupported feature names could overflow the `notsupp` diagnostic buffer, which was sized from `NPY_WITH_CPU_DISPATCH` rather than from the accepted environment variable length.

Both fixes avoid the trailing-space-and-trim pattern when building the diagnostic strings.

Noting though that the fix for the `notsupp` buffer increases stack usage in `npy__cpu_check_env` because the buffer is now bounded by `NPY__MAX_VAR_LEN` instead of  `sizeof(NPY_WITH_CPU_DISPATCH) + 1`. On my x86_64 laptop, `-fstack-usage` reports the function growing from 2224 bytes to 3184 bytes, a 960 bytes increase. The function is non-recursive and only runs while parsing CPU feature environment variables during import, however if the size icrease is deemed unacceptable I can change the approach to something like heap allocation, it will require more code changes though.

These tests are mainly sanitizer regressions, in non-sanitized builds, the previous out-of-bounds writes might not crash.

#### AI Disclosure
I used codex with the gpt 5.5 model. Guided to create the tests, (hence the tests are AI generated) and to review the C code changes, also to verify any incompatibilities (where it verified the stack increase) and to create small reproducers with the same logic for me to actually verify the issues exist.