### PR TITLE
MAINT, ENH: Tuple-spec `array_function_dispatch` 

### DIFF
--- a/numpy/_core/defchararray.py
+++ b/numpy/_core/defchararray.py
@@ -54,11 +54,7 @@ array_function_dispatch = functools.partial(
     overrides.array_function_dispatch, module='numpy.char')
 
 
-def _binary_op_dispatcher(x1, x2):
-    return (x1, x2)
-
-
-@array_function_dispatch(_binary_op_dispatcher)
+@array_function_dispatch(("x1", "x2"))
 def equal(x1, x2):
     """
     Return (x1 == x2) element-wise.
@@ -92,7 +88,7 @@ def equal(x1, x2):
     return compare_chararrays(x1, x2, '==', True)
 
 
-@array_function_dispatch(_binary_op_dispatcher)
+@array_function_dispatch(("x1", "x2"))
 def not_equal(x1, x2):
     """
     Return (x1 != x2) element-wise.
@@ -126,7 +122,7 @@ def not_equal(x1, x2):
     return compare_chararrays(x1, x2, '!=', True)
 
 
-@array_function_dispatch(_binary_op_dispatcher)
+@array_function_dispatch(("x1", "x2"))
 def greater_equal(x1, x2):
     """
     Return (x1 >= x2) element-wise.
@@ -161,7 +157,7 @@ def greater_equal(x1, x2):
     return compare_chararrays(x1, x2, '>=', True)
 
 
-@array_function_dispatch(_binary_op_dispatcher)
+@array_function_dispatch(("x1", "x2"))
 def less_equal(x1, x2):
     """
     Return (x1 <= x2) element-wise.
@@ -195,7 +191,7 @@ def less_equal(x1, x2):
     return compare_chararrays(x1, x2, '<=', True)
 
 
-@array_function_dispatch(_binary_op_dispatcher)
+@array_function_dispatch(("x1", "x2"))
 def greater(x1, x2):
     """
     Return (x1 > x2) element-wise.
@@ -229,7 +225,7 @@ def greater(x1, x2):
     return compare_chararrays(x1, x2, '>', True)
 
 
-@array_function_dispatch(_binary_op_dispatcher)
+@array_function_dispatch(("x1", "x2"))
 def less(x1, x2):
     """
     Return (x1 < x2) element-wise.

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -116,11 +116,7 @@ def _wrapreduction_any_all(obj, ufunc, method, axis, out,
     return ufunc.reduce(obj, axis, bool, out, **passkwargs)
 
 
-def _take_dispatcher(a, indices, axis=None, out=None, mode=None):
-    return (a, out)
-
-
-@array_function_dispatch(_take_dispatcher)
+@array_function_dispatch(("a", "out"))
 def take(a, indices, axis=None, out=None, mode='raise'):
     """
     Take elements from an array along an axis.
@@ -217,11 +213,7 @@ def take(a, indices, axis=None, out=None, mode='raise'):
     return _wrapfunc(a, 'take', indices, axis=axis, out=out, mode=mode)
 
 
-def _top_k_dispatcher(a, k, /, *, axis=-1, mode="largest", sorted=True):
-    return (a,)
-
-
-@array_function_dispatch(_top_k_dispatcher)
+@array_function_dispatch(("a",))
 def top_k(a, k, /, *, axis=-1, mode="largest", sorted=True):
     """
     Returns the ``k`` largest or smallest elements and their
@@ -323,11 +315,7 @@ def top_k(a, k, /, *, axis=-1, mode="largest", sorted=True):
     return (values, indices)
 
 
-def _reshape_dispatcher(a, /, shape, order=None, *, copy=None):
-    return (a,)
-
-
-@array_function_dispatch(_reshape_dispatcher)
+@array_function_dispatch(("a",))
 def reshape(a, /, shape, order='C', *, copy=None):
     """
     Returns a reshaped ndarray without changing data.
@@ -553,11 +541,7 @@ def choose(a, choices, out=None, mode='raise'):
     return _wrapfunc(a, 'choose', choices, out=out, mode=mode)
 
 
-def _repeat_dispatcher(a, repeats, axis=None):
-    return (a,)
-
-
-@array_function_dispatch(_repeat_dispatcher)
+@array_function_dispatch(("a",))
 def repeat(a, repeats, axis=None):
     """
     Repeat each element of an array after themselves
@@ -606,11 +590,7 @@ def repeat(a, repeats, axis=None):
     return _wrapfunc(a, 'repeat', repeats, axis=axis)
 
 
-def _put_dispatcher(a, ind, v, mode=None):
-    return (a, ind, v)
-
-
-@array_function_dispatch(_put_dispatcher)
+@array_function_dispatch(("a", "ind", "v"))
 def put(a, ind, v, mode='raise'):
     """
     Replaces specified elements of an array with given values.
@@ -670,11 +650,7 @@ def put(a, ind, v, mode='raise'):
     return put(ind, v, mode=mode)
 
 
-def _swapaxes_dispatcher(a, axis1, axis2):
-    return (a,)
-
-
-@array_function_dispatch(_swapaxes_dispatcher)
+@array_function_dispatch(("a",))
 def swapaxes(a, axis1, axis2):
     """
     Interchange two axes of an array.
@@ -722,11 +698,7 @@ def swapaxes(a, axis1, axis2):
     return _wrapfunc(a, 'swapaxes', axis1, axis2)
 
 
-def _transpose_dispatcher(a, axes=None):
-    return (a,)
-
-
-@array_function_dispatch(_transpose_dispatcher)
+@array_function_dispatch(("a",))
 def transpose(a, axes=None):
     """
     Returns an array with axes transposed.
@@ -802,10 +774,7 @@ def transpose(a, axes=None):
     return _wrapfunc(a, 'transpose', axes)
 
 
-def _matrix_transpose_dispatcher(x):
-    return (x,)
-
-@array_function_dispatch(_matrix_transpose_dispatcher)
+@array_function_dispatch(("x",))
 def matrix_transpose(x, /):
     """
     Transposes a matrix (or a stack of matrices) ``x``.
@@ -850,11 +819,7 @@ def matrix_transpose(x, /):
     return swapaxes(x, -1, -2)
 
 
-def _partition_dispatcher(a, kth, axis=None, kind=None, order=None, descending=None):
-    return (a,)
-
-
-@array_function_dispatch(_partition_dispatcher)
+@array_function_dispatch(("a",))
 def partition(a, kth, axis=-1, kind=np._NoValue, order=None, descending=np._NoValue):
     """
     Return a partitioned copy of an array.
@@ -987,11 +952,7 @@ def partition(a, kth, axis=-1, kind=np._NoValue, order=None, descending=np._NoVa
     return a
 
 
-def _argpartition_dispatcher(a, kth, axis=None, kind=None, order=None, descending=None):
-    return (a,)
-
-
-@array_function_dispatch(_argpartition_dispatcher)
+@array_function_dispatch(("a",))
 def argpartition(a, kth, axis=-1, kind=np._NoValue, order=None, descending=np._NoValue):
     """
     Perform an indirect partition along the given axis using the
@@ -1097,13 +1058,7 @@ def argpartition(a, kth, axis=-1, kind=np._NoValue, order=None, descending=np._N
     return _wrapfunc(a, "argpartition", kth, axis=axis, order=order, **kwargs)
 
 
-def _sort_dispatcher(
-    a, axis=None, kind=None, order=None, *, stable=None, descending=None
-):
-    return (a,)
-
-
-@array_function_dispatch(_sort_dispatcher)
+@array_function_dispatch(("a",))
 def sort(a, axis=-1, kind=None, order=None, *, stable=None, descending=np._NoValue):
     """
     Return a sorted copy of an array.
@@ -1254,13 +1209,7 @@ def sort(a, axis=-1, kind=None, order=None, *, stable=None, descending=np._NoVal
     return a
 
 
-def _argsort_dispatcher(
-    a, axis=None, kind=None, order=None, *, stable=None, descending=None
-):
-    return (a,)
-
-
-@array_function_dispatch(_argsort_dispatcher)
+@array_function_dispatch(("a",))
 def argsort(a, axis=-1, kind=None, order=None, *, stable=None, descending=np._NoValue):
     """
     Returns the indices that would sort an array.
@@ -1400,11 +1349,7 @@ def argsort(a, axis=-1, kind=None, order=None, *, stable=None, descending=np._No
         stable=stable,
     )
 
-def _argmax_dispatcher(a, axis=None, out=None, *, keepdims=np._NoValue):
-    return (a, out)
-
-
-@array_function_dispatch(_argmax_dispatcher)
+@array_function_dispatch(("a", "out"))
 def argmax(a, axis=None, out=None, *, keepdims=np._NoValue):
     """
     Returns the indices of the maximum values along an axis.
@@ -1500,11 +1445,7 @@ def argmax(a, axis=None, out=None, *, keepdims=np._NoValue):
     return _wrapfunc(a, 'argmax', axis=axis, out=out, **kwds)
 
 
-def _argmin_dispatcher(a, axis=None, out=None, *, keepdims=np._NoValue):
-    return (a, out)
-
-
-@array_function_dispatch(_argmin_dispatcher)
+@array_function_dispatch(("a", "out"))
 def argmin(a, axis=None, out=None, *, keepdims=np._NoValue):
     """
     Returns the indices of the minimum values along an axis.
@@ -1600,11 +1541,7 @@ def argmin(a, axis=None, out=None, *, keepdims=np._NoValue):
     return _wrapfunc(a, 'argmin', axis=axis, out=out, **kwds)
 
 
-def _searchsorted_dispatcher(a, v, side=None, sorter=None):
-    return (a, v, sorter)
-
-
-@array_function_dispatch(_searchsorted_dispatcher)
+@array_function_dispatch(("a", "v", "sorter"))
 def searchsorted(a, v, side='left', sorter=None):
     """
     Find indices where elements should be inserted to maintain order.
@@ -1687,11 +1624,7 @@ def searchsorted(a, v, side='left', sorter=None):
     return _wrapfunc(a, 'searchsorted', v, side=side, sorter=sorter)
 
 
-def _resize_dispatcher(a, new_shape):
-    return (a,)
-
-
-@array_function_dispatch(_resize_dispatcher)
+@array_function_dispatch(("a",))
 def resize(a, new_shape):
     """
     Return a new array with the specified shape.
@@ -1775,11 +1708,7 @@ def resize(a, new_shape):
     return reshape(a, new_shape)
 
 
-def _squeeze_dispatcher(a, axis=None):
-    return (a,)
-
-
-@array_function_dispatch(_squeeze_dispatcher)
+@array_function_dispatch(("a",))
 def squeeze(a, axis=None):
     """
     Remove axes of length one from `a`.
@@ -1849,11 +1778,7 @@ def squeeze(a, axis=None):
         return squeeze(axis=axis)
 
 
-def _diagonal_dispatcher(a, offset=None, axis1=None, axis2=None):
-    return (a,)
-
-
-@array_function_dispatch(_diagonal_dispatcher)
+@array_function_dispatch(("a",))
 def diagonal(a, offset=0, axis1=0, axis2=1):
     """
     Return specified diagonals.
@@ -1984,12 +1909,7 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
         return asanyarray(a).diagonal(offset=offset, axis1=axis1, axis2=axis2)
 
 
-def _trace_dispatcher(
-        a, offset=None, axis1=None, axis2=None, dtype=None, out=None):
-    return (a, out)
-
-
-@array_function_dispatch(_trace_dispatcher)
+@array_function_dispatch(("a", "out"))
 def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
     """
     Return the sum along diagonals of the array.
@@ -2058,11 +1978,7 @@ def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
         )
 
 
-def _ravel_dispatcher(a, order=None):
-    return (a,)
-
-
-@array_function_dispatch(_ravel_dispatcher)
+@array_function_dispatch(("a",))
 def ravel(a, order='C'):
     """Return a contiguous flattened array.
 
@@ -2172,11 +2088,7 @@ def ravel(a, order='C'):
         return asanyarray(a).ravel(order=order)
 
 
-def _nonzero_dispatcher(a):
-    return (a,)
-
-
-@array_function_dispatch(_nonzero_dispatcher)
+@array_function_dispatch(("a",))
 def nonzero(a):
     """
     Return the indices of the elements that are non-zero.
@@ -2263,11 +2175,7 @@ def nonzero(a):
     return _wrapfunc(a, 'nonzero')
 
 
-def _shape_dispatcher(a):
-    return (a,)
-
-
-@array_function_dispatch(_shape_dispatcher)
+@array_function_dispatch(("a",))
 def shape(a):
     """
     Return the shape of an array.
@@ -2316,11 +2224,7 @@ def shape(a):
     return result
 
 
-def _compress_dispatcher(condition, a, axis=None, out=None):
-    return (condition, a, out)
-
-
-@array_function_dispatch(_compress_dispatcher)
+@array_function_dispatch(("condition", "a", "out"))
 def compress(condition, a, axis=None, out=None):
     """
     Return selected slices of an array along given axis.
@@ -2385,12 +2289,7 @@ def compress(condition, a, axis=None, out=None):
     return _wrapfunc(a, 'compress', condition, axis=axis, out=out)
 
 
-def _clip_dispatcher(a, a_min=None, a_max=None, out=None, *, min=None,
-                     max=None, **kwargs):
-    return (a, a_min, a_max, out, min, max)
-
-
-@array_function_dispatch(_clip_dispatcher)
+@array_function_dispatch(("a", "a_min", "a_max", "out", "min", "max"))
 def clip(a, a_min=np._NoValue, a_max=np._NoValue, out=None, *,
          min=np._NoValue, max=np._NoValue, **kwargs):
     """
@@ -2836,12 +2735,7 @@ def _cumulative_func(x, func, axis, dtype, out, include_initial):
     return res
 
 
-def _cumulative_prod_dispatcher(x, /, *, axis=None, dtype=None, out=None,
-                                include_initial=None):
-    return (x, out)
-
-
-@array_function_dispatch(_cumulative_prod_dispatcher)
+@array_function_dispatch(("x", "out"))
 def cumulative_prod(x, /, *, axis=None, dtype=None, out=None,
                     include_initial=False):
     """
@@ -2913,12 +2807,7 @@ def cumulative_prod(x, /, *, axis=None, dtype=None, out=None,
     return _cumulative_func(x, um.multiply, axis, dtype, out, include_initial)
 
 
-def _cumulative_sum_dispatcher(x, /, *, axis=None, dtype=None, out=None,
-                               include_initial=None):
-    return (x, out)
-
-
-@array_function_dispatch(_cumulative_sum_dispatcher)
+@array_function_dispatch(("x", "out"))
 def cumulative_sum(x, /, *, axis=None, dtype=None, out=None,
                    include_initial=False):
     """
@@ -3003,11 +2892,7 @@ def cumulative_sum(x, /, *, axis=None, dtype=None, out=None,
     return _cumulative_func(x, um.add, axis, dtype, out, include_initial)
 
 
-def _cumsum_dispatcher(a, axis=None, dtype=None, out=None):
-    return (a, out)
-
-
-@array_function_dispatch(_cumsum_dispatcher)
+@array_function_dispatch(("a", "out"))
 def cumsum(a, axis=None, dtype=None, out=None):
     """
     Return the cumulative sum of the elements along a given axis.
@@ -3086,11 +2971,7 @@ def cumsum(a, axis=None, dtype=None, out=None):
     return _wrapfunc(a, 'cumsum', axis=axis, dtype=dtype, out=out)
 
 
-def _ptp_dispatcher(a, axis=None, out=None, keepdims=None):
-    return (a, out)
-
-
-@array_function_dispatch(_ptp_dispatcher)
+@array_function_dispatch(("a", "out"))
 def ptp(a, axis=None, out=None, keepdims=np._NoValue):
     """
     Range of values (maximum - minimum) along an axis.
@@ -3562,11 +3443,7 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
                           keepdims, initial, where)
 
 
-def _cumprod_dispatcher(a, axis=None, dtype=None, out=None):
-    return (a, out)
-
-
-@array_function_dispatch(_cumprod_dispatcher)
+@array_function_dispatch(("a", "out"))
 def cumprod(a, axis=None, dtype=None, out=None):
     """
     Return the cumulative product of elements along a given axis.
@@ -3632,11 +3509,7 @@ def cumprod(a, axis=None, dtype=None, out=None):
     return _wrapfunc(a, 'cumprod', axis=axis, dtype=dtype, out=out)
 
 
-def _ndim_dispatcher(a):
-    return (a,)
-
-
-@array_function_dispatch(_ndim_dispatcher)
+@array_function_dispatch(("a",))
 def ndim(a):
     """
     Return the number of dimensions of an array.
@@ -3675,11 +3548,7 @@ def ndim(a):
         return asarray(a).ndim
 
 
-def _size_dispatcher(a, axis=None):
-    return (a,)
-
-
-@array_function_dispatch(_size_dispatcher)
+@array_function_dispatch(("a",))
 def size(a, axis=None):
     """
     Return the number of elements along a given axis.
@@ -3732,11 +3601,7 @@ def size(a, axis=None):
         return math.prod(_shape[ax] for ax in axis)
 
 
-def _round_dispatcher(a, decimals=None, out=None):
-    return (a, out)
-
-
-@array_function_dispatch(_round_dispatcher)
+@array_function_dispatch(("a", "out"))
 def round(a, decimals=0, out=None):
     """
     Evenly round to the given number of decimals.
@@ -3831,7 +3696,7 @@ def round(a, decimals=0, out=None):
     return _wrapfunc(a, 'round', decimals=decimals, out=out)
 
 
-@array_function_dispatch(_round_dispatcher)
+@array_function_dispatch(("a", "out"))
 def around(a, decimals=0, out=None):
     """
     Round an array to the given number of decimals.
@@ -3848,12 +3713,7 @@ def around(a, decimals=0, out=None):
     return _wrapfunc(a, 'round', decimals=decimals, out=out)
 
 
-def _mean_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None, *,
-                     where=None):
-    return (a, where, out)
-
-
-@array_function_dispatch(_mean_dispatcher)
+@array_function_dispatch(("a", "where", "out"))
 def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
          where=np._NoValue):
     """
@@ -3982,12 +3842,7 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue, *,
                           out=out, **kwargs)
 
 
-def _std_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
-                    keepdims=None, *, where=None, mean=None, correction=None):
-    return (a, where, out, mean)
-
-
-@array_function_dispatch(_std_dispatcher)
+@array_function_dispatch(("a", "where", "out", "mean"))
 def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         where=np._NoValue, mean=np._NoValue, correction=np._NoValue):
     r"""
@@ -4186,12 +4041,7 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
                          **kwargs)
 
 
-def _var_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
-                    keepdims=None, *, where=None, mean=None, correction=None):
-    return (a, where, out, mean)
-
-
-@array_function_dispatch(_var_dispatcher)
+@array_function_dispatch(("a", "where", "out", "mean"))
 def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue, *,
         where=np._NoValue, mean=np._NoValue, correction=np._NoValue):
     r"""

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -2482,17 +2482,7 @@ def clip(a, a_min=np._NoValue, a_max=np._NoValue, out=None, *,
     return _wrapfunc(a, 'clip', a_min, a_max, out=out, **kwargs)
 
 
-def _sum_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
-                    initial=None, where=None):
-    return (a, out)
-
-
-# reduction= enables the C fast path for exact-ndarray reductions.
-# _ReductionKind selects the appropriate argument signature to use.
-@array_function_dispatch(
-    _sum_dispatcher,
-    reduction=(um.add, overrides._ReductionKind.SUM_PROD),
-)
+@array_function_dispatch(("a", "out"), reduction=um.add)
 def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
         initial=np._NoValue, where=np._NoValue):
     """
@@ -2618,15 +2608,8 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     )
 
 
-def _any_dispatcher(a, axis=None, out=None, keepdims=None, *,
-                    where=np._NoValue):
-    return (a, where, out)
-
-
-@array_function_dispatch(
-    _any_dispatcher,
-    reduction=(um.logical_or, overrides._ReductionKind.ANY_ALL),
-)
+@array_function_dispatch(("a", "where", "out"), reduction=um.logical_or,
+                         reduction_defaults={"dtype": bool})
 def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     """
     Test whether any array element along a given axis evaluates to True.
@@ -2733,15 +2716,8 @@ def any(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
                                   keepdims, where)
 
 
-def _all_dispatcher(a, axis=None, out=None, keepdims=None, *,
-                    where=None):
-    return (a, where, out)
-
-
-@array_function_dispatch(
-    _all_dispatcher,
-    reduction=(um.logical_and, overrides._ReductionKind.ANY_ALL),
-)
+@array_function_dispatch(("a", "where", "out"), reduction=um.logical_and,
+                         reduction_defaults={"dtype": bool})
 def all(a, axis=None, out=None, keepdims=np._NoValue, *, where=np._NoValue):
     """
     Test whether all array elements along a given axis evaluate to True.
@@ -3199,15 +3175,7 @@ def ptp(a, axis=None, out=None, keepdims=np._NoValue):
     return _methods._ptp(a, axis=axis, out=out, **kwargs)
 
 
-def _max_dispatcher(a, axis=None, out=None, keepdims=None, initial=None,
-                    where=None):
-    return (a, out)
-
-
-@array_function_dispatch(
-    _max_dispatcher,
-    reduction=(um.maximum, overrides._ReductionKind.MIN_MAX),
-)
+@array_function_dispatch(("a", "out"), reduction=um.maximum)
 @set_module('numpy')
 def max(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
          where=np._NoValue):
@@ -3323,10 +3291,7 @@ def max(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
                           keepdims, initial, where)
 
 
-@array_function_dispatch(
-    _max_dispatcher,
-    reduction=(um.maximum, overrides._ReductionKind.MIN_MAX),
-)
+@array_function_dispatch(("a", "out"), reduction=um.maximum)
 def amax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
          where=np._NoValue):
     """
