### PR TITLE
TYP: specialized ``a[rc]tan2`` and ``hypot`` ufuncs

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -401,6 +401,8 @@ from numpy._core.umath import (
     arcsinh as asinh,
     arctan,
     arctan as atan,
+    arctan2,
+    arctan2 as atan2,
     arctanh,
     arctanh as atanh,
     bitwise_count,
@@ -423,6 +425,7 @@ from numpy._core.umath import (
     greater,
     greater_equal,
     heaviside,
+    hypot,
     invert,
     invert as bitwise_invert,
     invert as bitwise_not,
@@ -7628,7 +7631,6 @@ class ufunc:
 
 # Parameters: `__name__`, `ntypes` and `identity`
 add: _UFunc_Nin2_Nout1[L["add"], L[22], L[0]]
-arctan2: _UFunc_Nin2_Nout1[L["arctan2"], L[5], None]
 bitwise_and: _UFunc_Nin2_Nout1[L["bitwise_and"], L[12], L[-1]]
 bitwise_or: _UFunc_Nin2_Nout1[L["bitwise_or"], L[12], L[0]]
 bitwise_xor: _UFunc_Nin2_Nout1[L["bitwise_xor"], L[12], L[0]]
@@ -7640,7 +7642,6 @@ fmax: _UFunc_Nin2_Nout1[L["fmax"], L[21], None]
 fmin: _UFunc_Nin2_Nout1[L["fmin"], L[21], None]
 fmod: _UFunc_Nin2_Nout1[L["fmod"], L[15], None]
 gcd: _UFunc_Nin2_Nout1[L["gcd"], L[11], L[0]]
-hypot: _UFunc_Nin2_Nout1[L["hypot"], L[5], L[0]]
 lcm: _UFunc_Nin2_Nout1[L["lcm"], L[11], None]
 left_shift: _UFunc_Nin2_Nout1[L["left_shift"], L[11], None]
 matmul: _GUFunc_Nin2_Nout1[L["matmul"], L[19], None, L["(n?,k),(k,m?)->(n?,m?)"]]
@@ -7655,7 +7656,6 @@ subtract: _UFunc_Nin2_Nout1[L["subtract"], L[21], None]
 vecdot: _GUFunc_Nin2_Nout1[L["vecdot"], L[19], None, L["(n),(n)->()"]]
 vecmat: _GUFunc_Nin2_Nout1[L["vecmat"], L[19], None, L["(n),(n,m)->(m)"]]
 
-atan2 = arctan2
 concat = concatenate
 bitwise_left_shift = left_shift
 bitwise_right_shift = right_shift

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -25,7 +25,6 @@ from numpy import (
     _CastingKind,
     _OrderKACF,
     add,
-    arctan2,
     bitwise_and,
     bitwise_or,
     bitwise_xor,
@@ -41,7 +40,6 @@ from numpy import (
     fmod,
     frompyfunc,
     gcd,
-    hypot,
     lcm,
     left_shift,
     matmul,
@@ -6129,6 +6127,12 @@ heaviside: Final[_ufunc_21_f[None]] = ...
 logaddexp: Final[_ufunc_21_f[float]] = ...
 logaddexp2: Final[_ufunc_21_f[float]] = ...
 nextafter: Final[_ufunc_21_f[None]] = ...
+
+# technically these also accept `object_` dtypes, but that requires the underlying python
+# object to have a `.arctan2`/`.hypot()` method, which is unlikely to exist on non-numpy
+# types, so it would be type-unsafe to (explicitly) allow `object_` dtypes here.
+arctan2: Final[_ufunc_21_f[None]] = ...
+hypot: Final[_ufunc_21_f[Literal[0]]] = ...
 
 ###
 # re-exports from `_core._multiarray_umath` that are used by `_core._ufunc_config`


### PR DESCRIPTION
These two ufuncs technically accept `object_` dtypes, but in that case it delegates to `arctan2`/`hypot` methods of the wrapped python objects, which in most cases will lead to an (IMO confusing) error:

```
In [1]: np.hypot(np.array(1, np.object_), 1)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[1], line 1
----> 1 np.hypot(np.array(1, np.object_), 1)

AttributeError: 'int' object has no attribute 'hypot'
```

(it took me a while to realize that it wasn't `np` that was shadowed by an `int` here)

So because of this type-unsafety, I instead recycled the existing `floating * floating -> floating` ufunc specialization here. 

---

No AI.