### PR TITLE
ENH: mark fixed-width string to StringDType casts as safe

### DIFF
--- a/doc/release/upcoming_changes/32095.compatibility.rst
+++ b/doc/release/upcoming_changes/32095.compatibility.rst
@@ -1,0 +1,12 @@
+Casting and validation changes for fixed-width to variable-width string conversions
+-----------------------------------------------------------------------------------
+* Casts from fixed-width `numpy.bytes_` and `nummpy.str_` arrays to
+  `numpy.dtypes.StringDType` are now considered `"safe"` rather than
+  `"same-kind"`.
+* These cast from `numpy.bytes_` to `numpy.dtypes.StringDType` now validates the
+  bytes are valid UTF-8 and raises a ``UnicodeDecodeError``
+  otherwise. Similarly, a `numpy.str_` entry containing a lone surrogate will
+  trigger a ``UnicodeDecodeError`` when converting to
+  `numpy.dtypes.StringDType`.
+* Casting a fixed-width `numpy.void_` array containing invalid UTF-8 now
+  triggers a ``UnicodeDecodeError`` rather than a ``TypeError``.

--- a/doc/release/upcoming_changes/32095.compatibility.rst
+++ b/doc/release/upcoming_changes/32095.compatibility.rst
@@ -1,0 +1,9 @@
+Casting and validation changes for fixed-width to variable-width string conversions
+-----------------------------------------------------------------------------------
+* Casts from fixed-width `numpy.bytes_` and `numpy.str_` arrays to
+  `numpy.dtypes.StringDType` are now considered `"safe"` rather than
+  `"same-kind"`.
+* These casts from `numpy.bytes_` to `numpy.dtypes.StringDType` now validate the
+  bytes are valid UTF-8 and raise a ``UnicodeDecodeError`` otherwise.
+* Casting a fixed-width `numpy.void_` array containing invalid UTF-8 now
+  triggers a ``UnicodeDecodeError`` rather than a ``TypeError``.

--- a/doc/release/upcoming_changes/32095.improvement.rst
+++ b/doc/release/upcoming_changes/32095.improvement.rst
@@ -1,0 +1,6 @@
+Fixed-width string to ``StringDType`` casts are now safe and validated
+----------------------------------------------------------------------
+The casts from fixed-width `numpy.bytes_` and `numpy.str_` to
+`numpy.dtypes.StringDType` are now marked `"safe"` rather than `"same-kind"`. We
+also now validate that `numpy.bytes_`, `numpy.void`, and `numpy.str_` arrays
+contain valid UTF-8 before converting to `numpy.dtypes.StringDType`.

--- a/doc/release/upcoming_changes/32296.change.rst
+++ b/doc/release/upcoming_changes/32296.change.rst
@@ -1,4 +1,4 @@
 * Casting a fixed-width byte string array (``np.bytes_``) to ``StringDType``
-  now raises ``TypeError`` when the bytes are not valid UTF-8. Previously the
+  now raises ``UnicodeDecodeError`` when the bytes are not valid UTF-8. Previously the
   invalid bytes were stored as-is and later caused undefined behavior in
   string operations.

--- a/doc/source/user/basics.strings.rst
+++ b/doc/source/user/basics.strings.rst
@@ -239,3 +239,8 @@ Care must be taken to ensure that the output array has enough space
 for the UTF-8 bytes in the string, since the size of a UTF-8
 bytestream in bytes is not necessarily the same as the number of
 characters in the string.
+
+Conversions in the other direction, from a fixed-width string array to
+``StringDType`` are ``"safe"`` casts. The bytes stored in a
+`numpy.bytes_` array must be valid UTF-8, and a ``UnicodeDecodeError``
+is raised during the cast if they are not.

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -314,7 +314,7 @@ fail:
 }
 
 static PyType_Slot u2s_slots[] = {{NPY_METH_resolve_descriptors,
-                                   (void *)&any_to_string_resolve_descriptors<NPY_SAME_KIND_CASTING>},
+                                   (void *)&any_to_string_resolve_descriptors<NPY_SAFE_CASTING>},
                                   {NPY_METH_strided_loop, (void *)&unicode_to_string},
                                   {0, NULL}};
 