@@ -3343,15 +3308,7 @@ def amax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
                           keepdims, initial, where)
 
 
-def _min_dispatcher(a, axis=None, out=None, keepdims=None, initial=None,
-                    where=None):
-    return (a, out)
-
-
-@array_function_dispatch(
-    _min_dispatcher,
-    reduction=(um.minimum, overrides._ReductionKind.MIN_MAX),
-)
+@array_function_dispatch(("a", "out"), reduction=um.minimum)
 def min(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
         where=np._NoValue):
     """
@@ -3467,10 +3424,7 @@ def min(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
                           keepdims, initial, where)
 
 
-@array_function_dispatch(
-    _min_dispatcher,
-    reduction=(um.minimum, overrides._ReductionKind.MIN_MAX),
-)
+@array_function_dispatch(("a", "out"), reduction=um.minimum)
 def amin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
          where=np._NoValue):
     """
@@ -3487,15 +3441,7 @@ def amin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
                           keepdims, initial, where)
 
 
-def _prod_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
-                     initial=None, where=None):
-    return (a, out)
-
-
-@array_function_dispatch(
-    _prod_dispatcher,
-    reduction=(um.multiply, overrides._ReductionKind.SUM_PROD),
-)
+@array_function_dispatch(("a", "out"), reduction=um.multiply)
 def prod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
          initial=np._NoValue, where=np._NoValue):
     """

--- a/numpy/_core/function_base.py
+++ b/numpy/_core/function_base.py
@@ -19,12 +19,7 @@ array_function_dispatch = functools.partial(
     overrides.array_function_dispatch, module='numpy')
 
 
-def _linspace_dispatcher(start, stop, num=None, endpoint=None, retstep=None,
-                         dtype=None, axis=None, *, device=None):
-    return (start, stop)
-
-
-@array_function_dispatch(_linspace_dispatcher)
+@array_function_dispatch(("start", "stop"))
 def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
              axis=0, *, device=None):
     """
@@ -201,12 +196,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         return y
 
 
-def _logspace_dispatcher(start, stop, num=None, endpoint=None, base=None,
-                         dtype=None, axis=None):
-    return (start, stop, base)
-
-
-@array_function_dispatch(_logspace_dispatcher)
+@array_function_dispatch(("start", "stop", "base"))
 def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
              axis=0):
     """
@@ -316,12 +306,7 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
     return _nx.power(base, y).astype(dtype, copy=False)
 
 
-def _geomspace_dispatcher(start, stop, num=None, endpoint=None, dtype=None,
-                          axis=None):
-    return (start, stop)
-
-
-@array_function_dispatch(_geomspace_dispatcher)
+@array_function_dispatch(("start", "stop"))
 def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
     """
     Return numbers spaced evenly on a log scale (a geometric progression).

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -88,13 +88,7 @@ __all__ = [
     'may_share_memory']
 
 
-def _zeros_like_dispatcher(
-    a, dtype=None, order=None, subok=None, shape=None, *, device=None
-):
-    return (a,)
-
-
-@array_function_dispatch(_zeros_like_dispatcher)
+@array_function_dispatch(("a",))
 def zeros_like(
     a, dtype=None, order='K', subok=True, shape=None, *, device=None
 ):
@@ -237,13 +231,7 @@ def ones(shape, dtype=None, order='C', *, device=None, like=None):
 _ones_with_like = array_function_dispatch()(ones)
 
 
-def _ones_like_dispatcher(
-    a, dtype=None, order=None, subok=None, shape=None, *, device=None
-):
-    return (a,)
-
-
-@array_function_dispatch(_ones_like_dispatcher)
+@array_function_dispatch(("a",))
 def ones_like(
     a, dtype=None, order='K', subok=True, shape=None, *, device=None
 ):
@@ -312,12 +300,6 @@ def ones_like(
     )
     multiarray.copyto(res, 1, casting='unsafe')
     return res
-
-
-def _full_dispatcher(
-    shape, fill_value, dtype=None, order=None, *, device=None, like=None
-):
-    return (like,)
 
 
 @finalize_array_function_like
@@ -390,14 +372,7 @@ def full(shape, fill_value, dtype=None, order='C', *, device=None, like=None):
 _full_with_like = array_function_dispatch()(full)
 
 
