### PR TITLE
BUG: make SeedSequence.spawn and np.random.set_bit_generator thread-safe

### DIFF
--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -38,7 +38,7 @@ from itertools import cycle
 import re
 from secrets import randbits
 
-from threading import RLock
+from threading import local, RLock
 
 from cpython.pycapsule cimport PyCapsule_New
 
@@ -62,6 +62,13 @@ cdef uint32_t MIX_MULT_L = 0xca01f9dd
 cdef uint32_t MIX_MULT_R = 0x4973f715
 cdef uint32_t XSHIFT = np.dtype(np.uint32).itemsize * 8 // 2
 cdef uint32_t MASK32 = 0xFFFFFFFF
+
+# Keep spawning synchronization outside the installed SeedSequence layout.
+# The prime stripe count distributes aligned object addresses without keeping
+# per-instance state alive.
+cdef tuple _seed_sequence_spawn_locks = tuple(RLock() for _ in range(257))
+cdef object _seed_sequence_spawn_local = local()
+
 
 def _int_to_uint32_array(n):
     arr = []
@@ -484,19 +491,50 @@ cdef class SeedSequence:
 
         """
         cdef uint32_t i
+        cdef object active_spawns
+        cdef object active_seed_sequence
+        cdef object spawn_lock
 
         if n_children < 0:
             raise ValueError("n_children must be non-negative")
 
-        seqs = []
-        for i in range(self.n_children_spawned,
-                       self.n_children_spawned + n_children):
-            seqs.append(type(self)(
-                self.entropy,
-                spawn_key=self.spawn_key + (i,),
-                pool_size=self.pool_size,
-            ))
-        self.n_children_spawned += n_children
+        active_spawns = getattr(
+            _seed_sequence_spawn_local, "active_spawns", None
+        )
+        if active_spawns is None:
+            active_spawns = []
+            _seed_sequence_spawn_local.active_spawns = active_spawns
+        else:
+            for active_seed_sequence in active_spawns:
+                if active_seed_sequence is self:
+                    raise RuntimeError(
+                        "SeedSequence.spawn cannot be re-entered for the "
+                        "same SeedSequence"
+                    )
+
+        active_spawns.append(self)
+        try:
+            spawn_lock = _seed_sequence_spawn_locks[
+                id(self) % len(_seed_sequence_spawn_locks)
+            ]
+            with spawn_lock:
+                if n_children > MASK32 - self.n_children_spawned:
+                    raise OverflowError(
+                        "n_children_spawned cannot exceed 4294967295"
+                    )
+                seqs = []
+                for i in range(self.n_children_spawned,
+                               self.n_children_spawned + n_children):
+                    seqs.append(type(self)(
+                        self.entropy,
+                        spawn_key=self.spawn_key + (i,),
+                        pool_size=self.pool_size,
+                    ))
+                self.n_children_spawned += n_children
+        finally:
+            active_spawns.pop()
+            if not active_spawns:
+                del _seed_sequence_spawn_local.active_spawns
         return seqs
 
 

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -3,6 +3,8 @@
 import operator
 import warnings
 from collections.abc import Sequence
+from contextlib import nullcontext
+from threading import RLock as _RLock
 
 import numpy as np
 
@@ -118,6 +120,103 @@ cdef object int64_to_long(object x):
     return x.astype('l', casting='unsafe')
 
 
+_RLOCK_TYPE = type(_RLock())
+
+
+cdef void _require_reentrant_lock(object lock) except *:
+    cdef bint acquired_once = False
+    cdef bint acquired_twice = False
+
+    # Native RLocks have a known reentrant contract and may already be held by
+    # another thread using the proposed BitGenerator.  Unknown compatible
+    # wrappers are checked without blocking or relying on private ownership
+    # introspection.  A busy unknown lock cannot be proved safe and is rejected
+    # transactionally.
+    if type(lock) is _RLOCK_TYPE:
+        return
+
+    try:
+        acquired_once = lock.acquire(False)
+        if acquired_once:
+            acquired_twice = lock.acquire(False)
+    finally:
+        try:
+            if acquired_twice:
+                lock.release()
+        finally:
+            if acquired_once:
+                lock.release()
+
+    if not acquired_once or not acquired_twice:
+        raise TypeError("BitGenerator lock must be reentrant")
+
+
+cdef class _BitGeneratorLock:
+    # Stable facade used only by the module-level RandomState.  The published
+    # inner lock identifies the complete RandomState generation.  Readers
+    # acquire a strong snapshot, take the BitGenerator's shared lock, and then
+    # validate the identity before touching RandomState-owned raw state.
+    cdef object _bit_generator_lock
+    cdef Py_ssize_t _depth
+
+    def __cinit__(self, bit_generator_lock):
+        self._bit_generator_lock = bit_generator_lock
+        self._depth = 0
+
+    cdef object _acquire_current(self, bint replacement):
+        cdef object bit_generator_lock
+        cdef bint reject_replacement
+
+        while True:
+            with cython.critical_section(self):
+                bit_generator_lock = self._bit_generator_lock
+
+            bit_generator_lock.acquire()
+            reject_replacement = False
+            with cython.critical_section(self):
+                # A waiter overtaken by replacement must retry on the new
+                # lock.  Incrementing depth in this same section also closes
+                # the re-entrant singleton replacement window before state is
+                # used.  A separate Generator owns its own bitgen_t snapshot,
+                # so recursively acquiring its shared RLock does not increment
+                # this singleton-only depth and may safely replace the
+                # singleton generation.
+                if bit_generator_lock is self._bit_generator_lock:
+                    if replacement and self._depth:
+                        reject_replacement = True
+                    else:
+                        if not replacement:
+                            self._depth += 1
+                        return bit_generator_lock
+            bit_generator_lock.release()
+            if reject_replacement:
+                raise RuntimeError(
+                    "cannot replace the bit generator while it is in use "
+                    "by the current thread"
+                )
+
+    def __enter__(self):
+        self._acquire_current(False)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        cdef object bit_generator_lock
+
+        with cython.critical_section(self):
+            self._depth -= 1
+            bit_generator_lock = self._bit_generator_lock
+        bit_generator_lock.release()
+
+    cdef object _begin_replacement(self):
+        return self._acquire_current(True)
+
+    cdef void _finish_replacement(self, object bit_generator_lock):
+        # Publishing the new lock last makes all previously captured waiters
+        # fail validation; new readers can observe the new state afterward.
+        with cython.critical_section(self):
+            self._bit_generator_lock = bit_generator_lock
+
+
 cdef class RandomState:
     # the first line is used to populate `__text_signature__`
     """RandomState(seed=None)\n--
@@ -193,8 +292,9 @@ cdef class RandomState:
         return f'{self} at 0x{id(self):X}'
 
     def __str__(self):
-        _str = self.__class__.__name__
-        _str += '(' + self._bit_generator.__class__.__name__ + ')'
+        with self.lock:
+            _str = self.__class__.__name__
+            _str += '(' + self._bit_generator.__class__.__name__ + ')'
         return _str
 
     # Pickling support:
@@ -211,19 +311,55 @@ cdef class RandomState:
         # contained in the bit generator that described the gaussian
         # generator. This argument is passed to __setstate__ after the
         # Generator is created.
-        return __randomstate_ctor, (self._bit_generator, ), self.get_state(legacy=False)
+        if isinstance(self.lock, _BitGeneratorLock):
+            with self.lock:
+                bit_generator = self._bit_generator
+                state = self.get_state(legacy=False)
+        else:
+            # Preserve pre-existing ordinary RandomState behavior.  A custom
+            # BitGenerator lock need not be reentrant merely because the
+            # module singleton has a replaceable generation.
+            bit_generator = self._bit_generator
+            state = self.get_state(legacy=False)
+        return __randomstate_ctor, (bit_generator, ), state
 
     cdef _initialize_bit_generator(self, bit_generator):
-        self._bit_generator = bit_generator
         capsule = bit_generator.capsule
         cdef const char *name = "BitGenerator"
+        cdef bitgen_t next_bitgen
+        cdef object next_lock
+        cdef object _old_bit_generator
+        cdef object old_lock
+        cdef _BitGeneratorLock lock_proxy
+
         if not PyCapsule_IsValid(capsule, name):
             raise ValueError("Invalid bit generator. The bit generator must "
                              "be instantized.")
-        self._bitgen = (<bitgen_t *> PyCapsule_GetPointer(capsule, name))[0]
+        next_bitgen = (<bitgen_t *> PyCapsule_GetPointer(capsule, name))[0]
+        next_lock = bit_generator.lock
+
+        if isinstance(self.lock, _BitGeneratorLock):
+            _require_reentrant_lock(next_lock)
+            lock_proxy = <_BitGeneratorLock>self.lock
+            old_lock = lock_proxy._begin_replacement()
+            _old_bit_generator = self._bit_generator
+            try:
+                self._bit_generator = bit_generator
+                self._bitgen = next_bitgen
+                self._aug_state.bit_generator = &self._bitgen
+                self._aug_state.has_gauss = 0
+                self._aug_state.gauss = 0.0
+                lock_proxy._finish_replacement(next_lock)
+            finally:
+                old_lock.release()
+            return
+
+        self._bit_generator = bit_generator
+        self._bitgen = next_bitgen
         self._aug_state.bit_generator = &self._bitgen
