### PR TITLE
BUG: support unary positive on boolean arrays

### DIFF
--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -526,6 +526,7 @@ defdict = {
     Ufunc(1, 1, None,
           docstrings.get('numpy._core.umath.positive'),
           'PyUFunc_SimpleUniformOperationTypeResolver',
+          TD('?', cfunc_alias='absolute', dispatch=[('loops_logical', '?')]),
           TD(ints + flts + timedeltaonly),
           TD(cmplx, f='pos'),
           TD(O, f='PyNumber_Positive'),

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -2829,8 +2829,18 @@ class TestBool:
     def test_exceptions(self):
         a = np.ones(1, dtype=np.bool)
         assert_raises(TypeError, np.negative, a)
-        assert_raises(TypeError, np.positive, a)
         assert_raises(TypeError, np.subtract, a, a)
+
+    def test_positive(self):
+        for value in (False, True):
+            result = np.positive(np.bool_(value))
+            assert_equal(result, value)
+            assert isinstance(result, np.bool_)
+
+        values = np.array([False, True], dtype=np.bool_)
+        result = np.positive(values)
+        assert_array_equal(result, values)
+        assert result.dtype == np.bool_
 
     def test_truth_table_logical(self):
         # 2, 3 and 4 serves as true values
@@ -3228,8 +3238,6 @@ class TestPositive:
             assert_equal(x, result, err_msg=str(dtype))
 
     def test_invalid(self):
-        with assert_raises(TypeError):
-            np.positive(True)
         with assert_raises(TypeError):
             np.positive(np.datetime64('2000-01-01'))
         with assert_raises(TypeError):


### PR DESCRIPTION
## Summary

- add a bool loop for `positive` by reusing the existing `BOOL_absolute` implementation
- dispatch bool inputs through `loops_logical` without adding a duplicate kernel
- cover bool scalar and array values, scalar type, and array dtype

Closes #32100.

## Testing

- RED before implementation: `TestBool::test_positive` failed with `_UFuncNoLoopError`
- `python -m spin test -t numpy._core.tests.test_umath::TestBool::test_positive`
- `python -m spin test numpy/_core/tests/test_umath.py -- -k 'TestBool or TestPositive'` (7 passed)
- `python -m spin test --no-build numpy/_core/tests/test_umath.py` (4,715 passed, 60 skipped)
- `python -m spin test --no-build -j auto numpy/_core/tests` (35,544 passed, 867 skipped, 47 xfailed; one unrelated `cbrt` 3-ULP failure)
- the same `cbrt` failure reproduces on a clean build of unmodified `origin/main` at `140ddeb611d8e30f7e2753558e618b8235b844ae`
- `python -m spin lint`
- `git diff --check`
