### PR TITLE
CI: Update CI to validate Limited API in debug job builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,7 +75,8 @@ jobs:
         pip install -r requirements/test_requirements.txt
     - name: Build NumPy debug
       run: |
-        spin build -- -Dbuildtype=debug -Dallow-noblas=true
+        spin build -- -Dbuildtype=debug -Dallow-noblas=true \
+          -Dpython.allow_limited_api=true
     - name: Run test suite
       run: |
         spin test -- --timeout=600 --durations=10


### PR DESCRIPTION
### PR summary

JOB: Check that the extension modules ported to the Limited C API were built against it.


> To check if each ported module has its own `abi3.so` file, in this CI each ported module is to be added in the list `for m in _pocketfft_umath; do`, I will do it manually when I add the `limited_api` for each extension module. 
> 
> Note: I think the regex would unnecessarily complicate things for temporary stage that's why I am going with manually adding approach  
> Once everything is shifted this can be easily automated as we will use `limited-api = true` in global meson build or complete all extended module checks.  
> 
> Reference: https://github.com/numpy/numpy/issues/31913#issuecomment-5100619300 and https://github.com/numpy/numpy/issues/31913#issuecomment-5101421868 

Updated: The debug interpreter doesn't produce `.abi3.so` named exenstion files at all, because it means this job proves the ported modules compile under `Py_LIMITED_API` so therefore they must have produced `.abi3.so` files. 


<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
For bash syntax  