### PR TITLE
BLD: make disable-highway actually disable Highway code

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -123,6 +123,7 @@ if use_highway
   )
 else
   highway_lib = []
+  add_project_arguments(['-DNPY_DISABLE_HIGHWAY'], language: ['cpp'])
 endif
 
 use_intel_sort = not get_option('disable-intel-sort') and cpu_family in ['x86', 'x86_64']

--- a/numpy/_core/src/common/simd/simd.hpp
+++ b/numpy/_core/src/common/simd/simd.hpp
@@ -17,7 +17,8 @@
  * When NPY_DISABLE_OPTIMIZATION is defined, SIMD operations are disabled
  * and the code falls back to scalar implementations.
  */
-#ifndef NPY_DISABLE_OPTIMIZATION
+
+#if !defined(NPY_DISABLE_OPTIMIZATION) && !defined(NPY_DISABLE_HIGHWAY)
 #include <hwy/highway.h>
 
 /**


### PR DESCRIPTION
### PR summary
Now the `-Ddisable-highway=true` flag turns off only the highway_lib linking (it provides `hwy::Abort`), but the Highway code itself continues to be compiled.
So, any code using Highway functions with hwy-asserts breaks when disable-highway is enabled.
[Example](https://github.com/numpy/numpy/actions/runs/30760913326/job/91531493053?pr=32163).

I added `NPY_DISABLE_HIGHWAY`. This is a define that is set when `-Ddisable-highway=true`. And it sets `NPY_HWY = 0`.

#### AI Disclosure
Claude helped me find this, when I wrote PR#32163
