### PR TITLE
MAINT, DOC: Clean up get_fieldstructure docstring and remove outdated XXX comment

### DIFF
--- a/numpy/lib/recfunctions.py
+++ b/numpy/lib/recfunctions.py
@@ -238,6 +238,11 @@ def get_fieldstructure(adtype, lastname=None, parents=None,):
     parents : dictionary
         Dictionary of parent fields (used internally during recursion).
 
+    Returns
+    -------
+    out : dict
+        Dictionary with fields indexing lists of their parent fields.
+
     Examples
     --------
     >>> import numpy as np
@@ -246,7 +251,6 @@ def get_fieldstructure(adtype, lastname=None, parents=None,):
     ...                     ('B', [('BA', int),
     ...                            ('BB', [('BBA', int), ('BBB', int)])])])
     >>> rfn.get_fieldstructure(ndtype)
-    ... # XXX: possible regression, order of BBA and BBB is swapped
     {'A': [], 'B': [], 'BA': ['B'], 'BB': ['B'], 'BBA': ['B', 'BB'], 'BBB': ['B', 'BB']}
 
     """


### PR DESCRIPTION
… XXX comment

The 'XXX: possible regression' comment in the get_fieldstructure docstring was outdated, as the dictionary order in modern Python versions preserves the insertion order correctly without swapping. Added the missing 'Returns' section to conform to NumPy docstring standards.


-->

### First time committer introduction
<!-- Hi everyone! I'm Omar Alshafai second year CS student. This is my very first open-source contribution! I use NumPy for my university and personal projects, and I was exploring the codebase to learn how the library works under the hood. While reading through recfunctions.py, I noticed this outdated XXX: possible regression comment. I wanted to help clean it up and ensure the docstring fully meets NumPy standards by adding the missing Returns section. Excited to be a part of the community!

-->

#### AI Disclosure
<Yes, I used an AI coding assistant (Antigravity) to help me set up my local development environment (compiling NumPy from source with spin), navigate the codebase, and verify the correct NumPy docstring formatting for my changes.
-->
