### PR TITLE
DOC: fix numpy.ma.vander docstring

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -2242,17 +2242,21 @@ def clump_masked(a):
 
 def vander(x, n=None):
     """
+    Generate a Vandermonde matrix.
+
     Masked values in the input array result in rows of zeros.
 
+    This function is the masked-array equivalent of `numpy.vander`.
+
+    See Also
+    --------
+    numpy.vander : Equivalent function for ndarrays.
     """
     _vander = np.vander(x, n)
     m = getmask(x)
     if m is not nomask:
         _vander[m] = 0
     return _vander
-
-
-vander.__doc__ = ma.doc_note(np.vander.__doc__, vander.__doc__)
 
 
 def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):

--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -2246,11 +2246,23 @@ def vander(x, n=None):
 
     Masked values in the input array result in rows of zeros.
 
-    This function is the masked-array equivalent of `numpy.vander`.
+    Parameters
+    ----------
+    x : array_like
+        1-D input array.
+    n : int, optional
+        Number of columns in the output. If `n` is not specified, a square
+        array is returned.
+
+    Returns
+    -------
+    out : ndarray
+        Vandermonde matrix.
 
     See Also
     --------
     numpy.vander : Equivalent function for ndarrays.
+
     """
     _vander = np.vander(x, n)
     m = getmask(x)


### PR DESCRIPTION
Fixes #32033 

Updated the docstring for `numpy.ma.vander` to match its actual API, replacing the inherited version. The new docstring removes mention of the unsupported increasing parameter but still refers users to `numpy.vander` for more information. This change only affects documentation and does not alter any behaviour.

### AI Disclosure
No uses of AI.