### PR TITLE
DOC: improve documentation for state stored in context variables

### DIFF
--- a/doc/source/reference/c-api/data_memory.rst
+++ b/doc/source/reference/c-api/data_memory.rst
@@ -52,7 +52,7 @@ functions may change during the lifetime of the process, each ``ndarray``
 carries with it the functions used at the time of its instantiation, and these
 will be used to reallocate or free the data memory of the instance.
 
-NumPy stores the memory handler state in a py:mod:`context variable
+NumPy stores the memory handler state in a :py:mod:`context variable
 <python:contextvars>`, allowing different threads or async tasks to have
 independent configurations. See :ref:`context_local` for more information.
 

--- a/doc/source/reference/c-api/data_memory.rst
+++ b/doc/source/reference/c-api/data_memory.rst
@@ -52,6 +52,10 @@ functions may change during the lifetime of the process, each ``ndarray``
 carries with it the functions used at the time of its instantiation, and these
 will be used to reallocate or free the data memory of the instance.
 
+NumPy stores the memory handler state in a py:mod:`context variable
+<python:contextvars>`, allowing different threads or async tasks to have
+independent configurations. See :ref:`context_local` for more information.
+
 .. c:type:: PyDataMem_Handler
 
     A struct to hold function pointers used to manipulate memory

--- a/doc/source/reference/routines.err.rst
+++ b/doc/source/reference/routines.err.rst
@@ -7,7 +7,7 @@ Floating point error handling
 
 Error handling settings are stored in :py:mod:`python:contextvars`
 allowing different threads or async tasks to have independent configurations.
-For more information, see :ref:`thread_safety`.
+For more information, see :ref:`context_local`.
 
 .. _misc-error-handling:
 

--- a/doc/source/reference/routines.io.rst
+++ b/doc/source/reference/routines.io.rst
@@ -66,7 +66,7 @@ Text formatting options
 
 Text formatting settings are maintained in a :py:mod:`context variable <python:contextvars>`,
 allowing different threads or async tasks to have independent configurations.
-For more information, see :ref:`context-local`.
+For more information, see :ref:`context_local`.
 
 .. autosummary::
    :toctree: generated/

--- a/doc/source/reference/routines.io.rst
+++ b/doc/source/reference/routines.io.rst
@@ -66,7 +66,7 @@ Text formatting options
 
 Text formatting settings are maintained in a :py:mod:`context variable <python:contextvars>`,
 allowing different threads or async tasks to have independent configurations.
-For more information, see :ref:`thread_safety`.
+For more information, see :ref:`context-local`.
 
 .. autosummary::
    :toctree: generated/

--- a/doc/source/reference/thread_safety.rst
+++ b/doc/source/reference/thread_safety.rst
@@ -62,8 +62,6 @@ statement. For example, you can update the numpy printing options state like so:
 
 This property applies to all context-local state, not just `numpy.printoptions`.
 
-.. _context_local:
-
 Interaction with the `threading` module
 +++++++++++++++++++++++++++++++++++++++
 

--- a/doc/source/reference/thread_safety.rst
+++ b/doc/source/reference/thread_safety.rst
@@ -42,9 +42,10 @@ NumPy stores user-adjustable configuration options in :py:mod:`context variables
 means each thread in a multithreaded program or task in an asyncio program has
 its own independent configuration. This includes the following state:
 
-* The `numpy.errstate` and all floating-point error handling configuration
+* The `numpy.errstate`, which storesl floating-point error handling configuration
   options and the ufunc buffer size settable via `numpy.setbufsize`. See
-  :doc:`/reference/routines.err` for more details.
+  :doc:`/reference/routines.err` and :ref:`use-of-internal-buffers` for
+  more details.
 * The `numpy.printoptions`  and all text-formatting configuration options.
   See :ref:`text_formatting_options` for more details.
 * The memory allocator, see :ref:`data_memory` and :ref:`NEP 49 <NEP49>` for
@@ -73,8 +74,6 @@ state. For example:
 .. code-block:: pycon
 
      $ python3.12
-     Python 3.12.13 (main, May 14 2026, 09:32:06) [Clang 21.0.0 (clang-2100.0.123.102)] on darwin
-     Type "help", "copyright", "credits" or "license" for more information.
      >>> import numpy, threading
      >>> def print_printoptions():
      ...     print(numpy.get_printoptions()['precision'])
@@ -90,8 +89,6 @@ behave:
 .. code-block:: pycon
 
      $ python3.14 -Xthread_inherit_context=1
-     Python 3.14.5 (main, May 22 2026, 08:10:06) [Clang 21.0.0 (clang-2100.0.123.102)] on darwin
-     Type "help", "copyright", "credits" or "license" for more information.
      >>> import numpy, threading
      >>> def print_printoptions():
      ...     print(numpy.get_printoptions()['precision'])

--- a/doc/source/reference/thread_safety.rst
+++ b/doc/source/reference/thread_safety.rst
@@ -32,17 +32,76 @@ from use of the `threading` module, and instead might be better served with
 `multiprocessing`. In particular, operations on arrays with ``dtype=np.object_``
 do not release the GIL.
 