-def _full_like_dispatcher(
-    a, fill_value, dtype=None, order=None, subok=None, shape=None,
-    *, device=None
-):
-    return (a,)
-
-
-@array_function_dispatch(_full_like_dispatcher)
+@array_function_dispatch(("a",))
 def full_like(
     a, fill_value, dtype=None, order='K', subok=True, shape=None,
     *, device=None
@@ -476,11 +451,7 @@ def full_like(
     return res
 
 
-def _count_nonzero_dispatcher(a, axis=None, *, keepdims=None):
-    return (a,)
-
-
-@array_function_dispatch(_count_nonzero_dispatcher)
+@array_function_dispatch(("a",))
 def count_nonzero(a, axis=None, *, keepdims=False):
     """
     Counts the number of non-zero values in the array ``a``.
@@ -613,11 +584,7 @@ def isfortran(a):
     return a.flags.fnc
 
 
-def _argwhere_dispatcher(a):
-    return (a,)
-
-
-@array_function_dispatch(_argwhere_dispatcher)
+@array_function_dispatch(("a",))
 def argwhere(a):
     """
     Find the indices of array elements that are non-zero, grouped by element.
@@ -668,11 +635,7 @@ def argwhere(a):
     return transpose(nonzero(a))
 
 
-def _flatnonzero_dispatcher(a):
-    return (a,)
-
-
-@array_function_dispatch(_flatnonzero_dispatcher)
+@array_function_dispatch(("a",))
 def flatnonzero(a):
     """
     Return indices that are non-zero in the flattened version of a.
@@ -714,11 +677,7 @@ def flatnonzero(a):
     return np.nonzero(np.ravel(a))[0]
 
 
-def _correlate_dispatcher(a, v, mode=None):
-    return (a, v)
-
-
-@array_function_dispatch(_correlate_dispatcher)
+@array_function_dispatch(("a", "v"))
 def correlate(a, v, mode='valid'):
     r"""
     Cross-correlation of two 1-dimensional sequences.
@@ -794,11 +753,7 @@ def correlate(a, v, mode='valid'):
     return multiarray.correlate2(a, v, mode)
 
 
-def _convolve_dispatcher(a, v, mode=None):
-    return (a, v)
-
-
-@array_function_dispatch(_convolve_dispatcher)
+@array_function_dispatch(("a", "v"))
 def convolve(a, v, mode='full'):
     """
     Returns the discrete, linear convolution of two one-dimensional sequences.
@@ -898,11 +853,7 @@ def convolve(a, v, mode='full'):
     return multiarray.correlate(a, v[::-1], mode)
 
 
-def _outer_dispatcher(a, b, out=None):
-    return (a, b, out)
-
-
-@array_function_dispatch(_outer_dispatcher)
+@array_function_dispatch(("a", "b", "out"))
 def outer(a, b, out=None):
     """
     Compute the outer product of two vectors.
@@ -990,11 +941,7 @@ def outer(a, b, out=None):
     return multiply(a.ravel()[:, newaxis], b.ravel()[newaxis, :], out)
 
 
-def _tensordot_dispatcher(a, b, axes=None):
-    return (a, b)
-
-
-@array_function_dispatch(_tensordot_dispatcher)
+@array_function_dispatch(("a", "b"))
 def tensordot(a, b, axes=2):
     """
     Compute tensor dot product along specified axes.
@@ -1220,11 +1167,7 @@ def tensordot(a, b, axes=2):
     return res.reshape(olda + oldb)
 
 
-def _roll_dispatcher(a, shift, axis=None):
-    return (a,)
-
-
-@array_function_dispatch(_roll_dispatcher)
+@array_function_dispatch(("a",))
 def roll(a, shift, axis=None):
     """
     Roll array elements along a given axis.
@@ -1330,11 +1273,7 @@ def roll(a, shift, axis=None):
         return result
 
 
-def _rollaxis_dispatcher(a, axis, start=None):
-    return (a,)
-
-
-@array_function_dispatch(_rollaxis_dispatcher)
+@array_function_dispatch(("a",))
 def rollaxis(a, axis, start=0):
     """
     Roll the specified axis backwards, until it lies in a given position.
@@ -1483,11 +1422,7 @@ def normalize_axis_tuple(axis, ndim, argname=None, allow_duplicate=False):
     return axis
 
 
-def _moveaxis_dispatcher(a, source, destination):
-    return (a,)
-
-
-@array_function_dispatch(_moveaxis_dispatcher)
+@array_function_dispatch(("a",))
 def moveaxis(a, source, destination):
     """
     Move axes of an array to new positions.
@@ -1557,11 +1492,7 @@ def moveaxis(a, source, destination):
     return result
 
 
-def _cross_dispatcher(a, b, axisa=None, axisb=None, axisc=None, axis=None):
-    return (a, b)
-
-
-@array_function_dispatch(_cross_dispatcher)
+@array_function_dispatch(("a", "b"))
 def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     """
     Return the cross product of two (arrays of) vectors.
@@ -2220,11 +2151,7 @@ def identity(n, dtype=None, *, like=None):
 _identity_with_like = array_function_dispatch()(identity)
 
 
-def _allclose_dispatcher(a, b, rtol=None, atol=None, equal_nan=None):
-    return (a, b, rtol, atol)
-
-
-@array_function_dispatch(_allclose_dispatcher)
+@array_function_dispatch(("a", "b", "rtol", "atol"))
 def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     """
     Returns True if two arrays are element-wise equal within a tolerance.
@@ -2314,11 +2241,7 @@ def allclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     return builtins.bool(res)
 
 
-def _isclose_dispatcher(a, b, rtol=None, atol=None, equal_nan=None):
-    return (a, b, rtol, atol)
-
-
-@array_function_dispatch(_isclose_dispatcher)
+@array_function_dispatch(("a", "b", "rtol", "atol"))
 def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     """
     Returns a boolean array where two arrays are element-wise equal within a
@@ -2450,10 +2373,6 @@ def isclose(a, b, rtol=1.e-5, atol=1.e-8, equal_nan=False):
     return result[()]  # Flatten 0d arrays to scalars
 
 
-def _array_equal_dispatcher(a1, a2, equal_nan=None):
-    return (a1, a2)
-
-
 _no_nan_types = {
     # should use np.dtype.BoolDType, but as of writing
     # that fails the reloading test.
@@ -2469,7 +2388,7 @@ def _dtype_cannot_hold_nan(dtype):
     return type(dtype) in _no_nan_types
 
 
-@array_function_dispatch(_array_equal_dispatcher)
+@array_function_dispatch(("a1", "a2"))
 def array_equal(a1, a2, equal_nan=False):
     """
     True if two arrays have the same shape and elements, False otherwise.
@@ -2555,11 +2474,7 @@ def array_equal(a1, a2, equal_nan=False):
     return builtins.bool(equal_or_both_nan.all())
 
 
-def _array_equiv_dispatcher(a1, a2):
-    return (a1, a2)
-
-
-@array_function_dispatch(_array_equiv_dispatcher)
+@array_function_dispatch(("a1", "a2"))
 def array_equiv(a1, a2):
     """
     Returns True if input arrays are shape consistent and all elements equal.
@@ -2608,11 +2523,7 @@ def array_equiv(a1, a2):
     return builtins.bool(asanyarray(a1 == a2).all())
 
 
-def _astype_dispatcher(x, dtype, /, *, copy=None, device=None):
-    return (x, dtype)
-
-
-@array_function_dispatch(_astype_dispatcher)
+@array_function_dispatch(("x", "dtype"))
 def astype(x, dtype, /, *, copy=True, device=None):
     """
     Copies an array to a specified data type.

--- a/numpy/_core/overrides.py
+++ b/numpy/_core/overrides.py
@@ -1,6 +1,5 @@
 """Implementation of __array_function__ overrides from NEP-18."""
 import collections
-import enum
 import functools
 import inspect
 
@@ -9,17 +8,49 @@ from numpy._core._multiarray_umath import (
     _get_implementing_args,
     add_docstring,
 )
+from numpy._globals import _NoValue
 from numpy._utils import set_module  # noqa: F401
 from numpy._utils._inspect import getargspec
 
 ARRAY_FUNCTIONS = set()
 
-# Signature families used by the exact-ndarray reduction fast path.
-class _ReductionKind(enum.IntEnum):
-    # Keep in sync with the enum in arrayfunction_override.c
-    SUM_PROD = 1
-    MIN_MAX = 2
-    ANY_ALL = 3
+# ufunc.reduce positional argument order, used by the exact-ndarray
+# reduction fast path.  Public reduction functions (np.sum, np.any, ...)
+# use these same parameter names, which is how their signatures are
+# mapped onto a direct ufunc.reduce call in C.
+_REDUCE_SLOTS = {
+    "a": 0, "axis": 1, "dtype": 2, "out": 3,
+    "keepdims": 4, "initial": 5, "where": 6,
+}
+# Values for reduce arguments the caller did not pass (or passed as
+# np._NoValue).  Slot 0 (`a`) has no default: it is required.
+_REDUCE_DEFAULTS = (None, None, None, None, False, _NoValue, True)
+
+
+def _resolve_reduction_spec(implementation, ufunc, defaults_override):
+    """Map ``implementation``'s parameters onto ``ufunc.reduce`` arguments.
+
+    Returns ``(reduce_callable, slots, defaults)`` where ``slots[i]`` is the
+    reduce-argument index of the i-th parameter (aligned with the
+    ``param_names`` table from ``_resolve_relevant_arg_spec``) and
+    ``defaults`` holds the reduce-call value for every argument the caller
+    omitted.  The C dispatcher uses this to call ``ufunc.reduce`` directly
+    for exact-ndarray calls, skipping the Python wrapper entirely.
+    """
+    defaults = list(_REDUCE_DEFAULTS)
+    if defaults_override:
+        for name, value in defaults_override.items():
+            defaults[_REDUCE_SLOTS[name]] = value
+    slots = []
+    for name, param in inspect.signature(implementation).parameters.items():
+        if (name not in _REDUCE_SLOTS
+                or param.kind not in (param.POSITIONAL_OR_KEYWORD,
+                                      param.KEYWORD_ONLY)):
+            raise RuntimeError(
+                f"reduction fast path cannot map parameter {name!r} of "
+                f"{implementation.__qualname__} onto ufunc.reduce")
+        slots.append(_REDUCE_SLOTS[name])
+    return (ufunc.reduce, tuple(slots), tuple(defaults))
 
 
 array_function_like_doc = (
@@ -87,7 +118,9 @@ add_docstring(
     Returns
     -------
     Sequence of arguments with __array_function__ methods, in the order in
-    which they should be called.
+    which they should be called.  Returns an empty sequence when every
+    argument is an exact ``ndarray`` or a basic Python type (the caller
+    short-circuits to the default implementation in that case).
     """)
 
 
@@ -116,20 +149,104 @@ def verify_matching_signatures(implementation, dispatcher):
                                'default argument values')
 
 
+def _resolve_relevant_arg_spec(implementation, relevant_arg_names):
+    """Resolve arg names into parameter indices against ``implementation``'s
+    signature.  Rejects an empty spec, ``*args`` (positions would be
+    ambiguous at call time), and unknown names.
+
+    An index ``i`` encodes both lookup channels: the arg may be matched
+    positionally iff ``i < n_pos_max`` (positional parameters form a prefix
+    of the signature) and by keyword iff ``param_names[i] is not None``
+    (None marks positional-only parameters).  This keeps signature-invalid
+    calls raising TypeError instead of dispatching on the wrong argument.
+
+    Returns ``(indices, sig_info)`` where ``sig_info`` is
+    ``(param_names, n_pos_max, n_required, has_varkw)`` describing the full
+    signature.  The C dispatcher uses it to validate the call shape before
+    forwarding to an ``__array_function__`` override (the no-override path
+    is validated by calling ``implementation`` itself).
+    """
+    if not relevant_arg_names:
+        raise ValueError(
+            "tuple-spec dispatcher requires at least one relevant "
+            "argument name; got empty tuple")
+    sig = inspect.signature(implementation)
+    Parameter = inspect.Parameter
+    spec = {}  # param name -> parameter index
+    param_names = []
+    n_pos_max = 0
+    n_required = 0
+    has_varkw = False
+    for pos, (name, param) in enumerate(sig.parameters.items()):
+        match param.kind:
+            case Parameter.VAR_POSITIONAL:
+                raise RuntimeError(
+                    f"tuple-spec dispatch does not support implementations "
+                    f"with *args; got {implementation.__qualname__}")
+            case Parameter.VAR_KEYWORD:
+                has_varkw = True
+                break
+            case Parameter.KEYWORD_ONLY:
+                if param.default is Parameter.empty:
+                    # validate_call_signature only tracks required positional
+                    # parameters; a missing required keyword-only argument
+                    # would be forwarded to an override unchecked.
+                    raise RuntimeError(
+                        f"tuple-spec dispatch does not support required "
+                        f"keyword-only parameters; got {name!r} in "
+                        f"{implementation.__qualname__}")
+                spec[name] = pos           # keyword channel only
+                param_names.append(name)
+            case Parameter.POSITIONAL_ONLY:
+                spec[name] = pos           # positional channel only
+                param_names.append(None)
+                n_pos_max += 1
+            case Parameter.POSITIONAL_OR_KEYWORD:
+                spec[name] = pos           # both channels
+                param_names.append(name)
+                n_pos_max += 1
+            case _:  # unreachable: Parameter.kind has no other values
+                raise RuntimeError(
+                    f"unsupported parameter kind {param.kind!r} for "
+                    f"{name!r} in {implementation.__qualname__}")
+        # required = contiguous no-default prefix of the positional params
+        if (param.default is Parameter.empty and param.kind in (
+                Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
+                and pos == n_required):
+            n_required += 1
+    resolved = []
+    for name in relevant_arg_names:
+        if not isinstance(name, str):
+            raise TypeError(
+                f"tuple-spec dispatcher must contain only strings; "
+                f"got {name!r}")
+        if name not in spec:
+            raise RuntimeError(
+                f"relevant arg {name!r} not found in "
+                f"{implementation.__qualname__} signature")
+        resolved.append(spec[name])
+    sig_info = (tuple(param_names), n_pos_max, n_required, has_varkw)
+    return tuple(resolved), sig_info
+
+
 def array_function_dispatch(dispatcher=None, module=None, verify=True,
-                            docs_from_dispatcher=False, reduction=None):
+                            docs_from_dispatcher=False, reduction=None,
+                            reduction_defaults=None):
     """Decorator for adding dispatch with the __array_function__ protocol.
 
     See NEP-18 for example usage.
 
     Parameters
     ----------
-    dispatcher : callable or None
-        Function that when called like ``dispatcher(*args, **kwargs)`` with
-        arguments from the NumPy function call returns an iterable of
+    dispatcher : callable, tuple of str, or None
+        If a callable: when called like ``dispatcher(*args, **kwargs)`` with
+        arguments from the NumPy function call it returns an iterable of
         array-like arguments to check for ``__array_function__``.
 
-        If `None`, the first argument is used as the single `like=` argument
+        If a tuple of strings: names of positional/keyword arguments of the
+        decorated function that should be checked for ``__array_function__``.
+
+        If ``None``, the first argument is used as the single `like=` argument
         and not passed on.  A function implementing `like=` must call its
         dispatcher with `like` as the first non-keyword argument.
     module : str, optional
@@ -147,39 +264,72 @@ def array_function_dispatch(dispatcher=None, module=None, verify=True,
         If True, copy docs from the dispatcher function onto the dispatched
         function, rather than from the implementation. This is useful for
         functions defined in C, which otherwise don't have docstrings.
-    reduction : tuple or None, optional
-        Private ``(ufunc, kind)`` specification for an exact-ndarray
-        reduction fast path.
+    reduction : ufunc or None, optional
+        Private: the decorated function is ``reduction.reduce`` under a
+        different signature.  Enables an exact-ndarray fast path that
+        calls ``reduction.reduce`` directly from C, mapping arguments by
+        parameter name (see ``_resolve_reduction_spec``).  Requires a
+        tuple-spec dispatcher.
+    reduction_defaults : dict or None, optional
+        Private: overrides for ``ufunc.reduce`` arguments the public
+        signature does not expose (e.g. ``{"dtype": bool}`` for
+        ``np.any``/``np.all``).
 
     Returns
     -------
     Function suitable for decorating the implementation of a NumPy function.
 
     """
+    # exact tuple only (matches C-side PyTuple_CheckExact)
+    is_tuple_spec = type(dispatcher) is tuple
+
+    if is_tuple_spec and docs_from_dispatcher:
+        raise TypeError(
+            "docs_from_dispatcher=True is not supported with a tuple-spec "
+            "dispatcher (there is no dispatcher function to copy docs from)")
+    if reduction is not None and not is_tuple_spec:
+        raise TypeError(
+            "reduction= requires a tuple-spec dispatcher")
+
     def decorator(implementation):
-        if verify:
-            if dispatcher is not None:
-                verify_matching_signatures(implementation, dispatcher)
+        if is_tuple_spec:
+            spec, sig_info = _resolve_relevant_arg_spec(
+                implementation, dispatcher)
+            if reduction is not None:
+                reduction_spec = _resolve_reduction_spec(
+                    implementation, reduction, reduction_defaults)
             else:
-                # Using __code__ directly similar to verify_matching_signature
-                co = implementation.__code__
-                last_arg = co.co_argcount + co.co_kwonlyargcount - 1
-                last_arg = co.co_varnames[last_arg]
-                if last_arg != "like" or co.co_kwonlyargcount == 0:
-                    raise RuntimeError(
-                        "__array_function__ expects `like=` to be the last "
-                        "argument and a keyword-only argument. "
-                        f"{implementation} does not seem to comply.")
+                reduction_spec = None
+            public_api = _ArrayFunctionDispatcher(
+                (spec, sig_info, reduction_spec), implementation)
+        else:
+            if verify:
+                if dispatcher is not None:
+                    verify_matching_signatures(implementation, dispatcher)
+                else:
+                    # Using __code__ directly similar to
+                    # verify_matching_signatures
+                    co = implementation.__code__
+                    last_arg = co.co_argcount + co.co_kwonlyargcount - 1
+                    last_arg = co.co_varnames[last_arg]
+                    if last_arg != "like" or co.co_kwonlyargcount == 0:
+                        raise RuntimeError(
+                            "__array_function__ expects `like=` to be the "
+                            "last argument and a keyword-only argument. "
+                            f"{implementation} does not seem to comply.")
 
-        if docs_from_dispatcher and dispatcher.__doc__ is not None:
-            doc = inspect.cleandoc(dispatcher.__doc__)
-            add_docstring(implementation, doc)
+            if docs_from_dispatcher and dispatcher.__doc__ is not None:
+                doc = inspect.cleandoc(dispatcher.__doc__)
+                add_docstring(implementation, doc)
 
-        config = None if reduction is None else (reduction[0].reduce, reduction[1])
-        public_api = _ArrayFunctionDispatcher(dispatcher, implementation, config)
+            public_api = _ArrayFunctionDispatcher(dispatcher, implementation)
+
         functools.update_wrapper(public_api, implementation)
 
-        if not verify and not getattr(implementation, "__text_signature__", None):
+        if not is_tuple_spec and not verify and not getattr(
+                implementation, "__text_signature__", None):
+            # update_wrapper does not help inspect.signature for
+            # implementations with a */** signature; use the dispatcher's.
             public_api.__signature__ = inspect.signature(dispatcher)
 
         if module is not None:

--- a/numpy/_core/overrides.pyi
+++ b/numpy/_core/overrides.pyi
@@ -1,4 +1,3 @@
-import enum
 from collections.abc import Callable, Iterable
 from typing import Any, Final, NamedTuple
 
@@ -12,10 +11,6 @@ type _Dispatcher[**_Tss] = Callable[_Tss, Iterable[object]]
 
 ARRAY_FUNCTIONS: set[Callable[..., Any]] = ...
 array_function_like_doc: Final[str] = ...
-class _ReductionKind(enum.IntEnum):
-    SUM_PROD = 1
-    MIN_MAX = 2
-    ANY_ALL = 3
 
 class ArgSpec(NamedTuple):
     args: list[str]
@@ -35,11 +30,12 @@ def verify_matching_signatures[**Tss](implementation: Callable[Tss, object], dis
 # specifies. Since the dispatcher only returns an iterable of passed array-like args,
 # this overridable behaviour is impossible to annotate.
 def array_function_dispatch[**Tss, FuncLikeT: _FuncLike](
-    dispatcher: _Dispatcher[Tss] | None = None,
+    dispatcher: _Dispatcher[Tss] | tuple[str, ...] | None = None,
     module: str | None = None,
     verify: bool = True,
     docs_from_dispatcher: bool = False,
-    reduction: tuple[np.ufunc, _ReductionKind] | None = None,
+    reduction: np.ufunc | None = None,
+    reduction_defaults: dict[str, Any] | None = None,
 ) -> Callable[[FuncLikeT], FuncLikeT]: ...
 
 #

--- a/numpy/_core/shape_base.py
+++ b/numpy/_core/shape_base.py
@@ -463,10 +463,8 @@ def stack(arrays, axis=0, out=None, *, dtype=None, casting="same_kind"):
     return _nx.concatenate(expanded_arrays, axis=axis, out=out,
                            dtype=dtype, casting=casting)
 
-def _unstack_dispatcher(x, /, *, axis=None):
-    return (x,)
 
-@array_function_dispatch(_unstack_dispatcher)
+@array_function_dispatch(("x",))
 def unstack(x, /, *, axis=0):
     """
     Split an array into a sequence of arrays along the given axis.

--- a/numpy/_core/src/multiarray/arrayfunction_override.c
+++ b/numpy/_core/src/multiarray/arrayfunction_override.c
@@ -7,7 +7,6 @@
 #include "numpy/ndarrayobject.h"
 #include "numpy/ndarraytypes.h"
 #include "get_attr_string.h"
-#include "npy_argparse.h"
 #include "npy_import.h"
 #include "npy_static_data.h"
 #include "multiarraymodule.h"
@@ -50,21 +49,43 @@ pyobject_array_insert(PyObject **array, int length, int index, PyObject *item)
 }
 
 
+/* Exact ndarray and basic Python builtins cannot carry an override. */
+static inline int
+is_safe_arg(PyObject *a)
+{
+    return PyArray_CheckExact(a) || _is_basic_python_type(Py_TYPE(a));
+}
+
+
 /*
  * Collects arguments with __array_function__ and their corresponding methods
  * in the order in which they should be tried (i.e., skipping redundant types).
- * `relevant_args` is expected to have been produced by PySequence_Fast.
- * Returns the number of arguments, or -1 on failure.
+ * `items` is a C array of `length` borrowed references.
+ * Returns the number of arguments, or -1 on failure.  Returns 0 without
+ * collecting when no argument can carry an override (the caller then
+ * dispatches to the default implementation).
  */
 static int
-get_implementing_args_and_methods(PyObject *relevant_args,
-                                  PyObject **implementing_args,
-                                  PyObject **methods)
+get_implementing_args_and_methods(
+        PyObject *const *items, Py_ssize_t length,
+        PyObject **implementing_args, PyObject **methods)
 {
     int num_implementing_args = 0;
 
-    PyObject **items = PySequence_Fast_ITEMS(relevant_args);
-    Py_ssize_t length = PySequence_Fast_GET_SIZE(relevant_args);
+    /*
+     * Fast path: no override is possible when every arg is safe.  This must
+     * stay a separate pass rather than a `continue` in the loop below: once
+     * any override candidate exists, safe args (exact ndarrays) still have
+     * to be collected so that the `types` passed to __array_function__
+     * includes ndarray; only the all-safe case may skip collection.
+     */
+    Py_ssize_t n_safe = 0;
+    while (n_safe < length && is_safe_arg(items[n_safe])) {
+        n_safe++;
+    }
+    if (n_safe == length) {
+        return 0;
+    }
 
     for (Py_ssize_t i = 0; i < length; i++) {
         int new_class = 1;
@@ -380,7 +401,9 @@ array__get_implementing_args(
     }
 
     int num_implementing_args = get_implementing_args_and_methods(
-        relevant_args, implementing_args, array_function_methods);
+            PySequence_Fast_ITEMS(relevant_args),
+            PySequence_Fast_GET_SIZE(relevant_args),
+            implementing_args, array_function_methods);
     if (num_implementing_args == -1) {
         goto cleanup;
     }
@@ -406,13 +429,22 @@ cleanup:
 }
 
 
-// Keep in sync with the enum in _core/overrides.py
-typedef enum {
-    REDUCTION_NONE = 0,
-    REDUCTION_SUM_PROD = 1,
-    REDUCTION_MIN_MAX = 2,
-    REDUCTION_ANY_ALL = 3,
-} npy_reduction_kind;
+/* Number of positional arguments of ufunc.reduce. */
+#define NPY_REDUCE_NARGS 7
+
+/*
+ * Reduction fast path state (see _resolve_reduction_spec): `call` is a
+ * bound ufunc.reduce invoked directly for exact-ndarray calls, `defaults`
+ * a tuple of NPY_REDUCE_NARGS values for omitted arguments, and `slots[i]`
+ * the reduce-argument index of the i-th public parameter (aligned with
+ * the dispatcher's param_names).  Allocated only for the few reduction
+ * dispatchers, in one block via the flexible array member.
+ */
+typedef struct {
+    PyObject *call;
+    PyObject *defaults;
+    int slots[];
+} npy_reduction_info;
 
 typedef struct {
     PyObject_HEAD
@@ -420,96 +452,117 @@ typedef struct {
     PyObject *dict;
     PyObject *relevant_arg_func;
     PyObject *default_impl;
-    PyObject *reduction;
-    npy_reduction_kind reduction_kind;
+    /* Full-signature table (set instead of relevant_arg_func for
+     * tuple-spec dispatchers; entries are NULL for positional-only
+     * params).  Positional parameters form a prefix of the signature, so
+     * a parameter index i encodes everything about parameter i: it may be
+     * matched positionally iff i < n_pos_max and by keyword iff
+     * param_names[i] != NULL.  See lookup_relevant_arg and
+     * validate_call_signature. */
+    int n_params;
+    int n_pos_max;
+    int n_required;
+    int has_varkw;
+    PyObject **param_names;
+    /* The relevant args are parameter indices into param_names. */
+    int n_relevant_args;
+    uint8_t *relevant_idx;
+    /* NULL unless this dispatcher has a reduction fast path. */
+    npy_reduction_info *reduction;
     /* The following fields are used to clean up TypeError messages only: */
     PyObject *dispatcher_name;
     PyObject *public_name;
 } PyArray_ArrayFunctionDispatcherObject;
 
 /*
- * Try the exact-ndarray reduction fast path by calling the configured ufunc's
- * reduce method directly from C, bypassing calling back into Python implementation;
- * returns 1 if handled, 0 fallback to normal dispatch, and -1 on error.
+ * Index of keyword `kw` in the full parameter table, or n_params when not
+ * found.  Keyword names at call sites are interned by the compiler and
+ * param_names is interned at construction, so a pointer-only pass finds
+ * the match without any calls; only runtime-built keywords (e.g. from a
+ * ``**kwargs`` dict with non-interned str keys) need the value-compare
+ * pass, which cannot fail since both operands are guaranteed to be str.
+ */
+static inline int
+find_param_index(const PyArray_ArrayFunctionDispatcherObject *self,
+                 PyObject *kw)
+{
+    int n = self->n_params;
+    for (int i = 0; i < n; i++) {
+        if (kw == self->param_names[i]) {
+            return i;
+        }
+    }
+    for (int i = 0; i < n; i++) {
+        PyObject *name = self->param_names[i];
+        if (name != NULL && PyUnicode_Compare(kw, name) == 0) {
+            return i;
+        }
+    }
+    return n;
+}
+
+
+/*
+ * Try the exact-ndarray reduction fast path: scatter the call's arguments
+ * into ufunc.reduce's argument slots via the per-parameter table built by
+ * _resolve_reduction_spec and call the bound reduce directly, bypassing
+ * the Python wrapper.  Any mismatch (unknown/duplicate/excess argument,
+ * non-exact array, missing `a`) falls back to normal dispatch, which
+ * either handles overrides or raises the proper TypeError from the
+ * Python implementation itself.
+ * Returns 1 if handled, 0 to fall back, and -1 on error (*result set on 1).
  */
 static int
 try_reduction(PyArray_ArrayFunctionDispatcherObject *self,
-        PyObject *const *args, Py_ssize_t nargsf, PyObject *kwnames, PyObject **result)
+        PyObject *const *args, Py_ssize_t nargsf, PyObject *kwnames,
+        PyObject **result)
 {
-    PyObject *a = NULL, *axis = Py_None, *out = Py_None;
-    PyObject *dtype = self->reduction_kind == REDUCTION_ANY_ALL ? (PyObject *)&PyBool_Type : Py_None;
-    PyObject *keepdims = npy_static_pydata._NoValue, *where = npy_static_pydata._NoValue;
-    PyObject *initial = npy_static_pydata._NoValue;
-    int parsed = 0;
-    switch (self->reduction_kind) {
-        case REDUCTION_SUM_PROD: {
-            NPY_PREPARE_ARGPARSER;
-            parsed = npy_parse_arguments("sum-like", args, PyVectorcall_NARGS(nargsf), kwnames,
-                {"a", NULL, &a},
-                {"|axis", NULL, &axis},
-                {"|dtype", NULL, &dtype},
-                {"|out", NULL, &out},
-                {"|keepdims", NULL, &keepdims},
-                {"|initial", NULL, &initial},
-                {"|where", NULL, &where});
-            break;
-        }
-        case REDUCTION_MIN_MAX: {
-            NPY_PREPARE_ARGPARSER;
-            parsed = npy_parse_arguments("min-like", args, PyVectorcall_NARGS(nargsf), kwnames,
-                {"a", NULL, &a},
-                {"|axis", NULL, &axis},
-                {"|out", NULL, &out},
-                {"|keepdims", NULL, &keepdims},
-                {"|initial", NULL, &initial},
-                {"|where", NULL, &where});
-            break;
-        }
-        case REDUCTION_ANY_ALL: {
-            NPY_PREPARE_ARGPARSER;
-            parsed = npy_parse_arguments("any-like", args, PyVectorcall_NARGS(nargsf), kwnames,
-                {"a", NULL, &a},
-                {"|axis", NULL, &axis},
-                {"|out", NULL, &out},
-                {"|keepdims", NULL, &keepdims},
-                {"$where", NULL, &where});
-            break;
-        }
-        default:
+    const npy_reduction_info *red = self->reduction;
+    PyObject *slots[NPY_REDUCE_NARGS] = {NULL};
+    Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
+
+    if (nargs > self->n_pos_max) {
+        return 0;
+    }
+    for (Py_ssize_t p = 0; p < nargs; p++) {
+        slots[red->slots[p]] = args[p];
+    }
+    Py_ssize_t nkwargs = (kwnames != NULL) ? PyTuple_GET_SIZE(kwnames) : 0;
+    for (Py_ssize_t k = 0; k < nkwargs; k++) {
+        PyObject *kw = PyTuple_GET_ITEM(kwnames, k);
+        int i = find_param_index(self, kw);
+        /*
+         * Positional parameters form a prefix of param_names (guaranteed
+         * by Python syntax; *args is rejected at decoration time), so
+         * `i < nargs` means slot i was already filled positionally.
+         */
+        if (i == self->n_params || i < nargs) {
+            /* unknown keyword or duplicate of a positional arg */
             return 0;
+        }
+        slots[red->slots[i]] = args[nargs + k];
     }
-
-    /*
-     * These parsers use no explicit argument converters, so a TypeError here
-     * means that the call does not match this fast-path signature. Clear it
-     * and fall back to normal dispatch; other parser errors are propagated later.
-     *
-     * TODO: Add an npy_parse_arguments probe mode that returns a distinct mismatch
-     * status instead of relying on exception-class matching here. See
-     * https://github.com/numpy/numpy/pull/32041#discussion_r3638882974
-     */
-    if (parsed < 0 && PyErr_ExceptionMatches(PyExc_TypeError)) {
-        PyErr_Clear();
+    if (slots[0] == NULL) {
+        /* required `a` missing */
         return 0;
     }
-    if (parsed < 0) {
-        return -1;
+    for (int s = 1; s < NPY_REDUCE_NARGS; s++) {
+        /* np._NoValue means "not passed" for the public functions */
+        if (slots[s] == NULL || slots[s] == npy_static_pydata._NoValue) {
+            slots[s] = PyTuple_GET_ITEM(red->defaults, s);
+        }
     }
+
+    PyObject *a = slots[0], *out = slots[3], *where = slots[6];
     if (!PyArray_CheckExact(a) ||
-        (out != Py_None && !PyArray_CheckExact(out)) ||
-        (where != npy_static_pydata._NoValue && where != Py_None &&
-            !PyBool_Check(where) && !PyArray_CheckExact(where))) {
+            (out != Py_None && !PyArray_CheckExact(out)) ||
+            (where != Py_None && !PyBool_Check(where)
+                && !PyArray_CheckExact(where))) {
         return 0;
     }
 
-    // This set of arguments must exactly match ufunc.reduce positional argument order
-    PyObject *call_args[] = {
-        a, axis, dtype, out,
-        keepdims == npy_static_pydata._NoValue ? Py_False : keepdims,
-        initial,
-        where == npy_static_pydata._NoValue ? Py_True : where,
-    };
-    *result = PyObject_Vectorcall(self->reduction, call_args, 7, NULL);
+    *result = PyObject_Vectorcall(
+            red->call, slots, NPY_REDUCE_NARGS, NULL);
     return *result != NULL ? 1 : -1;
 }
 
@@ -519,10 +572,23 @@ dispatcher_dealloc(PyArray_ArrayFunctionDispatcherObject *self)
 {
     Py_CLEAR(self->relevant_arg_func);
     Py_CLEAR(self->default_impl);
-    Py_CLEAR(self->reduction);
     Py_CLEAR(self->dict);
     Py_CLEAR(self->dispatcher_name);
     Py_CLEAR(self->public_name);
+    if (self->reduction != NULL) {
+        Py_XDECREF(self->reduction->call);
+        Py_XDECREF(self->reduction->defaults);
+        PyMem_Free(self->reduction);
+    }
+    if (self->relevant_idx != NULL) {
+        PyMem_Free(self->relevant_idx);
+    }
+    if (self->param_names != NULL) {
+        for (int i = 0; i < self->n_params; i++) {
+            Py_XDECREF(self->param_names[i]);
+        }
+        PyMem_Free(self->param_names);
+    }
     PyObject_FREE(self);
 }
 
@@ -531,6 +597,10 @@ static void
 fix_name_if_typeerror(PyArray_ArrayFunctionDispatcherObject *self)
 {
     if (!PyErr_ExceptionMatches(PyExc_TypeError)) {
+        return;
+    }
+    /* Nothing to rewrite for tuple-spec dispatchers. */
+    if (self->dispatcher_name == NULL) {
         return;
     }
 
@@ -587,6 +657,99 @@ fix_name_if_typeerror(PyArray_ArrayFunctionDispatcherObject *self)
 }
 
 
+/*
+ * For a tuple-spec dispatcher, extract the value of the i-th relevant arg
+ * from positional/keyword arguments.  Returns Py_None if the arg is missing
+ * (so downstream checks can short-circuit on None).
+ */
+static inline PyObject *
+lookup_relevant_arg(
+        const PyArray_ArrayFunctionDispatcherObject *self, int i,
+        PyObject *const *args, Py_ssize_t nargs,
+        PyObject *kwnames, Py_ssize_t nkwargs)
+{
+    assert(i >= 0 && i < self->n_relevant_args);
+    /* The index encodes both channels: positional parameters form a
+     * prefix of the signature, so idx is the positional slot iff
+     * idx < n_pos_max; param_names[idx] is NULL for positional-only. */
+    int idx = self->relevant_idx[i];
+    if (idx < self->n_pos_max && idx < nargs) {
+        return args[idx];
+    }
+    PyObject *name = self->param_names[idx];
+    /* NULL name: positional-only, never matched by keyword. */
+    if (name != NULL && nkwargs > 0) {
+        /* Pointer-only pass first: call-site keywords and `name` are
+         * interned, so this normally hits without any calls.  The
+         * value-compare pass only matters for runtime-built keyword
+         * strings and cannot fail (both operands are str). */
+        for (Py_ssize_t k = 0; k < nkwargs; k++) {
+            if (PyTuple_GET_ITEM(kwnames, k) == name) {
+                return args[nargs + k];
+            }
+        }
+        for (Py_ssize_t k = 0; k < nkwargs; k++) {
+            PyObject *kw = PyTuple_GET_ITEM(kwnames, k);
+            if (PyUnicode_Compare(kw, name) == 0) {
+                return args[nargs + k];
+            }
+        }
+    }
+    return Py_None;
+}
+
+
+/*
+ * Validate the call shape against the public function's signature before
+ * forwarding an unmodified call to an __array_function__ override.  The
+ * no-override path needs no check here: it calls default_impl, whose own
+ * signature raises the same TypeErrors.
+ * Returns 0 if the call is valid, -1 with a TypeError set otherwise.
+ */
+static int
+validate_call_signature(
+        const PyArray_ArrayFunctionDispatcherObject *self,
+        Py_ssize_t nargs, PyObject *kwnames, Py_ssize_t nkwargs)
+{
+    if (nargs > self->n_pos_max) {
+        PyErr_Format(PyExc_TypeError,
+                "%U() takes at most %d positional arguments but %zd were "
+                "given", self->public_name, self->n_pos_max, nargs);
+        return -1;
+    }
+    Py_ssize_t missing = self->n_required - nargs;  /* <= 0 when satisfied */
+    for (Py_ssize_t k = 0; k < nkwargs; k++) {
+        PyObject *kw = PyTuple_GET_ITEM(kwnames, k);
+        int i = find_param_index(self, kw);
+        if (i == self->n_params) {
+            if (self->has_varkw) {
+                continue;
+            }
+            PyErr_Format(PyExc_TypeError,
+                    "%U() got an unexpected keyword argument '%U'",
+                    self->public_name, kw);
+            return -1;
+        }
+        if (i < nargs) {
+            PyErr_Format(PyExc_TypeError,
+                    "%U() got multiple values for argument '%U'",
+                    self->public_name, kw);
+            return -1;
+        }
+        if (i < self->n_required) {
+            missing--;
+        }
+    }
+    if (missing > 0) {
+        PyErr_Format(PyExc_TypeError,
+                "%U() missing %zd required positional argument%s",
+                self->public_name, missing, missing == 1 ? "" : "s");
+        return -1;
+    }
+    return 0;
+}
+
+
 static PyObject *
 dispatcher_vectorcall(PyArray_ArrayFunctionDispatcherObject *self,
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
@@ -607,16 +770,45 @@ dispatcher_vectorcall(PyArray_ArrayFunctionDispatcherObject *self,
     int num_implementing_args;
 
     if (self->reduction != NULL) {
-        int reduction_status = try_reduction(self, args, len_args, kwnames, &result);
+        int reduction_status = try_reduction(
+                self, args, len_args, kwnames, &result);
         if (reduction_status < 0) {
             return NULL;
         }
         if (reduction_status == 1) {
             return result;
         }
+        result = NULL;
     }
 
-    if (self->relevant_arg_func != NULL) {
+    if (self->relevant_idx != NULL) {
+        /* Tuple-spec: extract relevant args from the call directly.  When
+         * all are safe, get_implementing_args_and_methods returns 0 and the
+         * shared no-overrides path below calls default_impl. */
+        public_api = (PyObject *)self;
+        PyObject *items[NPY_MAXARGS];
+        Py_ssize_t nargs = PyVectorcall_NARGS(len_args);
+        Py_ssize_t nkwargs = (kwnames != NULL) ? PyTuple_GET_SIZE(kwnames) : 0;
+
+        for (int i = 0; i < self->n_relevant_args; i++) {
+            items[i] = lookup_relevant_arg(
+                    self, i, args, nargs, kwnames, nkwargs);
+        }
+
+        num_implementing_args = get_implementing_args_and_methods(
+                items, self->n_relevant_args,
+                implementing_args, array_function_methods);
+        if (num_implementing_args < 0) {
+            return NULL;
+        }
+        /* An override takes the call as-is, so check the signature first
+         * (the no-override path is checked by default_impl itself). */
+        if (num_implementing_args > 0
+                && validate_call_signature(self, nargs, kwnames, nkwargs) < 0) {
+            goto cleanup;
+        }
+    }
+    else if (self->relevant_arg_func != NULL) {
         public_api = (PyObject *)self;
 
         /* Typical path, need to call the relevant_arg_func and unpack them */
@@ -633,7 +825,9 @@ dispatcher_vectorcall(PyArray_ArrayFunctionDispatcherObject *self,
         }
 
         num_implementing_args = get_implementing_args_and_methods(
-                relevant_args, implementing_args, array_function_methods);
+                PySequence_Fast_ITEMS(relevant_args),
+                PySequence_Fast_GET_SIZE(relevant_args),
+                implementing_args, array_function_methods);
         if (num_implementing_args < 0) {
             Py_DECREF(relevant_args);
             return NULL;
@@ -745,21 +939,144 @@ cleanup:
 }
 
 
+/*
+ * Fill self's tuple-spec fields from ``(pairs, sig_info)`` as built by
+ * _resolve_relevant_arg_spec: ``pairs`` holds the relevant (name, position)
+ * pairs and ``sig_info`` the full-signature validation table.  Returns -1
+ * with an exception set on error; partially-filled fields are released by
+ * dispatcher_dealloc.
+ */
+static int
+init_relevant_arg_spec(
+        PyArray_ArrayFunctionDispatcherObject *self, PyObject *full_spec)
+{
+    PyObject *spec, *sig_info, *reduction_spec;
+    if (!PyArg_ParseTuple(full_spec, "O!O!O:_ArrayFunctionDispatcher",
+            &PyTuple_Type, &spec, &PyTuple_Type, &sig_info,
+            &reduction_spec)) {
+        return -1;
+    }
+
+    PyObject *sig_names;
+    int has_varkw;
+    if (!PyArg_ParseTuple(sig_info, "O!iip:_ArrayFunctionDispatcher",
+            &PyTuple_Type, &sig_names,
+            &self->n_pos_max, &self->n_required, &has_varkw)) {
+        return -1;
+    }
+    self->has_varkw = has_varkw;
+    Py_ssize_t n_params = PyTuple_GET_SIZE(sig_names);
+    if (n_params > UINT8_MAX) {
+        /* relevant_idx stores uint8_t parameter indices */
+        PyErr_Format(PyExc_ValueError,
+                "too many parameters (%zd) for a tuple-spec dispatcher",
+                n_params);
+        return -1;
+    }
+    self->param_names = PyMem_Calloc(n_params, sizeof(PyObject *));
+    if (self->param_names == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    self->n_params = (int)n_params;
+    for (Py_ssize_t i = 0; i < n_params; i++) {
+        PyObject *name = PyTuple_GET_ITEM(sig_names, i);
+        if (name == Py_None) {
+            /* positional-only: never matched by keyword */
+            continue;
+        }
+        if (!PyUnicode_Check(name)) {
+            PyErr_Format(PyExc_TypeError,
+                    "signature param name must be str or None, got %.200s",
+                    Py_TYPE(name)->tp_name);
+            return -1;
+        }
+        /* Own the reference before interning: InternInPlace may
+         * replace (and release) the object it is given. */
+        Py_INCREF(name);
+        PyUnicode_InternInPlace(&name);
+        self->param_names[i] = name;
+    }
+
+    Py_ssize_t n = PyTuple_GET_SIZE(spec);
+    if (n == 0) {
+        PyErr_SetString(PyExc_ValueError,
+                "tuple-spec dispatcher requires at least one relevant "
+                "argument name; got empty tuple");
+        return -1;
+    }
+    if (n > NPY_MAXARGS) {
+        PyErr_Format(PyExc_ValueError,
+                "too many relevant args (%zd > %d)", n, NPY_MAXARGS);
+        return -1;
+    }
+    self->relevant_idx = PyMem_Malloc(n * sizeof(uint8_t));
+    if (self->relevant_idx == NULL) {
+        PyErr_NoMemory();
+        return -1;
+    }
+    self->n_relevant_args = (int)n;
+    for (Py_ssize_t i = 0; i < n; i++) {
+        long idx = PyLong_AsLong(PyTuple_GET_ITEM(spec, i));
+        if (idx < 0 || idx >= n_params) {
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(PyExc_ValueError,
+                        "relevant arg index out of range");
+            }
+            return -1;
+        }
+        self->relevant_idx[i] = (uint8_t)idx;
+    }
+
+    if (reduction_spec != Py_None) {
+        PyObject *reduce_call, *slots_tup, *defaults_tup;
+        if (!PyArg_ParseTuple(reduction_spec, "OO!O!:reduction",
+                &reduce_call, &PyTuple_Type, &slots_tup,
+                &PyTuple_Type, &defaults_tup)) {
+            return -1;
+        }
+        if (!PyCallable_Check(reduce_call)) {
+            PyErr_SetString(PyExc_TypeError,
+                    "reduction callable must be callable");
+            return -1;
+        }
+        if (PyTuple_GET_SIZE(slots_tup) != n_params
+                || PyTuple_GET_SIZE(defaults_tup) != NPY_REDUCE_NARGS) {
+            PyErr_SetString(PyExc_ValueError,
+                    "reduction spec does not match the signature table");
+            return -1;
+        }
+        npy_reduction_info *red = PyMem_Malloc(
+                sizeof(npy_reduction_info) + n_params * sizeof(int));
+        if (red == NULL) {
+            PyErr_NoMemory();
+            return -1;
+        }
+        for (Py_ssize_t i = 0; i < n_params; i++) {
+            long slot = PyLong_AsLong(PyTuple_GET_ITEM(slots_tup, i));
+            if (slot < 0 || slot >= NPY_REDUCE_NARGS) {
+                if (!PyErr_Occurred()) {
+                    PyErr_SetString(PyExc_ValueError,
+                            "reduction slot out of range");
+                }
+                PyMem_Free(red);
+                return -1;
+            }
+            red->slots[i] = (int)slot;
+        }
+        red->call = Py_NewRef(reduce_call);
+        red->defaults = Py_NewRef(defaults_tup);
+        /* Set last: its presence enables try_reduction. */
+        self->reduction = red;
+    }
+    return 0;
+}
+
+
 static PyObject *
 dispatcher_new(PyTypeObject *NPY_UNUSED(cls), PyObject *args, PyObject *kwargs)
 {
     PyArray_ArrayFunctionDispatcherObject *self;
-    PyObject *reduction = Py_None;
-    PyObject *relevant_arg_func;
-    PyObject *default_impl;
-
-    char *kwlist[] = {"", "", "reduction", NULL};
-    if (!PyArg_ParseTupleAndKeywords(
-            args, kwargs, "OO|O:_ArrayFunctionDispatcher", kwlist,
-            &relevant_arg_func, &default_impl, &reduction)) {
-        return NULL;
-    }
-
     self = PyObject_New(
             PyArray_ArrayFunctionDispatcherObject,
             &PyArrayFunctionDispatcher_Type);
@@ -767,20 +1084,51 @@ dispatcher_new(PyTypeObject *NPY_UNUSED(cls), PyObject *args, PyObject *kwargs)
         return PyErr_NoMemory();
     }
 
+    /* Init all fields before any fallible call so dispatcher_dealloc is safe. */
     self->vectorcall = (vectorcallfunc)dispatcher_vectorcall;
     self->dict = NULL;
-    self->reduction = NULL;
-    self->reduction_kind = REDUCTION_NONE;
     self->dispatcher_name = NULL;
     self->public_name = NULL;
-    self->relevant_arg_func = Py_NewRef(relevant_arg_func);
-    self->default_impl = Py_NewRef(default_impl);
+    self->relevant_arg_func = NULL;
+    self->default_impl = NULL;
+    self->relevant_idx = NULL;
+    self->n_relevant_args = 0;
+    self->param_names = NULL;
+    self->n_params = 0;
+    self->n_pos_max = 0;
+    self->n_required = 0;
+    self->has_varkw = 0;
+    self->reduction = NULL;
 
-    if (self->relevant_arg_func == Py_None) {
-        /* NULL in the relevant arg function means we use `like=` */
-        Py_CLEAR(self->relevant_arg_func);
+    PyObject *relevant_arg_spec;
+    PyObject *default_impl;
+    char *kwlist[] = {"", "", NULL};
+    if (!PyArg_ParseTupleAndKeywords(
+            args, kwargs, "OO:_ArrayFunctionDispatcher", kwlist,
+            &relevant_arg_spec, &default_impl)) {
+        goto fail;
+    }
+    Py_INCREF(default_impl);
+    self->default_impl = default_impl;
+
+    if (relevant_arg_spec == Py_None) {
+        /* NULL relevant_arg_func means we use `like=` */
+    }
+    else if (PyTuple_CheckExact(relevant_arg_spec)) {
+        /* dispatcher_name stays NULL: there is no dispatcher function
+         * name to rewrite in TypeError messages.  public_name is used by
+         * validate_call_signature's error messages. */
+        self->public_name = PyObject_GetAttrString(
+            self->default_impl, "__qualname__");
+        if (self->public_name == NULL) {
+            goto fail;
+        }
+        if (init_relevant_arg_spec(self, relevant_arg_spec) < 0) {
+            goto fail;
+        }
     }
     else {
+        self->relevant_arg_func = Py_NewRef(relevant_arg_spec);
         /* Fetch names to clean up TypeErrors (show actual name) */
         self->dispatcher_name = PyObject_GetAttrString(
             self->relevant_arg_func, "__qualname__");
@@ -792,32 +1140,6 @@ dispatcher_new(PyTypeObject *NPY_UNUSED(cls), PyObject *args, PyObject *kwargs)
         if (self->public_name == NULL) {
             goto fail;
         }
-    }
-
-    if (reduction != Py_None) {
-        PyObject *callable;
-        int kind;
-
-        if (self->relevant_arg_func == NULL) {
-            PyErr_SetString(
-                    PyExc_TypeError,
-                    "reduction is not supported for like= dispatchers");
-            goto fail;
-        }
-        if (!PyTuple_Check(reduction) ||
-                !PyArg_ParseTuple(reduction, "Oi:reduction", &callable, &kind) ||
-                !PyCallable_Check(callable)) {
-            PyErr_SetString(
-                    PyExc_TypeError,
-                    "reduction must be a (callable, kind) tuple");
-            goto fail;
-        }
-        if (kind < REDUCTION_SUM_PROD || kind > REDUCTION_ANY_ALL) {
-            PyErr_SetString(PyExc_ValueError, "invalid reduction kind");
-            goto fail;
-        }
-        self->reduction = Py_NewRef(callable);
-        self->reduction_kind = kind;
     }
 
     /* Need to be like a Python function that has arbitrary attributes */

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -141,12 +141,8 @@ def _clean_args(*args):
     return newargs
 
 
-def _multiply_dispatcher(a, i):
-    return (a,)
-
-
 @set_module("numpy.strings")
-@array_function_dispatch(_multiply_dispatcher)
+@array_function_dispatch(("a",))
 def multiply(a, i):
     """
     Return (a * i), that is string multiple concatenation,
@@ -210,12 +206,8 @@ def multiply(a, i):
     return _multiply_ufunc(a, i, out=out)
 
 
-def _mod_dispatcher(a, values):
-    return (a, values)
-
-
 @set_module("numpy.strings")
-@array_function_dispatch(_mod_dispatcher)
+@array_function_dispatch(("a", "values"))
 def mod(a, values):
     """
     Return (a % i), that is pre-Python 2.6 string formatting
@@ -528,12 +520,8 @@ def endswith(a, suffix, start=0, end=None):
     return _endswith_ufunc(a, suffix, start, end)
 
 
-def _code_dispatcher(a, encoding=None, errors=None):
-    return (a,)
-
-
 @set_module("numpy.strings")
-@array_function_dispatch(_code_dispatcher)
+@array_function_dispatch(("a",))
 def decode(a, encoding=None, errors=None):
     r"""
     Calls :meth:`bytes.decode` element-wise.
@@ -582,7 +570,7 @@ def decode(a, encoding=None, errors=None):
 
 
 @set_module("numpy.strings")
-@array_function_dispatch(_code_dispatcher)
+@array_function_dispatch(("a",))
 def encode(a, encoding=None, errors=None):
     """
     Calls :meth:`str.encode` element-wise.
@@ -627,12 +615,8 @@ def encode(a, encoding=None, errors=None):
         np.bytes_(b''))
 
 
-def _expandtabs_dispatcher(a, tabsize=None):
-    return (a,)
-
-
 @set_module("numpy.strings")
-@array_function_dispatch(_expandtabs_dispatcher)
+@array_function_dispatch(("a",))
 def expandtabs(a, tabsize=8):
     """
     Return a copy of each string element where all tab characters are
@@ -684,12 +668,8 @@ def expandtabs(a, tabsize=8):
     return _expandtabs(a, tabsize, out=out)
 
 
-def _just_dispatcher(a, width, fillchar=None):
-    return (a,)
-
-
 @set_module("numpy.strings")
-@array_function_dispatch(_just_dispatcher)
+@array_function_dispatch(("a",))
 def center(a, width, fillchar=' '):
     """
     Return a copy of `a` with its elements centered in a string of
@@ -758,7 +738,7 @@ def center(a, width, fillchar=' '):
 
 
 @set_module("numpy.strings")
-@array_function_dispatch(_just_dispatcher)
+@array_function_dispatch(("a",))
 def ljust(a, width, fillchar=' '):
     """
     Return an array with the elements of `a` left-justified in a
@@ -823,7 +803,7 @@ def ljust(a, width, fillchar=' '):
 
 
 @set_module("numpy.strings")
-@array_function_dispatch(_just_dispatcher)
+@array_function_dispatch(("a",))
 def rjust(a, width, fillchar=' '):
     """
     Return an array with the elements of `a` right-justified in a
@@ -887,12 +867,8 @@ def rjust(a, width, fillchar=' '):
     return _rjust(a, width, fillchar, out=out)
 
 
-def _zfill_dispatcher(a, width):
-    return (a,)
-
-
 @set_module("numpy.strings")
-@array_function_dispatch(_zfill_dispatcher)
+@array_function_dispatch(("a",))
 def zfill(a, width):
     """
     Return the numeric string left-filled with zeros. A leading
@@ -1077,12 +1053,8 @@ def strip(a, chars=None):
     return _strip_chars(a, chars)
 
 
-def _unary_op_dispatcher(a):
-    return (a,)
-
-
 @set_module("numpy.strings")
-@array_function_dispatch(_unary_op_dispatcher)
+@array_function_dispatch(("a",))
 def upper(a):
     """
     Return an array with the elements converted to uppercase.
@@ -1120,7 +1092,7 @@ def upper(a):
 
 
 @set_module("numpy.strings")
-@array_function_dispatch(_unary_op_dispatcher)
+@array_function_dispatch(("a",))
 def lower(a):
     """
     Return an array with the elements converted to lowercase.
@@ -1158,7 +1130,7 @@ def lower(a):
 
 
 @set_module("numpy.strings")
-@array_function_dispatch(_unary_op_dispatcher)
+@array_function_dispatch(("a",))
 def swapcase(a):
     """
     Return element-wise a copy of the string with
@@ -1199,7 +1171,7 @@ def swapcase(a):
 
 
 @set_module("numpy.strings")
-@array_function_dispatch(_unary_op_dispatcher)
+@array_function_dispatch(("a",))
 def capitalize(a):
     """
     Return a copy of ``a`` with only the first character of each element
@@ -1240,7 +1212,7 @@ def capitalize(a):
 
 
 @set_module("numpy.strings")
-@array_function_dispatch(_unary_op_dispatcher)
+@array_function_dispatch(("a",))
 def title(a):
     """
     Return element-wise title cased version of string or unicode.
@@ -1282,12 +1254,8 @@ def title(a):
     return _vec_string(a_arr, a_arr.dtype, 'title')
 
 
-def _replace_dispatcher(a, old, new, count=None):
-    return (a,)
-
-
 @set_module("numpy.strings")
-@array_function_dispatch(_replace_dispatcher)
+@array_function_dispatch(("a",))
 def replace(a, old, new, count=-1):
     """
     For each element in ``a``, return a copy of the string with
@@ -1351,11 +1319,7 @@ def replace(a, old, new, count=-1):
     return _replace(arr, old, new, counts, out=out)
 
 
-def _join_dispatcher(sep, seq):
-    return (sep, seq)
-
-
-@array_function_dispatch(_join_dispatcher)
+@array_function_dispatch(("sep", "seq"))
 def _join(sep, seq):
     """
     Return a string which is the concatenation of the strings in the
@@ -1392,11 +1356,7 @@ def _join(sep, seq):
         _vec_string(sep, np.object_, 'join', (seq,)), seq)
 
 
-def _split_dispatcher(a, sep=None, maxsplit=None):
-    return (a,)
-
-
-@array_function_dispatch(_split_dispatcher)
+@array_function_dispatch(("a",))
 def _split(a, sep=None, maxsplit=None):
     """
     For each element in `a`, return a list of the words in the
@@ -1441,7 +1401,7 @@ def _split(a, sep=None, maxsplit=None):
         a, np.object_, 'split', [sep] + _clean_args(maxsplit))
 
 
-@array_function_dispatch(_split_dispatcher)
+@array_function_dispatch(("a",))
 def _rsplit(a, sep=None, maxsplit=None):
     """
     For each element in `a`, return a list of the words in the
@@ -1487,11 +1447,7 @@ def _rsplit(a, sep=None, maxsplit=None):
         a, np.object_, 'rsplit', [sep] + _clean_args(maxsplit))
 
 
-def _splitlines_dispatcher(a, keepends=None):
-    return (a,)
-
-
-@array_function_dispatch(_splitlines_dispatcher)
+@array_function_dispatch(("a",))
 def _splitlines(a, keepends=None):
     """
     For each element in `a`, return a list of the lines in the
@@ -1529,12 +1485,8 @@ def _splitlines(a, keepends=None):
         a, np.object_, 'splitlines', _clean_args(keepends))
 
 
-def _partition_dispatcher(a, sep):
-    return (a,)
-
-
 @set_module("numpy.strings")
-@array_function_dispatch(_partition_dispatcher)
+@array_function_dispatch(("a",))
 def partition(a, sep):
     """
     Partition each element in ``a`` around ``sep``.
@@ -1603,7 +1555,7 @@ def partition(a, sep):
 
 
 @set_module("numpy.strings")
-@array_function_dispatch(_partition_dispatcher)
+@array_function_dispatch(("a",))
 def rpartition(a, sep):
     """
     Partition (split) each element around the right-most separator.
@@ -1672,12 +1624,8 @@ def rpartition(a, sep):
         a, sep, pos, out=(out["f0"], out["f1"], out["f2"]))
 
 
-def _translate_dispatcher(a, table, deletechars=None):
-    return (a,)
-
-
 @set_module("numpy.strings")
-@array_function_dispatch(_translate_dispatcher)
+@array_function_dispatch(("a",))
 def translate(a, table, deletechars=None):
     """
     For each element in `a`, return a copy of the string where all

--- a/numpy/_core/tests/test_overrides.py
+++ b/numpy/_core/tests/test_overrides.py
@@ -12,7 +12,6 @@ import numpy as np
 from numpy._core._multiarray_umath import _ArrayFunctionDispatcher
 from numpy._core.overrides import (
     _get_implementing_args,
-    _ReductionKind,
     array_function_dispatch,
     verify_matching_signatures,
 )
@@ -42,17 +41,20 @@ class TestGetImplementingArgs:
     def test_ndarray(self):
         array = np.array(1)
 
+        # When every arg is exact ndarray or a basic Python type, no
+        # override is possible; the collected list is empty and the caller
+        # short-circuits to the default implementation.
         args = _get_implementing_args([array])
-        assert_equal(list(args), [array])
+        assert_equal(list(args), [])
 
         args = _get_implementing_args([array, array])
-        assert_equal(list(args), [array])
+        assert_equal(list(args), [])
 
         args = _get_implementing_args([array, 1])
-        assert_equal(list(args), [array])
+        assert_equal(list(args), [])
 
         args = _get_implementing_args([1, array])
-        assert_equal(list(args), [array])
+        assert_equal(list(args), [])
 
     def test_ndarray_subclasses(self):
 
@@ -298,26 +300,26 @@ class TestVerifyMatchingSignatures:
             pass
 
     def test_reduction_configuration_errors(self):
-        implementation = lambda *args, **kwargs: None
-        dispatcher = lambda x: (x,)
+        # reduction= requires a tuple-spec dispatcher
+        with pytest.raises(TypeError, match="tuple-spec"):
+            @array_function_dispatch(lambda a, out=None: (a, out),
+                                     reduction=np.add)
+            def _f(a, out=None):
+                return a
 
-        with pytest.raises(TypeError, match="like= dispatchers"):
-            _ArrayFunctionDispatcher(
-                    None, implementation, (np.add.reduce, 1))
+        # parameters that cannot be mapped onto ufunc.reduce are rejected
+        with pytest.raises(RuntimeError, match="cannot map"):
+            @array_function_dispatch(("a", "out"), reduction=np.add)
+            def _g(a, out=None, bogus=None):
+                return a
 
-        invalid_reductions = [
-            object(),
-            (object(), _ReductionKind.SUM_PROD),
-            (np.add.reduce, object()),
-        ]
-        for reduction in invalid_reductions:
-            with pytest.raises(TypeError, match=r"callable, kind\) tuple"):
-                _ArrayFunctionDispatcher(
-                        dispatcher, implementation, reduction)
-
-        with pytest.raises(ValueError, match="invalid reduction kind"):
-            _ArrayFunctionDispatcher(
-                    dispatcher, implementation, (np.add.reduce, 99))
+        # unknown reduce argument names in the defaults are rejected
+        with pytest.raises(KeyError):
+            @array_function_dispatch(
+                    ("a", "out"), reduction=np.add,
+                    reduction_defaults={"bogus": 1})
+            def _h(a, out=None):
+                return a
 
     def test_dispatcher_constructor_argument_error(self):
         dispatcher = lambda x: (x,)
@@ -325,19 +327,25 @@ class TestVerifyMatchingSignatures:
         with pytest.raises(TypeError, match=r"_ArrayFunctionDispatcher\(\)"):
             _ArrayFunctionDispatcher(dispatcher)
 
-    def test_reduction_kinds_match_c_enum(self):
-        implementation = lambda *args, **kwargs: None
-        dispatcher = lambda x: (x,)
+    def test_reduction_dispatches_and_falls_back(self):
+        # exact-ndarray calls take the direct ufunc.reduce path; overrides
+        # and invalid signatures fall back to normal dispatch
+        @array_function_dispatch(("a", "out"), reduction=np.add)
+        def my_sum(a, axis=None, dtype=None, out=None):
+            return "python-impl"
 
-        for kind in _ReductionKind:
-            _ArrayFunctionDispatcher(
-                    dispatcher, implementation, (np.add.reduce, kind))
+        # exact ndarray: direct reduce call, wrapper never runs
+        assert my_sum(np.array([1, 2, 3])) == 6
+        assert my_sum(np.array([1, 2, 3]), axis=0) == 6
 
-        # A new C reduction kind must also be added to the Python enum.
-        next_kind = max(kind.value for kind in _ReductionKind) + 1
-        with pytest.raises(ValueError, match="invalid reduction kind"):
-            _ArrayFunctionDispatcher(
-                    dispatcher, implementation, (np.add.reduce, next_kind))
+        # non-exact arrays fall back to the Python implementation
+        assert my_sum([1, 2, 3]) == "python-impl"
+
+        # overrides still dispatch
+        class Duck:
+            def __array_function__(self, func, types, args, kwargs):
+                return "duck"
+        assert my_sum(Duck()) == "duck"
 
 
 def _new_duck_type_and_implements():
@@ -564,6 +572,26 @@ class TestNumPyFunctions:
     def test_inspect_sum(self):
         signature = inspect.signature(np.sum)
         assert_('axis' in signature.parameters)
+        assert_equal(signature, inspect.signature(np.sum._implementation))
+
+    @pytest.mark.parametrize("func", [
+        np.sum,            # tuple-spec dispatcher
+        np.reshape,        # tuple-spec, positional-only relevant arg
+        np.any,            # tuple-spec, keyword-only relevant arg
+        pytest.param(
+            np.concatenate,  # legacy callable dispatcher, C implementation
+            marks=pytest.mark.skipif(
+                sys.flags.optimize > 1,
+                reason="the C implementation's signature comes from its "
+                       "docstring, which -OO strips")),
+        np.fft.fft,        # tuple-spec in a submodule
+        np.linalg.solve,   # tuple-spec in a submodule
+    ])
+    def test_inspect_signature_matches_implementation(self, func):
+        # Both dispatcher forms expose the implementation's signature via
+        # __wrapped__ (set by functools.update_wrapper).
+        assert_equal(inspect.signature(func),
+                     inspect.signature(func._implementation))
 
     def test_override_sum(self):
         MyArray, implements = _new_duck_type_and_implements()
@@ -860,3 +888,200 @@ def test_function_like():
     bound = np.mean.__get__(MyClass)  # classmethod
     with pytest.raises(TypeError, match="unsupported operand type"):
         bound()
+
+
+def _make_duck(result, calls=None):
+    """A minimal class implementing __array_function__."""
+    class Duck:
+        def __array_function__(self, func, types, args, kwargs):
+            if calls is not None:
+                calls.append(func)
+            return result
+    return Duck
+
+
+# The same dispatch scenarios must behave identically for tuple-spec and
+# legacy callable dispatchers; tests using `dispatched_op` run through
+# both C code paths.
+@pytest.fixture(params=["tuple-spec", "callable"])
+def dispatched_op(request):
+    """An (a, out=None) function dispatched via each dispatcher form."""
+    if request.param == "tuple-spec":
+        decorator = array_function_dispatch(("a", "out"))
+    else:
+        decorator = array_function_dispatch(lambda a, out=None: (a, out))
+
+    @decorator
+    def op(a, out=None):
+        return "original"
+    return op
+
+
+class TestTupleSpecDispatch:
+    """Tuple-spec dispatcher: spec validation and construction."""
+
+    def test_construction_failure_does_not_crash(self):
+        from numpy._core._multiarray_umath import _ArrayFunctionDispatcher
+        with pytest.raises(TypeError):
+            _ArrayFunctionDispatcher(42, 42, 42)
+        with pytest.raises(TypeError):
+            _ArrayFunctionDispatcher(42)
+        with pytest.raises(TypeError):
+            _ArrayFunctionDispatcher()
+
+    def test_empty_tuple_spec_rejected(self):
+        with pytest.raises(ValueError, match="at least one relevant"):
+            @array_function_dispatch(())
+            def _f(a):
+                return a
+
+    def test_docs_from_dispatcher_incompatible_with_tuple_spec(self):
+        with pytest.raises(TypeError, match="docs_from_dispatcher"):
+            @array_function_dispatch(("a",), docs_from_dispatcher=True)
+            def _f(a):
+                return a
+
+    def test_var_positional_rejected(self):
+        # *args makes tuple-spec positions ambiguous at call time.
+        with pytest.raises(RuntimeError, match=r"\*args"):
+            @array_function_dispatch(("a", "out"))
+            def _f(a, *args, out=None):
+                return a
+
+    def test_required_keyword_only_rejected(self):
+        # validate_call_signature does not track required keyword-only
+        # parameters, so they cannot be allowed at decoration time.
+        with pytest.raises(RuntimeError, match="keyword-only"):
+            @array_function_dispatch(("a", "out"))
+            def _f(a, *, out):
+                return a
+
+    def test_unknown_arg_name_rejected(self):
+        with pytest.raises(RuntimeError, match="not found"):
+            @array_function_dispatch(("a", "missing"))
+            def _f(a, out=None):
+                return a
+
+    def test_non_string_spec_rejected(self):
+        with pytest.raises(TypeError, match="only strings"):
+            @array_function_dispatch(("a", 42))
+            def _f(a, out=None):
+                return a
+
+    def test_namedtuple_not_treated_as_tuple_spec(self):
+        # Match C-side PyTuple_CheckExact; tuple subclasses take callable path.
+        from collections import namedtuple
+        NT = namedtuple("NT", ["a", "b"])
+        spec = NT("a", "out")
+
+        with pytest.raises(TypeError):
+            @array_function_dispatch(spec)
+            def _f(a, out=None):
+                return a
+
+    def test_wrapped_impl_signature_followed(self):
+        # inspect.signature follows __wrapped__; reading __code__ would fail.
+        import functools
+
+        def _wrap(func):
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+            return wrapper
+
+        @array_function_dispatch(("a", "out"))
+        @_wrap
+        def _f(a, out=None):
+            return a
+
+        assert _f(np.arange(3)) is not None
+
+    def test_name_and_docstring_preserved(self):
+        @array_function_dispatch(("a",))
+        def my_func(a):
+            """My docstring."""
+            return a
+
+        assert my_func.__name__ == "my_func"
+        if sys.flags.optimize < 2:
+            assert my_func.__doc__ == "My docstring."
+
+    def test_kwonly_relevant_arg_excess_positional(self):
+        # A kwonly relevant arg (where) must never be read positionally:
+        # an invalid call with excess positional args raises TypeError
+        # instead of dispatching on the excess arg.
+        duck = _make_duck("duck")()
+        with pytest.raises(TypeError, match="positional"):
+            np.any(np.arange(3), 0, None, True, duck)
+        # valid keyword use still dispatches
+        assert np.any(np.arange(3), where=duck) == "duck"
+
+    def test_posonly_relevant_arg_by_keyword(self):
+        # A positional-only relevant arg (a in reshape) must never be
+        # matched by keyword: the invalid call raises TypeError instead
+        # of dispatching.
+        duck = _make_duck("duck")()
+        with pytest.raises(TypeError, match="positional-only"):
+            np.reshape(a=duck, shape=(2,))
+        # valid positional use still dispatches
+        assert np.reshape(duck, (2,)) == "duck"
+
+    def test_invalid_signature_with_override(self):
+        # A signature-invalid call must raise TypeError even when an
+        # __array_function__ override is present, instead of forwarding
+        # the invalid call to the override unchecked.
+        duck = _make_duck("duck")()
+        with pytest.raises(TypeError, match="unexpected keyword"):
+            np.sum(duck, bogus=3)
+        with pytest.raises(TypeError, match="multiple values"):
+            np.sum(duck, a="duplicate")
+        with pytest.raises(TypeError, match="positional arguments"):
+            np.sum(duck, 0, None, None, False, 0, True, "extra")
+        # the valid call still dispatches
+        assert np.sum(duck) == "duck"
+
+
+class TestDispatchFormEquivalence:
+    """The same scenarios through both tuple-spec and callable dispatchers."""
+
+    def test_all_safe_args_call_implementation(self, dispatched_op):
+        assert dispatched_op(np.arange(3)) == "original"
+        assert dispatched_op(np.arange(3), out=None) == "original"
+
+    def test_dispatches_ndarray_subclass(self, dispatched_op):
+        calls = []
+
+        class Sub(np.ndarray):
+            def __array_function__(self, func, types, args, kwargs):
+                calls.append(func)
+                return "subclass-handled"
+
+        assert dispatched_op(np.arange(3).view(Sub)) == "subclass-handled"
+        assert calls == [dispatched_op]
+
+    def test_dispatches_duck_array(self, dispatched_op):
+        calls = []
+        duck = _make_duck("duck-handled", calls)()
+        assert dispatched_op(duck) == "duck-handled"
+        assert calls == [dispatched_op]
+
+    def test_out_keyword_dispatch(self, dispatched_op):
+        calls = []
+        duck = _make_duck("duck-out", calls)()
+        assert dispatched_op(np.arange(3), out=duck) == "duck-out"
+        assert calls == [dispatched_op]
+
+    def test_not_implemented_no_fallback(self, dispatched_op):
+        duck = _make_duck(NotImplemented)()
+        with pytest.raises(TypeError, match="no implementation found"):
+            dispatched_op(duck)
+
+    def test_mixed_ndarray_and_duck(self, dispatched_op):
+        # ndarray fallback must stay in the chain when a subclass's
+        # override returns NotImplemented.
+        class Sub(np.ndarray):
+            def __array_function__(self, func, types, args, kwargs):
+                return NotImplemented
+
+        out = np.arange(3).view(Sub)
+        assert dispatched_op(np.arange(3), out=out) == "original"

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -113,11 +113,7 @@ def _swap_direction(norm):
                          '"ortho" or "forward".') from None
 
 
-def _fft_dispatcher(a, n=None, axis=None, norm=None, out=None):
-    return (a, out)
-
-
-@array_function_dispatch(_fft_dispatcher)
+@array_function_dispatch(("a", "out"))
 def fft(a, n=None, axis=-1, norm=None, out=None):
     """
     Compute the one-dimensional discrete Fourier Transform.
@@ -216,7 +212,7 @@ def fft(a, n=None, axis=-1, norm=None, out=None):
     return output
 
 
-@array_function_dispatch(_fft_dispatcher)
+@array_function_dispatch(("a", "out"))
 def ifft(a, n=None, axis=-1, norm=None, out=None):
     """
     Compute the one-dimensional inverse discrete Fourier Transform.
@@ -321,7 +317,7 @@ def ifft(a, n=None, axis=-1, norm=None, out=None):
     return output
 
 
-@array_function_dispatch(_fft_dispatcher)
+@array_function_dispatch(("a", "out"))
 def rfft(a, n=None, axis=-1, norm=None, out=None):
     """
     Compute the one-dimensional discrete Fourier Transform for real input.
@@ -418,7 +414,7 @@ def rfft(a, n=None, axis=-1, norm=None, out=None):
     return output
 
 
-@array_function_dispatch(_fft_dispatcher)
+@array_function_dispatch(("a", "out"))
 def irfft(a, n=None, axis=-1, norm=None, out=None):
     """
     Computes the inverse of `rfft`.
@@ -526,7 +522,7 @@ def irfft(a, n=None, axis=-1, norm=None, out=None):
     return output
 
 
-@array_function_dispatch(_fft_dispatcher)
+@array_function_dispatch(("a", "out"))
 def hfft(a, n=None, axis=-1, norm=None, out=None):
     """
     Compute the FFT of a signal that has Hermitian symmetry, i.e., a real
@@ -629,7 +625,7 @@ def hfft(a, n=None, axis=-1, norm=None, out=None):
     return output
 
 
-@array_function_dispatch(_fft_dispatcher)
+@array_function_dispatch(("a", "out"))
 def ihfft(a, n=None, axis=-1, norm=None, out=None):
     """
     Compute the inverse FFT of a signal that has Hermitian symmetry.
@@ -748,11 +744,7 @@ def _raw_fftnd(a, s=None, axes=None, function=fft, norm=None, out=None):
     return a
 
 
-def _fftn_dispatcher(a, s=None, axes=None, norm=None, out=None):
-    return (a, out)
-
-
-@array_function_dispatch(_fftn_dispatcher)
+@array_function_dispatch(("a", "out"))
 def fftn(a, s=None, axes=None, norm=None, out=None):
     """
     Compute the N-dimensional discrete Fourier Transform.
@@ -884,7 +876,7 @@ def fftn(a, s=None, axes=None, norm=None, out=None):
     return _raw_fftnd(a, s, axes, fft, norm, out=out)
 
 
-@array_function_dispatch(_fftn_dispatcher)
+@array_function_dispatch(("a", "out"))
 def ifftn(a, s=None, axes=None, norm=None, out=None):
     """
     Compute the N-dimensional inverse discrete Fourier Transform.
@@ -1016,7 +1008,7 @@ def ifftn(a, s=None, axes=None, norm=None, out=None):
     return _raw_fftnd(a, s, axes, ifft, norm, out=out)
 
 
-@array_function_dispatch(_fftn_dispatcher)
+@array_function_dispatch(("a", "out"))
 def fft2(a, s=None, axes=(-2, -1), norm=None, out=None):
     """
     Compute the 2-dimensional discrete Fourier Transform.
@@ -1141,7 +1133,7 @@ def fft2(a, s=None, axes=(-2, -1), norm=None, out=None):
     return _raw_fftnd(a, s, axes, fft, norm, out=out)
 
 
-@array_function_dispatch(_fftn_dispatcher)
+@array_function_dispatch(("a", "out"))
 def ifft2(a, s=None, axes=(-2, -1), norm=None, out=None):
     """
     Compute the 2-dimensional inverse discrete Fourier Transform.
@@ -1263,7 +1255,7 @@ def ifft2(a, s=None, axes=(-2, -1), norm=None, out=None):
     return _raw_fftnd(a, s, axes, ifft, norm, out=out)
 
 
-@array_function_dispatch(_fftn_dispatcher)
+@array_function_dispatch(("a", "out"))
 def rfftn(a, s=None, axes=None, norm=None, out=None):
     """
     Compute the N-dimensional discrete Fourier Transform for real input.
@@ -1390,7 +1382,7 @@ def rfftn(a, s=None, axes=None, norm=None, out=None):
     return a
 
 
-@array_function_dispatch(_fftn_dispatcher)
+@array_function_dispatch(("a", "out"))
 def rfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
     """
     Compute the 2-dimensional FFT of a real array.
@@ -1470,7 +1462,7 @@ def rfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
     return rfftn(a, s, axes, norm, out=out)
 
 
-@array_function_dispatch(_fftn_dispatcher)
+@array_function_dispatch(("a", "out"))
 def irfftn(a, s=None, axes=None, norm=None, out=None):
     """
     Computes the inverse of `rfftn`.
@@ -1609,7 +1601,7 @@ def irfftn(a, s=None, axes=None, norm=None, out=None):
     return a
 
 
-@array_function_dispatch(_fftn_dispatcher)
+@array_function_dispatch(("a", "out"))
 def irfft2(a, s=None, axes=(-2, -1), norm=None, out=None):
     """
     Computes the inverse of `rfft2`.

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -33,11 +33,7 @@ __all__ = [
 ]
 
 
-def _ediff1d_dispatcher(ary, to_end=None, to_begin=None):
-    return (ary, to_end, to_begin)
-
-
-@array_function_dispatch(_ediff1d_dispatcher)
+@array_function_dispatch(("ary", "to_end", "to_begin"))
 def ediff1d(ary, to_end=None, to_begin=None):
     """
     The differences between consecutive elements of an array.
@@ -136,13 +132,7 @@ def _unpack_tuple(x):
         return x
 
 
-def _unique_dispatcher(ar, return_index=None, return_inverse=None,
-                       return_counts=None, axis=None, *, equal_nan=None,
-                       sorted=True):
-    return (ar,)
-
-
-@array_function_dispatch(_unique_dispatcher)
+@array_function_dispatch(("ar",))
 def unique(ar, return_index=False, return_inverse=False,
            return_counts=False, axis=None, *, equal_nan=True,
            sorted=True):
@@ -433,11 +423,7 @@ class UniqueInverseResult(NamedTuple):
     inverse_indices: np.ndarray
 
 
-def _unique_all_dispatcher(x, /):
-    return (x,)
-
-
-@array_function_dispatch(_unique_all_dispatcher)
+@array_function_dispatch(("x",))
 def unique_all(x):
     """
     Find the unique elements of an array, and counts, inverse, and indices.
@@ -497,11 +483,7 @@ def unique_all(x):
     return UniqueAllResult(*result)
 
 
-def _unique_counts_dispatcher(x, /):
-    return (x,)
-
-
-@array_function_dispatch(_unique_counts_dispatcher)
+@array_function_dispatch(("x",))
 def unique_counts(x):
     """
     Find the unique elements and counts of an input array `x`.
@@ -553,11 +535,7 @@ def unique_counts(x):
     return UniqueCountsResult(*result)
 
 
-def _unique_inverse_dispatcher(x, /):
-    return (x,)
-
-
-@array_function_dispatch(_unique_inverse_dispatcher)
+@array_function_dispatch(("x",))
 def unique_inverse(x):
     """
     Find the unique elements of `x` and indices to reconstruct `x`.
@@ -610,11 +588,7 @@ def unique_inverse(x):
     return UniqueInverseResult(*result)
 
 
-def _unique_values_dispatcher(x, /):
-    return (x,)
-
-
-@array_function_dispatch(_unique_values_dispatcher)
+@array_function_dispatch(("x",))
 def unique_values(x):
     """
     Returns the unique elements of an input array `x`.
@@ -658,12 +632,7 @@ def unique_values(x):
     )
 
 
-def _intersect1d_dispatcher(
-        ar1, ar2, assume_unique=None, return_indices=None):
-    return (ar1, ar2)
-
-
-@array_function_dispatch(_intersect1d_dispatcher)
+@array_function_dispatch(("ar1", "ar2"))
 def intersect1d(ar1, ar2, assume_unique=False, return_indices=False):
     """
     Find the intersection of two arrays.
@@ -755,11 +724,7 @@ def intersect1d(ar1, ar2, assume_unique=False, return_indices=False):
         return int1d
 
 
-def _setxor1d_dispatcher(ar1, ar2, assume_unique=None):
-    return (ar1, ar2)
-
-
-@array_function_dispatch(_setxor1d_dispatcher)
+@array_function_dispatch(("ar1", "ar2"))
 def setxor1d(ar1, ar2, assume_unique=False):
     """
     Find the set exclusive-or of two arrays.
@@ -950,12 +915,7 @@ def _isin(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
         return ret[rev_idx]
 
 
-def _isin_dispatcher(element, test_elements, assume_unique=None, invert=None,
-                     *, kind=None):
-    return (element, test_elements)
-
-
-@array_function_dispatch(_isin_dispatcher)
+@array_function_dispatch(("element", "test_elements"))
 def isin(element, test_elements, assume_unique=False, invert=False, *,
          kind=None):
     """
@@ -1076,11 +1036,7 @@ def isin(element, test_elements, assume_unique=False, invert=False, *,
                  invert=invert, kind=kind).reshape(element.shape)
 
 
-def _union1d_dispatcher(ar1, ar2):
-    return (ar1, ar2)
-
-
-@array_function_dispatch(_union1d_dispatcher)
+@array_function_dispatch(("ar1", "ar2"))
 def union1d(ar1, ar2):
     """
     Find the union of two arrays.
@@ -1113,11 +1069,7 @@ def union1d(ar1, ar2):
     return unique(np.concatenate((ar1, ar2), axis=None))
 
 
-def _setdiff1d_dispatcher(ar1, ar2, assume_unique=None):
-    return (ar1, ar2)
-
-
-@array_function_dispatch(_setdiff1d_dispatcher)
+@array_function_dispatch(("ar1", "ar2"))
 def setdiff1d(ar1, ar2, assume_unique=False):
     """
     Find the set difference of two arrays.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -173,11 +173,7 @@ _QuantileMethods = {
     }}
 
 
-def _rot90_dispatcher(m, k=None, axes=None):
-    return (m,)
-
-
-@array_function_dispatch(_rot90_dispatcher)
+@array_function_dispatch(("m",))
 def rot90(m, k=1, axes=(0, 1)):
     """
     Rotate an array by 90 degrees in the plane specified by axes.
@@ -277,11 +273,7 @@ def rot90(m, k=1, axes=(0, 1)):
         return flip(transpose(m, axes_list), axes[1])
 
 
-def _flip_dispatcher(m, axis=None):
-    return (m,)
-
-
-@array_function_dispatch(_flip_dispatcher)
+@array_function_dispatch(("m",))
 def flip(m, axis=None):
     """
     Reverse the order of elements in an array along the given axis.
@@ -443,12 +435,7 @@ def _weights_are_valid(weights, a, axis):
     return wgt
 
 
-def _average_dispatcher(a, axis=None, weights=None, returned=None, *,
-                        keepdims=None):
-    return (a, weights)
-
-
-@array_function_dispatch(_average_dispatcher)
+@array_function_dispatch(("a", "weights"))
 def average(a, axis=None, weights=None, returned=False, *,
             keepdims=np._NoValue):
     """
@@ -929,11 +916,7 @@ def select(condlist, choicelist, default=0):
     return result
 
 
-def _copy_dispatcher(a, order=None, subok=None):
-    return (a,)
-
-
-@array_function_dispatch(_copy_dispatcher)
+@array_function_dispatch(("a",))
 def copy(a, order='K', subok=False):
     """
     Return an array copy of the given object.
@@ -1407,11 +1390,7 @@ def gradient(f, *varargs, axis=None, edge_order=1):
     return tuple(outvals)
 
 
-def _diff_dispatcher(a, n=None, axis=None, prepend=None, append=None):
-    return (a, prepend, append)
-
-
-@array_function_dispatch(_diff_dispatcher)
+@array_function_dispatch(("a", "prepend", "append"))
 def diff(a, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
     """
     Calculate the n-th discrete difference along the given axis.
@@ -1543,11 +1522,7 @@ def diff(a, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
     return a
 
 
-def _interp_dispatcher(x, xp, fp, left=None, right=None, period=None):
-    return (x, xp, fp)
-
-
-@array_function_dispatch(_interp_dispatcher)
+@array_function_dispatch(("x", "xp", "fp"))
 def interp(x, xp, fp, left=None, right=None, period=None):
     """
     One-dimensional linear interpolation for monotonically increasing sample points.
@@ -1687,11 +1662,7 @@ def interp(x, xp, fp, left=None, right=None, period=None):
     return interp_func(x, xp, fp, left, right)
 
 
-def _angle_dispatcher(z, deg=None):
-    return (z,)
-
-
-@array_function_dispatch(_angle_dispatcher)
+@array_function_dispatch(("z",))
 def angle(z, deg=False):
     """
     Return the angle of the complex argument.
@@ -1772,11 +1743,7 @@ def _unwrap_fallback(p, discont, period, axis):
     return up
 
 
-def _unwrap_dispatcher(p, discont=None, axis=None, *, period=None):
-    return (p,)
-
-
-@array_function_dispatch(_unwrap_dispatcher)
+@array_function_dispatch(("p",))
 def unwrap(p, discont=None, axis=-1, *, period=2 * pi):
     r"""
     Unwrap by taking the complement of large deltas with respect to the period.
@@ -2076,11 +2043,7 @@ def trim_zeros(filt, trim='fb', axis=None):
     return filt[sl]
 
 
-def _extract_dispatcher(condition, arr):
-    return (condition, arr)
-
-
-@array_function_dispatch(_extract_dispatcher)
+@array_function_dispatch(("condition", "arr"))
 def extract(condition, arr):
     """
     Return the elements of an array that satisfy some condition.
@@ -2133,11 +2096,7 @@ def extract(condition, arr):
     return _nx.take(ravel(arr), nonzero(ravel(condition))[0])
 
 
-def _place_dispatcher(arr, mask, vals):
-    return (arr, mask, vals)
-
-
-@array_function_dispatch(_place_dispatcher)
+@array_function_dispatch(("arr", "mask", "vals"))
 def place(arr, mask, vals):
     """
     Change elements of an array based on conditional and input values.
@@ -2708,12 +2667,7 @@ class vectorize:
         return outputs[0] if nout == 1 else outputs
 
 
-def _cov_dispatcher(m, y=None, rowvar=None, bias=None, ddof=None,
-                    fweights=None, aweights=None, *, dtype=None):
-    return (m, y, fweights, aweights)
-
-
-@array_function_dispatch(_cov_dispatcher)
+@array_function_dispatch(("m", "y", "fweights", "aweights"))
 def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
         aweights=None, *, dtype=None):
     """
@@ -2931,12 +2885,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
     return c.squeeze()
 
 
-def _corrcoef_dispatcher(x, y=None, rowvar=None, *,
-                         dtype=None):
-    return (x, y)
-
-
-@array_function_dispatch(_corrcoef_dispatcher)
+@array_function_dispatch(("x", "y"))
 def corrcoef(x, y=None, rowvar=True, *,
              dtype=None):
     """
@@ -3566,11 +3515,7 @@ def _i0_2(x):
     return exp(x) * _chbevl(32.0 / x - 2.0, _i0B) / sqrt(x)
 
 
-def _i0_dispatcher(x):
-    return (x,)
-
-
-@array_function_dispatch(_i0_dispatcher)
+@array_function_dispatch(("x",))
 def i0(x):
     """
     Modified Bessel function of the first kind, order 0.
@@ -3764,11 +3709,7 @@ def kaiser(M, beta):
     return i0(beta * sqrt(1 - ((n - alpha) / alpha)**2.0)) / i0(beta)
 
 
-def _sinc_dispatcher(x):
-    return (x,)
-
-
-@array_function_dispatch(_sinc_dispatcher)
+@array_function_dispatch(("x",))
 def sinc(x):
     r"""
     Return the normalized sinc function.
@@ -3935,12 +3876,7 @@ def _ureduce(a, func, keepdims=False, **kwargs):
     return r
 
 
-def _median_dispatcher(
-        a, axis=None, out=None, overwrite_input=None, keepdims=None):
-    return (a, out)
-
-
-@array_function_dispatch(_median_dispatcher)
+@array_function_dispatch(("a", "out"))
 def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     """
     Compute the median along the specified axis.
@@ -4084,12 +4020,7 @@ def _median(a, axis=None, out=None, overwrite_input=False):
     return rout
 
 
-def _percentile_dispatcher(a, q, axis=None, out=None, overwrite_input=None,
-                           method=None, keepdims=None, *, weights=None):
-    return (a, q, out, weights)
-
-
-@array_function_dispatch(_percentile_dispatcher)
+@array_function_dispatch(("a", "q", "out", "weights"))
 def percentile(a,
                q,
                axis=None,
@@ -4286,12 +4217,7 @@ def percentile(a,
         a, q, axis, out, overwrite_input, method, keepdims, weights, weak_q)
 
 
-def _quantile_dispatcher(a, q, axis=None, out=None, overwrite_input=None,
-                         method=None, keepdims=None, *, weights=None):
-    return (a, q, out, weights)
-
-
-@array_function_dispatch(_quantile_dispatcher)
+@array_function_dispatch(("a", "q", "out", "weights"))
 def quantile(a,
              q,
              axis=None,
@@ -4941,11 +4867,7 @@ def _quantile(
     return result
 
 
-def _trapezoid_dispatcher(y, x=None, dx=None, axis=None):
-    return (y, x)
-
-
-@array_function_dispatch(_trapezoid_dispatcher)
+@array_function_dispatch(("y", "x"))
 def trapezoid(y, x=None, dx=1.0, axis=-1):
     r"""
     Integrate along the given axis using the composite trapezoidal rule.
@@ -5239,11 +5161,7 @@ def meshgrid(*xi, copy=True, sparse=False, indexing='xy'):
     return output
 
 
-def _delete_dispatcher(arr, obj, axis=None):
-    return (arr, obj)
-
-
-@array_function_dispatch(_delete_dispatcher)
+@array_function_dispatch(("arr", "obj"))
 def delete(arr, obj, axis=None):
     """
     Return a new array with sub-arrays along an axis deleted. For a one
@@ -5423,11 +5341,7 @@ def delete(arr, obj, axis=None):
     return conv.wrap(new, to_scalar=False)
 
 
-def _insert_dispatcher(arr, obj, values, axis=None):
-    return (arr, obj, values)
-
-
-@array_function_dispatch(_insert_dispatcher)
+@array_function_dispatch(("arr", "obj", "values"))
 def insert(arr, obj, values, axis=None):
     """
     Insert values along the given axis before the given indices.
@@ -5620,11 +5534,7 @@ def insert(arr, obj, values, axis=None):
     return conv.wrap(new, to_scalar=False)
 
 
-def _append_dispatcher(arr, values, axis=None):
-    return (arr, values)
-
-
-@array_function_dispatch(_append_dispatcher)
+@array_function_dispatch(("arr", "values"))
 def append(arr, values, axis=None):
     """
     Append values to the end of an array.
@@ -5694,11 +5604,7 @@ def append(arr, values, axis=None):
     return concatenate((arr, values), axis=axis)
 
 
-def _digitize_dispatcher(x, bins, right=None):
-    return (x, bins)
-
-
-@array_function_dispatch(_digitize_dispatcher)
+@array_function_dispatch(("x", "bins"))
 def digitize(x, bins, right=False):
     """
     Return the indices of the bins to which each value in input array belongs.

--- a/numpy/lib/_histograms_impl.py
+++ b/numpy/lib/_histograms_impl.py
@@ -466,11 +466,7 @@ def _search_sorted_inclusive(a, v):
     ))
 
 
-def _histogram_bin_edges_dispatcher(a, bins=None, range=None, weights=None):
-    return (a, bins, weights)
-
-
-@array_function_dispatch(_histogram_bin_edges_dispatcher)
+@array_function_dispatch(("a", "bins", "weights"))
 def histogram_bin_edges(a, bins=10, range=None, weights=None):
     r"""
     Function to calculate only the edges of the bins used by the `histogram`
@@ -677,12 +673,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
     return bin_edges
 
 
-def _histogram_dispatcher(
-        a, bins=None, range=None, density=None, weights=None):
-    return (a, bins, weights)
-
-
-@array_function_dispatch(_histogram_dispatcher)
+@array_function_dispatch(("a", "bins", "weights"))
 def histogram(a, bins=10, range=None, density=None, weights=None):
     r"""
     Compute the histogram of a dataset.

--- a/numpy/lib/_index_tricks_impl.py
+++ b/numpy/lib/_index_tricks_impl.py
@@ -787,11 +787,7 @@ s_ = IndexExpression(maketuple=False)
 # applicable to N-dimensions.
 
 
-def _fill_diagonal_dispatcher(a, val, wrap=None):
-    return (a,)
-
-
-@array_function_dispatch(_fill_diagonal_dispatcher)
+@array_function_dispatch(("a",))
 def fill_diagonal(a, val, wrap=False):
     """Fill the main diagonal of the given array of any dimensionality.
 

--- a/numpy/lib/_nanfunctions_impl.py
+++ b/numpy/lib/_nanfunctions_impl.py
@@ -244,12 +244,7 @@ def _divide_by_count(a, b, out=None):
             return np.divide(a, b, out=out, casting='unsafe')
 
 
-def _nanmin_dispatcher(a, axis=None, out=None, keepdims=None,
-                       initial=None, where=None):
-    return (a, out)
-
-
-@array_function_dispatch(_nanmin_dispatcher)
+@array_function_dispatch(("a", "out"))
 def nanmin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
            where=np._NoValue):
     """
@@ -374,12 +369,7 @@ def nanmin(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     return res
 
 
-def _nanmax_dispatcher(a, axis=None, out=None, keepdims=None,
-                       initial=None, where=None):
-    return (a, out)
-
-
-@array_function_dispatch(_nanmax_dispatcher)
+@array_function_dispatch(("a", "out"))
 def nanmax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
            where=np._NoValue):
     """
@@ -503,11 +493,7 @@ def nanmax(a, axis=None, out=None, keepdims=np._NoValue, initial=np._NoValue,
     return res
 
 
-def _nanargmin_dispatcher(a, axis=None, out=None, *, keepdims=None):
-    return (a,)
-
-
-@array_function_dispatch(_nanargmin_dispatcher)
+@array_function_dispatch(("a",))
 def nanargmin(a, axis=None, out=None, *, keepdims=np._NoValue):
     """
     Return the indices of the minimum values in the specified axis ignoring
@@ -564,11 +550,7 @@ def nanargmin(a, axis=None, out=None, *, keepdims=np._NoValue):
     return res
 
 
-def _nanargmax_dispatcher(a, axis=None, out=None, *, keepdims=None):
-    return (a,)
-
-
-@array_function_dispatch(_nanargmax_dispatcher)
+@array_function_dispatch(("a",))
 def nanargmax(a, axis=None, out=None, *, keepdims=np._NoValue):
     """
     Return the indices of the maximum values in the specified axis ignoring
@@ -626,12 +608,7 @@ def nanargmax(a, axis=None, out=None, *, keepdims=np._NoValue):
     return res
 
 
-def _nansum_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
-                       initial=None, where=None):
-    return (a, out)
-
-
-@array_function_dispatch(_nansum_dispatcher)
+@array_function_dispatch(("a", "out"))
 def nansum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
            initial=np._NoValue, where=np._NoValue):
     """
@@ -727,12 +704,7 @@ def nansum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
                   initial=initial, where=where)
 
 
-def _nanprod_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
-                        initial=None, where=None):
-    return (a, out)
-
-
-@array_function_dispatch(_nanprod_dispatcher)
+@array_function_dispatch(("a", "out"))
 def nanprod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
             initial=np._NoValue, where=np._NoValue):
     """
@@ -809,11 +781,7 @@ def nanprod(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
                    initial=initial, where=where)
 
 
-def _nancumsum_dispatcher(a, axis=None, dtype=None, out=None):
-    return (a, out)
-
-
-@array_function_dispatch(_nancumsum_dispatcher)
+@array_function_dispatch(("a", "out"))
 def nancumsum(a, axis=None, dtype=None, out=None):
     """
     Return the cumulative sum of array elements over a given axis treating Not a
@@ -878,11 +846,7 @@ def nancumsum(a, axis=None, dtype=None, out=None):
     return np.cumsum(a, axis=axis, dtype=dtype, out=out)
 
 
-def _nancumprod_dispatcher(a, axis=None, dtype=None, out=None):
-    return (a, out)
-
-
-@array_function_dispatch(_nancumprod_dispatcher)
+@array_function_dispatch(("a", "out"))
 def nancumprod(a, axis=None, dtype=None, out=None):
     """
     Return the cumulative product of array elements over a given axis treating Not a
@@ -944,12 +908,7 @@ def nancumprod(a, axis=None, dtype=None, out=None):
     return np.cumprod(a, axis=axis, dtype=dtype, out=out)
 
 
-def _nanmean_dispatcher(a, axis=None, dtype=None, out=None, keepdims=None,
-                        *, where=None):
-    return (a, out)
-
-
-@array_function_dispatch(_nanmean_dispatcher)
+@array_function_dispatch(("a", "out"))
 def nanmean(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
             *, where=np._NoValue):
     """
@@ -1117,12 +1076,7 @@ def _nanmedian_small(a, axis=None, out=None, overwrite_input=False):
     return m.filled(fill_value)
 
 
-def _nanmedian_dispatcher(
-        a, axis=None, out=None, overwrite_input=None, keepdims=None):
-    return (a, out)
-
-
-@array_function_dispatch(_nanmedian_dispatcher)
+@array_function_dispatch(("a", "out"))
 def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=np._NoValue):
     """
     Compute the median along the specified axis, while ignoring NaNs.
@@ -1216,13 +1170,7 @@ def nanmedian(a, axis=None, out=None, overwrite_input=False, keepdims=np._NoValu
                         overwrite_input=overwrite_input)
 
 
-def _nanpercentile_dispatcher(
-        a, q, axis=None, out=None, overwrite_input=None,
-        method=None, keepdims=None, *, weights=None):
-    return (a, q, out, weights)
-
-
-@array_function_dispatch(_nanpercentile_dispatcher)
+@array_function_dispatch(("a", "q", "out", "weights"))
 def nanpercentile(
         a,
         q,
@@ -1395,12 +1343,7 @@ def nanpercentile(
         a, q, axis, out, overwrite_input, method, keepdims, weights, weak_q)
 
 
-def _nanquantile_dispatcher(a, q, axis=None, out=None, overwrite_input=None,
-                            method=None, keepdims=None, *, weights=None):
-    return (a, q, out, weights)
-
-
-@array_function_dispatch(_nanquantile_dispatcher)
+@array_function_dispatch(("a", "q", "out", "weights"))
 def nanquantile(
         a,
         q,
@@ -1681,13 +1624,7 @@ def _nanquantile_1d(
     )
 
 
-def _nanvar_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
-                       keepdims=None, *, where=None, mean=None,
-                       correction=None):
-    return (a, out)
-
-
-@array_function_dispatch(_nanvar_dispatcher)
+@array_function_dispatch(("a", "out"))
 def nanvar(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue,
            *, where=np._NoValue, mean=np._NoValue, correction=np._NoValue):
     """
