### PR TITLE
TYP: single-operand ``nditer`` should accept nested ``op_flags``

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -1789,7 +1789,7 @@ class nditer:
         /,
         op: ArrayLike,
         flags: Sequence[_NDIterFlagsKind] | None = None,
-        op_flags: Sequence[_NDIterFlagsOp] | None = None,
+        op_flags: Sequence[_NDIterFlagsOp] | Sequence[Sequence[_NDIterFlagsOp]] | None = None,
         op_dtypes: DTypeLike | None = None,
         order: _OrderKACF = "K",
         casting: _CastingKind = "safe",

--- a/numpy/typing/tests/data/fail/nditer.pyi
+++ b/numpy/typing/tests/data/fail/nditer.pyi
@@ -3,6 +3,5 @@ import numpy as np
 class Test(np.nditer): ...  # type: ignore[misc]
 
 np.nditer([0, 1], flags=["test"])  # type: ignore[list-item]
-np.nditer([0, 1], op_flags=[["test"]])  # type: ignore[list-item]
 np.nditer([0, 1], itershape=(1.0,))  # type: ignore[arg-type]
 np.nditer([0, 1], buffersize=1.0)  # type: ignore[call-overload]


### PR DESCRIPTION
At runtime you can do

```
In [1]: np.nditer(np.array([1,2,3]), op_flags=[["readwrite"]])
Out[1]: <numpy.nditer at 0x72bd5f5ba790>
```

but the stubs rejected this.

---

Fully written by me (a human); bug found by Claude Fable 5 ([here's the full (second) audit for those interested](https://gist.github.com/jorenham/9d55eb8ed68d85007d0aa8b0fb1b8813)).

(more stub fixes on the way)