### PR TITLE
TYP: type capabilities max dimensions

### DIFF
--- a/numpy/_array_api_info.py
+++ b/numpy/_array_api_info.py
@@ -73,6 +73,9 @@ class __array_namespace_info__:
           library supports data-dependent output shapes. Always ``True`` for
           NumPy.
 
+        - **"max dimensions"**: integer indicating maximum number of supported
+          dimensions. Always ``64`` for NumPy.
+
         See
         https://data-apis.org/array-api/latest/API_specification/generated/array_api.info.capabilities.html
         for more details.

--- a/numpy/_array_api_info.pyi
+++ b/numpy/_array_api_info.pyi
@@ -10,6 +10,7 @@ _Capabilities = TypedDict(
     {
         "boolean indexing": Literal[True],
         "data-dependent shapes": Literal[True],
+        "max dimensions": Literal[64],
     },
 )
 


### PR DESCRIPTION
### PR summary

Add type hint for `np.__array_namespace_info__().capabilities()["max dimensions"]`, previously type checkers would flag its use as an invalid key in a TypedDict.

### First time committer introduction
I'm a physicist and have been using NumPy for ~10 years during my undergraduate and PhD. I've recently started using type checkers and the array api standard, and noticed this issue, which seems simple to fix so thought I'd contribute it myself.

#### AI Disclosure
No AI tools used

