### PR TITLE
TST: use relative tolerance in polynomial overflow test

### DIFF
--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -276,7 +276,7 @@ class TestPolynomial:
         Regression test for gh-5096.
         """
         v = np.arange(1, 21)
-        assert_almost_equal(np.poly(v), np.poly(np.diag(v)))
+        assert_allclose(np.poly(v), np.poly(np.diag(v)))
 
     def test_zero_poly_dtype(self):
         """


### PR DESCRIPTION
Fixes #32060

### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

--> I investigated the history and figured out that the intended purpose of test_poly_int_overflow() was to prevent integer overflow and not bit by bit matching.

So I modified assert_almost_equal() to assert_allclose() because it would prevent the function from becoming sensitive at 1ULP level while ensuring numerical equivalence at the same time.

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
--> I am Anshika Gupta, a computer science student with interest in systems and open souce. This is my first contributor to numpy. I found this issue on an attempt to look some basic issues to get started with contributing on numpy.

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->  No AI tools used.
