### PR TITLE
TYP: Bound recursive array-like inference

### DIFF
--- a/numpy/_typing/_array_like.py
+++ b/numpy/_typing/_array_like.py
@@ -14,6 +14,14 @@ from ._shape import _AnyShape
 
 type NDArray[ScalarT: np.generic] = np.ndarray[_AnyShape, np.dtype[ScalarT]]
 
+type _FiniteNestedSequence[T] = (
+    T
+    | Sequence[T]
+    | Sequence[Sequence[T]]
+    | Sequence[Sequence[Sequence[T]]]
+    | Sequence[Sequence[Sequence[Sequence[T]]]]
+)
+
 # The `_SupportsArray` protocol only cares about the default dtype
 # (i.e. `dtype=None` or no `dtype` parameter at all) of the to-be returned
 # array.
@@ -39,7 +47,7 @@ class _SupportsArrayFunc(Protocol):
 # A subset of `npt.ArrayLike` that can be parametrized w.r.t. `np.generic`
 type _ArrayLike[ScalarT: np.generic] = (
     _SupportsArray[np.dtype[ScalarT]]
-    | _NestedSequence[_SupportsArray[np.dtype[ScalarT]]]
+    | _FiniteNestedSequence[_SupportsArray[np.dtype[ScalarT]]]
 )
 
 # A union representing array-like objects; consists of two typevars:

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -10,6 +10,8 @@ type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
 type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
 
+type _ArrayAny = np.ndarray[tuple[Any, ...], np.dtype[Any]]
+
 class SubClass[ScalarT: np.generic](np.ndarray[_AnyShape, np.dtype[ScalarT]]): ...
 
 class IntoSubClass[ScalarT: np.generic]:
@@ -60,6 +62,7 @@ assert_type(np.array(B, subok=True, ndmin=0), SubClass[np.float64])
 assert_type(np.array(B, subok=True, ndmin=1), SubClass[np.float64])
 assert_type(np.array(D), npt.NDArray[np.float64 | np.int64])
 assert_type(np.array(E, subok=True), SubClass[np.float64 | np.int64])
+assert_type(np.array([np.sum, np.mean]), _ArrayAny)
 # https://github.com/numpy/numpy/issues/29245
 assert_type(np.array([], dtype=np.bool), npt.NDArray[np.bool[Any]])
 


### PR DESCRIPTION
This changes the private `_ArrayLike` alias to use a bounded nested sequence union rather than the recursive `_NestedSequence` protocol when inferring scalar types for array-like inputs.

`_NestedSequence` already documents that it does not work in combination with type variables. The current `_ArrayLike` alias uses exactly that pattern:

```python
_NestedSequence[_SupportsArray[np.dtype[ScalarT]]]
```

For Pyright, this can lead to very expensive recursive protocol rejection for object arrays such as:

```python
import numpy as np

np.array([np.sum, np.mean])
```

The final inferred type still falls back to `ndarray[..., dtype[Any]]`, but Pyright spends substantial time proving the precise `_ArrayLike[ScalarT]` overload inapplicable.

Local measurements on `pandas/tests/apply/test_series_apply.py` with pip-installed Pyright 1.1.411:

| `_ArrayLike` model | Total | Check | Max RSS |
| --- | ---: | ---: | ---: |
| recursive `_NestedSequence` | 214.824s | 212.84s | 1,226,224 KB |
| bounded `_FiniteNestedSequence` | 5.87s | 3.93s | 478,104 KB |

The typing result for the motivating callable-array case remains the fallback `ndarray[..., dtype[Any]]`. The tradeoff is that this bounds scalar inference through this private `_ArrayLike` path to four nested sequence levels, avoiding a recursive protocol + type variable pattern that is both documented as unsupported and expensive for Pyright.

Validation performed locally:

- `python3 -m py_compile numpy/_typing/_array_like.py`
- `git diff --check`

I could not run the NumPy typing pytest target in the temporary environment because `pytest` is not installed there.