### PR TITLE
TYP: minor ``random`` typing fixes

### DIFF
--- a/numpy/random/_generator.pyi
+++ b/numpy/random/_generator.pyi
@@ -17,6 +17,7 @@ from numpy._typing import (
     _FloatLike_co,
     _Int64Codes,
     _NestedSequence,
+    _Shape,
     _ShapeLike,
 )
 
@@ -680,8 +681,10 @@ class Generator:
     def permutation(self, /, x: ArrayLike, axis: int = 0) -> np.ndarray: ...
 
     #
-    @overload
-    def permuted[ArrayT: np.ndarray](self, /, x: ArrayT, *, axis: int | None = None, out: None = None) -> ArrayT: ...
+    @overload  # does not preserve `ndarray` subtypes
+    def permuted[ShapeT: _Shape, DTypeT: np.dtype](
+        self, /, x: np.ndarray[ShapeT, DTypeT], *, axis: int | None = None, out: None = None
+    ) -> np.ndarray[ShapeT, DTypeT]: ...
     @overload
     def permuted(self, /, x: ArrayLike, *, axis: int | None = None, out: None = None) -> np.ndarray: ...
     @overload

--- a/numpy/random/mtrand.pyi
+++ b/numpy/random/mtrand.pyi
@@ -458,7 +458,7 @@ class RandomState:
         low: int,
         high: int | None = None,
         size: None = None,
-    ) -> int: ...
+    ) -> np.long: ...
     @overload
     def random_integers(
         self,


### PR DESCRIPTION
This fixes:

-  ``random.RandomState.random_integers`` scalar input returns ``np.long``, not a builtin ``int``
- ``random.Generator.permuted`` doesn't preserve array subtypes

I don't think this is worth backporting (legacy/niche)

---

No AI used for writing any code. Claude Fable 5 spotted these issues.