### PR TITLE
DOC clarify finfo attribute scalar types

### DIFF
--- a/numpy/_core/getlimits.py
+++ b/numpy/_core/getlimits.py
@@ -63,11 +63,11 @@ class finfo:
         Returns the dtype for which `finfo` returns information. For complex
         input, the returned dtype is the associated ``float*`` dtype for its
         real and complex components.
-    eps : float
+    eps : floating point number of the appropriate type
         The difference between 1.0 and the next smallest representable float
         larger than 1.0. For example, for 64-bit binary floats in the IEEE-754
         standard, ``eps = 2**-52``, approximately 2.22e-16.
-    epsneg : float
+    epsneg : floating point number of the appropriate type
         The difference between 1.0 and the next smallest representable float
         less than 1.0. For example, for 64-bit binary floats in the IEEE-754
         standard, ``epsneg = 2**-53``, approximately 1.11e-16.
@@ -100,12 +100,12 @@ class finfo:
     resolution : floating point number of the appropriate type
         The approximate decimal resolution of this type, i.e.,
         ``10**-precision``.
-    tiny : float
+    tiny : floating point number of the appropriate type
         An alias for `smallest_normal`, kept for backwards compatibility.
-    smallest_normal : float
+    smallest_normal : floating point number of the appropriate type
         The smallest positive floating point number with 1 as leading bit in
         the mantissa following IEEE-754 (see Notes).
-    smallest_subnormal : float
+    smallest_subnormal : floating point number of the appropriate type
         The smallest positive floating point number with 0 as leading bit in
         the mantissa following IEEE-754.
 
@@ -326,7 +326,7 @@ class finfo:
 
         Returns
         -------
-        tiny : float
+        tiny : floating point number of the appropriate type
             Value for the smallest normal, alias of smallest_normal.
 
         Warns


### PR DESCRIPTION
Addresses numpy/numpy#20501.

The `finfo` documentation currently labels several attributes as `float`, although they return NumPy floating-point scalars with the requested precision. This updates the attribute and property docs to describe the returned type accurately, without changing behavior.