-Context-local state
+.. _context_local:
+
+Context Local State
 -------------------
 
-NumPy maintains some state for ufuncs context-local basis, which means each
-thread in a multithreaded program or task in an asyncio program has its own
-independent configuration of the `numpy.errstate` (see
-:doc:`/reference/routines.err`), and of :ref:`text_formatting_options`.
+NumPy stores user-adjustable configuration options in py:mod:`context variables
+<python:contextvars>`. Context variables allow *context-local state*, which
+means each thread in a multithreaded program or task in an asyncio program has
+its own independent configuration. This includes the following state:
 
-You can update state stored in a context variable by entering a context manager.
-As soon as the context manager exits, the state will be reset to its value
-before entering the context manager.
+* The `numpy.errstate` and all floating-point error handling configuration
+  options. See :doc:`/reference/routines.err` for more details.
+* The `numpy.printoptions`  and all text-formatting configuration options.
+  See :ref:`text_formatting_options` for more details.
+* The memory allocator, see :ref:`data_memory` and NEP 49 for more details.
+
+State stored in a context variable is set syntactically using the ``with``
+statement. For example, you can update the numpy printing options state like so:
+
+.. code-block:: pycon
+
+   >>> with np.printoptions(precision=2):
+   ...    np.array([2.0]) / 3
+   array([0.67])
+   >>> np.array([2.0]) / 3
+   array([0.66666667])
+
+
+This property applies to all context-local state, not just `numpy.printoptions`.
+
+.. _context_local:
+
+Interaction with the `threading` module
++++++++++++++++++++++++++++++++++++++++
+
+Before Python 3.14, new threads always start with newly initialized context
+state. For example:
+
+.. code-block:: pycon
+
+     $ python3.12
+     Python 3.12.13 (main, May 14 2026, 09:32:06) [Clang 21.0.0 (clang-2100.0.123.102)] on darwin
+     Type "help", "copyright", "credits" or "license" for more information.
+     >>> import numpy, threading
+     >>> def print_printoptions():
+     ...     print(numpy.get_printoptions()['precision'])
+     >>> with numpy.printoptions(precision=2):
+     ...     threading.Thread(target=print_printoptions).start()
+     8
+
+Starting in Python 3.14 a new ``thread_inherit_context`` startup configuration
+option for Python allows opting into a new behavior where context state for
+spawned threads behaves syntactically as one would expect the above code to
+behave:
+
+.. code-block:: pycon
+
+     $ python3.14 -Xthread_inherit_context=1
+     Python 3.14.5 (main, May 22 2026, 08:10:06) [Clang 21.0.0 (clang-2100.0.123.102)] on darwin
+     Type "help", "copyright", "credits" or "license" for more information.
+     >>> import numpy, threading
+     >>> def print_printoptions():
+     ...     print(numpy.get_printoptions()['precision'])
+     >>> with numpy.printoptions(precision=2):
+     ...     threading.Thread(target=print_printoptions).start()
+     2
+
+See `the CPython documentation
+<https://docs.python.org/3/using/cmdline.html#envvar-PYTHON_THREAD_INHERIT_CONTEXT>`_
+for more details.
 
 Free-threaded Python
 --------------------
@@ -62,6 +121,9 @@ issues. In addition to the limitations about locking of the
 :class:`~numpy.ndarray` object noted above, this also means that arrays with
 ``dtype=np.object_`` are not protected by the GIL, creating data races for python
 objects that are not possible outside free-threaded python.
+
+Free-threaded Python has ``thread_inherit_context`` turned on by default
+starting in Python 3.14. See :ref:`context_local` for more information.
 
 C-API Threading Support
 -----------------------

--- a/doc/source/reference/thread_safety.rst
+++ b/doc/source/reference/thread_safety.rst
@@ -37,16 +37,18 @@ do not release the GIL.
 Context Local State
 -------------------
 
-NumPy stores user-adjustable configuration options in py:mod:`context variables
+NumPy stores user-adjustable configuration options in :py:mod:`context variables
 <python:contextvars>`. Context variables allow *context-local state*, which
 means each thread in a multithreaded program or task in an asyncio program has
 its own independent configuration. This includes the following state:
 
 * The `numpy.errstate` and all floating-point error handling configuration
-  options. See :doc:`/reference/routines.err` for more details.
+  options and the ufunc buffer size settable via `numpy.setbufsize`. See
+  :doc:`/reference/routines.err` for more details.
 * The `numpy.printoptions`  and all text-formatting configuration options.
   See :ref:`text_formatting_options` for more details.
-* The memory allocator, see :ref:`data_memory` and NEP 49 for more details.
+* The memory allocator, see :ref:`data_memory` and :ref:`NEP 49 <NEP49>` for
+  more details.
 
 State stored in a context variable is set syntactically using the ``with``
 statement. For example, you can update the numpy printing options state like so:


### PR DESCRIPTION
### PR summary
Fixes #32014.

Improves documentation for context variables. Also adds some explanation for the interaction with threads and some discussion about the `thread_inherit_context` startup option.

#### AI Disclosure
No AI use.
