### PR TITLE
BUG: add a special case for StringDType in np.isdtype (#32030)

### DIFF
--- a/numpy/_core/numerictypes.py
+++ b/numpy/_core/numerictypes.py
@@ -81,6 +81,7 @@ import numbers
 from numpy._utils import set_module
 
 from . import multiarray as ma
+from ._multiarray_umath import StringDType
 from .multiarray import (
     busday_count,
     busday_offset,
@@ -311,9 +312,15 @@ def _preprocess_dtype(dtype):
       1. fetching type from a data type
       2. verifying that types are built-in NumPy dtypes
     """
+    orig_dtype = dtype
     if isinstance(dtype, ma.dtype):
         dtype = dtype.type
     if isinstance(dtype, ndarray) or dtype not in allTypes.values():
+        if isinstance(orig_dtype, StringDType) or orig_dtype is StringDType:
+            # StringDType's scalar type is the builtin `str`, which is not
+            # a NumPy scalar type, so use the DType class to identify it.
+            # if we ever fix gh-28165, this should be deleted
+            return StringDType
         raise _PreprocessDTypeError
     return dtype
 

--- a/numpy/_core/tests/test_numerictypes.py
+++ b/numpy/_core/tests/test_numerictypes.py
@@ -470,6 +470,32 @@ class TestIsDType:
         with assert_raises_regex(ValueError, r".*not a known kind name.*"):
             np.isdtype(np.int64, "int64")
 
+    def test_isdtype_string_dtype(self):
+        # gh-27545: StringDType has no NumPy scalar type, but it is a
+        # built-in dtype, so `isdtype` must accept it rather than raise
+        dt = np.dtypes.StringDType()
+        assert not np.isdtype(dt, "bool")
+        for kind in self.dtype_group_dict:
+            assert not np.isdtype(dt, kind)
+
+        # matches itself and the StringDType class, which stands in for
+        # the scalar type that identifies the other dtypes
+        assert np.isdtype(dt, dt)
+        assert np.isdtype(dt, np.dtypes.StringDType)
+        assert np.isdtype(np.dtypes.StringDType, dt)
+        assert np.isdtype(dt, ("numeric", np.dtypes.StringDType))
+        assert not np.isdtype(np.int64, dt)
+        assert not np.isdtype(dt, ("integral", np.int64))
+
+        # dtype parameters are ignored, like datetime64 units
+        assert np.isdtype(np.dtypes.StringDType(na_object=None), dt)
+        assert np.isdtype(dt, np.dtypes.StringDType(na_object=np.nan,
+                                                    coerce=False))
+
+        # fixed-width unicode strings are a different kind
+        assert not np.isdtype(dt, np.str_)
+        assert not np.isdtype(np.dtype("U8"), dt)
+
     def test_sctypes_complete(self):
         # issue 26439: int32/intc were masking each other on 32-bit builds
         assert np.int32 in sctypes['int']


### PR DESCRIPTION
Backport of #32030.

### PR summary

Fixes #27545.

I don't see a cleaner way to fix this without just adding a special case in the error path. This function is only for built-in NumPy DTypes so it would be a bigger change to just make it return True if it's handed a dtype or dtypemeta instance, which is probably a more principled fix.

#### AI Disclosure

No AI use on this one.