### PR TITLE
BUG: avoid invalid Meson identifiers for f2py libraries

### DIFF
--- a/numpy/f2py/_backends/_meson.py
+++ b/numpy/f2py/_backends/_meson.py
@@ -11,6 +11,13 @@ from string import Template
 from ._backend import Backend
 
 
+def _meson_identifier(prefix: str, value: str, index: int) -> str:
+    safe_value = re.sub(r"[^a-zA-Z0-9_]", "_", value)
+    if not safe_value or safe_value[0].isdigit():
+        safe_value = f"_{safe_value}"
+    return f"{prefix}_{index}_{safe_value}"
+
+
 class MesonTemplate:
     """Template meson build file generation class."""
 
@@ -91,6 +98,11 @@ class MesonTemplate:
         )
 
     def libraries_substitution(self) -> None:
+        lib_names = [
+            (_meson_identifier("lib", lib, i), lib)
+            for i, lib in enumerate(self.libraries)
+        ]
+
         self.substitutions["lib_dir_declarations"] = "\n".join(
             [
                 f"lib_dir_{i} = declare_dependency(link_args : ['''-L{lib_dir}'''])"
@@ -100,13 +112,13 @@ class MesonTemplate:
 
         self.substitutions["lib_declarations"] = "\n".join(
             [
-                f"{lib.replace('.', '_')} = declare_dependency(link_args : ['-l{lib}'])"
-                for lib in self.libraries
+                f"{name} = declare_dependency(link_args : ['-l{lib}'])"
+                for name, lib in lib_names
             ]
         )
 
         self.substitutions["lib_list"] = f"\n{self.indent}".join(
-            [f"{self.indent}{lib.replace('.', '_')}," for lib in self.libraries]
+            [f"{self.indent}{name}," for name, _ in lib_names]
         )
         self.substitutions["lib_dir_list"] = f"\n{self.indent}".join(
             [f"{self.indent}lib_dir_{i}," for i in range(len(self.library_dirs))]

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -177,20 +177,11 @@ def test_meson_library_names_use_valid_identifiers():
     ).generate_meson_build()
 
     mparser.Parser(meson_build, "meson.build").parse()
-    expected_lib_declarations = [
-        "lib_0_foo_bar = declare_dependency(link_args : ['-lfoo.bar'])",
-        (
-            "lib_1_scalapack_openmpi = "
-            "declare_dependency(link_args : ['-lscalapack-openmpi'])"
-        ),
-        "lib_2_foo_bar = declare_dependency(link_args : ['-lfoo-bar'])",
-        "lib_3_foo_bar = declare_dependency(link_args : ['-lfoo_bar'])",
-        "lib_4__1foo = declare_dependency(link_args : ['-l1foo'])",
-    ]
-    for declaration in expected_lib_declarations:
-        assert declaration in meson_build
+    for lib in libraries:
+        assert f"declare_dependency(link_args : ['-l{lib}'])" in meson_build
 
     assert "\nfoo.bar =" not in meson_build
+    assert "\nscalapack-openmpi =" not in meson_build
     assert "\nfoo-bar =" not in meson_build
     assert "\n1foo =" not in meson_build
 

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -161,11 +161,12 @@ def test_gh26623():
 
 def test_meson_library_names_use_valid_identifiers():
     mparser = pytest.importorskip("mesonbuild.mparser")
+    libraries = ["foo.bar", "scalapack-openmpi", "foo-bar", "foo_bar", "1foo"]
     meson_build = MesonTemplate(
         modulename="Blah",
         sources=[Path("f90continuation.f90")],
         deps=[],
-        libraries=["foo.bar", "foo-bar", "foo_bar", "1foo"],
+        libraries=libraries,
         library_dirs=[],
         include_dirs=[],
         object_files=[],
@@ -176,10 +177,19 @@ def test_meson_library_names_use_valid_identifiers():
     ).generate_meson_build()
 
     mparser.Parser(meson_build, "meson.build").parse()
-    assert "-lfoo.bar" in meson_build
-    assert "-lfoo-bar" in meson_build
-    assert "-lfoo_bar" in meson_build
-    assert "-l1foo" in meson_build
+    expected_lib_declarations = [
+        "lib_0_foo_bar = declare_dependency(link_args : ['-lfoo.bar'])",
+        (
+            "lib_1_scalapack_openmpi = "
+            "declare_dependency(link_args : ['-lscalapack-openmpi'])"
+        ),
+        "lib_2_foo_bar = declare_dependency(link_args : ['-lfoo-bar'])",
+        "lib_3_foo_bar = declare_dependency(link_args : ['-lfoo_bar'])",
+        "lib_4__1foo = declare_dependency(link_args : ['-l1foo'])",
+    ]
+    for declaration in expected_lib_declarations:
+        assert declaration in meson_build
+
     assert "\nfoo.bar =" not in meson_build
     assert "\nfoo-bar =" not in meson_build
     assert "\n1foo =" not in meson_build

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -7,7 +7,6 @@ import pytest
 
 import numpy as np
 import numpy.testing as npt
-
 from numpy.f2py._backends._meson import MesonTemplate
 
 from . import util

--- a/numpy/f2py/tests/test_regression.py
+++ b/numpy/f2py/tests/test_regression.py
@@ -1,10 +1,14 @@
 import os
 import platform
+import sys
+from pathlib import Path
 
 import pytest
 
 import numpy as np
 import numpy.testing as npt
+
+from numpy.f2py._backends._meson import MesonTemplate
 
 from . import util
 
@@ -154,6 +158,32 @@ def test_gh26623():
         )
     except RuntimeError as rerr:
         assert "lparen got assign" not in str(rerr)
+
+
+def test_meson_library_names_use_valid_identifiers():
+    mparser = pytest.importorskip("mesonbuild.mparser")
+    meson_build = MesonTemplate(
+        modulename="Blah",
+        sources=[Path("f90continuation.f90")],
+        deps=[],
+        libraries=["foo.bar", "foo-bar", "foo_bar", "1foo"],
+        library_dirs=[],
+        include_dirs=[],
+        object_files=[],
+        linker_args=[],
+        fortran_args=[],
+        build_type="debug",
+        python_exe=sys.executable,
+    ).generate_meson_build()
+
+    mparser.Parser(meson_build, "meson.build").parse()
+    assert "-lfoo.bar" in meson_build
+    assert "-lfoo-bar" in meson_build
+    assert "-lfoo_bar" in meson_build
+    assert "-l1foo" in meson_build
+    assert "\nfoo.bar =" not in meson_build
+    assert "\nfoo-bar =" not in meson_build
+    assert "\n1foo =" not in meson_build
 
 
 @pytest.mark.slow


### PR DESCRIPTION
### PR summary

Fixes #31964.

Fixes invalid Meson variable names generated by the f2py Meson backend for `-l` libraries whose names are valid linker library names but are not valid Meson identifiers.

#26634 handled dotted library names by replacing `.` with `_`, but other inputs can still break or become ambiguous when the raw library name is used as the Meson variable name. For example, a library such as `scalapack-openmpi` can lead to an invalid assignment target in the generated `meson.build`.

This PR separates the internal Meson variable name from the user-provided linker library name. The generated dependency variable now uses a private indexed identifier, while the linker argument still preserves the original value, e.g. `-lscalapack-openmpi` remains `-lscalapack-openmpi`.

The regression test parses the generated `meson.build` and asserts that the generated dependency declarations preserve the original `-l<name>` linker arguments, while the unsafe original library names are not used directly as Meson assignment targets. It covers dotted, hyphenated, realistic hyphenated, underscore/collision, and digit-leading library names:

- `foo.bar`
- `scalapack-openmpi`
- `foo-bar`
- `foo_bar`
- `1foo`

Validation performed locally:

- `git diff --check`
- `spin lint`
- A direct `MesonTemplate` parser check using `mesonbuild.mparser.Parser(...).parse()`, which completed with `parse-ok` and verified that generated dependency declarations preserve the original `-l...` arguments.

I also attempted the focused pytest command below, but this unbuilt local source checkout stops during NumPy test configuration before selected tests run because the generated `numpy.version` module is unavailable:

```bash
D:\ZXY\Dev\Miniforge3\envs\prw-numpy-py312\python.exe -m pytest numpy/f2py/tests/test_regression.py -q -k "meson_library_names or gh26623"
```

### First time committer introduction

N/A.

#### AI Disclosure

Codex was used to investigate the failing f2py/Meson code path, draft the small code and regression-test change, run focused local validation, and draft this PR description. The diff and submission were reviewed by a human before opening the PR.
