### PR TITLE
BUG: f2py: mask string literals in depend harvest and fix sort order

### DIFF
--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -681,6 +681,23 @@ def split_by_unquoted(line, characters):
         return (d["before"], d["after"])
     return (line, "")
 
+_quoted_string_re = re.compile(
+    r"('([^'\\]|(\\.))*')" r'|' r'("([^"\\]|(\\.))*")')
+
+
+def mask_string_literals(expr):
+    """Blank the contents of Fortran string literals in *expr*.
+
+    Dependency scanning matches variable names against the right-hand
+    side of a declaration. A character parameter such as
+    ``mkdir = 'mkdir '`` must not be treated as depending on the
+    identifiers that happen to appear inside its own literal value, so
+    the quoted text is collapsed to empty quotes before the scan while
+    identifiers outside the quotes (e.g. in ``'x '//name``) are kept.
+    """
+    return _quoted_string_re.sub("''", expr)
+
+
 def _simplifyargs(argsline):
     a = []
     for n in markoutercomma(argsline).split('@,@'):
@@ -2877,8 +2894,12 @@ def analyzevars(block):
                 vars[n]['attrspec'].append('optional')
             if 'depend' not in vars[n]:
                 vars[n]['depend'] = []
+                # Mask string-literal contents so an identifier appearing
+                # only inside a character value is not harvested as a
+                # dependency (gh-28700).
+                rhs = mask_string_literals(vars[n]['='])
                 for v, m in list(dep_matches.items()):
-                    if m(vars[n]['=']):
+                    if m(rhs):
                         vars[n]['depend'].append(v)
                 if not vars[n]['depend']:
                     del vars[n]['depend']

--- a/numpy/f2py/crackfortran.py
+++ b/numpy/f2py/crackfortran.py
@@ -2146,6 +2146,35 @@ def postcrack(block, args=None, tab=''):
     return block
 
 
+def _sort_cyclic_dependents(dep, vars):
+    """Order variables in a dependency cycle for initialization.
+
+    When a cycle cannot be resolved topologically, prefer:
+
+    1. intent(in) inputs (e.g. ``a``) so shape-based hide vars can run
+    2. variables defined via ``=`` (e.g. ``n = shape(a, 1)``,
+       ``lda = MAX(1, n)``) so dimension expressions see real values
+    3. remaining hide arrays (e.g. ``work`` with ``dimension(3*n)``)
+
+    This restores a usable order after literal masking removes accidental
+    edges such as ``diag = 'N'`` matching ``n`` inside the quotes.
+    ``getarrdims`` blanks any dimension that names a later depargs
+    entry, so workspace arrays must not sort ahead of the scalars they
+    size from.
+    """
+    def sort_key(name):
+        var = vars[name]
+        if isintent_in(var) and not isintent_hide(var):
+            tier = 0
+        elif '=' in var:
+            tier = 1
+        else:
+            tier = 2
+        return (tier, dep.index(name))
+
+    return sorted(dep, key=sort_key)
+
+
 def sortvarnames(vars):
     indep = []
     dep = []
@@ -2170,7 +2199,7 @@ def sortvarnames(vars):
                 errmess('sortvarnames: failed to compute dependencies because'
                         ' of cyclic dependencies between '
                         + ', '.join(dep) + '\n')
-                indep = indep + dep
+                indep = indep + _sort_cyclic_dependents(dep, vars)
                 break
         else:
             indep.append(v)

--- a/numpy/f2py/tests/src/crackfortran/gh28700.f90
+++ b/numpy/f2py/tests/src/crackfortran/gh28700.f90
@@ -1,0 +1,12 @@
+module mod1
+    character(6), public, parameter :: mkdir = 'mkdir '
+    character(7), public, parameter :: badvar2 = "badvar2"
+    character(13), public, parameter :: realdep = 'mkdir '//badvar2
+end module mod1
+
+module np_bug
+contains
+    subroutine sub1
+        use mod1
+    end subroutine sub1
+end module np_bug

--- a/numpy/f2py/tests/src/crackfortran/gh28700_trcon.pyf
+++ b/numpy/f2py/tests/src/crackfortran/gh28700_trcon.pyf
@@ -1,0 +1,24 @@
+python module gh28700_trcon
+    interface
+        subroutine trcon(norm, uplo, diag, n, a, lda, rcond, work, irwork, info)
+            character optional intent(in), check(*norm=='1'||*norm=='I'||*norm=='O') :: norm = '1'
+            character optional intent(in), check(*uplo=='U'||*uplo=='L') :: uplo = 'U'
+            character optional intent(in), check(*diag=='N'||*diag=='U') :: diag = 'N'
+            real intent(in), dimension(lda, n) :: a
+            integer intent(hide), depend(a) :: n = shape(a, 1)
+            integer intent(hide), depend(n) :: lda = MAX(1, n)
+            real intent(hide), dimension(3*n), depend(n) :: work
+            integer intent(hide), dimension(n), depend(n) :: irwork
+            real intent(out) :: rcond
+            integer intent(out) :: info
+        end subroutine trcon
+        subroutine trcon_lwork(n, norm, rcond, work, lwork, info)
+            integer intent(in) :: n
+            character*1 intent(in) :: norm
+            real intent(out) :: rcond
+            integer depend(n, norm), optional, intent(hide) :: lwork = (*norm=='I'?3*n:n)
+            real intent(hide), depend(lwork), dimension(lwork) :: work
+            integer intent(out) :: info
+        end subroutine trcon_lwork
+    end interface
+end python module gh28700_trcon

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -286,6 +286,31 @@ class TestStringLiteralDepend:
         # while the one inside the literal is dropped
         assert vs["realdep"]["depend"] == ["badvar2"]
 
