### PR TITLE
BUG: reference leak in `simd_sequence_from_iterable`

### DIFF
--- a/numpy/_core/src/_simd/_simd_convert.inc
+++ b/numpy/_core/src/_simd/_simd_convert.inc
@@ -105,6 +105,7 @@ simd_sequence_from_iterable(PyObject *obj, simd_data_type dtype, Py_ssize_t min_
     }
     npyv_lanetype_u8 *dst = simd_sequence_new(seq_size, dtype);
     if (dst == NULL) {
+        Py_DECREF(seq_obj);
         return NULL;
     }
     PyObject **seq_items = PySequence_Fast_ITEMS(seq_obj);


### PR DESCRIPTION
### PR summary

`simd_sequence_from_iterable` leaked the `PySequence_Fast` result when `simd_sequence_new` failed: the min-size path already `Py_DECREF`d, the OOM path did not. Add the missing `Py_DECREF`.

No new test; the leak only runs on allocation failure, which we cannot force from Python. Same approach as #31968 (no `getrefcount` asserts).

No release note (internal leak; no API change).

### First time committer introduction

Exploring NumPy and submitting small correctness fixes (e.g. #31968).

### AI Disclosure

AI helped locate and draft the fix. Human-reviewed and submitted by a human.