### PR TITLE
BUG: f2py: distinguish grouping parens from array index in param_parse

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -3082,12 +3082,12 @@ def param_parse(d, params):
     >>> param_parse(d, params)
     3
     """
-    if "(" in d:
-        # this dimension expression is an array
-        dname = d[:d.find("(")]
+    dname = d[:d.find("(")] if "(" in d else ""
+    if dname:
+        # Text precedes the first "(", so this is array-parameter
+        # indexing such as pa(1) or myparamarray(nested(dim)).
         ddims = d[d.find("(") + 1:d.rfind(")")]
-        # this dimension expression is also a parameter;
-        # parse it recursively
+        # the index is itself an expression over params; parse it recursively
         index = int(param_parse(ddims, params))
         return str(params[dname][index])
     elif d in params:

--- a/numpy/f2py/tests/src/crackfortran/gh28095.f90
+++ b/numpy/f2py/tests/src/crackfortran/gh28095.f90
@@ -1,0 +1,13 @@
+module util
+integer mx_intl_curves
+integer mx_supply_curves
+integer mx_units
+parameter(mx_intl_curves = 12)
+parameter(mx_supply_curves = 14)
+parameter(mx_units = 1800)
+real*4 cmm_cl_btus((mx_supply_curves + mx_intl_curves), mx_units)
+contains
+ subroutine test
+ write(*,*) 'Hello'
+ end subroutine test
+end module util

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -417,6 +417,42 @@ class TestParamEval:
         pytest.raises(ValueError, crackfortran.param_eval, v, g_params, params,
                       dimspec=dimspec)
 
+
+class TestParamParseNestedParens:
+    # issue gh-28095: grouping parens in a dimension expression such as
+    # (mx_supply_curves + mx_intl_curves) must fold to a concrete size,
+    # not be mistaken for pa(index) array-parameter indexing.
+    def test_grouping_parens_fold(self):
+        params = {"mx_supply_curves": 14, "mx_intl_curves": 12}
+        out = crackfortran.param_parse(
+            "(mx_supply_curves + mx_intl_curves)", params)
+        assert out.replace(" ", "") == "(14+12)"
+
+    def test_grouping_parens_with_trailing_factor(self):
+        # A grouping paren need not span the whole token; the factor
+        # outside the parentheses must survive substitution.
+        params = {"n": 3, "m": 1800}
+        out = crackfortran.param_parse("(n + 1)*m", params)
+        assert out.replace(" ", "") == "(3+1)*1800"
+
+    def test_array_index_still_works(self):
+        params = {"pa": {1: 3, 2: 5}}
+        assert crackfortran.param_parse("pa(1)", params) == "3"
+        assert crackfortran.param_parse("pa(2)", params) == "5"
+
+    def test_nested_array_index(self):
+        params = {"dim": 2, "nested": {1: 1, 2: 2, 3: 3},
+                  "myparamarray": {1: 10, 2: 20, 3: 30}}
+        assert crackfortran.param_parse(
+            "myparamarray(nested(dim))", params) == "20"
+
+    def test_dimension_substituted_in_module(self):
+        fpath = util.getpath("tests", "src", "crackfortran", "gh28095.f90")
+        mod = crackfortran.crackfortran([str(fpath)])
+        vs = mod[0]["vars"]["cmm_cl_btus"]
+        assert vs["dimension"] == ["26", "1800"]
+
+
 @pytest.mark.slow
 class TestLowerF2PYDirective(util.F2PyTest):
     sources = [util.getpath("tests", "src", "crackfortran", "gh27697.f90")]


### PR DESCRIPTION
Closes #28095.
Supersedes #29857.

### Summary

`param_parse` treated any dimension token containing `(` as array-parameter
indexing (`pa(1)`). Grouping parentheses such as
`(mx_supply_curves + mx_intl_curves)` then hit `int('14 + 12')`, raised, and
were swallowed in `analyzevars`, leaving parameters unsubstituted (regression
since 1.26.4).

This fix branches on the text before the first `(`:

- non-empty name → array-index path (unchanged)
- empty name → general textual parameter substitution (keeps compound forms like `(n + 1)*m`)

### Tests

`TestParamParseNestedParens` in `test_crackfortran.py` (pure crackfortran; no
compile step) plus `tests/src/crackfortran/gh28095.f90`.

Verified locally: `5 passed` for `-k ParamParseNested`.

### Credits

Builds on the investigation and discussion in #29857 by @eia-akahan (co-author).
The approach here is a smaller discrimination in `param_parse` rather than a
separate balance/eval engine.