### PR TITLE
CI: Compile OpenBLAS with TSan for TSan CI

### DIFF
--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -1,0 +1,46 @@
+# Adapted from SciPy's ccache action:
+# https://github.com/scipy/scipy/blob/main/.github/ccache/action.yml
+name: Setup Compiler Cache
+description: Prepare and restore compiler cache using ccache
+inputs:
+  workflow_name:
+    description: "Name of the calling workflow to use as cache key prefix"
+    required: true
+  job_name:
+    description: "Name of the calling job, used as cache key prefix"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare compiler cache
+      id: prep-ccache
+      shell: bash
+      run: |
+        mkdir -p "${CCACHE_DIR:-$HOME/.ccache}"
+        echo "dir=${CCACHE_DIR:-$HOME/.ccache}" >> $GITHUB_OUTPUT
+        NOW=$(date -u +"%F-%T")
+        echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
+    - name: Setup compiler cache and save it
+      # Run a restore and save if running on main
+      # Note: we can't simply use restore followed by save because composite actions
+      # are not capable of running post job steps.
+      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.prep-ccache.outputs.dir }}
+        key: ${{ inputs.workflow_name }}-${{ inputs.job_name }}-ccache-linux-${{ steps.prep-ccache.outputs.timestamp }}
+        restore-keys: ${{ inputs.workflow_name }}-${{ inputs.job_name }}-ccache-linux-
+    - name: Setup compiler cache
+      # Run just the restore if not running on main
+      if: ${{ github.ref != 'refs/heads/main' }}
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.prep-ccache.outputs.dir }}
+        key: ${{ inputs.workflow_name }}-${{ inputs.job_name }}-ccache-linux-${{ steps.prep-ccache.outputs.timestamp }}
+        restore-keys: ${{ inputs.workflow_name }}-${{ inputs.job_name }}-ccache-linux-
+    - name: Reset stats
+      shell: bash
+      run: |
+        # Restoring the cache also restored the stats from the previous run
+        ccache --zero-stats

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - /.github/ccache
     schedule:
       interval: weekly
     cooldown:

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/numpy/numpy
           git submodule update --init --recursive
-      - name: Get OpenBLAS version ci_requirements.txt
+      - name: Get OpenBLAS version
         run: |
           version=$(sed -nE 's/^scipy-openblas64==([0-9]+\.[0-9]+\.[0-9]+)\..*$/\1/p' requirements/ci_requirements.txt)
           if [ -z "$version" ]; then
@@ -113,9 +113,6 @@ jobs:
 
       - name: Upgrade spin (gh-29777)
         run: pip install -U spin
-
-      - name: Install OpenBLAS build tools
-        run: pip install cmake
 
       - name: Set up ccache
         run: |
@@ -140,6 +137,7 @@ jobs:
       - name: Build OpenBLAS with ThreadSanitizer
         if: steps.cache-openblas.outputs.cache-hit != 'true'
         run: |
+          pip install cmake
           git clone --depth 1 --branch $OPENBLAS_VERSION \
             https://github.com/OpenMathLib/OpenBLAS.git openblas-src
           # Follows OpenBLAS's own TSAN CI (linux_thread_sanitizer), see
@@ -175,7 +173,9 @@ jobs:
           export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/openblas-tsan/lib/pkgconfig
           export CC="ccache $CC" CXX="ccache $CXX"
           export LDFLAGS="-fsanitize=thread"
-          python -m spin build -j2 -- -Db_sanitize=thread \
+          python -m spin build -j4 -- -Db_sanitize=thread \
+            -Dbuildtype=debugoptimized -Dcpu-dispatch=none \
+            -Ddisable-intel-sort=true -Ddisable-highway=true -Ddisable-svml=true \
             -Dblas=openblas -Dlapack=openblas -Dallow-noblas=false
           ccache -s
 

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -96,19 +96,95 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/numpy/numpy
           git submodule update --init --recursive
