### PR TITLE
ENH: Support DLPack for scalars by exporting read-only data

### DIFF
--- a/doc/release/upcoming_changes/32029.new_feature.rst
+++ b/doc/release/upcoming_changes/32029.new_feature.rst
@@ -1,0 +1,6 @@
+Add DLPack support to NumPy scalars
+-----------------------------------
+``scalar.__dlpack__`` and ``scalar.__dlpack_device__`` methods have been added
+to NumPy scalars to allow exporting them to DLPack, similarly to ndarrays.
+Scalars can only be exported with read-only access (``__dlpack__(copy=False)``)
+and to DLPack version 1.0 or higher.

--- a/doc/release/upcoming_changes/32029.new_feature.rst
+++ b/doc/release/upcoming_changes/32029.new_feature.rst
@@ -2,5 +2,3 @@ Add DLPack support to NumPy scalars
 -----------------------------------
 ``scalar.__dlpack__`` and ``scalar.__dlpack_device__`` methods have been added
 to NumPy scalars to allow exporting them to DLPack, similarly to ndarrays.
-Scalars can only be exported with read-only access (``__dlpack__(copy=False)``)
-and to DLPack version 1.0 or higher.

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -5123,6 +5123,18 @@ class generic(_ArrayOrScalarCommon, Generic[_ItemT_co]):
         /,
     ) -> ScalarT | ndarray[ShapeT, _dtype[ScalarT]]: ...
 
