### PR TITLE
ENH: infer sizes when casting or creating arrays from StringDType arrays

### DIFF
--- a/doc/release/upcoming_changes/32097.new_feature.rst
+++ b/doc/release/upcoming_changes/32097.new_feature.rst
@@ -1,0 +1,9 @@
+Size inference when converting ``StringDType`` arrays to fixed-width strings
+----------------------------------------------------------------------------
+Previously, converting a `numpy.dtypes.StringDType` array to a fixed-width
+string dtype with an unspecified size, such as ``arr.astype(np.str_)`` or
+``np.array(arr, dtype="S")``, raised a ``TypeError`` asking for an explicit
+size. NumPy now inspects the array values and infers a size big enough to
+store the widest entry without truncation, matching the existing behavior
+when converting sequences of Python strings. Passing an explicit size still
+truncates entries that do not fit.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -503,6 +503,13 @@ From other objects
     array but it needs to be of a specific *newtype* (including
     byte-order) or has certain *requirements*.
 
+    If *newtype* is an unsized flexible descriptor, the result takes the
+    itemsize of *op* without inspecting its values. :c:func:`PyArray_FromAny`
+    and :c:func:`PyArray_CastToType` instead adapt an unsized descriptor to the
+    values of *op*, so converting a ``NPY_VSTRING`` or ``NPY_OBJECT`` array to
+    ``NPY_STRING`` or ``NPY_UNICODE`` infers the width of the output by finding
+    the length of the longest input string.
+
 .. c:function:: PyObject* PyArray_FromStructInterface(PyObject* op)
 
     Returns an ndarray object from a Python object that exposes the

--- a/doc/source/user/basics.strings.rst
+++ b/doc/source/user/basics.strings.rst
@@ -198,30 +198,26 @@ Casting To and From Fixed-Width Strings
 `numpy.bytes_`, and `numpy.void`. Casting to a fixed-width string is
 most useful when strings need to be memory-mapped in an ndarray or
 when a fixed-width string is needed for reading and writing to a
-columnar data format with a known maximum string length.
+columnar data format with a known maximum string length. The
+`numpy.bytes_` cast is most useful for string data that is known to
+contain UTF-8 encoded text, including ASCII text.
 
-In all cases, casting to a fixed-width string requires specifying the
-maximum allowed string length::
+When converting an array to a fixed-width string dtype with an
+unspecified size using `numpy.ndarray.astype`, NumPy infers the size by
+inspecting the array values, producing a dtype wide enough to store the
+widest entry without truncation::
 
-   >>> arr = np.array(["hello", "world"], dtype=StringDType())
-   >>> arr.astype(np.str_)  # doctest: +IGNORE_EXCEPTION_DETAIL
-   Traceback (most recent call last):
-   ...
-   TypeError: Casting from StringDType to a fixed-width dtype with an
-   unspecified size is not currently supported, specify an explicit
-   size for the output dtype instead.
+   >>> arr = np.array(["hello", "world!!"], dtype=StringDType())
+   >>> arr.astype(np.str_)
+   array(['hello', 'world!!'], dtype='<U7')
+   >>> arr.astype("S")
+   array([b'hello', b'world!!'], dtype='|S7')
 
-   The above exception was the direct cause of the following
-   exception:
+An explicit size can still be passed, truncating entries that do not
+fit::
 
-   TypeError: cannot cast dtype StringDType() to <class 'numpy.dtypes.StrDType'>.
-   >>> arr.astype("U5")
-   array(['hello', 'world'], dtype='<U5')
-   
-The `numpy.bytes_` cast is most useful for string data that is known
-to contain only ASCII characters, as characters outside this range
-cannot be represented in a single byte in the UTF-8 encoding and are
-rejected.
+   >>> arr.astype("U4")
+   array(['hell', 'worl'], dtype='<U4')
 
 Any valid unicode string can be cast to `numpy.str_`, although
 since `numpy.str_` uses a 32-bit UCS4 encoding for all characters,

--- a/doc/source/user/basics.strings.rst
+++ b/doc/source/user/basics.strings.rst
@@ -200,7 +200,8 @@ most useful when strings need to be memory-mapped in an ndarray or
 when a fixed-width string is needed for reading and writing to a
 columnar data format with a known maximum string length. The
 `numpy.bytes_` cast is most useful for string data that is known to
-contain UTF-8 encoded text, including ASCII text.
+contain only ASCII characters, as characters outside this range cannot
+be represented in a single byte in the UTF-8 encoding and are rejected.
 
 When converting an array to a fixed-width string dtype with an
 unspecified size using `numpy.ndarray.astype`, NumPy infers the size by

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -16,6 +16,7 @@
 #include "convert_datatype.h"
 #include "dtypemeta.h"
 #include "stringdtype/dtype.h"
+#include "stringdtype/casts.h"
 
 #include "npy_argparse.h"
 #include "abstractdtypes.h"
