### PR TITLE
TYP: ``rec.from{arrays,records}`` should accept ``names=`` without ``formats=``

### DIFF
--- a/numpy/_core/records.pyi
+++ b/numpy/_core/records.pyi
@@ -1,4 +1,3 @@
-# pyright: reportSelfClsParameterName=false
 from _typeshed import Incomplete, StrOrBytesPath
 from collections.abc import Buffer, Iterable, Sequence
 from typing import (
@@ -145,14 +144,14 @@ def fromarrays(
     arrayList: Iterable[ArrayLike],
     dtype: None = None,
     shape: _ShapeLike | None = None,
-    *,
-    formats: DTypeLike | None,
+    formats: DTypeLike | None = None,
     names: str | Sequence[str] | None = None,
     titles: str | Sequence[str] | None = None,
     aligned: bool = False,
     byteorder: _ByteOrder | None = None,
 ) -> _RecArray[record]: ...
 
+# exported in `numpy.rec`
 @overload
 def fromrecords(
     recList: _ArrayLikeVoid_co | tuple[object, ...] | _NestedSequence[tuple[object, ...]],
@@ -169,8 +168,7 @@ def fromrecords(
     recList: _ArrayLikeVoid_co | tuple[object, ...] | _NestedSequence[tuple[object, ...]],
     dtype: None = None,
     shape: _ShapeLike | None = None,
-    *,
-    formats: DTypeLike | None,
+    formats: DTypeLike | None = None,
     names: str | Sequence[str] | None = None,
     titles: str | Sequence[str] | None = None,
     aligned: bool = False,

--- a/numpy/typing/tests/data/reveal/rec.pyi
+++ b/numpy/typing/tests/data/reveal/rec.pyi
@@ -61,6 +61,10 @@ assert_type(
     np.recarray,
 )
 assert_type(
+    np.rec.fromarrays(AR_LIST, names=["i8", "f8"]),
+    _RecArray,
+)
+assert_type(
     np.rec.fromarrays(
         AR_LIST,
         formats=[np.int64, np.float64],
@@ -73,7 +77,6 @@ assert_type(
     np.rec.fromrecords((1, 1.5)),
     _RecArray
 )
-
 assert_type(
     np.rec.fromrecords(
         [(1, 1.5)],
@@ -81,13 +84,16 @@ assert_type(
     ),
     _RecArray,
 )
-
 assert_type(
     np.rec.fromrecords(
         REC_AR_V,
         formats=[np.int64, np.float64],
         names=["i8", "f8"]
     ),
+    _RecArray,
+)
+assert_type(
+    np.rec.fromrecords(REC_AR_V, names=["i8", "f8"]),
     _RecArray,
 )
 


### PR DESCRIPTION
Previously, passing `names`  without `formats` to `np.rec.fromarrays` and `np.red.fromrecords` was rejected, even though it's valid at runtime:

```
In [1]: np.rec.fromarrays([np.array([1., 2.]), np.array([3, 4])], names="a,b")
Out[1]: 
rec.array([(1., 3), (2., 4)],
          dtype=[('a', '<f8'), ('b', '<i8')])
```

---

Fully written by me (a human); bug found by Claude Fable 5 ([here's the full (second) audit for those interested](https://gist.github.com/jorenham/9d55eb8ed68d85007d0aa8b0fb1b8813)).

(more stub fixes on the way)