+    def test_trcon_literal_masking_and_sort_order(self):
+        # SciPy flapack ?trcon regression: masking ``diag = 'N'`` must not
+        # harvest ``n`` from the literal. Cycle fallback must order
+        # ``a`` then ``n = shape(a, 1)`` then ``work`` so getarrdims keeps
+        # ``work_Dims[0]=3*n`` (not blanked to assumed-shape).
+        fpath = util.getpath("tests", "src", "crackfortran", "gh28700_trcon.pyf")
+        mod = crackfortran.crackfortran([str(fpath)])
+        iface = next(b for b in mod if b.get("name") == "gh28700_trcon")["body"][0]
+        trcon = next(b for b in iface["body"] if b.get("name") == "trcon")
+        vs = trcon["vars"]
+        assert "depend" not in vs["diag"]
+        assert vs["work"]["dimension"] == ["3 * n"]
+        assert vs["work"]["depend"] == ["n"]
+        order = trcon["sortvars"]
+        assert order.index("a") < order.index("n")
+        assert order.index("n") < order.index("work")
+        assert order.index("n") < order.index("lda")
+
+        lwork_case = next(b for b in iface["body"] if b.get("name") == "trcon_lwork")
+        lvs = lwork_case["vars"]
+        # depend harvest order follows vars dict iteration; compare as a set
+        assert set(lvs["lwork"]["depend"]) == {"norm", "n"}
+        assert lvs["lwork"]["="] == "(*norm=='i'?3*n:n)"
+        assert lvs["work"]["dimension"] == ["lwork"]
+
 
 @pytest.mark.slow
 class TestEval(util.F2PyTest):

--- a/numpy/f2py/tests/test_crackfortran.py
+++ b/numpy/f2py/tests/test_crackfortran.py
@@ -263,6 +263,30 @@ class TestModuleDeclaration:
         assert mod[0]["vars"]["abar"]["="] == "bar('abar')"
 
 
+class TestStringLiteralDepend:
+    # gh-28700: identifiers inside a character parameter's literal value
+    # must not be harvested as dependencies (a self-dependency crashes the
+    # dependency sort during a -c build).
+    def test_mask_string_literals(self):
+        mask = crackfortran.mask_string_literals
+        assert mask("'mkdir '") == "''"
+        assert mask('"badvar2"') == "''"
+        assert mask("'mkdir '//badvar2") == "''//badvar2"
+        assert mask("a + b") == "a + b"
+
+    def test_no_self_depend_from_literal(self):
+        fpath = util.getpath("tests", "src", "crackfortran", "gh28700.f90")
+        mod = crackfortran.crackfortran([str(fpath)])
+        m1 = next(b for b in mod if b.get("name") == "mod1")
+        vs = m1["vars"]
+        # string-only values gain no dependency at all
+        assert "depend" not in vs["mkdir"]
+        assert "depend" not in vs["badvar2"]
+        # a real identifier outside the quotes is still a dependency,
+        # while the one inside the literal is dropped
+        assert vs["realdep"]["depend"] == ["badvar2"]
+
+
 @pytest.mark.slow
 class TestEval(util.F2PyTest):
     def test_eval_scalar(self):


### PR DESCRIPTION
### PR summary

`analyzevars` matches every known variable name against the raw RHS of a
declaration, so a character parameter such as `mkdir = 'mkdir '` records
`depend=['mkdir']` and `_get_depend_dict` recurses until stack overflow
(Closes #28700; related #30363).

Mask quoted string contents with `mask_string_literals` (same quote grammar
as `split_by_unquoted`) before the `dep_matches` scan. Identifiers outside
quotes (for example operands of `//`) stay as real dependencies.

Literal masking also drops accidental edges such as `diag = 'N'` harvesting
`n`. That had been stabilizing SciPy flapack `?trcon` cyclic order so input
`a` preceded hide `n = shape(a, 1)`. After masking, restore a stable cycle
fallback in `sortvarnames`: intent(in) inputs, then `=` initializers, then
remaining hide arrays, so `a < n < work` and `work` keeps dimension `3*n`.

Two commits: mask + tests; sort-order fix + `?trcon` reproducer.

### First time committer introduction

N/A (NumPy maintainer).

#### AI Disclosure

No AI tools used.
