### PR TITLE
BUG: drop stray "ValueError:" prefix from einsum order error message

### DIFF
--- a/numpy/_core/einsumfunc.py
+++ b/numpy/_core/einsumfunc.py
@@ -1136,8 +1136,7 @@ def _parse_output_order(order, a_is_fcontig, b_is_fcontig):
             return "C"
     else:
         raise ValueError(
-            "ValueError: order must be one of "
-            f"'C', 'F', 'A', or 'K' (got '{order}')"
+            f"order must be one of 'C', 'F', 'A', or 'K' (got '{order}')"
         )
 
 

--- a/numpy/_core/tests/test_einsum.py
+++ b/numpy/_core/tests/test_einsum.py
@@ -1136,6 +1136,17 @@ class TestEinsum:
             tmp = np.einsum('...ft,mf->...mt', d, c, order='a', optimize=opt)
             assert_(tmp.flags.c_contiguous)
 
+    def test_invalid_output_order(self):
+        # an invalid order must report the accepted set without an accidental
+        # "ValueError: " prefix embedded in the message itself
+        a = np.ones((2, 3, 5), order='F')
+        b = np.ones((4, 3), order='F')
+        assert_raises_regex(
+            ValueError,
+            r"^order must be one of 'C', 'F', 'A', or 'K'",
+            np.einsum, '...ft,mf->...mt', a, b, order='z', optimize=True,
+        )
+
     def test_singleton_broadcasting(self):
         eq = "ijp,ipq,ikq->ijk"
         shapes = ((3, 1, 1), (3, 1, 3), (1, 3, 3))


### PR DESCRIPTION
`_parse_output_order` (reached from `np.einsum(..., order=..., optimize=True)`) raised a `ValueError` whose message string itself began with `"ValueError: "`:

```python
raise ValueError(
    "ValueError: order must be one of "
    f"'C', 'F', 'A', or 'K' (got '{order}')"
)
```

So an invalid order rendered as `ValueError: ValueError: order must be one of 'C', 'F', 'A', or 'K' (got 'Z')` — the class name embedded inside its own message, a copy-paste artifact. This drops the stray prefix. The enumerated set is unchanged and already correct (`K`, `C`, `F`, `A` are exactly the accepted orders).

A regression test (`test_invalid_output_order`) asserts the message with a start-anchored pattern (`^order must be one of ...`), which fails on the doubled prefix and passes once it's removed.
