### PR TITLE
PERF: avoid an unnecessary copy in np.take with out=

### DIFF
--- a/doc/release/upcoming_changes/31940.compatibility.rst
+++ b/doc/release/upcoming_changes/31940.compatibility.rst
@@ -1,0 +1,8 @@
+``np.take`` may modify ``out`` when an index is out of bounds
+-------------------------------------------------------------
+With the default ``mode="raise"``, `numpy.take` now writes its result
+directly into the ``out`` array instead of into a temporary copy. As a
+consequence, ``out`` may be partially modified when an out-of-bounds index
+raises an ``IndexError``; previously ``out`` was guaranteed to be left
+unchanged in that case. Code that relies on ``out`` keeping its previous
+contents after such an error should pass a fresh array as ``out``.

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -302,15 +302,6 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
         if (arrays_overlap(out, self)) {
             flags |= NPY_ARRAY_ENSURECOPY;
         }
-
-        if (clipmode == NPY_RAISE) {
-            /*
-             * we need to make sure and get a copy
-             * so the input array is not changed
-             * before the error is called
-             */
-            flags |= NPY_ARRAY_ENSURECOPY;
-        }
         dtype = PyArray_DESCR(self);
         out_dtype = PyArray_DESCR(out);
         if (dtype != out_dtype) {

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -6268,6 +6268,38 @@ class TestTake:
         ret = np.take(x, inds, out=out)
         assert ret is out
 
+    def test_out_matches_no_out(self):
+        # gh-28636: with out=, take now writes directly into out instead of
+        # through a temporary copy. The result must match a plain take.
+        rng = np.random.default_rng(1)
+        for dtype in (np.float64, np.int32, np.complex128, np.uint8):
+            x = (rng.random((4, 5, 6)) * 100).astype(dtype)
+            for axis in (0, 1, 2, -1):
+                idx = rng.integers(0, x.shape[axis], size=7)
+                expected = np.take(x, idx, axis=axis)
+                out = np.empty_like(expected)
+                ret = np.take(x, idx, axis=axis, out=out)
+                assert ret is out
+                assert_array_equal(out, expected)
+
+    def test_out_raise_still_raises(self):
+        # gh-28636: an out-of-bounds index must still raise with out=.
+        x = np.arange(10.0)
+        out = np.empty(3)
+        assert_raises(IndexError, np.take, x, [1, 20, 3], out=out)
+        assert_raises(IndexError, np.take, x, [-11, 1, 2], out=out)
+        # valid indices into the same out still work
+        assert_array_equal(np.take(x, [1, 2, 3], out=out), [1, 2, 3])
+
+    def test_out_object_identity(self):
+        # object dtype. references must be copied into out.
+        a, b, c = [1], [2], [3]
+        x = np.empty(3, dtype=object)
+        x[0], x[1], x[2] = a, b, c
+        out = np.empty(3, dtype=object)
+        np.take(x, [2, 0, 1], out=out)
+        assert out[0] is c and out[1] is a and out[2] is b
+
 
 class TestLexsort:
     @pytest.mark.parametrize('dtype', [


### PR DESCRIPTION
### PR summary

Fixes #28636.

`np.take(a, indices, out=out)` in the default `mode="raise"` was slower than the same call without `out`. `PyArray_TakeFrom` forced a defensive `ENSURECOPY` of `out` and wrote through a temporary that was copied back on success and only so `out` stayed unchanged if an out-of-bounds index raised

this removes that copy so in `raise` mode the result is written directly into `out` just like `mode="wrap"`/`"clip"` already do. The overlap-with-`self` copy (`arrays_overlap`) was kept so aliasing stays correct.

there **IS a behavior change on an out-of-bounds index** since `out` may now be partially written before `IndexError` is raised (previously it was left unchanged). `take` still raises. This proooobably warrants a release note and I'll write it after review

Before/after `out=`

- 1-D, 85 -> 9350 elems: `7.66us -> 4.90us` (1.56x)
- 1-D, 1000 -> 100000 elems: `99.5us -> 47.3us` (2.11x)
- axis 0, `(200, 64) -> (4000, 64)`: `214us -> 64.6us` (3.31x)

The no-`out` path is unchanged and the speedup grows with output size (since the removed copy is `O(n)`)

#### AI Disclosure

Used AI to double check my code + find any edge cases I might've missed :)