-        self.lock = bit_generator.lock
-        self._reset_gauss()
+        self.lock = next_lock
+        self._aug_state.has_gauss = 0
+        self._aug_state.gauss = 0.0
 
     cdef _reset_gauss(self):
         with self.lock:
@@ -250,9 +386,9 @@ cdef class RandomState:
         # Later, you want to restart the stream
         >>> rs = RandomState(MT19937(SeedSequence(987654321)))
         """
-        if not isinstance(self._bit_generator, _MT19937):
-            raise TypeError('can only re-seed a MT19937 BitGenerator')
         with self.lock:
+            if not isinstance(self._bit_generator, _MT19937):
+                raise TypeError('can only re-seed a MT19937 BitGenerator')
             self._bit_generator._legacy_seeding(seed)
             self._reset_gauss()
 
@@ -297,7 +433,8 @@ cdef class RandomState:
 
         """
         with self.lock:
-            st = self._bit_generator.state
+            bit_generator = self._bit_generator
+            st = bit_generator.state
             st['has_gauss'] = self._aug_state.has_gauss
             st['gauss'] = self._aug_state.gauss
         if st['bit_generator'] != 'MT19937' and legacy:
@@ -305,7 +442,7 @@ cdef class RandomState:
                           'MT19937 BitGenerator. To silence this warning, '
                           'set `legacy` to False.', RuntimeWarning)
             legacy = False
