### PR TITLE
ENH: note on the error when out may be partially written

### DIFF
--- a/numpy/_core/src/multiarray/common.c
+++ b/numpy/_core/src/multiarray/common.c
@@ -299,6 +299,23 @@ end:
     Py_XDECREF(shape2_j);
 }
 
+
+/* See common.h. The raised exception is left unchanged if add_note fails. */
+NPY_NO_EXPORT void
+npy_note_partial_write(void)
+{
+    PyObject *exc = PyErr_GetRaisedException();
+    if (exc == NULL) {
+        return;
+    }
+    PyObject *res = PyObject_CallMethod(
+            exc, "add_note", "s",
+            "the output array may have been partially modified");
+    Py_XDECREF(res);
+    PyErr_Clear();
+    PyErr_SetRaisedException(exc);
+}
+
 /**
  * unpack tuple of PyDataType_FIELDS(dtype) (descr, offset, title[not-needed])
  *

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -69,6 +69,13 @@ convert_shape_to_string(npy_intp n, npy_intp const *vals, char *ending);
 NPY_NO_EXPORT void
 dot_alignment_error(PyArrayObject *a, int i, PyArrayObject *b, int j);
 
+/*
+ * Note on the raised exception that a caller's out array may be partially
+ * written. Only call when writing straight into out (no internal copy).
+ */
+NPY_NO_EXPORT void
+npy_note_partial_write(void);
+
 
 /**
  * unpack tuple of PyDataType_FIELDS(dtype) (descr, offset, title[not-needed])

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -354,11 +354,18 @@ PyArray_TakeFrom(PyArrayObject *self0, PyObject *indices0, int axis,
             dest, src, indices_data, n, m, max_item, nelem, chunk,
             clipmode, itemsize, needs_refcounting, src_descr, dst_descr,
             axis) < 0) {
+        /* obj is out itself unless a writeback copy shielded it */
+        if (out != NULL &&
+                !(PyArray_FLAGS(obj) & NPY_ARRAY_WRITEBACKIFCOPY)) {
+            npy_note_partial_write();
+        }
         goto fail;
     }
 
     if (out != NULL && out != obj) {
         if (PyArray_ResolveWritebackIfCopy(obj) < 0) {
+            /* the writeback itself writes into out and can fail part-way */
+            npy_note_partial_write();
             goto fail;
         }
         Py_DECREF(obj);
@@ -389,6 +396,7 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
     char *src, *dest;
     int copied = 0;
     int overlap = 0;
+    int wrote_directly = 0;
 
     NPY_BEGIN_THREADS_DEF;
     NPY_cast_info cast_info;
@@ -469,6 +477,11 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
         }
     }
 
