### PR TITLE
TYP: override ``ma.MaskedArray.astype`` to return ``MaskedArray``

### DIFF
--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -28,6 +28,8 @@ from typing_extensions import TypeIs, TypeVar, deprecated
 
 import numpy as np
 from numpy import (
+    _CastingKind,
+    _CopyMode,
     _HasDType,
     _HasDTypeWithRealAndImag,
     _ModeKind,
@@ -1879,6 +1881,27 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
     def put(self, indices: _ArrayLikeInt_co, values: ArrayLike, mode: _ModeKind = "raise") -> None: ...
     def ids(self) -> tuple[int, int]: ...
     def iscontiguous(self) -> bool: ...
+
+    # keep in sync with ndarray.astype
+    @override
+    @overload
+    def astype[ScalarT: generic](
+        self,
+        dtype: _DTypeLike[ScalarT],
+        order: _OrderKACF = "K",
+        casting: _CastingKind = "unsafe",
+        subok: bool = True,
+        copy: bool | _CopyMode = True,
+    ) -> MaskedArray[_ShapeT_co, np.dtype[ScalarT]]: ...
+    @overload
+    def astype(
+        self,
+        dtype: DTypeLike | None,
+        order: _OrderKACF = "K",
+        casting: _CastingKind = "unsafe",
+        subok: bool = True,
+        copy: bool | _CopyMode = True,
+    ) -> MaskedArray[_ShapeT_co, np.dtype]: ...
 
     # Keep in sync with `ma.core.all`
     @overload  # type: ignore[override]

--- a/numpy/typing/tests/data/reveal/ma.pyi
+++ b/numpy/typing/tests/data/reveal/ma.pyi
@@ -460,6 +460,9 @@ assert_type(MAR_f8.view(dtype="float32", type=np.ndarray), np.ndarray[Any, Any])
 assert_type(MAR_2d_f4.view(dtype=np.float16), np.ma.MaskedArray[tuple[int, int], np.dtype[np.float16]])
 assert_type(MAR_2d_f4.view(dtype=np.dtype(np.float16)), np.ma.MaskedArray[tuple[int, int], np.dtype[np.float16]])
 
+assert_type(MAR_2d_f4.astype(np.float16), np.ma.MaskedArray[tuple[int, int], np.dtype[np.float16]])
+assert_type(MAR_2d_f4.astype("f2"), np.ma.MaskedArray[tuple[int, int], np.dtype[Any]])
+
 assert_type(MAR_f8.__deepcopy__(), MaskedArray[np.float64])
 
 assert_type(MAR_f8.argsort(), MaskedArray[np.intp])


### PR DESCRIPTION
`ma.MaskedArray.astype` used to be inherited from `ndarray.astype` in the stubs, causing it to return a `ndarray` kind instead of `MaskedArray`. The only way to fix this is by overriding `asarray` in `MaskedArray` (Python has no support for higher kinded typing and `typing.Self` cannot be used as a generic type).

---

Fully written by me (a human); bug found by Claude Fable 5 ([here's the full (second) audit for those interested](https://gist.github.com/jorenham/9d55eb8ed68d85007d0aa8b0fb1b8813)).

(even more stub fixes on the way)