### PR TITLE
TST: remove outdated test

### DIFF
--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1,7 +1,6 @@
 import copy
 import datetime
 import gc
-import os
 import pickle
 import sys
 import tempfile

--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import gc
+import os
 import pickle
 import sys
 import tempfile

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 from numpy.testing import (
     _assert_valid_refcount,

--- a/numpy/lib/tests/test_regression.py
+++ b/numpy/lib/tests/test_regression.py
@@ -214,18 +214,3 @@ class TestRegression:
             np.nansum(a)
         except Exception:
             raise AssertionError
-
-    def test_py3_compat(self):
-        # gh-2561
-        # Test if the oldstyle class test is bypassed in python3
-        class C:
-            """Old-style class in python2, normal class in python3"""
-            pass
-
-        out = open(os.devnull, 'w')
-        try:
-            np.info(C(), output=out)
-        except AttributeError:
-            raise AssertionError
-        finally:
-            out.close()


### PR DESCRIPTION
### PR summary

Deletes an unnecessary test.

This test was introduced in numpy/numpy#3885 to test code needed for Python 2 backwards compatibility. The code being tested was removed in numpy/numpy#15373 after dropping Python 2 compatibility.

### First time committer introduction

Hi 👋 I’m a physicist-turned-RSE and maintainer of a few [supernova](https://github.com/SNEWS2/snewpy) [neutrino](https://github.com/SNEWS2/sntools) packages that use numpy under the hood. I [originally started looking at this](https://github.com/numpy/numpy/issues/22635#issuecomment-3217140813) last year at the EuroSciPy 2025 sprints, but forgot to follow up until today at the EuroPython/EuroSciPy 2026 sprints.

#### AI Disclosure

No AI tools used.