### PR TITLE
DOC: fix typo "dectorator" in "Writing your own ufunc"

### DIFF
--- a/doc/source/user/c-info.ufunc-tutorial.rst
+++ b/doc/source/user/c-info.ufunc-tutorial.rst
@@ -942,7 +942,7 @@ Numpy ufuncs. For example:
             return log(p/(1-p))
 
 Here ``log`` is taken from the C standard library. The ``cdivision``
-dectorator and ``noexcept`` exception specification are Cython extensions
+decorator and ``noexcept`` exception specification are Cython extensions
 and ensure that a divide by zero will not raise a Python exception.
 They are useful for this specific example but not necessary for ufuncs
 generally.


### PR DESCRIPTION
DOC: fix typo "dectorator" in "Writing your own ufunc"

## Method

```console
% brew install typos-cli

% typos doc/source/user/c-info.ufunc-tutorial.rst
error: `dectorator` should be `decorator`
    ╭▸ doc/source/user/c-info.ufunc-tutorial.rst:945:1
    │
945 │ dectorator and ``noexcept`` exception specification are Cython extensions
    ╰╴━━━━━━━━━━

% typos --write-changes doc/source/user/c-info.ufunc-tutorial.rst
```