### PR TITLE
BUG: avoid segfaults when legacy copyswap slot is not defined

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1021,6 +1021,14 @@ _copy_and_return_void_setitem(_PyArray_LegacyDescr *dstdescr, char *dstdata,
                 break;
             }
             copyswap(dstdata + offset, srcdata + offset, 0, dummy_arr);
+            if (PyErr_Occurred()) {
+                /*
+                 * Clear the error and use the casting path, which
+                 * handles it and overwrites any partially copied fields.
+                 */
+                PyErr_Clear();
+                break;
+            }
         }
         if (i == names_size) {
             return 0;

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -2275,19 +2275,13 @@ STRING_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
 }
 
 
-/*
- * A missing legacy copyswap slot is a no-op for a swap-only request if byte
- * order does not apply to the dtype (returns 0); otherwise sets a TypeError
- * and returns -1.
- */
-static int
+/* See common.h for the contract of this helper. */
+NPY_NO_EXPORT int
 check_missing_copyswap(PyArray_Descr *dtype, int swap_only)
 {
-    if (swap_only && dtype->byteorder == NPY_IGNORE) {
-        return 0;
-    }
+    (void)swap_only;
     npy_gil_error(PyExc_TypeError,
-            "dtype %S does not support the copyswap operation",
+            "dtype %S does not implement copyswap",
             (PyObject *)dtype);
     return -1;
 }

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -2277,9 +2277,9 @@ STRING_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
 
 /* See common.h for the contract of this helper. */
 NPY_NO_EXPORT int
