### PR TITLE
MAINT: Update hypothesis version.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,4 +38,3 @@ updates:
       - dependency-name: "jupyterlite-pyodide-kernel"
       - dependency-name: "sphinx"
       - dependency-name: "pkgconf"
-      - dependency-name: "hypothesis"

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -2,7 +2,7 @@
 # kept in sync.
 
 Cython
-hypothesis==6.155.7
+hypothesis==6.161.4
 pytest==9.1.1
 pytest-cov==7.1.0
 meson


### PR DESCRIPTION
Hypothesis 1.161.2 should have support for riscv64, test that. If it works, reenable dependbot updates for it.

No AI.
