### PR TITLE
MAINT: Tell dependabot to ignore hypothesis.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,4 @@ updates:
       - dependency-name: "jupyterlite-pyodide-kernel"
       - dependency-name: "sphinx"
       - dependency-name: "pkgconf"
+      - dependency-name: "hypothesis"


### PR DESCRIPTION
The latest version of hypothesis uses Rust, consequently tests using it either need binary wheels or Rust installed so that it can be built from source. The risc64 tests have neither. Skip hypothesis updates until one or the other condition is met.

[skip actions] [skip azp]

#### AI Disclosure

No AI.