### PR TITLE
BUG: free `__array_struct__` resources on capsule setup failure

### DIFF
--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -460,10 +460,15 @@ array_struct_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
     }
     PyObject *ret = PyCapsule_New(inter, NULL, gentype_struct_free);
     if (ret == NULL) {
+        Py_XDECREF(inter->descr);
+        PyArray_free(inter->shape);
+        PyArray_free(inter);
         return NULL;
     }
     Py_INCREF(self);
     if (PyCapsule_SetContext(ret, self) < 0) {
+        Py_DECREF(self);
+        Py_DECREF(ret);
         return NULL;
     }
     return ret;


### PR DESCRIPTION
### PR summary

In `array_struct_get`, two rare failure paths returned without releasing
owned state: if `PyCapsule_New` failed, the malloc'd `PyArrayInterface`
(and shape/descr) leaked; if `PyCapsule_SetContext` failed after
`Py_INCREF(self)`, the capsule and the extra array ref were abandoned.

Free those resources on the error paths. No behavior change on success.

Similar ownership cleanup spirit to #31968 (no new tests as failure paths
are not reachable from pure Python; leak sanitizer CI covers normal
create/destroy usage).

### First time committer introduction

I've been contributing small NumPy fixes for a few weeks while exploring
the C codebase (e.g. #31968). Happy to keep helping with this kind of
correctness work.

#### AI Disclosure

AI was used to help locate and draft the fix. The change was reviewed and
validated by a human, and this PR is submitted by a human.