@@ -1871,13 +1808,7 @@ def nanvar(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue,
     return var
 
 
-def _nanstd_dispatcher(a, axis=None, dtype=None, out=None, ddof=None,
-                       keepdims=None, *, where=None, mean=None,
-                       correction=None):
-    return (a, out)
-
-
-@array_function_dispatch(_nanstd_dispatcher)
+@array_function_dispatch(("a", "out"))
 def nanstd(a, axis=None, dtype=None, out=None, ddof=0, keepdims=np._NoValue,
            *, where=np._NoValue, mean=np._NoValue, correction=np._NoValue):
     """

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -497,11 +497,7 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
                     f"Failed to interpret file {file!r} as a pickle") from e
 
 
-def _save_dispatcher(file, arr, allow_pickle=None):
-    return (arr,)
-
-
-@array_function_dispatch(_save_dispatcher)
+@array_function_dispatch(("arr",))
 def save(file, arr, allow_pickle=True):
     """
     Save an array to a binary file in NumPy ``.npy`` format.
@@ -1389,13 +1385,7 @@ def loadtxt(fname, dtype=float, comments='#', delimiter=None,
 _loadtxt_with_like = array_function_dispatch()(loadtxt)
 
 
-def _savetxt_dispatcher(fname, X, fmt=None, delimiter=None, newline=None,
-                        header=None, footer=None, comments=None,
-                        encoding=None):
-    return (X,)
-
-
-@array_function_dispatch(_savetxt_dispatcher)
+@array_function_dispatch(("X",))
 def savetxt(fname, X, fmt='%.18e', delimiter=' ', newline='\n', header='',
             footer='', comments='# ', encoding=None):
     """

--- a/numpy/lib/_polynomial_impl.py
+++ b/numpy/lib/_polynomial_impl.py
@@ -262,11 +262,7 @@ def roots(p):
     return roots
 
 
-def _polyint_dispatcher(p, m=None, k=None):
-    return (p,)
-
-
-@array_function_dispatch(_polyint_dispatcher)
+@array_function_dispatch(("p",))
 def polyint(p, m=1, k=None):
     """
     Return an antiderivative (indefinite integral) of a polynomial.
@@ -370,11 +366,7 @@ def polyint(p, m=1, k=None):
         return val
 
 
-def _polyder_dispatcher(p, m=None):
-    return (p,)
-
-
-@array_function_dispatch(_polyder_dispatcher)
+@array_function_dispatch(("p",))
 def polyder(p, m=1):
     """
     Return the derivative of the specified order of a polynomial.
@@ -453,11 +445,7 @@ def polyder(p, m=1):
     return val
 
 
-def _polyfit_dispatcher(x, y, deg, rcond=None, full=None, w=None, cov=None):
-    return (x, y, w)
-
-
-@array_function_dispatch(_polyfit_dispatcher)
+@array_function_dispatch(("x", "y", "w"))
 def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     """
     Least squares polynomial fit.
@@ -706,11 +694,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
         return c
 
 
-def _polyval_dispatcher(p, x):
-    return (p, x)
-
-
-@array_function_dispatch(_polyval_dispatcher)
+@array_function_dispatch(("p", "x"))
 def polyval(p, x):
     """
     Evaluate a polynomial at specific values.
@@ -790,11 +774,7 @@ def polyval(p, x):
     return y
 
 
-def _binary_op_dispatcher(a1, a2):
-    return (a1, a2)
-
-
-@array_function_dispatch(_binary_op_dispatcher)
+@array_function_dispatch(("a1", "a2"))
 def polyadd(a1, a2):
     """
     Find the sum of two polynomials.
@@ -863,7 +843,7 @@ def polyadd(a1, a2):
     return val
 
 
-@array_function_dispatch(_binary_op_dispatcher)
+@array_function_dispatch(("a1", "a2"))
 def polysub(a1, a2):
     """
     Difference (subtraction) of two polynomials.
@@ -920,7 +900,7 @@ def polysub(a1, a2):
     return val
 
 
-@array_function_dispatch(_binary_op_dispatcher)
+@array_function_dispatch(("a1", "a2"))
 def polymul(a1, a2):
     """
     Find the product of two polynomials.
@@ -984,11 +964,7 @@ def polymul(a1, a2):
     return val
 
 
-def _polydiv_dispatcher(u, v):
-    return (u, v)
-
-
-@array_function_dispatch(_polydiv_dispatcher)
+@array_function_dispatch(("u", "v"))
 def polydiv(u, v):
     """
     Returns the quotient and remainder of polynomial division.

--- a/numpy/lib/_scimath_impl.py
+++ b/numpy/lib/_scimath_impl.py
@@ -178,12 +178,8 @@ def _fix_real_abs_gt_1(x):
     return x
 
 
-def _unary_dispatcher(x):
-    return (x,)
-
-
 @set_module('numpy.lib.scimath')
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("x",))
 def sqrt(x):
     """
     Compute the square root of x.
@@ -239,7 +235,7 @@ def sqrt(x):
 
 
 @set_module('numpy.lib.scimath')
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("x",))
 def log(x):
     """
     Compute the natural logarithm of `x`.
@@ -289,7 +285,7 @@ def log(x):
 
 
 @set_module('numpy.lib.scimath')
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("x",))
 def log10(x):
     """
     Compute the logarithm base 10 of `x`.
@@ -340,12 +336,8 @@ def log10(x):
     return nx.log10(x)
 
 
-def _logn_dispatcher(n, x):
-    return (n, x,)
-
-
 @set_module('numpy.lib.scimath')
-@array_function_dispatch(_logn_dispatcher)
+@array_function_dispatch(("n", "x"))
 def logn(n, x):
     """
     Take log base n of x.
@@ -383,7 +375,7 @@ def logn(n, x):
 
 
 @set_module('numpy.lib.scimath')
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("x",))
 def log2(x):
     """
     Compute the logarithm base 2 of `x`.
@@ -432,12 +424,8 @@ def log2(x):
     return nx.log2(x)
 
 
-def _power_dispatcher(x, p):
-    return (x, p)
-
-
 @set_module('numpy.lib.scimath')
-@array_function_dispatch(_power_dispatcher)
+@array_function_dispatch(("x", "p"))
 def power(x, p):
     """
     Return x to the power p, (x**p).
@@ -492,7 +480,7 @@ def power(x, p):
 
 
 @set_module('numpy.lib.scimath')
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("x",))
 def arccos(x):
     """
     Compute the inverse cosine of x.
@@ -539,7 +527,7 @@ def arccos(x):
 
 
 @set_module('numpy.lib.scimath')
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("x",))
 def arcsin(x):
     """
     Compute the inverse sine of x.
@@ -587,7 +575,7 @@ def arcsin(x):
 
 
 @set_module('numpy.lib.scimath')
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("x",))
 def arctanh(x):
     """
     Compute the inverse hyperbolic tangent of `x`.

