### PR TITLE
DEP: Deprecate `numpy.linalg.lapack_lite` module

### DIFF
--- a/doc/release/upcoming_changes/32015.deprecation.rst
+++ b/doc/release/upcoming_changes/32015.deprecation.rst
@@ -1,0 +1,7 @@
+``numpy.linalg.lapack_lite`` is deprecated
+-------------------------------------------
+
+Importing ``numpy.linalg.lapack_lite`` is deprecated. The module is an
+internal implementation detail of `numpy.linalg` and was never intended
+as a public API. Users that need LAPACK or BLAS routines should use
+``scipy.linalg.lapack`` or ``scipy.linalg.blas`` instead.

--- a/numpy/linalg/lapack_lite.pyi
+++ b/numpy/linalg/lapack_lite.pyi
@@ -60,7 +60,12 @@ _ilp64: Final[bool] = ...
 
 class LapackError(Exception): ...
 
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
+@deprecated(
+    "The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. "
+    "It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS "
+    "routines should use scipy.linalg.lapack or scipy.linalg.blas instead. For users checking "
+    "BLAS/LAPACK library paths or configuration, use numpy.show_config() instead."
+)
 def dgelsd(
     m: int,
     n: int,
@@ -78,7 +83,12 @@ def dgelsd(
     info: int,
 ) -> _DGELSD: ...
 
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
+@deprecated(
+    "The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. "
+    "It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS "
+    "routines should use scipy.linalg.lapack or scipy.linalg.blas instead. For users checking "
+    "BLAS/LAPACK library paths or configuration, use numpy.show_config() instead."
+)
 def zgelsd(
     m: int,
     n: int,
@@ -98,7 +108,12 @@ def zgelsd(
 ) -> _ZGELSD: ...
 
 #
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
+@deprecated(
+    "The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. "
+    "It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS "
+    "routines should use scipy.linalg.lapack or scipy.linalg.blas instead. For users checking "
+    "BLAS/LAPACK library paths or configuration, use numpy.show_config() instead."
+)
 def dgeqrf(
     m: int,
     n: int,
@@ -110,7 +125,12 @@ def dgeqrf(
     info: int,  # out
 ) -> _DGEQRF: ...
 
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
+@deprecated(
+    "The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. "
+    "It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS "
+    "routines should use scipy.linalg.lapack or scipy.linalg.blas instead. For users checking "
+    "BLAS/LAPACK library paths or configuration, use numpy.show_config() instead."
+)
 def zgeqrf(
     m: int,
     n: int,
@@ -123,7 +143,12 @@ def zgeqrf(
 ) -> _ZGEQRF: ...
 
 #
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
+@deprecated(
+    "The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. "
+    "It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS "
+    "routines should use scipy.linalg.lapack or scipy.linalg.blas instead. For users checking "
+    "BLAS/LAPACK library paths or configuration, use numpy.show_config() instead."
+)
 def dorgqr(
     m: int,  # >=0
     n: int,  # m >= n >= 0
@@ -136,7 +161,12 @@ def dorgqr(
     info: int,  # out
 ) -> _DORGQR: ...
 
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
+@deprecated(
+    "The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. "
+    "It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS "
+    "routines should use scipy.linalg.lapack or scipy.linalg.blas instead. For users checking "
+    "BLAS/LAPACK library paths or configuration, use numpy.show_config() instead."
+)
 def zungqr(
     m: int,
     n: int,
@@ -150,5 +180,10 @@ def zungqr(
 ) -> _ZUNGQR: ...
 
 #
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
+@deprecated(
+    "The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. "
+    "It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS "
+    "routines should use scipy.linalg.lapack or scipy.linalg.blas instead. For users checking "
+    "BLAS/LAPACK library paths or configuration, use numpy.show_config() instead."
+)
 def xerbla(srname: object, info: int) -> None: ...

--- a/numpy/linalg/lapack_lite.pyi
+++ b/numpy/linalg/lapack_lite.pyi
@@ -1,4 +1,5 @@
 from typing import Final, TypedDict, type_check_only
+from typing_extensions import deprecated
 
 import numpy as np
 from numpy._typing import NDArray
@@ -59,6 +60,7 @@ _ilp64: Final[bool] = ...
 
 class LapackError(Exception): ...
 
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
 def dgelsd(
     m: int,
     n: int,
@@ -75,6 +77,8 @@ def dgelsd(
     iwork: NDArray[fortran_int],
     info: int,
 ) -> _DGELSD: ...
+
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
 def zgelsd(
     m: int,
     n: int,
@@ -94,6 +98,7 @@ def zgelsd(
 ) -> _ZGELSD: ...
 
 #
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
 def dgeqrf(
     m: int,
     n: int,
@@ -104,6 +109,8 @@ def dgeqrf(
     lwork: int,
     info: int,  # out
 ) -> _DGEQRF: ...
+
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
 def zgeqrf(
     m: int,
     n: int,
@@ -116,6 +123,7 @@ def zgeqrf(
 ) -> _ZGEQRF: ...
 
 #
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
 def dorgqr(
     m: int,  # >=0
     n: int,  # m >= n >= 0
@@ -127,6 +135,8 @@ def dorgqr(
     lwork: int,
     info: int,  # out
 ) -> _DORGQR: ...
+
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
 def zungqr(
     m: int,
     n: int,
@@ -140,4 +150,5 @@ def zungqr(
 ) -> _ZUNGQR: ...
 
 #
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
 def xerbla(srname: object, info: int) -> None: ...

--- a/numpy/linalg/lapack_lite.pyi
+++ b/numpy/linalg/lapack_lite.pyi
@@ -60,7 +60,7 @@ _ilp64: Final[bool] = ...
 
 class LapackError(Exception): ...
 
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
 def dgelsd(
     m: int,
     n: int,
@@ -78,7 +78,7 @@ def dgelsd(
     info: int,
 ) -> _DGELSD: ...
 
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
 def zgelsd(
     m: int,
     n: int,
@@ -98,7 +98,7 @@ def zgelsd(
 ) -> _ZGELSD: ...
 
 #
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
 def dgeqrf(
     m: int,
     n: int,
@@ -110,7 +110,7 @@ def dgeqrf(
     info: int,  # out
 ) -> _DGEQRF: ...
 
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
 def zgeqrf(
     m: int,
     n: int,
@@ -123,7 +123,7 @@ def zgeqrf(
 ) -> _ZGEQRF: ...
 
 #
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
 def dorgqr(
     m: int,  # >=0
     n: int,  # m >= n >= 0
@@ -136,7 +136,7 @@ def dorgqr(
     info: int,  # out
 ) -> _DORGQR: ...
 
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
 def zungqr(
     m: int,
     n: int,
@@ -150,5 +150,5 @@ def zungqr(
 ) -> _ZUNGQR: ...
 
 #
-@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg.")
+@deprecated("The numpy.linalg.lapack_lite module is deprecated and will be removed in a future release. It is an internal implementation detail of numpy.linalg. Users that need LAPACK or BLAS routines should use scipy.linalg.lapack or scipy.linalg.blas instead.")
 def xerbla(srname: object, info: int) -> None: ...

--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -454,6 +454,14 @@ lapack_lite_exec(PyObject *m)
     }
     module_loaded = 1;
 
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "The numpy.linalg.lapack_lite module is deprecated and will be "
+                     "removed in a future release. It is an internal implementation "
+                     "detail of numpy.linalg.",
+                     2) < 0) {
+        return -1;
+    }
+
     if (PyArray_ImportNumPyAPI() < 0) {
         return -1;
     }

--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -457,7 +457,8 @@ lapack_lite_exec(PyObject *m)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
                      "The numpy.linalg.lapack_lite module is deprecated and will be "
                      "removed in a future release. It is an internal implementation "
-                     "detail of numpy.linalg.",
+                     "detail of numpy.linalg. Users that need LAPACK or BLAS routines "
+                     "should use scipy.linalg.lapack or scipy.linalg.blas instead.",
                      2) < 0) {
         return -1;
     }

--- a/numpy/linalg/lapack_litemodule.c
+++ b/numpy/linalg/lapack_litemodule.c
@@ -458,7 +458,9 @@ lapack_lite_exec(PyObject *m)
                      "The numpy.linalg.lapack_lite module is deprecated and will be "
                      "removed in a future release. It is an internal implementation "
                      "detail of numpy.linalg. Users that need LAPACK or BLAS routines "
-                     "should use scipy.linalg.lapack or scipy.linalg.blas instead.",
+                     "should use scipy.linalg.lapack or scipy.linalg.blas instead. "
+                     "For users checking BLAS/LAPACK library paths or configuration, "
+                     "use numpy.show_config() instead.",
                      2) < 0) {
         return -1;
     }

--- a/numpy/linalg/tests/test_deprecations.py
+++ b/numpy/linalg/tests/test_deprecations.py
@@ -1,13 +1,9 @@
 """Test deprecation and future warnings.
 
 """
-import subprocess
-import sys
-
 import pytest
 
 import numpy as np
-from numpy.testing import IS_WASM
 
 
 def test_qr_mode_full_removed():
@@ -21,16 +17,3 @@ def test_qr_mode_full_removed():
         np.linalg.qr(a, mode='economic')
     with pytest.raises(ValueError, match="deprecated in NumPy 1.8"):
         np.linalg.qr(a, mode='e')
-
-
-@pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
-def test_lapack_lite_deprecation():
-    """Check that importing lapack_lite raises a DeprecationWarning."""
-    code = "import numpy.linalg.lapack_lite"
-    res = subprocess.run(
-        [sys.executable, "-W", "error::DeprecationWarning", "-c", code],
-        capture_output=True,
-        text=True,
-    )
-    assert res.returncode != 0
-    assert "The numpy.linalg.lapack_lite module is deprecated" in res.stderr

--- a/numpy/linalg/tests/test_deprecations.py
+++ b/numpy/linalg/tests/test_deprecations.py
@@ -1,9 +1,13 @@
 """Test deprecation and future warnings.
 
 """
+import subprocess
+import sys
+
 import pytest
 
 import numpy as np
+from numpy.testing import IS_WASM
 
 
 def test_qr_mode_full_removed():
@@ -17,3 +21,16 @@ def test_qr_mode_full_removed():
         np.linalg.qr(a, mode='economic')
     with pytest.raises(ValueError, match="deprecated in NumPy 1.8"):
         np.linalg.qr(a, mode='e')
+
+
+@pytest.mark.skipif(IS_WASM, reason="Cannot start subprocess")
+def test_lapack_lite_deprecation():
+    """Check that importing lapack_lite raises a DeprecationWarning."""
+    code = "import numpy.linalg.lapack_lite"
+    res = subprocess.run(
+        [sys.executable, "-W", "error::DeprecationWarning", "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode != 0
+    assert "The numpy.linalg.lapack_lite module is deprecated" in res.stderr

--- a/numpy/linalg/tests/test_linalg.py
+++ b/numpy/linalg/tests/test_linalg.py
@@ -46,7 +46,13 @@ from numpy.testing import (
 from numpy.testing._private.utils import run_subprocess
 
 try:
-    import numpy.linalg.lapack_lite
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="The numpy.linalg.lapack_lite module is deprecated",
+            category=DeprecationWarning,
+        )
+        import numpy.linalg.lapack_lite
 except ImportError:
     # May be broken when numpy was built without BLAS/LAPACK present
     # If so, ensure we don't break the whole test suite - the `lapack_lite`


### PR DESCRIPTION
### PR summary
As titled, based on: https://github.com/numpy/numpy/pull/31928#issuecomment-4989512472

Note: 
If a user simply `import numpy.linalg.lapack_lite` it will not give warning, it will warn only if used in test (run via pytest) or with `-W` flag with python3/python. 
 
CC: @seberg @mattip 
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
To write release note - it LGTM but someone please check it again. And to find the best way to write test for module dep. 