### PR TITLE
BUG: reject structured DTypes that contain StringDType fields

### DIFF
--- a/doc/release/upcoming_changes/32027.change.rst
+++ b/doc/release/upcoming_changes/32027.change.rst
@@ -1,0 +1,4 @@
+* Structured dtypes and subarray dtypes containing ``StringDType`` now
+  consistently raise ``TypeError``. Formerly some structured dtpes
+  containing ``StringDType`` could be created, but this could lead to
+  data corruption or crashes on array data accesses.

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -308,6 +308,18 @@ _convert_from_tuple(PyObject *obj, int align)
             return type;
         }
 
+        /*
+         * A subarray dtype is never attached to an array, so a base with
+         * per-instance state (a finalize slot, e.g. StringDType) could
+         * never be finalized and anything using the dtype would misbehave.
+         */
+        if (NPY_DT_SLOTS(NPY_DTYPE(type))->finalize_descr != NULL) {
+            PyErr_Format(PyExc_TypeError,
+                    "%s is not currently supported within subarray dtypes.",
+                    ((PyTypeObject *)NPY_DTYPE(type))->tp_name);
+            goto fail;
+        }
+
         /* validate and set shape */
         for (int i=0; i < shape.len; i++) {
             if (shape.ptr[i] < 0) {
@@ -389,21 +401,19 @@ _convert_from_tuple(PyObject *obj, int align)
 }
 
 /*
- * StringDType is not supported in structured dtypes.  Reject it as a field
- * dtype, including when it is wrapped in subarray dtypes.  Returns -1 with
- * an exception set if rejected, 0 otherwise.
+ * DTypes with a finalize slot (e.g. StringDType) carry per-instance state
+ * that array creation must finalize, which the structured dtype machinery
+ * does not do.  Reject them as field dtypes; they cannot be wrapped in
+ * subarray dtypes either, so subarray bases need not be checked.  Returns
+ * -1 with an exception set if rejected, 0 otherwise.
  */
 static int
-_reject_stringdtype_field(PyArray_Descr *descr)
+_reject_unsupported_field_dtype(PyArray_Descr *descr)
 {
-    while (PyDataType_HASSUBARRAY(descr)) {
-        descr = PyDataType_SUBARRAY(descr)->base;
-    }
-    if (PyObject_IsInstance((PyObject *)descr,
-                            (PyObject *)&PyArray_StringDType)) {
-        PyErr_SetString(PyExc_TypeError,
-                "StringDType is not currently supported for structured "
-                "dtype fields.");
+    if (NPY_DT_SLOTS(NPY_DTYPE(descr))->finalize_descr != NULL) {
+        PyErr_Format(PyExc_TypeError,
+                "%s is not currently supported for structured dtype "
+                "fields.", ((PyTypeObject *)NPY_DTYPE(descr))->tp_name);
         return -1;
     }
     return 0;
@@ -516,7 +526,7 @@ _convert_from_array_descr(PyObject *obj, int align)
                     "Field elements must be tuples with at most 3 elements, got '%R'", item);
             goto fail;
         }
-        if (_reject_stringdtype_field(conv) < 0) {
+        if (_reject_unsupported_field_dtype(conv) < 0) {
             Py_DECREF(conv);
             goto fail;
         }
@@ -660,7 +670,7 @@ _convert_from_list(PyObject *obj, int align)
         if (conv == NULL) {
             goto fail;
         }
-        if (_reject_stringdtype_field(conv) < 0) {
+        if (_reject_unsupported_field_dtype(conv) < 0) {
             Py_DECREF(conv);
             goto fail;
         }
@@ -1157,7 +1167,7 @@ _convert_from_dict(PyObject *obj, int align)
             Py_DECREF(ind);
             goto fail;
         }
-        if (_reject_stringdtype_field(newdescr) < 0) {
+        if (_reject_unsupported_field_dtype(newdescr) < 0) {
             Py_DECREF(newdescr);
             Py_DECREF(tup);
             Py_DECREF(ind);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -389,6 +389,27 @@ _convert_from_tuple(PyObject *obj, int align)
 }
 
 /*
+ * StringDType is not supported in structured dtypes.  Reject it as a field
+ * dtype, including when it is wrapped in subarray dtypes.  Returns -1 with
+ * an exception set if rejected, 0 otherwise.
+ */
+static int
+_reject_stringdtype_field(PyArray_Descr *descr)
+{
+    while (PyDataType_HASSUBARRAY(descr)) {
+        descr = PyDataType_SUBARRAY(descr)->base;
+    }
+    if (PyObject_IsInstance((PyObject *)descr,
+                            (PyObject *)&PyArray_StringDType)) {
+        PyErr_SetString(PyExc_TypeError,
+                "StringDType is not currently supported for structured "
+                "dtype fields.");
+        return -1;
+    }
+    return 0;
+}
+
+/*
  * obj is a list.  Each item is a tuple with
  *
  * (field-name, data-type (either a list or a string), and an optional
@@ -495,9 +516,8 @@ _convert_from_array_descr(PyObject *obj, int align)
                     "Field elements must be tuples with at most 3 elements, got '%R'", item);
             goto fail;
         }
-        if (PyObject_IsInstance((PyObject *)conv, (PyObject *)&PyArray_StringDType)) {
-            PyErr_Format(PyExc_TypeError,
-                         "StringDType is not currently supported for structured dtype fields.");
+        if (_reject_stringdtype_field(conv) < 0) {
+            Py_DECREF(conv);
             goto fail;
         }
         if ((PyDict_GetItemWithError(fields, name) != NULL) // noqa: borrowed-ref OK
@@ -638,6 +658,10 @@ _convert_from_list(PyObject *obj, int align)
         PyArray_Descr *conv = _convert_from_any(
                 PyList_GET_ITEM(obj, i), align); // noqa: borrowed-ref OK
         if (conv == NULL) {
+            goto fail;
+        }
+        if (_reject_stringdtype_field(conv) < 0) {
+            Py_DECREF(conv);
             goto fail;
         }
         dtypeflags |= (conv->flags & NPY_FROM_FIELDS);
@@ -1129,6 +1153,12 @@ _convert_from_dict(PyObject *obj, int align)
         PyArray_Descr *newdescr = _convert_from_any(descr, align);
         Py_DECREF(descr);
         if (newdescr == NULL) {
+            Py_DECREF(tup);
+            Py_DECREF(ind);
+            goto fail;
+        }
+        if (_reject_stringdtype_field(newdescr) < 0) {
+            Py_DECREF(newdescr);
             Py_DECREF(tup);
             Py_DECREF(ind);
             goto fail;

--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -483,3 +483,13 @@ def test_type_pickle():
 
 def test_is_numeric():
     assert SF._is_numeric
+
+
+def test_structured_field_allowed():
+    # dtypes without per-instance state (no finalize slot) are allowed as
+    # structured dtype fields and as subarray dtype bases
+    dt = np.dtype([("a", SF(2.))])
+    arr = np.zeros(2, dt)
+    arr["a"] = [1., 2.]
+    assert_array_equal(arr["a"].astype(np.float64), [1., 2.])
+    assert np.dtype((SF(2.), 3)).subdtype[0] == SF(2.)

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -115,28 +115,24 @@ def test_dtype_creation():
 
 @pytest.mark.parametrize("dtype_spec", [
     [("a", StringDType())],
+    [("a", StringDType(), 10)],
     [("a", (StringDType(), 10))],
-    [("a", np.dtype((StringDType(), 2)))],
-    [("a", (np.dtype((StringDType(), 2)), 3))],
     {"names": ["a"], "formats": [StringDType()]},
     {"names": ["a"], "formats": [(StringDType(), 2)]},
     {"a": (StringDType(), 0)},
     "T,i4",
 ])
 def test_structured_dtype_creation_rejected(dtype_spec):
-    with pytest.raises(TypeError,
-                       match="not currently supported for structured"):
+    with pytest.raises(TypeError, match="not currently supported"):
         np.dtype(dtype_spec)
 
 
-def test_subarray_dtype_allowed():
-    # subarray dtypes are not structured dtypes; array creation unwraps
-    # them into an extra dimension
-    arr = np.zeros(3, dtype=np.dtype((StringDType(), 2)))
-    assert arr.shape == (3, 2)
-    assert arr.dtype == StringDType()
-    arr[0, 0] = "hello" * 5
-    assert arr[0, 0] == "hello" * 5
+def test_subarray_dtype_rejected():
+    with pytest.raises(TypeError,
+                       match="not currently supported within subarray"):
+        np.dtype((StringDType(), 2))
+    # (dtype, ()) is equivalent to the dtype itself and remains allowed
+    assert np.dtype((StringDType(), ())) == StringDType()
 
 
 def test_dtype_equality(dtype):

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -113,6 +113,32 @@ def test_dtype_creation():
     assert len(hashes) == 4
 
 
+@pytest.mark.parametrize("dtype_spec", [
+    [("a", StringDType())],
+    [("a", (StringDType(), 10))],
+    [("a", np.dtype((StringDType(), 2)))],
+    [("a", (np.dtype((StringDType(), 2)), 3))],
+    {"names": ["a"], "formats": [StringDType()]},
+    {"names": ["a"], "formats": [(StringDType(), 2)]},
+    {"a": (StringDType(), 0)},
+    "T,i4",
+])
+def test_structured_dtype_creation_rejected(dtype_spec):
+    with pytest.raises(TypeError,
+                       match="not currently supported for structured"):
+        np.dtype(dtype_spec)
+
+
+def test_subarray_dtype_allowed():
+    # subarray dtypes are not structured dtypes; array creation unwraps
+    # them into an extra dimension
+    arr = np.zeros(3, dtype=np.dtype((StringDType(), 2)))
+    assert arr.shape == (3, 2)
+    assert arr.dtype == StringDType()
+    arr[0, 0] = "hello" * 5
+    assert arr[0, 0] == "hello" * 5
+
+
 def test_dtype_equality(dtype):
     assert dtype == dtype
     for ch in "SU":


### PR DESCRIPTION
### PR summary

Currently we reject structured dtypes that contain StringDType in only one code path:

https://github.com/numpy/numpy/blob/f67f65a1ab0d0998896703d6f205912d6975f966/numpy/_core/src/multiarray/descriptor.c#L498-L502

This rejects dtypes like `np.dtype([("a", StringDType())])` but lets through dtypes like `[("a", (T, 10))]` or `"T,i4"`.

This PR closes those holes.

There's also a reference leak in the existing error path, which this fixes.

### Open questions

Unfortunately people may be depending on the old, broken support. I'm not sure if closing these holes should trigger deprecation warnings?

Alternatively we could try to actually support StringDType subarrays, https://github.com/numpy/numpy/pull/32012#discussion_r3601337804 might have a path towards that.

#### AI Disclosure
I used an AI model to identify the code paths that need new errors. It also spotted the reference leak.