### PR TITLE
DOC clarify fromfunction vectorized calling convention

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1835,6 +1835,9 @@ def fromfunction(function, shape, *, dtype=float, like=None, **kwargs):
     The resulting array therefore has a value ``fn(x, y, z)`` at
     coordinate ``(x, y, z)``.
 
+    The function is called only once, with each parameter being an array of
+    coordinates, rather than once for every coordinate.
+
     Parameters
     ----------
     function : callable


### PR DESCRIPTION
Addresses numpy/numpy#26454.

Clarify that `fromfunction` calls the supplied function once with full coordinate arrays, rather than once per output coordinate. This documents the vectorized calling convention without changing behavior.