### PR TITLE
BUG: fix Py_ssize_t truncation in _void_to_hex

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -823,17 +823,18 @@ _void_to_hex(const char* argbuf, const Py_ssize_t arglen,
              const char *schars, const char *bprefix, const char *echars)
 {
     PyObject *retval;
-    int extrachars, slen;
+    Py_ssize_t extrachars, slen;
     char *retbuf;
     Py_ssize_t i, j;
     char const *hexdigits = "0123456789ABCDEF";
+    Py_ssize_t bytes_per = 2 + (Py_ssize_t)strlen(bprefix);
 
-    extrachars = strlen(schars) + strlen(echars);
-    slen = extrachars + arglen*(2 + strlen(bprefix));
+    extrachars = (Py_ssize_t)strlen(schars) + strlen(echars);
 
-    if (arglen > (PY_SSIZE_T_MAX / 2) - extrachars) {
+    if (arglen > (PY_SSIZE_T_MAX - extrachars) / bytes_per) {
         return PyErr_NoMemory();
     }
+    slen = extrachars + arglen*bytes_per;
 
     retbuf = (char *)PyMem_Malloc(slen);
     if (!retbuf) {


### PR DESCRIPTION
_void_to_hex holds the output length in an int (slen) while the fill loop writes extrachars + arglen*(2+strlen(bprefix)) bytes, and arglen is the void scalar's Py_ssize_t elsize. A large void such as repr(np.void(2**30)) makes that product overflow int and truncate to a tiny value, so PyMem_Malloc reserves a handful of bytes while the loop keeps writing about 4 GiB past it. The existing guard only caps arglen against PY_SSIZE_T_MAX/2, which never trips for the int-truncation case. Widen slen/extrachars to Py_ssize_t and check arglen against (PY_SSIZE_T_MAX - extrachars) / bytes_per before the multiply.