### PR TITLE
BUG: fix misleading error message for q.ndim in quantile/percentile

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4659,7 +4659,7 @@ def _quantile_ureduce_func(
         # The code below works fine for nd, but it might not have useful
         # semantics. For now, keep the supported dimensions the same as it was
         # before.
-        raise ValueError("q must be a scalar or 1d")
+        raise ValueError(f"q must have at most 2 dimensions (got {q.ndim})")
     if overwrite_input:
         if axis is None:
             axis = 0

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3988,6 +3988,15 @@ class TestQuantile:
         # Identification function used in several tests.
         return (x >= y) - alpha
 
+    def test_q_ndim(self):
+        # A 2d q is supported and returns a matching leading shape; only q with
+        # more than 2 dimensions is rejected, and the error names that limit
+        # (gh-30038).
+        a = np.arange(100.0)
+        assert np.quantile(a, np.full((2, 2), 0.5)).shape == (2, 2)
+        with pytest.raises(ValueError, match="q must have at most 2 dimensions"):
+            np.quantile(a, np.full((2, 2, 2), 0.5))
+
     def test_max_ulp(self):
         x = [0.0, 0.2, 0.4]
         a = np.quantile(x, 0.45)


### PR DESCRIPTION
Closes #30038.

In `_quantile_ureduce_func` (`numpy/lib/_function_base_impl.py`), the only restriction on `q` is:

```python
if q.ndim > 2:
    # The code below works fine for nd, but it might not have useful
    # semantics. For now, keep the supported dimensions the same as it was
    # before.
    raise ValueError("q must be a scalar or 1d")
```

The guard is `q.ndim > 2`, so a scalar (0d), 1d **and 2d** `q` are all accepted — only 3d+ is rejected. The message "q must be a scalar or 1d" is therefore factually wrong: it omits the 2d case the code deliberately supports (the comment confirms 2d is intentional).

```python
>>> np.quantile(np.arange(100.), np.full((2, 2), 0.5)).shape
(2, 2)                       # 2d q works
>>> np.quantile(np.arange(100.), np.full((2, 2, 2), 0.5))
ValueError: q must be a scalar or 1d      # only >2d is rejected
```

This changes the message (only — no behavior change) to state the real limit and the offending dimensionality, reached from both `quantile` and `percentile`:

```python
raise ValueError(f"q must have at most 2 dimensions (got {q.ndim})")
```

A regression test is added to `TestQuantile` asserting a 2d `q` succeeds and a 3d `q` raises the new message (the string was previously unasserted).

The change is message-only; correctness follows directly from the `q.ndim > 2` guard (0d/1d/2d pass through). Note: I could not complete a full local numpy build on Python 3.14 to run the suite, so CI will exercise the added test — happy to iterate if anything surfaces there.