### PR TITLE
BUG: ensure lock is held when accessing or writing to RNG state

### DIFF
--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import inspect
+import random
 import subprocess
 import sys
 import textwrap
@@ -39,6 +40,48 @@ def test_parallel_randomstate():
         rng.set_state(state)
 
     run_threaded(func, 8, pass_count=True)
+
+def test_parallel_seed_get_state():
+    seeds = [12345, 67890]
+    rng = np.random.RandomState()
+    expected = []
+    for seed in seeds:
+        rng.seed(seed)
+        expected.append(rng.get_state()[1])
+
+    def func(i, barrier):
+        rnd = random.Random(i)
+        barrier.wait()
+        for _ in range(100):
+            if rnd.randrange(2):
+                rng.seed(rnd.choice(seeds))
+            else:
+                key = rng.get_state()[1]
+                assert any((key == exp).all() for exp in expected)
+
+    run_threaded(func, pass_count=True, pass_barrier=True)
+
+@pytest.mark.parametrize(
+    "bitgen_name", ["MT19937", "PCG64", "PCG64DXSM", "Philox", "SFC64"])
+def test_parallel_bit_generator_state_access(bitgen_name):
+    bg = getattr(np.random, bitgen_name)(12345)
+    gen = np.random.Generator(bg)
+
+    def func(i, barrier):
+        rnd = random.Random(i)
+        barrier.wait()
+        for _ in range(100):
+            branch = rnd.randrange(3)
+            if branch == 0:
+                bg.state = bg.state
+            elif branch == 1:
+                gen.random(10)
+            elif hasattr(bg, "advance"):
+                bg.advance(10)
+            else:
+                _ = bg.state
+
+    run_threaded(func, pass_count=True, pass_barrier=True)
 
 def test_parallel_ufunc_execution():
     # if the loop data cache or dispatch cache are not thread-safe

--- a/numpy/random/_mt19937.pyx
+++ b/numpy/random/_mt19937.pyx
@@ -192,7 +192,7 @@ cdef class MT19937(BitGenerator):
                     raise ValueError("Seed must be between 0 and 2**32 - 1")
                 obj = obj.astype(np.uint32, casting='unsafe', order='C')
                 mt19937_init_by_array(&self.rng_state, <uint32_t*> obj.data, np.PyArray_DIM(obj, 0))
-        self._seed_seq = None
+            self._seed_seq = None
 
     cdef jump_inplace(self, iter):
         """
@@ -266,11 +266,12 @@ cdef class MT19937(BitGenerator):
             state of the PRNG
         """
         key = np.zeros(624, dtype=np.uint32)
-        for i in range(624):
-            key[i] = self.rng_state.key[i]
+        with self.lock:
+            for i in range(624):
+                key[i] = self.rng_state.key[i]
 
-        return {'bit_generator': self.__class__.__name__,
-                'state': {'key': key, 'pos': self.rng_state.pos}}
+            return {'bit_generator': self.__class__.__name__,
+                    'state': {'key': key, 'pos': self.rng_state.pos}}
 
     @state.setter
     def state(self, value):
@@ -286,6 +287,7 @@ cdef class MT19937(BitGenerator):
         if bitgen != self.__class__.__name__:
             raise ValueError(f'state must be for a {self.__class__.__name__} PRNG')
         key = value['state']['key']
-        for i in range(624):
-            self.rng_state.key[i] = key[i]
-        self.rng_state.pos = value['state']['pos']
+        with self.lock:
+            for i in range(624):
+                self.rng_state.key[i] = key[i]
+            self.rng_state.pos = value['state']['pos']

--- a/numpy/random/_pcg64.pyx
+++ b/numpy/random/_pcg64.pyx
@@ -206,9 +206,10 @@ cdef class PCG64(BitGenerator):
 
         # state_vec is state.high, state.low, inc.high, inc.low
         state_vec = <np.ndarray>np.empty(4, dtype=np.uint64)