--- a/numpy/lib/_shape_base_impl.py
+++ b/numpy/lib/_shape_base_impl.py
@@ -53,11 +53,7 @@ def _make_along_axis_idx(arr_shape, indices, axis):
     return tuple(fancy_index)
 
 
-def _take_along_axis_dispatcher(arr, indices, axis=None):
-    return (arr, indices)
-
-
-@array_function_dispatch(_take_along_axis_dispatcher)
+@array_function_dispatch(("arr", "indices"))
 def take_along_axis(arr, indices, axis=-1):
     """
     Take values from the input array by matching 1d index and data slices.
@@ -179,11 +175,7 @@ def take_along_axis(arr, indices, axis=-1):
     return arr[_make_along_axis_idx(arr.shape, indices, axis)]
 
 
-def _put_along_axis_dispatcher(arr, indices, values, axis):
-    return (arr, indices, values)
-
-
-@array_function_dispatch(_put_along_axis_dispatcher)
+@array_function_dispatch(("arr", "indices", "values"))
 def put_along_axis(arr, indices, values, axis):
     """
     Put values into the destination array by matching 1d index and data slices.
@@ -414,11 +406,7 @@ def apply_along_axis(func1d, axis, arr, *args, **kwargs):
     return conv.wrap(res)
 
 