-check_missing_copyswap(PyArray_Descr *dtype, int swap_only)
+check_missing_copyswap(PyArray_Descr *dtype, int inplace_swap)
 {
-    (void)swap_only;
+    (void)inplace_swap;
     npy_gil_error(PyExc_TypeError,
             "dtype %S does not implement copyswap",
             (PyObject *)dtype);
@@ -2318,11 +2318,8 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
             dummy_fields.descr = new;
             PyArray_CopySwapNFunc *copyswapn =
                     PyDataType_GetArrFuncs(new)->copyswapn;
-            if (copyswapn == NULL) {
-                if (check_missing_copyswap(new, src == NULL) < 0) {
-                    return;
-                }
-                continue;
+            if (copyswapn == NULL && check_missing_copyswap(new, src == NULL) < 0) {
+                return;
             }
             copyswapn(dst+offset, dstride,
                       (src != NULL ? src+offset : NULL),
@@ -2367,9 +2364,7 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
 
         PyArray_CopySwapNFunc *copyswapn =
                 PyDataType_GetArrFuncs(new)->copyswapn;
-        if (copyswapn == NULL) {
-            /* a no-op either way, but a TypeError may be set */
-            check_missing_copyswap(new, src == NULL);
+        if (copyswapn == NULL && check_missing_copyswap(new, src == NULL) < 0) {
             return;
         }
         num = descr->elsize / subitemsize;
@@ -2418,11 +2413,8 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
             dummy_fields.descr = new;
             PyArray_CopySwapFunc *copyswap =
                     PyDataType_GetArrFuncs(new)->copyswap;
-            if (copyswap == NULL) {
-                if (check_missing_copyswap(new, src == NULL) < 0) {
-                    return;
-                }
-                continue;
+            if (copyswap == NULL && check_missing_copyswap(new, src == NULL) < 0) {
+                return;
             }
             copyswap(dst+offset,
                      (src != NULL ? src+offset : NULL),
@@ -2463,9 +2455,7 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
 
         PyArray_CopySwapNFunc *copyswapn =
                 PyDataType_GetArrFuncs(new)->copyswapn;
-        if (copyswapn == NULL) {
-            /* a no-op either way, but a TypeError may be set */
-            check_missing_copyswap(new, src == NULL);
+        if (copyswapn == NULL && check_missing_copyswap(new, src == NULL) < 0) {
             return;
         }
         num = descr->elsize / subitemsize;

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1013,10 +1013,18 @@ _copy_and_return_void_setitem(_PyArray_LegacyDescr *dstdescr, char *dstdata,
             if (_setup_field(i, dstdescr, dummy_arr, &offset, dstdata)) {
                 return -1;
             }
-            PyDataType_GetArrFuncs(PyArray_DESCR(dummy_arr))->copyswap(dstdata + offset,
-                    srcdata + offset, 0, dummy_arr);
+            PyArray_CopySwapFunc *copyswap =
+                    PyDataType_GetArrFuncs(PyArray_DESCR(dummy_arr))->copyswap;
+            if (copyswap == NULL) {
+                /* a field dtype without the legacy copyswap slot; the
+                   casting path below handles it correctly */
+                break;
+            }
+            copyswap(dstdata + offset, srcdata + offset, 0, dummy_arr);
         }
-        return 0;
+        if (i == names_size) {
+            return 0;
+        }
     }
 
     /* Slow path */
@@ -2259,6 +2267,23 @@ STRING_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
 }
 
 
+/*
+ * A missing legacy copyswap slot is a no-op for a swap-only request if byte
+ * order does not apply to the dtype (returns 0); otherwise sets a TypeError
+ * and returns -1.
+ */
+static int
+check_missing_copyswap(PyArray_Descr *dtype, int swap_only)
+{
+    if (swap_only && dtype->byteorder == NPY_IGNORE) {
+        return 0;
+    }
+    npy_gil_error(PyExc_TypeError,
+            "dtype %S does not support the copyswap operation",
+            (PyObject *)dtype);
+    return -1;
+}
+
 /* */
 static void
 VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
@@ -2289,9 +2314,17 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
             }
 
             dummy_fields.descr = new;
-            PyDataType_GetArrFuncs(new)->copyswapn(dst+offset, dstride,
-                    (src != NULL ? src+offset : NULL),
-                    sstride, n, swap, dummy_arr);
+            PyArray_CopySwapNFunc *copyswapn =
+                    PyDataType_GetArrFuncs(new)->copyswapn;
+            if (copyswapn == NULL) {
+                if (check_missing_copyswap(new, src == NULL) < 0) {
+                    return;
+                }
+                continue;
+            }
+            copyswapn(dst+offset, dstride,
+                      (src != NULL ? src+offset : NULL),
+                      sstride, n, swap, dummy_arr);
         }
         return;
     }
@@ -2330,10 +2363,17 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
         PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
         ((PyArrayObject_fields *)dummy_arr)->descr = new;
 
+        PyArray_CopySwapNFunc *copyswapn =
+                PyDataType_GetArrFuncs(new)->copyswapn;
+        if (copyswapn == NULL) {
+            /* a no-op either way, but a TypeError may be set */
+            check_missing_copyswap(new, src == NULL);
+            return;
+        }
         num = descr->elsize / subitemsize;
         for (i = 0; i < n; i++) {
-            PyDataType_GetArrFuncs(new)->copyswapn(dstptr, subitemsize, srcptr,
-                    subitemsize, num, swap, dummy_arr);
+            copyswapn(dstptr, subitemsize, srcptr,
+                      subitemsize, num, swap, dummy_arr);
             dstptr += dstride;
             if (srcptr) {
                 srcptr += sstride;
@@ -2374,9 +2414,17 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
                 return;
             }
             dummy_fields.descr = new;
-            PyDataType_GetArrFuncs(new)->copyswap(dst+offset,
-                    (src != NULL ? src+offset : NULL),
-                    swap, dummy_arr);
+            PyArray_CopySwapFunc *copyswap =
+                    PyDataType_GetArrFuncs(new)->copyswap;
+            if (copyswap == NULL) {
+                if (check_missing_copyswap(new, src == NULL) < 0) {
+                    return;
+                }
+                continue;
+            }
+            copyswap(dst+offset,
+                     (src != NULL ? src+offset : NULL),
+                     swap, dummy_arr);
         }
         return;
     }
@@ -2411,9 +2459,16 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
         PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
         dummy_fields.descr = new;
 
+        PyArray_CopySwapNFunc *copyswapn =
+                PyDataType_GetArrFuncs(new)->copyswapn;
+        if (copyswapn == NULL) {
+            /* a no-op either way, but a TypeError may be set */
+            check_missing_copyswap(new, src == NULL);
+            return;
+        }
         num = descr->elsize / subitemsize;
-        PyDataType_GetArrFuncs(new)->copyswapn(dst, subitemsize, src,
-                subitemsize, num, swap, dummy_arr);
+        copyswapn(dst, subitemsize, src,
+                  subitemsize, num, swap, dummy_arr);
         return;
     }
     /* Must be a naive Void type (e.g. a "V8") so simple copy is sufficient. */
@@ -3049,6 +3104,13 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         /* Set the fields needed by compare or copyswap */
         dummy_struct.descr = new;
 
