### PR TITLE
BUG: Fix buffered iterator stride after removing multi-index

### DIFF
--- a/numpy/_core/src/multiarray/nditer_constr.c
+++ b/numpy/_core/src/multiarray/nditer_constr.c
@@ -3444,6 +3444,15 @@ npyiter_allocate_transfer_functions(NpyIter *iter)
         }
 
         /*
+         * RemoveMultiIndex may coalesce a size-one inner axis, changing its
+         * zero stride.  Do not specialize for a stride that can change.
+         */
+        if ((itflags & NPY_ITFLAG_HASMULTIINDEX) &&
+                NAD_SHAPE(axisdata) == 1 && op_stride == 0) {
+            op_stride = NPY_MAX_INTP;
+        }
+
+        /*
          * If we have determined that a buffer may be needed,
          * allocate the appropriate transfer functions
          */

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -1849,6 +1849,18 @@ def test_iter_remove_multi_index_inner_loop():
     assert_equal(i[0].shape, (24,))
     assert_equal(i.value, arange(24))
 
+
+def test_iter_remove_multi_index_buffered():
+    a = arange(10).reshape(10, 1)
+    i = nditer(a, ["buffered", "multi_index"], buffersize=5)
+
+    i.remove_multi_index()
+    i.enable_external_loop()
+
+    assert_equal(i.ndim, 1)
+    assert_array_equal(np.concatenate([chunk.copy() for chunk in i]), a.ravel())
+
+
 def test_iter_iterindex():
     # Make sure iterindex works
 

--- a/numpy/lib/tests/test_index_tricks.py
+++ b/numpy/lib/tests/test_index_tricks.py
@@ -204,6 +204,16 @@ class TestRavelUnravelIndex:
         # regression test for gh-29690
         np.unravel_index(np.array([[1, 0, 1, 0]], dtype=np.uint32), (4,))
 
+    def test_unravel_index_buffer_boundary(self):
+        indices = np.arange(10_000, dtype=np.intp)[:, None]
+        coords = np.unravel_index(indices, (100, 100))
+
+        assert_array_equal(
+            np.ravel_multi_index(coords, (100, 100)),
+            indices,
+        )
+
+
 class TestGrid:
     def test_basic(self):
         a = mgrid[-1:1:10j]


### PR DESCRIPTION
Backport of #31985.

### PR summary
This PR fixes a critical bug where incorrect coordinates are returned after the iterator buffer boundary for large `(N, 1)` index arrays. As seen in real-world applications (e.g., MRI reconstruction in `mckib2/pygrappa#107`), this can silently produce incorrect results without raising any exceptions.

**Root Cause:**
The issue occurs because the transfer loop is fixed to a zero stride for a size-one inner axis, failing to reflect the updated runtime stride after `remove_multi_index` is applied. 

**Fix:**
To resolve this, I modified `numpy/_core/src/multiarray/nditer_constr.c` to exclude mutable strides from the fixed-stride optimization. 

**Testing & Verification:**
- Added generic `nditer` regression tests in `numpy/_core/tests/test_nditer.py`.
- Added public `unravel_index` regression tests in `numpy/lib/tests/test_index_tricks.py`.
- I have manually run and confirmed that all core tests and linting pass successfully locally.

Closes #31980

### First time committer introduction
Hi, I am snoopuppy582, a developer using NumPy. I investigated this issue because of its silent but critical impact on real-world calculations, and I hope this patch helps improve the stability of the library. 

#### AI Disclosure
I used AI tools (OpenAI Codex / ChatGPT) **strictly for review and verification purposes** to ensure the quality of the fix. 

I manually analyzed the root cause, wrote the C modifications and regression tests, and executed all local validations. I have fully reviewed and understood the entire diff. Also, this PR description, the commit messages, and all future communications are written entirely by me manually.