-        pcg64_get_state(&self.rng_state,
-                        <uint64_t *>np.PyArray_DATA(state_vec),
-                        &has_uint32, &uinteger)
+        with self.lock:
+            pcg64_get_state(&self.rng_state,
+                            <uint64_t *>np.PyArray_DATA(state_vec),
+                            &has_uint32, &uinteger)
         state = int(state_vec[0]) * 2**64 + int(state_vec[1])
         inc = int(state_vec[2]) * 2**64 + int(state_vec[3])
         return {'bit_generator': self.__class__.__name__,
@@ -233,9 +234,10 @@ cdef class PCG64(BitGenerator):
         state_vec[3] = value['state']['inc'] % 2 ** 64
         has_uint32 = value['has_uint32']
         uinteger = value['uinteger']
-        pcg64_set_state(&self.rng_state,
-                        <uint64_t *>np.PyArray_DATA(state_vec),
-                        has_uint32, uinteger)
+        with self.lock:
+            pcg64_set_state(&self.rng_state,
+                            <uint64_t *>np.PyArray_DATA(state_vec),
+                            has_uint32, uinteger)
 
     def advance(self, delta):
         """
@@ -278,8 +280,9 @@ cdef class PCG64(BitGenerator):
         cdef np.ndarray d = np.empty(2, dtype=np.uint64)
         d[0] = delta // 2**64
         d[1] = delta % 2**64
-        pcg64_advance(&self.rng_state, <uint64_t *>np.PyArray_DATA(d))
-        self._reset_state_variables()
+        with self.lock:
+            pcg64_advance(&self.rng_state, <uint64_t *>np.PyArray_DATA(d))
+            self._reset_state_variables()
         return self
 
 
@@ -440,9 +443,10 @@ cdef class PCG64DXSM(BitGenerator):
 
         # state_vec is state.high, state.low, inc.high, inc.low
         state_vec = <np.ndarray>np.empty(4, dtype=np.uint64)
-        pcg64_get_state(&self.rng_state,
-                        <uint64_t *>np.PyArray_DATA(state_vec),
-                        &has_uint32, &uinteger)
+        with self.lock:
+            pcg64_get_state(&self.rng_state,
+                            <uint64_t *>np.PyArray_DATA(state_vec),
+                            &has_uint32, &uinteger)
         state = int(state_vec[0]) * 2**64 + int(state_vec[1])
         inc = int(state_vec[2]) * 2**64 + int(state_vec[3])
         return {'bit_generator': self.__class__.__name__,
@@ -467,9 +471,10 @@ cdef class PCG64DXSM(BitGenerator):
         state_vec[3] = value['state']['inc'] % 2 ** 64
         has_uint32 = value['has_uint32']
         uinteger = value['uinteger']
-        pcg64_set_state(&self.rng_state,
-                        <uint64_t *>np.PyArray_DATA(state_vec),
-                        has_uint32, uinteger)
+        with self.lock:
+            pcg64_set_state(&self.rng_state,
+                            <uint64_t *>np.PyArray_DATA(state_vec),
+                            has_uint32, uinteger)
 
     def advance(self, delta):
         """
@@ -512,6 +517,7 @@ cdef class PCG64DXSM(BitGenerator):
         cdef np.ndarray d = np.empty(2, dtype=np.uint64)
         d[0] = delta // 2**64
         d[1] = delta % 2**64
-        pcg64_cm_advance(&self.rng_state, <uint64_t *>np.PyArray_DATA(d))
-        self._reset_state_variables()
+        with self.lock:
+            pcg64_cm_advance(&self.rng_state, <uint64_t *>np.PyArray_DATA(d))
+            self._reset_state_variables()
         return self

--- a/numpy/random/_philox.pyx
+++ b/numpy/random/_philox.pyx
@@ -215,20 +215,21 @@ cdef class Philox(BitGenerator):
         ctr = np.empty(4, dtype=np.uint64)
         key = np.empty(2, dtype=np.uint64)
         buffer = np.empty(PHILOX_BUFFER_SIZE, dtype=np.uint64)
-        for i in range(4):
-            ctr[i] = self.rng_state.ctr.v[i]
-            if i < 2:
-                key[i] = self.rng_state.key.v[i]
-        for i in range(PHILOX_BUFFER_SIZE):
-            buffer[i] = self.rng_state.buffer[i]
+        with self.lock:
+            for i in range(4):
+                ctr[i] = self.rng_state.ctr.v[i]
+                if i < 2:
+                    key[i] = self.rng_state.key.v[i]
+            for i in range(PHILOX_BUFFER_SIZE):
+                buffer[i] = self.rng_state.buffer[i]
 
-        state = {'counter': ctr, 'key': key}
-        return {'bit_generator': self.__class__.__name__,
-                'state': state,
-                'buffer': buffer,
-                'buffer_pos': self.rng_state.buffer_pos,
-                'has_uint32': self.rng_state.has_uint32,
-                'uinteger': self.rng_state.uinteger}
+            state = {'counter': ctr, 'key': key}
+            return {'bit_generator': self.__class__.__name__,
+                    'state': state,
+                    'buffer': buffer,
+                    'buffer_pos': self.rng_state.buffer_pos,
+                    'has_uint32': self.rng_state.has_uint32,
+                    'uinteger': self.rng_state.uinteger}
 
     @state.setter
     def state(self, value):
@@ -237,16 +238,17 @@ cdef class Philox(BitGenerator):
         bitgen = value.get('bit_generator', '')
         if bitgen != self.__class__.__name__:
             raise ValueError(f'state must be for a {self.__class__.__name__} PRNG')
-        for i in range(4):
-            self.rng_state.ctr.v[i] = <uint64_t> value['state']['counter'][i]
-            if i < 2:
-                self.rng_state.key.v[i] = <uint64_t> value['state']['key'][i]
-        for i in range(PHILOX_BUFFER_SIZE):
-            self.rng_state.buffer[i] = <uint64_t> value['buffer'][i]
+        with self.lock:
+            for i in range(4):
+                self.rng_state.ctr.v[i] = <uint64_t> value['state']['counter'][i]
+                if i < 2:
+                    self.rng_state.key.v[i] = <uint64_t> value['state']['key'][i]
+            for i in range(PHILOX_BUFFER_SIZE):
+                self.rng_state.buffer[i] = <uint64_t> value['buffer'][i]
 
-        self.rng_state.has_uint32 = value['has_uint32']
-        self.rng_state.uinteger = value['uinteger']
-        self.rng_state.buffer_pos = value['buffer_pos']
+            self.rng_state.has_uint32 = value['has_uint32']
+            self.rng_state.uinteger = value['uinteger']
+            self.rng_state.buffer_pos = value['buffer_pos']
 
     cdef jump_inplace(self, iter):
         """
@@ -328,6 +330,7 @@ cdef class Philox(BitGenerator):
 
         cdef np.ndarray delta_a
         delta_a = int_to_array(delta, 'step', 256, 64)
-        philox_advance(<uint64_t *> delta_a.data, &self.rng_state)
-        self._reset_state_variables()
+        with self.lock:
+            philox_advance(<uint64_t *> delta_a.data, &self.rng_state)
+            self._reset_state_variables()
         return self

--- a/numpy/random/_sfc64.pyx
+++ b/numpy/random/_sfc64.pyx
@@ -118,9 +118,10 @@ cdef class SFC64(BitGenerator):
         cdef uint32_t uinteger
 
         state_vec = <np.ndarray>np.empty(4, dtype=np.uint64)
-        sfc64_get_state(&self.rng_state,
-                        <uint64_t *>np.PyArray_DATA(state_vec),
-                        &has_uint32, &uinteger)
+        with self.lock:
+            sfc64_get_state(&self.rng_state,
+                            <uint64_t *>np.PyArray_DATA(state_vec),
+                            &has_uint32, &uinteger)
         return {'bit_generator': self.__class__.__name__,
                 'state': {'state': state_vec},
                 'has_uint32': has_uint32,
@@ -140,6 +141,7 @@ cdef class SFC64(BitGenerator):
         state_vec[:] = value['state']['state']
         has_uint32 = value['has_uint32']
         uinteger = value['uinteger']
-        sfc64_set_state(&self.rng_state,
-                        <uint64_t *>np.PyArray_DATA(state_vec),
-                        has_uint32, uinteger)
+        with self.lock:
+            sfc64_set_state(&self.rng_state,
+                            <uint64_t *>np.PyArray_DATA(state_vec),
+                            has_uint32, uinteger)

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -296,15 +296,15 @@ cdef class RandomState:
         the user should know exactly what he/she is doing.
 
         """
-        st = self._bit_generator.state
+        with self.lock:
+            st = self._bit_generator.state
+            st['has_gauss'] = self._aug_state.has_gauss
+            st['gauss'] = self._aug_state.gauss
         if st['bit_generator'] != 'MT19937' and legacy:
             warnings.warn('get_state and legacy can only be used with the '
                           'MT19937 BitGenerator. To silence this warning, '
                           'set `legacy` to False.', RuntimeWarning)
             legacy = False
-        with self.lock:
-            st['has_gauss'] = self._aug_state.has_gauss
-            st['gauss'] = self._aug_state.gauss
         if legacy and not isinstance(self._bit_generator, _MT19937):
             raise ValueError(
                 "legacy can only be True when the underlying bitgenerator is "


### PR DESCRIPTION
### PR summary
Fixes #32059.

#30360 was supposed to fix these issues but clearly this is harder than I thought.

With this PR the lock is being held everywhere we access the RNG state. Also adds new tests for the case from the issue as well as some other spots I noticed while auditing the RNG codebase for similar issues.

I was able to reproduce the race in a slightly modified version of the script in the issue and it no longer triggers after this PR.

#### AI Disclosure
I used an AI model to find places where we access RNG state without holding the lock. It also helped with the new tests.