### PR TITLE
MAINT: f2py: parse .f2py_f2cmap without eval()

### DIFF
--- a/numpy/f2py/capi_maps.py
+++ b/numpy/f2py/capi_maps.py
@@ -10,6 +10,7 @@ from . import __version__
 
 f2py_version = __version__.version
 
+import ast
 import copy
 import os
 import re
@@ -139,6 +140,32 @@ f2cmap_default = copy.deepcopy(f2cmap_all)
 
 f2cmap_mapped = []
 
+
+def _eval_f2cmap_node(node):
+    """Recursively evaluate a single f2cmap AST node.
+
+    Only dict literals (``{...}``), ``dict(...)`` calls with keyword
+    arguments, and scalar constants are permitted.  Anything else raises
+    ``ValueError`` so an f2cmap file can never execute arbitrary code.
+    """
+    if isinstance(node, ast.Dict):
+        return {_eval_f2cmap_node(k): _eval_f2cmap_node(v)
+                for k, v in zip(node.keys, node.values)}
+    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            and node.func.id == 'dict' and not node.args
+            and all(kw.arg is not None for kw in node.keywords)):
+        return {kw.arg: _eval_f2cmap_node(kw.value) for kw in node.keywords}
+    if isinstance(node, ast.Constant):
+        return node.value
+    raise ValueError(
+        f'disallowed expression in f2cmap file: {ast.dump(node)}')
+
+
+def _f2cmap_from_str(source):
+    """Safely parse the contents of an f2cmap file into a dictionary."""
+    return _eval_f2cmap_node(ast.parse(source, mode='eval').body)
+
+
 def load_f2cmap_file(f2cmap_file):
     global f2cmap_all, f2cmap_mapped
 
@@ -158,7 +185,7 @@ def load_f2cmap_file(f2cmap_file):
     try:
         outmess(f'Reading f2cmap from {f2cmap_file!r} ...\n')
         with open(f2cmap_file) as f:
-            d = eval(f.read().lower(), {}, {})
+            d = _f2cmap_from_str(f.read().lower())
         f2cmap_all, f2cmap_mapped = process_f2cmap_dict(f2cmap_all, d, c2py_map, True)
         outmess('Successfully applied user defined f2cmap changes\n')
     except Exception as msg:

--- a/numpy/f2py/tests/test_f2cmap.py
+++ b/numpy/f2py/tests/test_f2cmap.py
@@ -1,6 +1,7 @@
 import pytest
 
 import numpy as np
+from numpy.f2py import capi_maps
 
 from . import util
 
@@ -18,3 +19,23 @@ class TestF2Cmap(util.F2PyTest):
         out = self.module.func1(inp)
         exp_out = 3
         assert out == exp_out
+
+
+class TestF2CmapParsing:
+    # An f2cmap file must never be able to execute arbitrary code.
+    def test_dict_literal_form(self):
+        d = capi_maps._f2cmap_from_str("{'real': {'low': 'float'}}")
+        assert d == {'real': {'low': 'float'}}
+
+    def test_dict_constructor_form(self):
+        d = capi_maps._f2cmap_from_str("dict(real=dict(rk='double'))")
+        assert d == {'real': {'rk': 'double'}}
+
+    @pytest.mark.parametrize("payload", [
+        "__import__('os').system('echo pwned')",
+        "(open('x', 'wb').write(b'pwned'), {'real': {'4': 'float'}})[1]",
+        "dict(real=__import__('os').getcwd())",
+    ])
+    def test_rejects_code_execution(self, payload):
+        with pytest.raises(ValueError):
+            capi_maps._f2cmap_from_str(payload)


### PR DESCRIPTION
Closes #32044

`load_f2cmap_file` in numpy/f2py/capi_maps.py evaluated the f2cmap file
with `eval(f.read().lower(), {}, {})`, which executes arbitrary Python.
The empty globals dict does not sandbox anything, since Python re-injects
`__builtins__`, so a crafted `.f2py_f2cmap` file could run code such as
`__import__('os').system(...)`. This file is also auto-loaded from the
current working directory.

This replaces `eval()` with a small restricted AST evaluator that accepts
only the two documented f2cmap formats and nothing else:
- dict literals: `{'real': {'low': 'float'}}`
- `dict(...)` keyword calls: `dict(real=dict(real64='double'))`

plus scalar constants. Anything else raises `ValueError`.

`ast.literal_eval` on its own was not sufficient, because it rejects the
documented `dict(...)` form used by the docs and by the existing test
fixtures. The restricted evaluator preserves all legitimate usage while
removing the code-execution path.

Added `TestF2CmapParsing` covering both accepted formats and confirming
that code-like payloads raise `ValueError` instead of executing.
