### PR TITLE
BUG: respect pathsep for f2py include paths

### DIFF
--- a/doc/release/upcoming_changes/31934.improvement.rst
+++ b/doc/release/upcoming_changes/31934.improvement.rst
@@ -1,0 +1,4 @@
+``f2py`` handles platform-specific separators in ``--include-paths``
+--------------------------------------------------------------------
+``f2py --include-paths`` now splits include directories using the platform
+path separator, fixing parsing of Windows paths containing drive letters.

--- a/doc/source/f2py/usage.rst
+++ b/doc/source/f2py/usage.rst
@@ -93,7 +93,7 @@ Here ``<fortran files>`` may also contain signature files. Among other options
   ``--freethreading-compatible``, as ``f2py`` does not analyze fortran code for
   thread safety issues.
 
-``--include-paths "<path1>:<path2>..."``
+``--include-paths "<path1><pathsep><path2>..."``
   Search include files from given directories.
 
   .. note:: The paths are to be separated by the correct operating system

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -113,8 +113,8 @@ Options:
                    --no-freethreading-compatible, as f2py does not analyze
                    fortran code for thread safety issues.
 
-  --include-paths <path1>:<path2>:...   Search include files from the given
-                   directories.
+  --include-paths <path1><pathsep><path2>...
+                  Search include files from the given directories.
 
   --f2cmap <filename>  Load Fortran-to-Python KIND specification from the given
                    file. Default: .f2py_f2cmap in current directory.
@@ -540,7 +540,7 @@ class CombineIncludePaths(argparse.Action):
         if option_string == "--include_paths":
             outmess("Use --include-paths or -I instead of --include_paths which will be removed")
         if option_string in {"--include-paths", "--include_paths"}:
-            include_paths_set.update(values.split(':'))
+            include_paths_set.update(values.split(os.pathsep))
         else:
             include_paths_set.add(values)
         namespace.include_paths = list(include_paths_set)

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from numpy.f2py.f2py2e import main as f2pycli
+from numpy.f2py.f2py2e import get_newer_options, main as f2pycli
 from numpy.testing._private.utils import NOGIL_BUILD
 
 from . import util
@@ -714,13 +714,44 @@ def test_cli_obj(capfd, hello_world_f90, monkeypatch):
             assert f"'''{obj}'''" in mbld
 
 
-def test_inclpath():
+def test_inclpath(monkeypatch):
     """Add to the include directories
 
     CLI :: --include-paths
     """
-    # TODO: populate
-    pass
+    monkeypatch.setattr(os, "pathsep", ";")
+
+    include_paths, ftcompat, remain = get_newer_options(
+        ["--include-paths", r"C:\inc1"]
+    )
+
+    assert include_paths == [r"C:\inc1"]
+    assert ftcompat is None
+    assert remain == []
+
+    include_paths, ftcompat, remain = get_newer_options(
+        ["--include-paths", r"C:\inc1;D:\inc2"]
+    )
+
+    assert set(include_paths) == {r"C:\inc1", r"D:\inc2"}
+    assert ftcompat is None
+    assert remain == []
+
+    include_paths, ftcompat, remain = get_newer_options(
+        ["--include_paths", r"C:\inc1;D:\inc2"]
+    )
+
+    assert set(include_paths) == {r"C:\inc1", r"D:\inc2"}
+    assert ftcompat is None
+    assert remain == []
+
+    include_paths, ftcompat, remain = get_newer_options(
+        ["-I", r"C:\inc1;D:\inc2"]
+    )
+
+    assert include_paths == [r"C:\inc1;D:\inc2"]
+    assert ftcompat is None
+    assert remain == []
 
 
 def test_hlink():


### PR DESCRIPTION
`--include-paths` is documented as a path-list option, so it should be parsed using the current platform's path separator. However, the implementation currently splits it with a hard-coded `:`, which incorrectly splits Windows drive-letter paths such as `C:\...`.

### PR summary

Fixes #31933.

#### What Problem This Solves

`f2py --include-paths` is documented as a path-list option whose entries should be separated with the platform path separator (`os.pathsep`): `:` on POSIX and `;` on Windows. The current parser instead splits `--include-paths` and the deprecated `--include_paths` form on `:` unconditionally.

That is incorrect for native Windows paths, because a drive-letter path such as `C:\inc1` contains `:` as part of the path itself. As a result, the parser can split a single Windows include directory into invalid pieces before F2PY passes the include path list downstream.

#### Changes

This PR updates the `--include-paths` and deprecated `--include_paths` parser branch to split on `os.pathsep`. It leaves `-I <path>` unchanged as a single include-directory option.

```diff
 if option_string in {--include-paths, --include_paths}:
-    include_paths_set.update(values.split(':'))
+    include_paths_set.update(values.split(os.pathsep))
 else:
     include_paths_set.add(values)
```

The change is intentionally scoped to F2PY CLI option parsing and the corresponding help/docs text. It does not change Fortran include-file resolution, Meson/backend include propagation, or compiler `-I` handling.

The PR also updates the CLI help/docs wording from the POSIX-looking `<path1>:<path2>` form to the platform-neutral `<path1><pathsep><path2>` form, and adds parser-level regression coverage for Windows-style drive-letter paths and Windows-style path lists.

#### Evidence

Validation performed locally:

- Parser-only check against the patched `numpy/f2py/f2py2e.py` definitions:
  - `--include-paths C:\inc1` remains one path
  - `--include-paths C:\inc1;D:\inc2` splits into two paths when `os.pathsep == ;`
  - deprecated `--include_paths` follows the same path-list behavior
  - `-I C:\inc1;D:\inc2` remains one single path
- `git diff --check`

Remote validation:

- CI passed on this PR, including lint, Windows, Linux, macOS, wheel builds, MyPy, stubtest, and CircleCI docs/build checks.

### First time committer introduction

This change was found while reviewing F2PY path handling on Windows, especially the difference between path-list parsing for `--include-paths` and single-path handling for `-I`.

#### AI Disclosure

AI assisted with identifying the issue and drafting the patch. The final code was reviewed and submitted by the human contributor.