### PR TITLE
DOC: clarify set_printoptions context-local behavior

### DIFF
--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -258,9 +258,9 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
 
     .. versionchanged:: 2.1
 
-   Print options are maintained per execution context rather than globally.
-   Different threads and asynchronous tasks have independent print option
-   settings.
+        Print options are maintained per execution context rather than globally.
+        Different threads and asynchronous tasks have independent print option
+        settings.
 
     **Concurrency note:** see :ref:`text_formatting_options`
 

--- a/numpy/_core/arrayprint.py
+++ b/numpy/_core/arrayprint.py
@@ -256,6 +256,12 @@ def set_printoptions(precision=None, threshold=None, edgeitems=None,
     * Use `printoptions` as a context manager to set the values temporarily.
     * These print options apply only to NumPy ndarrays, not to scalars.
 
+    .. versionchanged:: 2.1
+
+   Print options are maintained per execution context rather than globally.
+   Different threads and asynchronous tasks have independent print option
+   settings.
+
     **Concurrency note:** see :ref:`text_formatting_options`
 
     Examples


### PR DESCRIPTION
### PR summary

This PR updates the `set_printoptions` documentation to explicitly state that, since NumPy 2.1, print options are no longer global and are maintained per execution context.

Although this behavior is already described under the **Text formatting options** documentation, it is not mentioned directly on the `set_printoptions` API page. This change makes the behavior more discoverable for users who refer to the API documentation without navigating to the separate reference section.

Fixes #32014.

### First time committer introduction

Hi! This is my first contribution to NumPy.

I'm a Computer Science student with an interest in Python, data science, and open-source software. I use NumPy regularly in machine learning and data analysis projects, and I wanted to contribute by improving the documentation after coming across this issue.

#### AI Disclosure

AI tools were used to help understand the issue, navigate the documentation, and review the wording of the documentation change. The final documentation changes, verification of the relevant files, Git operations, and the pull request submission were performed by me. No AI-generated code was included in this pull request.