@@ -872,6 +873,21 @@ find_descriptor_from_array(
             if (*out_descr == NULL) {
                 return -1;
             }
+        }
+    }
+    else if (NPY_UNLIKELY(PyArray_TYPE(arr) == NPY_VSTRING &&
+                          (DType->type_num == NPY_STRING ||
+                           DType->type_num == NPY_UNICODE))) {
+        /*
+         * Casting a StringDType array to a fixed-width string DType with no
+         * size means finding the width of the widest entry first, so that
+         * the cast does not truncate.  Note that, like the object branch
+         * above, this inspects array values.
+         */
+        *out_descr = stringdtype_find_fixed_width_descr(
+                arr, DType->type_num);
+        if (*out_descr == NULL) {
+            return -1;
         }
     }
     else {

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -803,11 +803,12 @@ find_descriptor_from_array(
 
     if (NPY_UNLIKELY(NPY_DT_is_parametric(DType) && PyArray_ISOBJECT(arr))) {
         /*
-         * We have one special case, if (and only if) the input array is of
-         * object DType and the dtype is not fixed already but parametric.
-         * Then, we allow inspection of all elements, treating them as
-         * elements. We do this recursively, so nested 0-D arrays can work,
-         * but nested higher dimensional arrays will lead to an error.
+         * Inspecting array values is limited to this branch and the two
+         * below.  If the input array is of object DType and the dtype is
+         * not fixed already but parametric, we allow inspection of all
+         * elements, treating them as elements. We do this recursively, so
+         * nested 0-D arrays can work, but nested higher dimensional arrays
+         * will lead to an error.
          */
         assert(DType->type_num != NPY_OBJECT);  /* not parametric */
 
@@ -851,6 +852,20 @@ find_descriptor_from_array(
         }
         Py_DECREF(iter);
     }
+    else if (NPY_UNLIKELY(PyArray_TYPE(arr) == NPY_VSTRING &&
+                          (DType->type_num == NPY_STRING ||
+                           DType->type_num == NPY_UNICODE))) {
+        /*
+         * Casting a StringDType array to a fixed-width string DType with no
+         * size means finding the width of the widest entry first, so that
+         * the cast does not truncate.
+         */
+        *out_descr = stringdtype_find_fixed_width_descr(
+                arr, DType->type_num);
+        if (*out_descr == NULL) {
+            return -1;
+        }
+    }
     else if (NPY_UNLIKELY(DType->type_num == NPY_DATETIME) &&
                 PyArray_ISSTRING(arr)) {
         /*
@@ -873,21 +888,6 @@ find_descriptor_from_array(
             if (*out_descr == NULL) {
                 return -1;
             }
-        }
-    }
-    else if (NPY_UNLIKELY(PyArray_TYPE(arr) == NPY_VSTRING &&
-                          (DType->type_num == NPY_STRING ||
-                           DType->type_num == NPY_UNICODE))) {
-        /*
-         * Casting a StringDType array to a fixed-width string DType with no
-         * size means finding the width of the widest entry first, so that
-         * the cast does not truncate.  Note that, like the object branch
-         * above, this inspects array values.
-         */
-        *out_descr = stringdtype_find_fixed_width_descr(
-                arr, DType->type_num);
-        if (*out_descr == NULL) {
-            return -1;
         }
     }
     else {

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -801,10 +801,10 @@ find_descriptor_from_array(
         return 0;
     }
 
+    /* Special cases that inspect values to determine the output dtype */
     if (NPY_UNLIKELY(NPY_DT_is_parametric(DType) && PyArray_ISOBJECT(arr))) {
         /*
-         * Inspecting array values is limited to this branch and the two
-         * below.  If the input array is of object DType and the dtype is
+         * If the input array is of object DType and the dtype is
          * not fixed already but parametric, we allow inspection of all
          * elements, treating them as elements. We do this recursively, so
          * nested 0-D arrays can work, but nested higher dimensional arrays
@@ -853,8 +853,7 @@ find_descriptor_from_array(
         Py_DECREF(iter);
     }
     else if (NPY_UNLIKELY(PyArray_TYPE(arr) == NPY_VSTRING &&
-                          (DType->type_num == NPY_STRING ||
-                           DType->type_num == NPY_UNICODE))) {
+                          PyTypeNum_ISFLEXIBLE(DType->type_num))) {
         /*
          * Casting a StringDType array to a fixed-width string DType with no
          * size means finding the width of the widest entry first, so that

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1861,6 +1861,11 @@ PyArray_FromArray(PyArrayObject *arr, PyArray_Descr *newtype, int flags)
         Py_INCREF(oldtype);
     }
     else if (PyDataType_ISUNSIZED(newtype)) {
+        /*
+         * Legacy behavior: an unsized descriptor takes on the source
+         * itemsize with no value inspection, unlike `PyArray_CastToType`,
+         * which adapts unsized descriptors to the array values.
+         */
         PyArray_DESCR_REPLACE(newtype);
         if (newtype == NULL) {
             return NULL;

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -329,12 +329,14 @@ string_to_fixed_width_resolve_descriptors(
         npy_intp *NPY_UNUSED(view_offset))
 {
     if (given_descrs[1] == NULL) {
-        // currently there's no way to determine the correct output
-        // size, so set an error and bail
+        // the correct output size can only be discovered by inspecting the
+        // values of an array being cast, which happens in
+        // stringdtype_find_fixed_width_descr before descriptor resolution
         PyErr_SetString(
                 PyExc_TypeError,
                 "Casting from StringDType to a fixed-width dtype with an "
-                "unspecified size is not currently supported, specify "
+                "unspecified size is only supported when the widths can be "
+                "inferred from the values of an array being cast, specify "
                 "an explicit size for the output dtype instead.");
         return (NPY_CASTING)-1;
     }
@@ -349,13 +351,11 @@ string_to_fixed_width_resolve_descriptors(
     return NPY_SAME_KIND_CASTING;
 }
 
-static int
-load_nullable_string(const npy_packed_static_string *ps,
+// The caller must hold *allocator*, acquired from *descr*.
+NPY_NO_EXPORT int
+load_nullable_string(const PyArray_StringDTypeObject *descr,
+                     const npy_packed_static_string *ps,
                      npy_static_string *s,
-                     int has_null,
-                     int has_string_na,
-                     const npy_static_string *default_string,
-                     const npy_static_string *na_name,
                      npy_string_allocator *allocator,
                      const char *context)
 {
@@ -366,15 +366,121 @@ load_nullable_string(const npy_packed_static_string *ps,
         return -1;
     }
     else if (is_null) {
-        if (has_null && !has_string_na) {
+        if (descr->na_object != NULL && !descr->has_string_na) {
             // lossy but not much else we can do
-            *s = *na_name;
+            *s = descr->na_name;
         }
         else {
-            *s = *default_string;
+            *s = descr->default_string;
         }
     }
     return 0;
+}
+
+// Find a fixed-width string or unicode descriptor wide enough to store every
+// entry of *arr*, a StringDType array, without truncation.  Entries convert
+// exactly as in the corresponding cast loops: missing entries count with the
+// width of their effective value (see load_nullable_string above) and
+// embedded and trailing NULs count as data.  The result is at least "S1" or
+// "U1", including for empty arrays and arrays that only hold empty strings.
+//
+// For NPY_UNICODE the entries must be counted in code points, so invalid
+// UTF-8 is detected here and raises a UnicodeDecodeError.  For NPY_STRING
+// the width is the UTF-8 byte length; non-ASCII entries are not rejected
+// here, the cast loop raises a UnicodeEncodeError for them.
+//
+// Returns NULL with an error set on failure.
+NPY_NO_EXPORT PyArray_Descr *
+stringdtype_find_fixed_width_descr(PyArrayObject *arr, int type_num)
+{
+    assert(type_num == NPY_STRING || type_num == NPY_UNICODE);
+    assert(PyArray_TYPE(arr) == NPY_VSTRING);
+
+    PyArray_StringDTypeObject *descr =
+            (PyArray_StringDTypeObject *)PyArray_DESCR(arr);
+
+    // Create the iterator before acquiring the allocator
+    PyArrayIterObject *iter =
+            (PyArrayIterObject *)PyArray_IterNew((PyObject *)arr);
+    if (iter == NULL) {
+        return NULL;
+    }
+
+    npy_uint64 max_width = 1;
+    char *bad_buf = NULL;
+    size_t bad_size = 0;
+    PyArray_Descr *ret = NULL;
+
+    npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
+
+    while (iter->index < iter->size) {
+        const npy_packed_static_string *ps =
+                (const npy_packed_static_string *)iter->dataptr;
+        npy_static_string s = {0, NULL};
+        if (load_nullable_string(descr, ps, &s, allocator,
+                                 "fixed-width width discovery") == -1) {
+            goto fail;
+        }
+        npy_uint64 width;
+        if (type_num == NPY_STRING) {
+            width = (npy_uint64)s.size;
+        }
+        else {
+            size_t num_codepoints = 0;
+            if (num_codepoints_for_utf8_bytes(
+                        (const unsigned char *)s.buf, &num_codepoints,
+                        s.size) != 0) {
+                // defer raising error until after the allocator is dropped
+                bad_buf = (char *)PyMem_RawMalloc(s.size);
+                if (bad_buf == NULL) {
+                    PyErr_NoMemory();
+                    goto fail;
+                }
+                memcpy(bad_buf, s.buf, s.size);
+                bad_size = s.size;
+                goto fail;
+            }
+            width = (npy_uint64)num_codepoints;
+        }
+        if (width > max_width) {
+            max_width = width;
+        }
+        PyArray_ITER_NEXT(iter);
+    }
+
+    NpyString_release_allocator(allocator);
+    Py_DECREF(iter);
+
+    if (max_width > NPY_MAX_INT ||
+            (type_num == NPY_UNICODE && max_width > NPY_MAX_INT / 4)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "string too large to store inside array.");
+        return NULL;
+    }
+
+    ret = PyArray_DescrNewFromType(type_num);
+    if (ret == NULL) {
+        return NULL;
+    }
+    ret->elsize = (int)(type_num == NPY_UNICODE ? 4 * max_width : max_width);
+    return ret;
+
+fail:
+    NpyString_release_allocator(allocator);
+    Py_DECREF(iter);
+    if (bad_buf != NULL) {
+        // decode to construct a UnicodeDecodeError with positional information
+        PyObject *decoded = PyUnicode_Decode(bad_buf, bad_size, "utf-8",
+                                             "strict");
+        PyMem_RawFree(bad_buf);
+        if (decoded != NULL) {
+            Py_DECREF(decoded);
+            PyErr_SetString(PyExc_TypeError,
+                            "Invalid UTF-8 bytes found in string width "
+                            "discovery");
+        }
+    }
+    return NULL;
 }
 
 static int
@@ -384,10 +490,6 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
 {
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)context->descriptors[0];
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
-    int has_null = descr->na_object != NULL;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
-    const npy_static_string *na_name = &descr->na_name;
     npy_intp N = dimensions[0];
     char *in = data[0];
     Py_UCS4 *out = (Py_UCS4 *)data[1];
@@ -399,9 +501,8 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
-        if (load_nullable_string(ps, &s, has_null, has_string_na,
-                                 default_string, na_name, allocator,
-                                 "in string to unicode cast") == -1) {
+        if (load_nullable_string(descr, ps, &s, allocator,
+                                 "string to unicode cast") == -1) {
             goto fail;
         }
 
@@ -1810,10 +1911,6 @@ string_to_void(PyArrayMethod_Context *context, char *const data[],
 {
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)context->descriptors[0];
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
-    int has_null = descr->na_object != NULL;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
-    const npy_static_string *na_name = &descr->na_name;
     npy_intp N = dimensions[0];
     char *in = data[0];
     char *out = data[1];
@@ -1824,9 +1921,8 @@ string_to_void(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
-        if (load_nullable_string(ps, &s, has_null, has_string_na,
-                                 default_string, na_name, allocator,
-                                 "in string to void cast") == -1) {
+        if (load_nullable_string(descr, ps, &s, allocator,
+                                 "string to void cast") == -1) {
             goto fail;
         }
 
@@ -1925,10 +2021,6 @@ string_to_bytes(PyArrayMethod_Context *context, char *const data[],
                 NpyAuxData *NPY_UNUSED(auxdata))
 {
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)context->descriptors[0];
-    int has_null = descr->na_object != NULL;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
-    const npy_static_string *na_name = &descr->na_name;
     npy_intp N = dimensions[0];
     char *in = data[0];
     char *out = data[1];
@@ -1941,9 +2033,8 @@ string_to_bytes(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
-        if (load_nullable_string(ps, &s, has_null, has_string_na,
-                                 default_string, na_name, alloc.allocator(),
-                                 "in string to bytes cast") == -1) {
+        if (load_nullable_string(descr, ps, &s, alloc.allocator(),
+                                 "string to bytes cast") == -1) {
             return -1;
         }
 

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -410,6 +410,7 @@ stringdtype_find_fixed_width_descr(PyArrayObject *arr, int type_num)
     char *bad_buf = NULL;
     size_t bad_size = 0;
     PyArray_Descr *ret = NULL;
+    int succeeded = 0;
 
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
 
@@ -419,7 +420,7 @@ stringdtype_find_fixed_width_descr(PyArrayObject *arr, int type_num)
         npy_static_string s = {0, NULL};
         if (load_nullable_string(descr, ps, &s, allocator,
                                  "fixed-width width discovery") == -1) {
-            goto fail;
+            goto finish;
         }
         npy_uint64 width;
         if (type_num == NPY_STRING) {
@@ -434,11 +435,11 @@ stringdtype_find_fixed_width_descr(PyArrayObject *arr, int type_num)
                 bad_buf = (char *)PyMem_RawMalloc(s.size);
                 if (bad_buf == NULL) {
                     PyErr_NoMemory();
-                    goto fail;
+                    goto finish;
                 }
                 memcpy(bad_buf, s.buf, s.size);
                 bad_size = s.size;
-                goto fail;
+                goto finish;
             }
             width = (npy_uint64)num_codepoints;
         }
@@ -447,27 +448,13 @@ stringdtype_find_fixed_width_descr(PyArrayObject *arr, int type_num)
         }
         PyArray_ITER_NEXT(iter);
     }
+    succeeded = 1;
+
+finish:
 
     NpyString_release_allocator(allocator);
     Py_DECREF(iter);
 
-    if (max_width > NPY_MAX_INT ||
-            (type_num == NPY_UNICODE && max_width > NPY_MAX_INT / 4)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "string too large to store inside array.");
-        return NULL;
-    }
-
-    ret = PyArray_DescrNewFromType(type_num);
-    if (ret == NULL) {
-        return NULL;
-    }
-    ret->elsize = (int)(type_num == NPY_UNICODE ? 4 * max_width : max_width);
-    return ret;
-
-fail:
-    NpyString_release_allocator(allocator);
-    Py_DECREF(iter);
     if (bad_buf != NULL) {
         // decode to construct a UnicodeDecodeError with positional information
         PyObject *decoded = PyUnicode_Decode(bad_buf, bad_size, "utf-8",
@@ -480,7 +467,24 @@ fail:
                             "discovery");
         }
     }
-    return NULL;
+    if (!succeeded) {
+        // another error raised during the loop
+        return NULL;
+    }
+    if (max_width > NPY_MAX_INT ||
+            (type_num == NPY_UNICODE && max_width > NPY_MAX_INT / 4)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "string too large to store inside array.");
+        return NULL;
+    }
+
+    ret = PyArray_DescrNewFromType(type_num);
+
+    if (ret != NULL) {
+        ret->elsize = (int)(type_num == NPY_UNICODE ? 4 * max_width : max_width);
+    }
+
+    return ret;
 }
 
 static int

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -463,9 +463,11 @@ finish:
         PyMem_RawFree(bad_buf);
         if (decoded != NULL) {
             Py_DECREF(decoded);
-            PyErr_SetString(PyExc_TypeError,
-                            "Invalid UTF-8 bytes found in string width "
-                            "discovery");
+            PyErr_SetString(PyExc_RuntimeError,
+                            "Invalid UTF-8 bytes found in %s that the Python "
+                            "UTF-8 decoder accepted. If you did not set a "
+                            "custom 'strict' codec, this could indicate memory "
+                            "corruption or a race.");
         }
     }
     if (!succeeded) {

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -329,12 +329,14 @@ string_to_fixed_width_resolve_descriptors(
         npy_intp *NPY_UNUSED(view_offset))
 {
     if (given_descrs[1] == NULL) {
-        // currently there's no way to determine the correct output
-        // size, so set an error and bail
+        // the correct output size can only be discovered by inspecting the
+        // values of an array being cast, which happens in
+        // stringdtype_find_fixed_width_descr before descriptor resolution
         PyErr_SetString(
                 PyExc_TypeError,
                 "Casting from StringDType to a fixed-width dtype with an "
-                "unspecified size is not currently supported, specify "
+                "unspecified size is only supported when the widths can be "
+                "inferred from the values of an array being cast, specify "
                 "an explicit size for the output dtype instead.");
         return (NPY_CASTING)-1;
     }
@@ -349,13 +351,11 @@ string_to_fixed_width_resolve_descriptors(
     return NPY_SAME_KIND_CASTING;
 }
 
-static int
-load_nullable_string(const npy_packed_static_string *ps,
+// The caller must hold *allocator*, acquired from *descr*.
+NPY_NO_EXPORT int
+load_nullable_string(const PyArray_StringDTypeObject *descr,
+                     const npy_packed_static_string *ps,
                      npy_static_string *s,
-                     int has_null,
-                     int has_string_na,
-                     const npy_static_string *default_string,
-                     const npy_static_string *na_name,
                      npy_string_allocator *allocator,
                      const char *context)
 {
@@ -366,15 +366,121 @@ load_nullable_string(const npy_packed_static_string *ps,
         return -1;
     }
     else if (is_null) {
-        if (has_null && !has_string_na) {
+        if (descr->na_object != NULL && !descr->has_string_na) {
             // lossy but not much else we can do
-            *s = *na_name;
+            *s = descr->na_name;
         }
         else {
-            *s = *default_string;
+            *s = descr->default_string;
         }
     }
     return 0;
+}
+
+// Find a fixed-width string or unicode descriptor wide enough to store every
+// entry of *arr*, a StringDType array, without truncation.  Entries convert
+// exactly as in the corresponding cast loops: missing entries count with the
+// width of their effective value (see load_nullable_string above) and
+// embedded and trailing NULs count as data.  The result is at least "S1" or
+// "U1", including for empty arrays and arrays that only hold empty strings.
+//
+// For NPY_UNICODE the entries must be counted in code points, so invalid
+// UTF-8 is detected here and raises a UnicodeDecodeError.  For NPY_STRING
+// the width is the UTF-8 byte length; non-ASCII entries are not rejected
+// here, the cast loop raises a UnicodeEncodeError for them.
+//
+// Returns NULL with an error set on failure.
+NPY_NO_EXPORT PyArray_Descr *
+stringdtype_find_fixed_width_descr(PyArrayObject *arr, int type_num)
+{
+    assert(type_num == NPY_STRING || type_num == NPY_UNICODE);
+    assert(PyArray_TYPE(arr) == NPY_VSTRING);
+
+    PyArray_StringDTypeObject *descr =
+            (PyArray_StringDTypeObject *)PyArray_DESCR(arr);
+
+    // Create the iterator before acquiring the allocator
+    PyArrayIterObject *iter =
+            (PyArrayIterObject *)PyArray_IterNew((PyObject *)arr);
+    if (iter == NULL) {
+        return NULL;
+    }
+
+    npy_uint64 max_width = 1;
+    char *bad_buf = NULL;
+    size_t bad_size = 0;
+    PyArray_Descr *ret = NULL;
+
+    npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
+
+    while (iter->index < iter->size) {
+        const npy_packed_static_string *ps =
+                (const npy_packed_static_string *)iter->dataptr;
+        npy_static_string s = {0, NULL};
+        if (load_nullable_string(descr, ps, &s, allocator,
+                                 "fixed-width width discovery") == -1) {
+            goto fail;
+        }
+        npy_uint64 width;
+        if (type_num == NPY_STRING) {
+            width = (npy_uint64)s.size;
+        }
+        else {
+            size_t num_codepoints = 0;
+            if (num_codepoints_for_utf8_bytes(
+                        (const unsigned char *)s.buf, &num_codepoints,
+                        s.size) != 0) {
+                // defer raising error until after the allocator is dropped
+                bad_buf = (char *)PyMem_RawMalloc(s.size);
+                if (bad_buf == NULL) {
+                    PyErr_NoMemory();
+                    goto fail;
+                }
+                memcpy(bad_buf, s.buf, s.size);
+                bad_size = s.size;
+                goto fail;
+            }
+            width = (npy_uint64)num_codepoints;
+        }
+        if (width > max_width) {
+            max_width = width;
+        }
+        PyArray_ITER_NEXT(iter);
+    }
+
+    NpyString_release_allocator(allocator);
+    Py_DECREF(iter);
+
+    if (max_width > NPY_MAX_INT ||
+            (type_num == NPY_UNICODE && max_width > NPY_MAX_INT / 4)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "string too large to store inside array.");
+        return NULL;
+    }
+
+    ret = PyArray_DescrNewFromType(type_num);
+    if (ret == NULL) {
+        return NULL;
+    }
+    ret->elsize = (int)(type_num == NPY_UNICODE ? 4 * max_width : max_width);
+    return ret;
+
+fail:
+    NpyString_release_allocator(allocator);
+    Py_DECREF(iter);
+    if (bad_buf != NULL) {
+        // decode to construct a UnicodeDecodeError with positional information
+        PyObject *decoded = PyUnicode_Decode(bad_buf, bad_size, "utf-8",
+                                             "strict");
+        PyMem_RawFree(bad_buf);
+        if (decoded != NULL) {
+            Py_DECREF(decoded);
+            PyErr_SetString(PyExc_TypeError,
+                            "Invalid UTF-8 bytes found in string width "
+                            "discovery");
+        }
+    }
+    return NULL;
 }
 
 static int
@@ -384,10 +490,6 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
 {
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)context->descriptors[0];
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
-    int has_null = descr->na_object != NULL;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
-    const npy_static_string *na_name = &descr->na_name;
     npy_intp N = dimensions[0];
     char *in = data[0];
     Py_UCS4 *out = (Py_UCS4 *)data[1];
@@ -399,9 +501,8 @@ string_to_unicode(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
-        if (load_nullable_string(ps, &s, has_null, has_string_na,
-                                 default_string, na_name, allocator,
-                                 "in string to unicode cast") == -1) {
+        if (load_nullable_string(descr, ps, &s, allocator,
+                                 "string to unicode cast") == -1) {
             goto fail;
         }
 
@@ -1792,10 +1893,6 @@ string_to_void(PyArrayMethod_Context *context, char *const data[],
 {
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)context->descriptors[0];
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
-    int has_null = descr->na_object != NULL;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
-    const npy_static_string *na_name = &descr->na_name;
     npy_intp N = dimensions[0];
     char *in = data[0];
     char *out = data[1];
@@ -1806,9 +1903,8 @@ string_to_void(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
-        if (load_nullable_string(ps, &s, has_null, has_string_na,
-                                 default_string, na_name, allocator,
-                                 "in string to void cast") == -1) {
+        if (load_nullable_string(descr, ps, &s, allocator,
+                                 "string to void cast") == -1) {
             goto fail;
         }
 
@@ -1907,10 +2003,6 @@ string_to_bytes(PyArrayMethod_Context *context, char *const data[],
                 NpyAuxData *NPY_UNUSED(auxdata))
 {
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)context->descriptors[0];
-    int has_null = descr->na_object != NULL;
-    int has_string_na = descr->has_string_na;
-    const npy_static_string *default_string = &descr->default_string;
-    const npy_static_string *na_name = &descr->na_name;
     npy_intp N = dimensions[0];
     char *in = data[0];
     char *out = data[1];
@@ -1923,9 +2015,8 @@ string_to_bytes(PyArrayMethod_Context *context, char *const data[],
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
         npy_static_string s = {0, NULL};
-        if (load_nullable_string(ps, &s, has_null, has_string_na,
-                                 default_string, na_name, alloc.allocator(),
-                                 "in string to bytes cast") == -1) {
+        if (load_nullable_string(descr, ps, &s, alloc.allocator(),
+                                 "string to bytes cast") == -1) {
             return -1;
         }
 

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -380,14 +380,15 @@ load_nullable_string(const PyArray_StringDTypeObject *descr,
 // Find a fixed-width string or unicode descriptor wide enough to store every
 // entry of *arr*, a StringDType array, without truncation.  Entries convert
 // exactly as in the corresponding cast loops: missing entries count with the
-// width of their effective value (see load_nullable_string above) and
-// embedded and trailing NULs count as data.  The result is at least "S1" or
-// "U1", including for empty arrays and arrays that only hold empty strings.
+// width of the string load_nullable_string substitutes for them and embedded
+// and trailing NULs count as data.  The result is at least "S1" or "U1",
+// including for empty arrays and arrays that only hold empty strings.
 //
-// For NPY_UNICODE the entries must be counted in code points, so invalid
-// UTF-8 is detected here and raises a UnicodeDecodeError.  For NPY_STRING
-// the width is the UTF-8 byte length; non-ASCII entries are not rejected
-// here, the cast loop raises a UnicodeEncodeError for them.
+// For NPY_UNICODE the entries must be counted in code points, which also
+// validates them: NpyString_pack does not check its input, so C API users
+// can store invalid UTF-8, which raises a UnicodeDecodeError here.  For
+// NPY_STRING the width is the UTF-8 byte length; non-ASCII entries are not
+// rejected here, the cast loop raises a UnicodeEncodeError for them.
 //
 // Returns NULL with an error set on failure.
 NPY_NO_EXPORT PyArray_Descr *
@@ -471,8 +472,7 @@ finish:
         // another error raised during the loop
         return NULL;
     }
-    if (max_width > NPY_MAX_INT ||
-            (type_num == NPY_UNICODE && max_width > NPY_MAX_INT / 4)) {
+    if (max_width > (type_num == NPY_UNICODE ? NPY_MAX_INT / 4 : NPY_MAX_INT)) {
         PyErr_SetString(PyExc_TypeError,
                         "string too large to store inside array.");
         return NULL;

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -394,7 +394,7 @@ load_nullable_string(const PyArray_StringDTypeObject *descr,
 NPY_NO_EXPORT PyArray_Descr *
 stringdtype_find_fixed_width_descr(PyArrayObject *arr, int type_num)
 {
-    assert(type_num == NPY_STRING || type_num == NPY_UNICODE);
+    assert(PyTypeNum_ISFLEXIBLE(type_num));
     assert(PyArray_TYPE(arr) == NPY_VSTRING);
 
     PyArray_StringDTypeObject *descr =
@@ -424,10 +424,7 @@ stringdtype_find_fixed_width_descr(PyArrayObject *arr, int type_num)
             goto finish;
         }
         npy_uint64 width;
-        if (type_num == NPY_STRING) {
-            width = (npy_uint64)s.size;
-        }
-        else {
+        if (type_num == NPY_UNICODE) {
             size_t num_codepoints = 0;
             if (num_codepoints_for_utf8_bytes(
                         (const unsigned char *)s.buf, &num_codepoints,
@@ -443,6 +440,9 @@ stringdtype_find_fixed_width_descr(PyArrayObject *arr, int type_num)
                 goto finish;
             }
             width = (npy_uint64)num_codepoints;
+        }
+        else {
+            width = (npy_uint64)s.size;
         }
         if (width > max_width) {
             max_width = width;
@@ -1862,12 +1862,11 @@ string_to_void_resolve_descriptors(PyObject *NPY_UNUSED(self),
                                    npy_intp *NPY_UNUSED(view_offset))
 {
     if (given_descrs[1] == NULL) {
-        // currently there's no way to determine the correct output
-        // size, so set an error and bail
         PyErr_SetString(
                 PyExc_TypeError,
                 "Casting from StringDType to a fixed-width dtype with an "
-                "unspecified size is not currently supported, specify "
+                "unspecified size is only supported with the widths can be "
+                "inferred from the values of an array being cast, specify "
                 "an explicit size for the output dtype instead.");
         return (NPY_CASTING)-1;
     }

--- a/numpy/_core/src/multiarray/stringdtype/casts.h
+++ b/numpy/_core/src/multiarray/stringdtype/casts.h
@@ -6,7 +6,22 @@
 extern "C" {
 #endif
 
-PyArrayMethod_Spec **get_casts();
+PyArrayMethod_Spec **get_casts(void);
+
+// Load the effective value of *ps* for a conversion to a fixed-width dtype;
+// the caller must hold *allocator*, acquired from *descr*.
+NPY_NO_EXPORT int
+load_nullable_string(const PyArray_StringDTypeObject *descr,
+                     const npy_packed_static_string *ps,
+                     npy_static_string *s,
+                     npy_string_allocator *allocator,
+                     const char *context);
+
+// Find a fixed-width NPY_STRING or NPY_UNICODE descriptor wide enough to
+// store every entry of the StringDType array *arr* without truncation.
+// Returns NULL with an error set on failure.
+NPY_NO_EXPORT PyArray_Descr *
+stringdtype_find_fixed_width_descr(PyArrayObject *arr, int type_num);
 
 #ifdef __cplusplus
 }

--- a/numpy/_core/src/multiarray/stringdtype/casts.h
+++ b/numpy/_core/src/multiarray/stringdtype/casts.h
@@ -8,8 +8,11 @@ extern "C" {
 
 PyArrayMethod_Spec **get_casts(void);
 
-// Load the effective value of *ps* for a conversion to a fixed-width dtype;
-// the caller must hold *allocator*, acquired from *descr*.
+// Load the string representation for *ps*. This might be the packed string
+// itself or, for a missing entry, str(na_object) when the descriptor has a
+// non-string na_object and its default string otherwise (the na_object for a
+// string na_object, empty without one).  The caller must hold *allocator*,
+// acquired from *descr*.
 NPY_NO_EXPORT int
 load_nullable_string(const PyArray_StringDTypeObject *descr,
                      const npy_packed_static_string *ps,

--- a/numpy/_core/src/multiarray/stringdtype/casts.h
+++ b/numpy/_core/src/multiarray/stringdtype/casts.h
@@ -20,8 +20,9 @@ load_nullable_string(const PyArray_StringDTypeObject *descr,
                      npy_string_allocator *allocator,
                      const char *context);
 
-// Find a fixed-width NPY_STRING or NPY_UNICODE descriptor wide enough to
-// store every entry of the StringDType array *arr* without truncation.
+// Find a fixed-width NPY_STRING, NPY_UNICODE or NPY_VOID descriptor wide
+// enough to store every entry of the StringDType array *arr* without
+// truncation.
 // Returns NULL with an error set on failure.
 NPY_NO_EXPORT PyArray_Descr *
 stringdtype_find_fixed_width_descr(PyArrayObject *arr, int type_num);

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -330,6 +330,20 @@ def test_npystring_load(install_temp):
     assert result == 'abcd'
 
 
+def test_npystring_pack_invalid_utf8_width_inference(install_temp):
+    # NpyString_pack does not validate, so width inference can see bytes
+    # that do not decode
+    import checks
+
+    arr = np.array(["abc"], dtype="T")
+    assert checks.npystring_pack_invalid_utf8(arr, b"\xffbc") == 0
+    with pytest.raises(UnicodeDecodeError) as excinfo:
+        arr.astype("U")
+    exc = excinfo.value
+    assert (exc.encoding, exc.object, exc.start, exc.end) == (
+        "utf-8", b"\xffbc", 0, 1)
+
+
 def test_npystring_multiple_allocators(install_temp):
     """Check that the cython API can acquire/release multiple vstring allocators."""
     import checks

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -439,6 +439,178 @@ class TestStringLikeCasts:
                 sarr.astype("S20")
 
 
+UNSIZED_SPELLINGS = {
+    "S": ["S", "S0", np.dtype("S"), np.dtypes.BytesDType, np.bytes_],
+    "U": ["U", "U0", np.dtype("U"), np.dtypes.StrDType, np.str_],
+}
+
+
+CONVERSION_PATHS = [
+    pytest.param(lambda arr, req: arr.astype(req), id="astype"),
+    pytest.param(lambda arr, req: np.array(arr, dtype=req), id="np.array"),
+    pytest.param(lambda arr, req: np.asarray(arr, dtype=req),
+                 id="np.asarray"),
+    # exercises PyArray_CastToType
+    pytest.param(lambda arr, req: arr.__array__(dtype=np.dtype(req),
+                                                copy=True), id="__array__"),
+]
+
+
+class TestUnsizedFixedWidthCasts:
+    """Converting to an unsized "S" or "U" dtype infers the width by
+    inspecting the values in the array being converted."""
+
+    @pytest.mark.parametrize("kind", ["S", "U"])
+    def test_unsized_spellings(self, kind):
+        arr = np.array(["this", "is", "an", "array"], dtype="T")
+        expected = np.array(["this", "is", "an", "array"], dtype=f"{kind}5")
+        for spelling in UNSIZED_SPELLINGS[kind]:
+            assert_array_equal(arr.astype(spelling), expected)
+
+    @pytest.mark.parametrize("convert", CONVERSION_PATHS)
+    @pytest.mark.parametrize("kind", ["S", "U"])
+    @pytest.mark.parametrize(
+        "strings,width",
+        [
+            (["this", "is", "an", "array"], 5),
+            (["a" * 100, "", "b"], 100),
+            # embedded and trailing NULs count as data
+            (["x\0", "y\0\0z", ""], 4),
+            # empty arrays and all-empty entries produce width 1
+            ([], 1),
+            (["", "", ""], 1),
+        ],
+    )
+    def test_conversion_paths_infer_width(self, convert, kind, strings,
+                                          width):
+        arr = np.array(strings, dtype="T")
+        res = convert(arr, kind)
+        assert res.dtype == np.dtype(f"{kind}{width}")
+        assert_array_equal(res, np.array(strings, dtype=f"{kind}{width}"))
+
+    @pytest.mark.parametrize("kind", ["S", "U"])
+    def test_zero_dimensional(self, kind):
+        res = np.array("abcd", dtype="T").astype(kind)
+        assert res.dtype == np.dtype(f"{kind}4")
+        assert res == np.array("abcd", dtype=f"{kind}4")
+
+    @pytest.mark.parametrize("kind", ["S", "U"])
+    def test_strided_and_multidimensional(self, kind):
+        arr = np.array(
+            ["a long string entry", "ab", "c", "d"], dtype="T")
+        # only the short entries participate in a strided view
+        assert arr[1::2].astype(kind).dtype == np.dtype(f"{kind}2")
+        assert arr[::-1].astype(kind).dtype == np.dtype(f"{kind}19")
+        arr_2d = np.array([["a", "bb"], ["ccc", "dddd"]], dtype="T")
+        res = arr_2d.astype(kind)
+        assert res.dtype == np.dtype(f"{kind}4")
+        assert_array_equal(
+            res, np.array([["a", "bb"], ["ccc", "dddd"]], dtype=f"{kind}4"))
+
+    def test_multibyte_unicode_widths(self):
+        # "U" widths count code points, "S" widths count UTF-8 bytes
+        arr = np.array(["a😊b", "é"], dtype="T")
+        res = arr.astype("U")
+        assert res.dtype == np.dtype("U3")
+        assert_array_equal(res, np.array(["a😊b", "é"], dtype="U3"))
+        # the "S" cast sizes by bytes but rejects non-ASCII entries
+        with pytest.raises(UnicodeEncodeError):
+            arr.astype("S")
+        arr = np.array(["hello", "world!!"], dtype="T")
+        res = arr.astype("S")
+        assert res.dtype == np.dtype("S7")
+        assert_array_equal(res, np.array(["hello", "world!!"], dtype="S7"))
+
+    def test_multiple_arrays_promote_to_widest(self):
+        arr1 = np.array(["abc"], dtype="T")
+        arr2 = np.array(["longer!"], dtype="T")
+        assert np.array([arr1, arr2], dtype="S").dtype == np.dtype("S7")
+
+    @pytest.mark.parametrize("kind", ["S", "U"])
+    def test_descriptor_only_resolution_still_fails(self, kind):
+        # functions that adapt descriptors without inspecting array values
+        # cannot infer a width
+        arr = np.array(["abc"], dtype="T")
+        with pytest.raises(TypeError,
+                           match="cannot cast dtype StringDType"):
+            np.concatenate([arr, arr], dtype=kind)
+
+    def test_explicit_width_still_truncates(self):
+        arr = np.array(["abcdef"], dtype="T")
+        assert_array_equal(arr.astype("S3"), np.array([b"abc"], dtype="S3"))
+        assert_array_equal(arr.astype("U3"), np.array(["abc"], dtype="U3"))
+
+
+class TestUnsizedCastMissingValues:
+    def test_nan_na(self):
+        dt = StringDType(na_object=np.nan)
+        arr = np.array(["abcde", np.nan], dtype=dt)
+        res = arr.astype("U")
+        assert res.dtype == np.dtype("U5")
+        assert res[1] == "nan"
+        all_null = np.array([np.nan, np.nan], dtype=dt)
+        res = all_null.astype("U")
+        assert res.dtype == np.dtype("U3")
+        assert_array_equal(res, np.array(["nan", "nan"], dtype="U3"))
+
+    def test_non_ascii_string_na(self):
+        # a non-ASCII sentinel counts code points for "U" and raises for
+        # the ASCII-only "S" cast
+        dt = StringDType(na_object="😊😊")
+        arr = np.array(["ab", "😊😊"], dtype=dt)
+        res = arr.astype("U")
+        assert res.dtype == np.dtype("U2")
+        assert res[1] == "😊😊"
+        with pytest.raises(UnicodeEncodeError):
+            arr.astype("S")
+
+
+class TestStringDTypeNditer:
+    def test_infer_width_for_existing_operand(self):
+        arr = np.array(["abc", "defgh"], dtype="T")
+        for kind, expected in [("S", "S5"), ("U", "U5")]:
+            with np.nditer(
+                arr,
+                op_dtypes=[np.dtype(kind)],
+                flags=["buffered", "refs_ok"],
+                casting="same_kind",
+            ) as it:
+                assert it.dtypes[0] == np.dtype(expected)
+                assert [x[()] for x in it] == list(
+                    np.array(["abc", "defgh"], dtype=expected))
+
+    def test_readwrite_stringdtype_operand_fixed_width_buffers(self):
+        # reads convert to the inferred fixed-width dtype and writing
+        # back into the StringDType array round-trips the values
+        arr = np.array(["abc", "defgh"], dtype="T")
+        with np.nditer(
+            arr,
+            op_dtypes=[np.dtype("U")],
+            op_flags=[["readwrite"]],
+            flags=["buffered", "refs_ok"],
+            casting="same_kind",
+        ) as it:
+            assert it.dtypes[0] == np.dtype("U5")
+            for x in it:
+                x[...] = str(x[()]).upper()
+        assert_array_equal(
+            arr, np.array(["ABC", "DEFGH"], dtype="T"))
+
+    @pytest.mark.parametrize("kind,expected", [("S", "S1"), ("U", "U1")])
+    def test_allocated_output_stays_unsized_legacy(self, kind, expected):
+        # allocated outputs have no values to inspect, so an unsized
+        # request keeps the legacy one-character width
+        arr = np.array(["abc", "defgh"], dtype="T")
+        it = np.nditer(
+            [arr, None],
+            op_dtypes=[arr.dtype, np.dtype(kind)],
+            op_flags=[["readonly"], ["writeonly", "allocate"]],
+            flags=["buffered", "refs_ok"],
+            casting="unsafe",
+        )
+        assert it.operands[1].dtype == np.dtype(expected)
+
+
 def test_additional_unicode_cast(dtype):
     string_list = random_unicode_string_list()
     arr = np.array(string_list, dtype=dtype)

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -606,6 +606,178 @@ def test_zfill_no_padding_no_oob():
     assert _zfill(a, 20, out=a).tolist() == ["0" * 20]
 
 
+UNSIZED_SPELLINGS = {
+    "S": ["S", "S0", np.dtype("S"), np.dtypes.BytesDType, np.bytes_],
+    "U": ["U", "U0", np.dtype("U"), np.dtypes.StrDType, np.str_],
+}
+
+
+CONVERSION_PATHS = [
+    pytest.param(lambda arr, req: arr.astype(req), id="astype"),
+    pytest.param(lambda arr, req: np.array(arr, dtype=req), id="np.array"),
+    pytest.param(lambda arr, req: np.asarray(arr, dtype=req),
+                 id="np.asarray"),
+    # exercises PyArray_CastToType
+    pytest.param(lambda arr, req: arr.__array__(dtype=np.dtype(req),
+                                                copy=True), id="__array__"),
+]
+
+
+class TestUnsizedFixedWidthCasts:
+    """Converting to an unsized "S" or "U" dtype infers the width by
+    inspecting the values in the array being converted."""
+
+    @pytest.mark.parametrize("kind", ["S", "U"])
+    def test_unsized_spellings(self, kind):
+        arr = np.array(["this", "is", "an", "array"], dtype="T")
+        expected = np.array(["this", "is", "an", "array"], dtype=f"{kind}5")
+        for spelling in UNSIZED_SPELLINGS[kind]:
+            assert_array_equal(arr.astype(spelling), expected)
+
+    @pytest.mark.parametrize("convert", CONVERSION_PATHS)
+    @pytest.mark.parametrize("kind", ["S", "U"])
+    @pytest.mark.parametrize(
+        "strings,width",
+        [
+            (["this", "is", "an", "array"], 5),
+            (["a" * 100, "", "b"], 100),
+            # embedded and trailing NULs count as data
+            (["x\0", "y\0\0z", ""], 4),
+            # empty arrays and all-empty entries produce width 1
+            ([], 1),
+            (["", "", ""], 1),
+        ],
+    )
+    def test_conversion_paths_infer_width(self, convert, kind, strings,
+                                          width):
+        arr = np.array(strings, dtype="T")
+        res = convert(arr, kind)
+        assert res.dtype == np.dtype(f"{kind}{width}")
+        assert_array_equal(res, np.array(strings, dtype=f"{kind}{width}"))
+
+    @pytest.mark.parametrize("kind", ["S", "U"])
+    def test_zero_dimensional(self, kind):
+        res = np.array("abcd", dtype="T").astype(kind)
+        assert res.dtype == np.dtype(f"{kind}4")
+        assert res == np.array("abcd", dtype=f"{kind}4")
+
+    @pytest.mark.parametrize("kind", ["S", "U"])
+    def test_strided_and_multidimensional(self, kind):
+        arr = np.array(
+            ["a long string entry", "ab", "c", "d"], dtype="T")
+        # only the short entries participate in a strided view
+        assert arr[1::2].astype(kind).dtype == np.dtype(f"{kind}2")
+        assert arr[::-1].astype(kind).dtype == np.dtype(f"{kind}19")
+        arr_2d = np.array([["a", "bb"], ["ccc", "dddd"]], dtype="T")
+        res = arr_2d.astype(kind)
+        assert res.dtype == np.dtype(f"{kind}4")
+        assert_array_equal(
+            res, np.array([["a", "bb"], ["ccc", "dddd"]], dtype=f"{kind}4"))
+
+    def test_multibyte_unicode_widths(self):
+        # "U" widths count code points, "S" widths count UTF-8 bytes
+        arr = np.array(["a😊b", "é"], dtype="T")
+        res = arr.astype("U")
+        assert res.dtype == np.dtype("U3")
+        assert_array_equal(res, np.array(["a😊b", "é"], dtype="U3"))
+        # the "S" cast sizes by bytes but rejects non-ASCII entries
+        with pytest.raises(UnicodeEncodeError):
+            arr.astype("S")
+        arr = np.array(["hello", "world!!"], dtype="T")
+        res = arr.astype("S")
+        assert res.dtype == np.dtype("S7")
+        assert_array_equal(res, np.array(["hello", "world!!"], dtype="S7"))
+
+    def test_multiple_arrays_promote_to_widest(self):
+        arr1 = np.array(["abc"], dtype="T")
+        arr2 = np.array(["longer!"], dtype="T")
+        assert np.array([arr1, arr2], dtype="S").dtype == np.dtype("S7")
+
+    @pytest.mark.parametrize("kind", ["S", "U"])
+    def test_descriptor_only_resolution_still_fails(self, kind):
+        # functions that adapt descriptors without inspecting array values
+        # cannot infer a width
+        arr = np.array(["abc"], dtype="T")
+        with pytest.raises(TypeError,
+                           match="cannot cast dtype StringDType"):
+            np.concatenate([arr, arr], dtype=kind)
+
+    def test_explicit_width_still_truncates(self):
+        arr = np.array(["abcdef"], dtype="T")
+        assert_array_equal(arr.astype("S3"), np.array([b"abc"], dtype="S3"))
+        assert_array_equal(arr.astype("U3"), np.array(["abc"], dtype="U3"))
+
+
+class TestUnsizedCastMissingValues:
+    def test_nan_na(self):
+        dt = StringDType(na_object=np.nan)
+        arr = np.array(["abcde", np.nan], dtype=dt)
+        res = arr.astype("U")
+        assert res.dtype == np.dtype("U5")
+        assert res[1] == "nan"
+        all_null = np.array([np.nan, np.nan], dtype=dt)
+        res = all_null.astype("U")
+        assert res.dtype == np.dtype("U3")
+        assert_array_equal(res, np.array(["nan", "nan"], dtype="U3"))
+
+    def test_non_ascii_string_na(self):
+        # a non-ASCII sentinel counts code points for "U" and raises for
+        # the ASCII-only "S" cast
+        dt = StringDType(na_object="😊😊")
+        arr = np.array(["ab", "😊😊"], dtype=dt)
+        res = arr.astype("U")
+        assert res.dtype == np.dtype("U2")
+        assert res[1] == "😊😊"
+        with pytest.raises(UnicodeEncodeError):
+            arr.astype("S")
+
+
+class TestStringDTypeNditer:
+    def test_infer_width_for_existing_operand(self):
+        arr = np.array(["abc", "defgh"], dtype="T")
+        for kind, expected in [("S", "S5"), ("U", "U5")]:
+            with np.nditer(
+                arr,
+                op_dtypes=[np.dtype(kind)],
+                flags=["buffered", "refs_ok"],
+                casting="same_kind",
+            ) as it:
+                assert it.dtypes[0] == np.dtype(expected)
+                assert [x[()] for x in it] == list(
+                    np.array(["abc", "defgh"], dtype=expected))
+
+    def test_readwrite_stringdtype_operand_fixed_width_buffers(self):
+        # reads convert to the inferred fixed-width dtype and writing
+        # back into the StringDType array round-trips the values
+        arr = np.array(["abc", "defgh"], dtype="T")
+        with np.nditer(
+            arr,
+            op_dtypes=[np.dtype("U")],
+            op_flags=[["readwrite"]],
+            flags=["buffered", "refs_ok"],
+            casting="same_kind",
+        ) as it:
+            assert it.dtypes[0] == np.dtype("U5")
+            for x in it:
+                x[...] = str(x[()]).upper()
+        assert_array_equal(
+            arr, np.array(["ABC", "DEFGH"], dtype="T"))
+
+    @pytest.mark.parametrize("kind,expected", [("S", "S1"), ("U", "U1")])
+    def test_allocated_output_stays_unsized_legacy(self, kind, expected):
+        # allocated outputs have no values to inspect, so an unsized
+        # request keeps the legacy one-character width
+        arr = np.array(["abc", "defgh"], dtype="T")
+        it = np.nditer(
+            [arr, None],
+            op_dtypes=[arr.dtype, np.dtype(kind)],
+            op_flags=[["readonly"], ["writeonly", "allocate"]],
+            flags=["buffered", "refs_ok"],
+            casting="unsafe",
+        )
+        assert it.operands[1].dtype == np.dtype(expected)
+
+
 def test_additional_unicode_cast(dtype):
     string_list = random_unicode_string_list()
     arr = np.array(string_list, dtype=dtype)

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -632,7 +632,7 @@ class TestUnsizedFixedWidthCasts:
         arr = np.array(["this", "is", "an", "array"], dtype="T")
         expected = np.array(["this", "is", "an", "array"], dtype=f"{kind}5")
         for spelling in UNSIZED_SPELLINGS[kind]:
-            assert_array_equal(arr.astype(spelling), expected)
+            assert_array_equal(arr.astype(spelling), expected, strict=True)
 
     @pytest.mark.parametrize("convert", CONVERSION_PATHS)
     @pytest.mark.parametrize("kind", ["S", "U"])
@@ -680,13 +680,9 @@ class TestUnsizedFixedWidthCasts:
         res = arr.astype("U")
         assert res.dtype == np.dtype("U3")
         assert_array_equal(res, np.array(["a😊b", "é"], dtype="U3"))
-        # the "S" cast sizes by bytes but rejects non-ASCII entries
+        # the "S" cast rejects non-ASCII entries
         with pytest.raises(UnicodeEncodeError):
             arr.astype("S")
-        arr = np.array(["hello", "world!!"], dtype="T")
-        res = arr.astype("S")
-        assert res.dtype == np.dtype("S7")
-        assert_array_equal(res, np.array(["hello", "world!!"], dtype="S7"))
 
     def test_multiple_arrays_promote_to_widest(self):
         arr1 = np.array(["abc"], dtype="T")
@@ -713,21 +709,19 @@ class TestUnsizedCastMissingValues:
         dt = StringDType(na_object=np.nan)
         arr = np.array(["abcde", np.nan], dtype=dt)
         res = arr.astype("U")
-        assert res.dtype == np.dtype("U5")
-        assert res[1] == "nan"
+        assert_array_equal(res, np.array(["abcde", "nan"], dtype="U5"), strict=True)
         all_null = np.array([np.nan, np.nan], dtype=dt)
         res = all_null.astype("U")
-        assert res.dtype == np.dtype("U3")
-        assert_array_equal(res, np.array(["nan", "nan"], dtype="U3"))
+        assert_array_equal(res, np.array(["nan", "nan"], dtype="U3"), strict=True)
 
     def test_non_ascii_string_na(self):
-        # a non-ASCII sentinel counts code points for "U" and raises for
-        # the ASCII-only "S" cast
+        # a missing entry counts with the width of the sentinel, in code
+        # points for "U", and raises for the ASCII-only "S" cast
         dt = StringDType(na_object="😊😊")
-        arr = np.array(["ab", "😊😊"], dtype=dt)
+        arr = np.array(["ab", None], dtype=StringDType(na_object=None)).astype(dt)
+        assert arr[1] is dt.na_object
         res = arr.astype("U")
-        assert res.dtype == np.dtype("U2")
-        assert res[1] == "😊😊"
+        assert_array_equal(res, np.array(["ab", "😊😊"], dtype="U2"), strict=True)
         with pytest.raises(UnicodeEncodeError):
             arr.astype("S")
 

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -609,7 +609,21 @@ def test_zfill_no_padding_no_oob():
 UNSIZED_SPELLINGS = {
     "S": ["S", "S0", np.dtype("S"), np.dtypes.BytesDType, np.bytes_],
     "U": ["U", "U0", np.dtype("U"), np.dtypes.StrDType, np.str_],
+    "V": ["V", "V0", np.dtype("V"), np.dtypes.VoidDType, np.void],
 }
+
+
+def encode_nested(strings):
+    if isinstance(strings, str):
+        return strings.encode()
+    return [encode_nested(s) for s in strings]
+
+
+def fixed_width_array(strings, dtype):
+    # void dtypes only accept bytes
+    if np.dtype(dtype).kind == "V":
+        strings = encode_nested(strings)
+    return np.array(strings, dtype=dtype)
 
 
 CONVERSION_PATHS = [
@@ -624,18 +638,18 @@ CONVERSION_PATHS = [
 
 
 class TestUnsizedFixedWidthCasts:
-    """Converting to an unsized "S" or "U" dtype infers the width by
+    """Converting to an unsized "S", "U" or "V" dtype infers the width by
     inspecting the values in the array being converted."""
 
-    @pytest.mark.parametrize("kind", ["S", "U"])
+    @pytest.mark.parametrize("kind", ["S", "U", "V"])
     def test_unsized_spellings(self, kind):
         arr = np.array(["this", "is", "an", "array"], dtype="T")
-        expected = np.array(["this", "is", "an", "array"], dtype=f"{kind}5")
+        expected = fixed_width_array(["this", "is", "an", "array"], f"{kind}5")
         for spelling in UNSIZED_SPELLINGS[kind]:
             assert_array_equal(arr.astype(spelling), expected, strict=True)
 
     @pytest.mark.parametrize("convert", CONVERSION_PATHS)
-    @pytest.mark.parametrize("kind", ["S", "U"])
+    @pytest.mark.parametrize("kind", ["S", "U", "V"])
     @pytest.mark.parametrize(
         "strings,width",
         [
@@ -653,15 +667,15 @@ class TestUnsizedFixedWidthCasts:
         arr = np.array(strings, dtype="T")
         res = convert(arr, kind)
         assert res.dtype == np.dtype(f"{kind}{width}")
-        assert_array_equal(res, np.array(strings, dtype=f"{kind}{width}"))
+        assert_array_equal(res, fixed_width_array(strings, f"{kind}{width}"))
 
-    @pytest.mark.parametrize("kind", ["S", "U"])
+    @pytest.mark.parametrize("kind", ["S", "U", "V"])
     def test_zero_dimensional(self, kind):
         res = np.array("abcd", dtype="T").astype(kind)
         assert res.dtype == np.dtype(f"{kind}4")
-        assert res == np.array("abcd", dtype=f"{kind}4")
+        assert res == fixed_width_array("abcd", f"{kind}4")
 
-    @pytest.mark.parametrize("kind", ["S", "U"])
+    @pytest.mark.parametrize("kind", ["S", "U", "V"])
     def test_strided_and_multidimensional(self, kind):
         arr = np.array(
             ["a long string entry", "ab", "c", "d"], dtype="T")
@@ -672,14 +686,15 @@ class TestUnsizedFixedWidthCasts:
         res = arr_2d.astype(kind)
         assert res.dtype == np.dtype(f"{kind}4")
         assert_array_equal(
-            res, np.array([["a", "bb"], ["ccc", "dddd"]], dtype=f"{kind}4"))
+            res, fixed_width_array([["a", "bb"], ["ccc", "dddd"]], f"{kind}4"))
 
     def test_multibyte_unicode_widths(self):
-        # "U" widths count code points, "S" widths count UTF-8 bytes
+        # "U" widths count code points, "S" and "V" widths count UTF-8 bytes
         arr = np.array(["a😊b", "é"], dtype="T")
         res = arr.astype("U")
-        assert res.dtype == np.dtype("U3")
-        assert_array_equal(res, np.array(["a😊b", "é"], dtype="U3"))
+        assert_array_equal(res, np.array(["a😊b", "é"], dtype="U3"), strict=True)
+        res = arr.astype("V")
+        assert_array_equal(res, fixed_width_array(["a😊b", "é"], "V6"), strict=True)
         # the "S" cast rejects non-ASCII entries
         with pytest.raises(UnicodeEncodeError):
             arr.astype("S")
@@ -689,7 +704,7 @@ class TestUnsizedFixedWidthCasts:
         arr2 = np.array(["longer!"], dtype="T")
         assert np.array([arr1, arr2], dtype="S").dtype == np.dtype("S7")
 
-    @pytest.mark.parametrize("kind", ["S", "U"])
+    @pytest.mark.parametrize("kind", ["S", "U", "V"])
     def test_descriptor_only_resolution_still_fails(self, kind):
         # functions that adapt descriptors without inspecting array values
         # cannot infer a width
@@ -702,6 +717,7 @@ class TestUnsizedFixedWidthCasts:
         arr = np.array(["abcdef"], dtype="T")
         assert_array_equal(arr.astype("S3"), np.array([b"abc"], dtype="S3"))
         assert_array_equal(arr.astype("U3"), np.array(["abc"], dtype="U3"))
+        assert_array_equal(arr.astype("V3"), np.array([b"abc"], dtype="V3"))
 
 
 class TestUnsizedCastMissingValues:
@@ -710,18 +726,23 @@ class TestUnsizedCastMissingValues:
         arr = np.array(["abcde", np.nan], dtype=dt)
         res = arr.astype("U")
         assert_array_equal(res, np.array(["abcde", "nan"], dtype="U5"), strict=True)
+        res = arr.astype("V")
+        assert_array_equal(res, np.array([b"abcde", b"nan"], dtype="V5"), strict=True)
         all_null = np.array([np.nan, np.nan], dtype=dt)
         res = all_null.astype("U")
         assert_array_equal(res, np.array(["nan", "nan"], dtype="U3"), strict=True)
 
     def test_non_ascii_string_na(self):
         # a missing entry counts with the width of the sentinel, in code
-        # points for "U", and raises for the ASCII-only "S" cast
+        # points for "U" and UTF-8 bytes for "V", and raises for the
+        # ASCII-only "S" cast
         dt = StringDType(na_object="😊😊")
         arr = np.array(["ab", None], dtype=StringDType(na_object=None)).astype(dt)
         assert arr[1] is dt.na_object
         res = arr.astype("U")
         assert_array_equal(res, np.array(["ab", "😊😊"], dtype="U2"), strict=True)
+        res = arr.astype("V")
+        assert_array_equal(res, fixed_width_array(["ab", "😊😊"], "V8"), strict=True)
         with pytest.raises(UnicodeEncodeError):
             arr.astype("S")
 
@@ -729,16 +750,16 @@ class TestUnsizedCastMissingValues:
 class TestStringDTypeNditer:
     def test_infer_width_for_existing_operand(self):
         arr = np.array(["abc", "defgh"], dtype="T")
-        for kind, expected in [("S", "S5"), ("U", "U5")]:
+        for kind, expected in [("S", "S5"), ("U", "U5"), ("V", "V5")]:
             with np.nditer(
                 arr,
                 op_dtypes=[np.dtype(kind)],
                 flags=["buffered", "refs_ok"],
-                casting="same_kind",
+                casting="unsafe" if kind == "V" else "same_kind",
             ) as it:
                 assert it.dtypes[0] == np.dtype(expected)
                 assert [x[()] for x in it] == list(
-                    np.array(["abc", "defgh"], dtype=expected))
+                    fixed_width_array(["abc", "defgh"], expected))
 
     def test_readwrite_stringdtype_operand_fixed_width_buffers(self):
         # reads convert to the inferred fixed-width dtype and writing


### PR DESCRIPTION
### PR summary
Fixes #32031 along with #32095.

Adds a new helper `stringdtype_find_fixed_width_descr` and uses it in a new code path in `find_descriptor_from_array` that works like the existing [object string](https://github.com/numpy/numpy/blob/e49e932e4f77832f7f8a6c782931ac619959134a/numpy/_core/src/multiarray/array_coercion.c#L803-L852) and [datetime](https://github.com/numpy/numpy/blob/e49e932e4f77832f7f8a6c782931ac619959134a/numpy/_core/src/multiarray/array_coercion.c#L853-L876) code paths in that function that scan array values to infer the destination dtype.

Also adds tests for this new behavior.


#### AI Disclosure
I used an AI to iterate on the implementation and tests.