-def _apply_over_axes_dispatcher(func, a, axes):
-    return (a,)
-
-
-@array_function_dispatch(_apply_over_axes_dispatcher)
+@array_function_dispatch(("a",))
 def apply_over_axes(func, a, axes):
     """
     Apply a function repeatedly over multiple axes.
@@ -506,11 +494,7 @@ def apply_over_axes(func, a, axes):
     return val
 
 
-def _expand_dims_dispatcher(a, axis):
-    return (a,)
-
-
-@array_function_dispatch(_expand_dims_dispatcher)
+@array_function_dispatch(("a",))
 def expand_dims(a, axis):
     """
     Expand the shape of an array.
@@ -712,11 +696,7 @@ def dstack(tup):
     return _nx.concatenate(arrs, 2)
 
 
-def _array_split_dispatcher(ary, indices_or_sections, axis=None):
-    return (ary, indices_or_sections)
-
-
-@array_function_dispatch(_array_split_dispatcher)
+@array_function_dispatch(("ary", "indices_or_sections"))
 def array_split(ary, indices_or_sections, axis=0):
     """
     Split an array into multiple sub-arrays.
@@ -773,11 +753,7 @@ def array_split(ary, indices_or_sections, axis=0):
     return sub_arys
 
 
-def _split_dispatcher(ary, indices_or_sections, axis=None):
-    return (ary, indices_or_sections)
-
-
-@array_function_dispatch(_split_dispatcher)
+@array_function_dispatch(("ary", "indices_or_sections"))
 def split(ary, indices_or_sections, axis=0):
     """
     Split an array into multiple sub-arrays as views into `ary`.
