### PR TITLE
ENH: Add `commented_names` parameter to `genfromtxt` 

### DIFF
--- a/doc/release/upcoming_changes/31984.new_feature.rst
+++ b/doc/release/upcoming_changes/31984.new_feature.rst
@@ -1,0 +1,17 @@
+New ``commented_names`` keyword for ``np.genfromtxt``
+-----------------------------------------------------
+A new ``commented_names`` keyword argument has been added to
+`numpy.genfromtxt` to give explicit control over how column
+names are extracted when ``names=True``:
+
+``None`` (default) preserves the historical behavior: names are
+  taken from the first line after ``skip_header``, whether or not
+  that line is a comment.
+``True``: names are taken from the *last* comment line before
+  the first line of data. A ``ValueError`` is raised if no comment
+  line precedes the data.
+``False``: names are taken from the first non-comment line,
+  skipping any number of leading comment lines.
+
+Passing ``commented_names`` without ``names=True`` raises
+``ValueError``.

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1944,6 +1944,14 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     array([(b'text', b''), (b'hello world', b'11'), (b'numpy', b'5')],
       dtype=[('f0', 'S12'), ('f1', 'S12')])
 
+    Reading names from a comment line:
+
+    >>> from io import StringIO
+    >>> s = StringIO("# a b c\n1 2 3\n4 5 6\n")
+    >>> np.genfromtxt(s, names=True, commented_names=True,
+    ...               dtype=None, encoding=None).dtype.names
+    ('a', 'b', 'c')
+
     """
 
     if like is not None:

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1798,6 +1798,17 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         `names`.
         If `names` is None, the output is structured only if `dtype` is
         structured, in which case the field names are taken from `dtype`.
+    commented_names : {None, True, False}, optional
+        Only used when `names` is True.
+        If None, names are taken from the first line after `skip_header`
+        lines, whether or not it is a comment.
+        If True, names are taken from the last comment line before the
+        first line of data. A `ValueError` is raised if no comment line
+        precedes the data.
+        If False, names are taken from the first non-comment line,
+        skipping any number of leading comment lines.
+
+        .. versionadded:: 2.6.0
     excludelist : sequence, optional
         A list of names to exclude. This list is appended to the default list
         ['return','file','print']. Excluded names are appended with an

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1740,7 +1740,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                replace_space='_', autostrip=False, case_sensitive=True,
                defaultfmt="f%i", unpack=None, usemask=False, loose=True,
                invalid_raise=True, max_rows=None, encoding=None,
-               *, ndmin=0, like=None):
+               *, ndmin=0, commented_names=None, like=None):
     """
     Load data from a text file, with missing values handled as specified.
 
@@ -1946,7 +1946,7 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
             case_sensitive=case_sensitive, defaultfmt=defaultfmt,
             unpack=unpack, usemask=usemask, loose=loose,
             invalid_raise=invalid_raise, max_rows=max_rows, encoding=encoding,
-            ndmin=ndmin,
+            ndmin=ndmin, commented_names=commented_names,
         )
 
     _ensure_ndmin_ndarray_check_param(ndmin)
@@ -1958,6 +1958,15 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
                     "specified at the same time.")
         if max_rows < 1:
             raise ValueError("'max_rows' must be at least 1.")
+
+    if commented_names is not None:
+        if not isinstance(commented_names, (bool, np.bool_)):
+            raise ValueError(
+                "commented_names must be None, True, or False")
+        if names is not True:
+            raise ValueError(
+                "commented_names can only be used together with "
+                "names=True")
 
     if usemask:
         from numpy.ma import MaskedArray, make_mask_descr
@@ -2006,14 +2015,32 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
 
             # Keep on until we find the first valid values
             first_values = None
+            last_comment_line = None
+            skip_comment_lines = names is True and commented_names is not None
+            use_last_comment = names is True and commented_names is True
 
             while not first_values:
                 first_line = _decode_line(next(fhd), encoding)