+      - name: Get OpenBLAS version ci_requirements.txt
+        run: |
+          version=$(sed -nE 's/^scipy-openblas64==([0-9]+\.[0-9]+\.[0-9]+)\..*$/\1/p' requirements/ci_requirements.txt)
+          if [ -z "$version" ]; then
+            echo "Could not parse the scipy-openblas64 pin from requirements/ci_requirements.txt"
+            exit 1
+          fi
+          echo "OPENBLAS_VERSION=v$version"
+          echo "OPENBLAS_VERSION=v$version" >> "$GITHUB_ENV"
       - name: Uninstall pytest-xdist (conflicts with TSAN)
         run: pip uninstall -y pytest-xdist
+
+      - name: Uninstall scipy-openblas
+        run: pip uninstall -y scipy-openblas32 scipy-openblas64
 
       - name: Upgrade spin (gh-29777)
         run: pip install -U spin
 
+      - name: Install OpenBLAS build tools
+        run: pip install cmake
+
+      - name: Set up ccache
+        run: |
+          apt-get update && apt-get install -y ccache
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> "$GITHUB_ENV"
+          echo "CCACHE_MAXSIZE=500M" >> "$GITHUB_ENV"
+
+      - name: Cache compiler output (ccache)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .ccache
+          key: tsan-ccache-${{ github.sha }}
+          restore-keys: tsan-ccache-
+
+      - name: Cache TSAN-instrumented OpenBLAS
+        id: cache-openblas
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: openblas-tsan
+          key: tsan-openblas-${{ env.OPENBLAS_VERSION }}-core2
+
+      - name: Build OpenBLAS with ThreadSanitizer
+        if: steps.cache-openblas.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch $OPENBLAS_VERSION \
+            https://github.com/OpenMathLib/OpenBLAS.git openblas-src
+          # Follows OpenBLAS's own TSAN CI (linux_thread_sanitizer), see
+          # https://github.com/OpenMathLib/OpenBLAS/blob/develop/.github/workflows/dynamic_arch.yml
+          cmake -S openblas-src -B openblas-src/build -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_C_COMPILER=${CC:-clang} \
+            -DCMAKE_CXX_COMPILER=${CXX:-clang++} \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_FLAGS="-fsanitize=thread -g -O1 -fno-omit-frame-pointer" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=thread -g -O1 -fno-omit-frame-pointer" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=thread" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" \
+            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_STATIC_LIBS=OFF \
+            -DBUILD_TESTING=OFF \
+            -DDYNAMIC_ARCH=OFF \
+            -DNOFORTRAN=ON \
+            -DC_LAPACK=ON \
+            -DUSE_THREAD=ON \
+            -DUSE_OPENMP=OFF \
+            -DNUM_THREADS=64 \
+            -DNUM_PARALLEL=2 \
+            -DTARGET=CORE2 \
+            -DCMAKE_INSTALL_LIBDIR=lib \
+            -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/openblas-tsan
+          cmake --build openblas-src/build -j4
+          cmake --install openblas-src/build
+
       - name: Build NumPy with ThreadSanitizer
-        run: python -m spin build -j2 -- -Db_sanitize=thread
+        run: |
+          export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/openblas-tsan/lib/pkgconfig
+          export CC="ccache $CC" CXX="ccache $CXX"
+          export LDFLAGS="-fsanitize=thread"
+          python -m spin build -j2 -- -Db_sanitize=thread \
+            -Dblas=openblas -Dlapack=openblas -Dallow-noblas=false
+          ccache -s
 
       - name: Run tests under prebuilt TSAN container
         run: |
           export TSAN_OPTIONS="halt_on_error=0:allocator_may_return_null=1:suppressions=$GITHUB_WORKSPACE/tools/ci/tsan_suppressions.txt"
           echo "TSAN_OPTIONS=$TSAN_OPTIONS"
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/openblas-tsan/lib
+          python -m spin run python -P -c "import numpy; numpy.show_config()"
           python -m spin test \
           `find numpy -name "test*.py" | xargs grep -E -l "import threading|ThreadPoolExecutor" | tr '\n' ' '` \
            -- -v -s --timeout=600 --durations=10

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -105,27 +105,23 @@ jobs:
           fi
           echo "OPENBLAS_VERSION=v$version"
           echo "OPENBLAS_VERSION=v$version" >> "$GITHUB_ENV"
