### PR TITLE
TYP: specialized ``remainder``/``mod`` and ``floor_divide`` ufuncs

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -444,6 +444,7 @@ from numpy._core.umath import (
     logical_not,
     logical_or,
     logical_xor,
+    mod,
     modf,
     nextafter,
     not_equal,
@@ -452,6 +453,7 @@ from numpy._core.umath import (
     rad2deg,
     radians,
     reciprocal,
+    remainder,
     right_shift,
     right_shift as bitwise_right_shift,
     rint,
@@ -7647,13 +7649,11 @@ maximum: _UFunc_Nin2_Nout1[L["maximum"], L[21], None]
 minimum: _UFunc_Nin2_Nout1[L["minimum"], L[21], None]
 multiply: _UFunc_Nin2_Nout1[L["multiply"], L[23], L[1]]
 power: _UFunc_Nin2_Nout1[L["power"], L[18], None]
-remainder: _UFunc_Nin2_Nout1[L["remainder"], L[16], None]
 subtract: _UFunc_Nin2_Nout1[L["subtract"], L[21], None]
 vecdot: _GUFunc_Nin2_Nout1[L["vecdot"], L[19], None, L["(n),(n)->()"]]
 vecmat: _GUFunc_Nin2_Nout1[L["vecmat"], L[19], None, L["(n),(n,m)->(m)"]]
 
 concat = concatenate
-mod = remainder
 permute_dims = transpose
 pow = power
 

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -414,6 +414,7 @@ from numpy._core.umath import (
     fabs,
     float_power,
     floor,
+    floor_divide,
     fmod,
     frexp,
     gcd,
@@ -7640,7 +7641,6 @@ class ufunc:
 # Parameters: `__name__`, `ntypes` and `identity`
 add: _UFunc_Nin2_Nout1[L["add"], L[22], L[0]]
 divmod: _UFunc_Nin2_Nout2[L["divmod"], L[15], None]
-floor_divide: _UFunc_Nin2_Nout1[L["floor_divide"], L[21], None]
 fmax: _UFunc_Nin2_Nout1[L["fmax"], L[21], None]
 fmin: _UFunc_Nin2_Nout1[L["fmin"], L[21], None]
 matmul: _GUFunc_Nin2_Nout1[L["matmul"], L[19], None, L["(n?,k),(k,m?)->(n?,m?)"]]

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -37,11 +37,9 @@ from numpy import (
     matvec,
     maximum,
     minimum,
-    mod,
     multiply,
     pi,
     power,
-    remainder,
     subtract,
     true_divide,
     vecdot,
@@ -212,6 +210,7 @@ type _to_f64 = np.float64 | np.float32 | np.float16 | _to_integer
 type _to_c128 = np.complex128 | np.complex64 | _to_f64
 
 type _ArrayLikeIntObj_co = _DualArrayLike[np.dtype[_to_integer | np.object_], int]
+type _ArrayLikeFloatObj_co = _DualArrayLike[np.dtype[_to_floating | np.object_], float]
 type _ArrayLikeNumberObj_co = _DualArrayLike[np.dtype[_to_number | np.object_], complex]
 type _ArrayLikeNumericObj = _DualArrayLike[np.dtype[_numeric | np.object_], complex]
 type _ArrayLikeNumericObj_co = _DualArrayLike[np.dtype[_to_numeric | np.object_], complex]
@@ -9447,14 +9446,17 @@ class _ufunc_21_bio(_ufunc_21[_IdT_co], Generic[_IdT_co, _ScalarT_contra]):  # t
         out: np.ndarray | None = None,
     ) -> OutT: ...
 
-# bBhHiIlLqQefdgO, bBhHiIlLqQefdgO => bBhHiIlLqQefdgO
+# bBhHiIlLqQefdg[mO], bBhHiIlLqQefdg[mO] => bBhHiIlLqQefdg[mO]
 #
-# Object dtypes aren't included here because this simply calls `.fmod(_)` on the
-# underlying Python object, which in practice will usually lead to a `TypeError`.
+# Generic family of ufunc specializations for `fmod` and `remainder`/`mod`.
+#
+# Object dtypes aren't included for `fmod` here because this simply calls `.fmod(_)` on
+# the underlying Python object, which in practice will usually lead to a `TypeError`.
+# For `remainder`, the `object_` dtypes are a lot more flexible, so there it is supported.
 #
 # Only the i64/i32/i8/u8 int promotion rules are implemented, building upon `_ufunc_21_bio`.
 @type_check_only
-class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
+class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[misc]  # noqa: UP046
     @override
     @overload  # 0d +i8, 0d +i8
     def __call__(
@@ -9632,6 +9634,17 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> np.longdouble: ...
+    @overload  # 0d ~m64, 0d ~m64  (if `timedelta64` in domain)
+    def __call__(
+        self: _ufunc_21_mod[np.timedelta64],
+        x1: np.timedelta64,
+        x2: np.timedelta64,
+        /,
+        *,
+        out: None = None,
+        dtype: type[np.timedelta64] | np.dtype[np.timedelta64] | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.timedelta64: ...
     @overload  # 0d T@floating, 0d +float
     def __call__[FloatT: np.floating](
         self,
@@ -9874,30 +9887,41 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.longdouble]: ...
-    @overload  # Nd _, ?d _, dtype=<known>
-    def __call__[ScalarT: np.floating | np.integer | np.object_](
-        self,
-        x1: npt.NDArray[_to_floating],
-        x2: _ArrayLikeFloat_co,
+    @overload  # ?d ~m64, ?d ~m64  (if `timedelta64` in domain)
+    def __call__(
+        self: _ufunc_21_mod[np.timedelta64],
+        x1: _ArrayLike[np.timedelta64],
+        x2: _ArrayLike[np.timedelta64],
+        /,
+        *,
+        out: EllipsisType | npt.NDArray[np.timedelta64] | None = None,
+        dtype: type[np.timedelta64] | np.dtype[np.timedelta64] | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.timedelta64]: ...
+    @overload  # Nd ~obj, ?d +obj  (if `object_` in domain)
+    def __call__(
+        self: _ufunc_21_mod[np.object_],
+        x1: npt.NDArray[np.object_],
+        x2: _ArrayLikeFloatObj_co,
         /,
         *,
         out: EllipsisType | None = None,
-        dtype: _DTypeLike[ScalarT],
+        dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
-    ) -> npt.NDArray[ScalarT]: ...
-    @overload  # ?d _, Nd _, dtype=<known>
-    def __call__[ScalarT: np.floating | np.integer | np.object_](
-        self,
-        x1: _ArrayLikeFloat_co,
-        x2: npt.NDArray[_to_floating],
+    ) -> npt.NDArray[np.object_]: ...
+    @overload  # ?d +obj, Nd ~obj  (if `object_` in domain)
+    def __call__(
+        self: _ufunc_21_mod[np.object_],
+        x1: _ArrayLikeFloatObj_co,
+        x2: npt.NDArray[np.object_],
         /,
         *,
         out: EllipsisType | None = None,
-        dtype: _DTypeLike[ScalarT],
+        dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
-    ) -> npt.NDArray[ScalarT]: ...
+    ) -> npt.NDArray[np.object_]: ...
     @overload  # Nd T@floating, ?d +float
-    def __call__[ArrayT: npt.NDArray[np.floating]](
+    def __call__[ArrayT: npt.NDArray[np.floating | np.object_]](
         self,
         x1: ArrayT,
         x2: _DualArrayLike[np.dtype[np.int8 | np.uint8 | np.bool], float],
@@ -9908,7 +9932,7 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         **kwargs: Unpack[_Kwargs21],
     ) -> ArrayT: ...
     @overload  # ?d +float, Nd T@floating
-    def __call__[ArrayT: npt.NDArray[np.floating]](
+    def __call__[ArrayT: npt.NDArray[np.floating | np.object_]](
         self,
         x1: _DualArrayLike[np.dtype[np.int8 | np.uint8 | np.bool], float],
         x2: ArrayT,
@@ -9918,6 +9942,28 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> ArrayT: ...
+    @overload  # Nd _, ?d _, dtype=<known>
+    def __call__[ScalarT: np.floating | np.integer](
+        self,
+        x1: npt.NDArray[_to_floating],
+        x2: _ArrayLikeFloat_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # ?d _, Nd _, dtype=<known>
+    def __call__[ScalarT: np.floating | np.integer](
+        self,
+        x1: _ArrayLikeFloat_co,
+        x2: npt.NDArray[_to_floating],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[ScalarT]: ...
     @overload  # Nd ~float, ?d +float
     def __call__(
         self,
@@ -9943,8 +9989,8 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # out=<given>
     def __call__[OutT: np.ndarray](
         self,
-        x1: _ArrayLikeFloat_co,
-        x2: _ArrayLikeFloat_co,
+        x1: _ArrayLikeFloatObj_co,
+        x2: _ArrayLikeFloatObj_co,
         /,
         out: OutT,
         *,
@@ -9954,8 +10000,8 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # ?d ?, ?d ?  (fallback)
     def __call__(
         self,
-        x1: _ArrayLikeFloat_co,
-        x2: _ArrayLikeFloat_co,
+        x1: _ArrayLikeFloatObj_co,
+        x2: _ArrayLikeFloatObj_co,
         /,
         *,
         out: EllipsisType | None = None,
@@ -10163,6 +10209,17 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> np.longdouble: ...
+    @overload  # 0d ~m64, 0d ~m64  (if `timedelta64` in domain)
+    def outer(
+        self: _ufunc_21_mod[np.timedelta64],
+        x1: np.timedelta64,
+        x2: np.timedelta64,
+        /,
+        *,
+        out: None = None,
+        dtype: type[np.timedelta64] | np.dtype[np.timedelta64] | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.timedelta64: ...
     @overload  # 0d T@floating, 0d +float
     def outer[FloatT: np.floating](
         self,
@@ -10405,30 +10462,41 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.longdouble]: ...
-    @overload  # Nd _, ?d _, dtype=<known>
-    def outer[ScalarT: np.floating | np.integer | np.object_](
-        self,
-        x1: npt.NDArray[_to_floating],
-        x2: _ArrayLikeFloat_co,
+    @overload  # ?d ~m64, ?d ~m64  (if `timedelta64` in domain)
+    def outer(
+        self: _ufunc_21_mod[np.timedelta64],
+        x1: _ArrayLike[np.timedelta64],
+        x2: _ArrayLike[np.timedelta64],
+        /,
+        *,
+        out: EllipsisType | npt.NDArray[np.timedelta64] | None = None,
+        dtype: type[np.timedelta64] | np.dtype[np.timedelta64] | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.timedelta64]: ...
+    @overload  # Nd ~obj, ?d +obj  (if `object_` in domain)
+    def outer(
+        self: _ufunc_21_mod[np.object_],
+        x1: npt.NDArray[np.object_],
+        x2: _ArrayLikeFloatObj_co,
         /,
         *,
         out: EllipsisType | None = None,
-        dtype: _DTypeLike[ScalarT],
+        dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
-    ) -> npt.NDArray[ScalarT]: ...
-    @overload  # ?d _, Nd _, dtype=<known>
-    def outer[ScalarT: np.floating | np.integer | np.object_](
-        self,
-        x1: _ArrayLikeFloat_co,
-        x2: npt.NDArray[_to_floating],
+    ) -> npt.NDArray[np.object_]: ...
+    @overload  # ?d +obj, Nd ~obj  (if `object_` in domain)
+    def outer(
+        self: _ufunc_21_mod[np.object_],
+        x1: _ArrayLikeFloatObj_co,
+        x2: npt.NDArray[np.object_],
         /,
         *,
         out: EllipsisType | None = None,
-        dtype: _DTypeLike[ScalarT],
+        dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
-    ) -> npt.NDArray[ScalarT]: ...
+    ) -> npt.NDArray[np.object_]: ...
     @overload  # Nd T@floating, ?d +float
-    def outer[ArrayT: npt.NDArray[np.floating]](
+    def outer[ArrayT: npt.NDArray[np.floating | np.object_]](
         self,
         x1: ArrayT,
         x2: _DualArrayLike[np.dtype[np.int8 | np.uint8 | np.bool], float],
@@ -10439,7 +10507,7 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         **kwargs: Unpack[_Kwargs21],
     ) -> ArrayT: ...
     @overload  # ?d +float, Nd T@floating
-    def outer[ArrayT: npt.NDArray[np.floating]](
+    def outer[ArrayT: npt.NDArray[np.floating | np.object_]](
         self,
         x1: _DualArrayLike[np.dtype[np.int8 | np.uint8 | np.bool], float],
         x2: ArrayT,
@@ -10449,6 +10517,28 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> ArrayT: ...
+    @overload  # Nd _, ?d _, dtype=<known>
+    def outer[ScalarT: np.floating | np.integer](
+        self,
+        x1: npt.NDArray[_to_floating],
+        x2: _ArrayLikeFloat_co,
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[ScalarT]: ...
+    @overload  # ?d _, Nd _, dtype=<known>
+    def outer[ScalarT: np.floating | np.integer](
+        self,
+        x1: _ArrayLikeFloat_co,
+        x2: npt.NDArray[_to_floating],
+        /,
+        *,
+        out: EllipsisType | None = None,
+        dtype: _DTypeLike[ScalarT],
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[ScalarT]: ...
     @overload  # Nd ~float, ?d +float
     def outer(
         self,
@@ -10474,8 +10564,8 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # out=<given>
     def outer[OutT: np.ndarray](
         self,
-        x1: _ArrayLikeFloat_co,
-        x2: _ArrayLikeFloat_co,
+        x1: _ArrayLikeFloatObj_co,
+        x2: _ArrayLikeFloatObj_co,
         /,
         out: OutT,
         *,
@@ -10485,8 +10575,8 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # ?d ?, ?d ?  (fallback)
     def outer(
         self,
-        x1: _ArrayLikeFloat_co,
-        x2: _ArrayLikeFloat_co,
+        x1: _ArrayLikeFloatObj_co,
+        x2: _ArrayLikeFloatObj_co,
         /,
         *,
         out: EllipsisType | None = None,
@@ -10518,7 +10608,23 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
 
     #
     @overload
-    def at(self, a: npt.NDArray[_to_floating], indices: _ArrayLikeInt, b: _ArrayLikeFloat_co, /) -> None: ...  # pyrefly:ignore[bad-override]
+    def at(  # pyrefly:ignore[bad-override]
+        self: _ufunc_21_mod[np.timedelta64],
+        a: npt.NDArray[np.timedelta64],
+        indices: _ArrayLikeInt,
+        b: _ArrayLike[np.timedelta64],
+        /,
+    ) -> None: ...
+    @overload
+    def at(
+        self: _ufunc_21_mod[np.object_],
+        a: npt.NDArray[np.object_],
+        indices: _ArrayLikeInt,
+        b: _ArrayLikeFloatObj_co,
+        /,
+    ) -> None: ...
+    @overload
+    def at(self, a: npt.NDArray[_to_floating], indices: _ArrayLikeInt, b: _ArrayLikeFloat_co, /) -> None: ...
     @overload
     def at[OtherT, IxT, OutT](self, a: _CanUfuncAt2L[OtherT, IxT, OutT], indices: IxT, b: OtherT, /) -> OutT: ...
     @overload
@@ -10604,6 +10710,84 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         initial: bool | _to_i8 = ...,
         where: _ArrayLikeBool_co = True,
     ) -> npt.NDArray[np.int8]: ...
+    @overload  # ~timedelta64
+    def reduce[MT: np.timedelta64](
+        self: _ufunc_21_mod[np.timedelta64],
+        array: npt.NDArray[MT],
+        /,
+        *,
+        axis: int | tuple[int, ...] = 0,
+        dtype: None = None,
+        out: EllipsisType | None = None,
+        keepdims: Literal[False] = False,
+        initial: np.timedelta64 = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[MT] | Any: ...
+    @overload  # ~timedelta64, axis=None
+    def reduce[MT: np.timedelta64](
+        self: _ufunc_21_mod[np.timedelta64],
+        array: npt.NDArray[MT],
+        /,
+        *,
+        axis: None,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[False] = False,
+        initial: np.timedelta64 = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> MT: ...
+    @overload  # ~timedelta64, keepdims=True
+    def reduce[MT: np.timedelta64](
+        self: _ufunc_21_mod[np.timedelta64],
+        array: npt.NDArray[MT],
+        /,
+        *,
+        axis: int | tuple[int, ...] | None = 0,
+        dtype: None = None,
+        out: EllipsisType | None = None,
+        keepdims: Literal[True],
+        initial: np.timedelta64 = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[MT]: ...
+    @overload  # ~object_
+    def reduce(
+        self: _ufunc_21_mod[np.object_],
+        array: npt.NDArray[np.object_],
+        /,
+        *,
+        axis: int | tuple[int, ...] = 0,
+        dtype: None = None,
+        out: EllipsisType | None = None,
+        keepdims: Literal[False] = False,
+        initial: object = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[np.object_] | Any: ...
+    @overload  # ~object_, axis=None
+    def reduce(
+        self: _ufunc_21_mod[np.object_],
+        array: npt.NDArray[np.object_],
+        /,
+        *,
+        axis: None,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[False] = False,
+        initial: object = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> Any: ...
+    @overload  # ~object_, keepdims=True
+    def reduce(
+        self: _ufunc_21_mod[np.object_],
+        array: npt.NDArray[np.object_],
+        /,
+        *,
+        axis: int | tuple[int, ...] | None = 0,
+        dtype: None = None,
+        out: EllipsisType | None = None,
+        keepdims: Literal[True],
+        initial: object = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[np.object_]: ...
     @overload  # ~int
     def reduce(
         self,
@@ -10748,6 +10932,28 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         out: None = None,
     ) -> npt.NDArray[ScalarT]: ...
+    @overload  # ~timedelta64
+    def reduceat[MT: np.timedelta64](
+        self: _ufunc_21_mod[np.timedelta64],
+        array: npt.NDArray[MT],
+        /,
+        indices: tuple[int, ...],
+        *,
+        axis: int = 0,
+        dtype: None = None,
+        out: None = None,
+    ) -> npt.NDArray[MT]: ...
+    @overload  # ~object_
+    def reduceat(
+        self: _ufunc_21_mod[np.object_],
+        array: npt.NDArray[np.object_],
+        /,
+        indices: tuple[int, ...],
+        *,
+        axis: int = 0,
+        dtype: None = None,
+        out: None = None,
+    ) -> npt.NDArray[np.object_]: ...
     @overload  # ~bool
     def reduceat(
         self,
@@ -10782,7 +10988,7 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         out: None = None,
     ) -> npt.NDArray[np.float64]: ...
     @overload  # dtype=<known>
-    def reduceat[ScalarT: np.floating | np.integer | np.object_](
+    def reduceat[ScalarT: np.floating | np.integer | np.timedelta64 | np.object_](
         self,
         array: _ArrayLikeFloat_co,
         /,
@@ -10795,7 +11001,7 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # dtype=<unknown>
     def reduceat(
         self,
-        array: _ArrayLikeFloat_co,
+        array: _ArrayLikeFloatObj_co,
         /,
         indices: tuple[int, ...],
         *,
@@ -10838,6 +11044,26 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         out: None = None,
     ) -> npt.NDArray[ScalarT]: ...
+    @overload  # ~timedelta64
+    def accumulate[MT: np.timedelta64](
+        self: _ufunc_21_mod[np.timedelta64],
+        array: npt.NDArray[MT],
+        /,
+        *,
+        axis: int = 0,
+        dtype: None = None,
+        out: None = None,
+    ) -> npt.NDArray[MT]: ...
+    @overload  # ~object_
+    def accumulate(
+        self: _ufunc_21_mod[np.object_],
+        array: npt.NDArray[np.object_],
+        /,
+        *,
+        axis: int = 0,
+        dtype: None = None,
+        out: None = None,
+    ) -> npt.NDArray[np.object_]: ...
     @overload  # ~bool
     def accumulate(
         self,
@@ -10869,7 +11095,7 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
         out: None = None,
     ) -> npt.NDArray[np.float64]: ...
     @overload  # dtype=<known>
-    def accumulate[ScalarT: np.floating | np.integer | np.object_](
+    def accumulate[ScalarT: np.floating | np.integer | np.timedelta64 | np.object_](
         self,
         array: _ArrayLikeFloat_co,
         /,
@@ -10881,23 +11107,13 @@ class _ufunc_21_fmod(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # dtype=<unknown>
     def accumulate(
         self,
-        array: _ArrayLikeFloat_co,
+        array: _ArrayLikeFloatObj_co,
         /,
         *,
         axis: int = 0,
         dtype: str | type,
         out: None = None,
     ) -> npt.NDArray[Any]: ...
-    @overload  # out=<given>
-    def accumulate[OutT: npt.NDArray[np.floating | np.integer | np.object_]](
-        self,
-        array: _ArrayLikeFloat_co,
-        /,
-        *,
-        axis: int = 0,
-        dtype: npt.DTypeLike | None = None,
-        out: OutT,
-    ) -> OutT: ...
     @overload  # array.__array_ufunc__(self, "accumulate", array, ...)
     def accumulate[OutT](
         self,
@@ -10946,7 +11162,10 @@ bitwise_and: Final[_ufunc_21_bio[Literal[-1], np.bool | np.integer | np.object_]
 bitwise_or: Final[_ufunc_21_bio[Literal[0], np.bool | np.integer | np.object_]] = ...
 bitwise_xor: Final[_ufunc_21_bio[Literal[0], np.bool | np.integer | np.object_]] = ...
 
-fmod: Final[_ufunc_21_fmod] = ...
+fmod: Final[_ufunc_21_mod[np.inexact]] = ...
+
+remainder: Final[_ufunc_21_mod[np.inexact | np.timedelta64 | np.object_]] = ...
+mod = remainder
 
 ###
 # re-exports from `_core._multiarray_umath` that are used by `_core._ufunc_config`

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -29,7 +29,6 @@ from numpy import (
     divmod,
     e,
     euler_gamma,
-    floor_divide,
     fmax,
     fmin,
     frompyfunc,
@@ -173,6 +172,7 @@ __all__ = [
 
 _IdT_co = TypeVar("_IdT_co", covariant=True, default=None)
 _ScalarT_contra = TypeVar("_ScalarT_contra", bound=np.generic, contravariant=True)
+_ScalarT_co = TypeVar("_ScalarT_co", bound=np.generic, covariant=True)
 
 type _Array[ShapeT: _Shape, ScalarT: np.generic] = np.ndarray[ShapeT, np.dtype[ScalarT]]
 type _Array0D[ScalarT: np.generic] = _Array[tuple[()], ScalarT]
@@ -9449,6 +9449,8 @@ class _ufunc_21_bio(_ufunc_21[_IdT_co], Generic[_IdT_co, _ScalarT_contra]):  # t
 # bBhHiIlLqQefdg[mO], bBhHiIlLqQefdg[mO] => bBhHiIlLqQefdg[mO]
 #
 # Generic family of ufunc specializations for `fmod` and `remainder`/`mod`.
+# The first type param represents the domain, and the second the output type in case of
+# (timedelta64, timedelta64) input.
 #
 # Object dtypes aren't included for `fmod` here because this simply calls `.fmod(_)` on
 # the underlying Python object, which in practice will usually lead to a `TypeError`.
@@ -9456,7 +9458,7 @@ class _ufunc_21_bio(_ufunc_21[_IdT_co], Generic[_IdT_co, _ScalarT_contra]):  # t
 #
 # Only the i64/i32/i8/u8 int promotion rules are implemented, building upon `_ufunc_21_bio`.
 @type_check_only
-class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[misc]  # noqa: UP046
+class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra, _ScalarT_co]):  # type: ignore[misc]  # noqa: UP046
     @override
     @overload  # 0d +i8, 0d +i8
     def __call__(
@@ -9635,16 +9637,27 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
         **kwargs: Unpack[_Kwargs21],
     ) -> np.longdouble: ...
     @overload  # 0d ~m64, 0d ~m64  (if `timedelta64` in domain)
-    def __call__(
-        self: _ufunc_21_mod[np.timedelta64],
+    def __call__[OutT: np.generic](
+        self: _ufunc_21_mod[np.timedelta64, OutT],
         x1: np.timedelta64,
         x2: np.timedelta64,
         /,
         *,
         out: None = None,
-        dtype: type[np.timedelta64] | np.dtype[np.timedelta64] | None = None,
+        dtype: type[OutT] | np.dtype[OutT] | None = None,
         **kwargs: Unpack[_Kwargs21],
-    ) -> np.timedelta64: ...
+    ) -> OutT: ...
+    @overload  # 0d ~m64, 0d +floating  (iff `timedelta64 * timedelta64 -> int64`)
+    def __call__[OutT: np.timedelta64](
+        self: _ufunc_21_mod[np.timedelta64, np.int64],
+        x1: OutT,
+        x2: float | np.floating | np.integer,
+        /,
+        *,
+        out: None = None,
+        dtype: type[OutT] | np.dtype[OutT] | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> OutT: ...
     @overload  # 0d T@floating, 0d +float
     def __call__[FloatT: np.floating](
         self,
@@ -9888,19 +9901,30 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.longdouble]: ...
     @overload  # ?d ~m64, ?d ~m64  (if `timedelta64` in domain)
-    def __call__(
-        self: _ufunc_21_mod[np.timedelta64],
+    def __call__[OutT: np.generic](
+        self: _ufunc_21_mod[np.timedelta64, OutT],
         x1: _ArrayLike[np.timedelta64],
         x2: _ArrayLike[np.timedelta64],
         /,
         *,
-        out: EllipsisType | npt.NDArray[np.timedelta64] | None = None,
-        dtype: type[np.timedelta64] | np.dtype[np.timedelta64] | None = None,
+        out: EllipsisType | npt.NDArray[OutT] | None = None,
+        dtype: type[OutT] | np.dtype[OutT] | None = None,
         **kwargs: Unpack[_Kwargs21],
-    ) -> npt.NDArray[np.timedelta64]: ...
+    ) -> npt.NDArray[OutT]: ...
+    @overload  # 0d ~m64, 0d +floating  (iff `timedelta64 * timedelta64 -> int64`)
+    def __call__[OutT: np.timedelta64](
+        self: _ufunc_21_mod[np.timedelta64, np.int64],
+        x1: _ArrayLike[OutT],
+        x2: _DualArrayLike[np.dtype[np.floating | np.integer], float],
+        /,
+        *,
+        out: EllipsisType | npt.NDArray[OutT] | None = None,
+        dtype: type[OutT] | np.dtype[OutT] | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[OutT]: ...
     @overload  # Nd ~obj, ?d +obj  (if `object_` in domain)
     def __call__(
-        self: _ufunc_21_mod[np.object_],
+        self: _ufunc_21_mod[np.object_, Any],
         x1: npt.NDArray[np.object_],
         x2: _ArrayLikeFloatObj_co,
         /,
@@ -9911,7 +9935,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> npt.NDArray[np.object_]: ...
     @overload  # ?d +obj, Nd ~obj  (if `object_` in domain)
     def __call__(
-        self: _ufunc_21_mod[np.object_],
+        self: _ufunc_21_mod[np.object_, Any],
         x1: _ArrayLikeFloatObj_co,
         x2: npt.NDArray[np.object_],
         /,
@@ -10210,16 +10234,27 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
         **kwargs: Unpack[_Kwargs21],
     ) -> np.longdouble: ...
     @overload  # 0d ~m64, 0d ~m64  (if `timedelta64` in domain)
-    def outer(
-        self: _ufunc_21_mod[np.timedelta64],
+    def outer[OutT: np.generic](
+        self: _ufunc_21_mod[np.timedelta64, OutT],
         x1: np.timedelta64,
         x2: np.timedelta64,
         /,
         *,
         out: None = None,
-        dtype: type[np.timedelta64] | np.dtype[np.timedelta64] | None = None,
+        dtype: type[OutT] | np.dtype[OutT] | None = None,
         **kwargs: Unpack[_Kwargs21],
-    ) -> np.timedelta64: ...
+    ) -> OutT: ...
+    @overload  # 0d ~m64, 0d +floating  (iff `timedelta64 * timedelta64 -> int64`)
+    def outer[OutT: np.timedelta64](
+        self: _ufunc_21_mod[np.timedelta64, np.int64],
+        x1: OutT,
+        x2: float | np.floating | np.integer,
+        /,
+        *,
+        out: None = None,
+        dtype: type[OutT] | np.dtype[OutT] | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> OutT: ...
     @overload  # 0d T@floating, 0d +float
     def outer[FloatT: np.floating](
         self,
@@ -10463,19 +10498,30 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.longdouble]: ...
     @overload  # ?d ~m64, ?d ~m64  (if `timedelta64` in domain)
-    def outer(
-        self: _ufunc_21_mod[np.timedelta64],
+    def outer[OutT: np.generic](
+        self: _ufunc_21_mod[np.timedelta64, OutT],
         x1: _ArrayLike[np.timedelta64],
         x2: _ArrayLike[np.timedelta64],
         /,
         *,
-        out: EllipsisType | npt.NDArray[np.timedelta64] | None = None,
-        dtype: type[np.timedelta64] | np.dtype[np.timedelta64] | None = None,
+        out: EllipsisType | npt.NDArray[OutT] | None = None,
+        dtype: type[OutT] | np.dtype[OutT] | None = None,
         **kwargs: Unpack[_Kwargs21],
-    ) -> npt.NDArray[np.timedelta64]: ...
+    ) -> npt.NDArray[OutT]: ...
+    @overload  # ?d ~m64, ?d +floating  (iff `timedelta64 * timedelta64 -> int64`)
+    def outer[OutT: np.timedelta64](
+        self: _ufunc_21_mod[np.timedelta64, np.int64],
+        x1: _ArrayLike[OutT],
+        x2: _DualArrayLike[np.dtype[np.floating | np.integer], float],
+        /,
+        *,
+        out: EllipsisType | npt.NDArray[OutT] | None = None,
+        dtype: type[OutT] | np.dtype[OutT] | None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[OutT]: ...
     @overload  # Nd ~obj, ?d +obj  (if `object_` in domain)
     def outer(
-        self: _ufunc_21_mod[np.object_],
+        self: _ufunc_21_mod[np.object_, Any],
         x1: npt.NDArray[np.object_],
         x2: _ArrayLikeFloatObj_co,
         /,
@@ -10486,7 +10532,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> npt.NDArray[np.object_]: ...
     @overload  # ?d +obj, Nd ~obj  (if `object_` in domain)
     def outer(
-        self: _ufunc_21_mod[np.object_],
+        self: _ufunc_21_mod[np.object_, Any],
         x1: _ArrayLikeFloatObj_co,
         x2: npt.NDArray[np.object_],
         /,
@@ -10609,7 +10655,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     #
     @overload
     def at(  # pyrefly:ignore[bad-override]
-        self: _ufunc_21_mod[np.timedelta64],
+        self: _ufunc_21_mod[np.timedelta64, Any],
         a: npt.NDArray[np.timedelta64],
         indices: _ArrayLikeInt,
         b: _ArrayLike[np.timedelta64],
@@ -10617,7 +10663,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> None: ...
     @overload
     def at(
-        self: _ufunc_21_mod[np.object_],
+        self: _ufunc_21_mod[np.object_, Any],
         a: npt.NDArray[np.object_],
         indices: _ArrayLikeInt,
         b: _ArrayLikeFloatObj_co,
@@ -10712,7 +10758,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> npt.NDArray[np.int8]: ...
     @overload  # ~timedelta64
     def reduce[MT: np.timedelta64](
-        self: _ufunc_21_mod[np.timedelta64],
+        self: _ufunc_21_mod[np.timedelta64, np.timedelta64],
         array: npt.NDArray[MT],
         /,
         *,
@@ -10725,7 +10771,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> npt.NDArray[MT] | Any: ...
     @overload  # ~timedelta64, axis=None
     def reduce[MT: np.timedelta64](
-        self: _ufunc_21_mod[np.timedelta64],
+        self: _ufunc_21_mod[np.timedelta64, np.timedelta64],
         array: npt.NDArray[MT],
         /,
         *,
@@ -10738,7 +10784,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> MT: ...
     @overload  # ~timedelta64, keepdims=True
     def reduce[MT: np.timedelta64](
-        self: _ufunc_21_mod[np.timedelta64],
+        self: _ufunc_21_mod[np.timedelta64, np.timedelta64],
         array: npt.NDArray[MT],
         /,
         *,
@@ -10751,7 +10797,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> npt.NDArray[MT]: ...
     @overload  # ~object_
     def reduce(
-        self: _ufunc_21_mod[np.object_],
+        self: _ufunc_21_mod[np.object_, Any],
         array: npt.NDArray[np.object_],
         /,
         *,
@@ -10764,7 +10810,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> npt.NDArray[np.object_] | Any: ...
     @overload  # ~object_, axis=None
     def reduce(
-        self: _ufunc_21_mod[np.object_],
+        self: _ufunc_21_mod[np.object_, Any],
         array: npt.NDArray[np.object_],
         /,
         *,
@@ -10777,7 +10823,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> Any: ...
     @overload  # ~object_, keepdims=True
     def reduce(
-        self: _ufunc_21_mod[np.object_],
+        self: _ufunc_21_mod[np.object_, Any],
         array: npt.NDArray[np.object_],
         /,
         *,
@@ -10934,7 +10980,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> npt.NDArray[ScalarT]: ...
     @overload  # ~timedelta64
     def reduceat[MT: np.timedelta64](
-        self: _ufunc_21_mod[np.timedelta64],
+        self: _ufunc_21_mod[np.timedelta64, np.timedelta64],
         array: npt.NDArray[MT],
         /,
         indices: tuple[int, ...],
@@ -10945,7 +10991,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> npt.NDArray[MT]: ...
     @overload  # ~object_
     def reduceat(
-        self: _ufunc_21_mod[np.object_],
+        self: _ufunc_21_mod[np.object_, Any],
         array: npt.NDArray[np.object_],
         /,
         indices: tuple[int, ...],
@@ -11046,7 +11092,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> npt.NDArray[ScalarT]: ...
     @overload  # ~timedelta64
     def accumulate[MT: np.timedelta64](
-        self: _ufunc_21_mod[np.timedelta64],
+        self: _ufunc_21_mod[np.timedelta64, np.timedelta64],
         array: npt.NDArray[MT],
         /,
         *,
@@ -11056,7 +11102,7 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[
     ) -> npt.NDArray[MT]: ...
     @overload  # ~object_
     def accumulate(
-        self: _ufunc_21_mod[np.object_],
+        self: _ufunc_21_mod[np.object_, Any],
         array: npt.NDArray[np.object_],
         /,
         *,
@@ -11162,10 +11208,10 @@ bitwise_and: Final[_ufunc_21_bio[Literal[-1], np.bool | np.integer | np.object_]
 bitwise_or: Final[_ufunc_21_bio[Literal[0], np.bool | np.integer | np.object_]] = ...
 bitwise_xor: Final[_ufunc_21_bio[Literal[0], np.bool | np.integer | np.object_]] = ...
 
-fmod: Final[_ufunc_21_mod[np.inexact]] = ...
-
-remainder: Final[_ufunc_21_mod[np.inexact | np.timedelta64 | np.object_]] = ...
+fmod: Final[_ufunc_21_mod[np.inexact, Never]] = ...
+remainder: Final[_ufunc_21_mod[np.inexact | np.timedelta64 | np.object_, np.timedelta64]] = ...
 mod = remainder
+floor_divide: Final[_ufunc_21_mod[np.inexact | np.timedelta64 | np.object_, np.int64]] = ...
 
 ###
 # re-exports from `_core._multiarray_umath` that are used by `_core._ufunc_config`

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -1920,7 +1920,7 @@ assert_type(np.bitwise_or.accumulate(_py_b_1d), npt.NDArray[np.bool])
 assert_type(np.bitwise_or.accumulate(_bool_nd), npt.NDArray[np.bool])
 
 ###
-# _ufunc_21_mod[inexact]
+# _ufunc_21_mod[inexact, Never]
 # (fmod)
 
 assert_type(np.fmod(_py_b_0d, _py_b_0d), np.int8)
@@ -2351,9 +2351,9 @@ assert_type(np.fmod.accumulate(_py_i_1d, dtype=np.int16), npt.NDArray[np.int16])
 assert_type(np.fmod.accumulate(_py_i_1d, dtype="i2"), npt.NDArray[Any])
 
 ###
-# _ufunc_21_mod[inexact | timedelta64 | object_]
+# _ufunc_21_mod[inexact | timedelta64 | object_, timedelta64]
 # (remainder, mod)
-# same as above but with additional `timedelta64` and `object_` overloads
+# same as `fmod` but with additional `timedelta64` and `object_` overloads
 
 assert_type(np.mod(_td_ns_0d, _td_ns_0d), np.timedelta64)
 assert_type(np.mod(_td_ns_0d, _td_ns_1d), npt.NDArray[np.timedelta64])
@@ -2385,3 +2385,50 @@ assert_type(np.mod.reduceat(_obj_nd, (1,)), npt.NDArray[np.object_])
 
 assert_type(np.mod.accumulate(_td_ns_nd), npt.NDArray[np.timedelta64[int]])
 assert_type(np.mod.accumulate(_obj_nd), npt.NDArray[np.object_])
+
+###
+# _ufunc_21_mod[inexact | timedelta64 | object_, int64]
+# (floor_divide)
+# same as above `fmod` with additional `timedelta64` and `object_` overloads
+
+assert_type(np.floor_divide(_td_ns_0d, _py_i_0d), np.timedelta64[int])
+assert_type(np.floor_divide(_td_ns_0d, _py_i_1d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_1d, _py_i_0d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_1d, _py_i_1d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_0d, _py_f_0d), np.timedelta64[int])
+assert_type(np.floor_divide(_td_ns_0d, _py_f_1d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_1d, _py_f_0d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_1d, _py_f_1d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_0d, _i16_0d), np.timedelta64[int])
+assert_type(np.floor_divide(_td_ns_0d, _i16_1d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_1d, _i16_0d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_1d, _i16_1d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_0d, _f32_0d), np.timedelta64[int])
+assert_type(np.floor_divide(_td_ns_0d, _f32_1d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_1d, _f32_0d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_1d, _f32_1d), npt.NDArray[np.timedelta64[int]])
+assert_type(np.floor_divide(_td_ns_0d, _td_ns_0d), np.int64)
+assert_type(np.floor_divide(_td_ns_0d, _td_ns_1d), npt.NDArray[np.int64])
+assert_type(np.floor_divide(_td_ns_1d, _td_ns_0d), npt.NDArray[np.int64])
+assert_type(np.floor_divide(_td_ns_1d, _td_ns_1d), npt.NDArray[np.int64])
+
+assert_type(np.floor_divide(_obj_1d, _py_f_0d), npt.NDArray[np.object_])
+assert_type(np.floor_divide(_obj_1d, _py_f_1d), npt.NDArray[np.object_])
+assert_type(np.floor_divide(_obj_1d, _i16_0d), npt.NDArray[np.object_])
+assert_type(np.floor_divide(_obj_1d, _i16_1d), npt.NDArray[np.object_])
+assert_type(np.floor_divide(_obj_1d, _f32_0d), npt.NDArray[np.object_])
+assert_type(np.floor_divide(_obj_1d, _f32_1d), npt.NDArray[np.object_])
+assert_type(np.floor_divide(_obj_1d, _obj_1d), npt.NDArray[np.object_])
+
+# floor_divide.outer is equivalent to __call__
+
+assert_type(np.floor_divide.at(_td_ns_1d, 1, _td_ns_0d), None)
+assert_type(np.floor_divide.at(_obj_1d, 1, _py_f_0d), None)
+
+assert_type(np.floor_divide.reduce(_obj_nd), npt.NDArray[np.object_] | Any)
+assert_type(np.floor_divide.reduce(_obj_nd, axis=None), Any)
+assert_type(np.floor_divide.reduce(_obj_nd, keepdims=True), npt.NDArray[np.object_])
+
+assert_type(np.floor_divide.reduceat(_obj_nd, (1,)), npt.NDArray[np.object_])
+
+assert_type(np.floor_divide.accumulate(_obj_nd), npt.NDArray[np.object_])

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -1919,7 +1919,8 @@ assert_type(np.bitwise_or.reduceat(_bool_nd, (1,)), npt.NDArray[np.bool])
 assert_type(np.bitwise_or.accumulate(_py_b_1d), npt.NDArray[np.bool])
 assert_type(np.bitwise_or.accumulate(_bool_nd), npt.NDArray[np.bool])
 
-# _ufunc_21_fmod
+###
+# _ufunc_21_mod[inexact]
 # (fmod)
 
 assert_type(np.fmod(_py_b_0d, _py_b_0d), np.int8)
@@ -2348,3 +2349,39 @@ assert_type(np.fmod.accumulate(_f64_nd), npt.NDArray[np.float64])
 assert_type(np.fmod.accumulate(_f80_nd), npt.NDArray[np.longdouble])
 assert_type(np.fmod.accumulate(_py_i_1d, dtype=np.int16), npt.NDArray[np.int16])
 assert_type(np.fmod.accumulate(_py_i_1d, dtype="i2"), npt.NDArray[Any])
+
+###
+# _ufunc_21_mod[inexact | timedelta64 | object_]
+# (remainder, mod)
+# same as above but with additional `timedelta64` and `object_` overloads
+
+assert_type(np.mod(_td_ns_0d, _td_ns_0d), np.timedelta64)
+assert_type(np.mod(_td_ns_0d, _td_ns_1d), npt.NDArray[np.timedelta64])
+assert_type(np.mod(_td_ns_1d, _td_ns_0d), npt.NDArray[np.timedelta64])
+assert_type(np.mod(_td_ns_1d, _td_ns_1d), npt.NDArray[np.timedelta64])
+
+assert_type(np.mod(_obj_1d, _py_f_0d), npt.NDArray[np.object_])
+assert_type(np.mod(_obj_1d, _py_f_1d), npt.NDArray[np.object_])
+assert_type(np.mod(_obj_1d, _i16_0d), npt.NDArray[np.object_])
+assert_type(np.mod(_obj_1d, _i16_1d), npt.NDArray[np.object_])
+assert_type(np.mod(_obj_1d, _f32_0d), npt.NDArray[np.object_])
+assert_type(np.mod(_obj_1d, _f32_1d), npt.NDArray[np.object_])
+assert_type(np.mod(_obj_1d, _obj_1d), npt.NDArray[np.object_])
+
+# mod.outer is equivalent to __call__
+
+assert_type(np.mod.at(_td_ns_1d, 1, _td_ns_0d), None)
+assert_type(np.mod.at(_obj_1d, 1, _py_f_0d), None)
+
+assert_type(np.mod.reduce(_td_ns_nd), npt.NDArray[np.timedelta64[int]] | Any)
+assert_type(np.mod.reduce(_obj_nd), npt.NDArray[np.object_] | Any)
+assert_type(np.mod.reduce(_td_ns_nd, axis=None), np.timedelta64[int])
+assert_type(np.mod.reduce(_obj_nd, axis=None), Any)
+assert_type(np.mod.reduce(_td_ns_nd, keepdims=True), npt.NDArray[np.timedelta64[int]])
+assert_type(np.mod.reduce(_obj_nd, keepdims=True), npt.NDArray[np.object_])
+
+assert_type(np.mod.reduceat(_td_ns_nd, (1,)), npt.NDArray[np.timedelta64[int]])
+assert_type(np.mod.reduceat(_obj_nd, (1,)), npt.NDArray[np.object_])
+
+assert_type(np.mod.accumulate(_td_ns_nd), npt.NDArray[np.timedelta64[int]])
+assert_type(np.mod.accumulate(_obj_nd), npt.NDArray[np.object_])


### PR DESCRIPTION
Building upon #32003, this parametrizes the specialized `ufunc` subtype for `fmod` so that it can also be used for `remainder` (a.k.a. `mod`) and `floor_divide`. These two additionally support `object_` dtypes, and also `timedelta64` but in different ways:

```
In [1]: s = np.timedelta64(1, "s")

In [2]: np.remainder(s, s)
Out[2]: np.timedelta64(0,'s')

In [3]: np.floor_divide(s, s)
Out[3]: np.int64(1)

In [4]: np.floor_divide(s, 1.0)
Out[4]: np.timedelta64(1,'s')

In [5]: np.remainder(s, 1.0)
---------------------------------------------------------------------------
UFuncTypeError                            Traceback (most recent call last)
Cell In[5], line 1
----> 1 np.remainder(s, 1.0)

UFuncTypeError: ufunc 'remainder' cannot use operands with types dtype('<m8[s]') and dtype('float64')
```

<details>
<summary>Promotion tables:</summary>

`fmod`:

```
      b8   i8   u8  i16  u16  i32  u32  i64  u64  f16  f32  f64  f80 O
b8    i8   i8   u8  i16  u16  i32  u32  i64  u64  f16  f32  f64  f80  
i8    i8   i8  i16  i16  i32  i32  i64  i64  f64  f16  f32  f64  f80  
u8    u8  i16   u8  i16  u16  i32  u32  i64  u64  f16  f32  f64  f80  
i16  i16  i16  i16  i16  i32  i32  i64  i64  f64  f32  f32  f64  f80  
u16  u16  i32  u16  i32  u16  i32  u32  i64  u64  f32  f32  f64  f80  
i32  i32  i32  i32  i32  i32  i32  i64  i64  f64  f64  f64  f64  f80  
u32  u32  i64  u32  i64  u32  i64  u32  i64  u64  f64  f64  f64  f80  
i64  i64  i64  i64  i64  i64  i64  i64  i64  f64  f64  f64  f64  f80  
u64  u64  f64  u64  f64  u64  f64  u64  f64  u64  f64  f64  f64  f80  
f16  f16  f16  f16  f32  f32  f64  f64  f64  f64  f16  f32  f64  f80  
f32  f32  f32  f32  f32  f32  f64  f64  f64  f64  f32  f32  f64  f80  
f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f80  
f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  
O                                                                     
```

`remainder`:

```
      b8   i8   u8  i16  u16  i32  u32  i64  u64  f16  f32  f64  f80  m  O
b8    i8   i8   u8  i16  u16  i32  u32  i64  u64  f16  f32  f64  f80     O
i8    i8   i8  i16  i16  i32  i32  i64  i64  f64  f16  f32  f64  f80     O
u8    u8  i16   u8  i16  u16  i32  u32  i64  u64  f16  f32  f64  f80     O
i16  i16  i16  i16  i16  i32  i32  i64  i64  f64  f32  f32  f64  f80     O
u16  u16  i32  u16  i32  u16  i32  u32  i64  u64  f32  f32  f64  f80     O
i32  i32  i32  i32  i32  i32  i32  i64  i64  f64  f64  f64  f64  f80     O
u32  u32  i64  u32  i64  u32  i64  u32  i64  u64  f64  f64  f64  f80     O
i64  i64  i64  i64  i64  i64  i64  i64  i64  f64  f64  f64  f64  f80     O
u64  u64  f64  u64  f64  u64  f64  u64  f64  u64  f64  f64  f64  f80     O
f16  f16  f16  f16  f32  f32  f64  f64  f64  f64  f16  f32  f64  f80     O
f32  f32  f32  f32  f32  f32  f64  f64  f64  f64  f32  f32  f64  f80     O
f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f80     O
f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80     O
m                                                                     m   
O      O    O    O    O    O    O    O    O    O    O    O    O    O     O
```

`floor_divide`:

```
      b8   i8   u8  i16  u16  i32  u32  i64  u64  f16  f32  f64  f80    m  O
b8    i8   i8   u8  i16  u16  i32  u32  i64  u64  f16  f32  f64  f80       O
i8    i8   i8  i16  i16  i32  i32  i64  i64  f64  f16  f32  f64  f80       O
u8    u8  i16   u8  i16  u16  i32  u32  i64  u64  f16  f32  f64  f80       O
i16  i16  i16  i16  i16  i32  i32  i64  i64  f64  f32  f32  f64  f80       O
u16  u16  i32  u16  i32  u16  i32  u32  i64  u64  f32  f32  f64  f80       O
i32  i32  i32  i32  i32  i32  i32  i64  i64  f64  f64  f64  f64  f80       O
u32  u32  i64  u32  i64  u32  i64  u32  i64  u64  f64  f64  f64  f80       O
i64  i64  i64  i64  i64  i64  i64  i64  i64  f64  f64  f64  f64  f80       O
u64  u64  f64  u64  f64  u64  f64  u64  f64  u64  f64  f64  f64  f80       O
f16  f16  f16  f16  f32  f32  f64  f64  f64  f64  f16  f32  f64  f80       O
f32  f32  f32  f32  f32  f32  f64  f64  f64  f64  f32  f32  f64  f80       O
f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f64  f80       O
f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80  f80       O
m           m    m    m    m    m    m    m    m    m    m    m    m  i64  O
O      O    O    O    O    O    O    O    O    O    O    O    O    O    O  O
```

</details>

I captured this difference in `timedelta64` signatures using a second (covariant) type parameter. The first (contravariant) type parameter represents the scalar-type domain, same as for the bitwise and gcd/lcm ufuncs from two days ago.

The main advantage of this generic parametrization trick is that it's a lot more DRY (or rather, less un-DRY).

---

No AI.