### PR TITLE
ENH: Stabilize Poisson computation for large lambda

### DIFF
--- a/doc/release/upcoming_changes/32026.improvement.rst
+++ b/doc/release/upcoming_changes/32026.improvement.rst
@@ -1,6 +1,6 @@
 Poisson sampling is more accurate for large ``lam``
 ---------------------------------------------------
-The transformed rejection method used by `numpy.random.Generator.poisson` and
-`numpy.random.RandomState.poisson` now evaluates the Poisson probability
-without cancellation. This prevents the sampled variance from becoming
-inaccurate for large values of ``lam``.
+The transformed rejection method used by `numpy.random.Generator.poisson` now
+evaluates the Poisson probability without cancellation. This prevents the
+sampled variance from becoming inaccurate for large values of ``lam``. The
+legacy stream produced by `numpy.random.RandomState.poisson` is unchanged.

--- a/doc/release/upcoming_changes/32026.improvement.rst
+++ b/doc/release/upcoming_changes/32026.improvement.rst
@@ -1,0 +1,6 @@
+Poisson sampling is more accurate for large ``lam``
+---------------------------------------------------
+The transformed rejection method used by `numpy.random.Generator.poisson` and
+`numpy.random.RandomState.poisson` now evaluates the Poisson probability
+without cancellation. This prevents the sampled variance from becoming
+inaccurate for large values of ``lam``.

--- a/doc/release/upcoming_changes/32026.improvement.rst
+++ b/doc/release/upcoming_changes/32026.improvement.rst
@@ -2,5 +2,11 @@ Poisson sampling is more accurate for large ``lam``
 ---------------------------------------------------
 The transformed rejection method used by `numpy.random.Generator.poisson` now
 evaluates the Poisson probability without cancellation. This prevents the
-sampled variance from becoming inaccurate for large values of ``lam``. The
-legacy stream produced by `numpy.random.RandomState.poisson` is unchanged.
+sampled variance from becoming inaccurate for large values of ``lam``.
+
+As a result, ``Generator.poisson`` and ``Generator.negative_binomial`` (which
+uses Poisson internally) may now return different samples for the same seed.
+
+The legacy `numpy.random.RandomState.poisson` and
+`numpy.random.RandomState.negative_binomial` are not affected: they preserve
+the original behavior, so existing streams remain reproducible.

