### PR TITLE
DOC: add Examples section to np.ma.apply_along_axis [skip ci]

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -349,7 +349,36 @@ def flatten_inplace(seq):
 
 def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     """
-    (This docstring should be overwritten)
+    Apply a function to 1-D slices of a masked array along an axis.
+
+    This function is the equivalent of `numpy.apply_along_axis` that returns
+    a masked array.  See `numpy.apply_along_axis` for the full documentation.
+
+    See Also
+    --------
+    numpy.apply_along_axis : Equivalent function for ndarrays.
+
+    Examples
+    --------
+    >>> import numpy as np
+
+    Sum each column, skipping masked values:
+
+    >>> a = np.ma.array([[1, 2, 3],
+    ...                  [4, 5, 6]], mask=[[0, 1, 0],
+    ...                                    [0, 0, 1]])
+    >>> np.ma.apply_along_axis(np.ma.sum, 0, a)
+    masked_array(data=[5, 5, 3],
+                 mask=False,
+           fill_value=999999)
+
+    Compute the mean of each row, ignoring masked values:
+
+    >>> np.ma.apply_along_axis(np.ma.mean, 1, a)
+    masked_array(data=[2. , 4.5],
+                 mask=False,
+           fill_value=1e+20)
+
     """
     arr = array(arr, copy=False, subok=True)
     nd = arr.ndim
@@ -429,7 +458,6 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     return result
 
 
-apply_along_axis.__doc__ = np.apply_along_axis.__doc__
 
 
 def apply_over_axes(func, a, axes):


### PR DESCRIPTION
### PR summary
- Replaced the placeholder docstring with a real one and added two Examples showing masked array behavior.
- Removed the __doc__ override line which shows nothing about masked array


### First time committer introduction
Not a first-time contributor - this is my fourth documentation PR
#31802 
#31852 
#31907 

#### AI Disclosure
An AI assistant (Anthropic's Claude, via the Claude desktop app) was used to locate np.ma.apply_along_axis as a function whose docstring lacked masked-array-specific examples, draft the standalone docstring and two examples, and verify they pass as doctests. I reviewed and understand each line; the change is documentation-only.