+        if (PyDataType_GetArrFuncs(new)->compare == NULL) {
+            npy_gil_error(PyExc_TypeError,
+                    "dtype %S does not support comparison",
+                    (PyObject *)new);
+            /* res is 0, so the caller sees equality alongside the error */
+            goto finish;
+        }
         swap = PyArray_ISBYTESWAPPED(dummy);
         nip1 = ip1 + offset;
         nip2 = ip2 + offset;

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -2277,7 +2277,7 @@ STRING_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
 
 /* See common.h for the contract of this helper. */
 NPY_NO_EXPORT int
-check_missing_copyswap(PyArray_Descr *dtype, int inplace_swap)
+raise_missing_copyswap(PyArray_Descr *dtype, int inplace_swap)
 {
     (void)inplace_swap;
     npy_gil_error(PyExc_TypeError,
@@ -2318,7 +2318,7 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
             dummy_fields.descr = new;
             PyArray_CopySwapNFunc *copyswapn =
                     PyDataType_GetArrFuncs(new)->copyswapn;
-            if (copyswapn == NULL && check_missing_copyswap(new, src == NULL) < 0) {
+            if (copyswapn == NULL && raise_missing_copyswap(new, src == NULL) < 0) {
                 return;
             }
             copyswapn(dst+offset, dstride,
@@ -2364,7 +2364,7 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
 
         PyArray_CopySwapNFunc *copyswapn =
                 PyDataType_GetArrFuncs(new)->copyswapn;
-        if (copyswapn == NULL && check_missing_copyswap(new, src == NULL) < 0) {
+        if (copyswapn == NULL && raise_missing_copyswap(new, src == NULL) < 0) {
             return;
         }
         num = descr->elsize / subitemsize;
@@ -2413,7 +2413,7 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
             dummy_fields.descr = new;
             PyArray_CopySwapFunc *copyswap =
                     PyDataType_GetArrFuncs(new)->copyswap;
-            if (copyswap == NULL && check_missing_copyswap(new, src == NULL) < 0) {
+            if (copyswap == NULL && raise_missing_copyswap(new, src == NULL) < 0) {
                 return;
             }
             copyswap(dst+offset,
@@ -2455,7 +2455,7 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
 
         PyArray_CopySwapNFunc *copyswapn =
                 PyDataType_GetArrFuncs(new)->copyswapn;
-        if (copyswapn == NULL && check_missing_copyswap(new, src == NULL) < 0) {
+        if (copyswapn == NULL && raise_missing_copyswap(new, src == NULL) < 0) {
             return;
         }
         num = descr->elsize / subitemsize;

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -65,9 +65,19 @@ _IsWriteable(PyArrayObject *ap);
  * TypeError and returns -1.  `inplace_swap` marks a request that only
  * swaps bytes in place (no data copy); it is unused for now, but is
  * passed so that such requests can become a no-op (returning 0) when
- * byte order does not apply to the dtype (see gh-32150).  Callers
- * propagate the error return and do not yet handle success, since it
- * cannot currently happen.
+ * byte order does not apply to the dtype (see gh-32150).
+ *
+ * WARNING: every call site is written as
+ *
+ *     if (copyswap == NULL && check_missing_copyswap(...) < 0) {
+ *         <error return>;
+ *     }
+ *     copyswap(...);
+ *
+ * which calls through the NULL slot if this function returns 0.  This is
+ * safe only while it unconditionally returns -1: before changing it to
+ * return 0, every call site must first be restructured to skip the
+ * copyswap call on success.
  */
 NPY_NO_EXPORT int
 check_missing_copyswap(PyArray_Descr *dtype, int inplace_swap);

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -60,16 +60,17 @@ NPY_NO_EXPORT npy_bool
 _IsWriteable(PyArrayObject *ap);
 
 /*
- * Handle a dtype whose legacy copyswap slot is missing (e.g. a dtype
- * written using the new DType API).  Currently this always raises a
- * TypeError and returns -1.  `inplace_swap` marks a request that only
- * swaps bytes in place (no data copy); it is unused for now, but is
- * passed so that such requests can become a no-op (returning 0) when
- * byte order does not apply to the dtype (see gh-32150).
+ * Raise a TypeError for a dtype whose legacy copyswap slot is missing
+ * (e.g. a dtype written using the new DType API).  This never succeeds:
+ * it always returns -1, so that it can be chained onto the NULL test at
+ * the call site.  `inplace_swap` marks a request that only swaps bytes
+ * in place (no data copy); it is unused for now, but is passed so that
+ * such requests can become a no-op (returning 0) when byte order does
+ * not apply to the dtype (see gh-32150).
  *
  * WARNING: every call site is written as
  *
- *     if (copyswap == NULL && check_missing_copyswap(...) < 0) {
+ *     if (copyswap == NULL && raise_missing_copyswap(...) < 0) {
  *         <error return>;
  *     }
  *     copyswap(...);
@@ -80,7 +81,7 @@ _IsWriteable(PyArrayObject *ap);
  * copyswap call on success.
  */
 NPY_NO_EXPORT int
-check_missing_copyswap(PyArray_Descr *dtype, int inplace_swap);
+raise_missing_copyswap(PyArray_Descr *dtype, int inplace_swap);
 
 NPY_NO_EXPORT PyObject *
 convert_shape_to_string(npy_intp n, npy_intp const *vals, char *ending);

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -59,6 +59,16 @@ _array_find_python_scalar_type(PyObject *op);
 NPY_NO_EXPORT npy_bool
 _IsWriteable(PyArrayObject *ap);
 
+/*
+ * Handle a dtype whose legacy copyswap slot is missing (e.g. a dtype
+ * written using the new DType API).  Currently always raises a TypeError
+ * and returns -1; `swap_only` marks a swap-only (no data copy) request and
+ * is reserved for making such a request a no-op when byte order does not
+ * apply to the dtype (returning 0).
+ */
+NPY_NO_EXPORT int
+check_missing_copyswap(PyArray_Descr *dtype, int swap_only);
+
 NPY_NO_EXPORT PyObject *
 convert_shape_to_string(npy_intp n, npy_intp const *vals, char *ending);
 

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -61,13 +61,16 @@ _IsWriteable(PyArrayObject *ap);
 
 /*
  * Handle a dtype whose legacy copyswap slot is missing (e.g. a dtype
- * written using the new DType API).  Currently always raises a TypeError
- * and returns -1; `swap_only` marks a swap-only (no data copy) request and
- * is reserved for making such a request a no-op when byte order does not
- * apply to the dtype (returning 0).
+ * written using the new DType API).  Currently this always raises a
+ * TypeError and returns -1.  `inplace_swap` marks a request that only
+ * swaps bytes in place (no data copy); it is unused for now, but is
+ * passed so that such requests can become a no-op (returning 0) when
+ * byte order does not apply to the dtype (see gh-32150).  Callers
+ * propagate the error return and do not yet handle success, since it
+ * cannot currently happen.
  */
 NPY_NO_EXPORT int
-check_missing_copyswap(PyArray_Descr *dtype, int swap_only);
+check_missing_copyswap(PyArray_Descr *dtype, int inplace_swap);
 
 NPY_NO_EXPORT PyObject *
 convert_shape_to_string(npy_intp n, npy_intp const *vals, char *ending);

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -433,6 +433,7 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
         NPY_cast_info_xfree(&cast_info);
     }
     else {
+        int needs_api = PyDataType_FLAGCHK(PyArray_DESCR(array), NPY_NEEDS_PYAPI);
         NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(array));
         for (i = 0; i < ni; i++) {
             if (mask_data[i]) {
@@ -441,12 +442,15 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
                 }
 
                 copyswap(dest + i*chunk, src + j*chunk, 0, array);
+                if (needs_api && PyErr_Occurred()) {
+                    /* e.g. a structured dtype field that does not support copyswap */
+                    break;
+                }
                 j++;
             }
         }
         NPY_END_THREADS;
         if (PyErr_Occurred()) {
-            /* e.g. a structured dtype field that does not support copyswap */
             goto fail;
         }
     }

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -445,6 +445,10 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
             }
         }
         NPY_END_THREADS;
+        if (PyErr_Occurred()) {
+            /* e.g. a structured dtype field that does not support copyswap */
+            goto fail;
+        }
     }
 
     Py_XDECREF(values);

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -719,6 +719,10 @@ array_flat_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
             PyArray_ITER_RESET(arrit);
         }
     }
