### PR TITLE
BUG: fix subclass problems introduced in linspace by gh-31620

### DIFF
--- a/numpy/_core/function_base.py
+++ b/numpy/_core/function_base.py
@@ -10,7 +10,7 @@ from numpy._core._multiarray_umath import _array_converter
 from numpy._core.multiarray import add_docstring
 
 from . import numeric as _nx
-from .numeric import asanyarray, nan, ndim, result_type
+from .numeric import asanyarray, nan, result_type
 
 __all__ = ['logspace', 'linspace', 'geomspace']
 
@@ -137,29 +137,26 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
     else:
         integer_dtype = _nx.issubdtype(dtype, _nx.integer)
 
-    # Use `dtype=type(dt)` to enforce a floating point evaluation.
     # Equal endpoints (including equal infinities) must produce a zero step,
     # so skip the subtraction there: `inf - inf` would otherwise yield a
     # spurious nan and an "invalid value" warning.  Using `where=` avoids the
     # bad element entirely rather than suppressing warnings globally, so
     # genuine invalid operations (e.g. mixed infinities) still warn.
     equal = start == stop
-    if equal.ndim == 0:
-        delta = dt.type(0) if equal else np.subtract(
-            stop, start, dtype=type(dt))
-    else:
-        delta = np.subtract(stop, start, dtype=type(dt), where=~equal,
-                            out=np.zeros(equal.shape, dtype=type(dt)))
-    y = _nx.arange(
+    # Wrapping y ensures that ndarray subclasses like astropy's Quantity
+    # can override the further operations below. See gh-7142.
+    y = conv.wrap(_nx.arange(
         0, num, dtype=dt, device=device
-    ).reshape((-1,) + (1,) * ndim(delta))
+    ).reshape((-1,) + (1,) * equal.ndim), to_scalar=False)
+    delta = np.zeros_like(y, shape=equal.shape, dtype=type(dt))
+    # Use `dtype=type(dt)` to enforce a floating point evaluation.
+    np.subtract(stop, start, dtype=type(dt), where=~equal, out=delta)
 
-    # In-place multiplication y *= delta/div is faster, but prevents
-    # the multiplicant from overriding what class is produced, and thus
-    # prevents, e.g. use of Quantities, see gh-7142. Hence, we multiply
-    # in place only for standard scalar types.
+    # In-place multiplication y *= delta/div is faster, but cannot work
+    # if the input and output shapes are not equal. Hence, we multiply
+    # in place only if delta is scalar.
     if div > 0:
-        _mult_inplace = _nx.isscalar(delta)
+        _mult_inplace = delta.ndim == 0
         step = delta / div
         any_step_zero = (
             step == 0 if _mult_inplace else _nx.asanyarray(step == 0).any())
@@ -178,7 +175,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
         # sequences with 0 items or 1 item with endpoint=True (i.e. div <= 0)
         # have an undefined step
         step = nan
-        # Multiply with delta to allow possible override of output class.
+        # Multiply with delta out-of-place in case delta is not scalar.
         y = y * delta
 
     y += start
@@ -192,7 +189,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
     if integer_dtype:
         _nx.floor(y, out=y)
 
-    y = conv.wrap(y.astype(dtype, copy=False))
+    y = y.astype(dtype, copy=False)
     if retstep:
         return y, step
     else:

--- a/numpy/_core/tests/test_function_base.py
+++ b/numpy/_core/tests/test_function_base.py
@@ -67,6 +67,45 @@ class PhysicalQuantity(float):
 class PhysicalQuantity2(ndarray):
     __array_priority__ = 10
 
+    def __array_ufunc__(self, ufunc, method, *args, **kwargs):
+        out = kwargs.get("out")
+        if out is not None:
+            new_out = []
+            for o in out:
+                if o is None:
+                    new_out.append(None)
+                elif isinstance(o, PhysicalQuantity2):
+                    new_out.append(o.view(np.ndarray))
+                else:
+                    return NotImplemented
+            kwargs["out"] = tuple(new_out)
+        args = [np.asarray(a) for a in args]
+
+        res = super().__array_ufunc__(ufunc, method, *args, **kwargs)
+        if ((dtype := getattr(res, "dtype", None)) is not None
+            and dtype.kind != "b"):
+            res = res[...].view(PhysicalQuantity2)
+        return res
+
+    def __getitem__(self, item):
+        res = super().__getitem__(item)
+        if not isinstance(res, PhysicalQuantity2):
+            res = res[...].view(PhysicalQuantity2)
+        return res
+
+    def __str__(self):
+        return super().__str__(self.view(np.ndarray))
+
+    def __repr__(self):
+        prefixstr = self.__class__.__name__ + "("
+        arrstr = np.array2string(
+            self.view(np.ndarray), separator=", ", prefix=prefixstr
+        )
+        return f"{prefixstr}{arrstr})"
+
+    def __array_wrap__(self, arr, *args, **kwargs):
+        return arr.view(PhysicalQuantity2)
+
 
 class TestLogspace:
 
@@ -393,13 +432,17 @@ class TestLinspace:
 
     def test_subclass(self):
         a = array(0).view(PhysicalQuantity2)
-        b = array(1).view(PhysicalQuantity2)
+        b = array(np.arange(3)).view(PhysicalQuantity2)
         ls = linspace(a, b)
         assert type(ls) is PhysicalQuantity2
-        assert_equal(ls, linspace(0.0, 1.0))
-        ls = linspace(a, b, 1)
+        assert_equal(ls, linspace(0.0, np.arange(3.0)))
+        # Also test mixes of subclass and something else.
+        ls = linspace(a, 1.0)
         assert type(ls) is PhysicalQuantity2
-        assert_equal(ls, linspace(0.0, 1.0, 1))
+        assert_equal(ls, linspace(0.0, 1.0))
+        ls = linspace(np.array(0.0), b, 1)
+        assert type(ls) is PhysicalQuantity2
+        assert_equal(ls, linspace(0.0, np.arange(3.0), 1))
 
     def test_array_interface(self):
         # Regression test for https://github.com/numpy/numpy/pull/6659


### PR DESCRIPTION
#31620 made some nice improvements to `np.linspace`'s handling of infinities which unfortunately broke astropy (https://github.com/astropy/astropy/issues/20043). This PR fixes them. Unfortunately, the fix was a little involved, so the diff is more than I had hoped; see inline comments. cc @Ijtihed, who wrote #31620.

It would be good to get this in before the next release...

No AI used.