### PR TITLE
DOC: Fix full name of chebinterpolate in the Chebyshev.interpolate docstring.

### DIFF
--- a/numpy/polynomial/chebyshev.py
+++ b/numpy/polynomial/chebyshev.py
@@ -2038,7 +2038,7 @@ class Chebyshev(ABCPolyBase):
 
         Notes
         -----
-        See `numpy.polynomial.chebinterpolate` for more details.
+        See `numpy.polynomial.chebyshev.chebinterpolate` for more details.
 
         """
         if domain is None:


### PR DESCRIPTION
Fix a name referenced in the docstring of `Chebyshev.interpolate`: `numpy.polynomial.chebinterpolate` $\rightarrow$ `numpy.polynomial.chebyshev.chebinterpolate`.


#### AI Disclosure
No AI tools used.

