### PR TITLE
BUG: stop object argmax/argmin on comparison errors

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -3321,7 +3321,7 @@ OBJECT_argmax(PyObject **ip, npy_intp n, npy_intp *max_ind,
                 int greater_than = PyObject_RichCompareBool(val, mp, Py_GT);
 
                 if (greater_than < 0) {
-                    return 0;
+                    return -1;
                 }
                 if (greater_than) {
                     mp = val;
@@ -3385,7 +3385,7 @@ OBJECT_argmin(PyObject **ip, npy_intp n, npy_intp *min_ind,
                 int less_than = PyObject_RichCompareBool(val, mp, Py_LT);
 
                 if (less_than < 0) {
-                    return 0;
+                    return -1;
                 }
                 if (less_than) {
                     mp = val;

--- a/numpy/_core/src/multiarray/calculation.c
+++ b/numpy/_core/src/multiarray/calculation.c
@@ -174,7 +174,12 @@ _PyArray_ArgMinMaxCommon(PyArrayObject *op,
     n = PyArray_SIZE(ap)/m;
     rptr = (npy_intp *)PyArray_DATA(rp);
     for (ip = PyArray_DATA(ap), i = 0; i < n; i++, ip += elsize*m) {
-        arg_func(ip, m, rptr, ap);
+        if (arg_func(ip, m, rptr, ap) < 0) {
+            NPY_END_THREADS_DESCR(PyArray_DESCR(ap));
+            /* `rp` may be a WRITEBACKIFCOPY of `out`; do not write back */
+            PyArray_DiscardWritebackIfCopy(rp);
+            goto fail;
+        }
         rptr += 1;
     }
     NPY_END_THREADS_DESCR(PyArray_DESCR(ap));

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -5690,6 +5690,32 @@ class TestArgmaxArgminCommon:
         a[1] = vals[1]
         assert_equal(arg_method(), 1)
 
+    @pytest.mark.parametrize('method, op',
+        [('argmax', '__gt__'),
+         ('argmin', '__lt__')])
+    def test_object_comparison_error(self, method, op):
+        # gh-31977: an exception raised by an object comparison was
+        # swallowed: the loop kept comparing with the error set and kept
+        # writing result indices, finally raising a chained SystemError.
+        class Bad:
+            def __init__(self, v):
+                self.v = v
+
+        def cmp(self, other):
+            if self.v == 3 or other.v == 3:
+                raise ValueError("comparison error")
+            return getattr(self.v, op)(other.v)
+        setattr(Bad, op, cmp)
+
+        a = np.array([[Bad(1), Bad(2)],
+                      [Bad(3), Bad(4)],
+                      [Bad(1), Bad(2)]], dtype=object)
+        out = np.full(3, -1, dtype=np.intp)
+        with pytest.raises(ValueError, match="comparison error"):
+            getattr(np, method)(a, axis=1, out=out)
+        # rows past the failing one must not have been written
+        assert out[2] == -1
+
 class TestArgmax:
     usg_data = [
         ([1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0], 0),


### PR DESCRIPTION
### PR summary

Fixes #31977.

`np.argmax`/`np.argmin` on object arrays kept going after a comparison raised so `OBJECT_argmax`/`OBJECT_argmin` returned 0 (success) when `PyObject_RichCompareBool` failed and `_PyArray_ArgMinMaxCommon` ignored the argfunc return value entirely so the outer loop kept calling comparisons with the exception already pending (chained `SystemError`s) and kept writing indices into `out` after the error.

This makes the object argfuncs return -1 on comparison failure and checks the return value in `_PyArray_ArgMinMaxCommon` which discards the pending writeback to `out` on error. same pattern as gh-29688 / #31565 (`np.dot` object loop) but here the ArgFunc returns int so the error can propagate properly instead of the early-exit workaround. rows after the failing one are no longer written and `np.sort`/`np.argsort` already behave this way

#### AI Disclosure

Used Claude to  double check my work and make sure i didn't miss anything 