+    #
+    def __dlpack__(
+        self,
+        /,
+        *,
+        stream: int | Any | None = None,
+        max_version: tuple[int, int] | None = None,
+        dl_device: tuple[int, int] | None = None,
+        copy: py_bool | None = None,
+    ) -> CapsuleType: ...
+    def __dlpack_device__(self, /) -> tuple[L[1], L[0]]: ...
+
     @property
     def base(self) -> None: ...
     @property

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -6932,6 +6932,13 @@ add_newdoc('numpy._core.numerictypes', 'generic', ('size',
 add_newdoc('numpy._core.numerictypes', 'generic', ('strides',
     """Tuple of bytes steps in each dimension."""))
 
+add_newdoc('numpy._core.numerictypes', 'generic', ('__dlpack__',
+    """Exports the scalar for consumption by ``from_dlpack()`` as a DLPack capsule."""))
+
+add_newdoc('numpy._core.numerictypes', 'generic', ('__dlpack_device__',
+    """Returns device type (``1``) and device ID (``0``) in DLPack format.
+    Meant for use within ``from_dlpack()``."""))
+
 # Methods
 
 add_newdoc('numpy._core.numerictypes', 'number', ('__class_getitem__',

--- a/numpy/_core/src/common/npy_dlpack.h
+++ b/numpy/_core/src/common/npy_dlpack.h
@@ -26,6 +26,15 @@ array_dlpack_device(PyArrayObject *self, PyObject *NPY_UNUSED(args));
 
 
 NPY_NO_EXPORT PyObject *
+gentype_dlpack(PyObject *self, PyObject *const *args, Py_ssize_t len_args,
+               PyObject *kwnames);
+
+
+NPY_NO_EXPORT PyObject *
+gentype_dlpack_device(PyObject *NPY_UNUSED(self), PyObject *NPY_UNUSED(args));
+
+
+NPY_NO_EXPORT PyObject *
 from_dlpack(PyObject *NPY_UNUSED(self),
         PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames);
 

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -661,10 +661,15 @@ gentype_dlpack(PyObject *self,
     }
 
     if (copy_mode == NPY_COPY_ALWAYS) {
-        // Scalars cannot be copied
-        PyErr_SetString(PyExc_BufferError,
-            "Cannot export scalars with copy=True to DLPack.");
-        return NULL;
+        /* Export a fresh 0-d array that owns the copied data. */
+        PyArrayObject *arr = (PyArrayObject *)PyArray_FromScalar(self, NULL);
+        if (arr == NULL) {
+            return NULL;
+        }
+        PyObject *res = create_dlpack_capsule(
+                NULL, arr, major_version >= 1, &result_device, 1);
+        Py_DECREF(arr);
+        return res;
     }
 
     if (major_version < 1) {
@@ -675,8 +680,7 @@ gentype_dlpack(PyObject *self,
     }
 
     return create_dlpack_capsule(
-            self, NULL, major_version >= 1, &result_device,
-            copy_mode == NPY_COPY_ALWAYS);
+            self, NULL, major_version >= 1, &result_device, 0);
 }
 
 NPY_NO_EXPORT PyObject *

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -396,7 +396,15 @@ fill_dl_tensor_information_from_scalar(
     DLTensor *dl_tensor, PyObject *self, DLDevice *result_device)
 {
     PyArray_Descr *dtype = PyArray_DescrFromScalar(self);
+    if (dtype == NULL) {
+        return -1;
+    }
+
     void *data = scalar_value(self, dtype);
+    if (data == NULL) {
+        Py_DECREF(dtype);
+        return -1;
+    }
 
     int ret = fill_dl_tensor_information(dl_tensor, result_device,
         dtype->elsize, 0, NULL, NULL, dtype, data);
@@ -546,7 +554,7 @@ array_dlpack(PyArrayObject *self,
             {"$stream", NULL, &stream},
             {"$max_version", NULL, &max_version},
             {"$dl_device", &device_converter, &result_device},
-            {"$copy", &PyArray_CopyConverter, &copy_mode})) {
+            {"$copy", &PyArray_CopyConverter, &copy_mode}) < 0) {
         return NULL;
     }
 
@@ -621,8 +629,7 @@ gentype_dlpack(PyObject *self,
     PyObject *stream = Py_None;
     PyObject *max_version = Py_None;
     NPY_COPYMODE copy_mode = NPY_COPY_IF_NEEDED;
-    /* For scalars, version >=1 is supported, so set default to 1. */
-    long major_version = 1;
+    long major_version = 0;
     /* We allow the user to request a result device in principle. */
     DLDevice result_device = {kDLCPU, 0};
 
@@ -631,7 +638,7 @@ gentype_dlpack(PyObject *self,
             {"$stream", NULL, &stream},
             {"$max_version", NULL, &max_version},
             {"$dl_device", &device_converter, &result_device},
-            {"$copy", &PyArray_CopyConverter, &copy_mode})) {
+            {"$copy", &PyArray_CopyConverter, &copy_mode}) < 0) {
         return NULL;
     }
 
@@ -667,21 +674,13 @@ gentype_dlpack(PyObject *self,
         return NULL;
     }
 
-    /*
-     * TODO: The versioned and non-versioned structs of DLPack are very
-     * similar but not ABI compatible so that the function called here requires
-     * branching (templating didn't seem worthwhile).
-     *
-     * Version 0 support should be deprecated in NumPy 2.1 and the branches
-     * can then be removed again.
-     */
     return create_dlpack_capsule(
             self, NULL, major_version >= 1, &result_device,
             copy_mode == NPY_COPY_ALWAYS);
 }
 
 NPY_NO_EXPORT PyObject *
-gentype_dlpack_device(PyObject *self, PyObject *NPY_UNUSED(args))
+gentype_dlpack_device(PyObject *NPY_UNUSED(self), PyObject *NPY_UNUSED(args))
 {
     return Py_BuildValue("ii", kDLCPU, 0);
 }

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -106,7 +106,7 @@ array_dlpack_deleter(DLManagedTensorVersioned *self)
 
     PyGILState_STATE state = PyGILState_Ensure();
 
-    PyArrayObject *array = (PyArrayObject *)self->manager_ctx;
+    PyObject *array = self->manager_ctx;
     // This will also free the shape and strides as it's one allocation.
     PyMem_Free(self);
     Py_XDECREF(array);
@@ -127,25 +127,6 @@ array_dlpack_deleter_unversioned(DLManagedTensor *self)
     PyArrayObject *array = (PyArrayObject *)self->manager_ctx;
     PyMem_Free(self);
     Py_XDECREF(array);
