### PR TITLE
ENH: add NEP-50 style semantics for string scalars and StringDType

### DIFF
--- a/doc/release/upcoming_changes/32040.change.rst
+++ b/doc/release/upcoming_changes/32040.change.rst
@@ -1,0 +1,6 @@
+Python ``str`` ufunc operands convert with the resolved dtype
+-------------------------------------------------------------
+A Python ``str`` scalar containing trailing nulls now preserves the trailing nulls
+in operations with StringDType. For example, ``np.array(["x\0"],
+dtype=np.dtypes.StringDType()) == "x\0"`` now gives ``[True]`` rather than
+``[False]``.

--- a/doc/release/upcoming_changes/32040.improvement.rst
+++ b/doc/release/upcoming_changes/32040.improvement.rst
@@ -1,0 +1,5 @@
+StringDType ``partition`` accepts ``str`` separators
+----------------------------------------------------
+`np.strings.partition` and `np.strings.rpartition` now accept a Python
+``str`` or fixed-width unicode separator when operating on ``StringDType``
+arrays. Previously the separator had to be a ``StringDType`` array itself.

--- a/numpy/_core/src/multiarray/abstractdtypes.h
+++ b/numpy/_core/src/multiarray/abstractdtypes.h
@@ -79,6 +79,23 @@ npy_mark_tmp_array_if_pyscalar(
 }
 
 
