### PR TITLE
DOC: Add docstrings to ndarray for __complex__, __float__, and __int_…

### DIFF
--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3246,7 +3246,7 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__int__',
 
     int(a)
 
-    Returns the array as an intger number. The array must be
+    Returns the array as an integer number. The array must be
     0-dimensional and have a compatible dtype.
 
     """))

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3191,15 +3191,15 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__class_getitem__',
 
     """))
 
-add_newdoc('numpy._core.multiarray', 'ndarry', ('__complex__',
+add_newdoc('numpy._core.multiarray', 'ndarray', ('__complex__',
     """
     __complex__($self, /)
     --
 
-    a.__complex__()
+    complex(a)
 
-    Returns the array as a complex number. Raises an error if more than
-    one argument.
+    Returns the array as a complex number. The array must be
+    0-dimensional and have a compatible dtype.
 
     """))
 
@@ -3227,27 +3227,27 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__dlpack_device__',
 
     """))
 
-add_newdoc('numpy._core.multiarray', 'ndarry', ('__float__',
+add_newdoc('numpy._core.multiarray', 'ndarray', ('__float__',
     """
     __float__($self, /)
     --
 
-    a.__float__()
+    float(a)
 
-    Returns the array as a floating point number. Raises an error if more than
-    one argument.
+    Returns the array as a floating point number. The array must be
+    0-dimensional and have a compatible dtype.
 
     """))
 
-add_newdoc('numpy._core.multiarray', 'ndarry', ('__int__',
+add_newdoc('numpy._core.multiarray', 'ndarray', ('__int__',
     """
     __int__($self, /)
     --
 
-    a.__int__()
+    int(a)
 
-    Returns the array as an intger number. Raises an error if more than
-    one argument.
+    Returns the array as an intger number. The array must be
+    0-dimensional and have a compatible dtype.
 
     """))
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -3191,6 +3191,17 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__class_getitem__',
 
     """))
 
+add_newdoc('numpy._core.multiarray', 'ndarry', ('__complex__',
+    """
+    __complex__($self, /)
+    --
+
+    a.__complex__()
+
+    Returns the array as a complex number. Raises an error if more than
+    one argument.
+
+    """))
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__dlpack__',
     """
@@ -3216,6 +3227,29 @@ add_newdoc('numpy._core.multiarray', 'ndarray', ('__dlpack_device__',
 
     """))
 
+add_newdoc('numpy._core.multiarray', 'ndarry', ('__float__',
+    """
+    __float__($self, /)
+    --
+
+    a.__float__()
+
+    Returns the array as a floating point number. Raises an error if more than
+    one argument.
+
+    """))
+
+add_newdoc('numpy._core.multiarray', 'ndarry', ('__int__',
+    """
+    __int__($self, /)
+    --
+
+    a.__int__()
+
+    Returns the array as an intger number. Raises an error if more than
+    one argument.
+
+    """))
 
 add_newdoc('numpy._core.multiarray', 'ndarray', ('__reduce__',
     """


### PR DESCRIPTION
…_. See #28311

### PR summary
In the _add_newdocs.py file, I added docstrings for the ndarray __complex__, __float__, and __int__ to partially fulfill issue #28311 asking for explanations for these dunder methods.

### First time committer introduction
I am a first time committer to Numpy (and first time committer to any open source project!), which is why I wanted to try my first commit on something easy. I have used Numpy in both school and at work in a data science capacity.

#### AI Disclosure
I only used Claude to help me understand the code structure of the _add_newdocs.py file as I have not interacted with a file like this with functions/objects defined in C-extension modules.

However, I used the patterns and syntax of the surrounding docstrings in the _add_newdocs.py file to formulate my docstrings for __complex__, __float__, and __int__. Therefore, all code (including this PR description) is my own and written by hand.