-
-    PyGILState_Release(state);
-}
-
-/*
- * Deleter for a NumPy exported scalar dlpack DLManagedTensor(Versioned).
- */
-static void
-scalar_dlpack_deleter(DLManagedTensorVersioned *self)
-{
-    if (!Py_IsInitialized()) {
-        return;
-    }
-
-    PyGILState_STATE state = PyGILState_Ensure();
-
-    PyObject *scalar = (PyObject *)self->manager_ctx;
-    PyMem_Free(self);
-    Py_XDECREF(scalar);
 
     PyGILState_Release(state);
 }
@@ -454,12 +435,7 @@ create_dlpack_capsule(PyObject *scalar, PyArrayObject *array,
         DLManagedTensorVersioned *managed = (DLManagedTensorVersioned *)ptr;
         capsule_name = NPY_DLPACK_VERSIONED_CAPSULE_NAME;
         capsule_deleter = (PyCapsule_Destructor)dlpack_capsule_deleter;
-        if (array == NULL) {
-            managed->deleter = scalar_dlpack_deleter;
-        }
-        else {
-            managed->deleter = array_dlpack_deleter;
-        }
+        managed->deleter = array_dlpack_deleter;
         managed->manager_ctx = self;
 
         dl_tensor = &managed->dl_tensor;

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -6,6 +6,7 @@
 
 #include "dlpack/dlpack.h"
 #include "numpy/arrayobject.h"
+#include "scalartypes.h"
 #include "npy_pycompat.h"
 #include "npy_argparse.h"
 #include "npy_dlpack.h"
@@ -130,6 +131,24 @@ array_dlpack_deleter_unversioned(DLManagedTensor *self)
     PyGILState_Release(state);
 }
 
