### PR TITLE
BUG: fix bug to pass sorted kwarg in unique_all, unique_counts, and u…

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -493,6 +493,7 @@ def unique_all(x):
         return_inverse=True,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueAllResult(*result)
 
@@ -549,6 +550,7 @@ def unique_counts(x):
         return_inverse=False,
         return_counts=True,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueCountsResult(*result)
 
@@ -606,6 +608,7 @@ def unique_inverse(x):
         return_inverse=True,
         return_counts=False,
         equal_nan=False,
+        sorted=False,
     )
     return UniqueInverseResult(*result)
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -1217,15 +1217,15 @@ class TestUnique:
         for res_unique_array_api, res_unique in [
             (
                 np.unique_values(arr),
-                np.unique(arr, equal_nan=False)
+                np.unique(arr, equal_nan=False, sorted=False)
             ),
             (
                 np.unique_counts(arr),
-                np.unique(arr, return_counts=True, equal_nan=False)
+                np.unique(arr, return_counts=True, equal_nan=False, sorted=False)
             ),
             (
                 np.unique_inverse(arr),
-                np.unique(arr, return_inverse=True, equal_nan=False)
+                np.unique(arr, return_inverse=True, equal_nan=False, sorted=False)
             ),
             (
                 np.unique_all(arr),
@@ -1234,7 +1234,8 @@ class TestUnique:
                     return_index=True,
                     return_inverse=True,
                     return_counts=True,
-                    equal_nan=False
+                    equal_nan=False,
+                    sorted=False
                 )
             )
         ]:
@@ -1247,6 +1248,67 @@ class TestUnique:
             for actual, expected in zip(res_unique_array_api, res_unique):
                 # Order of output is not guaranteed
                 assert_equal(np.sort(actual), np.sort(expected))
+
+    @pytest.mark.parametrize(
+        "func, expected_kwargs",
+        [
+            (
+                np.unique_values,
+                {
+                    "return_index": False,
+                    "return_inverse": False,
+                    "return_counts": False,
+                    "equal_nan": False,
+                    "sorted": False,
+                },
+            ),
+            (
+                np.unique_counts,
+                {
+                    "return_index": False,
+                    "return_inverse": False,
+                    "return_counts": True,
+                    "equal_nan": False,
+                    "sorted": False,
+                },
+            ),
+            (
+                np.unique_inverse,
+                {
+                    "return_index": False,
+                    "return_inverse": True,
+                    "return_counts": False,
+                    "equal_nan": False,
+                    "sorted": False,
+                },
+            ),
+            (
+                np.unique_all,
+                {
+                    "return_index": True,
+                    "return_inverse": True,
+                    "return_counts": True,
+                    "equal_nan": False,
+                    "sorted": False,
+                },
+            ),
+        ],
+    )
+    def test_array_api_unique_forwards_kwargs(self, monkeypatch, func, expected_kwargs):
+        import numpy.lib._arraysetops_impl as arraysetops_impl
+
+        calls = []
+        original_unique = arraysetops_impl.unique
+
+        def spy(*args, **kwargs):
+            calls.append(kwargs)
+            return original_unique(*args, **kwargs)
+
+        monkeypatch.setattr(arraysetops_impl, "unique", spy)
+
+        func(np.array([2, 1, 2, 3, 1, 4]))
+
+        assert calls == [expected_kwargs]
 
     def test_unique_inverse_shape(self):
         # Regression test for https://github.com/numpy/numpy/issues/25552


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

This PR ensures that the Array API helper functions `unique_all`, `unique_counts`, and `unique_inverse` explicitly forward the `sorted=False` keyword argument to the underlying unique implementation.

Basically the changes are:
- Passing sorted=False for the Array API wrapper functions
- Updating the existing tests
- Adding a regression test to verify that each wrapper forwards the expected keyword arguments

Fixes #31241 

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
AI was used to implement the test to verify the kwargs passed to the functions. 
