### PR TITLE
BUG: make base_repr upper-bound error message track len(digits)

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -2145,7 +2145,9 @@ def base_repr(number, base=2, padding=0):
     """
     digits = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
     if base > len(digits):
-        raise ValueError("Bases greater than 36 not handled in base_repr.")
+        raise ValueError(
+            f"Bases greater than {len(digits)} not handled in base_repr."
+        )
     elif base < 2:
         raise ValueError("Bases less than 2 not handled in base_repr.")
 

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -2095,7 +2095,9 @@ class TestBaseRepr:
     def test_base_range(self):
         with assert_raises(ValueError):
             np.base_repr(1, 1)
-        with assert_raises(ValueError):
+        # the upper-bound message reports len(digits), so it stays correct if
+        # the digit alphabet is ever extended
+        with assert_raises_regex(ValueError, "Bases greater than 36"):
             np.base_repr(1, 37)
 
     def test_minimal_signed_int(self):


### PR DESCRIPTION
`base_repr` derives its upper bound from the digit alphabet:

```python
digits = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
if base > len(digits):
    raise ValueError("Bases greater than 36 not handled in base_repr.")
```

The guard uses `len(digits)` specifically to avoid hardcoding the bound, but the error message re-hardcodes `36`. If `digits` is ever changed, the guard adapts while the message silently reports the stale number. This makes the message derive the bound the same way the guard does, via an f-string, so the two can't drift apart. The rendered text is identical today (`len(digits) == 36`) and behavior is unchanged.

`test_base_range` is tightened to assert the message (`assert_raises_regex(..., "Bases greater than 36")`) instead of just the exception type, pinning the reported bound.