@@ -856,11 +832,7 @@ def split(ary, indices_or_sections, axis=0):
     return array_split(ary, indices_or_sections, axis)
 
 
-def _hvdsplit_dispatcher(ary, indices_or_sections):
-    return (ary, indices_or_sections)
-
-
-@array_function_dispatch(_hvdsplit_dispatcher)
+@array_function_dispatch(("ary", "indices_or_sections"))
 def hsplit(ary, indices_or_sections):
     """
     Split an array into multiple sub-arrays horizontally (column-wise).
@@ -931,7 +903,7 @@ def hsplit(ary, indices_or_sections):
         return split(ary, indices_or_sections, 0)
 
 
-@array_function_dispatch(_hvdsplit_dispatcher)
+@array_function_dispatch(("ary", "indices_or_sections"))
 def vsplit(ary, indices_or_sections):
     """
     Split an array into multiple sub-arrays vertically (row-wise).
@@ -985,7 +957,7 @@ def vsplit(ary, indices_or_sections):
     return split(ary, indices_or_sections, 0)
 
 
-@array_function_dispatch(_hvdsplit_dispatcher)
+@array_function_dispatch(("ary", "indices_or_sections"))
 def dsplit(ary, indices_or_sections):
     """
     Split array into multiple sub-arrays along the 3rd axis (depth).
@@ -1031,11 +1003,7 @@ def dsplit(ary, indices_or_sections):
     return split(ary, indices_or_sections, 2)
 
 
-def _kron_dispatcher(a, b):
-    return (a, b)
-
-
-@array_function_dispatch(_kron_dispatcher)
+@array_function_dispatch(("a", "b"))
 def kron(a, b):
     """
     Kronecker product of two arrays.
@@ -1150,11 +1118,7 @@ def kron(a, b):
     return result if not is_any_mat else matrix(result, copy=False)
 
 
-def _tile_dispatcher(A, reps):
-    return (A, reps)
-
-
-@array_function_dispatch(_tile_dispatcher)
+@array_function_dispatch(("A", "reps"))
 def tile(A, reps):
     """
     Construct an array by repeating A the number of times given by reps.

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -57,11 +57,7 @@ def _min_int(low, high):
     return int64
 
 
-def _flip_dispatcher(m):
-    return (m,)
-
-
-@array_function_dispatch(_flip_dispatcher)
+@array_function_dispatch(("m",))
 def fliplr(m):
     """
     Reverse the order of elements along axis 1 (left/right).
@@ -117,7 +113,7 @@ def fliplr(m):
     return m[:, ::-1]
 
 
-@array_function_dispatch(_flip_dispatcher)
+@array_function_dispatch(("m",))
 def flipud(m):
     """
     Reverse the order of elements along axis 0 (up/down).
@@ -253,11 +249,7 @@ def eye(N, M=None, k=0, dtype=float, order='C', *, device=None, like=None):
 _eye_with_like = array_function_dispatch()(eye)
 
 
-def _diag_dispatcher(v, k=None):
-    return (v,)
-
-
-@array_function_dispatch(_diag_dispatcher)
+@array_function_dispatch(("v",))
 def diag(v, k=0):
     """
     Extract a diagonal or construct a diagonal array.
@@ -330,7 +322,7 @@ def diag(v, k=0):
         raise ValueError("Input must be 1- or 2-d.")
 
 
-@array_function_dispatch(_diag_dispatcher)
+@array_function_dispatch(("v",))
 def diagflat(v, k=0):
     """
     Create a two-dimensional array with the flattened input as a diagonal.
@@ -474,11 +466,7 @@ def tri(N, M=None, k=0, dtype=float, *, like=None):
 _tri_with_like = array_function_dispatch()(tri)
 
 
-def _trilu_dispatcher(m, k=None):
-    return (m,)
-
-
-@array_function_dispatch(_trilu_dispatcher)
+@array_function_dispatch(("m",))
 def tril(m, k=0):
     """
     Lower triangle of an array.
@@ -534,7 +522,7 @@ def tril(m, k=0):
     return where(mask, m, zeros(1, m.dtype))
 
 
-@array_function_dispatch(_trilu_dispatcher)
+@array_function_dispatch(("m",))
 def triu(m, k=0):
     """
     Upper triangle of an array.
@@ -579,12 +567,8 @@ def triu(m, k=0):
     return where(mask, zeros(1, m.dtype), m)
 
 
-def _vander_dispatcher(x, N=None, increasing=None):
-    return (x,)
-
-
 # Originally borrowed from John Hunter and matplotlib
-@array_function_dispatch(_vander_dispatcher)
+@array_function_dispatch(("x",))
 def vander(x, N=None, increasing=False):
     """
     Generate a Vandermonde matrix.
@@ -1016,11 +1000,7 @@ def tril_indices(n, k=0, m=None):
                  for inds in indices(tri_.shape, sparse=True))
 
 
-def _trilu_indices_form_dispatcher(arr, k=None):
-    return (arr,)
-
-
-@array_function_dispatch(_trilu_indices_form_dispatcher)
+@array_function_dispatch(("arr",))
 def tril_indices_from(arr, k=0):
     """
     Return the indices for the lower-triangle of arr.
@@ -1179,7 +1159,7 @@ def triu_indices(n, k=0, m=None):
                  for inds in indices(tri_.shape, sparse=True))
 
 
-@array_function_dispatch(_trilu_indices_form_dispatcher)
+@array_function_dispatch(("arr",))
 def triu_indices_from(arr, k=0):
     """
     Return the indices for the upper-triangle of arr.

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -78,11 +78,7 @@ def mintypecode(typechars, typeset='GDFgdf', default='d'):
     return min(intersection, key=_typecodes_by_elsize.index)
 
 
-def _real_dispatcher(val):
-    return (val,)
-
-
-@array_function_dispatch(_real_dispatcher)
+@array_function_dispatch(("val",))
 def real(val):
     """
     Return the real part of the complex argument.
@@ -125,11 +121,7 @@ def real(val):
         return asanyarray(val).real
 
 
-def _imag_dispatcher(val):
-    return (val,)
-
-
-@array_function_dispatch(_imag_dispatcher)
+@array_function_dispatch(("val",))
 def imag(val):
     """
     Return the imaginary part of the complex argument.
@@ -169,11 +161,7 @@ def imag(val):
         return asanyarray(val).imag
 
 
-def _is_type_dispatcher(x):
-    return (x,)
-
-
-@array_function_dispatch(_is_type_dispatcher)
+@array_function_dispatch(("x",))
 def iscomplex(x):
     """
     Returns a bool array, where True if input element is complex.
@@ -211,7 +199,7 @@ def iscomplex(x):
     return res[()]   # convert to scalar if needed
 
 
-@array_function_dispatch(_is_type_dispatcher)
+@array_function_dispatch(("x",))
 def isreal(x):
     """
     Returns a bool array, where True if input element is real.
@@ -262,7 +250,7 @@ def isreal(x):
     return imag(x) == 0
 
 
-@array_function_dispatch(_is_type_dispatcher)
+@array_function_dispatch(("x",))
 def iscomplexobj(x):
     """
     Check for a complex type or an array of complex numbers.
@@ -304,7 +292,7 @@ def iscomplexobj(x):
     return issubclass(type_, _nx.complexfloating)
 
 
-@array_function_dispatch(_is_type_dispatcher)
+@array_function_dispatch(("x",))
 def isrealobj(x):
     """
     Return True if x is a not complex type or an array of complex numbers.
@@ -361,11 +349,7 @@ def _getmaxmin(t):
     return f.max, f.min
 
 
-def _nan_to_num_dispatcher(x, copy=None, nan=None, posinf=None, neginf=None):
-    return (x,)
-
-
-@array_function_dispatch(_nan_to_num_dispatcher)
+@array_function_dispatch(("x",))
 def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     """
     Replace NaN with zero and infinity with large finite numbers (default
@@ -488,11 +472,8 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
 
 #-----------------------------------------------------------------------------
 
-def _real_if_close_dispatcher(a, tol=None):
-    return (a,)
 
-
-@array_function_dispatch(_real_if_close_dispatcher)
+@array_function_dispatch(("a",))
 def real_if_close(a, tol=100):
     """
     If input is complex with all imaginary parts close to zero, return

--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -24,11 +24,7 @@ __all__ = [
     ]
 
 
-def _recursive_fill_fields_dispatcher(input, output):
-    return (input, output)
-
-
-@array_function_dispatch(_recursive_fill_fields_dispatcher)
+@array_function_dispatch(("input", "output"))
 def recursive_fill_fields(input, output):
     """
     Fills fields from output with fields from input,
@@ -497,11 +493,7 @@ def merge_arrays(seqarrays, fill_value=-1, flatten=False,
     return output
 
 
-def _drop_fields_dispatcher(base, drop_names, usemask=None, asrecarray=None):
-    return (base,)
-
-
-@array_function_dispatch(_drop_fields_dispatcher)
+@array_function_dispatch(("base",))
 def drop_fields(base, drop_names, usemask=True, asrecarray=False):
     """
     Return a new array with fields in `drop_names` dropped.
@@ -588,11 +580,7 @@ def _keep_fields(base, keep_names, usemask=True, asrecarray=False):
     return _fix_output(output, usemask=usemask, asrecarray=asrecarray)
 
 
-def _rec_drop_fields_dispatcher(base, drop_names):
-    return (base,)
-
-
-@array_function_dispatch(_rec_drop_fields_dispatcher)
+@array_function_dispatch(("base",))
 def rec_drop_fields(base, drop_names):
     """
     Returns a new numpy.recarray with fields in `drop_names` dropped.
@@ -600,11 +588,7 @@ def rec_drop_fields(base, drop_names):
     return drop_fields(base, drop_names, usemask=False, asrecarray=True)
 
 
-def _rename_fields_dispatcher(base, namemapper):
-    return (base,)
-
-
-@array_function_dispatch(_rename_fields_dispatcher)
+@array_function_dispatch(("base",))
 def rename_fields(base, namemapper):
     """
     Rename the fields from a flexible-datatype ndarray or recarray.
@@ -762,11 +746,7 @@ def rec_append_fields(base, names, data, dtypes=None):
                          asrecarray=True, usemask=False)
 
 
-def _repack_fields_dispatcher(a, align=None, recurse=None):
-    return (a,)
-
-
-@array_function_dispatch(_repack_fields_dispatcher)
+@array_function_dispatch(("a",))
 def repack_fields(a, align=False, recurse=False):
     """
     Re-pack the fields of a structured array or dtype in memory.
@@ -932,11 +912,7 @@ def _common_stride(offsets, counts, itemsize):
     return stride
 
 
-def _structured_to_unstructured_dispatcher(arr, dtype=None, copy=None,
-                                           casting=None):
-    return (arr,)
-
-@array_function_dispatch(_structured_to_unstructured_dispatcher)
+@array_function_dispatch(("arr",))
 def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
     """
     Converts an n-D structured array into an (n+1)-D unstructured array.
@@ -1067,11 +1043,7 @@ def structured_to_unstructured(arr, dtype=None, copy=False, casting='unsafe'):
     return arr.view((out_dtype, (sum(counts),)))
 
 
