### PR TITLE
TYP: specialized ``subtract`` ufunc

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -467,6 +467,7 @@ from numpy._core.umath import (
     spacing,
     square,
     sqrt,
+    subtract,
     tan,
     tanh,
     trunc,
@@ -7650,7 +7651,6 @@ matvec: _GUFunc_Nin2_Nout1[L["matvec"], L[19], None, L["(m,n),(n)->(m)"]]
 maximum: _UFunc_Nin2_Nout1[L["maximum"], L[21], None]
 minimum: _UFunc_Nin2_Nout1[L["minimum"], L[21], None]
 multiply: _UFunc_Nin2_Nout1[L["multiply"], L[23], L[1]]
-subtract: _UFunc_Nin2_Nout1[L["subtract"], L[21], None]
 vecdot: _GUFunc_Nin2_Nout1[L["vecdot"], L[19], None, L["(n),(n)->()"]]
 vecmat: _GUFunc_Nin2_Nout1[L["vecmat"], L[19], None, L["(n),(n,m)->(m)"]]
 

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -38,7 +38,6 @@ from numpy import (
     minimum,
     multiply,
     pi,
-    subtract,
     true_divide,
     vecdot,
     vecmat,
@@ -11171,12 +11170,12 @@ class _ufunc_21_mod(_ufunc_21[None], Generic[_ScalarT_contra, _ScalarT_co]):  # 
         out: np.ndarray | None = None,
     ) -> OutT: ...
 
-# bBhHiIlLqQefdgFDGO, bBhHiIlLqQefdgFDGO => bBhHiIlLqQefdgFDGO
+# bBhHiIlLqQefdgFDGO[Mm], bBhHiIlLqQefdgFDGO[Mm] => bBhHiIlLqQefdgFDGO[Mm]
 #
 # This builds upon `_ufunc_21_mod`, and only covers the i64/i32/i8/u8 int promotions,
 # the closed f32/f64 float promotions, and the closed c64/c128 complex promotions.
 @type_check_only
-class _ufunc_21_pow(_ufunc_21[None]):  # type: ignore[misc]
+class _ufunc_21_pow_sub(_ufunc_21[None], Generic[_ScalarT_contra]):  # type: ignore[misc]  # noqa: UP046
     @override
     @overload  # 0d +i8, 0d +i8
     def __call__(
@@ -11398,6 +11397,50 @@ class _ufunc_21_pow(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> np.complex128: ...
+    @overload  # 0d ~timedelta, 0d +timedelta  (if timedelta in domain)
+    def __call__(
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        x1: np.timedelta64,
+        x2: np.timedelta64 | _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.timedelta64: ...
+    @overload  # 0d +timedelta, 0d ~timedelta  (if timedelta in domain)
+    def __call__(
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        x1: np.timedelta64 | _IntLike_co,
+        x2: np.timedelta64,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.timedelta64: ...
+    @overload  # 0d ~datetime64, 0d +timedelta  (if datetime in domain)
+    def __call__(
+        self: _ufunc_21_pow_sub[np.datetime64],
+        x1: np.datetime64,
+        x2: np.timedelta64 | _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.datetime64: ...
+    @overload  # 0d ~datetime64, 0d ~datetime64  (if datetime in domain)
+    def __call__(
+        self: _ufunc_21_pow_sub[np.datetime64],
+        x1: np.datetime64,
+        x2: np.datetime64,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.timedelta64: ...
     @overload  # 0d T@inexact, 0d +float
     def __call__[ScalarT: np.inexact](
         self,
@@ -11761,6 +11804,50 @@ class _ufunc_21_pow(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.object_]: ...
+    @overload  # ?d ~timedelta, ?d +timedelta  (if timedelta in domain)
+    def __call__(
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        x1: _ArrayLike[np.timedelta64],
+        x2: _DualArrayLike[np.dtype[np.timedelta64 | _to_integer], int],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.timedelta64]: ...
+    @overload  # ?d +timedelta, ?d ~timedelta  (if timedelta in domain)
+    def __call__(
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        x1: _DualArrayLike[np.dtype[np.timedelta64 | _to_integer], int],
+        x2: _ArrayLike[np.timedelta64],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.timedelta64]: ...
+    @overload  # ?d ~datetime64, ?d +timedelta  (if datetime in domain)
+    def __call__(
+        self: _ufunc_21_pow_sub[np.datetime64],
+        x1: _ArrayLike[np.datetime64],
+        x2: _DualArrayLike[np.dtype[np.timedelta64 | _to_integer], int],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.datetime64]: ...
+    @overload  # ?d ~datetime64, ?d ~datetime64  (if datetime in domain)
+    def __call__(
+        self: _ufunc_21_pow_sub[np.datetime64],
+        x1: _ArrayLike[np.datetime64],
+        x2: _ArrayLike[np.datetime64],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.timedelta64]: ...
     @overload  # Nd ~complex, ?d +complex
     def __call__(
         self,
@@ -11883,7 +11970,7 @@ class _ufunc_21_pow(_ufunc_21[None]):  # type: ignore[misc]
         **kwargs: Unpack[_Kwargs21],
     ) -> OutT: ...
 
-    # TODO: keep in sync with `__call__`
+    # NOTE: keep in sync with `__call__`
     @override
     @overload  # 0d +i8, 0d +i8
     def outer(  # pyrefly:ignore[bad-override]
@@ -12105,6 +12192,50 @@ class _ufunc_21_pow(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> np.complex128: ...
+    @overload  # 0d ~timedelta, 0d +timedelta  (if timedelta in domain)
+    def outer(
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        x1: np.timedelta64,
+        x2: np.timedelta64 | _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.timedelta64: ...
+    @overload  # 0d +timedelta, 0d ~timedelta  (if timedelta in domain)
+    def outer(
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        x1: np.timedelta64 | _IntLike_co,
+        x2: np.timedelta64,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.timedelta64: ...
+    @overload  # 0d ~datetime64, 0d +timedelta  (if datetime in domain)
+    def outer(
+        self: _ufunc_21_pow_sub[np.datetime64],
+        x1: np.datetime64,
+        x2: np.timedelta64 | _IntLike_co,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.datetime64: ...
+    @overload  # 0d ~datetime64, 0d ~datetime64  (if datetime in domain)
+    def outer(
+        self: _ufunc_21_pow_sub[np.datetime64],
+        x1: np.datetime64,
+        x2: np.datetime64,
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> np.timedelta64: ...
     @overload  # 0d T@inexact, 0d +float
     def outer[ScalarT: np.inexact](
         self,
@@ -12468,6 +12599,50 @@ class _ufunc_21_pow(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         **kwargs: Unpack[_Kwargs21],
     ) -> npt.NDArray[np.object_]: ...
+    @overload  # ?d ~timedelta, ?d +timedelta  (if timedelta in domain)
+    def outer(
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        x1: _ArrayLike[np.timedelta64],
+        x2: _DualArrayLike[np.dtype[np.timedelta64 | _to_integer], int],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.timedelta64]: ...
+    @overload  # ?d +timedelta, ?d ~timedelta  (if timedelta in domain)
+    def outer(
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        x1: _DualArrayLike[np.dtype[np.timedelta64 | _to_integer], int],
+        x2: _ArrayLike[np.timedelta64],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.timedelta64]: ...
+    @overload  # ?d ~datetime64, ?d +timedelta  (if datetime in domain)
+    def outer(
+        self: _ufunc_21_pow_sub[np.datetime64],
+        x1: _ArrayLike[np.datetime64],
+        x2: _DualArrayLike[np.dtype[np.timedelta64 | _to_integer], int],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.datetime64]: ...
+    @overload  # ?d ~datetime64, ?d ~datetime64  (if datetime in domain)
+    def outer(
+        self: _ufunc_21_pow_sub[np.datetime64],
+        x1: _ArrayLike[np.datetime64],
+        x2: _ArrayLike[np.datetime64],
+        /,
+        *,
+        out: None = None,
+        dtype: None = None,
+        **kwargs: Unpack[_Kwargs21],
+    ) -> npt.NDArray[np.timedelta64]: ...
     @overload  # Nd ~complex, ?d +complex
     def outer(
         self,
@@ -12595,6 +12770,14 @@ class _ufunc_21_pow(_ufunc_21[None]):  # type: ignore[misc]
     @overload
     def at(self, a: npt.NDArray[_to_number | np.object_], indices: _ArrayLikeInt, b: _ArrayLikeNumberObj_co, /) -> None: ...  # pyrefly:ignore[bad-override]
     @overload
+    def at(
+        self: _ufunc_21_pow_sub[np.timedelta64 | np.datetime64],
+        a: npt.NDArray[np.timedelta64 | np.datetime64 | _to_integer],
+        indices: _ArrayLikeInt,
+        b: _DualArrayLike[np.dtype[np.timedelta64 | _to_integer], int],
+        /,
+    ) -> None: ...
+    @overload
     def at[OtherT, IxT, OutT](self, a: _CanUfuncAt2L[OtherT, IxT, OutT], indices: IxT, b: OtherT, /) -> OutT: ...
     @overload
     def at[OtherT, IxT, OutT](self, a: OtherT, indices: IxT, b: _CanUfuncAt2R[OtherT, IxT, OutT], /) -> OutT: ...
@@ -12692,6 +12875,45 @@ class _ufunc_21_pow(_ufunc_21[None]):  # type: ignore[misc]
         initial: bool | _to_i8 = ...,
         where: _ArrayLikeBool_co = True,
     ) -> npt.NDArray[np.int8]: ...
+    @overload  # ~timedelta64  (if timedelta in domain)
+    def reduce[TimedeltaT: np.timedelta64](
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        array: _ArrayLike[TimedeltaT],
+        /,
+        *,
+        axis: int | tuple[int, ...] = 0,
+        dtype: None = None,
+        out: EllipsisType | None = None,
+        keepdims: Literal[False] = False,
+        initial: np.timedelta64 | _IntLike_co = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[TimedeltaT] | Any: ...
+    @overload  # ~timedelta64, axis=None  (if timedelta in domain)
+    def reduce[TimedeltaT: np.timedelta64](
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        array: _ArrayLike[TimedeltaT],
+        /,
+        *,
+        axis: None,
+        dtype: None = None,
+        out: None = None,
+        keepdims: Literal[False] = False,
+        initial: np.timedelta64 | _IntLike_co = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> TimedeltaT: ...
+    @overload  # ~timedelta64, keepdims=True  (if timedelta in domain)
+    def reduce[TimedeltaT: np.timedelta64](
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        array: _ArrayLike[TimedeltaT],
+        /,
+        *,
+        axis: int | tuple[int, ...] | None = 0,
+        dtype: None = None,
+        out: EllipsisType | None = None,
+        keepdims: Literal[True],
+        initial: np.timedelta64 | _IntLike_co = ...,
+        where: _ArrayLikeBool_co = True,
+    ) -> npt.NDArray[TimedeltaT]: ...
     @overload  # ~int
     def reduce(
         self,
@@ -12886,6 +13108,17 @@ class _ufunc_21_pow(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         out: None = None,
     ) -> npt.NDArray[np.int8]: ...
+    @overload  # ~timedelta64  (if timedelta in domain)
+    def reduceat[TimedeltaT: np.timedelta64](
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        array: _ArrayLike[TimedeltaT],
+        /,
+        indices: tuple[int, ...],
+        *,
+        axis: int = 0,
+        dtype: None = None,
+        out: None = None,
+    ) -> npt.NDArray[TimedeltaT]: ...
     @overload  # ~int
     def reduceat(
         self,
@@ -12986,6 +13219,16 @@ class _ufunc_21_pow(_ufunc_21[None]):  # type: ignore[misc]
         dtype: None = None,
         out: None = None,
     ) -> npt.NDArray[np.int8]: ...
+    @overload  # ~timedelta64  (if timedelta in domain)
+    def accumulate[TimedeltaT: np.timedelta64](
+        self: _ufunc_21_pow_sub[np.timedelta64],
+        array: _ArrayLike[TimedeltaT],
+        /,
+        *,
+        axis: int = 0,
+        dtype: None = None,
+        out: None = None,
+    ) -> npt.NDArray[TimedeltaT]: ...
     @overload  # ~int
     def accumulate(
         self,
@@ -13099,7 +13342,8 @@ remainder: Final[_ufunc_21_mod[np.inexact | np.timedelta64 | np.object_, np.time
 mod = remainder
 floor_divide: Final[_ufunc_21_mod[np.inexact | np.timedelta64 | np.object_, np.int64]] = ...
 
-power: Final[_ufunc_21_pow] = ...
+power: Final[_ufunc_21_pow_sub[np.bool | np.number | np.object_]] = ...
+subtract: Final[_ufunc_21_pow_sub[np.bool | np.number | np.object_ | np.timedelta64 | np.datetime64]] = ...
 
 ###
 # re-exports from `_core._multiarray_umath` that are used by `_core._ufunc_config`

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -2434,7 +2434,7 @@ assert_type(np.floor_divide.reduceat(_obj_nd, (1,)), npt.NDArray[np.object_])
 assert_type(np.floor_divide.accumulate(_obj_nd), npt.NDArray[np.object_])
 
 ###
-# _ufunc_21_pow
+# _ufunc_21_pow_sub[bool | number | object_]
 # (pow[er])
 
 assert_type(np.pow(_py_b_0d, _py_b_0d), np.int8)
@@ -2814,3 +2814,52 @@ assert_type(np.pow.accumulate(_c128_nd), npt.NDArray[np.complex128])
 assert_type(np.pow.accumulate(_obj_nd), npt.NDArray[np.object_])
 assert_type(np.pow.accumulate(_py_i_1d, dtype=np.int16), npt.NDArray[np.int16])
 assert_type(np.pow.accumulate(_py_i_1d, dtype="i2"), npt.NDArray[Any])
+
+###
+# _ufunc_21_pow_sub[bool | number | object_ | timedelta64 | datetime64]
+# (subtract)
+# same as `pow[er]` above with additional `timedelta64` and `datetime64` overloads
+
+assert_type(np.subtract(_py_b_0d, _td_ns_0d), np.timedelta64)
+assert_type(np.subtract(_py_b_1d, _td_ns_1d), npt.NDArray[np.timedelta64])
+
+assert_type(np.subtract(_py_i_0d, _td_ns_0d), np.timedelta64)
+assert_type(np.subtract(_py_i_1d, _td_ns_1d), npt.NDArray[np.timedelta64])
+
+assert_type(np.subtract(_i64_0d, _td_ns_0d), np.timedelta64)
+assert_type(np.subtract(_i64_1d, _td_ns_1d), npt.NDArray[np.timedelta64])
+
+assert_type(np.subtract(_td_ns_0d, _py_b_0d), np.timedelta64)
+assert_type(np.subtract(_td_ns_1d, _py_b_1d), npt.NDArray[np.timedelta64])
+assert_type(np.subtract(_td_ns_0d, _py_i_0d), np.timedelta64)
+assert_type(np.subtract(_td_ns_1d, _py_i_1d), npt.NDArray[np.timedelta64])
+assert_type(np.subtract(_td_ns_0d, _i64_0d), np.timedelta64)
+assert_type(np.subtract(_td_ns_1d, _i64_1d), npt.NDArray[np.timedelta64])
+assert_type(np.subtract(_td_ns_0d, _td_ns_0d), np.timedelta64)
+assert_type(np.subtract(_td_ns_1d, _td_ns_1d), npt.NDArray[np.timedelta64])
+
+assert_type(np.subtract(_dt_ns_0d, _py_b_0d), np.datetime64)
+assert_type(np.subtract(_dt_ns_1d, _py_b_1d), npt.NDArray[np.datetime64])
+assert_type(np.subtract(_dt_ns_0d, _py_i_0d), np.datetime64)
+assert_type(np.subtract(_dt_ns_1d, _py_i_1d), npt.NDArray[np.datetime64])
+assert_type(np.subtract(_dt_ns_0d, _i64_0d), np.datetime64)
+assert_type(np.subtract(_dt_ns_1d, _i64_1d), npt.NDArray[np.datetime64])
+assert_type(np.subtract(_dt_ns_0d, _td_ns_0d), np.datetime64)
+assert_type(np.subtract(_dt_ns_1d, _td_ns_1d), npt.NDArray[np.datetime64])
+assert_type(np.subtract(_dt_ns_0d, _dt_ns_0d), np.timedelta64)
+assert_type(np.subtract(_dt_ns_1d, _dt_ns_1d), npt.NDArray[np.timedelta64])
+
+# subtract.outer is equivalent to __call__
+
+assert_type(np.subtract.at(_td_ns_1d, 1, _py_b_1d), None)
+assert_type(np.subtract.at(_td_ns_1d, 1, _py_i_1d), None)
+assert_type(np.subtract.at(_td_ns_1d, 1, _i64_1d), None)
+assert_type(np.subtract.at(_td_ns_1d, 1, _td_ns_1d), None)
+
+assert_type(np.subtract.reduce(_td_ns_1d), npt.NDArray[np.timedelta64[int]] | Any)
+assert_type(np.subtract.reduce(_td_ns_1d, axis=None), np.timedelta64[int])
+assert_type(np.subtract.reduce(_td_ns_1d, keepdims=True), npt.NDArray[np.timedelta64[int]])
+
+assert_type(np.subtract.reduceat(_td_ns_1d, (1,)), npt.NDArray[np.timedelta64[int]])
+
+assert_type(np.subtract.accumulate(_td_ns_1d), npt.NDArray[np.timedelta64[int]])


### PR DESCRIPTION
Building upon #32047, this parametrizes the `pow[er]` ufunc subtype and adds conditional `timedelta64` and `datetime64` overloads so that the same type can also be used for `np.subtract` (`subtract` and `pow` only differ in signatures for datetime/timedelta).

<details>
<summary>promotion tables:</summary>

`power`:

```
        b8    i8    u8   i16   u16   i32   u32   i64   u64   f16   f32   f64   f80   c64  c128  c160  O
b8      i8    i8    u8   i16   u16   i32   u32   i64   u64   f16   f32   f64   f80   c64  c128  c160  O
i8      i8    i8   i16   i16   i32   i32   i64   i64   f64   f16   f32   f64   f80   c64  c128  c160  O
u8      u8   i16    u8   i16   u16   i32   u32   i64   u64   f16   f32   f64   f80   c64  c128  c160  O
i16    i16   i16   i16   i16   i32   i32   i64   i64   f64   f32   f32   f64   f80   c64  c128  c160  O
u16    u16   i32   u16   i32   u16   i32   u32   i64   u64   f32   f32   f64   f80   c64  c128  c160  O
i32    i32   i32   i32   i32   i32   i32   i64   i64   f64   f64   f64   f64   f80  c128  c128  c160  O
u32    u32   i64   u32   i64   u32   i64   u32   i64   u64   f64   f64   f64   f80  c128  c128  c160  O
i64    i64   i64   i64   i64   i64   i64   i64   i64   f64   f64   f64   f64   f80  c128  c128  c160  O
u64    u64   f64   u64   f64   u64   f64   u64   f64   u64   f64   f64   f64   f80  c128  c128  c160  O
f16    f16   f16   f16   f32   f32   f64   f64   f64   f64   f16   f32   f64   f80   c64  c128  c160  O
f32    f32   f32   f32   f32   f32   f64   f64   f64   f64   f32   f32   f64   f80   c64  c128  c160  O
f64    f64   f64   f64   f64   f64   f64   f64   f64   f64   f64   f64   f64   f80  c128  c128  c160  O
f80    f80   f80   f80   f80   f80   f80   f80   f80   f80   f80   f80   f80   f80  c160  c160  c160  O
c64    c64   c64   c64   c64   c64  c128  c128  c128  c128   c64   c64  c128  c160   c64  c128  c160  O
c128  c128  c128  c128  c128  c128  c128  c128  c128  c128  c128  c128  c128  c160  c128  c128  c160  O
c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  O
O        O     O     O     O     O     O     O     O     O     O     O     O     O     O     O     O  O
```

`subtract`:

```
        b8    i8    u8   i16   u16   i32   u32   i64   u64   f16   f32   f64   f80   c64  c128  c160  m  M  O
b8            i8    u8   i16   u16   i32   u32   i64   u64   f16   f32   f64   f80   c64  c128  c160  m     O
i8      i8    i8   i16   i16   i32   i32   i64   i64   f64   f16   f32   f64   f80   c64  c128  c160  m     O
u8      u8   i16    u8   i16   u16   i32   u32   i64   u64   f16   f32   f64   f80   c64  c128  c160  m     O
i16    i16   i16   i16   i16   i32   i32   i64   i64   f64   f32   f32   f64   f80   c64  c128  c160  m     O
u16    u16   i32   u16   i32   u16   i32   u32   i64   u64   f32   f32   f64   f80   c64  c128  c160  m     O
i32    i32   i32   i32   i32   i32   i32   i64   i64   f64   f64   f64   f64   f80  c128  c128  c160  m     O
u32    u32   i64   u32   i64   u32   i64   u32   i64   u64   f64   f64   f64   f80  c128  c128  c160  m     O
i64    i64   i64   i64   i64   i64   i64   i64   i64   f64   f64   f64   f64   f80  c128  c128  c160  m     O
u64    u64   f64   u64   f64   u64   f64   u64   f64   u64   f64   f64   f64   f80  c128  c128  c160  m     O
f16    f16   f16   f16   f32   f32   f64   f64   f64   f64   f16   f32   f64   f80   c64  c128  c160        O
f32    f32   f32   f32   f32   f32   f64   f64   f64   f64   f32   f32   f64   f80   c64  c128  c160        O
f64    f64   f64   f64   f64   f64   f64   f64   f64   f64   f64   f64   f64   f80  c128  c128  c160        O
f80    f80   f80   f80   f80   f80   f80   f80   f80   f80   f80   f80   f80   f80  c160  c160  c160        O
c64    c64   c64   c64   c64   c64  c128  c128  c128  c128   c64   c64  c128  c160   c64  c128  c160        O
c128  c128  c128  c128  c128  c128  c128  c128  c128  c128  c128  c128  c128  c160  c128  c128  c160        O
c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160  c160        O
m        m     m     m     m     m     m     m     m     m                                            m      
M        M     M     M     M     M     M     M     M     M                                            M  m   
O        O     O     O     O     O     O     O     O     O     O     O     O     O     O     O     O        O
```

</details>

---

No AI.