### PR TITLE
BUG: fix crash on 32 bit systems using abi3t (#31771)

### DIFF
--- a/doc/release/upcoming_changes/31771.c_api.rust
+++ b/doc/release/upcoming_changes/31771.c_api.rust
@@ -1,0 +1,15 @@
+``PyArray_StringDTypeObject`` is opaque under the abi3t stable ABI
+------------------------------------------------------------------
+
+The ``PyArray_StringDTypeObject`` was accidentally exposed in NumPy
+2.5 when targeting the free-threading-compatible stable ABI
+(``Py_TARGET_ABI3T``). ``PyArray_StringDTypeObject`` is now an opaque
+struct: extensions compiled that way cannot access its fields, since
+the struct layout depends on the size of the object header. Any code
+that accessed ``PyArray_StringDTypeObject`` fields in an abi3t build
+would have crashed, so we are making this API change in a bugfix
+release.
+
+The ``NpyString`` allocator API remains usable by passing the
+descriptor object pointer, e.g.
+``NpyString_acquire_allocator((PyArray_StringDTypeObject *)descr)``.

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -627,7 +627,7 @@ typedef struct _PyArray_Descr_fields {
          * be two type_numbers with the same type
          * object.
          */
-        PyTypeObject *typeobj;
+        _NPY_OPAQUE_FIRST_FIELD PyTypeObject *typeobj;
         /* kind for this type */
         char kind;
         /* unique-character representing this type */
@@ -659,7 +659,7 @@ typedef struct _PyArray_Descr_fields {
 
 typedef struct _PyArray_Descr {
         PyObject_HEAD
-        PyTypeObject *typeobj;
+        _NPY_OPAQUE_FIRST_FIELD PyTypeObject *typeobj;
         char kind;
         char type;
         char byteorder;
@@ -670,7 +670,7 @@ typedef struct _PyArray_Descr {
 /* To access modified fields, define the full 2.0 struct: */
 typedef struct {
         PyObject_HEAD
-        PyTypeObject *typeobj;
+        _NPY_OPAQUE_FIRST_FIELD PyTypeObject *typeobj;
         char kind;
         char type;
         char byteorder;
@@ -697,7 +697,7 @@ typedef struct {
 #ifndef Py_TARGET_ABI3T
         PyObject_HEAD
 #endif
-        PyTypeObject *typeobj;
+        _NPY_OPAQUE_FIRST_FIELD PyTypeObject *typeobj;
         char kind;
         char type;
         char byteorder;
@@ -792,7 +792,7 @@ typedef struct tagPyArrayObject_fields {
     PyObject_HEAD
 #endif
     /* Pointer to the raw data buffer */
-    char *data;
+    _NPY_OPAQUE_FIRST_FIELD char *data;
     /* The number of dimensions, also called 'ndim' */
     int nd;
     /* The size in each dimension, also called 'shape' */
@@ -1219,7 +1219,7 @@ typedef struct PyArrayIterObject_fields {
 #ifndef Py_TARGET_ABI3T
         PyObject_HEAD
 #endif
-        int               nd_m1;            /* number of dimensions - 1 */
+        _NPY_OPAQUE_FIRST_FIELD int nd_m1;      /* number of dimensions - 1 */
         npy_intp          index, size;
         npy_intp          coordinates[NPY_MAXDIMS_LEGACY_ITERS];/* N-dimensional loop */
         npy_intp          dims_m1[NPY_MAXDIMS_LEGACY_ITERS];    /* ao->dimensions - 1 */
@@ -1245,7 +1245,7 @@ typedef struct {
 #ifndef Py_TARGET_ABI3T
         PyObject_HEAD
 #endif
-        int                  numiter;                 /* number of iters */
+        _NPY_OPAQUE_FIRST_FIELD int numiter;              /* number of iters */
         npy_intp             size;                    /* broadcasted size */
         npy_intp             index;                   /* current index */
         int                  nd;                      /* number of dims */
@@ -1292,7 +1292,7 @@ typedef struct {
     /*
      * PyArrayIterObject part: keep this in this exact order
      */
-    int               nd_m1;            /* number of dimensions - 1 */
+    _NPY_OPAQUE_FIRST_FIELD int nd_m1;      /* number of dimensions - 1 */
     npy_intp          index, size;
     npy_intp          coordinates[NPY_MAXDIMS_LEGACY_ITERS];/* N-dimensional loop */
     npy_intp          dims_m1[NPY_MAXDIMS_LEGACY_ITERS];    /* ao->dimensions - 1 */
@@ -1439,6 +1439,7 @@ typedef struct npy_unpacked_static_string {
  */
 typedef struct npy_string_allocator npy_string_allocator;
 
+#ifndef Py_TARGET_ABI3T
 typedef struct {
     PyArray_Descr_fields base;
     // The object representing a null value
@@ -1461,6 +1462,15 @@ typedef struct {
     // no longer needed
     npy_string_allocator *allocator;
 } PyArray_StringDTypeObject;
+#else
+/*
+ * Accessing StringDType instance fields is not supported under the abi3t
+ * stable ABI. The NpyString allocator API still works with the opaque
+ * struct: pass the descriptor object pointer, i.e.
+ * NpyString_acquire_allocator((PyArray_StringDTypeObject *)descr).
+ */
+typedef struct PyArray_StringDTypeObject PyArray_StringDTypeObject;
+#endif
 
 /*
  * PyArray_DTypeMeta related definitions.

--- a/numpy/_core/include/numpy/ufuncobject.h
+++ b/numpy/_core/include/numpy/ufuncobject.h
@@ -3,6 +3,7 @@
 
 #include <numpy/npy_math.h>
 #include <numpy/npy_common.h>
+#include <numpy/utils.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -108,7 +109,8 @@ typedef struct _tagPyUFuncObject {
          * nout: Number of outputs
          * nargs: Always nin + nout (Why is it stored?)
          */
-        int nin, nout, nargs;
+        _NPY_OPAQUE_FIRST_FIELD int nin;
+        int nout, nargs;
 
         /*
          * Identity for reduction, any of PyUFunc_One, PyUFunc_Zero

--- a/numpy/_core/include/numpy/utils.h
+++ b/numpy/_core/include/numpy/utils.h
@@ -13,12 +13,74 @@
     #endif
 #endif
 
+// Older compilers may name `_Alignas` differently; to allow compilation on such
+// unsupported platforms, we don't redefine NPY_DECL_ALIGNED if it's already
+// defined similar to CPython's _Py_ALIGNED_DEF.
+#ifndef NPY_DECL_ALIGNED
 #if defined(__GNUC__) || defined(__ICC) || defined(__clang__)
     #define NPY_DECL_ALIGNED(x) __attribute__ ((aligned (x)))
 #elif defined(_MSC_VER)
     #define NPY_DECL_ALIGNED(x) __declspec(align(x))
+#elif defined(__cplusplus)
+    #define NPY_DECL_ALIGNED(x) alignas(x)
 #else
-    #define NPY_DECL_ALIGNED(x)
+    #define NPY_DECL_ALIGNED(x) _Alignas(x)
+#endif
+#endif
+/*
+ * Force the first field of a struct to be 8-byte aligned on Python 3.15+ to achieve
+ * ABI compatibility of `_fields` structs with and without `PyObject_HEAD`.
+ *
+ * When we expose (or may want to) expose an object structs contents to the Python
+ * stable ABI we define it as:
+ *
+ *     struct _PyArray_Descr {
+ *     #if !defined(Py_TARGET_ABI3T)
+ *         PyObject_HEAD;
+ *     #endif
+ *         _NPY_OPAQUE_FIRST_FIELD T first_field;
+ *         ...
+ *     } fields;
+ *
+ * Effectively creating two versions, one `fields_obj` and `fields_no_obj` depending
+ * on the build target. These builds must be ABI compatible and for that:
+ *
+ *     offsetof(fields_obj, first_field) % alignof(fields_no_obj) == 0
+ *
+ * must hold. If it does not hold, then `fields_obj` (minus the PyObject_HEAD) will
+ * be padded differently from `fields_no_obj`.  Concretely, this happened for 32bit
+ * free-threaded builds (PyObject_HEAD having a size of 20 bytes) where the uint64
+ * flags required padding to achieve 8 byte alignment, but with the `PyObject_HEAD`.
+ *
+ * The only way to ensure the above holds always is to pad the first field so that
+ * it's offset is a multiple of the alignment. The simplest path (e.g. what PEP 697
+ * also does) may be to always pad to `alignof(max_align_t)`.
+ * We do _not_ do this, because we have to remain ABI compatible to abi3 builds and
+ * Python GIL enabled builds have a PyObject_HEAD size that is a multiple of
+ * 8/16 (32bit/64bit systems) alignment.
+ * So, instead we use 8 bytes. We could choose 16 for 64bit systems but it currently
+ * makes no difference (there is a static_assert to notify us if it might matter).
+ *
+ * Because the ABI3T target was added in Python 3.15 we _can_ freely add padding for
+ * Python 3.15+ builds for them. And this is where it matters, because 32bit
+ * free-threaded builds have a `sizeof(PyObject) == 20` which gives 4 byte max
+ * alignment which breaks the requirement above.
+ *
+ * As an actual implementation we add the padding by explicitly aligning the first
+ * field to 8 bytes.
+ * In theory this might guarantee an alignment larger than `alignof(max_align_t)`,
+ * we assume that we would notice this first and in practice malloc alignment is >=8.
+ *
+ * One may be able to expose >8 byte aligned fields, but this requires thoughts on
+ * how it affects abi3, abi3t builds and compatibility with older Python/NumPy builds.
+ *
+ * Note that assertions concerning these assumptions are paired with the
+ * `*_GET_ITEM_DATA` function definitions (in `arrayobject.c`).
+ */
+#if PY_VERSION_HEX >= 0x030f0000
+    #define _NPY_OPAQUE_FIRST_FIELD NPY_DECL_ALIGNED(8)
+#else
+    #define _NPY_OPAQUE_FIRST_FIELD
 #endif
 
 /* Use this to tag a variable as not used. It will remove unused variable

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -465,8 +465,8 @@ PyArrayMethod_FromSpec_int(PyArrayMethod_Spec *spec, int private)
         PyErr_NoMemory();
         return NULL;
     }
-    memset((char *)(res->method) + sizeof(PyObject), 0,
-           sizeof(PyArrayMethodObject) - sizeof(PyObject));
+    memset((char *)(res->method) + offsetof(PyArrayMethodObject, name), 0,
+           sizeof(PyArrayMethodObject) - offsetof(PyArrayMethodObject, name));
 
     res->method->nin = spec->nin;
     res->method->nout = spec->nout;

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -1277,53 +1277,82 @@ NPY_NO_EXPORT PyTypeObject PyArray_Type = {
 };
 
 /*
-    The following *_GET_ITEM_DATA functions are used to get the pointer to the fields of the
-    corresponding struct from the given object. It is technically undefined behaviour
-    to access the fields of the struct through a pointer that is not of the same type,
-    but in our case it is not a problem in practice because this is used only in stable ABI
-    extensions where the original object layout is opaque.
-*/
+ * Python stable ABI compatible object field accessor functions.
+ *
+ * The following *_GET_ITEM_DATA functions are used to get the pointer to the fields of the
+ * corresponding struct from the given object. It is technically undefined behaviour
+ * to access the fields of the struct through a pointer that is not of the same type,
+ * but in our case it is not a problem in practice because this is used only in stable ABI
+ * extensions where the original object layout is opaque.
+ *
+ * To expose the struct this way alignment guarantees must be met, see `utils.h` and the
+ * definition of `_NPY_OPAQUE_FIRST_FIELD`.
+ */
+
+#if SIZEOF_VOID_P != 4  // not a 32bit build
+/*
+ * If this assert fails then Python changed the sizeof(PyObject). If we simply remove the
+ * assert we lose flexibility to add 16byte aligned fields to the stable ABI fields.
+ * We can choose that this is fine or increase the padding to 16/max_align_t when it happens.
+ * (See comments in `ndarraytypes.h` for more details.)
+ */
+static_assert(sizeof(PyObject) % 16 == 0,
+    "Expected sizeof(PyObject) to be multiple of 16 on 64bit builds.");
+#endif
+
+static_assert(NPY_ALIGNOF(PyArray_Descr_fields) <= 8,
+              "PyArray_Descr must not require more than 8-byte alignment");
+static_assert(NPY_ALIGNOF(_PyArray_LegacyDescr_fields) <= 8,
+              "_PyArray_LegacyDescr must not require more than 8-byte alignment");
+static_assert(NPY_ALIGNOF(PyArrayObject_fields) <= 8,
+              "PyArrayObject must not require more than 8-byte alignment");
+static_assert(NPY_ALIGNOF(PyArrayMultiIterObject_fields) <= 8,
+              "PyArrayMultiIterObject must not require more than 8-byte alignment");
+static_assert(NPY_ALIGNOF(PyArrayIterObject_fields) <= 8,
+              "PyArrayIterObject must not require more than 8-byte alignment");
+static_assert(NPY_ALIGNOF(PyArrayNeighborhoodIterObject_fields) <= 8,
+              "PyArrayNeighborhoodIterObject must not require more than 8-byte alignment");
 #undef _PyDataType_GET_ITEM_DATA
 /*NUMPY_API*/
 NPY_NO_EXPORT PyArray_Descr_fields *
 _PyDataType_GET_ITEM_DATA(const PyArray_Descr *dtype)
 {
-    return (PyArray_Descr_fields *)(((char *)dtype) + sizeof(PyObject));
+    return (PyArray_Descr_fields *)(((char *)dtype) + offsetof(PyArray_Descr, typeobj));
 }
 #undef _PyArray_LegacyDescr_GET_ITEM_DATA
 /*NUMPY_API*/
 NPY_NO_EXPORT _PyArray_LegacyDescr_fields *
 _PyArray_LegacyDescr_GET_ITEM_DATA(const _PyArray_LegacyDescr *dtype)
 {
-    return (_PyArray_LegacyDescr_fields *)(((char *)dtype) + sizeof(PyObject));
+    return (_PyArray_LegacyDescr_fields *)(((char *)dtype) + offsetof(_PyArray_LegacyDescr, typeobj));
 }
 #undef _PyArray_GET_ITEM_DATA
 /*NUMPY_API*/
 NPY_NO_EXPORT PyArrayObject_fields *
 _PyArray_GET_ITEM_DATA(const PyArrayObject *arr)
 {
-    return (PyArrayObject_fields *)(((char *)arr) + sizeof(PyObject));
+    return (PyArrayObject_fields *)(((char *)arr) + offsetof(PyArrayObject_fields, data));
 }
 #undef _PyArrayMultiIter_GET_ITEM_DATA
 /*NUMPY_API*/
 NPY_NO_EXPORT PyArrayMultiIterObject_fields *
 _PyArrayMultiIter_GET_ITEM_DATA(const PyArrayMultiIterObject *multi)
 {
-    return (PyArrayMultiIterObject_fields *)(((char *)multi) + sizeof(PyObject));
+    return (PyArrayMultiIterObject_fields *)(((char *)multi) + offsetof(PyArrayMultiIterObject_fields, numiter));
 }
 #undef _PyArrayIter_GET_ITEM_DATA
 /*NUMPY_API*/
 NPY_NO_EXPORT PyArrayIterObject_fields *
 _PyArrayIter_GET_ITEM_DATA(const PyArrayIterObject *iter)
 {
-    return (PyArrayIterObject_fields *)(((char *)iter) + sizeof(PyObject));
+    return (PyArrayIterObject_fields *)(((char *)iter) + offsetof(PyArrayIterObject_fields, nd_m1));
 }
 #undef _PyArrayNeighborhoodIter_GET_ITEM_DATA
 /*NUMPY_API*/
 NPY_NO_EXPORT PyArrayNeighborhoodIterObject_fields *
 _PyArrayNeighborhoodIter_GET_ITEM_DATA(const PyArrayNeighborhoodIterObject *iter)
 {
-    return (PyArrayNeighborhoodIterObject_fields *)(((char *)iter) + sizeof(PyObject));
+    return (PyArrayNeighborhoodIterObject_fields *)(((char *)iter) + offsetof(PyArrayNeighborhoodIterObject_fields, nd_m1));
 }
 #undef _PyDatetimeScalarObject_GetMetadata
 /*NUMPY_API*/

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1976,9 +1976,9 @@ PyArray_DescrNew(PyArray_Descr *base_descr)
         return NULL;
     }
     /* Don't copy PyObject_HEAD part */
-    memcpy((char *)newdescr + sizeof(PyObject),
-           (char *)base + sizeof(PyObject),
-           sizeof(_PyArray_LegacyDescr) - sizeof(PyObject));
+    memcpy((char *)newdescr + offsetof(_PyArray_LegacyDescr, typeobj),
+           (char *)base + offsetof(_PyArray_LegacyDescr, typeobj),
+           sizeof(_PyArray_LegacyDescr) - offsetof(_PyArray_LegacyDescr, typeobj));
 
     /*
      * The c_metadata has a by-value ownership model, need to clone it

--- a/numpy/_core/src/umath/_scaled_float_dtype.c
+++ b/numpy/_core/src/umath/_scaled_float_dtype.c
@@ -158,9 +158,9 @@ sfloat_scaled_copy(PyArray_SFloatDescr *self, double factor) {
         return NULL;
     }
     /* Don't copy PyObject_HEAD part */
-    memcpy((char *)new + sizeof(PyObject),
-            (char *)self + sizeof(PyObject),
-            sizeof(PyArray_SFloatDescr) - sizeof(PyObject));
+    memcpy((char *)new + offsetof(PyArray_Descr, typeobj),
+            (char *)self + offsetof(PyArray_Descr, typeobj),
+            sizeof(PyArray_SFloatDescr) - offsetof(PyArray_Descr, typeobj));
 
     new->scaling = new->scaling * factor;
     return (PyArray_Descr *)new;

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -5489,11 +5489,13 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
 #undef _SETCPTR
 
 #undef _PyUFuncObject_GET_ITEM_DATA
+static_assert(NPY_ALIGNOF(PyUFuncObject_fields) <= 8,
+              "PyUFuncObject must not require more than 8-byte alignment");
 /*UFUNC_API*/
 NPY_NO_EXPORT PyUFuncObject_fields *
 _PyUFuncObject_GET_ITEM_DATA(const PyUFuncObject *obj)
 {
-    return (PyUFuncObject_fields *)((char *)obj + sizeof(PyObject));
+    return (PyUFuncObject_fields *)((char *)obj + offsetof(PyUFuncObject_fields, nin));
 }
 
 static void

--- a/numpy/_core/tests/examples/limited_api/limited_api.c
+++ b/numpy/_core/tests/examples/limited_api/limited_api.c
@@ -350,6 +350,38 @@ limited_api_datetime_metadata(PyObject *mod, PyArrayObject *arr)
                          (int)dt_meta->meta.base, dt_meta->meta.num);
 }
 
+/*
+ * Test the NpyString allocator API. Under the abi3t stable ABI
+ * PyArray_StringDTypeObject is an opaque struct; the descriptor object
+ * pointer is passed to NpyString_acquire_allocator without accessing any
+ * struct fields. The API only exists when targeting NumPy 2.0+.
+ */
+#if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+static PyObject *
+limited_api_stringdtype_load(PyObject *mod, PyArrayObject *arr)
+{
+    npy_string_allocator *allocator = NpyString_acquire_allocator(
+            (PyArray_StringDTypeObject *)PyArray_DESCR(arr));
+    npy_packed_static_string *packed =
+            (npy_packed_static_string *)PyArray_DATA(arr);
+    npy_static_string s = {0, NULL};
+    PyObject *res = NULL;
+    int is_null = NpyString_load(allocator, packed, &s);
+    if (is_null == -1) {
+        PyErr_SetString(PyExc_RuntimeError, "NpyString_load failed");
+    }
+    else if (is_null) {
+        res = Py_None;
+        Py_INCREF(res);
+    }
+    else {
+        res = PyUnicode_FromStringAndSize(s.buf, (Py_ssize_t)s.size);
+    }
+    NpyString_release_allocator(allocator);
+    return res;
+}
+#endif  /* NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION */
+
 static PyMethodDef limited_api_methods[] = {
     {"nonzero", (PyCFunction)limited_api_nonzero, METH_O,
      "Count the number of non-zero elements in the array."},
@@ -376,6 +408,10 @@ static PyMethodDef limited_api_methods[] = {
     {"datetime_metadata", (PyCFunction)limited_api_datetime_metadata,
      METH_O,
      "Get (flags, unit base, unit num) from a datetime64/timedelta64 array."},
+#if NPY_FEATURE_VERSION >= NPY_2_0_API_VERSION
+    {"stringdtype_load", (PyCFunction)limited_api_stringdtype_load, METH_O,
+     "Load the first element of a StringDType array via the NpyString API."},
+#endif
     {NULL, NULL, 0, NULL}  /* Sentinel */
 };
 

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -8,7 +8,7 @@ import sysconfig
 import pytest
 
 import numpy as np
-from numpy.testing import IS_64BIT, IS_EDITABLE, IS_WASM, NOGIL_BUILD
+from numpy.testing import IS_EDITABLE, IS_WASM, NOGIL_BUILD
 from numpy.testing._private.utils import run_subprocess
 
 # This import is copied from random.tests.test_extending
@@ -155,6 +155,21 @@ def _check_api_module(mod, cython=False):
         with pytest.raises(RuntimeError):
             mod.datetime_metadata(np.arange(3))
 
+        # NpyString allocator API; under abi3t PyArray_StringDTypeObject is
+        # opaque and only the descriptor object pointer is passed. Absent
+        # when the module targets NumPy < 2.0 (the "default" target).
+        if hasattr(mod, "stringdtype_load"):
+            arr = np.array(["hello", "world"], dtype=np.dtypes.StringDType())
+            assert mod.stringdtype_load(arr) == "hello"
+            # A long string is stored on the heap, so loading it
+            # dereferences the allocator acquired from the descriptor.
+            text = "numpy" * 20
+            arr = np.array([text, "world"], dtype=np.dtypes.StringDType())
+            assert mod.stringdtype_load(arr) == text
+            arr = np.array([None, "world"],
+                           dtype=np.dtypes.StringDType(na_object=None))
+            assert mod.stringdtype_load(arr) is None
+
 
 # Test limited API extension modules for all supported Python and NumPy versions
 # The _PY_ABI3_VERSIONS and _NPY_TARGET_VERSIONS lists should be kept in sync
@@ -223,9 +238,6 @@ def test_limited_api_cython(install_temp, module_name):
 
 @pytest.mark.skipif(
     sys.version_info < (3, 15), reason="opaque PyObject requires Python 3.15+"
-)
-@pytest.mark.skipif(
-    not IS_64BIT, reason="opaque abi3t extensions are broken on 32-bit"
 )
 @pytest.mark.skipif(
     sys.platform == "win32" and not sysconfig.get_config_var('Py_GIL_DISABLED'),


### PR DESCRIPTION
Backport of #31771.

### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?



-->
Fixes https://github.com/numpy/numpy/issues/31762

This PR fixes the crash on 32 bit systems when using abi3t ABI. In this PR, the first member of the `PyArrayDescr` is now aligned to 8 bytes so that regardless of the size of the actual `PyObject`, the field accesses remain correct. 8 bytes is used instead of `alignof(max_align_t)` to preserve backwards compatibility with exisiting abi3 extensions where `sizeof(PyObject)` is a multiple of 8 thereby the added alignment is no-op and does not changes the offset for such extensions. 



#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

AI was used to create the test. 
