### PR TITLE
CI: Move the lint job to separate workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,49 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - maintenance/**
+    paths-ignore:
+      - "**.md"
+      - "**.rst"
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    # To enable this job and subsequent jobs on a fork, comment out:
+    if: github.repository == 'numpy/numpy' && github.event_name != 'push'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Install linter requirements
+        run: python -m pip install -r requirements/linter_requirements.txt
+      - name: Run linter on PR
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: spin lint
+      - name: Check Python.h is first file included
+        run: |
+          python tools/check_python_h_first.py

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,33 +32,6 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  lint:
-    # To enable this job and subsequent jobs on a fork, comment out:
-    if: github.repository == 'numpy/numpy' && github.event_name != 'push'
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        submodules: recursive
-        fetch-depth: 0
-        persist-credentials: false
-    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-      with:
-        python-version: '3.12'
-    - name: Install linter requirements
-      run:
-        python -m pip install -r requirements/linter_requirements.txt
-    - name: Run linter on PR
-      env:
-        BASE_REF: ${{ github.base_ref }}
-      run:
-        spin lint
-    - name: Check Python.h is first file included
-      run: |
-        python tools/check_python_h_first.py
-
-
   smoke_test:
     # To enable this job on a fork, comment out:
     if: github.repository == 'numpy/numpy'


### PR DESCRIPTION
This way it's easier to also have the linter run on `.pyi`-only changes, so that we can avoid oopsies like #32021.

---

No AI.