### PR TITLE
TYP/CI: Fix ruff error in `_core.umath` stubs

### DIFF
--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -9349,7 +9349,7 @@ class _ufunc_21_bio(_ufunc_21[_IdT_co], Generic[_IdT_co, _ScalarT_contra]):  # t
         indices: tuple[int, ...],
         *,
         axis: int = 0,
-        dtype: str |  type,
+        dtype: str | type,
         out: None = None,
     ) -> npt.NDArray[Any]: ...
     @overload  # out=<given>


### PR DESCRIPTION
The lint CI job is failing on main because of a ruff error in the stubs (mea culpa). Not sure why this wasn't caught before...

```console
$ spin lint
Running Ruff Check...
error[E222][*]: Multiple spaces after operator
    --> numpy/_core/umath.pyi:9352:21
     |
9350 |         *,
9351 |         axis: int = 0,
9352 |         dtype: str |  type,
     |                     ^^
9353 |         out: None = None,
9354 |     ) -> npt.NDArray[Any]: ...
     |
help: Replace with single space
9349 |         indices: tuple[int, ...],
9350 |         *,
9351 |         axis: int = 0,
     -         dtype: str |  type,
9352 +         dtype: str | type,
9353 |         out: None = None,
9354 |     ) -> npt.NDArray[Any]: ...
9355 |     @overload  # out=<given>

Found 1 error.
[*] 1 fixable with the `--fix` option.
```

---

No AI.