-        if legacy and not isinstance(self._bit_generator, _MT19937):
+        if legacy and not isinstance(bit_generator, _MT19937):
             raise ValueError(
                 "legacy can only be True when the underlying bitgenerator is "
                 "an instance of MT19937."
@@ -685,8 +822,8 @@ cdef class RandomState:
         randoms_data = <int64_t*>np.PyArray_DATA(randoms)
         n = np.PyArray_SIZE(randoms)
 
-        for i in range(n):
-            with self.lock, nogil:
+        with self.lock, nogil:
+            for i in range(n):
                 randoms_data[i] = random_positive_int(&self._bitgen)
         return randoms
 
@@ -1034,18 +1171,26 @@ cdef class RandomState:
                 p = p.copy()
                 found = np.zeros(shape, dtype=np.long)
                 flat_found = found.ravel()
-                while n_uniq < size:
-                    x = self.rand(size - n_uniq)
-                    if n_uniq > 0:
-                        p[flat_found[0:n_uniq]] = 0
-                    cdf = np.cumsum(p)
-                    cdf /= cdf[-1]
-                    new = cdf.searchsorted(x, side='right')
-                    _, unique_indices = np.unique(new, return_index=True)
-                    unique_indices.sort()
-                    new = new.take(unique_indices)
-                    flat_found[n_uniq:n_uniq + new.size] = new
-                    n_uniq += new.size
+                # Only the module singleton has a replaceable generation.  Do
+                # not add a new recursive-lock requirement to ordinary
+                # RandomState instances using a custom BitGenerator lock.
+                generation_lock = (
+                    self.lock if isinstance(self.lock, _BitGeneratorLock)
+                    else nullcontext()
+                )
+                with generation_lock:
+                    while n_uniq < size:
+                        x = self.rand(size - n_uniq)
+                        if n_uniq > 0:
+                            p[flat_found[0:n_uniq]] = 0
+                        cdf = np.cumsum(p)
+                        cdf /= cdf[-1]
+                        new = cdf.searchsorted(x, side='right')
+                        _, unique_indices = np.unique(new, return_index=True)
+                        unique_indices.sort()
+                        new = new.take(unique_indices)
+                        flat_found[n_uniq:n_uniq + new.size] = new
+                        n_uniq += new.size
                 idx = found
             else:
                 idx = self.permutation(pop_size)[:size]
@@ -4761,7 +4906,12 @@ cdef class RandomState:
         self.shuffle(idx)
         return arr[idx]
 
+cdef void _install_stable_bit_generator_lock(RandomState random_state):
+    random_state.lock = _BitGeneratorLock(random_state.lock)
+
+
 _rand = RandomState()
+_install_stable_bit_generator_lock(_rand)
 
 beta = _rand.beta
 binomial = _rand.binomial
@@ -4829,11 +4979,14 @@ def seed(seed=None):
     --------
     numpy.random.Generator
     """
-    if isinstance(_rand._bit_generator, _MT19937):
-        return _rand.seed(seed)
-    else:
-        bg_type = type(_rand._bit_generator)
-        _rand.set_state(bg_type(seed).state)
+    cdef RandomState singleton
+    singleton = _rand
+    with singleton.lock:
+        if isinstance(singleton._bit_generator, _MT19937):
+            return singleton.seed(seed)
+        else:
+            bg_type = type(singleton._bit_generator)
+            singleton.set_state(bg_type(seed).state)
 
 def get_bit_generator():
     """
@@ -4859,7 +5012,10 @@ def get_bit_generator():
     set_bit_generator
     numpy.random.Generator
     """
-    return _rand._bit_generator
+    cdef RandomState singleton
+    singleton = _rand
+    with singleton.lock:
+        return singleton._bit_generator
 
 def set_bit_generator(bitgen):
     """

--- a/numpy/random/tests/test_direct.py
+++ b/numpy/random/tests/test_direct.py
@@ -178,6 +178,7 @@ def test_generator_spawning():
     expected_keys = [seq.spawn_key + (i,) for i in range(10, 15)]
     found_keys = [rng.bit_generator.seed_seq.spawn_key for rng in new_rngs]
     assert found_keys == expected_keys
+    assert seq.n_children_spawned == 15
 
     # Sanity check that streams are actually different:
     assert new_rngs[0].uniform() != new_rngs[1].uniform()

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -1,13 +1,18 @@
+import gc
 import hashlib
+import os
 import pickle
+import subprocess
 import sys
+import threading
 import warnings
+import weakref
 
 import pytest
 
 import numpy as np
 from numpy import random
-from numpy.random import MT19937, PCG64
+from numpy.random import MT19937, PCG64, SFC64, BitGenerator, Philox
 from numpy.testing import (
     IS_WASM,
     assert_,
@@ -59,10 +64,14 @@ def int_func(request):
 
 @pytest.fixture
 def restore_singleton_bitgen():
-    """Ensures that the singleton bitgen is restored after a test"""
+    """Restore the singleton bit generator and its complete state."""
     orig_bitgen = np.random.get_bit_generator()
-    yield
-    np.random.set_bit_generator(orig_bitgen)
+    orig_state = np.random.get_state(legacy=False)
+    try:
+        yield
+    finally:
+        np.random.set_bit_generator(orig_bitgen)
+        np.random.set_state(orig_state)
 
 
 def assert_mt19937_state_equal(a, b):
@@ -2045,6 +2054,903 @@ def test_hot_swap(restore_singleton_bitgen):
     assert bg is second_bg
 
 
+class _BlockingLock:
+    def __init__(self):
+        self._lock = threading.RLock()
+        self.armed = False
+        self.entered = threading.Event()
+        self.waiter_started = threading.Event()
+        self.release_draw = threading.Event()
+        self.draw_thread = None
+
+    def acquire(self, blocking=True):
+        # Pause the first draw after it selects and acquires this lock, and
+        # expose when the setter subsequently attempts to acquire it.
+        if not blocking:
+            acquired = self._lock.acquire(False)
+            if (not acquired and self.entered.is_set()
+                    and threading.get_ident() != self.draw_thread):
+                self.waiter_started.set()
+            return acquired
+        if (self.entered.is_set()
+                and threading.get_ident() != self.draw_thread):
+            self.waiter_started.set()
+        self._lock.acquire()
+        if self.armed and not self.entered.is_set():
+            self.draw_thread = threading.get_ident()
+            self.entered.set()
+            if not self.release_draw.wait(10):
+                self._lock.release()
+                raise TimeoutError("blocked draw timed out")
+        return True
+
+    def release(self):
+        self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *args):
+        self.release()
+
+
+class _CountingLock:
+    def __init__(self):
+        self._lock = threading.RLock()
+        self.reset()
+
+    def reset(self):
+        self.acquisitions = 0
+        self.depth = 0
+        self.max_depth = 0
+
+    def acquire(self, blocking=True):
+        acquired = self._lock.acquire(blocking)
+        if acquired:
+            self.acquisitions += 1
+            self.depth += 1
+            self.max_depth = max(self.max_depth, self.depth)
+        return acquired
+
+    def release(self):
+        self.depth -= 1
+        self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *args):
+        self.release()
+
+
+class _RoutedLock:
+    def __init__(self):
+        self._lock = threading.RLock()
+        self.armed = False
+        self.draw_thread = None
+        self.draw_selected = threading.Event()
+        self.allow_draw = threading.Event()
+
+    def acquire(self, blocking=True):
+        if (self.armed
+                and threading.get_ident() == self.draw_thread
+                and not self.draw_selected.is_set()):
+            self.draw_selected.set()
+            if not self.allow_draw.wait(10):
+                raise TimeoutError("routed draw timed out")
+        return self._lock.acquire(blocking)
+
+    def release(self):
+        self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *args):
+        self.release()
+
+
+class _ReentrantSwapList(list):
+    def __init__(self, values, bit_generator):
+        super().__init__(values)
+        self.bit_generator = bit_generator
+        self.error = None
+        self.replaced = False
+
+    def __setitem__(self, key, value):
+        if not self.replaced:
+            self.replaced = True
+            try:
+                random.set_bit_generator(self.bit_generator)
+            except RuntimeError as exc:
+                self.error = exc
+        super().__setitem__(key, value)
+
+
+class _ReentrantSwapErrorList(list):
+    def __init__(self, values, bit_generator):
+        super().__init__(values)
+        self.bit_generator = bit_generator
+        self.error = None
+        self.replaced = False
+
+    def __setitem__(self, key, value):
+        if not self.replaced:
+            self.replaced = True
+            try:
+                random.set_bit_generator(self.bit_generator)
+            except Exception as exc:
+                self.error = exc
+        super().__setitem__(key, value)
+
+
+class _PickleLockMT19937(MT19937):
+    def __init__(self, seed=None, test_lock=None):
+        self._test_lock = test_lock
+        super().__init__(seed)
+
+    @property
+    def lock(self):
+        if self._test_lock is not None:
+            return self._test_lock
+        return BitGenerator.lock.__get__(self, type(self))
+
+
+class _HiddenOwnershipRLock:
+    """RLock-compatible wrapper without CPython ownership introspection."""
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self.acquisitions = 0
+        self.releases = 0
+        self.depth = 0
+
+    def acquire(self, blocking=True):
+        acquired = self._lock.acquire(blocking)
+        if acquired:
+            self.acquisitions += 1
+            self.depth += 1
+        return acquired
+
+    def release(self):
+        self.releases += 1
+        self.depth -= 1
+        self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *args):
+        self.release()
+
+
+def _run_hot_swap_subprocess(scenario, tmp_path):
+    install_root = os.path.dirname(os.path.dirname(np.__file__))
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    if pythonpath:
+        install_root += os.pathsep + pythonpath
+    env["PYTHONPATH"] = install_root
+    code = (
+        "from numpy.random.tests.test_randomstate import "
+        f"{scenario}; {scenario}()"
+    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-P", "-c", code],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(
+            f"{scenario} timed out\nstdout={exc.stdout!r}\n"
+            f"stderr={exc.stderr!r}",
+            pytrace=False,
+        )
+    if result.returncode:
+        pytest.fail(
+            f"{scenario} failed with exit code {result.returncode}\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}",
+            pytrace=False,
+        )
+
+
+def _hot_swap_same_bit_generator_scenario():
+    original = random.get_bit_generator()
+    try:
+        bit_generator = PCG64(123)
+        direct = random.RandomState(PCG64(123))
+        random.set_bit_generator(bit_generator)
+        for _ in range(10):
+            state = pickle.dumps(bit_generator.state)
+            random.set_bit_generator(random.get_bit_generator())
+            assert pickle.dumps(bit_generator.state) == state
+            assert_equal(random.random_sample(), direct.random_sample())
+        assert_equal(bit_generator.state, direct._bit_generator.state)
+    finally:
+        random.set_bit_generator(original)
+
+
+def _hot_swap_reentrant_singleton_scenario():
+    original = random.get_bit_generator()
+    try:
+        new = PCG64(456)
+        new_state = new.state
+        seed = 123
+        bit_generator = MT19937(seed)
+        random.set_bit_generator(bit_generator)
+        values = _ReentrantSwapList(range(10), new)
+        expected = list(range(10))
+        direct = random.RandomState(MT19937(seed))
+
+        random.shuffle(values)
+        direct.shuffle(expected)
+
+        assert values.replaced
+        assert isinstance(values.error, RuntimeError)
+        assert "in use by the current thread" in str(values.error)
+        assert values == expected
+        assert random.get_bit_generator() is bit_generator
+        assert_equal(bit_generator.state, direct._bit_generator.state)
+        assert_equal(new.state, new_state)
+    finally:
+        random.set_bit_generator(original)
+
+
+def _hot_swap_reentrant_shared_generator_scenario():
+    original = random.get_bit_generator()
+    try:
+        for hidden_ownership in (False, True):
+            seed = 123
+            if hidden_ownership:
+                hidden_lock = _HiddenOwnershipRLock()
+
+                class HiddenLockMT19937(MT19937):
+                    @property
+                    def lock(self):
+                        return hidden_lock
+
+                bit_generator = HiddenLockMT19937(seed)
+            else:
+                bit_generator = MT19937(seed)
+
+            reference_bit_generator = MT19937(seed)
+            generator = random.Generator(bit_generator)
+            reference_generator = random.Generator(reference_bit_generator)
+            new = PCG64(456)
+            new_state = pickle.dumps(new.state)
+            random.set_bit_generator(bit_generator)
+            if hidden_ownership:
+                assert hidden_lock.acquisitions == 2
+                assert hidden_lock.releases == 2
+                assert hidden_lock.depth == 0
+            values = _ReentrantSwapList(range(10), new)
+            expected = list(range(10))
+
+            generator.shuffle(values)
+            reference_generator.shuffle(expected)
+
+            assert values.replaced
+            assert values.error is None
+            assert values == expected
+            assert random.get_bit_generator() is new
+            assert_array_equal(
+                bit_generator.state["state"]["key"],
+                reference_bit_generator.state["state"]["key"],
+            )
+            assert_equal(
+                bit_generator.state["state"]["pos"],
+                reference_bit_generator.state["state"]["pos"],
+            )
+            assert pickle.dumps(new.state) == new_state
+
+            new_reference = random.RandomState(PCG64(456))
+            assert_equal(random.random_sample(),
+                         new_reference.random_sample())
+            assert_equal(new.state, new_reference._bit_generator.state)
+    finally:
+        random.set_bit_generator(original)
+
+
+def _ordinary_randomstate_plain_lock_pickle_scenario():
+    seed = 5
+    actual = random.RandomState(
+        _PickleLockMT19937(seed, threading.Lock())
+    )
+    expected = random.RandomState(_PickleLockMT19937(seed))
+
+    assert_equal(actual.standard_normal(), expected.standard_normal())
+    restored = pickle.loads(pickle.dumps(actual))
+
+    assert_equal(
+        restored.get_state(legacy=False),
+        expected.get_state(legacy=False),
+    )
+    assert_equal(restored.standard_normal(10), expected.standard_normal(10))
+
+
+def _hot_swap_incompatible_lock_scenario():
+    class NonReentrantRLock(type(threading.RLock())):
+        def __init__(self):
+            self._plain_lock = threading.Lock()
+
+        def acquire(self, blocking=True):
+            return self._plain_lock.acquire(blocking)
+
+        def release(self):
+            self._plain_lock.release()
+
+    original = random.get_bit_generator()
+    try:
+        seed = 123
+        old = MT19937(seed)
+        direct = random.RandomState(MT19937(seed))
+        random.set_bit_generator(old)
+        assert_equal(random.standard_normal(), direct.standard_normal())
+
+        incompatible = _PickleLockMT19937(456, threading.Lock())
+        incompatible_state = pickle.dumps(incompatible.state)
+        with pytest.raises(TypeError, match="lock must be reentrant"):
+            random.set_bit_generator(incompatible)
+
+        assert random.get_bit_generator() is old
+        assert_equal(
+            random.get_state(legacy=False), direct.get_state(legacy=False)
+        )
+        assert pickle.dumps(incompatible.state) == incompatible_state
+
+        dishonest_subclass = _PickleLockMT19937(
+            654, NonReentrantRLock()
+        )
+        dishonest_state = pickle.dumps(dishonest_subclass.state)
+        with pytest.raises(TypeError, match="lock must be reentrant"):
+            random.set_bit_generator(dishonest_subclass)
+        assert random.get_bit_generator() is old
+        assert_equal(
+            random.get_state(legacy=False), direct.get_state(legacy=False)
+        )
+        assert pickle.dumps(dishonest_subclass.state) == dishonest_state
+
+        probabilities = np.full(4, 0.25)
+        assert_equal(
+            random.choice(4, size=4, replace=False, p=probabilities),
+            direct.choice(4, size=4, replace=False, p=probabilities),
+        )
+
+        proposed = _PickleLockMT19937(789, threading.Lock())
+        proposed_state = pickle.dumps(proposed.state)
+        values = _ReentrantSwapErrorList(range(10), proposed)
+        expected = list(range(10))
+        random.shuffle(values)
+        direct.shuffle(expected)
+
+        assert values.replaced
+        assert isinstance(values.error, TypeError)
+        assert "lock must be reentrant" in str(values.error)
+        assert values == expected
+        assert random.get_bit_generator() is old
+        assert_equal(
+            random.get_state(legacy=False), direct.get_state(legacy=False)
+        )
+        assert pickle.dumps(proposed.state) == proposed_state
+    finally:
+        random.set_bit_generator(original)
+
+
+def _ordinary_randomstate_plain_lock_choice_scenario():
+    plain_lock = threading.Lock()
+
+    class PlainLockMT19937(MT19937):
+        @property
+        def lock(self):
+            return plain_lock
+
+    seed = 5
+    actual = random.RandomState(PlainLockMT19937(seed))
+    expected = random.RandomState(MT19937(seed))
+    probabilities = np.full(4, 0.25)
+
+    assert_equal(
+        actual.choice(4, size=4, replace=False, p=probabilities),
+        expected.choice(4, size=4, replace=False, p=probabilities),
+    )
+    assert_equal(
+        actual._bit_generator.state["state"],
+        expected._bit_generator.state["state"],
+    )
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+@pytest.mark.skipif(IS_WASM, reason="can't start thread")
+@pytest.mark.parametrize(
+    ("method", "args"),
+    [
+        pytest.param("random_sample", (), id="bitgen-helper"),
+        pytest.param("standard_normal", (), id="augmented-helper"),
+        pytest.param("tomaxint", ((4,),), id="direct-lock"),
+    ],
+)
+def test_hot_swap_waits_for_inflight_draw(
+        restore_singleton_bitgen, method, args):
+    old_lock = _BlockingLock()
+
+    class BlockingMT19937(MT19937):
+        @property
+        def lock(self):
+            return old_lock
+
+    old_seed = 123
+    old = BlockingMT19937(old_seed)
+    old_ref = weakref.ref(old)
+    new = PCG64(456)
+    new_state = new.state
+    expected = getattr(random.RandomState(MT19937(old_seed)), method)(*args)
+    result = []
+    errors = []
+    setter_started = threading.Event()
+    setter_finished = threading.Event()
+
+    random.set_bit_generator(old)
+    del old
+    old_lock.armed = True
+
+    def draw():
+        try:
+            if method == "tomaxint":
+                draw_method = random.mtrand._rand.tomaxint
+            else:
+                draw_method = getattr(random, method)
+            result.append(draw_method(*args))
+        except BaseException as exc:
+            errors.append(exc)
+
+    def replace():
+        setter_started.set()
+        try:
+            random.set_bit_generator(new)
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            setter_finished.set()
+
+    worker = threading.Thread(target=draw)
+    setter = threading.Thread(target=replace)
+    worker_started = False
+    setter_thread_started = False
+    try:
+        worker.start()
+        worker_started = True
+        assert old_lock.entered.wait(2), "draw did not acquire the old lock"
+        setter.start()
+        setter_thread_started = True
+        assert setter_started.wait(2), "setter did not start"
+        assert old_lock.waiter_started.wait(2), "setter did not wait on old lock"
+        setter_finished_while_blocked = setter_finished.is_set()
+        gc.collect()
+        old_alive_while_blocked = old_ref() is not None
+    finally:
+        old_lock.release_draw.set()
+        if worker_started:
+            worker.join(5)
+        if setter_thread_started:
+            setter.join(5)
+
+    assert not worker.is_alive(), "draw thread did not finish"
+    assert not setter.is_alive(), "setter thread did not finish"
+    assert not errors
+    assert not setter_finished_while_blocked
+    assert old_alive_while_blocked
+    assert_equal(result[0], expected)
+    assert_equal(new.state, new_state)
+    gc.collect()
+    assert old_ref() is None
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+@pytest.mark.skipif(IS_WASM, reason="can't start thread")
+def test_hot_swap_waits_for_shared_generator(restore_singleton_bitgen):
+    old_lock = _BlockingLock()
+
+    class BlockingMT19937(MT19937):
+        @property
+        def lock(self):
+            return old_lock
+
+    old_seed = 123
+    old = BlockingMT19937(old_seed)
+    generator = random.Generator(old)
+    new = PCG64(456)
+    new_state = new.state
+    expected = random.Generator(MT19937(old_seed)).random()
+    result = []
+    errors = []
+    setter_started = threading.Event()
+    setter_finished = threading.Event()
+
+    random.set_bit_generator(old)
+    old_lock.armed = True
+
+    def draw():
+        try:
+            result.append(generator.random())
+        except BaseException as exc:
+            errors.append(exc)
+
+    def replace():
+        setter_started.set()
+        try:
+            random.set_bit_generator(new)
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            setter_finished.set()
+
+    worker = threading.Thread(target=draw)
+    setter = threading.Thread(target=replace)
+    worker_started = False
+    setter_thread_started = False
+    try:
+        worker.start()
+        worker_started = True
+        assert old_lock.entered.wait(2), "draw did not acquire the old lock"
+        setter.start()
+        setter_thread_started = True
+        assert setter_started.wait(2), "setter did not start"
+        assert old_lock.waiter_started.wait(2), "setter did not wait on old lock"
+        setter_finished_while_blocked = setter_finished.is_set()
+    finally:
+        old_lock.release_draw.set()
+        if worker_started:
+            worker.join(5)
+        if setter_thread_started:
+            setter.join(5)
+
+    assert not worker.is_alive(), "draw thread did not finish"
+    assert not setter.is_alive(), "setter thread did not finish"
+    assert not errors
+    assert not setter_finished_while_blocked
+    assert_equal(result[0], expected)
+    assert random.get_bit_generator() is new
+    assert_equal(new.state, new_state)
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+@pytest.mark.skipif(IS_WASM, reason="can't start thread")
+def test_hot_swap_stale_waiter_retries(restore_singleton_bitgen):
+    old_lock = _RoutedLock()
+    new_lock = _RoutedLock()
+
+    class RoutedMT19937(MT19937):
+        @property
+        def lock(self):
+            return old_lock
+
+    class RoutedPCG64(PCG64):
+        @property
+        def lock(self):
+            return new_lock
+
+    old = RoutedMT19937(123)
+    old_state = pickle.dumps(old.state)
+    new_seed = 456
+    new = RoutedPCG64(new_seed)
+    expected = random.RandomState(PCG64(new_seed)).random_sample()
+    result = []
+    errors = []
+    setter_finished = threading.Event()
+
+    random.set_bit_generator(old)
+    old_lock.armed = True
+
+    def draw():
+        old_lock.draw_thread = threading.get_ident()
+        try:
+            result.append(random.random_sample())
+        except BaseException as exc:
+            errors.append(exc)
+
+    def replace():
+        try:
+            random.set_bit_generator(new)
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            setter_finished.set()
+
+    worker = threading.Thread(target=draw)
+    setter = threading.Thread(target=replace)
+    worker_started = False
+    setter_started = False
+    try:
+        worker.start()
+        worker_started = True
+        assert old_lock.draw_selected.wait(2), "draw did not select old lock"
+        setter.start()
+        setter_started = True
+        assert setter_finished.wait(2), "setter did not overtake stale draw"
+        new_lock.draw_thread = old_lock.draw_thread
+        new_lock.armed = True
+        old_lock.allow_draw.set()
+        assert new_lock.draw_selected.wait(2), "draw did not retry new lock"
+        assert worker.is_alive(), "draw did not wait for the new lock"
+    finally:
+        old_lock.allow_draw.set()
+        new_lock.allow_draw.set()
+        if worker_started:
+            worker.join(5)
+        if setter_started:
+            setter.join(5)
+
+    assert not worker.is_alive(), "draw thread did not finish"
+    assert not setter.is_alive(), "setter thread did not finish"
+    assert not errors
+    assert_equal(result[0], expected)
+    assert pickle.dumps(old.state) == old_state
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+@pytest.mark.skipif(IS_WASM, reason="can't start thread")
+def test_hot_swap_pickle_generation_is_coherent(restore_singleton_bitgen):
+    old_lock = _BlockingLock()
+    seed = 123
+    old = _PickleLockMT19937(seed, old_lock)
+    direct = random.RandomState(_PickleLockMT19937(seed))
+    new = PCG64(456)
+    new_state = pickle.dumps(new.state)
+    pickled = []
+    errors = []
+    pickle_finished = threading.Event()
+    setter_finished = threading.Event()
+
+    random.set_bit_generator(old)
+    assert_equal(random.standard_normal(), direct.standard_normal())
+    expected_state = direct.get_state(legacy=False)
+    old_lock.armed = True
+
+    def serialize():
+        try:
+            pickled.append(pickle.dumps(random.mtrand._rand))
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            pickle_finished.set()
+
+    def replace():
+        try:
+            random.set_bit_generator(new)
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            setter_finished.set()
+
+    worker = threading.Thread(target=serialize)
+    setter = threading.Thread(target=replace)
+    worker_started = False
+    setter_started = False
+    try:
+        worker.start()
+        worker_started = True
+        assert old_lock.entered.wait(2), "pickle did not acquire the old lock"
+        setter.start()
+        setter_started = True
+        assert old_lock.waiter_started.wait(2), "setter did not wait on old lock"
+        assert not pickle_finished.is_set(), "pickle escaped the old generation"
+        setter_finished_while_blocked = setter_finished.is_set()
+    finally:
+        old_lock.release_draw.set()
+        if worker_started:
+            worker.join(5)
+        if setter_started:
+            setter.join(5)
+
+    assert not worker.is_alive(), "pickle thread did not finish"
+    assert not setter.is_alive(), "setter thread did not finish"
+    assert not errors
+    assert not setter_finished_while_blocked
+    assert len(pickled) == 1
+    assert random.get_bit_generator() is new
+    assert pickle.dumps(new.state) == new_state
+
+    restored = pickle.loads(pickled[0])
+    assert_equal(restored.get_state(legacy=False), expected_state)
+    assert_equal(restored.standard_normal(10), direct.standard_normal(10))
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+def test_hot_swap_invalid_bit_generator_is_transactional(
+        restore_singleton_bitgen):
+    class InvalidBitGenerator:
+        capsule = None
+        lock = threading.RLock()
+
+    class RaisingLockMT19937(MT19937):
+        @property
+        def lock(self):
+            raise RuntimeError("test lock property failure")
+
+    bit_generator = MT19937(123)
+    direct = random.RandomState(MT19937(123))
+    random.set_bit_generator(bit_generator)
+    assert_equal(random.standard_normal(), direct.standard_normal())
+    with pytest.raises(ValueError, match="Invalid bit generator"):
+        random.set_bit_generator(InvalidBitGenerator())
+    assert random.get_bit_generator() is bit_generator
+
+    proposed = RaisingLockMT19937(456)
+    proposed_state = pickle.dumps(proposed.state)
+    with pytest.raises(RuntimeError, match="test lock property failure"):
+        random.set_bit_generator(proposed)
+    assert random.get_bit_generator() is bit_generator
+    assert_equal(
+        random.get_state(legacy=False), direct.get_state(legacy=False)
+    )
+    assert pickle.dumps(proposed.state) == proposed_state
+    assert_equal(random.random_sample(), direct.random_sample())
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+@pytest.mark.skipif(IS_WASM, reason="can't start thread")
+def test_hot_swap_busy_unknown_lock_is_transactional(
+        restore_singleton_bitgen):
+    busy_lock = _HiddenOwnershipRLock()
+
+    class BusyLockMT19937(MT19937):
+        @property
+        def lock(self):
+            return busy_lock
+
+    old = MT19937(123)
+    direct = random.RandomState(MT19937(123))
+    proposed = BusyLockMT19937(456)
+    proposed_state = pickle.dumps(proposed.state)
+    entered = threading.Event()
+    release = threading.Event()
+    replacement_finished = threading.Event()
+    holder_errors = []
+    replacement_errors = []
+
+    random.set_bit_generator(old)
+    assert_equal(random.standard_normal(), direct.standard_normal())
+
+    def hold_lock():
+        try:
+            with busy_lock:
+                entered.set()
+                if not release.wait(10):
+                    raise TimeoutError("busy lock holder timed out")
+        except BaseException as exc:
+            holder_errors.append(exc)
+
+    def replace():
+        try:
+            random.set_bit_generator(proposed)
+        except BaseException as exc:
+            replacement_errors.append(exc)
+        finally:
+            replacement_finished.set()
+
+    holder = threading.Thread(target=hold_lock, daemon=True)
+    replacement = threading.Thread(target=replace, daemon=True)
+    holder_started = False
+    replacement_started = False
+    replacement_finished_while_busy = False
+    try:
+        holder.start()
+        holder_started = True
+        assert entered.wait(2), "busy lock holder did not acquire the lock"
+        replacement.start()
+        replacement_started = True
+        replacement_finished_while_busy = replacement_finished.wait(2)
+    finally:
+        release.set()
+        if holder_started:
+            holder.join(5)
+        if replacement_started:
+            replacement.join(5)
+
+    assert not holder.is_alive(), "busy lock holder did not finish"
+    assert not replacement.is_alive(), "replacement worker did not finish"
+    assert not holder_errors
+    assert replacement_finished_while_busy, (
+        "set_bit_generator blocked while validating the busy proposed lock"
+    )
+    assert len(replacement_errors) == 1
+    with pytest.raises(TypeError, match="lock must be reentrant"):
+        raise replacement_errors[0]
+    assert random.get_bit_generator() is old
+    assert_equal(
+        random.get_state(legacy=False), direct.get_state(legacy=False)
+    )
+    assert pickle.dumps(proposed.state) == proposed_state
+    assert_equal(random.random_sample(), direct.random_sample())
+    assert busy_lock.depth == 0
+    assert busy_lock.acquisitions == busy_lock.releases
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+def test_hot_swap_multidraw_calls_hold_one_generation(
+        restore_singleton_bitgen):
+    lock = _CountingLock()
+
+    class CountingMT19937(MT19937):
+        @property
+        def lock(self):
+            return lock
+
+    seed = 5
+    bit_generator = CountingMT19937(seed)
+    direct = random.RandomState(MT19937(seed))
+    random.set_bit_generator(bit_generator)
+    lock.reset()
+
+    actual = random.mtrand._rand.tomaxint((4,))
+    expected = direct.tomaxint((4,))
+
+    assert_equal(actual, expected)
+    assert lock.acquisitions == 1
+    assert lock.max_depth == 1
+    assert_equal(bit_generator.state["state"],
+                 direct._bit_generator.state["state"])
+
+    bit_generator = CountingMT19937(seed)
+    direct = random.RandomState(MT19937(seed))
+    random.set_bit_generator(bit_generator)
+    lock.reset()
+    probabilities = np.full(4, 0.25)
+
+    actual = random.choice(4, size=4, replace=False, p=probabilities)
+    expected = direct.choice(4, size=4, replace=False, p=probabilities)
+
+    assert_equal(actual, expected)
+    assert lock.max_depth == 2
+    assert_equal(bit_generator.state["state"],
+                 direct._bit_generator.state["state"])
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+def test_hot_swap_resets_gauss_cache(restore_singleton_bitgen):
+    random.set_bit_generator(MT19937(123))
+    random.standard_normal()
+    assert random.get_state(legacy=False)["has_gauss"] == 1
+
+    seed = 456
+    bit_generator = PCG64(seed)
+    direct = random.RandomState(PCG64(seed))
+    random.set_bit_generator(bit_generator)
+    assert random.get_state(legacy=False)["has_gauss"] == 0
+
+    assert_equal(random.standard_normal(), direct.standard_normal())
+    assert_equal(random.get_state(legacy=False),
+                 direct.get_state(legacy=False))
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+def test_swapped_singleton_shared_state_continuity(restore_singleton_bitgen):
+    seed = 123
+    bit_generator = PCG64(seed)
+    reference_bit_generator = PCG64(seed)
+    generator = random.Generator(bit_generator)
+    reference_generator = random.Generator(reference_bit_generator)
+    reference_random_state = random.RandomState(reference_bit_generator)
+    random.set_bit_generator(bit_generator)
+
+    assert_equal(random.random_sample(),
+                 reference_random_state.random_sample())
+    assert_equal(generator.random(), reference_generator.random())
+    assert_equal(random.randint(0, 2 ** 30),
+                 reference_random_state.randint(0, 2 ** 30))
+    assert_equal(generator.integers(0, 2 ** 30),
+                 reference_generator.integers(0, 2 ** 30))
+    assert_equal(bit_generator.state, reference_bit_generator.state)
+
+
 @pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
 def test_seed_alt_bit_gen(restore_singleton_bitgen):
     # GH 21808
