### PR TITLE
BUG: return error in try_reduction if PyObject_Vectorcall fails

### DIFF
--- a/numpy/_core/src/multiarray/arrayfunction_override.c
+++ b/numpy/_core/src/multiarray/arrayfunction_override.c
@@ -510,7 +510,7 @@ try_reduction(PyArray_ArrayFunctionDispatcherObject *self,
         where == npy_static_pydata._NoValue ? Py_True : where,
     };
     *result = PyObject_Vectorcall(self->reduction, call_args, 7, NULL);
-    return 1;
+    return *result != NULL ? 1 : -1;
 }
 
 


### PR DESCRIPTION
### PR summary
As pointed out by @da-woods here: https://github.com/numpy/numpy/pull/32041#discussion_r3661054369. It turns out that the caller already does the right thing, but it seems more correct to me to return error here explicitly.
  
#### AI Disclosure
No AI tools used.
