### PR TITLE
BUG: restore ndarray.conjugate() for legacy user-defined dtypes

### DIFF
--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -828,16 +828,16 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
 NPY_NO_EXPORT PyObject *
 PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
 {
-    if (NPY_DT_SLOTS(NPY_DTYPE(PyArray_DTYPE(self)))->imag_meth != NULL
-            || PyArray_ISUSERDEF(self)) {
-        /*
-         * The dtype has `arr.imag` so `conjugate` must exist (or error).
-         * Legacy user-defined dtypes (`type_num >= NPY_USERDEF`) have no
-         * `imag_meth` and are not flagged numeric, but they may register a
-         * `conjugate` ufunc loop (e.g., quaternion), so dispatch to the ufunc
-         * for them as well, preserving the pre-2.5 behavior.  (New-style
-         * user dtypes have `type_num == -1` and are unaffected by this.)
-         */
+    PyArray_DTypeMeta *dtype = NPY_DTYPE(PyArray_DESCR(self));
+    /*
+     * If a dtype doesn't define `imag_meth` and is numeric, we assume it isn't
+     * a complex dtype (`conjugate()` does nothing).
+     * For user defined legacy dtypes we always try the ufunc unless for backwards
+     * compatibility (could be deprecated). Unless they flag "numeric" because if
+     * they do they live in a future where they could set `imag_meth` as well.
+     */
+    if (NPY_DT_SLOTS(dtype)->imag_meth != NULL
+            || (PyArray_ISUSERDEF(self) && !NPY_DT_is_numeric(dtype))) {
         if (out == NULL) {
             return PyArray_GenericUnaryFunction(self,
                                                 n_ops.conjugate);
@@ -849,7 +849,7 @@ PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
         }
     }
     else {
-        if (!NPY_DT_is_numeric(NPY_DTYPE(PyArray_DTYPE(self)))) {
+        if (!NPY_DT_is_numeric(dtype)) {
             PyErr_SetString(PyExc_TypeError,
                             "cannot conjugate non-numeric dtype");
             return NULL;

--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -832,7 +832,7 @@ PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
     /*
      * If a dtype doesn't define `imag_meth` and is numeric, we assume it isn't
      * a complex dtype (`conjugate()` does nothing).
-     * For user defined legacy dtypes we always try the ufunc unless for backwards
+     * For user defined legacy dtypes we always try the ufunc for backwards
      * compatibility (could be deprecated). Unless they flag "numeric" because if
      * they do they live in a future where they could set `imag_meth` as well.
      */

--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -828,8 +828,16 @@ PyArray_Clip(PyArrayObject *self, PyObject *min, PyObject *max, PyArrayObject *o
 NPY_NO_EXPORT PyObject *
 PyArray_Conjugate(PyArrayObject *self, PyArrayObject *out)
 {
-    if (NPY_DT_SLOTS(NPY_DTYPE(PyArray_DTYPE(self)))->imag_meth != NULL) {
-        /* The dtype has `arr.imag` so `conjugate` must exist (or error) */
+    if (NPY_DT_SLOTS(NPY_DTYPE(PyArray_DTYPE(self)))->imag_meth != NULL
+            || PyArray_ISUSERDEF(self)) {
+        /*
+         * The dtype has `arr.imag` so `conjugate` must exist (or error).
+         * Legacy user-defined dtypes (`type_num >= NPY_USERDEF`) have no
+         * `imag_meth` and are not flagged numeric, but they may register a
+         * `conjugate` ufunc loop (e.g., quaternion), so dispatch to the ufunc
+         * for them as well, preserving the pre-2.5 behavior.  (New-style
+         * user dtypes have `type_num == -1` and are unaffected by this.)
+         */
         if (out == NULL) {
             return PyArray_GenericUnaryFunction(self,
                                                 n_ops.conjugate);

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -4535,6 +4535,14 @@ class TestMethods:
         with pytest.raises(TypeError, match="cannot conjugate non-numeric dtype"):
             a.conj()
 
+    def test_conjugate_legacy_user_dtype(self):
+        # gh-31754 : legacy user-defined dtypes are not flagged numeric and have
+        # no `.imag`, but `conjugate` must still dispatch to the ufunc (which
+        # falls back to a cast for `rational`) rather than raising.
+        a = np.array([1, 2, 3], dtype=rational)
+        assert_array_equal(a.conjugate(), np.conjugate(a))
+        assert_array_equal(a.conjugate(), [1, 2, 3])
+
     def test_conjugate_out(self):
         # Minimal test for the out argument being passed on correctly
         # NOTE: The ability to pass `out` is currently undocumented!


### PR DESCRIPTION
Kept the old PR.  The problem is that while legacy user dtypes _can_ implement things and even make themselves "Numeric" in theory, they aren't in practice and they should probably just keep trying the ufunc...

However, unlike the old PR.  However, at least open a path forward if the numeric flag is set (possible via new "backport" API) and maybe we can even provide a nicer way to set it (not that you can't just do it in theory...).

CC @moble 

Closes gh-31754