@@ -2099,9 +3005,79 @@ def test_swap_worked(restore_singleton_bitgen):
 
 
 @pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
-def test_swapped_singleton_against_direct(restore_singleton_bitgen):
-    np.random.set_bit_generator(PCG64(98765))
-    singleton_vals = np.random.randint(0, 2 ** 30, 10)
-    rg = np.random.RandomState(PCG64(98765))
-    non_singleton_vals = rg.randint(0, 2 ** 30, 10)
-    assert_equal(non_singleton_vals, singleton_vals)
+@pytest.mark.parametrize("bit_generator_type", [MT19937, PCG64, Philox, SFC64])
+def test_swapped_singleton_against_direct(
+        restore_singleton_bitgen, bit_generator_type):
+    seed = 98765
+    bit_generator = bit_generator_type(seed)
+    initial_state = bit_generator.state
+    np.random.set_bit_generator(bit_generator)
+    assert np.random.get_bit_generator() is bit_generator
+    assert_equal(bit_generator.state, initial_state)
+
+    direct = np.random.RandomState(bit_generator_type(seed))
+    calls = [
+        ("random_sample", (5,)),
+        ("randint", (0, 2 ** 30, 10)),
+        ("standard_normal", (5,)),
+        ("binomial", (10, 0.25, 5)),
+    ]
+    for method, args in calls:
+        singleton_vals = getattr(np.random, method)(*args)
+        direct_vals = getattr(direct, method)(*args)
+        assert_equal(singleton_vals, direct_vals)
+    assert_equal(np.random.get_state(legacy=False),
+                 direct.get_state(legacy=False))
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+def test_swapped_singleton_pickle(restore_singleton_bitgen):
+    np.random.set_bit_generator(Philox(123))
+    np.random.standard_normal()
+    restored = pickle.loads(pickle.dumps(np.random.mtrand._rand))
+    assert_equal(restored.get_state(legacy=False),
+                 np.random.get_state(legacy=False))
+    assert_equal(restored.standard_normal(10),
+                 np.random.standard_normal(10))
+
+
+@pytest.mark.skipif(IS_WASM, reason="can't start subprocess")
+def test_hot_swap_same_bit_generator(tmp_path):
+    _run_hot_swap_subprocess(
+        "_hot_swap_same_bit_generator_scenario", tmp_path
+    )
+
+
+@pytest.mark.skipif(IS_WASM, reason="can't start subprocess")
+def test_hot_swap_reentrant_rejected(tmp_path):
+    _run_hot_swap_subprocess(
+        "_hot_swap_reentrant_singleton_scenario", tmp_path
+    )
+
+
+@pytest.mark.skipif(IS_WASM, reason="can't start subprocess")
+def test_hot_swap_reentrant_shared_generator_is_coherent(tmp_path):
+    _run_hot_swap_subprocess(
+        "_hot_swap_reentrant_shared_generator_scenario", tmp_path
+    )
+
+
+@pytest.mark.skipif(IS_WASM, reason="can't start subprocess")
+def test_randomstate_pickle_accepts_nonreentrant_bit_generator_lock(tmp_path):
+    _run_hot_swap_subprocess(
+        "_ordinary_randomstate_plain_lock_pickle_scenario", tmp_path
+    )
+
+
+@pytest.mark.skipif(IS_WASM, reason="can't start subprocess")
+def test_hot_swap_rejects_nonreentrant_bit_generator_lock(tmp_path):
+    _run_hot_swap_subprocess(
+        "_hot_swap_incompatible_lock_scenario", tmp_path
+    )
+
+
+@pytest.mark.skipif(IS_WASM, reason="can't start subprocess")
+def test_weighted_choice_accepts_nonreentrant_bit_generator_lock(tmp_path):
+    _run_hot_swap_subprocess(
+        "_ordinary_randomstate_plain_lock_choice_scenario", tmp_path
+    )

