### PR TITLE
MAINT: fix ma.vander docstring to match its actual signature

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -2242,6 +2242,34 @@ def clump_masked(a):
 
 def vander(x, n=None):
     """
+    Generate a Vandermonde matrix, treating masked values as zero rows.
+
+    The columns of the output matrix are powers of the input vector,
+    with the `i`-th output column equal to the input vector raised
+    element-wise to the power of ``n - i - 1``.
+
+    Parameters
+    ----------
+    x : array_like
+        1-D input array. Masked values are set to zero in the
+        corresponding rows of the output.
+    n : int, optional
+        Number of columns in the output. If `n` is not specified, a
+        square array is returned (``n = len(x)``).
+
+    Returns
+    -------
+    out : ndarray
+        Vandermonde matrix. The first column is ``x^(n-1)``, the
+        second ``x^(n-2)`` and so forth. Rows corresponding to masked
+        values in `x` are set to zero.
+
+    See Also
+    --------
+    numpy.vander
+
+    Notes
+    -----
     Masked values in the input array result in rows of zeros.
 
     """
@@ -2250,9 +2278,6 @@ def vander(x, n=None):
     if m is not nomask:
         _vander[m] = 0
     return _vander
-
-
-vander.__doc__ = ma.doc_note(np.vander.__doc__, vander.__doc__)
 
 
 def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -60,6 +60,7 @@ from numpy.ma.extras import (
     stack,
     union1d,
     unique,
+    vander,
     vstack,
 )
 from numpy.ma.testutils import (
@@ -1447,6 +1448,30 @@ class TestCorrcoef:
         test = corrcoef(x)
         control = np.corrcoef(x)
         assert_almost_equal(test[:-1, :-1], control[:-1, :-1])
+
+
+class TestVander:
+
+    def test_vander(self):
+        # ma.vander should match np.vander for unmasked input, and zero
+        # out rows corresponding to masked entries.
+        x = np.array([1, 2, 3, 5])
+        assert_equal(vander(x, 3), np.vander(x, 3))
+        assert_equal(vander(x), np.vander(x))
+
+        mx = MaskedArray(x, mask=[0, 1, 0, 0])
+        expected = np.vander(x)
+        expected[1] = 0
+        assert_equal(vander(mx), expected)
+
+    def test_vander_docstring_matches_signature(self):
+        # ma.vander does not support the `increasing` keyword that
+        # np.vander documents; its docstring should not claim otherwise.
+        # See https://github.com/numpy/numpy/issues/32033
+        assert 'increasing' not in vander.__doc__
+        x = np.array([1, 2, 3, 5])
+        with pytest.raises(TypeError):
+            vander(x, increasing=True)
 
 
 class TestPolynomial:


### PR DESCRIPTION
Closes #32033.

## Problem

`numpy.ma.vander` reuses `numpy.vander`'s docstring via `ma.doc_note(np.vander.__doc__, vander.__doc__)`, but `ma.vander`'s actual signature is `(x, n=None)` -- it does not implement the `increasing` parameter that the inherited docstring describes (and documents with an example). Following the published docs and calling `np.ma.vander(x, increasing=True)` raises `TypeError`.

## Fix

This resolves the mismatch by giving `ma.vander` its own accurate, self-contained docstring describing only the parameters it actually accepts (`x`, `n`), plus a `Notes` section describing the masked-value behavior. This is option 2 from the issue discussion (correct the docs to match the implementation, rather than adding `increasing` support to the implementation).

## Testing

Added `TestVander` to `numpy/ma/tests/test_extras.py`:
- `test_vander`: verifies `ma.vander` matches `np.vander` for unmasked input and zeroes masked rows.
- `test_vander_docstring_matches_signature`: asserts `increasing` is no longer mentioned in the docstring, and that passing it still raises `TypeError` (regression guard against re-introducing the mismatch).

Ran the full `numpy/ma/tests/test_extras.py` suite (105 tests) against the patched module in an isolated environment -- all pass, no regressions.