### PR TITLE
DOC: add Examples section to np.ma.view [skip actions]

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3254,6 +3254,28 @@ class MaskedArray(ndarray):
         memory. Therefore if ``a`` is C-ordered versus fortran-ordered, versus
         defined as a slice or transpose, etc., the view may give different
         results.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> a = np.ma.array([1.0, 2.0, 3.0], mask=[0, 1, 0])
+        >>> a
+        masked_array(data=[1.0, --, 3.0],
+                     mask=[False,  True, False],
+               fill_value=1e+20)
+
+        Use ``fill_value`` to set a custom fill value on the view without
+        copying the data:
+
+        >>> a.view(fill_value=-999.0)
+        masked_array(data=[1.0, --, 3.0],
+                     mask=[False,  True, False],
+               fill_value=-999.0)
+
+        View as a plain :class:`numpy.ndarray` — the mask is not preserved:
+
+        >>> a.view(np.ndarray)
+        array([1., 2., 3.])
         """
 
         if type is None and (isinstance(dtype, builtins.type)


### PR DESCRIPTION
### PR summary

MaskedArray.view in numpy/ma/core.py has Parameters, See Also, and Notes sections but no Examples. This PR adds three illustrative doctests showing:

1. The default view of a masked array (same dtype and mask preserved)
2. Using the fill_value parameter - unique to MaskedArray.view vs ndarray.view -  to set a custom fill value on the view without copying data
3. Viewing as a plain numpy.ndarray, which does not preserve the mask


### First time committer introduction
Not a first-time contributor

#### AI Disclosure
Claude (Anthropic) was used to assist in drafting the docstring examples and verifying expected output values. All examples were reviewed and confirmed correct by running them manually. The final content and PR submission are my own work.