--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -573,6 +573,12 @@ static RAND_INT_TYPE random_poisson_mult(bitgen_t *bitgen_state, double lam) {
 #define LS2PI 0.91893853320467267
 #define TWELFTH 0.083333333333333333333333
 
+/*
+ * Stable Poisson probability evaluation based on:
+ * C. Loader, "Fast and Accurate Computation of Binomial Probabilities",
+ * 2002, equations 4, 6, and 7.
+ */
+
 /* Stirling's error: log(n!) - log(sqrt(2*pi*n) * (n/e)^n). */
 static double random_stirlerr(RAND_INT_TYPE n) {
   static const double sfe[16] = {

--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -572,12 +572,85 @@ static RAND_INT_TYPE random_poisson_mult(bitgen_t *bitgen_state, double lam) {
  */
 #define LS2PI 0.91893853320467267
 #define TWELFTH 0.083333333333333333333333
+
+/* Stirling's error: log(n!) - log(sqrt(2*pi*n) * (n/e)^n). */
+static double random_stirlerr(RAND_INT_TYPE n) {
+  static const double sfe[16] = {
+      0.0,
+      0.081061466795327258219670264,
+      0.041340695955409294093822081,
+      0.0276779256849983391487892927,
+      0.020790672103765093111522771,
+      0.0166446911898211921631948653,
+      0.013876128823070747998745727,
+      0.0118967099458917700950557241,
+      0.010411265261972096497478567,
+      0.0092554621827127329177286366,
+      0.008330563433362871256469318,
+      0.0075736754879518407949720242,
+      0.006942840107209529865664152,
+      0.0064089941880042070684396310,
+      0.005951370112758847735624416,
+      0.0055547335519628013710386899};
+  const double S0 = 0.083333333333333333333;
+  const double S1 = 0.00277777777777777777778;
+  const double S2 = 0.00079365079365079365079365;
+  const double S3 = 0.000595238095238095238095238;
+  const double S4 = 0.0008417508417508417508417508;
+  double nn;
+
+  if (n < 16) {
+    return sfe[n];
+  }
+  nn = (double)n * (double)n;
+  if (n > 500) {
+    return (S0 - S1 / nn) / (double)n;
+  }
+  if (n > 80) {
+    return (S0 - (S1 - S2 / nn) / nn) / (double)n;
+  }
+  if (n > 35) {
+    return (S0 - (S1 - (S2 - S3 / nn) / nn) / nn) / (double)n;
+  }
+  return (S0 - (S1 - (S2 - (S3 - S4 / nn) / nn) / nn) / nn) /
+         (double)n;
+}
+
+/* Compute x*log(x/np) + np - x without cancellation when x is near np. */
+static double random_bd0(double x, double np) {
+  double ej, s, s1, v;
+  int j;
+
+  if (fabs(x - np) < 0.1 * (x + np)) {
+    s = (x - np) * (x - np) / (x + np);
+    v = (x - np) / (x + np);
+    ej = 2.0 * x * v;
+    v *= v;
+    for (j = 1;; ++j) {
+      ej *= v;
+      s1 = s + ej / (2 * j + 1);
+      if (s1 == s) {
+        return s1;
+      }
+      s = s1;
+    }
+  }
+  return x * log(x / np) + np - x;
+}
+
+static double random_poisson_logpmf(RAND_INT_TYPE k, double lam) {
+  if (k == 0) {
+    return -lam;
+  }
+  return -random_stirlerr(k) - random_bd0((double)k, lam) - LS2PI -
+         0.5 * log((double)k);
+}
+
 static RAND_INT_TYPE random_poisson_ptrs(bitgen_t *bitgen_state, double lam) {
   RAND_INT_TYPE k;
-  double U, V, slam, loglam, a, b, invalpha, vr, us;
+  double U, V, slam, a, b, invalpha, vr, us;
 
   slam = sqrt(lam);
-  loglam = log(lam);
   b = 0.931 + 2.53 * slam;
   a = -0.059 + 0.02483 * b;
   invalpha = 1.1239 + 1.1328 / (b - 3.4);
@@ -597,7 +670,7 @@ static RAND_INT_TYPE random_poisson_ptrs(bitgen_t *bitgen_state, double lam) {
     /* log(V) == log(0.0) ok here */
     /* if U==0.0 so that us==0.0, log is ok since always returns */
     if ((log(V) + log(invalpha) - log(a / (us * us) + b)) <=
-        (-lam + (double)k * loglam - random_loggam((double)k + 1))) {
+        random_poisson_logpmf(k, lam)) {
       return k;
     }
   }

--- a/numpy/random/src/legacy/legacy-distributions.c
+++ b/numpy/random/src/legacy/legacy-distributions.c
@@ -127,7 +127,7 @@ double legacy_noncentral_chisquare(aug_bitgen_t *aug_state, double df,
     const double n = legacy_gauss(aug_state) + sqrt(nonc);
     return Chi2 + n * n;
   } else {
-    const long i = random_poisson(aug_state->bit_generator, nonc / 2.0);
+    const long i = legacy_random_poisson(aug_state->bit_generator, nonc / 2.0);
     out = legacy_chisquare(aug_state, df + 2 * i);
     /* Insert nan guard here to avoid changing the stream */
     if (npy_isnan(nonc)){
@@ -178,7 +178,7 @@ double legacy_standard_t(aug_bitgen_t *aug_state, double df) {
 
 int64_t legacy_negative_binomial(aug_bitgen_t *aug_state, double n, double p) {
   double Y = legacy_gamma(aug_state, n, (1 - p) / p);
-  return (int64_t)random_poisson(aug_state->bit_generator, Y);
+  return legacy_random_poisson(aug_state->bit_generator, Y);
 }
 
 double legacy_standard_cauchy(aug_bitgen_t *aug_state) {
@@ -571,8 +571,70 @@ int64_t legacy_random_hypergeometric(bitgen_t *bitgen_state, int64_t good,
 }
 
 
+static RAND_INT_TYPE legacy_random_poisson_mult(bitgen_t *bitgen_state,
+                                                double lam) {
+  RAND_INT_TYPE X;
+  double prod, U, enlam;
+
+  enlam = exp(-lam);
+  X = 0;
+  prod = 1.0;
+  while (1) {
+    U = next_double(bitgen_state);
+    prod *= U;
+    if (prod > enlam) {
+      X += 1;
+    } else {
+      return X;
+    }
+  }
+}
+
+/*
+ * The transformed rejection method for generating Poisson random variables
+ * W. Hoermann
+ * Insurance: Mathematics and Economics 12, 39-45 (1993)
+ */
+static RAND_INT_TYPE legacy_random_poisson_ptrs(bitgen_t *bitgen_state,
+                                                double lam) {
+  RAND_INT_TYPE k;
+  double U, V, slam, loglam, a, b, invalpha, vr, us;
+
+  slam = sqrt(lam);
+  loglam = log(lam);
+  b = 0.931 + 2.53 * slam;
+  a = -0.059 + 0.02483 * b;
+  invalpha = 1.1239 + 1.1328 / (b - 3.4);
+  vr = 0.9277 - 3.6224 / (b - 2);
+
+  while (1) {
+    U = next_double(bitgen_state) - 0.5;
+    V = next_double(bitgen_state);
+    us = 0.5 - fabs(U);
+    k = (RAND_INT_TYPE)floor((2 * a / us + b) * U + lam + 0.43);
+    if ((us >= 0.07) && (V <= vr)) {
+      return k;
+    }
+    if ((k < 0) || ((us < 0.013) && (V > us))) {
+      continue;
+    }
+    /* log(V) == log(0.0) ok here */
+    /* if U==0.0 so that us==0.0, log is ok since always returns */
+    if ((log(V) + log(invalpha) - log(a / (us * us) + b)) <=
+        (-lam + (double)k * loglam - random_loggam((double)k + 1))) {
+      return k;
+    }
+  }
+}
+
 int64_t legacy_random_poisson(bitgen_t *bitgen_state, double lam) {
-  return (int64_t)random_poisson(bitgen_state, lam);
+  if (lam >= 10) {
+    return (int64_t)legacy_random_poisson_ptrs(bitgen_state, lam);
+  } else if (lam == 0) {
+    return 0;
+  } else {
+    return (int64_t)legacy_random_poisson_mult(bitgen_state, lam);
+  }
 }
 
 int64_t legacy_random_zipf(bitgen_t *bitgen_state, double a) {

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -883,6 +883,15 @@ class TestRandomDist:
                             [0, 0]])
         assert_array_equal(actual, desired)
 
+    def test_poisson_large_lambda(self):
+        # The direct log-PMF used by PTRS loses precision through cancellation
+        # at large lambda, which distorts the variance of the samples.
+        lam = 1e17
+        rng = random.RandomState(self.seed)
+        samples = rng.poisson(lam=lam, size=10_000)
+
+        assert 0.8 < samples.var() / lam < 1.2
+
     def test_poisson_exceptions(self):
         lambig = np.iinfo('l').max
         lamneg = -1

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -892,8 +892,16 @@ class TestRandomDist:
         # at large lambda, which distorts the variance of the samples.
         lam = 1e17
         rng = random.RandomState(self.seed)
-        samples = rng.poisson(lam=lam, size=10_000)
+        actual = rng.poisson(lam=lam, size=3)
+        desired = np.array([
+            100000000107423792,
+            100000000449696768,
+            99999999962367168,
+        ])
+        assert_array_equal(actual, desired)
 
+        rng = np.random.default_rng(self.seed)
+        samples = rng.poisson(lam=lam, size=10_000)
         assert 0.8 < samples.var() / lam < 1.2
 
     def test_poisson_exceptions(self):

--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -883,6 +883,10 @@ class TestRandomDist:
                             [0, 0]])
         assert_array_equal(actual, desired)
 
+    @pytest.mark.skipif(
+        np.iinfo('l').max < 1e17,
+        reason="test requires support for lam=1e17",
+    )
     def test_poisson_large_lambda(self):
         # The direct log-PMF used by PTRS loses precision through cancellation
         # at large lambda, which distorts the variance of the samples.


### PR DESCRIPTION
### PR summary
This PR addresses [#31986](https://github.com/numpy/numpy/issues/31986) by implementing a stable calculation of Poisson log-PMF, adapted from [dbinom.c](https://web.archive.org/web/20011227233957/http://cm.bell-labs.com/cm/ms/departments/sia/catherine/dbinom/dbinom.c).

It is about approximately 10% faster on average (only tested on my system) and does not suffer from instabilities at larger $$\lambda$$, as seen by this plot created by [benchmark_poisson_ptrs.py](https://github.com/user-attachments/files/30116360/benchmark_poisson_ptrs.py). 

<img width="1800" height="1800" alt="performanceplot" src="https://github.com/user-attachments/assets/13268fd5-482e-44e3-b003-28848134c70d" />

### First time committer introduction
I’m interested in contributing to open-source software, and this is my first pull request to NumPy. I hope to continue contributing in the future. I’d be grateful for any feedback from the maintainers.

#### AI Disclosure
I used Codex Sol Light to check the port of the code discussed in the original issue, and to create the benchmarking script. The submitted C changes and regression test were prepared with this assistance and reviewed and tested by me.

