### PR TITLE
DOC: fix typos for "documentaion" in "user/basics.performant_code"

### DIFF
--- a/doc/source/user/basics.performant_code.rst
+++ b/doc/source/user/basics.performant_code.rst
@@ -101,7 +101,7 @@ If you encounter pickling-related issues, consider the following strategies:
 * Consider third-party libraries such as `joblib <https://github.com/joblib/joblib>`__.
   ``joblib``'s default backend ``loky`` relies on `cloudpickle <https://github.com/cloudpipe/cloudpickle>`__
   for serialization and can handle a wider range of Python objects than the standard ``pickle`` module.
-  See the ``joblib`` documentaion on `Serialization of un-picklable objects <https://joblib.readthedocs.io/en/latest/auto_examples/serialization_and_wrappers.html>`__ for more details.
+  See the ``joblib`` documentation on `Serialization of un-picklable objects <https://joblib.readthedocs.io/en/latest/auto_examples/serialization_and_wrappers.html>`__ for more details.
 
 
 
@@ -438,7 +438,7 @@ not only for a single machine but also for a cluster of machines.
 It also provides ``DaskArray`` which has a similar API to NumPy's ``ndarray``. 
 If you are familiar with NumPy, you can easily get started with ``DaskArray``.
 
-* Dask Documentaion: https://docs.dask.org/en/stable/
+* Dask Documentation: https://docs.dask.org/en/stable/
 * Dask GitHub Repository: https://github.com/dask/dask
 
 


### PR DESCRIPTION
### PR summary

Fix typos:
* `documentaion` --> `documentation`
* `Documentaion` --> `Documentation`
in the document:
"user/basics.performant_code"
(Writing Performant NumPy Code with Multi-Core CPUs)

### First time committer introduction

Second time is the charm (following PR template this time)! I'm new to
contributing to this repo, but I've been using Python since version
2.3. My background is in air pollution modeing (chemical engineer),
high-throughput computing, as well as blockchain and Linux systems.
I'm also the founder of VGMusic.com, one of the oldest music archives
on the Internet. Looking to keep my PRs to useful typo corrections.
I'm not a pedant. I just hate second guessing misspelled words, and
want to prevent the same annoyance to other people.

#### AI Disclosure

No AI tools used. Although I have a high failure rate at CAPTCHAs
and sometimes question my humanity.