+/*
+ * Deleter for a NumPy exported scalar dlpack DLManagedTensor(Versioned).
+ */
+static void
+scalar_dlpack_deleter(DLManagedTensorVersioned *self)
+{
+    if (!Py_IsInitialized()) {
+        return;
+    }
+
+    PyGILState_STATE state = PyGILState_Ensure();
+
+    PyObject *scalar = (PyObject *)self->manager_ctx;
+    PyMem_Free(self);
+    Py_XDECREF(scalar);
+
+    PyGILState_Release(state);
+}
 
 /*
  * Deleter for a DLPack capsule wrapping a DLManagedTensor(Versioned).
@@ -262,31 +281,16 @@ array_get_dl_device(PyArrayObject *self) {
 
 
 /*
- * Fill the dl_tensor struct from the `self` array.
+ * Fill the dl_tensor struct from array or scalar details.
  * This struct could be versioned, but as of now is not.
  */
 static int
 fill_dl_tensor_information(
-    DLTensor *dl_tensor, PyArrayObject *self, DLDevice *result_device)
+    DLTensor *dl_tensor, DLDevice *result_device,
+    npy_intp itemsize, int ndim, npy_intp *strides, npy_intp *shape,
+    PyArray_Descr *dtype, void *data)
 {
-    npy_intp itemsize = PyArray_ITEMSIZE(self);
-    int ndim = PyArray_NDIM(self);
-    npy_intp *strides = PyArray_STRIDES(self);
-    npy_intp *shape = PyArray_SHAPE(self);
-
-    if (!PyArray_IS_C_CONTIGUOUS(self) && PyArray_SIZE(self) != 1) {
-        for (int i = 0; i < ndim; ++i) {
-            if (shape[i] != 1 && strides[i] % itemsize != 0) {
-                PyErr_SetString(PyExc_BufferError,
-                        "DLPack only supports strides which are a multiple of "
-                        "itemsize.");
-                return -1;
-            }
-        }
-    }
-
     DLDataType managed_dtype;
-    PyArray_Descr *dtype = PyArray_DESCR(self);
 
     if (PyDataType_ISBYTESWAPPED(dtype)) {
         PyErr_SetString(PyExc_BufferError,
@@ -356,7 +360,7 @@ fill_dl_tensor_information(
      * that NumPy MUST use `byte_offset` to adhere to the standard (as
      * specified in the header)!
      */
-    dl_tensor->data = PyArray_DATA(self);
+    dl_tensor->data = data;
     dl_tensor->byte_offset = 0;
     dl_tensor->device = *result_device;
     dl_tensor->dtype = managed_dtype;
@@ -366,19 +370,66 @@ fill_dl_tensor_information(
         // Strides in DLPack are items; in NumPy are bytes.
         dl_tensor->strides[i] = strides[i] / itemsize;
     }
-
     dl_tensor->ndim = ndim;
-    dl_tensor->byte_offset = 0;
 
     return 0;
 }
 
 
-static PyObject *
-create_dlpack_capsule(
-        PyArrayObject *self, int versioned, DLDevice *result_device, int copied)
+/*
+ * Fill the dl_tensor struct from a `self` array.
+ */
+static int
+fill_dl_tensor_information_from_array(
+    DLTensor *dl_tensor, PyArrayObject *self, DLDevice *result_device)
 {
+    npy_intp itemsize = PyArray_ITEMSIZE(self);
     int ndim = PyArray_NDIM(self);
+    npy_intp *strides = PyArray_STRIDES(self);
+    npy_intp *shape = PyArray_SHAPE(self);
+
+    if (!PyArray_IS_C_CONTIGUOUS(self) && PyArray_SIZE(self) != 1) {
+        for (int i = 0; i < ndim; ++i) {
+            if (shape[i] != 1 && strides[i] % itemsize != 0) {
+                PyErr_SetString(PyExc_BufferError,
+                        "DLPack only supports strides which are a multiple of "
+                        "itemsize.");
+                return -1;
+            }
+        }
+    }
+
+    PyArray_Descr *dtype = PyArray_DESCR(self);
+    void *data = PyArray_DATA(self);
+
+    return fill_dl_tensor_information(dl_tensor, result_device,
+            itemsize, ndim, strides, shape, dtype, data);
+}
+
+
+/*
+ * Fill the dl_tensor struct from a `self` scalar.
+ */
+static int
+fill_dl_tensor_information_from_scalar(
+    DLTensor *dl_tensor, PyObject *self, DLDevice *result_device)
+{
+    PyArray_Descr *dtype = PyArray_DescrFromScalar(self);
+    void *data = scalar_value(self, dtype);
+
+    int ret = fill_dl_tensor_information(dl_tensor, result_device,
+        dtype->elsize, 0, NULL, NULL, dtype, data);
+    Py_DECREF(dtype);
+    return ret;
+}
+
+
+static PyObject *
+create_dlpack_capsule(PyObject *scalar, PyArrayObject *array,
+    int versioned, DLDevice *result_device, int copied)
+{
+    int ndim = array == NULL ? 0 : PyArray_NDIM(array);
+    PyObject *self = array == NULL ? scalar : (PyObject *)array;
 
     /*
      * We align shape and strides at the end but need to align them, offset
@@ -403,7 +454,12 @@ create_dlpack_capsule(
         DLManagedTensorVersioned *managed = (DLManagedTensorVersioned *)ptr;
         capsule_name = NPY_DLPACK_VERSIONED_CAPSULE_NAME;
         capsule_deleter = (PyCapsule_Destructor)dlpack_capsule_deleter;
-        managed->deleter = array_dlpack_deleter;
+        if (array == NULL) {
+            managed->deleter = scalar_dlpack_deleter;
+        }
+        else {
+            managed->deleter = array_dlpack_deleter;
+        }
         managed->manager_ctx = self;
 
         dl_tensor = &managed->dl_tensor;
@@ -413,11 +469,16 @@ create_dlpack_capsule(
         managed->version.minor = 0;
 
         managed->flags = 0;
-        if (!PyArray_CHKFLAGS(self, NPY_ARRAY_WRITEABLE)) {
-            managed->flags |= DLPACK_FLAG_BITMASK_READ_ONLY;
+        if (array != NULL) {
+            if (!PyArray_CHKFLAGS(array, NPY_ARRAY_WRITEABLE)) {
+                managed->flags |= DLPACK_FLAG_BITMASK_READ_ONLY;
+            }
+            if (copied) {
+                managed->flags |= DLPACK_FLAG_BITMASK_IS_COPIED;
+            }
         }
-        if (copied) {
-            managed->flags |= DLPACK_FLAG_BITMASK_IS_COPIED;
+        else {
+            managed->flags |= DLPACK_FLAG_BITMASK_READ_ONLY;
         }
     }
     else {
@@ -433,7 +494,16 @@ create_dlpack_capsule(
     dl_tensor->shape = (ndim > 0) ? (int64_t *)((char *)ptr + offset) : NULL;
     dl_tensor->strides = (ndim > 0) ? dl_tensor->shape + ndim : NULL;
 
-    if (fill_dl_tensor_information(dl_tensor, self, result_device) < 0) {
+    int ret;
+    if (array == NULL) {
+        ret = fill_dl_tensor_information_from_scalar(dl_tensor,
+            scalar, result_device);
+    }
+    else {
+        ret = fill_dl_tensor_information_from_array(dl_tensor,
+            array, result_device);
+    }
+    if (ret < 0) {
         PyMem_Free(ptr);
         return NULL;
     }
@@ -551,7 +621,7 @@ array_dlpack(PyArrayObject *self,
      * can then be removed again.
      */
     PyObject *res = create_dlpack_capsule(
-            self, major_version >= 1, &result_device,
+            NULL, self, major_version >= 1, &result_device,
             copy_mode == NPY_COPY_ALWAYS);
     Py_DECREF(self);
 
@@ -566,6 +636,78 @@ array_dlpack_device(PyArrayObject *self, PyObject *NPY_UNUSED(args))
         return NULL;
     }
     return Py_BuildValue("ii", device.device_type, device.device_id);
+}
+
+NPY_NO_EXPORT PyObject *
+gentype_dlpack(PyObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+{
+    PyObject *stream = Py_None;
+    PyObject *max_version = Py_None;
+    NPY_COPYMODE copy_mode = NPY_COPY_IF_NEEDED;
+    /* For scalars, version >=1 is supported, so set default to 1. */
+    long major_version = 1;
+    /* We allow the user to request a result device in principle. */
+    DLDevice result_device = {kDLCPU, 0};
+
+    NPY_PREPARE_ARGPARSER;
+    if (npy_parse_arguments("__dlpack__", args, len_args, kwnames,
+            {"$stream", NULL, &stream},
+            {"$max_version", NULL, &max_version},
+            {"$dl_device", &device_converter, &result_device},
+            {"$copy", &PyArray_CopyConverter, &copy_mode})) {
+        return NULL;
+    }
+
+    if (max_version != Py_None) {
+        if (!PyTuple_Check(max_version) || PyTuple_GET_SIZE(max_version) != 2) {
+            PyErr_SetString(PyExc_TypeError,
+                    "max_version must be None or a tuple with two elements.");
+            return NULL;
+        }
+        major_version = PyLong_AsLong(PyTuple_GET_ITEM(max_version, 0));
+        if (major_version == -1 && PyErr_Occurred()) {
+            return NULL;
+        }
+    }
+
+    if (stream != Py_None) {
+        PyErr_SetString(PyExc_ValueError,
+                "NumPy only supports stream=None.");
+        return NULL;
+    }
+
+    if (copy_mode == NPY_COPY_ALWAYS) {
+        // Scalars cannot be copied
+        PyErr_SetString(PyExc_BufferError,
+            "Cannot export scalars with copy=True to DLPack.");
+        return NULL;
+    }
+
+    if (major_version < 1) {
+        PyErr_SetString(PyExc_BufferError,
+            "Cannot export scalars since signalling readonly "
+            "is unsupported by DLPack (supported by newer DLPack version).");
+        return NULL;
+    }
+
+    /*
+     * TODO: The versioned and non-versioned structs of DLPack are very
+     * similar but not ABI compatible so that the function called here requires
+     * branching (templating didn't seem worthwhile).
+     *
+     * Version 0 support should be deprecated in NumPy 2.1 and the branches
+     * can then be removed again.
+     */
+    return create_dlpack_capsule(
+            self, NULL, major_version >= 1, &result_device,
+            copy_mode == NPY_COPY_ALWAYS);
+}
+
+NPY_NO_EXPORT PyObject *
+gentype_dlpack_device(PyObject *self, PyObject *NPY_UNUSED(args))
+{
+    return Py_BuildValue("ii", kDLCPU, 0);
 }
 
 NPY_NO_EXPORT PyObject *

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -663,7 +663,8 @@ gentype_dlpack(PyObject *self,
         return NULL;
     }
 
-    if (copy_mode == NPY_COPY_ALWAYS) {
+    if (copy_mode != NPY_COPY_NEVER && major_version < 1
+        || copy_mode == NPY_COPY_ALWAYS) {
         /* Export a fresh 0-d array that owns the copied data. */
         PyArrayObject *arr = (PyArrayObject *)PyArray_FromScalar(self, NULL);
         if (arr == NULL) {
@@ -678,7 +679,8 @@ gentype_dlpack(PyObject *self,
     if (major_version < 1) {
         PyErr_SetString(PyExc_BufferError,
             "Cannot export scalars since signalling readonly "
-            "is unsupported by DLPack (supported by newer DLPack version).");
+            "is unsupported by DLPack (supported by newer DLPack version)."
+            "Consider using `copy=True` if possible.");
         return NULL;
     }
 

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -663,13 +663,16 @@ gentype_dlpack(PyObject *self,
         return NULL;
     }
 
-    if (copy_mode != NPY_COPY_NEVER && major_version < 1
-        || copy_mode == NPY_COPY_ALWAYS) {
+    if ((copy_mode != NPY_COPY_NEVER && major_version < 1)
+        || (copy_mode == NPY_COPY_ALWAYS)) {
         /* Export a fresh 0-d array that owns the copied data. */
         PyArrayObject *arr = (PyArrayObject *)PyArray_FromScalar(self, NULL);
         if (arr == NULL) {
             return NULL;
         }
+        /* Ensure the array is not a view */
+        assert(PyArray_BASE(arr) == NULL);
+
         PyObject *res = create_dlpack_capsule(
                 NULL, arr, major_version >= 1, &result_device, 1);
         Py_DECREF(arr);

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -420,6 +420,9 @@ create_dlpack_capsule(PyObject *scalar, PyArrayObject *array,
     int ndim = array == NULL ? 0 : PyArray_NDIM(array);
     PyObject *self = array == NULL ? scalar : (PyObject *)array;
 
+    /* Scalars are exported read-only, which only versioned capsules can signal. */
+    assert(array != NULL || versioned);
+ 
     /*
      * We align shape and strides at the end but need to align them, offset
      * gives the offset of the shape (and strides) including the struct size.

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -422,7 +422,7 @@ create_dlpack_capsule(PyObject *scalar, PyArrayObject *array,
 
     /* Scalars are exported read-only, which only versioned capsules can signal. */
     assert(array != NULL || versioned);
- 
+
     /*
      * We align shape and strides at the end but need to align them, offset
      * gives the offset of the shape (and strides) including the struct size.

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -36,6 +36,7 @@
 #include "dragon4.h"
 #include "npy_longdouble.h"
 #include "npy_buffer.h"
+#include "npy_dlpack.h"
 #include "npy_static_data.h"
 #include "multiarraymodule.h"
 #include "array_api_standard.h"
@@ -2830,6 +2831,14 @@ static PyMethodDef gentype_methods[] = {
     {"setflags",
         (PyCFunction)gentype_setflags,
         METH_VARARGS | METH_KEYWORDS, NULL},
+
+    /* For data interchange between libraries */
+    {"__dlpack__",
+        (PyCFunction)gentype_dlpack,
+        METH_FASTCALL | METH_KEYWORDS, NULL},
+    {"__dlpack_device__",
+        (PyCFunction)gentype_dlpack_device,
+        METH_NOARGS, NULL},
 
     /* For Array API compatibility */
     {"__array_namespace__",

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -309,6 +309,10 @@ class TestScalarDLPack:
             # None is equivalent to (0, 0)
             x.__dlpack__()
 
+        # if copy=True, then we create a 0-D array, so should work
+        x.__dlpack__(max_version=(0, 0), copy=True)
+        x.__dlpack__(max_version=None, copy=True)
+
     def test_dlpack_copy(self):
         x = np.float64(2)
         y = np.from_dlpack(x, copy=True)

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -309,10 +309,26 @@ class TestScalarDLPack:
             # None is equivalent to (0, 0)
             x.__dlpack__()
 
-    def test_dlpack_cannot_copy(self):
+    def test_dlpack_copy(self):
         x = np.float64(2)
-        with pytest.raises(BufferError, match="copy=True"):
-            np.from_dlpack(x, copy=True)
+        y = np.from_dlpack(x, copy=True)
+        assert x.dtype == y.dtype
+        assert y.shape == ()
+        assert x == y
+
+        y[()] = 3
+        assert x == 2
+        assert y == 3
+
+    @pytest.mark.parametrize("copy", [False, None])
+    def test_dlpack_read_only(self, copy):
+        x = np.float64(2)
+        y = np.from_dlpack(x, copy=copy)
+
+        with pytest.raises(
+            ValueError, match="assignment destination is read-only"
+        ):
+            y[()] = 3
 
     @pytest.mark.parametrize("dtype", [np.str_, np.datetime64])
     def test_invalid_dtype(self, dtype):
@@ -332,12 +348,3 @@ class TestScalarDLPack:
             x.__dlpack__(dl_device=(10, 0), max_version=(1, 0))
         with pytest.raises(ValueError):
             np.from_dlpack(x, device="gpu")
-
-    def test_cannot_write_to_scalar(self):
-        x = np.float64(2)
-        y = np.from_dlpack(x)
-
-        with pytest.raises(
-            ValueError, match="assignment destination is read-only"
-        ):
-            y[()] = 3

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -296,7 +296,7 @@ class TestScalarDLPack:
 
     def test_dunder_dlpack_refcount(self):
         x = np.float64(2)
-        y = x.__dlpack__()
+        y = x.__dlpack__(max_version=(1, 0))
         startcount = sys.getrefcount(x)
         del y
         assert startcount - sys.getrefcount(x) == 1
@@ -305,6 +305,9 @@ class TestScalarDLPack:
         x = np.float64(2)
         with pytest.raises(BufferError, match="readonly is unsupported"):
             x.__dlpack__(max_version=(0, 0))
+        with pytest.raises(BufferError, match="readonly is unsupported"):
+            # None is equivalent to (0, 0)
+            x.__dlpack__()
 
     def test_dlpack_cannot_copy(self):
         x = np.float64(2)
@@ -321,12 +324,12 @@ class TestScalarDLPack:
     def test_device(self):
         x = np.float64(2)
         # requesting (1, 0), i.e. CPU device works in both calls:
-        x.__dlpack__(dl_device=(1, 0))
+        x.__dlpack__(dl_device=(1, 0), max_version=(1, 0))
         np.from_dlpack(x, device="cpu")
         np.from_dlpack(x, device=None)
 
         with pytest.raises(BufferError):
-            x.__dlpack__(dl_device=(10, 0))
+            x.__dlpack__(dl_device=(10, 0), max_version=(1, 0))
         with pytest.raises(ValueError):
             np.from_dlpack(x, device="gpu")
 

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -260,3 +260,81 @@ class TestRegisterDlpackDtype:
         arr.__dlpack__()  # passes
         with pytest.raises(BufferError):
             np.from_dlpack(arr)  # doesn't round-trip
+
+
+class TestScalarDLPack:
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            np.bool_,
+            np.uint8,
+            np.int32,
+            np.int64,
+            np.float16,
+            np.float32,
+            np.float64,
+            np.complex128,
+        ],
+    )
+    def test_dlpack(self, dtype):
+        x = dtype(2)
+        y = np.from_dlpack(x)
+
+        assert x.dtype == y.dtype
+        assert y.shape == ()
+        assert x == y
+
+        # copy=False
+        y = np.from_dlpack(x, copy=False)
+        assert x.dtype == y.dtype
+        assert y.shape == ()
+        assert x == y
+
+    def test_dlpack_device(self):
+        x = np.float64(2)
+        assert x.__dlpack_device__() == (1, 0)
+
+    def test_dunder_dlpack_refcount(self):
+        x = np.float64(2)
+        y = x.__dlpack__()
+        startcount = sys.getrefcount(x)
+        del y
+        assert startcount - sys.getrefcount(x) == 1
+
+    def test_dunder_dlpack_version(self):
+        x = np.float64(2)
+        with pytest.raises(BufferError, match="readonly is unsupported"):
+            x.__dlpack__(max_version=(0, 0))
+
+    def test_dlpack_cannot_copy(self):
+        x = np.float64(2)
+        with pytest.raises(BufferError, match="copy=True"):
+            np.from_dlpack(x, copy=True)
+
+    @pytest.mark.parametrize("dtype", [np.str_, np.datetime64])
+    def test_invalid_dtype(self, dtype):
+        x = dtype('2021-05-27')
+
+        with pytest.raises(BufferError):
+            np.from_dlpack(x)
+
+    def test_device(self):
+        x = np.float64(2)
+        # requesting (1, 0), i.e. CPU device works in both calls:
+        x.__dlpack__(dl_device=(1, 0))
+        np.from_dlpack(x, device="cpu")
+        np.from_dlpack(x, device=None)
+
+        with pytest.raises(BufferError):
+            x.__dlpack__(dl_device=(10, 0))
+        with pytest.raises(ValueError):
+            np.from_dlpack(x, device="gpu")
+
+    def test_cannot_write_to_scalar(self):
+        x = np.float64(2)
+        y = np.from_dlpack(x)
+
+        with pytest.raises(
+            ValueError, match="assignment destination is read-only"
+        ):
+            y[()] = 3

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -304,10 +304,10 @@ class TestScalarDLPack:
     def test_dunder_dlpack_version(self):
         x = np.float64(2)
         with pytest.raises(BufferError, match="readonly is unsupported"):
-            x.__dlpack__(max_version=(0, 0))
+            x.__dlpack__(max_version=(0, 0), copy=False)
         with pytest.raises(BufferError, match="readonly is unsupported"):
             # None is equivalent to (0, 0)
-            x.__dlpack__()
+            x.__dlpack__(copy=False)
 
         # if copy=True, then we create a 0-D array, so should work
         x.__dlpack__(max_version=(0, 0), copy=True)
@@ -324,10 +324,9 @@ class TestScalarDLPack:
         assert x == 2
         assert y == 3
 
-    @pytest.mark.parametrize("copy", [False, None])
-    def test_dlpack_read_only(self, copy):
+    def test_dlpack_read_only(self):
         x = np.float64(2)
-        y = np.from_dlpack(x, copy=copy)
+        y = np.from_dlpack(x, copy=False)
 
         with pytest.raises(
             ValueError, match="assignment destination is read-only"


### PR DESCRIPTION
Resolves #27137 by adding DLPack support to scalars. Unlike #31893, this does not convert to a dummy 0-D array, instead as suggested by @seberg, exposes a read-only reference to the scalar's underlying data (the same function used for the buffer protocol). As a result only `copy=False` is allowed, the shared memory is read-only and signaled as such, and therefore DLPack >=1 is supported.

I'm going to recheck some of the trickier things around argument parsing / defaults, but this should be mostly ready for review. Thanks!

#### AI Disclosure
I used an agent to find correctness issues and suggest missing tests.
