### PR TITLE
BUG: Ensure errno from strtold_l is preserved on Darwin/iOS

### DIFF
--- a/numpy/_core/src/common/numpyos.c
+++ b/numpy/_core/src/common/numpyos.c
@@ -591,7 +591,14 @@ NumPyOS_ascii_strtold(const char *s, char** endptr)
     if (clocale) {
         errno = 0;
         result = strtold_l(s, endptr, clocale);
+        /*
+         * On some platforms (e.g. Darwin/iOS), freelocale can set errno.
+         * We're interested in the strtold_l failure; so save the errno
+         * after that call, and restore after freelocale(). See gh-32124.
+         */
+        int saved_errno = errno;
         freelocale(clocale);
+        errno = saved_errno;
     }
     else {
         if (endptr != NULL) {

--- a/numpy/_core/src/common/numpyos.c
+++ b/numpy/_core/src/common/numpyos.c
@@ -592,7 +592,7 @@ NumPyOS_ascii_strtold(const char *s, char** endptr)
         errno = 0;
         result = strtold_l(s, endptr, clocale);
         /*
-         * On some platforms (e.g. Darwin/iOS), freelocale can set errno.
+         * On some platforms (e.g. Darwin/iOS), successful freelocale can set errno.
          * We're interested in the strtold_l failure; so save the errno
          * after that call, and restore after freelocale(). See gh-32124.
          */


### PR DESCRIPTION
### PR summary

CI has been reporting an intermittent failure on iOS - when it occurs, a large number of tests fail, all ending with:
```
RuntimeError: Could not parse python long as longdouble: 0 (Invalid argument)
```

I believe this is caused by unhandled error values from locale handling. 

Under POSIX, `freelocale()` is [documented as having no return value or errors](https://www.man7.org/linux/man-pages/man3/freelocale.3p.html). However, under Darwin (macOS and iOS), [it has both a return value and an error](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/freelocale.3.html); it will [set `errno = EINVAL` if the locale provided is NULL, the global locale, or otherwise invalid](https://github.com/apple-oss-distributions/Libc/blob/main/locale/xlocale.c#L318-L328).

This means that on macOS/iOS, `freelocale()` can override the errno returned by `strtold_l`, an otherwise successful longdouble conversion will report EINVAL, which is then converted into the "Could not parse..." error that is seen in the test output.

It's unclear to me why this `freelocale()` call would be failing intermittently; because it's intermittent, it's difficult to reproduce the failure reliably; and because it's iOS, the cost of re-running the test repeatedly to generate the failure is high. 
 
This PR takes a pragmatic approach, ensuring that the state of errno after invoking `NumPyOS_ascii_strtold` is the state resulting from the invocation of `strtold_l`. This admittedly means that `freelocale()` failures are silently ignored. However:

* If the locale that returned by `newlocale()` was the global locale or the C locale, we can't free it anyway. This *shouldn't* be happening, but 🤷 
* We're already checking that a valid locale was allocated, so can't be freeing a NULL or invalid pointer
* The only method invoked between allocating and freeing the locale is `strtold_l`, so we *shouldn't* have an invalid or corrupt locale.

The third point is the only explanation that makes sense - that there's some sort of memory corruption going on, which is surfacing as something modifying the locale between the new and free. However, if that's happening, it's either:

1. a NumPy problem that isn't iOS specific - iOS is just revealing it because of different performance characteristics; or 
2. an iOS problem that isn't NumPy specific - it's an OS or simulator bug.

Either way, the problem is not related to freeing the locale - that's just the canary revealing the problem.

Fixes #32124

#### AI Disclosure

Investigation assisted by Claude Opus 5.