### PR TITLE
BUG: avoid possible stack overflow in arraydescr_dealloc

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2098,7 +2098,7 @@ arraydescr_dealloc(PyArray_Descr *self)
          * stealing the link is unobservable and each node still runs
          * its own, now shallow, dealloc.
          *
-         * If descriptors ever become heap types and/or GC types, we can
+         * If descriptors ever get the Py_TPFLAGS_HAVE_GC flag, we can
          * use CPython's stack protection via the trashcan macros
          * instead.
          */
@@ -2107,9 +2107,8 @@ arraydescr_dealloc(PyArray_Descr *self)
         /*
          * The Py_REFCNT(..) == 1 check is intentional. This happens in
          * a deallocator for a type that doesn't support weakrefs and
-         * isn't a GC type, so it's impossible for another thread to
-         * concurrently change the reference count if we observe the
-         * reference count is 1 here. We can't use
+         * isn't a GC type, so it's impossible to get here with a refcount
+         * of 1 without us being the only owner. We can't use
          * PyUnstable_Object_IsUniquelyReferenced because that excludes
          * objects on remote threads.
          */
@@ -2119,7 +2118,7 @@ arraydescr_dealloc(PyArray_Descr *self)
             // (Py_CLEAR without a DECREF)
             base = lbase->subarray->base;
             lbase->subarray->base = NULL;
-            // lbase no longer owns a reference to base, so its deallocator
+            // lbase no longer owns a reference to base, so base's deallocator
             // doesn't fire
             Py_DECREF(lbase);
         }

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2089,8 +2089,24 @@ arraydescr_dealloc(PyArray_Descr *self)
     Py_XDECREF(lself->fields);
     if (lself->subarray) {
         Py_XDECREF(lself->subarray->shape);
-        Py_DECREF(lself->subarray->base);
+        /*
+         * A subarray dtype's base may itself be a subarray dtype, so
+         * decref'ing the base here can re-enter this function, one C
+         * stack frame per nesting level. Unwind the chain iteratively
+         * instead; at refcount 1 this dealloc holds the only
+         * reference (descriptors support neither weakrefs nor GC), so
+         * stealing the link is unobservable and each node still runs
+         * its own, now shallow, dealloc.
+         */
+        PyArray_Descr *base = lself->subarray->base;
         PyArray_free(lself->subarray);
+        while (base != NULL && Py_REFCNT(base) == 1 && PyDataType_HASSUBARRAY(base)) {
+            _PyArray_LegacyDescr *lbase = (_PyArray_LegacyDescr *)base;
+            base = lbase->subarray->base;
+            lbase->subarray->base = NULL;
+            Py_DECREF(lbase);
+        }
+        Py_XDECREF(base);
     }
     Py_XDECREF(lself->metadata);
     NPY_AUXDATA_FREE(lself->c_metadata);

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2097,13 +2097,30 @@ arraydescr_dealloc(PyArray_Descr *self)
          * reference (descriptors support neither weakrefs nor GC), so
          * stealing the link is unobservable and each node still runs
          * its own, now shallow, dealloc.
+         *
+         * If descriptors ever become heap types and/or GC types, we can
+         * use CPython's stack protection via the trashcan macros
+         * instead.
          */
         PyArray_Descr *base = lself->subarray->base;
         PyArray_free(lself->subarray);
+        /*
+         * The Py_REFCNT(..) == 1 check is intentional. This happens in
+         * a deallocator for a type that doesn't support weakrefs and
+         * isn't a GC type, so it's impossible for another thread to
+         * concurrently change the reference count if we observe the
+         * reference count is 1 here. We can't use
+         * PyUnstable_Object_IsUniquelyReferenced because that excludes
+         * objects on remote threads.
+         */
         while (base != NULL && Py_REFCNT(base) == 1 && PyDataType_HASSUBARRAY(base)) {
             _PyArray_LegacyDescr *lbase = (_PyArray_LegacyDescr *)base;
+            // steal reference owned by lbase and stash it in base
+            // (Py_CLEAR without a DECREF)
             base = lbase->subarray->base;
             lbase->subarray->base = NULL;
+            // lbase no longer owns a reference to base, so its deallocator
+            // doesn't fire
             Py_DECREF(lbase);
         }
         Py_XDECREF(base);

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -5,7 +5,6 @@ import operator
 import os
 import pickle
 import sys
-import textwrap
 import types
 import warnings
 from itertools import permutations
@@ -21,14 +20,13 @@ from numpy._core._multiarray_tests import create_custom_field_dtype
 from numpy._core._rational_tests import rational, rational2
 from numpy.testing import (
     HAS_REFCOUNT,
-    HAS_SUBPROCESSES,
     IS_64BIT,
     assert_,
     assert_array_equal,
     assert_equal,
     assert_raises,
 )
-from numpy.testing._private.utils import requires_deep_recursion, run_subprocess
+from numpy.testing._private.utils import requires_deep_recursion
 
 
 def assert_dtype_equal(a, b):
@@ -899,28 +897,26 @@ class TestMonsterType:
         with contextlib.suppress(RecursionError):
             np.dtype(d)
 
-    @pytest.mark.skipif(not HAS_SUBPROCESSES,
-                        reason="platform cannot start subprocesses")
     def test_deep_subarray_dtype_dealloc(self):