--- a/numpy/random/tests/test_seed_sequence.py
+++ b/numpy/random/tests/test_seed_sequence.py
@@ -1,11 +1,167 @@
+import copy
+import pickle
+import threading
+
+import pytest
+
 import numpy as np
 from numpy.random import SeedSequence
 from numpy.testing import (
+    IS_WASM,
     assert_array_compare,
     assert_array_equal,
     assert_raises,
     assert_raises_regex,
 )
+
+_THREAD_TIMEOUT = 5
+_SPAWN_LOCK_STRIPES = 257
+
+
+class _BlockingSeedSequence(SeedSequence):
+    entered = None
+    release = None
+    entry_count = 0
+    entry_count_lock = threading.Lock()
+    local = threading.local()
+
+    def __init__(self, *args, **kwargs):
+        cls = type(self)
+        if cls.release is not None and not getattr(cls.local, "entered", False):
+            cls.local.entered = True
+            with cls.entry_count_lock:
+                entry = cls.entry_count
+                cls.entry_count += 1
+            cls.entered[entry].set()
+            if not cls.release.wait(_THREAD_TIMEOUT):
+                raise TimeoutError("child construction gate timed out")
+        super().__init__(*args, **kwargs)
+
+
+class _CustomSeedSequence(SeedSequence):
+    pass
+
+
+class _FailingSeedSequence(SeedSequence):
+    fail_at = None
+    fail_thread = None
+    failure_entered = None
+    release_failure = None
+    success_entered = None
+
+    def __init__(self, *args, **kwargs):
+        cls = type(self)
+        spawn_key = kwargs.get("spawn_key", ())
+        should_fail = (
+            spawn_key
+            and spawn_key[-1] == cls.fail_at
+            and (
+                cls.fail_thread is None
+                or cls.fail_thread == threading.get_ident()
+            )
+        )
+        if (
+            spawn_key
+            and cls.success_entered is not None
+            and cls.fail_thread != threading.get_ident()
+        ):
+            cls.success_entered.set()
+        if should_fail:
+            if cls.failure_entered is not None:
+                cls.failure_entered.set()
+            if (
+                cls.release_failure is not None
+                and not cls.release_failure.wait(_THREAD_TIMEOUT)
+            ):
+                raise TimeoutError("failure gate timed out")
+            raise RuntimeError("failed child construction")
+        super().__init__(*args, **kwargs)
+
+
+class _ReentrantSeedSequence(SeedSequence):
+    spawn_during_init = None
+
+    def __init__(self, *args, **kwargs):
+        cls = type(self)
+        spawn_key = kwargs.get("spawn_key", ())
+        if spawn_key and cls.spawn_during_init is not None:
+            seed_sequence = cls.spawn_during_init
+            cls.spawn_during_init = None
+            seed_sequence.spawn(1)
+        super().__init__(*args, **kwargs)
+
+
+class _RecordingSeedSequence(SeedSequence):
+    constructed_spawn_keys = None
+
+    def __init__(self, *args, **kwargs):
+        spawn_key = kwargs.get("spawn_key", ())
+        if spawn_key and type(self).constructed_spawn_keys is not None:
+            type(self).constructed_spawn_keys.append(tuple(spawn_key))
+        super().__init__(*args, **kwargs)
+
+
+class _HistoricalSeedSequencePickle:
+    def __init__(self, seed_sequence, checksum):
+        self.seed_sequence = seed_sequence
+        self.checksum = checksum
+
+    def __reduce__(self):
+        constructor, args, state = self.seed_sequence.__reduce__()
+        return constructor, (args[0], self.checksum, state)
+
+
+def _pickle_roundtrip(value):
+    return pickle.loads(pickle.dumps(value))
+
+
+def _spawn_worker(spawn, n_children, started, results, errors, index):
+    started.set()
+    try:
+        results[index] = spawn(n_children)
+    except BaseException as exc:
+        errors[index] = exc
+
+
+def _join_threads(threads):
+    for thread in threads:
+        if thread.ident is not None:
+            thread.join(_THREAD_TIMEOUT)
+    assert not [thread.name for thread in threads if thread.is_alive()]
+
+
+def _bounded_spawn(spawn, n_children=1):
+    started = threading.Event()
+    results = [None]
+    errors = [None]
+    thread = threading.Thread(
+        target=_spawn_worker,
+        args=(spawn, n_children, started, results, errors, 0),
+        daemon=True,
+    )
+    thread.start()
+    assert started.wait(_THREAD_TIMEOUT), "spawn worker did not start"
+    _join_threads([thread])
+    return results[0], errors[0]
+
+
+def _reset_blocking_seed_sequence():
+    _BlockingSeedSequence.release = None
+    _BlockingSeedSequence.entered = None
+    _BlockingSeedSequence.entry_count = 0
+    _BlockingSeedSequence.local = threading.local()
+
+
+def _find_seed_sequence_on_stripe(seed_sequence, same_stripe):
+    stripe = id(seed_sequence) % _SPAWN_LOCK_STRIPES
+    candidates = []
+    for entropy in range(1, _SPAWN_LOCK_STRIPES * 4):
+        candidate = type(seed_sequence)(entropy)
+        candidates.append(candidate)
+        matches = id(candidate) % _SPAWN_LOCK_STRIPES == stripe
+        if matches is same_stripe:
+            return candidate, candidates
+    pytest.fail("could not allocate a SeedSequence on the requested stripe")
 
 
 def test_reference_data():
