### PR TITLE
BUG: broadcast the condition in np.ma.masked_where

### DIFF
--- a/doc/release/upcoming_changes/32039.improvement.rst
+++ b/doc/release/upcoming_changes/32039.improvement.rst
@@ -1,0 +1,8 @@
+``np.ma.masked_where`` broadcasts the condition
+-----------------------------------------------
+`numpy.ma.masked_where` now broadcasts the ``condition`` against ``a`` instead
+of requiring their shapes to match exactly, matching the behaviour of
+`numpy.where` and boolean indexing. A broadcastable condition such as a column
+of shape ``(3, 1)`` against a ``(3, 2)`` input previously raised an
+``IndexError``; it now masks the selected entries. Genuinely incompatible
+shapes still raise ``IndexError``.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -1988,8 +1988,15 @@ def masked_where(condition, a, copy=True):
 
     (cshape, ashape) = (cond.shape, a.shape)
     if cshape and cshape != ashape:
-        raise IndexError("Inconsistent shape between the condition and the input"
-                         f" (got {cshape} and {ashape})")
+        # Broadcast the condition against the input, matching the semantics of
+        # np.where and boolean indexing. Only raise when the shapes are
+        # genuinely incompatible.
+        try:
+            cond = np.broadcast_to(cond, ashape).copy()
+        except ValueError:
+            raise IndexError(
+                "Inconsistent shape between the condition and the input"
+                f" (got {cshape} and {ashape})") from None
     if hasattr(a, '_mask'):
         cond = mask_or(cond, a._mask)
         cls = type(a)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4548,6 +4548,24 @@ class TestMaskedArrayFunctions:
         test = masked_equal(a, 1)
         assert_equal(test.mask, [0, 1, 0, 0, 0, 0, 0, 0, 0, 0])
 
+    def test_masked_where_broadcast(self):
+        # gh-17605: the condition is broadcast against the input, matching
+        # the semantics of np.where and boolean indexing.
+        a = np.arange(6).reshape(3, 2)
+        # column condition (3, 1) -> (3, 2)
+        test = masked_where(np.array([[False], [True], [False]]), a)
+        assert_equal(test.mask, [[0, 0], [1, 1], [0, 0]])
+        # row condition (2,) -> (3, 2)
+        test = masked_where(np.array([True, False]), a)
+        assert_equal(test.mask, [[1, 0], [1, 0], [1, 0]])
+        # the mask of the input is still combined with the (broadcast) condition
+        am = array(a, mask=[[1, 0], [0, 0], [0, 0]])
+        test = masked_where(np.array([[False], [True], [False]]), am)
+        assert_equal(test.mask, [[1, 0], [1, 1], [0, 0]])
+        # genuinely incompatible shapes still raise
+        with assert_raises(IndexError):
+            masked_where(np.array([True, False, True, False]), a)
+
     def test_masked_where_structured(self):
         # test that masked_where on a structured array sets a structured
         # mask (see issue #2972)


### PR DESCRIPTION
Fixes gh-17605.

np.ma.masked_where raised IndexError whenever the condition's shape differed from the input, even when the condition was broadcastable against it. That is inconsistent with np.where and boolean indexing, which both broadcast the condition. So a column-shaped condition like (3, 1) against a (3, 2) array raised instead of masking the selected rows.

The change broadcasts the condition against the input with np.broadcast_to and only raises when the shapes are genuinely incompatible. The existing behaviour of combining the condition with the input's own mask is preserved.

Added test_masked_where_broadcast covering a column condition, a row condition, the mask-combining case, and a genuinely incompatible shape that still raises. It fails on main and passes with the change.

Happy to add a release note fragment once this has a PR number (added in a follow-up commit).
