### PR TITLE
BUG: fix segfault in StringDType byteswap()

### DIFF
--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -537,22 +537,30 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
         if (PyArray_FailUnlessWriteable(self, "array to be byte-swapped") < 0) {
             return NULL;
         }
-        size = PyArray_SIZE(self);
-        if (PyArray_ISONESEGMENT(self)) {
-            copyswapn(PyArray_DATA(self), PyArray_ITEMSIZE(self), NULL, -1, size, 1, self);
-        }
-        else { /* Use iterator */
-            int axis = -1;
-            npy_intp stride;
-            it = (PyArrayIterObject *)                      \
-                PyArray_IterAllButAxis((PyObject *)self, &axis);
-            stride = PyArray_STRIDES(self)[axis];
-            size = PyArray_DIMS(self)[axis];
-            while (it->index < it->size) {
-                copyswapn(it->dataptr, stride, NULL, -1, size, 1, self);
-                PyArray_ITER_NEXT(it);
+        /*
+         * Some dtypes (e.g. StringDType) do not provide a legacy copyswapn
+         * function because their data has no meaningful byte order to swap.
+         * Treat byteswapping as a no-op for those instead of crashing on a
+         * NULL function pointer.
+         */
+        if (copyswapn != NULL) {
+            size = PyArray_SIZE(self);
+            if (PyArray_ISONESEGMENT(self)) {
+                copyswapn(PyArray_DATA(self), PyArray_ITEMSIZE(self), NULL, -1, size, 1, self);
             }
-            Py_DECREF(it);
+            else { /* Use iterator */
+                int axis = -1;
+                npy_intp stride;
+                it = (PyArrayIterObject *)                      \
+                    PyArray_IterAllButAxis((PyObject *)self, &axis);
+                stride = PyArray_STRIDES(self)[axis];
+                size = PyArray_DIMS(self)[axis];
+                while (it->index < it->size) {
+                    copyswapn(it->dataptr, stride, NULL, -1, size, 1, self);
+                    PyArray_ITER_NEXT(it);
+                }
+                Py_DECREF(it);
+            }
         }
 
         Py_INCREF(self);

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -724,6 +724,26 @@ def test_fancy_indexing(string_list):
         assert_array_equal(sarr[ind], uarr[ind])
 
 
+def test_byteswap():
+    # byteswap() used to segfault on a NULL copyswapn. StringDType
+    # data has no meaningful byte order, so byteswap is a no-op.
+    arr = np.array(['b', 'short', 'x' * 40, '', 'café'], dtype='T')
+
+    swapped = arr.byteswap()
+    assert_array_equal(swapped, arr)
+
+    # 2-D and a non-contiguous (transposed) view
+    arr2d = np.array([['aa', 'bb'], ['c' * 30, 'dd']], dtype='T')
+    assert_array_equal(arr2d.byteswap(), arr2d)
+    assert_array_equal(arr2d.T.byteswap(), arr2d.T)
+
+    # in-place returns self, unchanged
+    ret = arr.byteswap(inplace=True)
+    assert ret is arr
+    assert_array_equal(arr, np.array(['b', 'short', 'x' * 40, '', 'café'],
+                                     dtype='T'))
+
+
 def test_flatiter_indexing():
     # see gh-29659
     arr = np.array(['hello', 'world'], dtype='T')


### PR DESCRIPTION
  ``ndarray.byteswap()`` crashed for StringDType arrays because
  `PyArray_Byteswap` unconditionally called the legacy ``copyswapn`` ArrFuncs
  slot, which is NULL for StringDType -- i.e. a call through a NULL function
  pointer.

  StringDType stores its data in a byte-order independent representation, so
  byteswapping has no meaning. Skip the swap when ``copyswapn`` is NULL,
  making byteswap a no-op for such dtypes instead of crashing.

TODO: Format PR description properly.