### PR TITLE
ENH: improve np.cross error message for 0-d input

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1595,8 +1595,7 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     Raises
     ------
     ValueError
-        When the dimension of the vector(s) in `a` or `b` does not equal 3,
-        or when either `a` or `b` is 0-dimensional (e.g., a scalar).
+        When the dimension of the vector(s) in `a` or `b` does not equal 3.
 
     See Also
     --------

--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -1595,7 +1595,8 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     Raises
     ------
     ValueError
-        When the dimension of the vector(s) in `a` or `b` does not equal 3.
+        When the dimension of the vector(s) in `a` or `b` does not equal 3,
+        or when either `a` or `b` is 0-dimensional (e.g., a scalar).
 
     See Also
     --------
@@ -1668,7 +1669,10 @@ def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
     b = asarray(b)
 
     if (a.ndim < 1) or (b.ndim < 1):
-        raise ValueError("At least one array has zero dimension")
+        raise ValueError(
+            "Input arrays must be at least 1-dimensional, but "
+            f"a.ndim = {a.ndim} and b.ndim = {b.ndim}"
+        )
 
     # Check axisa and axisb are within bounds
     axisa = normalize_axis_index(axisa, a.ndim, msg_prefix='axisa')

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -4019,7 +4019,7 @@ class TestCross:
     def test_zero_dimension(self, a, b):
         with pytest.raises(ValueError) as exc:
             np.cross(a, b)
-        assert "At least one array has zero dimension" in str(exc.value)
+        assert "Input arrays must be at least 1-dimensional" in str(exc.value)
 
 
 def test_outer_out_param():


### PR DESCRIPTION
### PR summary

Improves the error message in `np.cross` when a 0-d (scalar) input is passed.

**Before:**
```python
>>> np.cross(5, [1, 2, 3])
ValueError: At least one array has zero dimension
```

**After:**
```python
>>> np.cross(5, [1, 2, 3])
ValueError: Input arrays must be at least 1-dimensional, but a.ndim = 0 and b.ndim = 1
```

The phrase "zero dimension" is ambiguous — it can be read as "empty array" rather than the intended meaning of `ndim == 0`. The new message:
- States the requirement clearly ("must be at least 1-dimensional")
- Includes the actual `ndim` values for both inputs
- Follows the same f-string pattern used by the other `ValueError` in the same function (line 1687)

Also updates the docstring `Raises` section to document this `ValueError`, which was previously only documenting the vector-length check.

**Changes:**
- `numpy/_core/numeric.py`: Updated error message + docstring `Raises` section
- `numpy/_core/tests/test_numeric.py`: Updated `test_zero_dimension` assertion to match new message

Relates to #24079 (which fixed the original `AxisError` crash by adding this guard, but the message clarity was not addressed).



#### AI Disclosure
An AI was used to format a draft for better readability.