-        script = textwrap.dedent("""
-            import threading
+        import threading
 
-            import numpy as np
+        import numpy as np
 
-            def build_and_drop():
-                d = np.dtype(np.int32)
-                for _ in range(200000):
-                    d = np.dtype((d, (1,)))
-                held = d.base
-                del d
-                del held
+        def build_and_drop():
+            d = np.dtype(np.int32)
+            for _ in range(200000):
+                d = np.dtype((d, (1,)))
+            # hold a second reference so teardown exercises stopping
+            # and resuming
+            held = d.base
+            del d
+            del held
 
-            threading.stack_size(1024 * 1024)
-            t = threading.Thread(target=build_and_drop)
-            t.start()
-            t.join()
-        """)
-        run_subprocess([sys.executable, "-c", script], timeout=180)
+        # small stack size to fail reliably if deallocation is recusive
+        threading.stack_size(1024 * 1024)
+        t = threading.Thread(target=build_and_drop)
+        t.start()
+        t.join()
 
     @requires_deep_recursion
     def test_dict_recursion(self):

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -898,6 +898,7 @@ class TestMonsterType:
         with contextlib.suppress(RecursionError):
             np.dtype(d)
 
+    @pytest.mark.thread_unsafe(reason="Sets global threading stack size")
     @pytest.mark.skipif(IS_WASM, reason="wasm doesn't have support for threads")
     def test_deep_subarray_dtype_dealloc(self):
         import threading
@@ -915,10 +916,13 @@ class TestMonsterType:
             del held
 
         # small stack size to fail reliably if deallocation is recusive
-        threading.stack_size(1024 * 1024)
-        t = threading.Thread(target=build_and_drop)
-        t.start()
-        t.join()
+        old_stack_size = threading.stack_size(1024 * 1024)
+        try:
+            t = threading.Thread(target=build_and_drop)
+            t.start()
+            t.join()
+        finally:
+            threading.stack_size(old_stack_size)
 
     @requires_deep_recursion
     def test_dict_recursion(self):

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -5,6 +5,7 @@ import operator
 import os
 import pickle
 import sys
+import textwrap
 import types
 import warnings
 from itertools import permutations
@@ -20,13 +21,14 @@ from numpy._core._multiarray_tests import create_custom_field_dtype
 from numpy._core._rational_tests import rational, rational2
 from numpy.testing import (
     HAS_REFCOUNT,
+    HAS_SUBPROCESSES,
     IS_64BIT,
     assert_,
     assert_array_equal,
     assert_equal,
     assert_raises,
 )
-from numpy.testing._private.utils import requires_deep_recursion
+from numpy.testing._private.utils import requires_deep_recursion, run_subprocess
 
 
 def assert_dtype_equal(a, b):
@@ -888,10 +890,6 @@ class TestMonsterType:
             np.dtype(l)
 
     @requires_deep_recursion
-    @pytest.mark.skipif(
-        sys.platform.startswith("darwin"),
-        reason="test now segfaults on some mac setups",
-    )
     def test_tuple_recursion(self):
         d = np.int32
         for i in range(100000):
@@ -900,6 +898,29 @@ class TestMonsterType:
         # see gh-30370 and cpython issue #142253
         with contextlib.suppress(RecursionError):
             np.dtype(d)
+
+    @pytest.mark.skipif(not HAS_SUBPROCESSES,
+                        reason="platform cannot start subprocesses")
+    def test_deep_subarray_dtype_dealloc(self):
+        script = textwrap.dedent("""
+            import threading
+
+            import numpy as np
+
+            def build_and_drop():
+                d = np.dtype(np.int32)
+                for _ in range(200000):
+                    d = np.dtype((d, (1,)))
+                held = d.base
+                del d
+                del held
+
+            threading.stack_size(1024 * 1024)
+            t = threading.Thread(target=build_and_drop)
+            t.start()
+            t.join()
+        """)
+        run_subprocess([sys.executable, "-c", script], timeout=180)
 
     @requires_deep_recursion
     def test_dict_recursion(self):

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -21,6 +21,7 @@ from numpy._core._rational_tests import rational, rational2
 from numpy.testing import (
     HAS_REFCOUNT,
     IS_64BIT,
+    IS_WASM,
     assert_,
     assert_array_equal,
     assert_equal,
@@ -897,6 +898,7 @@ class TestMonsterType:
         with contextlib.suppress(RecursionError):
             np.dtype(d)
 
+    @pytest.mark.skipif(IS_WASM, reason="wasm doesn't have support for threads")
     def test_deep_subarray_dtype_dealloc(self):
         import threading
 


### PR DESCRIPTION
### PR summary
The `Py_DECREF(lself->subarray->base)` we currently have can lead to situations where the DECREF causes a deallocation, which then recursively calls into `arraydescr_dealloc`. With a properly setup dtype, this can lead to a stack overflow on newer Python versions. See https://github.com/python/cpython/issues/142253 for the upstream issue that was opened about that and https://github.com/numpy/numpy/issues/30370 on the NumPy side.

My fix is to check for cases when decrefing will deallocate and in those cases explicitly detach the `base` before decrefing, avoiding the recursive call.


#### AI Disclosure
I used an AI model to understand the problem and debug the fix and new test.