+    if (PyErr_Occurred()) {
+        /* e.g. a structured dtype field that does not support copyswap */
+        goto exit;
+    }
     retval = 0;
 
  exit:

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -713,15 +713,16 @@ array_flat_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
     swap = PyArray_ISNOTSWAPPED(self) != PyArray_ISNOTSWAPPED(arr);
     while(selfit->index < selfit->size) {
         copyswap(selfit->dataptr, arrit->dataptr, swap, self);
+        if (PyErr_Occurred()) {
+            /* e.g. a structured dtype field that does not support copyswap;
+               stop writing as soon as the error is visible */
+            goto exit;
+        }
         PyArray_ITER_NEXT(selfit);
         PyArray_ITER_NEXT(arrit);
         if (arrit->index == arrit->size) {
             PyArray_ITER_RESET(arrit);
         }
-    }
-    if (PyErr_Occurred()) {
-        /* e.g. a structured dtype field that does not support copyswap */
-        goto exit;
     }
     retval = 0;
 

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -533,26 +533,13 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
     PyArrayIterObject *it;
 
     copyswapn = PyDataType_GetArrFuncs(PyArray_DESCR(self))->copyswapn;
-    if (copyswapn == NULL) {
-        /*
-         * A dtype written using the new DType API does not fill the legacy
-         * copyswap slot (structured dtypes go through VOID_copyswapn, which
-         * handles missing field slots itself).
-         */
-        if (check_missing_copyswap(PyArray_DESCR(self), 1) < 0) {
-            return NULL;
-        }
-        /* no-op: byte order does not apply to the dtype */
-        if (!inplace) {
-            return PyArray_NewCopy(self, NPY_ANYORDER);
-        }
-        Py_INCREF(self);
-        return (PyObject *)self;
+    if (inplace && PyArray_FailUnlessWriteable(self, "array to be byte-swapped") < 0) {
+        return NULL;
+    }
+    if (copyswapn == NULL && check_missing_copyswap(PyArray_DESCR(self), 1) < 0) {
+        return NULL;
     }
     if (inplace) {
-        if (PyArray_FailUnlessWriteable(self, "array to be byte-swapped") < 0) {
-            return NULL;
-        }
         size = PyArray_SIZE(self);
         if (PyArray_ISONESEGMENT(self)) {
             copyswapn(PyArray_DATA(self), PyArray_ITEMSIZE(self), NULL, -1, size, 1, self);

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -533,6 +533,22 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
     PyArrayIterObject *it;
 
     copyswapn = PyDataType_GetArrFuncs(PyArray_DESCR(self))->copyswapn;
+    if (copyswapn == NULL) {
+        /*
+         * A dtype written using the new DType API does not fill the legacy
+         * copyswap slot (structured dtypes go through VOID_copyswapn, which
+         * handles missing field slots itself).
+         */
+        if (check_missing_copyswap(PyArray_DESCR(self), 1) < 0) {
+            return NULL;
+        }
+        /* no-op: byte order does not apply to the dtype */
+        if (!inplace) {
+            return PyArray_NewCopy(self, NPY_ANYORDER);
+        }
+        Py_INCREF(self);
+        return (PyObject *)self;
+    }
     if (inplace) {
         if (PyArray_FailUnlessWriteable(self, "array to be byte-swapped") < 0) {
             return NULL;

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -536,7 +536,7 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
     if (inplace && PyArray_FailUnlessWriteable(self, "array to be byte-swapped") < 0) {
         return NULL;
     }
-    if (copyswapn == NULL && check_missing_copyswap(PyArray_DESCR(self), 1) < 0) {
+    if (copyswapn == NULL && raise_missing_copyswap(PyArray_DESCR(self), 1) < 0) {
         return NULL;
     }
     if (inplace) {

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -554,6 +554,10 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
             }
             Py_DECREF(it);
         }
+        if (PyErr_Occurred()) {
+            /* e.g. a structured dtype field that does not support copyswap */
+            return NULL;
+        }
 
         Py_INCREF(self);
         return (PyObject *)self;
@@ -564,6 +568,10 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
             return NULL;
         }
         new = PyArray_Byteswap(ret, NPY_TRUE);
+        if (new == NULL) {
+            Py_DECREF(ret);
+            return NULL;
+        }
         Py_DECREF(new);
         return (PyObject *)ret;
     }

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2177,13 +2177,31 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
         descr = PyArray_DescrFromScalar(self);
         data = (void *)scalar_value(self, descr);
 
+        PyArray_CopySwapFunc *copyswap =
+                PyDataType_GetArrFuncs(descr)->copyswap;
+        if (copyswap == NULL && descr->byteorder != NPY_IGNORE) {
+            /*
+             * As in PyArray_Byteswap, DTypes written using the new DType
+             * API do not fill the legacy copyswap slot and can only be
+             * byteswapped as a no-op, if byte order does not apply to them.
+             */
+            PyErr_Format(PyExc_TypeError,
+                    "dtype %S does not support byteswapping",
+                    (PyObject *)descr);
+            Py_DECREF(descr);
+            return NULL;
+        }
         newmem = PyMem_Malloc(descr->elsize);
         if (newmem == NULL) {
             Py_DECREF(descr);
             return PyErr_NoMemory();
         }
+        else if (copyswap == NULL) {
+            /* byte order does not apply, so byteswapping is a no-op */
+            memcpy(newmem, data, descr->elsize);
+        }
         else {
-            PyDataType_GetArrFuncs(descr)->copyswap(newmem, data, 1, NULL);
+            copyswap(newmem, data, 1, NULL);
         }
         new = PyArray_Scalar(newmem, descr, NULL);
         PyMem_Free(newmem);

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2188,10 +2188,6 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
             Py_DECREF(descr);
             return PyErr_NoMemory();
         }
-        else if (copyswap == NULL) {
-            /* byte order does not apply, copy the bytes unchanged */
-            memcpy(newmem, data, descr->elsize);
-        }
         else {
             copyswap(newmem, data, 1, NULL);
         }

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2179,15 +2179,7 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
 
         PyArray_CopySwapFunc *copyswap =
                 PyDataType_GetArrFuncs(descr)->copyswap;
-        if (copyswap == NULL && descr->byteorder != NPY_IGNORE) {
-            /*
-             * As in PyArray_Byteswap, DTypes written using the new DType
-             * API do not fill the legacy copyswap slot and can only be
-             * byteswapped as a no-op, if byte order does not apply to them.
-             */
-            PyErr_Format(PyExc_TypeError,
-                    "dtype %S does not support byteswapping",
-                    (PyObject *)descr);
+        if (copyswap == NULL && check_missing_copyswap(descr, 1) < 0) {
             Py_DECREF(descr);
             return NULL;
         }
@@ -2197,7 +2189,7 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
             return PyErr_NoMemory();
         }
         else if (copyswap == NULL) {
-            /* byte order does not apply, so byteswapping is a no-op */
+            /* byte order does not apply, copy the bytes unchanged */
             memcpy(newmem, data, descr->elsize);
         }
         else {

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2179,7 +2179,7 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
 
         PyArray_CopySwapFunc *copyswap =
                 PyDataType_GetArrFuncs(descr)->copyswap;
-        if (copyswap == NULL && check_missing_copyswap(descr, 1) < 0) {
+        if (copyswap == NULL && raise_missing_copyswap(descr, 1) < 0) {
             Py_DECREF(descr);
             return NULL;
         }

--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -63,6 +63,12 @@ class TestSFloat:
         with pytest.raises(TypeError, match="does not implement copyswap"):
             arr.byteswap()
 
+        # the in-place writeability check fires before the missing-slot
+        # check, matching the behavior for dtypes that fill the slot
+        arr.flags.writeable = False
+        with pytest.raises(ValueError, match="array to be byte-swapped"):
+            arr.byteswap(inplace=True)
+
     def test_structured_field_place_and_flat_raise(self):
         # requests that need to copy through the missing legacy copyswap
         # slot raise instead of crashing

--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -78,6 +78,20 @@ class TestSFloat:
         with pytest.raises(TypeError, match="does not implement copyswap"):
             arr.flat = arr[:1]
 
+        # both stop copying as soon as the error is detected, so elements
+        # after the first (failing) one keep their values, even for fields
+        # that could have been copied
+        marr = np.zeros(3, dtype=[("a", "i4"), ("v", SF(1.))])
+        marr["a"] = [5, 6, 7]
+        src = marr[:1].copy()
+        src["a"] = 1
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            marr.flat = src
+        assert marr["a"].tolist()[1:] == [6, 7]
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            np.place(marr, [True, True, True], src)
+        assert marr["a"].tolist()[1:] == [6, 7]
+
     def test_structured_field_sort_raises(self):
         # VOID_compare called the field's legacy compare slot, which
         # new-style DTypes do not fill

--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -44,6 +44,57 @@ class TestSFloat:
         assert a.dtype.get_scaling() == scaling
         assert_array_equal(scaling * a.view(np.float64), [1., 2., 3.])
 
+    def test_structured_field_byteswap(self):
+        # this previously segfaulted via the unguarded field copyswap
+        # calls in VOID_copyswapn; the sfloat field's byteorder is '|'
+        # so it is skipped while other fields are swapped
+        arr = np.zeros(2, dtype=[("a", "i4"), ("v", SF(1.))])
+        arr["a"] = [1, 2]
+        arr["v"] = np.array([1., 2.]).view(SF(1.))
+
+        swapped = arr.byteswap()
+        assert_array_equal(swapped["a"],
+                           np.array([1, 2], dtype="i4").byteswap())
+        assert_array_equal(swapped["v"].view(np.float64),
+                           arr["v"].view(np.float64))
+
+        # subarray fields with byteorder '|' are skipped as well
+        subarr = np.zeros(2, dtype=[("v", SF(1.), (2,))])
+        res = subarr.byteswap()
+        assert_array_equal(res["v"].view(np.float64),
+                           subarr["v"].view(np.float64))
+
+    def test_structured_field_place_and_flat_raise(self):
+        # requests that need to copy through the missing legacy copyswap
+        # slot raise instead of crashing
+        arr = np.zeros(2, dtype=[("v", SF(1.))])
+        with pytest.raises(TypeError, match="does not support the copyswap"):
+            np.place(arr, [True, False], arr[:1])
+        with pytest.raises(TypeError, match="does not support the copyswap"):
+            arr.flat = arr[:1]
+
+    def test_structured_field_sort_raises(self):
+        # VOID_compare called the field's legacy compare slot, which
+        # new-style DTypes do not fill
+        arr = np.zeros(3, dtype=[("v", SF(1.))])
+        with pytest.raises(TypeError, match="does not support comparison"):
+            np.sort(arr, order="v")
+
+        # misaligned fields take a different path through VOID_compare
+        packed_dt = np.dtype({"names": ["a", "v"],
+                              "formats": ["u1", SF(1.)],
+                              "offsets": [0, 1], "itemsize": 17})
+        with pytest.raises(TypeError, match="does not support comparison"):
+            np.sort(np.zeros(3, dtype=packed_dt), order="v")
+
+    def test_structured_setitem_uses_cast_path(self):
+        # scalar assignment between equivalent structured dtypes used to
+        # segfault in the copyswap fast path; it now falls back to casting
+        arr = np.zeros(2, dtype=[("v", SF(1.))])
+        arr["v"] = np.array([1., 2.]).view(SF(1.))
+        arr[0] = arr[1]
+        assert arr["v"].view(np.float64).tolist() == [2., 2.]
+
     def test_repr(self):
         # Check the repr, mainly to cover the code paths:
         assert repr(SF(scaling=1.)) == "_ScaledFloatTestDType(scaling=1.0)"

--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -58,11 +58,14 @@ class TestSFloat:
         assert_array_equal(swapped["v"].view(np.float64),
                            arr["v"].view(np.float64))
 
-        # subarray fields with byteorder '|' are skipped as well
+        # subarray fields with byteorder '|' are skipped as well; use
+        # distinct nonzero values so that a swapped or zeroed field would
+        # be caught (byteswapped zeros are indistinguishable from zeros)
         subarr = np.zeros(2, dtype=[("v", SF(1.), (2,))])
+        subarr["v"] = np.array([[1., 2.], [3., 4.]]).view(SF(1.))
         res = subarr.byteswap()
         assert_array_equal(res["v"].view(np.float64),
-                           subarr["v"].view(np.float64))
+                           [[1., 2.], [3., 4.]])
 
     def test_structured_field_place_and_flat_raise(self):
         # requests that need to copy through the missing legacy copyswap
@@ -80,7 +83,11 @@ class TestSFloat:
         with pytest.raises(TypeError, match="does not support comparison"):
             np.sort(arr, order="v")
 
-        # misaligned fields take a different path through VOID_compare
+        # packed fields are misaligned; the compare == NULL check fires
+        # before VOID_compare's alignment handling, so this exits through
+        # the same guard as the aligned case above and never reaches the
+        # misaligned buffer path (which would call the missing copyswap
+        # slot); it checks that the guard keeps covering that layout
         packed_dt = np.dtype({"names": ["a", "v"],
                               "formats": ["u1", SF(1.)],
                               "offsets": [0, 1], "itemsize": 17})
@@ -94,6 +101,24 @@ class TestSFloat:
         arr["v"] = np.array([1., 2.]).view(SF(1.))
         arr[0] = arr[1]
         assert arr["v"].view(np.float64).tolist() == [2., 2.]
+
+    def test_structured_setitem_nested_uses_cast_path(self):
+        # for a nested field the copyswap slot is VOID_copyswap, which
+        # fails on the inner sfloat field only after it is called; the
+        # error must not leak out of a successful-looking assignment and
+        # the copy falls back to the casting path like the flat case
+        arr = np.zeros(2, dtype=[("a", "i4"), ("nested", [("v", SF(1.))])])
+        arr["a"] = [1, 2]
+        arr["nested"]["v"] = np.array([1., 2.]).view(SF(1.))
+        arr[0] = arr[1]
+        assert arr["a"].tolist() == [2, 2]
+        assert arr["nested"]["v"].view(np.float64).tolist() == [2., 2.]
+
+        # same for a subarray field of an sfloat dtype
+        arr = np.zeros(2, dtype=[("sub", SF(1.), (2,))])
+        arr["sub"] = np.array([[1., 2.], [3., 4.]]).view(SF(1.))
+        arr[0] = arr[1]
+        assert arr["sub"].view(np.float64).tolist() == [[3., 4.], [3., 4.]]
 
     def test_repr(self):
         # Check the repr, mainly to cover the code paths:

--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -44,36 +44,32 @@ class TestSFloat:
         assert a.dtype.get_scaling() == scaling
         assert_array_equal(scaling * a.view(np.float64), [1., 2., 3.])
 
-    def test_structured_field_byteswap(self):
-        # this previously segfaulted via the unguarded field copyswap
-        # calls in VOID_copyswapn; the sfloat field's byteorder is '|'
-        # so it is skipped while other fields are swapped
+    def test_structured_field_byteswap_raises(self):
+        # a field (or subarray field) whose dtype lacks the legacy copyswap
+        # slot cannot be byteswapped; previously this segfaulted via the
+        # unguarded field copyswap calls in VOID_copyswapn
         arr = np.zeros(2, dtype=[("a", "i4"), ("v", SF(1.))])
-        arr["a"] = [1, 2]
-        arr["v"] = np.array([1., 2.]).view(SF(1.))
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            arr.byteswap()
 
-        swapped = arr.byteswap()
-        assert_array_equal(swapped["a"],
-                           np.array([1, 2], dtype="i4").byteswap())
-        assert_array_equal(swapped["v"].view(np.float64),
-                           arr["v"].view(np.float64))
-
-        # subarray fields with byteorder '|' are skipped as well; use
-        # distinct nonzero values so that a swapped or zeroed field would
-        # be caught (byteswapped zeros are indistinguishable from zeros)
         subarr = np.zeros(2, dtype=[("v", SF(1.), (2,))])
-        subarr["v"] = np.array([[1., 2.], [3., 4.]]).view(SF(1.))
-        res = subarr.byteswap()
-        assert_array_equal(res["v"].view(np.float64),
-                           [[1., 2.], [3., 4.]])
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            subarr.byteswap()
+
+    def test_byteswap_raises(self):
+        # a top-level DType without the legacy copyswap slot does not
+        # support byteswapping
+        arr = np.zeros(2, dtype=SF(1.))
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            arr.byteswap()
 
     def test_structured_field_place_and_flat_raise(self):
         # requests that need to copy through the missing legacy copyswap
         # slot raise instead of crashing
         arr = np.zeros(2, dtype=[("v", SF(1.))])
-        with pytest.raises(TypeError, match="does not support the copyswap"):
+        with pytest.raises(TypeError, match="does not implement copyswap"):
             np.place(arr, [True, False], arr[:1])
-        with pytest.raises(TypeError, match="does not support the copyswap"):
+        with pytest.raises(TypeError, match="does not implement copyswap"):
             arr.flat = arr[:1]
 
     def test_structured_field_sort_raises(self):


### PR DESCRIPTION
### PR summary
Towards addressing #24859 (see also #30795 ping @SwayamInSync). This avoids segfaults in many operations if `copyswap` or `copyswapn` isn't defined. Also see #32150 which does the same thing along with a small behavior change in `np.byteswap`.


#### AI Disclosure
I used an AI model to search the codebase and debug/test the fixes.