### PR TITLE
BUG: support integer pinv inputs with rtol=None

### DIFF
--- a/doc/release/upcoming_changes/31942.improvement.rst
+++ b/doc/release/upcoming_changes/31942.improvement.rst
@@ -1,0 +1,4 @@
+`numpy.linalg.pinv` handles integer inputs with ``rtol=None``
+--------------------------------------------------------------
+`numpy.linalg.pinv` now accepts integer input arrays when ``rtol=None``
+uses the Array API default tolerance.

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -2213,7 +2213,7 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
         if rtol is _NoValue:
             rcond = 1e-15
         elif rtol is None:
-            rcond = max(a.shape[-2:]) * finfo(a.dtype).eps
+            rcond = max(a.shape[-2:]) * finfo(_commonType(a)[1]).eps
         else:
             rcond = rtol
     elif rtol is not _NoValue:

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -945,6 +945,16 @@ def test_pinv_rtol_arg():
         np.linalg.pinv(a, rcond=0.5, rtol=0.5)
 
 
+@pytest.mark.parametrize("dtype", [np.int32, np.int64])
+def test_pinv_rtol_none_integer(dtype):
+    a = np.array([[1, 2], [3, 4]], dtype=dtype)
+
+    assert_allclose(
+        np.linalg.pinv(a, rtol=None),
+        np.linalg.pinv(a.astype(np.float64), rtol=None),
+    )
+
+
 class DetCases(LinalgSquareTestCase, LinalgGeneralizedSquareTestCase):
 
     def do(self, a, b, tags):


### PR DESCRIPTION
Closes #30917

`numpy.linalg.pinv(..., rtol=None)` currently computes the Array API default cutoff using the input dtype. That raises `ValueError` for integer arrays because `finfo` only accepts inexact dtypes.

Use the promoted linear-algebra result dtype for the cutoff instead. This matches the dtype already used by the SVD path and keeps the existing behavior for floating-point inputs.

Regression coverage compares `int32` and `int64` inputs against their `float64` equivalents.

Tests:

- `spin test --no-build numpy/linalg/tests/test_linalg.py` (`443 passed, 2 skipped, 2 xfailed`)
- Focused `pinv` `rtol` tests (`3 passed`)
- `ruff check numpy/linalg/_linalg.py numpy/linalg/tests/test_linalg.py`