@@ -101,3 +257,369 @@ def test_seedsequence_rejects_nested_sequence():
         cyclic_seed = []
         cyclic_seed.append(cyclic_seed)
         SeedSequence(cyclic_seed)
+
+
+@pytest.mark.skipif(IS_WASM, reason="can't start thread")
+@pytest.mark.thread_unsafe(
+    reason="uses shared mutable helper class state",
+)
+def test_spawn_concurrent_unique_ranges():
+    seed_sequence = _BlockingSeedSequence(12345)
+    entered = [threading.Event(), threading.Event()]
+    release = threading.Event()
+    started = [threading.Event(), threading.Event()]
+    results = [None, None]
+    errors = [None, None]
+    threads = [
+        threading.Thread(
+            target=_spawn_worker,
+            args=(
+                seed_sequence.spawn,
+                n_children,
+                started[index],
+                results,
+                errors,
+                index,
+            ),
+            daemon=True,
+        )
+        for index, n_children in enumerate((2, 3))
+    ]
+
+    _BlockingSeedSequence.entered = entered
+    _BlockingSeedSequence.release = release
+
+    try:
+        threads[0].start()
+        assert entered[0].wait(_THREAD_TIMEOUT), "first spawn did not block"
+        threads[1].start()
+        assert started[1].wait(_THREAD_TIMEOUT), "second spawn did not start"
+        # The worker signals immediately before calling spawn. Without
+        # exclusion, its first child reaches this event while the other child
+        # constructor is still gated.
+        assert not entered[1].wait(1), (
+            "second spawn entered child construction while the first call "
+            "was still active"
+        )
+    finally:
+        release.set()
+        try:
+            _join_threads(threads)
+        finally:
+            _reset_blocking_seed_sequence()
+
+    assert errors == [None, None]
+    batches = results
+
+    indexes_by_call = [
+        [child.spawn_key[-1] for child in batch]
+        for batch in batches
+    ]
+    for indexes in indexes_by_call:
+        assert indexes == list(range(indexes[0], indexes[0] + len(indexes)))
+
+    indexes = sorted(index for batch in indexes_by_call for index in batch)
+    assert indexes == list(range(5))
+    assert seed_sequence.n_children_spawned == 5
+    assert seed_sequence.spawn(1)[0].spawn_key == (5,)
+    assert seed_sequence.n_children_spawned == 6
+
+
+@pytest.mark.skipif(IS_WASM, reason="can't start thread")
+@pytest.mark.thread_unsafe(
+    reason="uses shared mutable helper class state",
+)
+def test_spawn_independent_seed_sequences_use_different_stripes():
+    first = _BlockingSeedSequence(12345)
+    second, candidates = _find_seed_sequence_on_stripe(first, False)
+    assert candidates
+
+    entered = [threading.Event(), threading.Event()]
+    release = threading.Event()
+    started = [threading.Event(), threading.Event()]
+    results = [None, None]
+    errors = [None, None]
+    threads = [
+        threading.Thread(
+            target=_spawn_worker,
+            args=(
+                seed_sequence.spawn,
+                1,
+                started[index],
+                results,
+                errors,
+                index,
+            ),
+            daemon=True,
+        )
+        for index, seed_sequence in enumerate((first, second))
+    ]
+
+    _BlockingSeedSequence.entered = entered
+    _BlockingSeedSequence.release = release
+    try:
+        threads[0].start()
+        assert entered[0].wait(_THREAD_TIMEOUT), "first spawn did not block"
+        threads[1].start()
+        assert entered[1].wait(_THREAD_TIMEOUT), (
+            "independent SeedSequences on different stripes were serialized"
+        )
+    finally:
+        release.set()
+        try:
+            _join_threads(threads)
+        finally:
+            _reset_blocking_seed_sequence()
+
+    assert errors == [None, None]
+    assert [batch[0].spawn_key for batch in results] == [(0,), (0,)]
+    assert first.n_children_spawned == second.n_children_spawned == 1
+
+
+def test_spawn_sequential_ranges():
+    seed_sequence = SeedSequence(
+        12345,
+        spawn_key=(7,),
+        n_children_spawned=4,
+    )
+
+    first_batch = seed_sequence.spawn(3)
+    first_keys = [(7, 4), (7, 5), (7, 6)]
+    assert [child.spawn_key for child in first_batch] == first_keys
+    assert seed_sequence.n_children_spawned == 7
+
+    assert seed_sequence.spawn(0) == []
+    assert seed_sequence.n_children_spawned == 7
+
+    second_batch = seed_sequence.spawn(2)
+    second_keys = [(7, 7), (7, 8)]
+    assert [child.spawn_key for child in second_batch] == second_keys
+    assert seed_sequence.n_children_spawned == 9
+
+    for child, spawn_key in zip(first_batch + second_batch,
+                                first_keys + second_keys):
+        expected = SeedSequence(12345, spawn_key=spawn_key)
+        assert_array_equal(child.generate_state(4), expected.generate_state(4))
+
+
+@pytest.mark.thread_unsafe(
+    reason="uses shared mutable helper class state",
+)
+def test_spawn_rejects_uint32_counter_overflow_before_construction():
+    max_uint32 = np.iinfo(np.uint32).max
+    seed_sequence = _RecordingSeedSequence(
+        12345,
+        n_children_spawned=max_uint32 - 1,
+    )
+    constructed_spawn_keys = []
+    _RecordingSeedSequence.constructed_spawn_keys = constructed_spawn_keys
+    try:
+        with pytest.raises(
+            OverflowError,
+            match="n_children_spawned cannot exceed 4294967295",
+        ):
+            seed_sequence.spawn(2)
+        assert constructed_spawn_keys == []
+        assert seed_sequence.n_children_spawned == max_uint32 - 1
+
+        child = seed_sequence.spawn(1)[0]
+        assert child.spawn_key == (max_uint32 - 1,)
+        assert seed_sequence.n_children_spawned == max_uint32
+
+        constructed_spawn_keys.clear()
+        with pytest.raises(
+            OverflowError,
+            match="n_children_spawned cannot exceed 4294967295",
+        ):
+            seed_sequence.spawn(1)
+        assert constructed_spawn_keys == []
+        assert seed_sequence.n_children_spawned == max_uint32
+    finally:
+        _RecordingSeedSequence.constructed_spawn_keys = None
+
+
+@pytest.mark.thread_unsafe(
+    reason="uses shared mutable helper class state",
+)
+def test_spawn_partial_failure_does_not_advance_counter():
+    seed_sequence = _FailingSeedSequence(12345)
+    _FailingSeedSequence.fail_at = 2
+    _FailingSeedSequence.fail_thread = threading.get_ident()
+    try:
+        with pytest.raises(RuntimeError, match="failed child construction"):
+            seed_sequence.spawn(4)
+    finally:
+        _FailingSeedSequence.fail_at = None
+        _FailingSeedSequence.fail_thread = None
+
+    assert seed_sequence.n_children_spawned == 0
+    children = seed_sequence.spawn(4)
+    assert [child.spawn_key for child in children] == [
+        (0,), (1,), (2,), (3,)
+    ]
+    assert seed_sequence.n_children_spawned == 4
+
+
+@pytest.mark.skipif(IS_WASM, reason="can't start thread")
+@pytest.mark.thread_unsafe(
+    reason="uses shared mutable helper class state",
+)
+def test_spawn_concurrent_failure_and_success_are_transactional():
+    seed_sequence = _FailingSeedSequence(12345)
+    failure_entered = threading.Event()
+    release_failure = threading.Event()
+    success_entered = threading.Event()
+    started = [threading.Event(), threading.Event()]
+    results = [None, None]
+    errors = [None, None]
+
+    def fail_spawn():
+        _FailingSeedSequence.fail_thread = threading.get_ident()
+        _spawn_worker(
+            seed_sequence.spawn, 3, started[0], results, errors, 0
+        )
+
+    threads = [
+        threading.Thread(target=fail_spawn, daemon=True),
+        threading.Thread(
+            target=_spawn_worker,
+            args=(
+                seed_sequence.spawn,
+                2,
+                started[1],
+                results,
+                errors,
+                1,
+            ),
+            daemon=True,
+        ),
+    ]
+    _FailingSeedSequence.fail_at = 1
+    _FailingSeedSequence.failure_entered = failure_entered
+    _FailingSeedSequence.release_failure = release_failure
+    _FailingSeedSequence.success_entered = success_entered
+
+    try:
+        threads[0].start()
+        assert failure_entered.wait(_THREAD_TIMEOUT), (
+            "failing spawn did not reach the configured child"
+        )
+        threads[1].start()
+        assert started[1].wait(_THREAD_TIMEOUT), "successful spawn did not start"
+        assert not success_entered.wait(1), (
+            "successful spawn entered child construction before the failing "
+            "call released its range"
+        )
+    finally:
+        release_failure.set()
+        try:
+            _join_threads(threads)
+        finally:
+            _FailingSeedSequence.fail_at = None
+            _FailingSeedSequence.fail_thread = None
+            _FailingSeedSequence.failure_entered = None
+            _FailingSeedSequence.release_failure = None
+            _FailingSeedSequence.success_entered = None
+
+    assert results[0] is None
+    assert isinstance(errors[0], RuntimeError)
+    assert errors[1] is None
+    assert success_entered.is_set()
+    assert [child.spawn_key for child in results[1]] == [(0,), (1,)]
+    assert seed_sequence.n_children_spawned == 2
+
+
+@pytest.mark.skipif(IS_WASM, reason="can't start thread")
+@pytest.mark.thread_unsafe(
+    reason="uses shared mutable helper class state",
+)
+def test_spawn_same_object_reentry_is_rejected_and_cleaned_up():
+    seed_sequence = _ReentrantSeedSequence(12345)
+    _ReentrantSeedSequence.spawn_during_init = seed_sequence
+    try:
+        result, error = _bounded_spawn(seed_sequence.spawn)
+    finally:
+        _ReentrantSeedSequence.spawn_during_init = None
+
+    assert result is None
+    assert isinstance(error, RuntimeError)
+    assert "cannot be re-entered" in str(error)
+    assert seed_sequence.n_children_spawned == 0
+    assert seed_sequence.spawn(1)[0].spawn_key == (0,)
+    assert seed_sequence.n_children_spawned == 1
+
+
+@pytest.mark.skipif(IS_WASM, reason="can't start thread")
+@pytest.mark.thread_unsafe(
+    reason="uses shared mutable helper class state",
+)
+def test_spawn_different_object_reentry_on_same_stripe():
+    seed_sequence = _ReentrantSeedSequence(12345)
+    nested, candidates = _find_seed_sequence_on_stripe(seed_sequence, True)
+    assert candidates
+    _ReentrantSeedSequence.spawn_during_init = nested
+    try:
+        children, error = _bounded_spawn(seed_sequence.spawn)
+    finally:
+        _ReentrantSeedSequence.spawn_during_init = None
+
+    assert error is None
+    assert children[0].spawn_key == (0,)
+    assert nested.n_children_spawned == 1
+    assert seed_sequence.n_children_spawned == 1
+
+
+@pytest.mark.parametrize(
+    ("copier", "shares_pool"),
+    [
+        pytest.param(copy.copy, True, id="copy"),
+        pytest.param(copy.deepcopy, False, id="deepcopy"),
+        pytest.param(_pickle_roundtrip, False, id="pickle"),
+    ],
+)
+def test_seedsequence_copy_and_pickle(copier, shares_pool):
+    seed_sequence = _CustomSeedSequence(
+        12345,
+        spawn_key=(7,),
+        pool_size=6,
+    )
+    seed_sequence.spawn(3)
+    seed_sequence.pool[0] ^= 1
+    seed_sequence.custom_attribute = "preserved"
+
+    clone = copier(seed_sequence)
+
+    assert type(clone) is _CustomSeedSequence
+    assert clone is not seed_sequence
+    assert clone.state == seed_sequence.state
+    assert_array_equal(clone.pool, seed_sequence.pool)
+    assert (clone.pool is seed_sequence.pool) is shares_pool
+    assert clone.custom_attribute == "preserved"
+
+    clone_children = clone.spawn(2)
+    assert [child.spawn_key for child in clone_children] == [(7, 3), (7, 4)]
+    assert clone.n_children_spawned == 5
+    assert seed_sequence.n_children_spawned == 3
+
+    original_children = seed_sequence.spawn(2)
+    assert [child.spawn_key for child in original_children] == [(7, 3), (7, 4)]
+    assert seed_sequence.n_children_spawned == 5
+
+
+@pytest.mark.parametrize("checksum", [0x3EAA222, 0xC464C19, 0xF88304A])
+def test_seedsequence_historical_pickle_checksums(checksum):
+    seed_sequence = SeedSequence(
+        12345,
+        spawn_key=(7,),
+        pool_size=6,
+        n_children_spawned=3,
+    )
+
+    clone = _pickle_roundtrip(
+        _HistoricalSeedSequencePickle(seed_sequence, checksum)
+    )
+
+    assert type(clone) is SeedSequence
+    assert clone.state == seed_sequence.state
+    assert_array_equal(clone.pool, seed_sequence.pool)
+    assert [child.spawn_key for child in clone.spawn(2)] == [(7, 3), (7, 4)]