+
+    /* writes below land in the caller's array unless it was copied */
+    if (!copied) {
+        wrote_directly = 1;
+    }
 
     if (has_references) {
         const npy_intp one = 1;
@@ -595,6 +608,10 @@ PyArray_PutTo(PyArrayObject *self, PyObject* values0, PyObject *indices0,
  fail:
     NPY_cast_info_xfree(&cast_info);
 
+    if (wrote_directly) {
+        npy_note_partial_write();
+    }
+
     Py_XDECREF(indices);
     Py_XDECREF(values);
     if (copied) {
@@ -681,6 +698,7 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
     npy_bool *mask_data;
     int copied = 0;
     int overlap = 0;
+    int wrote_directly = 0;
     NPY_BEGIN_THREADS_DEF;
 
     mask = NULL;
@@ -766,6 +784,11 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
             NPY_BEGIN_THREADS;
         }
 
+        /* the cast below writes into the caller's array unless it was copied */
+        if (!copied) {
+            wrote_directly = 1;
+        }
+
         for (npy_intp i = 0, j = 0; i < ni; i++, j++) {
             if (j >= nv) {
                 j = 0;
@@ -799,6 +822,9 @@ PyArray_PutMask(PyArrayObject *self, PyObject* values0, PyObject* mask0)
     Py_RETURN_NONE;
 
  fail:
+    if (wrote_directly) {
+        npy_note_partial_write();
+    }
     Py_XDECREF(mask);
     Py_XDECREF(values);
     if (copied) {
@@ -1030,6 +1056,7 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     /* PyArray_MultiIterFromObjects below bounds n by NPY_MAXARGS */
     NPY_cast_info cast_infos[NPY_MAXARGS];
     int needs_transfer = 0;
+    int copy_existing_out = 0;
     NPY_BEGIN_THREADS_DEF;
     ap = NULL;
 
@@ -1058,7 +1085,6 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     }
     dtype = PyArray_DESCR(mps[0]);
 
-    int copy_existing_out = 0;
     /* Set-up return array */
     if (out == NULL) {
         Py_INCREF(dtype);
@@ -1211,6 +1237,8 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
         int res = PyArray_CopyInto(out, obj);
         Py_DECREF(obj);
         if (res < 0) {
+            /* the copy back writes into out and can fail part-way */
+            npy_note_partial_write();
             return NULL;
         }
         return Py_NewRef(out);
@@ -1230,6 +1258,10 @@ PyArray_Choose(PyArrayObject *ip, PyObject *op, PyArrayObject *out,
     }
     Py_XDECREF(ap);
     PyDataMem_FREE(mps);
+    /* obj is out itself when not copied (never the case for NPY_RAISE) */
+    if (out != NULL && !copy_existing_out) {
+        npy_note_partial_write();
+    }
     PyArray_DiscardWritebackIfCopy(obj);
     Py_XDECREF(obj);
     return NULL;

--- a/numpy/_core/tests/test_item_selection.py
+++ b/numpy/_core/tests/test_item_selection.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 import pytest
 
@@ -176,3 +177,66 @@ class TestPut:
         # Allowing empty values like this is weird...
         np.put(arr, [1, 2, 3], [])
         assert_array_equal(arr, arr_copy)
+
+
+class TestPartialWriteNote:
+    # Operations writing straight into a caller's array can raise part-way
+    # through; the error then carries a note saying the array may be partially
+    # modified. No note when an internal copy shielded the array.
+    note = "may have been partially modified"
+
+    def _has_note(self, exc):
+        return any(self.note in n for n in getattr(exc, "__notes__", []))
+
+    def test_put_oob_notes_partial_write(self):
+        a = np.arange(10)
+        with pytest.raises(IndexError) as exc_info:
+            np.put(a, [0, 1, 99], [100, 101, 102])
+        assert self._has_note(exc_info.value)
+        # the note must not change the error or get duplicated
+        assert "out of bounds" in str(exc_info.value)
+        notes = exc_info.value.__notes__
+        assert len([n for n in notes if self.note in n]) == 1
+        # the write up to the bad index really happened
+        assert a[0] == 100 and a[1] == 101
+
+    def test_take_out_copy_not_noted(self):
+        # dtype mismatch forces a writeback copy, so out stays untouched
+        a = np.arange(10)
+        out = np.zeros(3, dtype=np.float64)
+        with pytest.raises(IndexError) as exc_info:
+            np.take(a, [0, 1, 99], out=out)
+        assert not self._has_note(exc_info.value)
+        assert_array_equal(out, np.zeros(3))
+
+    def test_choose_raise_not_noted(self):
+        # mode="raise" copies out internally, so out stays untouched
+        choices = [np.zeros(3, dtype=int), np.ones(3, dtype=int)]
+        out = np.full(3, -7)
+        with pytest.raises(ValueError) as exc_info:
+            np.choose(np.array([0, 1, 5]), choices, out=out, mode="raise")
+        assert not self._has_note(exc_info.value)
+        assert_array_equal(out, np.full(3, -7))
+
+    def test_take_writeback_failure_noted(self):
+        # the copy shields out from the main loop, but casting the result
+        # back into out can itself fail part-way through (the object->intp
+        # out is deprecated, but the writeback still runs until it expires)
+        a = np.array([1, None, 3], dtype=object)
+        out = np.zeros(3, dtype=np.intp)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            with pytest.raises(TypeError) as exc_info:
+                np.take(a, [0, 1, 2], out=out)
+        assert self._has_note(exc_info.value)
+        assert out[0] == 1
+
+    def test_choose_writeback_failure_noted(self):
+        # same for choose: the copy back into out fails on the None
+        choices = [np.array([1, None, 3], dtype=object),
+                   np.zeros(3, dtype=object)]
+        out = np.full(3, -7)
+        with pytest.raises(TypeError) as exc_info:
+            np.choose(np.array([0, 0, 0]), choices, out=out, mode="raise")
+        assert self._has_note(exc_info.value)
+        assert out[0] == 1


### PR DESCRIPTION
### PR summary

follow up to the discussion in #31940

`np.put` and `np.putmask` write directly into the caller's array and can raise part-way through (e.g. on an out-of-bounds index) which silently leave it partially modified. this adds a central helper that attaches a PEP 678 note to the error

```
IndexError: index 99 is out of bounds for axis 0 with size 10
the output array may have been partially modified
```

the note is only added when no internal copy shielded the caller's array. `np.take` and `np.choose` are wired up too but their `mode="raise"` paths currently copy first so the note only takes effect there if that copy is removed

#### AI Disclosure
Used Claude for double checking if I missed anything