### PR TITLE
BUG: Preserve f2py argv tokens containing spaces

### DIFF
--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -554,7 +554,6 @@ def f2py_parser():
     return parser
 
 def get_newer_options(iline):
-    iline = (' '.join(iline)).split()
     parser = f2py_parser()
     args, remain = parser.parse_known_args(iline)
     ipaths = args.include_paths

--- a/numpy/f2py/tests/test_f2py2e.py
+++ b/numpy/f2py/tests/test_f2py2e.py
@@ -754,6 +754,51 @@ def test_inclpath(monkeypatch):
     assert remain == []
 
 
+def test_get_newer_options_preserves_tokenized_arguments_with_spaces(monkeypatch):
+    """Preserve already-tokenized argv entries that contain spaces."""
+    monkeypatch.setattr(os, "pathsep", ";")
+
+    include_paths, ftcompat, remain = get_newer_options(
+        ["-I", r"C:\Users\First Last\include", r"C:\src\fib.f90"]
+    )
+
+    assert include_paths == [r"C:\Users\First Last\include"]
+    assert ftcompat is None
+    assert remain == [r"C:\src\fib.f90"]
+
+    include_paths, ftcompat, remain = get_newer_options(
+        [
+            "--include-paths",
+            r"C:\Users\First Last\include;D:\vendor headers",
+            r"C:\src\fib.f90",
+        ]
+    )
+
+    assert set(include_paths) == {
+        r"C:\Users\First Last\include",
+        r"D:\vendor headers",
+    }
+    assert ftcompat is None
+    assert remain == [r"C:\src\fib.f90"]
+
+    include_paths, ftcompat, remain = get_newer_options(
+        [
+            "--build-dir",
+            r"C:\Users\First Last\f2py build",
+            "--freethreading-compatible",
+            r"C:\Users\First Last\src\fib.f90",
+        ]
+    )
+
+    assert include_paths == []
+    assert ftcompat is True
+    assert remain == [
+        "--build-dir",
+        r"C:\Users\First Last\f2py build",
+        r"C:\Users\First Last\src\fib.f90",
+    ]
+
+
 def test_hlink():
     """Add to the include directories
 


### PR DESCRIPTION
## Summary

Fixes #31958.

`get_newer_options` receives an already-tokenized argv list from the normal f2py entry points, but it rebuilt that list as a string and split it again. That loses token boundaries for valid arguments containing spaces, such as Windows include paths, build directories, and source paths under user profile or OneDrive directories.

This PR passes the token list directly to `argparse.parse_known_args`, preserving already-tokenized argv entries while keeping the existing parsing behavior for `-I`, `--include-paths`, `--include_paths`, and `--freethreading-compatible`.

## Tests

- `python3 -m py_compile numpy/f2py/f2py2e.py numpy/f2py/tests/test_f2py2e.py`
- Focused parser harness against the patched `get_newer_options` definitions:
  - preserves `-I "C:\Users\First Last\include"`
  - preserves `--include-paths "C:\Users\First Last\include;D:\vendor headers"`
  - preserves `--build-dir "C:\Users\First Last\f2py build"` in the remaining argv while parsing `--freethreading-compatible`
- Verified the pre-fix `(' '.join(iline)).split()` behavior reproduces the reported token split.
