### PR TITLE
MAINT: Group dependabot actions updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       prefix: "MAINT"
     labels:
       - "03 - Maintenance"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "bus1/cabuild"
   - package-ecosystem: pip


### PR DESCRIPTION
This should fix continuing problems with codeql updates as well as reducing dependabot spam.

[skip azp] [skip actions]

No AI.
