### PR TITLE
BUG: fix swallowed cast error in fancy indexing assignment (#31975)

### DIFF
--- a/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
@@ -2153,6 +2153,11 @@ mapiter_@name@(
         }
 /**end repeat1**/
     }
+
+    /* Check if the above iteration ended with an error */
+    if (PyErr_Occurred()) {
+        return -1;
+    }
     return 0;
 }
 

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -777,6 +777,17 @@ class TestFancyIndexingCast:
                      zero_array.__setitem__, bool_index, np.array([1j]))
         assert_equal(zero_array[0, 1], 0)
 
+    def test_fancy_assign_buffered_cast_error(self):
+        # gh-31974: a cast failure while refilling the iterator buffer
+        # (only possible when the array exceeds one buffer chunk) ended
+        # iteration silently, leaving the error set but unraised.
+        N = 20000
+        dst = np.zeros(N, dtype=int)
+        vals = np.arange(N, dtype=object)
+        vals[9000] = None
+        with pytest.raises(TypeError):
+            dst[np.arange(N)] = vals
+
 
 class TestFancyIndexingEquivalence:
     def test_object_assign(self):


### PR DESCRIPTION
Backport of #31975.

### PR summary

Fixes #31974.

`arr[idx] = vals` can swallow a cast error when the values are buffered and the cast fails while the iterator refills a buffer chunk (array bigger than one 8192-element chunk). the buffered iternext returns 0 on error which looks exactly like a normal end of iteration, so `mapiter_set`/`mapiter_get` returned success with the exception still set. depending on what runs next that's either a silent bogus success (the error surfaces at a later unrelated call) or `SystemError: ... returned a result with an exception set` (e.g. via `np.put_along_axis`).

this adds a `PyErr_Occurred()` check after the iteration loops in `mapiter_@name@`. small arrays already raise cleanly since first-chunk failures are caught at `NpyIter_Reset` so this just makes big arrays consistent. kept the check unconditional (not `needs_api`-gated) because non-object casts can fail too, e.g. a string -> int cast hits the same leak

#### AI Disclosure

Used Claude to double check my work and mae sure I didn't miss anything 