### PR DESCRIPTION
### PR summary

Fixes #32063

This PR addresses two independent thread-safety bugs in `numpy.random`.

First, concurrent calls to `SeedSequence.spawn()` can read the same child
counter and produce children with identical `spawn_key` values. The resulting
random streams are identical rather than independent. This can silently
invalidate parallel Monte Carlo simulations, bootstrap calculations,
randomized optimization, simulations, and machine-learning experiments. The
program may complete normally while its effective sample size, variance,
confidence intervals, or error estimates are incorrect. `BitGenerator.spawn()`
and `Generator.spawn()` inherit the same problem.

Second, `np.random.set_bit_generator()` can race with ordinary module-level
draws such as `np.random.random()`, `normal()`, and `choice()`. Replacing the
singleton BitGenerator updates several related values, including the Python
owner, function pointers, state pointer, cached Gaussian state, and
synchronization lock. If a draw observes a mixture of the old and new
generations, it may call one algorithm's function with another algorithm's
state, access an already-released BitGenerator, or execute concurrently under
different locks. Possible consequences include incorrect random values,
corrupted RNG state, out-of-bounds memory access, and segmentation faults.

#### `SeedSequence.spawn()`

The fix uses a private, module-owned tuple of 257 `threading.RLock` instances.
Each `SeedSequence` selects a stripe using `id(self) % 257`, so concurrent calls
on the same object always acquire the same lock, while independent objects
mapped to different stripes can still spawn concurrently.

