### PR TITLE
ENH: Use `PyModule_AddObjectRef` in `_umath_linalg`

### DIFF
--- a/numpy/linalg/umath_linalg.cpp
+++ b/numpy/linalg/umath_linalg.cpp
@@ -4681,7 +4681,7 @@ GUFUNC_DESCRIPTOR_t gufunc_descriptors [] = {
 };
 
 static int
-addUfuncs(PyObject *dictionary) {
+addUfuncs(PyObject *module) {
     PyUFuncObject *f;
     int i;
     const int gufunc_count = sizeof(gufunc_descriptors)/
@@ -4707,7 +4707,7 @@ addUfuncs(PyObject *dictionary) {
 #if _UMATH_LINALG_DEBUG
         dump_ufunc_object((PyUFuncObject*) f);
 #endif
-        int ret = PyDict_SetItemString(dictionary, d->name, (PyObject *)f);
+        int ret = PyModule_AddObjectRef(module, d->name, (PyObject *)f);
         Py_DECREF(f);
         if (ret < 0) {
             return -1;
@@ -4730,7 +4730,6 @@ static int module_loaded = 0;
 static int
 _umath_linalg_exec(PyObject *m)
 {
-    PyObject *d;
     PyObject *version;
 
     // https://docs.python.org/3/howto/isolating-extensions.html#opt-out-limiting-to-one-module-object-per-process
@@ -4748,23 +4747,18 @@ _umath_linalg_exec(PyObject *m)
         return -1;
     }
 
-    d = PyModule_GetDict(m);
-    if (d == NULL) {
-        return -1;
-    }
-
     version = PyUnicode_FromString(umath_linalg_version_string);
     if (version == NULL) {
         return -1;
     }
-    int ret = PyDict_SetItemString(d, "__version__", version);
+    int ret = PyModule_AddObjectRef(m, "__version__", version);
     Py_DECREF(version);
     if (ret < 0) {
         return -1;
     }
 
     /* Load the ufunc operators into the module's namespace */
-    if (addUfuncs(d) < 0) {
+    if (addUfuncs(m) < 0) {
         return -1;
     }
 
@@ -4777,9 +4771,13 @@ _umath_linalg_exec(PyObject *m)
 #endif
 
 #ifdef HAVE_BLAS_ILP64
-    PyDict_SetItemString(d, "_ilp64", Py_True);
+    if (PyModule_AddObjectRef(m, "_ilp64", Py_True) < 0) {
+        return -1;
+    }
 #else
-    PyDict_SetItemString(d, "_ilp64", Py_False);
+    if (PyModule_AddObjectRef(m, "_ilp64", Py_False) < 0) {
+        return -1;
+    }
 #endif
 
     return 0;


### PR DESCRIPTION
### PR summary

<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

In the [PyModule_GetDict](https://docs.python.org/3/c-api/module.html#c.PyModule_GetDict)'s docs it's mentioned:
`It is recommended extensions use other PyModule_* and PyObject_* functions rather than directly manipulate a module’s [__dict__].`

I also noticed `PyDict_SetItemString` can fail (returns -1)  [ref ](https://docs.python.org/3/c-api/dict.html#c.PyDict_SetItemString), but in the current code the return value was ignored. (Edited)

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
Final review with claude, it suggested to change `dictionary` word to `module` in `addUfuncs`