### PR TITLE
BUG: fully reset cached RNG state for non-MT19937 RNGs

### DIFF
--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -4833,7 +4833,7 @@ def seed(seed=None):
         return _rand.seed(seed)
     else:
         bg_type = type(_rand._bit_generator)
-        _rand._bit_generator.state = bg_type(seed).state
+        _rand.set_state(bg_type(seed).state)
 
 def get_bit_generator():
     """

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -2061,6 +2061,15 @@ def test_seed_alt_bit_gen(restore_singleton_bitgen):
 
 
 @pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+def test_seed_alt_bit_gen_resets_gauss_cache(restore_singleton_bitgen):
+    np.random.set_bit_generator(PCG64(0))
+    np.random.seed(12345)
+    expected = np.random.standard_normal()
+    np.random.seed(12345)
+    assert np.random.standard_normal() == expected
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
 def test_state_error_alt_bit_gen(restore_singleton_bitgen):
     # GH 21808
     state = np.random.get_state()


### PR DESCRIPTION
### PR summary
I noticed this working on #32061 but it's a separate issue unrelated to thread safety. See the test for a case where it could lead to an RNG producing output based on an old state.

#### AI Disclosure
An AI model identified the bug.
