### PR TITLE
BUG: #31993: Return FAIL if PyArray_ClipmodeConverter is called with an invalid integer value.

### DIFF
--- a/numpy/_core/src/multiarray/conversion_utils.c
+++ b/numpy/_core/src/multiarray/conversion_utils.c
@@ -793,6 +793,7 @@ PyArray_ClipmodeConverter(PyObject *object, NPY_CLIPMODE *val)
             PyErr_Format(PyExc_ValueError,
                     "integer clipmode must be RAISE, WRAP, or CLIP "
                     "from 'numpy._core.multiarray'");
+            return NPY_FAIL;
         }
     }
     return NPY_SUCCEED;

--- a/numpy/_core/tests/test_conversion_utils.py
+++ b/numpy/_core/tests/test_conversion_utils.py
@@ -161,6 +161,12 @@ class TestClipmodeConverter(StringConverterTestCase):
         assert self.conv(WRAP) == 'NPY_WRAP'
         assert self.conv(RAISE) == 'NPY_RAISE'
 
+    def test_invalid(self):
+        with pytest.raises(ValueError):
+            self.conv('invalid')
+        with pytest.raises(ValueError):
+            self.conv(99)
+
 
 class TestCastingConverter(StringConverterTestCase):
     """ Tests of PyArray_CastingConverter """


### PR DESCRIPTION
### PR summary

PyArray_ClipmodeConverter sets the exception if an invalid value is passed but, for numbers, also returned NPY_SUCCEED.

Python in debug mode catches this and aserts/aborts.

Returning NPY_FAIL correctly propagates the exception at the right point.

Before this change, the new test caused `spin test` to
silently fail with exit code 250.  

<details>
<summary>Test output tail</summary>

```
numpy/_core/tests/test_casting_unittests.py::TestCasting::test_same_value_naninf[nan] PASSED                                                                        [  3%]
numpy/_core/tests/test_casting_unittests.py::TestCasting::test_same_value_naninf[inf] PASSED                                                                        [  3%]
numpy/_core/tests/test_casting_unittests.py::TestCasting::test_same_value_naninf[-inf] PASSED                                                                       [  3%]
numpy/_core/tests/test_casting_unittests.py::TestCasting::test_same_value_complex PASSED                                                                            [  3%]
numpy/_core/tests/test_casting_unittests.py::TestCasting::test_same_value_scalar PASSED                                                                             [  3%]
numpy/_core/tests/test_conversion_utils.py::TestByteorderConverter::test_wrong_type PASSED                                                                          [  3%]
numpy/_core/tests/test_conversion_utils.py::TestByteorderConverter::test_wrong_value PASSED                                                                         [  3%]
numpy/_core/tests/test_conversion_utils.py::TestByteorderConverter::test_valid PASSED                                                                               [  3%]
numpy/_core/tests/test_conversion_utils.py::TestSortkindConverter::test_wrong_type PASSED                                                                           [  3%]
numpy/_core/tests/test_conversion_utils.py::TestSortkindConverter::test_wrong_value PASSED                                                                          [  3%]
numpy/_core/tests/test_conversion_utils.py::TestSortkindConverter::test_valid PASSED                                                                                [  3%]
numpy/_core/tests/test_conversion_utils.py::TestSelectkindConverter::test_wrong_type PASSED                                                                         [  3%]
numpy/_core/tests/test_conversion_utils.py::TestSelectkindConverter::test_wrong_value PASSED                                                                        [  3%]
numpy/_core/tests/test_conversion_utils.py::TestSelectkindConverter::test_valid PASSED                                                                              [  3%]
numpy/_core/tests/test_conversion_utils.py::TestSearchsideConverter::test_wrong_type PASSED                                                                         [  3%]
numpy/_core/tests/test_conversion_utils.py::TestSearchsideConverter::test_wrong_value PASSED                                                                        [  3%]
numpy/_core/tests/test_conversion_utils.py::TestSearchsideConverter::test_valid PASSED                                                                              [  3%]
numpy/_core/tests/test_conversion_utils.py::TestOrderConverter::test_wrong_type PASSED                                                                              [  3%]
numpy/_core/tests/test_conversion_utils.py::TestOrderConverter::test_wrong_value PASSED                                                                             [  3%]
numpy/_core/tests/test_conversion_utils.py::TestOrderConverter::test_valid PASSED                                                                                   [  3%]
numpy/_core/tests/test_conversion_utils.py::TestOrderConverter::test_flatten_invalid_order PASSED                                                                   [  3%]
numpy/_core/tests/test_conversion_utils.py::TestClipmodeConverter::test_wrong_type PASSED                                                                           [  3%]
numpy/_core/tests/test_conversion_utils.py::TestClipmodeConverter::test_wrong_value PASSED                                                                          [  3%]
numpy/_core/tests/test_conversion_utils.py::TestClipmodeConverter::test_valid PASSED                                                                                [  3%]
numpy/_core/tests/test_conversion_utils.py::TestClipmodeConverter::test_invalid ⏎
sstagg@sapphire ~/s/numpy [250]>
``` 
</details>

With the change tests pass as expected.

### First time committer introduction

Hi 👋, I've been using numpy since about 2009 maybe, I'm getting to the point where I can do some fuzz testing of `pandas` on things like json/csv, parquet etc, but along the way, I was checking that numpy would work, and stumbled across this really niche issue, but the fix is so tiny/self-evident I thought I'd get it in.

#### AI Disclosure

Codex was used in helping identify/debug the initial root cause of the debug abort.

No AI tools were used in the actual development of this PR

Fixed: #31993