### PR TITLE
BUG: fix `np.fromiter` corruption when reusing a `StringDType` instance  (#32012)

### DIFF
--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -3984,11 +3984,7 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
 
     elsize = dtype->elsize;
 
-    /*
-     * Note that PyArray_DESCR(ret) may not match dtype.  There are exactly
-     * two cases where this can happen: empty strings/bytes/void (rejected
-     * above) and subarray dtypes (supported by sticking with `dtype`).
-     */
+
     Py_INCREF(dtype);
     ret = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type, dtype, 1,
                                                 &elcount, NULL,NULL, 0, NULL);
@@ -4000,6 +3996,12 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
     PyArray_Dims new_dims = {dims, PyArray_NDIM(ret)};
 
     char *item = PyArray_BYTES(ret);
+
+    /*
+     * Note that PyArray_DESCR(ret) may not match dtype.
+     */
+    PyArray_Descr *pack_descr = PyDataType_HASSUBARRAY(dtype) ? dtype : PyArray_DESCR(ret);
+
     for (i = 0; i < count || count == -1; i++, item += elsize) {
         PyObject *value = PyIter_Next(iter);
         if (value == NULL) {
@@ -4028,7 +4030,7 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
             item = ((char *)PyArray_DATA(ret)) + i * elsize;
         }
 
-        if (PyArray_Pack(dtype, item, value) < 0) {
+        if (PyArray_Pack(pack_descr, item, value) < 0) {
             Py_DECREF(value);
             goto fail;
         }

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -724,6 +724,17 @@ def test_fancy_indexing(string_list):
         assert_array_equal(sarr[ind], uarr[ind])
 
 
+def test_fromiter_reused_dtype():
+    # Reusing the same StringDType instance across fromiter
+    # calls used to write strings into the wrong arena, creating corrupted arrays
+    sd = np.dtypes.StringDType()
+    data = ["a" * 18, "b" * 18] * 8
+    arr1 = np.fromiter(iter(data), dtype=sd, count=len(data))
+    arr2 = np.fromiter(iter(data), dtype=sd, count=len(data))
+    # This used to fail with MemoryError.
+    assert_array_equal(arr1, arr2)
+
+
 def test_flatiter_indexing():
     # see gh-29659
     arr = np.array(['hello', 'world'], dtype='T')


### PR DESCRIPTION
Backport of #32012.

### PR summary

Fixes https://github.com/numpy/numpy/issues/32013

`np.fromiter` is buggy for StringDtype arrays. Specifically, when the dtype instance is already owned by someother array,
it creates corrupted structures since it re-uses the input dtype instance to create the output array.

This PR fixes this issue to avoid using the input dtype descriptor to write the output.

Reproducer which this PR fixes:

```
In [2]: sd = np.dtypes.StringDType()

In [3]: a = ["a"*18, "b"*18]*10_000

In [4]: np.fromiter(iter(a), dtype=sd, count=len(a))
Out[4]: 
array(['aaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbb', 'aaaaaaaaaaaaaaaaaa',
       ..., 'bbbbbbbbbbbbbbbbbb', 'aaaaaaaaaaaaaaaaaa',
       'bbbbbbbbbbbbbbbbbb'], shape=(20000,), dtype=StringDType())

In [5]: np.fromiter(iter(a), dtype=sd, count=len(a))
Out[5]: Fatal Python error: Segmentation fault
```


#### AI Disclosure

I’ve used Claude Opus to shepherd this along.