### PR TITLE
MAINT: Use Py_CHARMASK for ctype calls on signed char in string parsers

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -141,11 +141,11 @@ swab_separator(const char *sep)
         return NULL;
     }
     /* add space to front if there isn't one */
-    if (*sep != '\0' && !isspace(*sep)) {
+    if (*sep != '\0' && !isspace(Py_CHARMASK(*sep))) {
         *s = ' '; s++;
     }
     while (*sep != '\0') {
-        if (isspace(*sep)) {
+        if (isspace(Py_CHARMASK(*sep))) {
             if (skip_space) {
                 sep++;
             }
@@ -209,7 +209,7 @@ fromstr_skip_separator(char **s, const char *sep, const char *end)
         }
         else if (*sep == ' ') {
             /* whitespace wildcard */
-            if (!isspace(c)) {
+            if (!isspace(Py_CHARMASK(c))) {
                 sep++;
                 continue;
             }

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2585,9 +2585,9 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
 
         /* Check for a NaT string */
         if (len <= 0 || (len == 3 &&
-                        tolower(str[0]) == 'n' &&
-                        tolower(str[1]) == 'a' &&
-                        tolower(str[2]) == 't')) {
+                        tolower(Py_CHARMASK(str[0])) == 'n' &&
+                        tolower(Py_CHARMASK(str[1])) == 'a' &&
+                        tolower(Py_CHARMASK(str[2])) == 't')) {
             *out = NPY_DATETIME_NAT;
             succeeded = 1;
         }

--- a/numpy/_core/src/multiarray/datetime_busdaycal.c
+++ b/numpy/_core/src/multiarray/datetime_busdaycal.c
@@ -74,7 +74,7 @@ general_weekmask_string:
         /* a string like "SatSun" or "Mon Tue Wed" */
         memset(weekmask, 0, 7);
         for (Py_ssize_t i = 0; i < len; i += 3) {
-            while (isspace(str[i]))
+            while (isspace(Py_CHARMASK(str[i])))
                 ++i;
 
             if (i == len) {

--- a/numpy/_core/src/multiarray/datetime_strings.c
+++ b/numpy/_core/src/multiarray/datetime_strings.c
@@ -245,9 +245,9 @@ NpyDatetime_ParseISO8601Datetime(
      * not even matching the strcmp function signature as it should.
      */
     if (len <= 0 || (len == 3 &&
-                        tolower(str[0]) == 'n' &&
-                        tolower(str[1]) == 'a' &&
-                        tolower(str[2]) == 't')) {
+                        tolower(Py_CHARMASK(str[0])) == 'n' &&
+                        tolower(Py_CHARMASK(str[1])) == 'a' &&
+                        tolower(Py_CHARMASK(str[2])) == 't')) {
         out->year = NPY_DATETIME_NAT;
 
         /*
@@ -280,11 +280,11 @@ NpyDatetime_ParseISO8601Datetime(
      * switching to an adjacent day depending on the current time and your
      * timezone.
      */
-    if (len == 5 && tolower(str[0]) == 't' &&
-                    tolower(str[1]) == 'o' &&
-                    tolower(str[2]) == 'd' &&
-                    tolower(str[3]) == 'a' &&
-                    tolower(str[4]) == 'y') {
+    if (len == 5 && tolower(Py_CHARMASK(str[0])) == 't' &&
+                    tolower(Py_CHARMASK(str[1])) == 'o' &&
+                    tolower(Py_CHARMASK(str[2])) == 'd' &&
+                    tolower(Py_CHARMASK(str[3])) == 'a' &&
+                    tolower(Py_CHARMASK(str[4])) == 'y') {
         NPY_TIME_T rawtime = 0;
         struct tm tm_;
 
@@ -323,9 +323,9 @@ NpyDatetime_ParseISO8601Datetime(
     }
 
     /* The string "now" resolves to the current UTC time */
-    if (len == 3 && tolower(str[0]) == 'n' &&
-                    tolower(str[1]) == 'o' &&
-                    tolower(str[2]) == 'w') {
+    if (len == 3 && tolower(Py_CHARMASK(str[0])) == 'n' &&
+                    tolower(Py_CHARMASK(str[1])) == 'o' &&
+                    tolower(Py_CHARMASK(str[2])) == 'w') {
         NPY_TIME_T rawtime = 0;
         PyArray_DatetimeMetaData meta;
 
@@ -371,7 +371,7 @@ NpyDatetime_ParseISO8601Datetime(
     sublen = len;
 
     /* Skip leading whitespace */
-    while (sublen > 0 && isspace(*substr)) {
+    while (sublen > 0 && isspace(Py_CHARMASK(*substr))) {
         ++substr;
         --sublen;
     }
@@ -388,7 +388,7 @@ NpyDatetime_ParseISO8601Datetime(
 
     /* PARSE THE YEAR (digits until the '-' character) */
     out->year = 0;
-    while (sublen > 0 && isdigit(*substr)) {
+    while (sublen > 0 && isdigit(Py_CHARMASK(*substr))) {
         out->year = 10 * out->year + (*substr - '0');
         ++substr;
         --sublen;
@@ -420,7 +420,8 @@ NpyDatetime_ParseISO8601Datetime(
     }
 
     /* PARSE THE MONTH (2 digits) */
-    if (sublen >= 2 && isdigit(substr[0]) && isdigit(substr[1])) {
+    if (sublen >= 2 && isdigit(Py_CHARMASK(substr[0]))
+            && isdigit(Py_CHARMASK(substr[1]))) {
         out->month = 10 * (substr[0] - '0') + (substr[1] - '0');
 
         if (out->month < 1 || out->month > 12) {
@@ -454,7 +455,8 @@ NpyDatetime_ParseISO8601Datetime(
     }
 
     /* PARSE THE DAY (2 digits) */
-    if (sublen >= 2 && isdigit(substr[0]) && isdigit(substr[1])) {
+    if (sublen >= 2 && isdigit(Py_CHARMASK(substr[0]))
+            && isdigit(Py_CHARMASK(substr[1]))) {
         out->day = 10 * (substr[0] - '0') + (substr[1] - '0');
 
         if (out->day < 1 ||
@@ -484,7 +486,8 @@ NpyDatetime_ParseISO8601Datetime(
     }
 
     /* PARSE THE HOURS (2 digits) */
-    if (sublen >= 2 && isdigit(substr[0]) && isdigit(substr[1])) {
+    if (sublen >= 2 && isdigit(Py_CHARMASK(substr[0]))
+            && isdigit(Py_CHARMASK(substr[1]))) {
         out->hour = 10 * (substr[0] - '0') + (substr[1] - '0');
 
         if (out->hour >= 24) {
@@ -515,7 +518,8 @@ NpyDatetime_ParseISO8601Datetime(
     }
 
     /* PARSE THE MINUTES (2 digits) */
-    if (sublen >= 2 && isdigit(substr[0]) && isdigit(substr[1])) {
+    if (sublen >= 2 && isdigit(Py_CHARMASK(substr[0]))
+            && isdigit(Py_CHARMASK(substr[1]))) {
         out->min = 10 * (substr[0] - '0') + (substr[1] - '0');
 
         if (out->min >= 60) {
@@ -546,7 +550,8 @@ NpyDatetime_ParseISO8601Datetime(
     }
 
     /* PARSE THE SECONDS (2 digits) */
-    if (sublen >= 2 && isdigit(substr[0]) && isdigit(substr[1])) {
+    if (sublen >= 2 && isdigit(Py_CHARMASK(substr[0]))
+            && isdigit(Py_CHARMASK(substr[1]))) {
         out->sec = 10 * (substr[0] - '0') + (substr[1] - '0');
 
         if (out->sec >= 60) {
@@ -575,7 +580,7 @@ NpyDatetime_ParseISO8601Datetime(
     numdigits = 0;
     for (i = 0; i < 6; ++i) {
         out->us *= 10;
-        if (sublen > 0  && isdigit(*substr)) {
+        if (sublen > 0  && isdigit(Py_CHARMASK(*substr))) {
             out->us += (*substr - '0');
             ++substr;
             --sublen;
@@ -583,7 +588,7 @@ NpyDatetime_ParseISO8601Datetime(
         }
     }
 
-    if (sublen == 0 || !isdigit(*substr)) {
+    if (sublen == 0 || !isdigit(Py_CHARMASK(*substr))) {
         if (numdigits > 3) {
             bestunit = NPY_FR_us;
         }
@@ -597,7 +602,7 @@ NpyDatetime_ParseISO8601Datetime(
     numdigits = 0;
     for (i = 0; i < 6; ++i) {
         out->ps *= 10;
-        if (sublen > 0 && isdigit(*substr)) {
+        if (sublen > 0 && isdigit(Py_CHARMASK(*substr))) {
             out->ps += (*substr - '0');
             ++substr;
             --sublen;
@@ -605,7 +610,7 @@ NpyDatetime_ParseISO8601Datetime(
         }
     }
 
-    if (sublen == 0 || !isdigit(*substr)) {
+    if (sublen == 0 || !isdigit(Py_CHARMASK(*substr))) {
         if (numdigits > 3) {
             bestunit = NPY_FR_ps;
         }
@@ -619,7 +624,7 @@ NpyDatetime_ParseISO8601Datetime(
     numdigits = 0;
     for (i = 0; i < 6; ++i) {
         out->as *= 10;
-        if (sublen > 0 && isdigit(*substr)) {
+        if (sublen > 0 && isdigit(Py_CHARMASK(*substr))) {
             out->as += (*substr - '0');
             ++substr;
             --sublen;
@@ -671,7 +676,8 @@ parse_timezone:
         --sublen;
 
         /* The hours offset */
-        if (sublen >= 2 && isdigit(substr[0]) && isdigit(substr[1])) {
+        if (sublen >= 2 && isdigit(Py_CHARMASK(substr[0]))
+                && isdigit(Py_CHARMASK(substr[1]))) {
             offset_hour = 10 * (substr[0] - '0') + (substr[1] - '0');
             substr += 2;
             sublen -= 2;
@@ -695,7 +701,8 @@ parse_timezone:
             }
 
             /* The minutes offset (at the end of the string) */
-            if (sublen >= 2 && isdigit(substr[0]) && isdigit(substr[1])) {
+            if (sublen >= 2 && isdigit(Py_CHARMASK(substr[0]))
+                    && isdigit(Py_CHARMASK(substr[1]))) {
                 offset_minute = 10 * (substr[0] - '0') + (substr[1] - '0');
                 substr += 2;
                 sublen -= 2;
@@ -720,7 +727,7 @@ parse_timezone:
     }
 
     /* Skip trailing whitespace */
-    while (sublen > 0 && isspace(*substr)) {
+    while (sublen > 0 && isspace(Py_CHARMASK(*substr))) {
         ++substr;
         --sublen;
     }

--- a/numpy/_core/src/umath/_rational_tests.c
+++ b/numpy/_core/src/umath/_rational_tests.c
@@ -425,7 +425,7 @@ pyrational_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
             if (scan_rational(&s,&r)) {
                 const char* p;
                 for (p = s; *p; p++) {
-                    if (!isspace(*p)) {
+                    if (!isspace(Py_CHARMASK(*p))) {
                         goto bad;
                     }
                 }


### PR DESCRIPTION
### PR summary

The datetime, business-day and fromstring/fromfile parsers hand a plain `char` straight to `isdigit`/`isspace`/`tolower`, so any input byte above `0x7f` arrives as a negative value and the ctype call is undefined per the C standard, which requires the argument be representable as `unsigned char` or equal to `EOF`. These paths run on user data: `np.datetime64` and timedelta strings, `np.busdaycalendar(weekmask=...)`, the `np.fromstring`/`np.fromfile` separator, and rational string parsing. Each argument is wrapped in `Py_CHARMASK`, the same guard `numpyos.c` already uses for its ctype calls.

Reachable examples that currently drive a high byte into a bare ctype call:

- `np.datetime64('\xe9020-01-01')`
- `np.busdaycalendar(weekmask='\xe9on Tue')`
- `np.fromstring('1\xe92\xe93', sep='\xe9', dtype=int)`

Valid-input behaviour is unchanged; the datetime and multiarray test suites pass locally.

### First time committer introduction

I use NumPy day to day for numerical and data-processing work. I came across this while reading through the string parsing code and noticed the ctype calls were being fed signed `char` directly, so I put together a fix that follows the `Py_CHARMASK` idiom already used elsewhere in the tree.