+/*
+ * As above for an exact Python str.  Promotion is deliberately unaffected,
+ * so there is no abstract DType and the array's DType is not replaced
+ * (see NPY_ARRAY_WAS_PYTHON_STR).  str subclasses, including np.str_,
+ * are deliberately not marked and convert as before.
+ */
+static inline int
+npy_mark_tmp_array_if_pystr(PyObject *obj, PyArrayObject *arr)
+{
+    if (PyUnicode_CheckExact(obj)) {
+        _PyArray_GET_ITEM_DATA(arr)->flags |= NPY_ARRAY_WAS_PYTHON_STR;
+        return 1;
+    }
+    return 0;
+}
+
+
 NPY_NO_EXPORT int
 npy_update_operand_for_scalar(
     PyArrayObject **operand, PyObject *scalar, PyArray_Descr *descr,

--- a/numpy/_core/src/multiarray/arrayobject.h
+++ b/numpy/_core/src/multiarray/arrayobject.h
@@ -61,6 +61,15 @@ static const int NPY_ARRAY_WAS_INT_AND_REPLACED = (1 << 27);
 static const int NPY_ARRAY_WAS_PYTHON_LITERAL = (1 << 30 | 1 << 29 | 1 << 28);
 
 /*
+ * Mark an array converted from an exact Python str.  Unlike the flags above
+ * it does not participate in promotion (the array keeps its discovered
+ * dtype); it only lets the ufunc machinery convert the operand again from
+ * the original object once the loop's descriptors are resolved.  Not part
+ * of NPY_ARRAY_WAS_PYTHON_LITERAL, whose consumers assume a numeric scalar.
+ */
+static const int NPY_ARRAY_WAS_PYTHON_STR = (1 << 25);
+
+/*
  * This flag allows same kind casting, similar to NPY_ARRAY_FORCECAST.
  *
  * An array never has this flag set; they're only used as parameter

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2357,6 +2357,17 @@ string_unicode_bool_output_promoter(
 }
 
 static int
+string_partition_promoter(
+        PyObject *ufunc, PyArray_DTypeMeta *const op_dtypes[],
+        PyArray_DTypeMeta *const signature[],
+        PyArray_DTypeMeta *new_op_dtypes[])
+{
+    return string_inputs_promoter(
+            ufunc, op_dtypes, signature,
+            new_op_dtypes, &PyArray_StringDType, &PyArray_StringDType);
+}
+
+static int
 is_integer_dtype(PyArray_DTypeMeta *DType)
 {
     if (DType == &PyArray_PyLongDType) {
@@ -3110,6 +3121,27 @@ init_stringdtype_ufuncs(PyObject *umath)
                        string_partition_strided_loop, 2, 3, NPY_NO_CASTING,
                        (NPY_ARRAYMETHOD_FLAGS) 0, &partition_startpositions[i]) < 0) {
             return -1;
+        }
+    }
+
+    PyArray_DTypeMeta *partition_promoter_dtypes[2][5] = {
+        {
+            &PyArray_StringDType, &PyArray_UnicodeDType,
+            &PyArray_StringDType, &PyArray_StringDType, &PyArray_StringDType,
+        },
+        {
+            &PyArray_UnicodeDType, &PyArray_StringDType,
+            &PyArray_StringDType, &PyArray_StringDType, &PyArray_StringDType,
+        },
+    };
+
+    for (int i=0; i<2; i++) {
+        for (int j=0; j<2; j++) {
+            if (add_promoter(umath, partition_names[i],
+                             partition_promoter_dtypes[j], 5,
+                             string_partition_promoter) < 0) {
+                return -1;
+            }
         }
     }
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -707,6 +707,17 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
         out_op_DTypes[i] = NPY_DTYPE(PyArray_DESCR(out_op[i]));
         Py_INCREF(out_op_DTypes[i]);
 
+        if (PyArray_NDIM(out_op[i]) == 0) {
+            any_scalar = NPY_TRUE;
+        }
+        else {
+            all_scalar = NPY_FALSE;
+            continue;
+        }
+
+        /* Does not affect promotion, only conversion after resolution. */
+        npy_mark_tmp_array_if_pystr(obj, out_op[i]);
+
         if (nin == 1) {
             /*
              * TODO: If nin == 1 we don't promote!  This has exactly the effect
@@ -719,14 +730,6 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
              *
              *       This is issue is part of the NEP 50 adoption.
              */
-            break;
-        }
-
-        if (PyArray_NDIM(out_op[i]) == 0) {
-            any_scalar = NPY_TRUE;
-        }
-        else {
-            all_scalar = NPY_FALSE;
             continue;
         }
 
@@ -4500,8 +4503,12 @@ resolve_descriptors(int nop,
         /*
          * If we are working with Python literals/scalars, deal with them.
          * If needed, we create new array with the right descriptor.
+         * An exact Python str must be replaced from the original object to
+         * preserve trailing nulls, so it requires an available input tuple.
          */
-        if ((PyArray_FLAGS(operands[i]) & NPY_ARRAY_WAS_PYTHON_LITERAL)) {
+        if ((PyArray_FLAGS(operands[i]) & NPY_ARRAY_WAS_PYTHON_LITERAL) ||
+                (inputs_tup != NULL &&
+                 (PyArray_FLAGS(operands[i]) & NPY_ARRAY_WAS_PYTHON_STR))) {
             PyObject *input;
             if (inputs_tup == NULL) {
                 input = NULL;
@@ -5917,7 +5924,8 @@ static inline int
 is_known_scalar(PyObject *obj)
 {
     return (PyLong_CheckExact(obj) || PyFloat_CheckExact(obj)
-            || PyComplex_CheckExact(obj) || is_anyscalar_exact(obj));
+            || PyComplex_CheckExact(obj) || PyUnicode_CheckExact(obj)
+            || is_anyscalar_exact(obj));
 }
 
 
@@ -6489,6 +6497,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
         int force_legacy_promotion = 0;
 
         npy_bool op2_is_pyscalar = NPY_FALSE;
+        npy_bool op2_is_pystr = NPY_FALSE;
         if (op2_array != NULL) {
             /* Owned: `resolve_descriptors` may replace it for Python scalars */
             tmp_operands[1] = op2_array;
@@ -6498,6 +6507,9 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
             if (mark_pyscalar_operand(
                     op2, &tmp_operands[1], &operand_DTypes[1])) {
                 op2_is_pyscalar = NPY_TRUE;
+            }
+            else if (npy_mark_tmp_array_if_pystr(op2, tmp_operands[1])) {
+                op2_is_pystr = NPY_TRUE;
             }
             tmp_operands[2] = tmp_operands[0];
             operand_DTypes[2] = operand_DTypes[0];
@@ -6518,7 +6530,7 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
         int resolve_result = -1;
         PyObject *inputs_tup = NULL;
-        if (op2_is_pyscalar) {
+        if (op2_is_pyscalar || op2_is_pystr) {
             inputs_tup = PyTuple_Pack(2, op1, op2);
             if (inputs_tup == NULL) {
                 goto finish_resolution;

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -703,20 +703,11 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
             if (out_op[i] == NULL) {
                 goto fail;
             }
+            /* Does not affect promotion, only conversion after resolution. */
+            npy_mark_tmp_array_if_pystr(obj, out_op[i]);
         }
         out_op_DTypes[i] = NPY_DTYPE(PyArray_DESCR(out_op[i]));
         Py_INCREF(out_op_DTypes[i]);
-
-        if (PyArray_NDIM(out_op[i]) == 0) {
-            any_scalar = NPY_TRUE;
-        }
-        else {
-            all_scalar = NPY_FALSE;
-            continue;
-        }
-
-        /* Does not affect promotion, only conversion after resolution. */
-        npy_mark_tmp_array_if_pystr(obj, out_op[i]);
 
         if (nin == 1) {
             /*
@@ -730,6 +721,14 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
              *
              *       This is issue is part of the NEP 50 adoption.
              */
+            break;
+        }
+
+        if (PyArray_NDIM(out_op[i]) == 0) {
+            any_scalar = NPY_TRUE;
+        }
+        else {
+            all_scalar = NPY_FALSE;
             continue;
         }
 
@@ -4504,7 +4503,8 @@ resolve_descriptors(int nop,
          * If we are working with Python literals/scalars, deal with them.
          * If needed, we create new array with the right descriptor.
          * An exact Python str must be replaced from the original object to
-         * preserve trailing nulls, so it requires an available input tuple.
+         * preserve trailing nulls, so it requires an available input tuple
+         * (only `ufunc.resolve_dtypes` has no input tuple).
          */
         if ((PyArray_FLAGS(operands[i]) & NPY_ARRAY_WAS_PYTHON_LITERAL) ||
                 (inputs_tup != NULL &&

--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -1331,16 +1331,20 @@ def replace(a, old, new, count=-1):
 
     arr = np.asanyarray(a)
     old_dtype = getattr(old, 'dtype', None)
-    old = np.asanyarray(old)
+    old_arr = np.asanyarray(old)
     new_dtype = getattr(new, 'dtype', None)
-    new = np.asanyarray(new)
+    new_arr = np.asanyarray(new)
 
-    if np.result_type(arr, old, new).char == "T":
-        return _replace(arr, old, new, count)
+    if np.result_type(arr, old_arr, new_arr).char == "T":
+        # pass exact str objects so the ufunc converts them directly
+        a = a if type(a) is str else arr
+        old = old if type(old) is str else old_arr
+        new = new if type(new) is str else new_arr
+        return _replace(a, old, new, count)
 
     a_dt = arr.dtype
-    old = old.astype(old_dtype or a_dt, copy=False)
-    new = new.astype(new_dtype or a_dt, copy=False)
+    old = old_arr.astype(old_dtype or a_dt, copy=False)
+    new = new_arr.astype(new_dtype or a_dt, copy=False)
     max_int64 = np.iinfo(np.int64).max
     counts = _count_ufunc(arr, old, 0, max_int64)
     counts = np.where(count < 0, counts, np.minimum(counts, count))
@@ -1577,13 +1581,17 @@ def partition(a, sep):
      array(['is nice!'], dtype='<U8'))
 
     """
-    a = np.asanyarray(a)
-    sep = np.asanyarray(sep)
+    a_arr = np.asanyarray(a)
+    sep_arr = np.asanyarray(sep)
 
-    if np.result_type(a, sep).char == "T":
+    if np.result_type(a_arr, sep_arr).char == "T":
+        # pass exact str objects so the ufunc converts them directly
+        a = a if type(a) is str else a_arr
+        sep = sep if type(sep) is str else sep_arr
         return _partition(a, sep)
 
-    sep = sep.astype(a.dtype, copy=False)
+    a = a_arr
+    sep = sep_arr.astype(a_arr.dtype, copy=False)
     pos = _find_ufunc(a, sep, 0, MAX)
     a_len = str_len(a)
     sep_len = str_len(sep)
@@ -1646,13 +1654,17 @@ def rpartition(a, sep):
      array(['', '  ', 'Bba'], dtype='<U3'))
 
     """
-    a = np.asanyarray(a)
-    sep = np.asanyarray(sep)
+    a_arr = np.asanyarray(a)
+    sep_arr = np.asanyarray(sep)
 
-    if np.result_type(a, sep).char == "T":
+    if np.result_type(a_arr, sep_arr).char == "T":
+        # pass exact str objects so the ufunc converts them directly
+        a = a if type(a) is str else a_arr
+        sep = sep if type(sep) is str else sep_arr
         return _rpartition(a, sep)
 
-    sep = sep.astype(a.dtype, copy=False)
+    a = a_arr
+    sep = sep_arr.astype(a_arr.dtype, copy=False)
     pos = _rfind_ufunc(a, sep, 0, MAX)
     a_len = str_len(a)
     sep_len = str_len(sep)

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -231,6 +231,69 @@ def test_np_str_trailing_nul_preserved(coerce):
     assert np.array([value], dtype=dtype)[0] == "q\x00"
 
 
+def test_pystr_scalar_ufunc_operand_preserves_nulls():
+    arr = np.array(["abc\0", "abc"], dtype="T")
+
+    assert_array_equal(arr == "abc\0", [True, False])
+    assert_array_equal(arr != "abc\0", [False, True])
+    # expected values are wrapped in StringDType arrays because converting
+    # the plain lists would itself go through fixed-width unicode
+    assert_array_equal(
+        arr + "x\0", np.array(["abc\0x\0", "abcx\0"], dtype="T"))
+    assert_array_equal(
+        "x\0" + arr, np.array(["x\0abc\0", "x\0abc"], dtype="T"))
+    assert_array_equal(np.strings.str_len(arr + "x\0"), [6, 5])
+
+    arr2 = arr.copy()
+    arr2 += "\0"
+    assert_array_equal(arr2, np.array(["abc\0\0", "abc\0"], dtype="T"))
+
+    assert_array_equal(np.strings.endswith(arr, "c\0"), [True, False])
+    assert_array_equal(np.strings.count(arr, "\0"), [1, 0])
+    assert_array_equal(np.strings.find(arr, "c\0"), [2, -1])
+    assert_array_equal(np.strings.replace(arr, "\0", "!"), ["abc!", "abc"])
+
+
+def test_pystr_scalar_ufunc_outer_preserves_nulls():
+    arr = np.array(["x"], dtype="T")
+    assert np.add.outer(arr, "y\0").item() == "xy\0"
+    assert np.add.outer("y\0", arr).item() == "y\0x"
+
+
+def test_pystr_scalar_ufunc_at_preserves_nulls():
+    arr = np.array(["x"], dtype="T")
+    np.add.at(arr, 0, "y\0")
+    assert arr[0] == "xy\0"
+
+
+def test_pystr_scalar_ufunc_operand_any_instance(dtype):
+    arr = np.array(["abc\0"], dtype=dtype)
+    assert_array_equal(arr == "abc\0", [True])
+    assert (arr + "x\0")[0] == "abc\0x\0"
+
+
+def test_partition_str_sep():
+    arr = np.array(["a-b\0c", "nosep"], dtype="T")
+
+    parts = np.strings.partition(arr, "-")
+    expected = [["a", "nosep"], ["-", ""], ["b\0c", ""]]
+    for res, exp in zip(parts, expected):
+        assert_array_equal(res, np.array(exp, dtype="T"))
+
+    rparts = np.strings.rpartition(np.array(["a-b-c", "nosep"], dtype="T"),
+                                   np.str_("-"))
+    expected = [["a-b", ""], ["-", ""], ["c", "nosep"]]
+    for res, exp in zip(rparts, expected):
+        assert_array_equal(res, np.array(exp, dtype="T"))
+
+    parts = np.strings.partition(np.array(["ab\0cd"], dtype="T"), "\0")
+    for res, exp in zip(parts, [["ab"], ["\0"], ["cd"]]):
+        assert_array_equal(res, np.array(exp, dtype="T"))
+
+    with pytest.raises(ValueError, match="empty separator"):
+        np.strings.partition(arr, "")
+
+
 @pytest.mark.parametrize(
     "op, pyop",
     [

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -201,6 +201,40 @@ def test_in_place_multiply_no_overflow(dt):
 
 
 @pytest.mark.parametrize("dt", ["S", "U", "T"])
+def test_string_function_array_likes_converted_once(dt):
+    class ArrayLike:
+        def __init__(self, value):
+            self.value = value
+            self.array_calls = 0
+
+        def __array__(self, dtype=None, copy=None):
+            self.array_calls += 1
+            arr = np.array(self.value, dtype=dt)
+            if dtype is not None:
+                arr = arr.astype(dtype, copy=False)
+            return arr
+
+        def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+            raise NotImplementedError
+
+    for func in [np.strings.partition, np.strings.rpartition]:
+        a = ArrayLike(["a-b"])
+        sep = ArrayLike("-")
+        result = func(a, sep)
+        for actual, expected in zip(result, [["a"], ["-"], ["b"]]):
+            assert_array_equal(
+                actual, np.array(expected, dtype=dt), strict=True)
+        assert a.array_calls == sep.array_calls == 1
+
+    a = ArrayLike(["a-b"])
+    old = ArrayLike("-")
+    new = ArrayLike("+")
+    result = np.strings.replace(a, old, new)
+    assert_array_equal(result, np.array(["a+b"], dtype=dt), strict=True)
+    assert a.array_calls == old.array_calls == new.array_calls == 1
+
+
+@pytest.mark.parametrize("dt", ["S", "U", "T"])
 class TestMethods:
 
     @pytest.mark.parametrize("in1,in2,out", [

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -3208,6 +3208,22 @@ def test_addition_unicode_inverse_byte_order(order1, order2):
     assert result == 2 * element
 
 
+def test_pystr_scalar_converted_with_resolved_descriptor():
+    # an object loop receives the original str object
+    arr = np.array(["x"], dtype=object)
+    res = (arr + "y\0")[0]
+    assert type(res) is str
+    assert res == "xy\0"
+    # for fixed-width unicode trailing nulls are padding
+    assert (np.array(["x"], dtype="U1") + "y\0")[0] == "xy"
+    # np.str_ is a fixed-width scalar, not special-cased like exact str
+    assert (arr + np.str_("y\0"))[0] == "xy"
+
+    # unary object loops also receive the original str object
+    identity = np.frompyfunc(lambda value: value, 1, 1)
+    assert identity("y\0") == "y\0"
+
+
 @pytest.mark.parametrize("dtype", [np.int8, np.int16, np.int32, np.int64])
 def test_find_non_long_args(dtype):
     element = 'abcd'


### PR DESCRIPTION
### PR summary

While working on ByteStringDType, I noticed that trailing nulls are currently stripped when StringDType operations use python scalars. For example:

```python
>>> np.array(["hello", "world"], dtype="T") + "hello\0\0"
array(['hellohello', 'worldhello'], dtype=StringDType())
```

This is happening because `"hello\0\0"` is coerced to a fixed-width unicode array, which strips the trailing NULLs.

@seberg let me know that the infrastructure in NumPy to do this is already in NumPy to support NEP-50. Somewhat differently from the other NEP-50 cases, I don't think it's necessary to add a new abstract dtype to represent python strings because we don't want string scalars and string arrays to have different semantics.

While working on this I realized that partition and rpartition need a promoter to be able to work with this new functionality, so this includes that as well.


#### AI Disclosure
I iterated on the implementation with an AI model.