@@ -1858,19 +1858,18 @@ static PyType_Slot s2v_slots[] = {
     {0, NULL}
 };
 
-// void to string
-
+// void to string and bytes to string
 static int
-void_to_string(PyArrayMethod_Context *context, char *const data[],
-               npy_intp const dimensions[], npy_intp const strides[],
-               NpyAuxData *NPY_UNUSED(auxdata))
+fixed_width_bytes_to_string(PyArrayMethod_Context *context, char *const data[],
+                            npy_intp const dimensions[], npy_intp const strides[],
+                            NpyAuxData *NPY_UNUSED(auxdata))
 {
     PyArray_Descr *const *descrs = context->descriptors;
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)descrs[1];
+    const char *context_name = descrs[0]->type_num == NPY_VOID ?
+            "void to string cast" : "bytes to string cast";
 
-    npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
-
-    long max_in_size = descrs[0]->elsize;
+    size_t max_in_size = descrs[0]->elsize;
 
     npy_intp N = dimensions[0];
     unsigned char *in = (unsigned char *)data[0];
@@ -1879,41 +1878,66 @@ void_to_string(PyArrayMethod_Context *context, char *const data[],
     npy_intp in_stride = strides[0];
     npy_intp out_stride = strides[1];
 
-    while(N--) {
-        Py_ssize_t out_num_bytes = utf8_buffer_size(in, max_in_size);
-        if (out_num_bytes < 0) {
-            npy_gil_error(PyExc_TypeError,
-                          "Invalid UTF-8 bytes found, cannot convert to UTF-8");
-            goto fail;
+    np::raii::NpyStringAcquireAllocator alloc(descr);
+
+    while (N--) {
+        size_t out_num_bytes = max_in_size;
+
+        // ignore trailing nulls
+        while (out_num_bytes > 0 && in[out_num_bytes - 1] == 0) {
+            out_num_bytes--;
         }
+
+        size_t num_codepoints = 0;
+        if (num_codepoints_for_utf8_bytes(in, &num_codepoints,
+                                          out_num_bytes) != 0) {
+            // Building the UnicodeDecodeError needs the GIL but we have to copy
+            // the bytes before releasing the allocator and acquiring the GIL
+            char *bad = (char *)PyMem_RawMalloc(out_num_bytes);
+            if (bad == NULL) {
+                alloc.release();
+                npy_gil_error(PyExc_MemoryError,
+                              "Failed to allocate memory for unicode "
+                              "decoding error");
+                return -1;
+            }
+            memcpy(bad, in, out_num_bytes);
+            size_t bad_size = out_num_bytes;
+            alloc.release();
+
+            np::raii::EnsureGIL ensure_gil{};
+
+            // decode only to construct a UnicodeDecodeError with positional information
+            PyObject *decoded = PyUnicode_Decode(bad, bad_size, "utf-8",
+                                                 "strict");
+            PyMem_RawFree(bad);
+            if (decoded != NULL) {
+                Py_DECREF(decoded);
+                PyErr_Format(PyExc_TypeError,
+                             "Invalid UTF-8 bytes found in %s", context_name);
+            }
+            return -1;
+        }
+
         npy_static_string out_ss = {0, NULL};
         if (load_new_string((npy_packed_static_string *)out,
-                            &out_ss, (size_t)out_num_bytes, allocator,
-                            "void to string cast") == -1) {
-            goto fail;
+                            &out_ss, out_num_bytes, alloc.allocator(),
+                            context_name) == -1) {
+            return -1;
         }
         // ignores const to fill in the buffer
-        char *out_buf = (char *)out_ss.buf;
-        memcpy(out_buf, in, out_num_bytes);
+        memcpy((char *)out_ss.buf, in, out_num_bytes);
 
         in += in_stride;
         out += out_stride;
     }
 
-    NpyString_release_allocator(allocator);
-
     return 0;
-
-fail:
-
-    NpyString_release_allocator(allocator);
-
-    return -1;
 }
 
 static PyType_Slot v2s_slots[] = {
     {NPY_METH_resolve_descriptors, (void *)&any_to_string_resolve_descriptors<NPY_SAME_KIND_CASTING>},
-    {NPY_METH_strided_loop, (void *)&void_to_string},
+    {NPY_METH_strided_loop, (void *)&fixed_width_bytes_to_string},
     {0, NULL}
 };
 
@@ -2020,63 +2044,9 @@ static PyType_Slot s2bytes_slots[] = {
 
 // bytes to string
 
-static int
-bytes_to_string(PyArrayMethod_Context *context, char *const data[],
-                npy_intp const dimensions[], npy_intp const strides[],
-                NpyAuxData *NPY_UNUSED(auxdata))
-{
-    PyArray_Descr *const *descrs = context->descriptors;
-    PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)descrs[1];
-
-    npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
-
-    size_t max_in_size = descrs[0]->elsize;
-
-    npy_intp N = dimensions[0];
-    unsigned char *in = (unsigned char *)data[0];
-    char *out = data[1];
-
-    npy_intp in_stride = strides[0];
-    npy_intp out_stride = strides[1];
-
-    while(N--) {
-        size_t out_num_bytes = max_in_size;
-
-        // ignore trailing nulls
-        while (out_num_bytes > 0 && in[out_num_bytes - 1] == 0) {
-            out_num_bytes--;
-        }
-
-        npy_static_string out_ss = {0, NULL};
-        if (load_new_string((npy_packed_static_string *)out,
-                            &out_ss, out_num_bytes, allocator,
-                            "void to string cast") == -1) {
-            goto fail;
-        }
-
-        // ignores const to fill in the buffer
-        char *out_buf = (char *)out_ss.buf;
-        memcpy(out_buf, in, out_num_bytes);
-
-        in += in_stride;
-        out += out_stride;
-    }
-
-    NpyString_release_allocator(allocator);
-
-    return 0;
-
-fail:
-
-    NpyString_release_allocator(allocator);
-
-    return -1;
-}
-
-
 static PyType_Slot bytes2s_slots[] = {
-    {NPY_METH_resolve_descriptors, (void *)&any_to_string_resolve_descriptors<NPY_SAME_KIND_CASTING>},
-    {NPY_METH_strided_loop, (void *)&bytes_to_string},
+    {NPY_METH_resolve_descriptors, (void *)&any_to_string_resolve_descriptors<NPY_SAFE_CASTING>},
+    {NPY_METH_strided_loop, (void *)&fixed_width_bytes_to_string},
     {0, NULL}
 };
 
@@ -2167,7 +2137,7 @@ get_casts() {
 
     PyArrayMethod_Spec *UnicodeToStringCastSpec = get_cast_spec(
         make_type2s_name(NPY_UNICODE),
-        NPY_SAME_KIND_CASTING,
+        NPY_SAFE_CASTING,
         NPY_METH_NO_FLOATINGPOINT_ERRORS,
         u2s_dtypes,
         u2s_slots
@@ -2288,7 +2258,7 @@ get_casts() {
 
     PyArrayMethod_Spec *BytesToStringCastSpec = get_cast_spec(
         make_type2s_name(NPY_BYTE),
-        NPY_SAME_KIND_CASTING,
+        NPY_SAFE_CASTING,
         NPY_METH_NO_FLOATINGPOINT_ERRORS,
         bytes2s_dtypes,
         bytes2s_slots

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -1913,8 +1913,11 @@ fixed_width_bytes_to_string(PyArrayMethod_Context *context, char *const data[],
             PyMem_RawFree(bad);
             if (decoded != NULL) {
                 Py_DECREF(decoded);
-                PyErr_Format(PyExc_TypeError,
-                             "Invalid UTF-8 bytes found in %s", context_name);
+                PyErr_Format(PyExc_RuntimeError,
+                             "Invalid UTF-8 bytes found in %s that the Python "
+                             "UTF-8 decoder accepted. If you did not set a "
+                             "custom 'strict' codec, this could indicate memory "
+                             "corruption or a race.", context_name);
             }
             return -1;
         }

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -314,7 +314,7 @@ fail:
 }
 
 static PyType_Slot u2s_slots[] = {{NPY_METH_resolve_descriptors,
-                                   (void *)&any_to_string_resolve_descriptors<NPY_SAME_KIND_CASTING>},
+                                   (void *)&any_to_string_resolve_descriptors<NPY_SAFE_CASTING>},
                                   {NPY_METH_strided_loop, (void *)&unicode_to_string},
                                   {0, NULL}};
 
@@ -1858,19 +1858,18 @@ static PyType_Slot s2v_slots[] = {
     {0, NULL}
 };
 
-// void to string
-
+// void to string and bytes to string
 static int
-void_to_string(PyArrayMethod_Context *context, char *const data[],
-               npy_intp const dimensions[], npy_intp const strides[],
-               NpyAuxData *NPY_UNUSED(auxdata))
+fixed_width_bytes_to_string(PyArrayMethod_Context *context, char *const data[],
+                            npy_intp const dimensions[], npy_intp const strides[],
+                            NpyAuxData *NPY_UNUSED(auxdata))
 {
     PyArray_Descr *const *descrs = context->descriptors;
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)descrs[1];
+    const char *context_name = descrs[0]->type_num == NPY_VOID ?
+            "void to string cast" : "bytes to string cast";
 
-    npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
-
-    long max_in_size = descrs[0]->elsize;
+    size_t max_in_size = descrs[0]->elsize;
 
     npy_intp N = dimensions[0];
     unsigned char *in = (unsigned char *)data[0];
@@ -1879,41 +1878,66 @@ void_to_string(PyArrayMethod_Context *context, char *const data[],
     npy_intp in_stride = strides[0];
     npy_intp out_stride = strides[1];
 
-    while(N--) {
-        Py_ssize_t out_num_bytes = utf8_buffer_size(in, max_in_size);
-        if (out_num_bytes < 0) {
-            npy_gil_error(PyExc_TypeError,
-                          "Invalid UTF-8 bytes found, cannot convert to UTF-8");
-            goto fail;
+    np::raii::NpyStringAcquireAllocator alloc(descr);
+
+    while (N--) {
+        size_t out_num_bytes = max_in_size;
+
+        // ignore trailing nulls
+        while (out_num_bytes > 0 && in[out_num_bytes - 1] == 0) {
+            out_num_bytes--;
         }
+
+        size_t num_codepoints = 0;
+        if (num_codepoints_for_utf8_bytes(in, &num_codepoints,
+                                          out_num_bytes) != 0) {
+            // Building the UnicodeDecodeError needs the GIL but we have to copy
+            // the bytes before releasing the allocator and acquiring the GIL
+            char *bad = (char *)PyMem_RawMalloc(out_num_bytes);
+            if (bad == NULL) {
+                alloc.release();
+                npy_gil_error(PyExc_MemoryError,
+                              "Failed to allocate memory for unicode "
+                              "decoding error");
+                return -1;
+            }
+            memcpy(bad, in, out_num_bytes);
+            size_t bad_size = out_num_bytes;
+            alloc.release();
+
+            np::raii::EnsureGIL ensure_gil{};
+
+            // decode only to construct a UnicodeDecodeError with positional information
+            PyObject *decoded = PyUnicode_Decode(bad, bad_size, "utf-8",
+                                                 "strict");
+            PyMem_RawFree(bad);
+            if (decoded != NULL) {
+                Py_DECREF(decoded);
+                PyErr_Format(PyExc_TypeError,
+                             "Invalid UTF-8 bytes found in %s", context_name);
+            }
+            return -1;
+        }
+
         npy_static_string out_ss = {0, NULL};
         if (load_new_string((npy_packed_static_string *)out,
-                            &out_ss, (size_t)out_num_bytes, allocator,
-                            "void to string cast") == -1) {
-            goto fail;
+                            &out_ss, out_num_bytes, alloc.allocator(),
+                            context_name) == -1) {
+            return -1;
         }
         // ignores const to fill in the buffer
-        char *out_buf = (char *)out_ss.buf;
-        memcpy(out_buf, in, out_num_bytes);
+        memcpy((char *)out_ss.buf, in, out_num_bytes);
 
         in += in_stride;
         out += out_stride;
     }
 
-    NpyString_release_allocator(allocator);
-
     return 0;
-
-fail:
-
-    NpyString_release_allocator(allocator);
-
-    return -1;
 }
 
 static PyType_Slot v2s_slots[] = {
     {NPY_METH_resolve_descriptors, (void *)&any_to_string_resolve_descriptors<NPY_SAME_KIND_CASTING>},
-    {NPY_METH_strided_loop, (void *)&void_to_string},
+    {NPY_METH_strided_loop, (void *)&fixed_width_bytes_to_string},
     {0, NULL}
 };
 
@@ -2020,65 +2044,9 @@ static PyType_Slot s2bytes_slots[] = {
 
 // bytes to string
 
-static int
-bytes_to_string(PyArrayMethod_Context *context, char *const data[],
-                npy_intp const dimensions[], npy_intp const strides[],
-                NpyAuxData *NPY_UNUSED(auxdata))
-{
-    PyArray_Descr *const *descrs = context->descriptors;
-    PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)descrs[1];
-
-    npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
-
-    size_t max_in_size = descrs[0]->elsize;
-
-    npy_intp N = dimensions[0];
-    unsigned char *in = (unsigned char *)data[0];
-    char *out = data[1];
-
-    npy_intp in_stride = strides[0];
-    npy_intp out_stride = strides[1];
-
-    while(N--) {
-        // reject non-UTF-8 input; readers of the stored bytes assume validity
-        Py_ssize_t out_num_bytes = utf8_buffer_size(in, max_in_size);
-        if (out_num_bytes < 0) {
-            npy_gil_error(PyExc_TypeError,
-                          "Invalid UTF-8 bytes found, cannot convert to "
-                          "StringDType");
-            goto fail;
-        }
-
-        npy_static_string out_ss = {0, NULL};
-        if (load_new_string((npy_packed_static_string *)out,
-                            &out_ss, (size_t)out_num_bytes, allocator,
-                            "bytes to string cast") == -1) {
-            goto fail;
-        }
-
-        // ignores const to fill in the buffer
-        char *out_buf = (char *)out_ss.buf;
-        memcpy(out_buf, in, out_num_bytes);
-
-        in += in_stride;
-        out += out_stride;
-    }
-
-    NpyString_release_allocator(allocator);
-
-    return 0;
-
-fail:
-
-    NpyString_release_allocator(allocator);
-
-    return -1;
-}
-
-
 static PyType_Slot bytes2s_slots[] = {
-    {NPY_METH_resolve_descriptors, (void *)&any_to_string_resolve_descriptors<NPY_SAME_KIND_CASTING>},
-    {NPY_METH_strided_loop, (void *)&bytes_to_string},
+    {NPY_METH_resolve_descriptors, (void *)&any_to_string_resolve_descriptors<NPY_SAFE_CASTING>},
+    {NPY_METH_strided_loop, (void *)&fixed_width_bytes_to_string},
     {0, NULL}
 };
 
@@ -2169,7 +2137,7 @@ get_casts() {
 
     PyArrayMethod_Spec *UnicodeToStringCastSpec = get_cast_spec(
         make_type2s_name(NPY_UNICODE),
-        NPY_SAME_KIND_CASTING,
+        NPY_SAFE_CASTING,
         NPY_METH_NO_FLOATINGPOINT_ERRORS,
         u2s_dtypes,
         u2s_slots
@@ -2290,7 +2258,7 @@ get_casts() {
 
     PyArrayMethod_Spec *BytesToStringCastSpec = get_cast_spec(
         make_type2s_name(NPY_STRING),
-        NPY_SAME_KIND_CASTING,
+        NPY_SAFE_CASTING,
         NPY_METH_NO_FLOATINGPOINT_ERRORS,
         bytes2s_dtypes,
         bytes2s_slots

--- a/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
+++ b/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
@@ -210,46 +210,6 @@ utf8_decode(uint32_t* state, uint32_t* codep, uint32_t byte) {
 
 /*******************************************************************************/
 
-// calculate the size in bytes required to store a UTF-8 encoded version of the
-// UTF-32 encoded string stored in **s**, which is **max_bytes** long.
-NPY_NO_EXPORT Py_ssize_t
-utf8_buffer_size(const uint8_t *s, size_t max_bytes)
-{
-    uint32_t codepoint;
-    uint32_t state = 0;
-    size_t num_bytes = 0;
-    Py_ssize_t encoded_size_in_bytes = 0;
-
-    // ignore trailing nulls
-    while (max_bytes > 0 && s[max_bytes - 1] == 0) {
-        max_bytes--;
-    }
-
-    if (max_bytes == 0) {
-        return 0;
-    }
-
-    for (; num_bytes < max_bytes; ++s)
-    {
-        utf8_decode(&state, &codepoint, *s);
-        if (state == UTF8_REJECT)
-        {
-            return -1;
-        }
-        else if(state == UTF8_ACCEPT)
-        {
-            encoded_size_in_bytes += num_utf8_bytes_for_codepoint(codepoint);
-        }
-        num_bytes += 1;
-    }
-
-    if (state != UTF8_ACCEPT) {
-        return -1;
-    }
-    return encoded_size_in_bytes;
-}
-
-
 // calculate the number of UTF-32 code points in the UTF-8 encoded string
 // stored in **s**, which is **max_bytes** long. Unlike the fixed-width
 // conversion helpers above, this is length-explicit and does not trim trailing

--- a/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
+++ b/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
@@ -210,47 +210,6 @@ utf8_decode(uint32_t* state, uint32_t* codep, uint32_t byte) {
 
 /*******************************************************************************/
 
-// calculate the number of bytes, excluding trailing null bytes, needed to
-// store the UTF-8 encoded buffer **s**, which is **max_bytes** long. Returns
-// -1 if **s** is not valid, complete UTF-8.
-NPY_NO_EXPORT Py_ssize_t
-utf8_buffer_size(const uint8_t *s, size_t max_bytes)
-{
-    uint32_t codepoint;
-    uint32_t state = 0;
-    size_t num_bytes = 0;
-    Py_ssize_t encoded_size_in_bytes = 0;
-
-    // ignore trailing nulls
-    while (max_bytes > 0 && s[max_bytes - 1] == 0) {
-        max_bytes--;
-    }
-
-    if (max_bytes == 0) {
-        return 0;
-    }
-
-    for (; num_bytes < max_bytes; ++s)
-    {
-        utf8_decode(&state, &codepoint, *s);
-        if (state == UTF8_REJECT)
-        {
-            return -1;
-        }
-        else if(state == UTF8_ACCEPT)
-        {
-            encoded_size_in_bytes += num_utf8_bytes_for_codepoint(codepoint);
-        }
-        num_bytes += 1;
-    }
-
-    if (state != UTF8_ACCEPT) {
-        return -1;
-    }
-    return encoded_size_in_bytes;
-}
-
-
 // calculate the number of UTF-32 code points in the UTF-8 encoded string
 // stored in **s**, which is **max_bytes** long. Unlike the fixed-width
 // conversion helpers above, this is length-explicit and does not trim trailing

--- a/numpy/_core/src/multiarray/stringdtype/utf8_utils.h
+++ b/numpy/_core/src/multiarray/stringdtype/utf8_utils.h
@@ -35,9 +35,6 @@ utf8_size(const Py_UCS4 *codepoints, long max_length, size_t *num_codepoints,
 NPY_NO_EXPORT size_t
 ucs4_code_to_utf8_char(Py_UCS4 code, char *c);
 
-NPY_NO_EXPORT Py_ssize_t
-utf8_buffer_size(const uint8_t *s, size_t max_bytes);
-
 NPY_NO_EXPORT void
 find_start_end_locs(char* buf, size_t buffer_size, npy_int64 start_index, npy_int64 end_index,
                     char **start_loc, char **end_loc);

--- a/numpy/_core/src/multiarray/stringdtype/utf8_utils.h
+++ b/numpy/_core/src/multiarray/stringdtype/utf8_utils.h
@@ -54,9 +54,6 @@ utf8_size(const Py_UCS4 *codepoints, long max_length, size_t *num_codepoints,
 NPY_NO_EXPORT size_t
 ucs4_code_to_utf8_char(Py_UCS4 code, char *c);
 
-NPY_NO_EXPORT Py_ssize_t
-utf8_buffer_size(const uint8_t *s, size_t max_bytes);
-
 NPY_NO_EXPORT void
 find_start_end_locs(char* buf, size_t buffer_size, npy_int64 start_index, npy_int64 end_index,
                     char **start_loc, char **end_loc);

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -997,12 +997,59 @@ def test_string_to_bytes_invalid_ascii_error():
 
 
 def test_void_to_string_invalid_utf8_error():
-    # invalid UTF-8 in a void buffer used to surface as a confusing
-    # MemoryError because the error return of utf8_buffer_size was
-    # stored in an unsigned variable
     varr = np.array([b"\xff\xff\xff\xff"], dtype="V4")
-    with pytest.raises(TypeError, match="Invalid UTF-8"):
-        varr.astype(StringDType())
+    with pytest.raises(UnicodeDecodeError) as excinfo:
+        varr.astype("T")
+    exc = excinfo.value
+    assert exc.encoding == "utf-8"
+    assert exc.object == b"\xff\xff\xff\xff"
+    assert exc.start == 0
+
+
+class TestFixedWidthCastSafety:
+    def test_fixed_width_to_stringdtype_is_safe(self):
+        for source in ["S10", "U10"]:
+            assert np.can_cast(source, "T", casting="safe")
+            assert np.can_cast(source, "T", casting="same_kind")
+            assert not np.can_cast(source, "T", casting="no")
+            assert not np.can_cast(source, "T", casting="equiv")
+
+    def test_stringdtype_to_fixed_width_is_same_kind(self):
+        for target in ["S5", "U5", "S", "U"]:
+            assert not np.can_cast("T", target, casting="safe")
+            assert np.can_cast("T", target, casting="same_kind")
+            assert np.can_cast("T", target, casting="unsafe")
+
+    def test_unicode_surrogate_runtime_error(self):
+        arr = np.array(["\ud800"], dtype="U1")
+        assert np.can_cast(arr.dtype, "T", casting="safe")
+        with pytest.raises(TypeError, match="Invalid unicode code point"):
+            arr.astype("T")
+
+    def test_bytes_to_stringdtype_valid_utf8(self):
+        barr = np.array(["café".encode(), "😊".encode()], dtype="S5")
+        assert_array_equal(
+            barr.astype("T"),
+            np.array(["café", "😊"], dtype="T"),
+        )
+
+    @pytest.mark.parametrize("kind", ["S", "V"])
+    @pytest.mark.parametrize(
+        "bad,reason",
+        [
+            (b"a\xffb", "invalid start byte"),
+            # 0xc3 starts a two-byte sequence the itemsize truncates
+            (b"a\xc3", "unexpected end of data"),
+        ],
+    )
+    def test_invalid_utf8_error(self, kind, bad, reason):
+        arr = np.array([bad], dtype=f"{kind}{len(bad)}")
+        with pytest.raises(UnicodeDecodeError) as excinfo:
+            arr.astype("T")
+        exc = excinfo.value
+        assert exc.encoding == "utf-8"
+        assert exc.object == bad
+        assert (exc.start, exc.end, exc.reason) == (1, 2, reason)
 
 
 @pytest.mark.parametrize(

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -530,7 +530,7 @@ INVALID_UTF8 = [
 @pytest.mark.parametrize("bad", INVALID_UTF8)
 def test_bytes_cast_rejects_invalid_utf8(bad):
     arr = np.array([bad], dtype=f"S{len(bad)}")
-    with pytest.raises(TypeError, match="Invalid UTF-8"):
+    with pytest.raises(UnicodeDecodeError):
         arr.astype(StringDType())
 
 
@@ -538,7 +538,7 @@ def test_bytes_cast_rejects_invalid_utf8(bad):
 def test_void_cast_rejects_invalid_utf8(bad):
     # the void ('V') -> StringDType cast validates the same way as bytes
     arr = np.array([bad], dtype=f"V{len(bad)}")
-    with pytest.raises(TypeError, match="Invalid UTF-8"):
+    with pytest.raises(UnicodeDecodeError):
         arr.astype(StringDType())
 
 

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1363,12 +1363,59 @@ def test_string_to_bytes_invalid_ascii_error():
 
 
 def test_void_to_string_invalid_utf8_error():
-    # invalid UTF-8 in a void buffer used to surface as a confusing
-    # MemoryError because the error return of utf8_buffer_size was
-    # stored in an unsigned variable
     varr = np.array([b"\xff\xff\xff\xff"], dtype="V4")
-    with pytest.raises(TypeError, match="Invalid UTF-8"):
-        varr.astype(StringDType())
+    with pytest.raises(UnicodeDecodeError) as excinfo:
+        varr.astype("T")
+    exc = excinfo.value
+    assert exc.encoding == "utf-8"
+    assert exc.object == b"\xff\xff\xff\xff"
+    assert exc.start == 0
+
+
+class TestFixedWidthCastSafety:
+    def test_fixed_width_to_stringdtype_is_safe(self):
+        for source in ["S10", "U10"]:
+            assert np.can_cast(source, "T", casting="safe")
+            assert np.can_cast(source, "T", casting="same_kind")
+            assert not np.can_cast(source, "T", casting="no")
+            assert not np.can_cast(source, "T", casting="equiv")
+
+    def test_stringdtype_to_fixed_width_is_same_kind(self):
+        for target in ["S5", "U5", "S", "U"]:
+            assert not np.can_cast("T", target, casting="safe")
+            assert np.can_cast("T", target, casting="same_kind")
+            assert np.can_cast("T", target, casting="unsafe")
+
+    def test_unicode_surrogate_runtime_error(self):
+        arr = np.array(["\ud800"], dtype="U1")
+        assert np.can_cast(arr.dtype, "T", casting="safe")
+        with pytest.raises(TypeError, match="Invalid unicode code point"):
+            arr.astype("T")
+
+    def test_bytes_to_stringdtype_valid_utf8(self):
+        barr = np.array(["café".encode(), "😊".encode()], dtype="S5")
+        assert_array_equal(
+            barr.astype("T"),
+            np.array(["café", "😊"], dtype="T"),
+        )
+
+    @pytest.mark.parametrize("kind", ["S", "V"])
+    @pytest.mark.parametrize(
+        "bad,reason",
+        [
+            (b"a\xffb", "invalid start byte"),
+            # 0xc3 starts a two-byte sequence the itemsize truncates
+            (b"a\xc3", "unexpected end of data"),
+        ],
+    )
+    def test_invalid_utf8_error(self, kind, bad, reason):
+        arr = np.array([bad], dtype=f"{kind}{len(bad)}")
+        with pytest.raises(UnicodeDecodeError) as excinfo:
+            arr.astype("T")
+        exc = excinfo.value
+        assert exc.encoding == "utf-8"
+        assert exc.object == bad
+        assert (exc.start, exc.end, exc.reason) == (1, 2, reason)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### PR summary
Towards fixing #32031.

This is one half of what #32031 proposes. The implementation ended up allowing me to delete a bunch of code, since the function I'm changing was the only customer of an old helper function that I inlined. I also made the void and bytes casts share the same loop, although I'm not touching void cast safety here.

#### AI Disclosure
I used an AI model to help debug the change.