The selected lock is held across the overflow check, allocation of the
contiguous child-index range, construction of every child, and the final
counter update. The counter advances only after all children have been
constructed successfully. If construction raises an exception,
`n_children_spawned` remains unchanged, allowing the next call to reuse the
uncommitted range. This provides transactional semantics for the spawn counter
and child range, although it does not attempt to undo external side effects
from a custom subclass constructor.

A thread-local identity stack rejects recursive spawning of the same object.
The striped locks are reentrant so that constructing one `SeedSequence` can
safely spawn from a different object mapped to the same stripe without
self-deadlocking.

The locks are stored at module scope rather than in a new `SeedSequence`
instance field. Consequently, `bit_generator.pxd`, the Cython object layout,
field offsets, vtable, and `SeedSequence.__basicsize__` remain unchanged. This
avoids the downstream Cython ABI regression caused by adding a per-instance
`cdef` lock field. Stripe collisions between unrelated objects may introduce
occasional unnecessary serialization, but they do not affect correctness and
do not require a lifetime-managed lock registry.

#### Module-level `RandomState` replacement

For the module-level `RandomState` singleton, the fix installs a stable
`_BitGeneratorLock` facade. The facade remains installed as `_rand.lock`; only
its reference to the current BitGenerator's real lock changes when a new
generation is published. User-created `RandomState` instances retain their
existing behavior.

Ordinary draws use a snapshot, acquire, validate, and retry protocol. A thread
first snapshots the currently published BitGenerator lock, acquires it, and
then verifies that the facade still publishes the same lock. If replacement
occurred while the thread was waiting, it releases the stale lock without
touching RNG state and retries with the current lock. A stale waiter therefore
cannot use an old lock to access a new generation.

Replacement acquires the old generation's real lock and retains a strong
reference to the old BitGenerator. It updates the Python owner, copied
`bitgen_t`, state pointers, and cached augmentation state before publishing the
new lock as the final commit step. In-flight old-generation operations must
finish before replacement proceeds, and the retained owner keeps the old state
alive until the transition is complete. Readers consequently observe one
complete old or new generation rather than a mixture of both.

Operations that perform several internal draws, including `tomaxint(size)` and
weighted `choice(replace=False)`, hold one generation for the entire public
call. This prevents a returned array or sampling operation from combining
values from two RNG generations. Nested internal draws are safe because the
real BitGenerator lock is reentrant. A shared `Generator` uses that same real
lock, so replacement also waits for concurrent draws performed through the
shared BitGenerator.

Before installing a custom BitGenerator lock into the singleton, replacement
transactionally verifies that the lock supports recursive acquisition. Native
`threading.RLock` objects are accepted directly; unknown locks must pass two
nonblocking acquisitions and matching releases. An incompatible or currently
busy unknown lock is rejected before any generation field is modified.

The facade also tracks the current thread's singleton-operation depth.
Attempting to replace the BitGenerator recursively from inside an active
module-level random operation raises `RuntimeError` before mutation. This
prevents an outer operation from resuming with local information from the old
generation after the singleton has published a new one.

#### Validation

Both original races were reproduced deterministically before the fixes.

For `SeedSequence.spawn()`, an event-controlled subclass paused both threads
during construction of their first child. Before the fix, both calls read
`n_children_spawned == 0` and returned the same `(0,)`, `(1,)`, and `(2,)`
spawn keys. Six children were reported, but only three keys were unique.

For `set_bit_generator()`, a controllable old-generation lock paused a worker
after it had captured the old lock but before acquisition. The singleton was
then replaced with `PCG64` while its new lock was held. Before the fix,
releasing the stale old lock allowed the worker to complete using the new
generation without acquiring its lock. This was reproduced through split
state/lock, direct-lock, and Gaussian augmentation paths.

The final regular-GIL build produced the following results:

| Test | Result |
|---|---:|
| Clean Meson build | 328/328 targets |
| `test_seed_sequence.py` | 17 passed |
| `test_direct.py` | 95 passed, 5 CFFI-dependent skips |
| Repeated Stage 1 high-risk selection | 70/70 passed |
| Focused RandomState replacement tests | 21 passed, 181 deselected |
| Full `test_randomstate.py` | 202 passed |
| Repeated Stage 2 watchdog processes | 850/850 passed |
| Non-slow `numpy/random` | 1,377 passed, 10 skipped, 8 deselected |
| Ruff, C API borrow-reference scan, and Cython lint | passed |

The five `test_direct.py` skips were caused by unavailable CFFI support and did
not skip any #32063 regression test.

A free-threaded build was tested on macOS arm64 with CPython 3.14.5rc1t,
`Py_GIL_DISABLED=1`, and `sys._is_gil_enabled() == False`. The clean build,
SeedSequence tests, delegated spawning and serialization tests, focused and
full RandomState tests, the non-slow random suite, parallel Stage 1 tests, and
180 repeated high-risk Stage 2 cases passed without a hang or timeout.
Generated C inspection confirmed that the facade metadata sections use
`PyCriticalSection_Begin` and `PyCriticalSection_End` in this build.

A regular-GIL Limited-API build was tested with
`Py_LIMITED_API=0x030d0000`. All nine `numpy.random` extensions were emitted as
`.abi3.so`, and the Stage 1, focused and full Stage 2, non-slow random, and 140
repeated concurrency/deadlock cases passed. This validates the tested
regular-GIL Limited-API lowering. It does not claim validation of a
free-threaded abi3t NumPy extension build.

The downstream Cython ABI matrix covered consumers compiled against both the
base and corrected declarations and loaded them against both runtimes. All
four combinations passed. An old compiled Cython subclass loaded against the
corrected runtime with matching 64-byte compiled and runtime `SeedSequence`
sizes, intact subclass fields, working `spawn()` and vtable methods, and no
Cython type-size warning. Compiler and Python runtime warnings were treated as
errors.

#### Performance

The stable facade adds a measurable fixed cost to scalar calls:

| Call | Added time | Relative change |
|---|---:|---:|
| MT19937 `random_sample()` | 31.015 ns | 46.39% |
| PCG64 `random_sample()` | 32.432 ns | 50.00% |
| MT19937 `standard_normal()` | 32.138 ns | 31.65% |
| PCG64 `standard_normal()` | 33.220 ns | 32.87% |

The fixed cost is amortized for arrays: `random_sample(1024)` increased by
0.36% with MT19937 and 0.84% with PCG64, while size 100,000 remained within
approximately 1%. Weighted no-replacement `choice()` remained approximately
neutral. `tomaxint(1024)` improved by approximately 24.46x and 16.42x because
the public call now acquires the generation once rather than once per element.
The scalar overhead is therefore a real design tradeoff for maintainers to
evaluate.

The final hash was not tested on Linux, Windows, x86-64, 32-bit systems,
mobile or WebAssembly targets, other compilers or Cython versions, or under
ASan/TSan. Whole-package and cross-minor ABI3 loading, the free-threaded
old-consumer/new-runtime matrix, a NumPy abi3t extension build, CFFI/Numba
paths, fork-while-locked behavior, and deliberately adversarial lock-like
objects also remain unverified.

### First time committer introduction

This is my first contribution to NumPy. I use NumPy while learning machine
learning.

I chose this issue because I care about bugs that can cause real harm to
users. The first race can silently break the independence of random streams,
making scientific-computing results appear normal while actually being
unreliable. The second race can cause the Python process to crash. This is not
a formatting issue, documentation change, or minor optimization, but a real
correctness and stability problem.

#### AI Disclosure

I used OpenAI Codex to assist with writing, modifying, and validating the code
in this pull request. The implementation and test changes were produced or
modified with Codex assistance. I personally reviewed every change, fully
understand the implementation and tests, and made the final decisions about
the contribution. I also used Codex for basic English translation and grammar
assistance for the pull request text.