-def _unstructured_to_structured_dispatcher(arr, dtype=None, names=None,
-                                           align=None, copy=None, casting=None):
-    return (arr,)
-
-@array_function_dispatch(_unstructured_to_structured_dispatcher)
+@array_function_dispatch(("arr",))
 def unstructured_to_structured(arr, dtype=None, names=None, align=False,
                                copy=False, casting='unsafe'):
     """
@@ -1179,10 +1151,8 @@ def unstructured_to_structured(arr, dtype=None, names=None, align=False,
     # finally view as the final nested dtype and remove the last axis
     return arr.view(out_dtype)[..., 0]
 
-def _apply_along_fields_dispatcher(func, arr):
-    return (arr,)
 
-@array_function_dispatch(_apply_along_fields_dispatcher)
+@array_function_dispatch(("arr",))
 def apply_along_fields(func, arr):
     """
     Apply function 'func' as a reduction across fields of a structured array.
@@ -1226,10 +1196,8 @@ def apply_along_fields(func, arr):
     # works and avoids axis requirement, but very, very slow:
     #return np.apply_along_axis(func, -1, uarr)
 
-def _assign_fields_by_name_dispatcher(dst, src, zero_unassigned=None):
-    return dst, src
 
-@array_function_dispatch(_assign_fields_by_name_dispatcher)
+@array_function_dispatch(("dst", "src"))
 def assign_fields_by_name(dst, src, zero_unassigned=True):
     """
     Assigns values from one structured array to another by field name.
@@ -1267,10 +1235,8 @@ def assign_fields_by_name(dst, src, zero_unassigned=True):
             assign_fields_by_name(dst[name], src[name],
                                   zero_unassigned)
 
-def _require_fields_dispatcher(array, required_dtype):
-    return (array,)
 
-@array_function_dispatch(_require_fields_dispatcher)
+@array_function_dispatch(("array",))
 def require_fields(array, required_dtype):
     """
     Casts a structured array to a new dtype using assignment by field-name.
@@ -1408,12 +1374,7 @@ def stack_arrays(arrays, defaults=None, usemask=True, asrecarray=False,
                        usemask=usemask, asrecarray=asrecarray)
 
 
-def _find_duplicates_dispatcher(
-        a, key=None, ignoremask=None, return_index=None):
-    return (a,)
-
-
-@array_function_dispatch(_find_duplicates_dispatcher)
+@array_function_dispatch(("a",))
 def find_duplicates(a, key=None, ignoremask=True, return_index=False):
     """
     Find the duplicates in a structured array along a given key
@@ -1472,13 +1433,7 @@ def find_duplicates(a, key=None, ignoremask=True, return_index=False):
         return duplicates
 
 
-def _join_by_dispatcher(
-        key, r1, r2, jointype=None, r1postfix=None, r2postfix=None,
-        defaults=None, usemask=None, asrecarray=None):
-    return (r1, r2)
-
-
-@array_function_dispatch(_join_by_dispatcher)
+@array_function_dispatch(("r1", "r2"))
 def join_by(key, r1, r2, jointype='inner', r1postfix='1', r2postfix='2',
             defaults=None, usemask=True, asrecarray=False):
     """
@@ -1656,13 +1611,7 @@ def join_by(key, r1, r2, jointype='inner', r1postfix='1', r2postfix='2',
     return _fix_output(_fix_defaults(output, defaults), **kwargs)
 
 
-def _rec_join_dispatcher(
-        key, r1, r2, jointype=None, r1postfix=None, r2postfix=None,
-        defaults=None):
-    return (r1, r2)
-
-
-@array_function_dispatch(_rec_join_dispatcher)
+@array_function_dispatch(("r1", "r2"))
 def rec_join(key, r1, r2, jointype='inner', r1postfix='1', r2postfix='2',
              defaults=None):
     """

--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -285,11 +285,8 @@ def transpose(a):
 
 # Linear equations
 
-def _tensorsolve_dispatcher(a, b, axes=None):
-    return (a, b)
 
-
-@array_function_dispatch(_tensorsolve_dispatcher)
+@array_function_dispatch(("a", "b"))
 def tensorsolve(a, b, axes=None):
     """
     Solve the tensor equation ``a x = b`` for x.
@@ -366,11 +363,7 @@ def tensorsolve(a, b, axes=None):
     return res.reshape(oldshape)
 
 
-def _solve_dispatcher(a, b):
-    return (a, b)
-
-
-@array_function_dispatch(_solve_dispatcher)
+@array_function_dispatch(("a", "b"))
 def solve(a, b):
     """
     Solve a linear matrix equation, or system of linear scalar equations.
@@ -464,11 +457,7 @@ def solve(a, b):
     return wrap(r.astype(result_t, copy=False))
 
 
-def _tensorinv_dispatcher(a, ind=None):
-    return (a,)
-
-
-@array_function_dispatch(_tensorinv_dispatcher)
+@array_function_dispatch(("a",))
 def tensorinv(a, ind=2):
     """
     Compute the 'inverse' of an N-dimensional array.
@@ -539,11 +528,8 @@ def tensorinv(a, ind=2):
 
 # Matrix inversion
 
-def _unary_dispatcher(a):
-    return (a,)
 
-
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("a",))
 def inv(a):
     """
     Compute the inverse of a matrix.
@@ -659,11 +645,7 @@ def inv(a):
     return wrap(ainv.astype(result_t, copy=False))
 
 
-def _matrix_power_dispatcher(a, n):
-    return (a,)
-
-
-@array_function_dispatch(_matrix_power_dispatcher)
+@array_function_dispatch(("a",))
 def matrix_power(a, n):
     """
     Raise a square matrix to the (integer) power `n`.
@@ -781,11 +763,8 @@ def matrix_power(a, n):
 
 # Cholesky decomposition
 
-def _cholesky_dispatcher(a, /, *, upper=None):
-    return (a,)
 
-
-@array_function_dispatch(_cholesky_dispatcher)
+@array_function_dispatch(("a",))
 def cholesky(a, /, *, upper=False):
     """
     Cholesky decomposition.
@@ -890,11 +869,7 @@ def cholesky(a, /, *, upper=False):
 # outer product
 
 
-def _outer_dispatcher(x1, x2):
-    return (x1, x2)
-
-
-@array_function_dispatch(_outer_dispatcher)
+@array_function_dispatch(("x1", "x2"))
 def outer(x1, x2, /):
     """
     Compute the outer product of two vectors.
@@ -968,11 +943,7 @@ def outer(x1, x2, /):
 # QR decomposition
 
 
-def _qr_dispatcher(a, mode=None):
-    return (a,)
-
-
-@array_function_dispatch(_qr_dispatcher)
+@array_function_dispatch(("a",))
 def qr(a, mode='reduced'):
     """
     Compute the qr factorization of a matrix.
@@ -1153,7 +1124,7 @@ def qr(a, mode='reduced'):
 # Eigenvalues
 
 
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("a",))
 def eigvals(a):
     """
     Compute the eigenvalues of a general matrix.
@@ -1237,11 +1208,7 @@ def eigvals(a):
     return w.astype(_complexType(result_t), copy=False)
 
 
-def _eigvalsh_dispatcher(a, UPLO=None):
-    return (a,)
-
-
-@array_function_dispatch(_eigvalsh_dispatcher)
+@array_function_dispatch(("a",))
 def eigvalsh(a, UPLO='L'):
     """
     Compute the eigenvalues of a complex Hermitian or real symmetric matrix.
@@ -1338,7 +1305,7 @@ def eigvalsh(a, UPLO='L'):
 # Eigenvectors
 
 
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("a",))
 def eig(a):
     """
     Compute the eigenvalues and right eigenvectors of a square array.
@@ -1485,7 +1452,7 @@ def eig(a):
     return EigResult(w, wrap(vt))
 
 
-@array_function_dispatch(_eigvalsh_dispatcher)
+@array_function_dispatch(("a",))
 def eigh(a, UPLO='L'):
     """
     Return the eigenvalues and eigenvectors of a complex Hermitian
@@ -1634,11 +1601,8 @@ def eigh(a, UPLO='L'):
 
 # Singular value decomposition
 
-def _svd_dispatcher(a, full_matrices=None, compute_uv=None, hermitian=None):
-    return (a,)
 
-
-@array_function_dispatch(_svd_dispatcher)
+@array_function_dispatch(("a",))
 def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
     """
     Singular Value Decomposition.
@@ -1827,11 +1791,7 @@ def svd(a, full_matrices=True, compute_uv=True, hermitian=False):
         return s
 
 
-def _svdvals_dispatcher(x):
-    return (x,)
-
-
-@array_function_dispatch(_svdvals_dispatcher)
+@array_function_dispatch(("x",))
 def svdvals(x, /):
     """
     Returns the singular values of a matrix (or a stack of matrices) ``x``.
@@ -1881,11 +1841,7 @@ def svdvals(x, /):
     return svd(x, compute_uv=False, hermitian=False)
 
 
-def _cond_dispatcher(x, p=None):
-    return (x,)
-
-
-@array_function_dispatch(_cond_dispatcher)
+@array_function_dispatch(("x",))
 def cond(x, p=None):
     """
     Compute the condition number of a matrix.
@@ -2002,11 +1958,7 @@ def cond(x, p=None):
     return r
 
 
-def _matrix_rank_dispatcher(A, tol=None, hermitian=None, *, rtol=None):
-    return (A,)
-
-
-@array_function_dispatch(_matrix_rank_dispatcher)
+@array_function_dispatch(("A",))
 def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
     """
     Return matrix rank of array using SVD method
@@ -2121,11 +2073,8 @@ def matrix_rank(A, tol=None, hermitian=False, *, rtol=None):
 
 # Generalized inverse
 
-def _pinv_dispatcher(a, rcond=None, hermitian=None, *, rtol=None):
-    return (a,)
 
-
-@array_function_dispatch(_pinv_dispatcher)
+@array_function_dispatch(("a",))
 def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
     """
     Compute the (Moore-Penrose) pseudo-inverse of a matrix.
@@ -2243,7 +2192,7 @@ def pinv(a, rcond=None, hermitian=False, *, rtol=_NoValue):
 # Determinant
 
 
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("a",))
 def slogdet(a):
     """
     Compute the sign and (natural) logarithm of the determinant of an array.
@@ -2327,7 +2276,7 @@ def slogdet(a):
     return SlogdetResult(sign, logdet)
 
 
-@array_function_dispatch(_unary_dispatcher)
+@array_function_dispatch(("a",))
 def det(a):
     """
     Compute the determinant of an array.
@@ -2385,11 +2334,8 @@ def det(a):
 
 # Linear Least Squares
 
-def _lstsq_dispatcher(a, b, rcond=None):
-    return (a, b)
 
-
-@array_function_dispatch(_lstsq_dispatcher)
+@array_function_dispatch(("a", "b"))
 def lstsq(a, b, rcond=None):
     r"""
     Return the least-squares solution to a linear matrix equation.
@@ -2565,11 +2511,7 @@ def _multi_svd_norm(x, row_axis, col_axis, op, initial=None):
     return result
 
 
-def _norm_dispatcher(x, ord=None, axis=None, keepdims=None):
-    return (x,)
-
-
-@array_function_dispatch(_norm_dispatcher)
+@array_function_dispatch(("x",))
 def norm(x, ord=None, axis=None, keepdims=False):
     """
     Matrix or vector norm.
@@ -3032,11 +2974,8 @@ def _multi_dot(arrays, order, i, j, out=None):
 
 # diagonal
 
-def _diagonal_dispatcher(x, /, *, offset=None):
-    return (x,)
 
-
-@array_function_dispatch(_diagonal_dispatcher)
+@array_function_dispatch(("x",))
 def diagonal(x, /, *, offset=0):
     """
     Returns specified diagonals of a matrix (or a stack of matrices) ``x``.
@@ -3128,11 +3067,8 @@ def diagonal(x, /, *, offset=0):
 
 # trace
 
-def _trace_dispatcher(x, /, *, offset=None, dtype=None):
-    return (x,)
 
-
-@array_function_dispatch(_trace_dispatcher)
+@array_function_dispatch(("x",))
 def trace(x, /, *, offset=0, dtype=None):
     """
     Returns the sum along the specified diagonals of a matrix
@@ -3213,11 +3149,8 @@ def trace(x, /, *, offset=0, dtype=None):
 
 # cross
 
-def _cross_dispatcher(x1, x2, /, *, axis=None):
-    return (x1, x2,)
 
-
-@array_function_dispatch(_cross_dispatcher)
+@array_function_dispatch(("x1", "x2"))
 def cross(x1, x2, /, *, axis=-1):
     """
     Returns the cross product of 3-element vectors.
@@ -3284,11 +3217,8 @@ def cross(x1, x2, /, *, axis=-1):
 
 # matmul
 
-def _matmul_dispatcher(x1, x2, /):
-    return (x1, x2)
 
-
-@array_function_dispatch(_matmul_dispatcher)
+@array_function_dispatch(("x1", "x2"))
 def matmul(x1, x2, /):
     """
     Computes the matrix product.
@@ -3375,11 +3305,7 @@ def matmul(x1, x2, /):
 # tensordot
 
 
-def _tensordot_dispatcher(a, b, /, *, axes=None):
-    return (a, b)
-
-
-@array_function_dispatch(_tensordot_dispatcher)
+@array_function_dispatch(("a", "b"))
 def tensordot(a, b, /, *, axes=2):
     return _core_tensordot(a, b, axes=axes)
 
@@ -3389,10 +3315,8 @@ tensordot.__doc__ = _core_tensordot.__doc__
 
 # matrix_transpose
 
-def _matrix_transpose_dispatcher(x):
-    return (x,)
 
-@array_function_dispatch(_matrix_transpose_dispatcher)
+@array_function_dispatch(("x",))
 def matrix_transpose(x, /):
     return _core_matrix_transpose(x)
 
@@ -3407,10 +3331,8 @@ matrix_transpose.__doc__ = f"""{_core_matrix_transpose.__doc__}
 
 # matrix_norm
 
-def _matrix_norm_dispatcher(x, /, *, keepdims=None, ord=None):
-    return (x,)
 
-@array_function_dispatch(_matrix_norm_dispatcher)
+@array_function_dispatch(("x",))
 def matrix_norm(x, /, *, keepdims=False, ord="fro"):
     """
     Computes the matrix norm of a matrix (or a stack of matrices) ``x``.
@@ -3470,10 +3392,8 @@ def matrix_norm(x, /, *, keepdims=False, ord="fro"):
 
 # vector_norm
 
-def _vector_norm_dispatcher(x, /, *, axis=None, keepdims=None, ord=None):
-    return (x,)
 
-@array_function_dispatch(_vector_norm_dispatcher)
+@array_function_dispatch(("x",))
 def vector_norm(x, /, *, axis=None, keepdims=False, ord=2):
     """
     Computes the vector norm of a vector (or batch of vectors) ``x``.
@@ -3572,10 +3492,8 @@ def vector_norm(x, /, *, axis=None, keepdims=False, ord=2):
 
 # vecdot
 
-def _vecdot_dispatcher(x1, x2, /, *, axis=None):
-    return (x1, x2)
 
-@array_function_dispatch(_vecdot_dispatcher)
+@array_function_dispatch(("x1", "x2"))
 def vecdot(x1, x2, /, *, axis=-1):
     """
     Computes the vector dot product.


### PR DESCRIPTION
We allow `@array_function_dispatch` to take a tuple of relevant-argument names instead of a callable dispatcher. The names are resolved to `(kwname, position)` pairs at decoration time. The tuple approach avoids the overhead of calling the dispatcher and creating an intermediate tuple. Fast paths are added for exact numpy arrays and python basic types.

Fixes https://github.com/numpy/numpy/issues/31866. Also see https://github.com/numpy/numpy/issues/31098.

About 260 trivial dispatchers are migrated (~600 lines removed); the callable form remains for sequence dispatchers 

Benchmark results (Python 3.14):
```
np.sum(array_4): Mean +- std dev: [bench_main_sq] 621 ns +- 5 ns -> [bench_branch_sq] 576 ns +- 4 ns: 1.08x faster
np.sum(array_20): Mean +- std dev: [bench_main_sq] 625 ns +- 4 ns -> [bench_branch_sq] 579 ns +- 3 ns: 1.08x faster
np.prod(array_20): Mean +- std dev: [bench_main_sq] 598 ns +- 3 ns -> [bench_branch_sq] 550 ns +- 7 ns: 1.09x faster
np.max(array_20): Mean +- std dev: [bench_main_sq] 591 ns +- 3 ns -> [bench_branch_sq] 560 ns +- 10 ns: 1.06x faster
np.sum(int_20): Mean +- std dev: [bench_main_sq] 628 ns +- 9 ns -> [bench_branch_sq] 585 ns +- 14 ns: 1.07x faster
np.sum(10x10): Mean +- std dev: [bench_main_sq] 635 ns +- 5 ns -> [bench_branch_sq] 587 ns +- 3 ns: 1.08x faster
np.sum(10x10,axis=0): Mean +- std dev: [bench_main_sq] 1.20 us +- 0.02 us -> [bench_branch_sq] 1.14 us +- 0.02 us: 1.05x faster
np.sum(10x10,axis=1): Mean +- std dev: [bench_main_sq] 1.14 us +- 0.02 us -> [bench_branch_sq] 1.10 us +- 0.02 us: 1.04x faster
np.any(bool_20): Mean +- std dev: [bench_main_sq] 572 ns +- 16 ns -> [bench_branch_sq] 516 ns +- 8 ns: 1.11x faster
np.sum(2x2_float): Mean +- std dev: [bench_main_sq] 628 ns +- 8 ns -> [bench_branch_sq] 575 ns +- 5 ns: 1.09x faster
np.sum(2x2_int): Mean +- std dev: [bench_main_sq] 626 ns +- 7 ns -> [bench_branch_sq] 584 ns +- 9 ns: 1.07x faster
np.sin(array_20): Mean +- std dev: [bench_main_sq] 371 ns +- 6 ns -> [bench_branch_sq] 376 ns +- 4 ns: 1.01x slower
np.sum(subclass_20): Mean +- std dev: [bench_main_sq] 972 ns +- 10 ns -> [bench_branch_sq] 945 ns +- 16 ns: 1.03x faster
np.transpose(10x10): Mean +- std dev: [bench_main_sq] 259 ns +- 2 ns -> [bench_branch_sq] 226 ns +- 1 ns: 1.15x faster
np.ravel(array_20): Mean +- std dev: [bench_main_sq] 233 ns +- 4 ns -> [bench_branch_sq] 196 ns +- 2 ns: 1.19x faster

Geometric mean: 1.08x faster
```

`np.sin` is the control (not dispatched through `@array_function_dispatch`).

<details>
<summary>Benchmark script</summary>

```python
"""Micro-benchmark for np.sum/prod/max/any dispatcher overhead."""
import numpy as np
import pyperf


class MyArr(np.ndarray):
    pass


def make_setup():
    return {
        "array_4":    np.arange(4, dtype=np.float64),
        "array_20":   np.arange(20, dtype=np.float64),
        "int_20":     np.arange(20, dtype=np.int64),
        "bool_20":    np.ones(20, dtype=bool),
        "arr_10x10":  np.arange(100, dtype=np.float64).reshape(10, 10),
        "arr_2x2f":   np.arange(4, dtype=np.float64).reshape(2, 2),
        "arr_2x2i":   np.arange(4, dtype=np.int64).reshape(2, 2),
        "subclass_20":np.arange(20, dtype=np.float64).view(MyArr),
    }


BENCHES = [
    ("np.sum(array_4)",         "np.sum(a['array_4'])"),
    ("np.sum(array_20)",        "np.sum(a['array_20'])"),
    ("np.prod(array_20)",       "np.prod(a['array_20'])"),
    ("np.max(array_20)",        "np.max(a['array_20'])"),
    ("np.sum(int_20)",          "np.sum(a['int_20'])"),
    ("np.sum(10x10)",           "np.sum(a['arr_10x10'])"),
    ("np.sum(10x10,axis=0)",    "np.sum(a['arr_10x10'], axis=0)"),
    ("np.sum(10x10,axis=1)",    "np.sum(a['arr_10x10'], axis=1)"),
    ("np.any(bool_20)",         "np.any(a['bool_20'])"),
    ("np.sum(2x2_float)",       "np.sum(a['arr_2x2f'])"),
    ("np.sum(2x2_int)",         "np.sum(a['arr_2x2i'])"),
    ("np.sin(array_20)",        "np.sin(a['array_20'])"),
    ("np.sum(subclass_20)",     "np.sum(a['subclass_20'])"),
    # cheap view ops migrated in the mass tuple-spec conversion
    ("np.transpose(10x10)",     "np.transpose(a['arr_10x10'])"),
    ("np.ravel(array_20)",      "np.ravel(a['array_20'])"),
]


def main():
    runner = pyperf.Runner()
    runner.metadata['numpy_version'] = np.__version__
    a = make_setup()
    for name, expr in BENCHES:
        runner.timeit(name=name, stmt=expr, globals={'np': np, 'a': a})


if __name__ == '__main__':
    main()
```

</details>




#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
Claude Opus 4.x was used to find optimizations for the dispatcher overhead. The corresponding issue contains an alternative. After selecting this option, Claude was used to refine the PR. 