### PR TITLE
DOC: Remove uses of 'skip cirrus' in the docs.

### DIFF
--- a/doc/RELEASE_WALKTHROUGH.rst
+++ b/doc/RELEASE_WALKTHROUGH.rst
@@ -301,7 +301,7 @@ Update the ``version`` in ``pyproject.toml``::
     $ gvim pyproject.toml
 
 Commit the result, edit the commit message, note the files in the commit, and
-add a line ``[skip cirrus] [skip actions]``, then push::
+add a line ``[skip actions]``, then push::
 
     $ git commit -a -m"MAINT: Prepare 2.4.x for further development"
     $ git rebase -i HEAD^

--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -214,12 +214,6 @@ these fragments in each commit message of a PR:
   you may need to run these tests to verify that the doctests are still valid.
   `See the configuration file for these checks. <https://github.com/numpy/numpy/blob/main/.circleci/config.yml>`__
 
-* ``[skip cirrus]``: skip Cirrus jobs
-
-  `CirrusCI <https://cirrus-ci.org/>`__ mostly triggers Linux aarch64 and MacOS Arm64 wheels
-  uploads.
-  `See the configuration file for these checks. <https://github.com/numpy/numpy/blob/main/.cirrus.star>`__
-
 Test building wheels
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
We no longer use Cirrus, so remove references to the old `[skip cirrus]` tag.

#### AI Disclosure
No AI tools used.
