### PR TITLE
MAINT: parse nditer flags as unicode directly (gh-15317)

### DIFF
--- a/numpy/_core/src/multiarray/nditer_pywrap.c
+++ b/numpy/_core/src/multiarray/nditer_pywrap.c
@@ -112,7 +112,7 @@ NpyIter_GlobalFlagsConverter(PyObject *flags_in, npy_uint32 *flags)
     int iflags, nflags;
 
     PyObject *f;
-    char *str = NULL;
+    const char *str = NULL;
     Py_ssize_t length = 0;
     npy_uint32 flag;
 
@@ -135,18 +135,13 @@ NpyIter_GlobalFlagsConverter(PyObject *flags_in, npy_uint32 *flags)
         }
 
         if (PyUnicode_Check(f)) {
-            /* accept unicode input */
-            PyObject *f_str;
-            f_str = PyUnicode_AsASCIIString(f);
-            if (f_str == NULL) {
+            str = PyUnicode_AsUTF8AndSize(f, &length);
+            if (str == NULL) {
                 Py_DECREF(f);
                 return 0;
             }
-            Py_DECREF(f);
-            f = f_str;
         }
-
-        if (PyBytes_AsStringAndSize(f, &str, &length) < 0) {
+        else if (PyBytes_AsStringAndSize(f, (char **)&str, &length) < 0) {
             Py_DECREF(f);
             return 0;
         }
@@ -258,7 +253,7 @@ NpyIter_OpFlagsConverter(PyObject *op_flags_in,
     *op_flags = 0;
     for (iflags = 0; iflags < nflags; ++iflags) {
         PyObject *f;
-        char *str = NULL;
+        const char *str = NULL;
         Py_ssize_t length = 0;
 
         f = PySequence_GetItem(op_flags_in, iflags);
@@ -267,18 +262,13 @@ NpyIter_OpFlagsConverter(PyObject *op_flags_in,
         }
 
         if (PyUnicode_Check(f)) {
-            /* accept unicode input */
-            PyObject *f_str;
-            f_str = PyUnicode_AsASCIIString(f);
-            if (f_str == NULL) {
+            str = PyUnicode_AsUTF8AndSize(f, &length);
+            if (str == NULL) {
                 Py_DECREF(f);
                 return 0;
             }
-            Py_DECREF(f);
-            f = f_str;
         }
-
-        if (PyBytes_AsStringAndSize(f, &str, &length) < 0) {
+        else if (PyBytes_AsStringAndSize(f, (char **)&str, &length) < 0) {
             PyErr_Clear();
             Py_DECREF(f);
             PyErr_SetString(PyExc_ValueError,

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -851,6 +851,11 @@ def test_iter_flags_errors():
     assert_raises(ValueError, nditer, [a], ['bad flag'], [['readonly']])
     # Bad op flag
     assert_raises(ValueError, nditer, [a], [], [['readonly', 'bad flag']])
+    # Bad non-ASCII flag
+    assert_raises(ValueError, nditer, [a], ['\N{SNOWMAN}'], [['readonly']])
+    assert_raises(ValueError, nditer, [a], [], [['readonly', '\N{SNOWMAN}']])
+    # Bad flag type
+    assert_raises(TypeError, nditer, [a], [1], [['readonly']])
     # Bad order parameter
     assert_raises(ValueError, nditer, [a], [], [['readonly']], order='G')
     # Bad casting parameter
@@ -914,6 +919,11 @@ def test_iter_flags_errors():
     assert_raises(ValueError, assign_iterrange, i)
     # Can't iterate if size is zero
     assert_raises(ValueError, nditer, np.array([]))
+
+def test_iter_bytes_flags():
+    a = arange(6)
+    i = nditer(a, [b'multi_index'], [[b'readonly']])
+    assert_equal([x_[()] for x_ in i], list(range(6)))
 
 def test_iter_slice():
     a, b, c = np.arange(3), np.arange(3), np.arange(3.)


### PR DESCRIPTION
Part of gh-15317 (cleaning up internal callers of `PyUnicode_AsASCIIString`).

`NpyIter_GlobalFlagsConverter` and `NpyIter_OpFlagsConverter` encoded unicode flag strings to bytes with `PyUnicode_AsASCIIString` before inspecting them. For any non-ASCII input that raises a `UnicodeEncodeError`, which is less useful than numpy's own "unexpected flag" error.

This works with the unicode object directly via `PyUnicode_AsUTF8AndSize` (matching the idiom already used elsewhere in `multiarray`), so a non-ASCII flag now reports a `ValueError` naming the offending flag instead:

```python
>>> import numpy as np
>>> np.nditer(np.arange(3), flags=['\N{SNOWMAN}'])
ValueError: Unexpected iterator global flag "☃"
```

Kept intentionally small — this is one file / two twin converters. The remaining `PyUnicode_AsASCIIString` call sites from gh-15317 can follow as separate PRs (some, e.g. the `S`-dtype setitem and `tofile` paths, deserve their own discussion since ASCII encoding is arguably intentional there).

### Notes
- Behavior for valid ASCII/bytes flags is unchanged; only the error for non-ASCII input improves.
- Regression tests added: non-ASCII and non-string flags in `test_iter_flags_errors`, plus `test_iter_bytes_flags` pinning that bytes flags remain accepted (that branch was previously untested).

Draft while CI builds/runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
