### PR TITLE
ENH: Optimize `np.unique` with adaptive thresholding for hashing vs sorting

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -370,7 +370,7 @@ def _unique1d(ar, return_index=False, return_inverse=False,
         # Hashing is faster for variable-width StringDType.
         # For other types (numeric, fixed-width string/unicode), sorting is
         # faster at larger scales, but hashing is faster at small scales (size < _UNIQUE_HASH_THRESHOLD).
-        is_vstring = getattr(ar.dtype, "__class__", None).__name__ == "StringDType"
+        is_vstring = isinstance(ar.dtype, np.dtypes.StringDType)
         if is_vstring or len(ar) < _UNIQUE_HASH_THRESHOLD:
             # First we convert the array to a numpy array, later we wrap it back
             # in case it was a subclass of numpy.ndarray.

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -32,6 +32,8 @@ __all__ = [
     "unique_values"
 ]
 
+_UNIQUE_HASH_THRESHOLD = 100
+
 
 def _ediff1d_dispatcher(ary, to_end=None, to_begin=None):
     return (ary, to_end, to_begin)
@@ -367,16 +369,16 @@ def _unique1d(ar, return_index=False, return_inverse=False,
     if not optional_indices and not return_counts and not np.ma.is_masked(ar):
         # Hashing is faster for variable-width StringDType.
         # For other types (numeric, fixed-width string/unicode), sorting is
-        # faster at larger scales, but hashing is faster at small scales (size < 100).
+        # faster at larger scales, but hashing is faster at small scales (size < _UNIQUE_HASH_THRESHOLD).
         is_vstring = getattr(ar.dtype, "__class__", None).__name__ == "StringDType"
-        if is_vstring or len(ar) < 100:
+        if is_vstring or len(ar) < _UNIQUE_HASH_THRESHOLD:
             # First we convert the array to a numpy array, later we wrap it back
             # in case it was a subclass of numpy.ndarray.
             conv = _array_converter(ar)
             ar_, = conv
 
-            if (hash_unique := _unique_hash(ar_, equal_nan=equal_nan)) \
-                is not NotImplemented:
+            hash_unique = _unique_hash(ar_, equal_nan=equal_nan)
+            if hash_unique is not NotImplemented:
                 if sorted:
                     hash_unique.sort()
                 # We wrap the result back in case it was a subclass of numpy.ndarray.

--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -365,17 +365,22 @@ def _unique1d(ar, return_index=False, return_inverse=False,
 
     # masked arrays are not supported yet.
     if not optional_indices and not return_counts and not np.ma.is_masked(ar):
-        # First we convert the array to a numpy array, later we wrap it back
-        # in case it was a subclass of numpy.ndarray.
-        conv = _array_converter(ar)
-        ar_, = conv
+        # Hashing is faster for variable-width StringDType.
+        # For other types (numeric, fixed-width string/unicode), sorting is
+        # faster at larger scales, but hashing is faster at small scales (size < 100).
+        is_vstring = getattr(ar.dtype, "__class__", None).__name__ == "StringDType"
+        if is_vstring or len(ar) < 100:
+            # First we convert the array to a numpy array, later we wrap it back
+            # in case it was a subclass of numpy.ndarray.
+            conv = _array_converter(ar)
+            ar_, = conv
 
-        if (hash_unique := _unique_hash(ar_, equal_nan=equal_nan)) \
-            is not NotImplemented:
-            if sorted:
-                hash_unique.sort()
-            # We wrap the result back in case it was a subclass of numpy.ndarray.
-            return (conv.wrap(hash_unique),)
+            if (hash_unique := _unique_hash(ar_, equal_nan=equal_nan)) \
+                is not NotImplemented:
+                if sorted:
+                    hash_unique.sort()
+                # We wrap the result back in case it was a subclass of numpy.ndarray.
+                return (conv.wrap(hash_unique),)
 
     # If we don't use the hash map, we use the slower sorting method.
     if optional_indices:


### PR DESCRIPTION
Closes: #31969 

#### Proposed Changes
This PR implements adaptive thresholding for `np.unique` to select the most efficient pathway (hashing vs sorting) based on the input dtype and size:
* **`StringDType`**: Always routed to `_unique_hash` as hashing variable-width strings remains faster than sorting.
* **All other dtypes** (numeric, complex, fixed-width unicode): Routed to `_unique_hash` only if the array size is **`< 100`** elements (where Python/C setup overhead of sorting dominates). For larger sizes, it directly uses the SIMD-accelerated sorting-based unique pathway.

#### Benchmarks (1,000,000 elements)

| Dtype / Scenario | Before (ms) | After (ms) | Speedup | Pathway Used |
| :--- | :---: | :---: | :---: | :---: |
| `int64` (All unique) | 712.6 ms | 15.2 ms | **46x** | Sorting (After) vs Hashing (Before) |
| `int64` (10 unique) | 45.7 ms | 15.8 ms | **2.9x** | Sorting (After) vs Hashing (Before) |
| `'U15'` (Distinct strings) | 99.4 ms | 12.2 ms | **8.1x** | Sorting (After) vs Hashing (Before) |
| `StringDType` (1M repeated) | 99.5 ms | 99.5 ms | **1.0x** | Hashing (Unchanged) |

#### Benchmarks (10 elements)

| Dtype | Before (us) | After (us) | Speedup | Pathway Used |
| :--- | :---: | :---: | :---: | :---: |
| `int64` | 6.0 us | 6.0 us | **1.0x** | Hashing (Unchanged) |

#### Verification
All set operation tests pass:
```bash
pytest numpy/lib/tests/test_arraysetops.py
```
**Output**: `117 passed in 0.73s`


### First time committer introduction

I use it a lot for data chuking.

<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure

Used Gemini 3.1 Pro in benchmarking the results.

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
