### PR TITLE
BUG: centralized helper for output coerce and na_object in stringdtype operations (#31884)

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -211,6 +211,62 @@ stringdtype_compatible_na(PyObject *na1, PyObject *na2, PyObject **out_na) {
     return 0;
 }
 
+// Combine the na_object and coerce attributes of the string descriptors in
+// descrs, ignoring descriptors of other dtypes. The na_objects must be
+// compatible, and coercion is only enabled if it is enabled for all string
+// descriptors. Returns -1 with an error set if two descriptors have
+// incompatible na_objects. out_na_object (a borrowed reference) and
+// out_coerce may be NULL if only the compatibility check is needed.
+NPY_NO_EXPORT int
+stringdtype_common_na_coerce(int ndescrs, PyArray_Descr *const descrs[],
+                             PyObject **out_na_object, int *out_coerce)
+{
+    PyObject *na_object = NULL;
+    int coerce = 1;
+    for (int i = 0; i < ndescrs; i++) {
+        if (NPY_DTYPE(descrs[i]) != &PyArray_StringDType) {
+            continue;
+        }
+        PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)descrs[i];
+        if (stringdtype_compatible_na(na_object, descr->na_object, &na_object) == -1) {
+            return -1;
+        }
+        coerce = coerce && descr->coerce;
+    }
+    if (out_na_object != NULL) {
+        *out_na_object = na_object;
+    }
+    if (out_coerce != NULL) {
+        *out_coerce = coerce;
+    }
+    return 0;
+}
+
+// Select the descriptor that determines how nulls are handled in an
+// operation accepting several string operands whose descriptors may differ,
+// ignoring descriptors of other dtypes. The caller has already checked that
+// the na_objects are compatible, so the first string descriptor with a set
+// na_object determines the null-handling behavior for the whole operation.
+// Returns the first string descriptor if none has an na_object set.
+NPY_NO_EXPORT PyArray_StringDTypeObject *
+stringdtype_effective_na_descr(int ndescrs, PyArray_Descr *const descrs[])
+{
+    PyArray_StringDTypeObject *first = NULL;
+    for (int i = 0; i < ndescrs; i++) {
+        if (NPY_DTYPE(descrs[i]) != &PyArray_StringDType) {
+            continue;
+        }
+        PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)descrs[i];
+        if (descr->na_object != NULL) {
+            return descr;
+        }
+        if (first == NULL) {
+            first = descr;
+        }
+    }
+    return first;
+}
+
 /*
  * This is used to determine the correct dtype to return when dealing
  * with a mix of different dtypes (for example when creating an array
@@ -219,10 +275,11 @@ stringdtype_compatible_na(PyObject *na1, PyObject *na2, PyObject **out_na) {
 static PyArray_StringDTypeObject *
 common_instance(PyArray_StringDTypeObject *dtype1, PyArray_StringDTypeObject *dtype2)
 {
+    PyArray_Descr *descrs[2] = {(PyArray_Descr *)dtype1, (PyArray_Descr *)dtype2};
     PyObject *out_na_object = NULL;
+    int out_coerce = 1;
 
-    if (stringdtype_compatible_na(
-                dtype1->na_object, dtype2->na_object, &out_na_object) == -1) {
+    if (stringdtype_common_na_coerce(2, descrs, &out_na_object, &out_coerce) == -1) {
         PyErr_Format(PyExc_TypeError,
                      "Cannot find common instance for incompatible dtypes "
                      "'%R' and '%R'", (PyObject *)dtype1, (PyObject *)dtype2);
@@ -230,7 +287,7 @@ common_instance(PyArray_StringDTypeObject *dtype1, PyArray_StringDTypeObject *dt
     }
 
     return (PyArray_StringDTypeObject *)new_stringdtype_instance(
-            out_na_object, dtype1->coerce && dtype2->coerce);
+            out_na_object, out_coerce);
 }
 
 /*
@@ -461,17 +518,12 @@ _compare(void *a, void *b, PyArray_StringDTypeObject *descr_a,
 {
     npy_string_allocator *allocator_a = descr_a->allocator;
     npy_string_allocator *allocator_b = descr_b->allocator;
-    // descr_a and descr_b are either the same object or objects
-    // that are equal, so we can safely refer only to descr_a.
-    // This is enforced in the resolve_descriptors for comparisons
-    //
-    // Note that even though the default_string isn't checked in comparisons,
-    // it will still be the same for both descrs because the value of
-    // default_string is always the empty string unless na_object is a string.
-    int has_null = descr_a->na_object != NULL;
-    int has_string_na = descr_a->has_string_na;
-    int has_nan_na = descr_a->has_nan_na;
-    npy_static_string *default_string = &descr_a->default_string;
+    PyArray_Descr *descrs[2] = {(PyArray_Descr *)descr_a, (PyArray_Descr *)descr_b};
+    PyArray_StringDTypeObject *nadescr = stringdtype_effective_na_descr(2, descrs);
+    int has_null = nadescr->na_object != NULL;
+    int has_string_na = nadescr->has_string_na;
+    int has_nan_na = nadescr->has_nan_na;
+    npy_static_string *default_string = &nadescr->default_string;
     const npy_packed_static_string *ps_a = (npy_packed_static_string *)a;
     npy_static_string s_a = {0, NULL};
     int a_is_null = NpyString_load(allocator_a, ps_a, &s_a);

--- a/numpy/_core/src/multiarray/stringdtype/dtype.h
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.h
@@ -57,6 +57,13 @@ NPY_NO_EXPORT int
 stringdtype_compatible_na(PyObject *na1, PyObject *na2, PyObject **out_na);
 
 NPY_NO_EXPORT int
+stringdtype_common_na_coerce(int ndescrs, PyArray_Descr *const descrs[],
+                             PyObject **out_na_object, int *out_coerce);
+
+NPY_NO_EXPORT PyArray_StringDTypeObject *
+stringdtype_effective_na_descr(int ndescrs, PyArray_Descr *const descrs[]);
+
+NPY_NO_EXPORT int
 na_eq_cmp(PyObject *a, PyObject *b);
 
 #ifdef __cplusplus

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -240,19 +240,17 @@ static int multiply_left_strided_loop(
 }
 
 static NPY_CASTING
-binary_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
+binary_resolve_descriptors(struct PyArrayMethodObject_tag *method,
                            PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
                            PyArray_Descr *const given_descrs[],
                            PyArray_Descr *loop_descrs[],
                            npy_intp *NPY_UNUSED(view_offset))
 {
-    PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
-    PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    int out_coerce = descr1->coerce && descr2->coerce;
     PyObject *out_na_object = NULL;
+    int out_coerce = 1;
 
-    if (stringdtype_compatible_na(
-                descr1->na_object, descr2->na_object, &out_na_object) == -1) {
+    if (stringdtype_common_na_coerce(method->nin, given_descrs,
+                                     &out_na_object, &out_coerce) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -289,10 +287,12 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
     PyArray_StringDTypeObject *s1descr = (PyArray_StringDTypeObject *)context->descriptors[0];
     PyArray_StringDTypeObject *s2descr = (PyArray_StringDTypeObject *)context->descriptors[1];
     PyArray_StringDTypeObject *odescr = (PyArray_StringDTypeObject *)context->descriptors[2];
-    int has_null = s1descr->na_object != NULL;
-    int has_nan_na = s1descr->has_nan_na;
-    int has_string_na = s1descr->has_string_na;
-    const npy_static_string *default_string = &s1descr->default_string;
+    PyArray_StringDTypeObject *nadescr = stringdtype_effective_na_descr(
+            context->method->nin, context->descriptors);
+    int has_null = nadescr->na_object != NULL;
+    int has_nan_na = nadescr->has_nan_na;
+    int has_string_na = nadescr->has_string_na;
+    const npy_static_string *default_string = &nadescr->default_string;
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -468,11 +468,12 @@ string_comparison_strided_loop(PyArrayMethod_Context *context, char *const data[
     npy_bool res_for_gt = ((npy_bool *)context->method->static_data)[2];
     npy_bool res_for_ne = !res_for_eq;
     npy_bool eq_or_ne = res_for_lt == res_for_gt;
-    PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)context->descriptors[0];
-    int has_null = descr1->na_object != NULL;
-    int has_nan_na = descr1->has_nan_na;
-    int has_string_na = descr1->has_string_na;
-    const npy_static_string *default_string = &descr1->default_string;
+    PyArray_StringDTypeObject *nadescr = stringdtype_effective_na_descr(
+            context->method->nin, context->descriptors);
+    int has_null = nadescr->na_object != NULL;
+    int has_nan_na = nadescr->has_nan_na;
+    int has_string_na = nadescr->has_string_na;
+    const npy_static_string *default_string = &nadescr->default_string;
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -549,15 +550,13 @@ fail:
 
 static NPY_CASTING
 string_comparison_resolve_descriptors(
-        struct PyArrayMethodObject_tag *NPY_UNUSED(method),
+        struct PyArrayMethodObject_tag *method,
         PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
         PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[], npy_intp *NPY_UNUSED(view_offset))
 {
-    PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
-    PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-
-    if (stringdtype_compatible_na(descr1->na_object, descr2->na_object, NULL) == -1) {
+    if (stringdtype_common_na_coerce(
+                method->nin, given_descrs, NULL, NULL) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -779,16 +778,14 @@ string_findlike_promoter(PyObject *NPY_UNUSED(ufunc),
 
 static NPY_CASTING
 string_findlike_resolve_descriptors(
-        struct PyArrayMethodObject_tag *NPY_UNUSED(method),
+        struct PyArrayMethodObject_tag *method,
         PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
         PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[],
         npy_intp *NPY_UNUSED(view_offset))
 {
-    PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
-    PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-
-    if (stringdtype_compatible_na(descr1->na_object, descr2->na_object, NULL) == -1) {
+    if (stringdtype_common_na_coerce(
+                method->nin, given_descrs, NULL, NULL) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -828,16 +825,14 @@ string_startswith_endswith_promoter(
 
 static NPY_CASTING
 string_startswith_endswith_resolve_descriptors(
-        struct PyArrayMethodObject_tag *NPY_UNUSED(method),
+        struct PyArrayMethodObject_tag *method,
         PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
         PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[],
         npy_intp *NPY_UNUSED(view_offset))
 {
-    PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
-    PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-
-    if (stringdtype_compatible_na(descr1->na_object, descr2->na_object, NULL) == -1) {
+    if (stringdtype_common_na_coerce(
+                method->nin, given_descrs, NULL, NULL) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -872,11 +867,12 @@ string_findlike_strided_loop(PyArrayMethod_Context *context,
 {
     const char *ufunc_name = ((PyUFuncObject *)context->caller)->name;
     find_like_function *function = *(find_like_function *)(context->method->static_data);
-    PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)context->descriptors[0];
+    PyArray_StringDTypeObject *nadescr = stringdtype_effective_na_descr(
+            context->method->nin, context->descriptors);
 
-    int has_null = descr1->na_object != NULL;
-    int has_string_na = descr1->has_string_na;
-    const npy_static_string *default_string = &descr1->default_string;
+    int has_null = nadescr->na_object != NULL;
+    int has_string_na = nadescr->has_string_na;
+    const npy_static_string *default_string = &nadescr->default_string;
 
     npy_string_allocator *allocators[2] = {};
     NpyString_acquire_allocators(2, context->descriptors, allocators);
@@ -948,12 +944,13 @@ string_startswith_endswith_strided_loop(PyArrayMethod_Context *context,
 {
     const char *ufunc_name = ((PyUFuncObject *)context->caller)->name;
     STARTPOSITION startposition = *(STARTPOSITION *)context->method->static_data;
-    PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)context->descriptors[0];
+    PyArray_StringDTypeObject *nadescr = stringdtype_effective_na_descr(
+            context->method->nin, context->descriptors);
 
-    int has_null = descr1->na_object != NULL;
-    int has_string_na = descr1->has_string_na;
-    int has_nan_na = descr1->has_nan_na;
-    const npy_static_string *default_string = &descr1->default_string;
+    int has_null = nadescr->na_object != NULL;
+    int has_string_na = nadescr->has_string_na;
+    int has_nan_na = nadescr->has_nan_na;
+    const npy_static_string *default_string = &nadescr->default_string;
 
     npy_string_allocator *allocators[2] = {};
     NpyString_acquire_allocators(2, context->descriptors, allocators);
@@ -1064,12 +1061,13 @@ string_lrstrip_chars_strided_loop(
 {
     const char *ufunc_name = ((PyUFuncObject *)context->caller)->name;
     STRIPTYPE striptype = *(STRIPTYPE *)context->method->static_data;
-    PyArray_StringDTypeObject *s1descr = (PyArray_StringDTypeObject *)context->descriptors[0];
-    int has_null = s1descr->na_object != NULL;
-    int has_string_na = s1descr->has_string_na;
-    int has_nan_na = s1descr->has_nan_na;
+    PyArray_StringDTypeObject *nadescr = stringdtype_effective_na_descr(
+            context->method->nin, context->descriptors);
+    int has_null = nadescr->na_object != NULL;
+    int has_string_na = nadescr->has_string_na;
+    int has_nan_na = nadescr->has_nan_na;
 
-    const npy_static_string *default_string = &s1descr->default_string;
+    const npy_static_string *default_string = &nadescr->default_string;
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -1298,25 +1296,17 @@ string_replace_promoter(PyObject *NPY_UNUSED(ufunc),
 }
 
 static NPY_CASTING
-replace_resolve_descriptors(struct PyArrayMethodObject_tag *NPY_UNUSED(method),
+replace_resolve_descriptors(struct PyArrayMethodObject_tag *method,
                             PyArray_DTypeMeta *const NPY_UNUSED(dtypes[]),
                             PyArray_Descr *const given_descrs[],
                             PyArray_Descr *loop_descrs[],
                             npy_intp *NPY_UNUSED(view_offset))
 {
-    PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
-    PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    PyArray_StringDTypeObject *descr3 = (PyArray_StringDTypeObject *)given_descrs[2];
-    int out_coerce = descr1->coerce && descr2->coerce && descr3->coerce;
     PyObject *out_na_object = NULL;
+    int out_coerce = 1;
 
-    if (stringdtype_compatible_na(
-                descr1->na_object, descr2->na_object, &out_na_object) == -1) {
-        return (NPY_CASTING)-1;
-    }
-
-    if (stringdtype_compatible_na(
-                out_na_object, descr3->na_object, &out_na_object) == -1) {
+    if (stringdtype_common_na_coerce(method->nin, given_descrs,
+                                     &out_na_object, &out_coerce) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -1364,12 +1354,12 @@ string_replace_strided_loop(
 
     npy_intp N = dimensions[0];
 
-    PyArray_StringDTypeObject *descr0 =
-            (PyArray_StringDTypeObject *)context->descriptors[0];
-    int has_null = descr0->na_object != NULL;
-    int has_string_na = descr0->has_string_na;
-    int has_nan_na = descr0->has_nan_na;
-    const npy_static_string *default_string = &descr0->default_string;
+    PyArray_StringDTypeObject *nadescr = stringdtype_effective_na_descr(
+            context->method->nin, context->descriptors);
+    int has_null = nadescr->na_object != NULL;
+    int has_string_na = nadescr->has_string_na;
+    int has_nan_na = nadescr->has_nan_na;
+    const npy_static_string *default_string = &nadescr->default_string;
 
 
     npy_string_allocator *allocators[5] = {};
@@ -1646,17 +1636,15 @@ string_center_ljust_rjust_promoter(
 
 static NPY_CASTING
 center_ljust_rjust_resolve_descriptors(
-        struct PyArrayMethodObject_tag *NPY_UNUSED(method),
+        struct PyArrayMethodObject_tag *method,
         PyArray_DTypeMeta *const dtypes[], PyArray_Descr *const given_descrs[],
         PyArray_Descr *loop_descrs[], npy_intp *NPY_UNUSED(view_offset))
 {
-    PyArray_StringDTypeObject *input_descr = (PyArray_StringDTypeObject *)given_descrs[0];
-    PyArray_StringDTypeObject *fill_descr = (PyArray_StringDTypeObject *)given_descrs[2];
-    int out_coerce = input_descr->coerce && fill_descr->coerce;
     PyObject *out_na_object = NULL;
+    int out_coerce = 1;
 
-    if (stringdtype_compatible_na(
-                input_descr->na_object, fill_descr->na_object, &out_na_object) == -1) {
+    if (stringdtype_common_na_coerce(method->nin, given_descrs,
+                                     &out_na_object, &out_coerce) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -1695,11 +1683,12 @@ center_ljust_rjust_strided_loop(PyArrayMethod_Context *context,
                                 npy_intp const strides[],
                                 NpyAuxData *NPY_UNUSED(auxdata))
 {
-    PyArray_StringDTypeObject *s1descr = (PyArray_StringDTypeObject *)context->descriptors[0];
-    int has_null = s1descr->na_object != NULL;
-    int has_nan_na = s1descr->has_nan_na;
-    int has_string_na = s1descr->has_string_na;
-    const npy_static_string *default_string = &s1descr->default_string;
+    PyArray_StringDTypeObject *nadescr = stringdtype_effective_na_descr(
+            context->method->nin, context->descriptors);
+    int has_null = nadescr->na_object != NULL;
+    int has_nan_na = nadescr->has_nan_na;
+    int has_string_na = nadescr->has_string_na;
+    const npy_static_string *default_string = &nadescr->default_string;
     npy_intp N = dimensions[0];
     char *in1 = data[0];
     char *in2 = data[1];
@@ -1969,13 +1958,11 @@ string_partition_resolve_descriptors(
         return (NPY_CASTING)-1;
     }
 
-    PyArray_StringDTypeObject *descr1 = (PyArray_StringDTypeObject *)given_descrs[0];
-    PyArray_StringDTypeObject *descr2 = (PyArray_StringDTypeObject *)given_descrs[1];
-    int out_coerce = descr1->coerce && descr2->coerce;
     PyObject *out_na_object = NULL;
+    int out_coerce = 1;
 
-    if (stringdtype_compatible_na(
-                descr1->na_object, descr2->na_object, &out_na_object) == -1) {
+    if (stringdtype_common_na_coerce(self->nin, given_descrs,
+                                     &out_na_object, &out_coerce) == -1) {
         return (NPY_CASTING)-1;
     }
 
@@ -2029,10 +2016,10 @@ string_partition_strided_loop(
     npy_string_allocator *out2allocator = allocators[3];
     npy_string_allocator *out3allocator = allocators[4];
 
-    PyArray_StringDTypeObject *idescr =
-            (PyArray_StringDTypeObject *)context->descriptors[0];
-    int has_string_na = idescr->has_string_na;
-    const npy_static_string *default_string = &idescr->default_string;
+    PyArray_StringDTypeObject *nadescr = stringdtype_effective_na_descr(
+            context->method->nin, context->descriptors);
+    int has_string_na = nadescr->has_string_na;
+    const npy_static_string *default_string = &nadescr->default_string;
 
     while (N--) {
         const npy_packed_static_string *i1ps = (npy_packed_static_string *)in1;

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1827,6 +1827,10 @@ def test_unset_na_coercion():
         res = arr + op
         assert_array_equal(res, ["hello2", "world2"])
         assert res.dtype == expected
+        # the promotion must not depend on the operand order
+        res = op + arr
+        assert_array_equal(res, ["2hello", "2world"])
+        assert res.dtype == expected
 
     # dtype instances with distinct explicitly set NA objects are incompatible
     for op_dtype in [StringDType(na_object=pd_NA), StringDType(na_object="")]:
@@ -1859,6 +1863,76 @@ def test_coerce_promotion_commutative():
     assert np.promote_types(dt_no_coerce, dt) == dt_no_coerce
     assert np.promote_types(dt, dt) == dt
     assert np.promote_types(dt_no_coerce, dt_no_coerce) == dt_no_coerce
+
+
+def test_mixed_instance_null_handling():
+    # the rules for picking a result dtype when mixing dtype instances
+    # shouldn't depend on the input order
+    nan_dt = StringDType(na_object=np.nan)
+    plain = np.array(["x", "y"], dtype=StringDType())
+    withna = np.array(["z", np.nan], dtype=nan_dt)
+
+    # missing values propagate through add in both operand orders
+    res = np.add(plain, withna)
+    assert res.dtype == nan_dt
+    assert res[0] == "xz" and np.isnan(res[1])
+    res = np.add(withna, plain)
+    assert res.dtype == nan_dt
+    assert res[0] == "zx" and np.isnan(res[1])
+
+    # nulls sort to the end with a nan-like NA, in both operand orders
+    assert np.isnan(np.maximum(plain, withna)[1])
+    assert np.isnan(np.maximum(withna, plain)[1])
+    assert np.minimum(plain, withna)[1] == "y"
+    assert np.minimum(withna, plain)[1] == "y"
+
+    # a missing value never compares equal to or smaller than a string
+    empty = np.array(["", ""], dtype=StringDType())
+    assert_array_equal(empty == withna, [False, False])
+    assert_array_equal(withna == empty, [False, False])
+    assert_array_equal(empty < withna, [True, False])
+    assert_array_equal(withna < empty, [False, False])
+
+    # operations that reject non-string nulls do so in both orders
+    for a, b in [(plain, withna), (withna, plain)]:
+        with pytest.raises(ValueError, match="not supported"):
+            np.strings.find(a, b)
+
+
+@pytest.mark.parametrize("op", [
+    lambda a, b: np.add(a, b),
+    lambda a, b: np.maximum(a, b),
+    lambda a, b: np.minimum(a, b),
+    lambda a, b: a == b,
+    lambda a, b: a < b,
+    lambda a, b: np.strings.find(a, b),
+    lambda a, b: np.strings.count(a, b),
+    lambda a, b: np.strings.startswith(a, b),
+    lambda a, b: np.strings.endswith(a, b),
+    lambda a, b: np.strings.lstrip(a, b),
+    lambda a, b: np.strings.strip(a, b),
+    lambda a, b: np.strings.replace(a, b, "R"),
+    lambda a, b: np.strings.center(a, 4, b),
+    lambda a, b: np.strings.partition(a, b),
+    lambda a, b: np.strings.rpartition(a, b),
+])
+def test_mixed_instance_string_na_matches_common_instance(op):
+    # with a string na_object, nulls behave like the na string; mixing an
+    # instance that has an na_object with one that does not must give the
+    # same result as casting both operands to the common instance,
+    # regardless of the operand order
+    sdt = StringDType(na_object="M")
+    plain = np.array(["M", "n"], dtype=StringDType())
+    withna = np.array(["M", "q"], dtype=sdt)
+
+    for left, right in [(plain, withna), (withna, plain)]:
+        expected = op(left.astype(sdt), right.astype(sdt))
+        result = op(left, right)
+        if not isinstance(expected, tuple):
+            expected, result = (expected,), (result,)
+        for e, r in zip(expected, result):
+            assert r.dtype == e.dtype
+            assert_array_equal(r, e)
 
 
 def test_repeat(string_array):


### PR DESCRIPTION
Backport of #31884.

### PR summary
Related to #31825 but issuing it as a separate PR because the two changes don't overlap at all.

We currently have custom logic for determining the correct `na_object` and `coerce` value when operations mix `StringDType` instances. In some cases this can even lead to crashes. The following script segfaults for me because the `na_object` in the fill character array is not being handled correctly.

```python
Python 3.14.5 (main, May 22 2026, 08:10:06) [Clang 21.0.0 (clang-2100.0.123.102)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> from numpy.dtypes import StringDType
>>> print(np.__version__)
2.5.1
>>> arr = np.array(["a"], dtype="T")
>>> fill = np.array("*", dtype=StringDType(na_object="*"))
>>> print(np.strings.center(arr, 5, fill))
[1]    87011 segmentation fault  python
```

This centralizes the logic for handling the `na_object` and `coerce` argument in ufunc loops and in the comparison machinery into one set of shared helpers.

Also adds tests for this behavior, including the case that leads to a crash above.

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
I found this issue using an AI model. I also used an AI model to help with the tests and the approach for the fix.