-                if (names is True) and (comments is not None):
-                    if comments in first_line:
-                        first_line = (
+                is_comment_line = (
+                    comments is not None and comments in first_line)
+
+                if is_comment_line and skip_comment_lines:
+                    if use_last_comment:
+                        last_comment_line = (
                             ''.join(first_line.split(comments)[1:]))
-                first_values = split_line(first_line)
+                    continue
+
+                if is_comment_line and names is True:
+                    first_line = ''.join(first_line.split(comments)[1:])
+
+                if use_last_comment:
+                    if last_comment_line is None:
+                        raise ValueError(
+                            "commented_names=True but no comment line "
+                            "was found before the first line of data.")
+                    first_values = split_line(last_comment_line)
+                else:
+                    first_values = split_line(first_line)
         except StopIteration:
             # return an empty array if the datafile is empty
             first_line = ''
@@ -2043,7 +2070,8 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
         # Check the names and overwrite the dtype.names if needed
         if names is True:
             names = validate_names([str(_.strip()) for _ in first_values])
-            first_line = ''
+            if commented_names is not True:
+                first_line = ''
         elif _is_string_like(names):
             names = validate_names([_.strip() for _ in names.split(',')])
         elif names:

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -1944,10 +1944,11 @@ def genfromtxt(fname, dtype=float, comments='#', delimiter=None,
     array([(b'text', b''), (b'hello world', b'11'), (b'numpy', b'5')],
       dtype=[('f0', 'S12'), ('f1', 'S12')])
 
-    Reading names from a comment line:
+    Reading names from a comment line
 
-    >>> from io import StringIO
-    >>> s = StringIO("# a b c\n1 2 3\n4 5 6\n")
+    >>> s = StringIO('''# a b c
+    ... 1 2 3
+    ... 4 5 6''')
     >>> np.genfromtxt(s, names=True, commented_names=True,
     ...               dtype=None, encoding=None).dtype.names
     ('a', 'b', 'c')

--- a/numpy/lib/_npyio_impl.pyi
+++ b/numpy/lib/_npyio_impl.pyi
@@ -226,6 +226,7 @@ def genfromtxt(
     encoding: str | None = None,
     *,
     ndmin: L[0, 1, 2] = 0,
+    commented_names: bool | None = None,
     like: _SupportsArrayFunc | None = None,
 ) -> NDArray[Any]: ...
 @overload
@@ -255,6 +256,7 @@ def genfromtxt[ScalarT: np.generic](
     encoding: str | None = None,
     *,
     ndmin: L[0, 1, 2] = 0,
+    commented_names: bool | None = None,
     like: _SupportsArrayFunc | None = None,
 ) -> NDArray[ScalarT]: ...
 @overload
@@ -284,5 +286,6 @@ def genfromtxt(
     encoding: str | None = None,
     *,
     ndmin: L[0, 1, 2] = 0,
+    commented_names: bool | None = None,
     like: _SupportsArrayFunc | None = None,
 ) -> NDArray[Any]: ...

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2496,6 +2496,40 @@ M   33  21.99
 
         assert_array_equal(a, b)
 
+    def test_genfromtxt_commented_names_false_skips_multiple_comments(self):
+        data = TextIO(
+            "# unrelated note\n"
+            "# Color Type Origin Stolen\n"
+            "Color Type Origin Stolen\n"
+            "Red Sports Domestic Yes\n"
+        )
+        a = np.genfromtxt(data, dtype=None, names=True,
+                         commented_names=False, encoding=None)
+        assert a.dtype.names == ('Color', 'Type', 'Origin', 'Stolen')
+
+    def test_genfromtxt_commented_names_true_uses_last_comment(self):
+        data = TextIO(
+            "# unrelated note\n"
+            "# Color Type Origin Stolen\n"
+            "Red Sports Domestic Yes\n"
+            "Yellow SUV Imported No\n"
+        )
+        a = np.genfromtxt(data, dtype=None, names=True,
+                           commented_names=True, encoding=None)
+        assert a.dtype.names == ('Color', 'Type', 'Origin', 'Stolen')
+        assert len(a) == 2
+
+    def test_genfromtxt_commented_names_true_no_comment_raises(self):
+        data = TextIO("Red Sports Domestic Yes\n")
+        with pytest.raises(ValueError):
+            np.genfromtxt(data, dtype=None, names=True,
+                       commented_names=True, encoding=None)
+
+    def test_genfromtxt_commented_names_requires_names_true(self):
+        data = TextIO("1,2,3\n")
+        with pytest.raises(ValueError):
+            np.genfromtxt(data, delimiter=",", names=False,
+                           commented_names=True)
 
 class TestPathUsage:
     # Test that pathlib.Path can be used

--- a/numpy/lib/tests/test_io.py
+++ b/numpy/lib/tests/test_io.py
@@ -2525,11 +2525,42 @@ M   33  21.99
             np.genfromtxt(data, dtype=None, names=True,
                        commented_names=True, encoding=None)
 
-    def test_genfromtxt_commented_names_requires_names_true(self):
-        data = TextIO("1,2,3\n")
-        with pytest.raises(ValueError):
-            np.genfromtxt(data, delimiter=",", names=False,
-                           commented_names=True)
+    def test_genfromtxt_commented_names_none_matches_legacy(self):
+        text = (
+            "# Color Type Origin Stolen\n"
+            "Red Sports Domestic Yes\n"
+            "Yellow SUV Imported No\n"
+        )
+        a = np.genfromtxt(TextIO(text), dtype=None, names=True,
+                          encoding=None)
+        b = np.genfromtxt(TextIO(text), dtype=None, names=True,
+                          commented_names=None, encoding=None)
+        assert a.dtype.names == b.dtype.names
+        assert_array_equal(a, b)
+
+    def test_genfromtxt_commented_names_false_no_comments(self):
+        data = TextIO(
+            "Color Type Origin Stolen\n"
+            "Red Sports Domestic Yes\n"
+        )
+        a = np.genfromtxt(data, dtype=None, names=True,
+                          commented_names=False, encoding=None)
+        assert a.dtype.names == ('Color', 'Type', 'Origin', 'Stolen')
+
+    @pytest.mark.parametrize("kwargs, match", [
+        # Wrong type for commented_names
+        (dict(dtype=None, names=True, commented_names="yes",
+              encoding=None), "commented_names"),
+        # commented_names used without names=True
+        (dict(delimiter=",", names=False, commented_names=True),
+         "names=True"),
+    ])
+    def test_genfromtxt_commented_names_invalid_usage_raises(
+            self, kwargs, match):
+        data = TextIO("# a b\n1 2\n")
+        with pytest.raises(ValueError, match=match):
+            np.genfromtxt(data, **kwargs)
+
 
 class TestPathUsage:
     # Test that pathlib.Path can be used


### PR DESCRIPTION
Fixes #389 
### PR summary
- i followed @WarrenWeckesser suggestion
- added a new `commented_names` option to `genfromtxt` so we can control exactly where it look for column names, instead of guessing based on comments.
- set `commented_names=True` to grab the names from the last comment line before the data starts or `commented_names=False` to skip all comments
- left the default behaviour `commented_names=None` unchanged

- As its quite old issue (2012) , excited to move forward with this 😀 
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.


  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
- yes i've used for generating test and some improvement were suggested 


So lets call this work done by *Semi-human*
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