-      - name: Uninstall pytest-xdist (conflicts with TSAN)
-        run: pip uninstall -y pytest-xdist
-
-      - name: Uninstall scipy-openblas
-        run: pip uninstall -y scipy-openblas32 scipy-openblas64
+      - name: Uninstall pytest-xdist and scipy-openblas (conflicts with TSAN)
+        run: pip uninstall -y pytest-xdist scipy-openblas32 scipy-openblas64
 
       - name: Upgrade spin (gh-29777)
         run: pip install -U spin
 
-      - name: Set up ccache
+      - name: Install ccache
         run: |
           apt-get update && apt-get install -y ccache
           echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> "$GITHUB_ENV"
           echo "CCACHE_MAXSIZE=500M" >> "$GITHUB_ENV"
 
-      - name: Cache compiler output (ccache)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Set up ccache
+        uses: ./.github/ccache
         with:
-          path: .ccache
-          key: tsan-ccache-${{ github.sha }}
-          restore-keys: tsan-ccache-
+          workflow_name: ${{ github.workflow }}
+          job_name: ${{ github.job }}
 
       - name: Cache TSAN-instrumented OpenBLAS
         id: cache-openblas

--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -123,6 +123,8 @@ jobs:
           workflow_name: ${{ github.workflow }}
           job_name: ${{ github.job }}
 
+      # This caches the completed OpenBLAS build; we aim to build once per `OPENBLAS_VERSION`.
+      # If this cache step hits, the next step (building OpenBLAS) is skipped by its `if:` condition.
       - name: Cache TSAN-instrumented OpenBLAS
         id: cache-openblas
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -167,12 +169,17 @@ jobs:
       - name: Build NumPy with ThreadSanitizer
         run: |
           export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/openblas-tsan/lib/pkgconfig
-          export CC="ccache $CC" CXX="ccache $CXX"
+          export CC="ccache ${CC:-clang}" CXX="ccache ${CXX:-clang++}"
           export LDFLAGS="-fsanitize=thread"
           python -m spin build -j4 -- -Db_sanitize=thread \
             -Dbuildtype=debugoptimized -Dcpu-dispatch=none \
             -Ddisable-intel-sort=true -Ddisable-highway=true -Ddisable-svml=true \
             -Dblas=openblas -Dlapack=openblas -Dallow-noblas=false
+
+      - name: Ccache performance
+        shell: bash -l {0}
+        run: |
+          ccache --evict-older-than 1d
           ccache -s
 
       - name: Run tests under prebuilt TSAN container

--- a/tools/ci/tsan_suppressions.txt
+++ b/tools/ci/tsan_suppressions.txt
@@ -9,3 +9,8 @@ race:count_nonzero_bool
 race:count_nonzero_float
 race:DOUBLE_nonzero
 
+# Lazy initialization of machine constants in the f2c-translated LAPACK
+# used by OpenBLAS C_LAPACK builds (lapack-netlib/INSTALL/{s,d}lamch.c).
+race:dlamch_
+race:slamch_
+


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

This PR compiles OpenBLAS with tsan so that data races inside OpenBLAS can be detected. 

 The TSAN job now builds OpenBLAS from source with ThreadSanitizer instrumentation and links NumPy against it, instead of running with the uninstrumented scipy-openblas wheel. It is cached so that it is only rebuilt when openblas version changes and it doesn't increases the CI time. To further speed up the CI I changed the config to disable CPU dispatch/SIMD extras (highway, SVML, Intel sort) that the threading tests don't need and added ccache to reduce compile time from ~9 to ~6 mins. 

There are some harmless data races in C_LAPACK due to lazy initialization being racy for which I have added suppressions. 

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

AI was used to help edit the CI file. 