### PR TITLE
MAINT: pixi-packages: use `python` 3.15 branch

### DIFF
--- a/pixi-packages/asan/pixi.toml
+++ b/pixi-packages/asan/pixi.toml
@@ -16,7 +16,7 @@ extra-args = ["-Csetup-args=-Db_sanitize=address", "-Csetup-args=-Dbuildtype=deb
 python.flags = ["asan"]
 python.git = "https://github.com/python/cpython"
 python.subdirectory = "Tools/pixi-packages"
-python.rev = "abdd7aea18bde039fe35983b5c0d8036bc16f1a7"
+python.rev = "847d099efa4785658ba9bd3163e35cb4ae742f6d"
 
 meson-python = "*"
 cython = "*"

--- a/pixi-packages/default/pixi.toml
+++ b/pixi-packages/default/pixi.toml
@@ -24,7 +24,7 @@ python = "*"
 # python.flags = ["default"]
 # python.git = "https://github.com/python/cpython"
 # python.subdirectory = "Tools/pixi-packages"
-# python.rev = "abdd7aea18bde039fe35983b5c0d8036bc16f1a7"  # v3.15.0a8
+# python.rev = "847d099efa4785658ba9bd3163e35cb4ae742f6d"
 
 meson-python = "*"
 cython = "*"

--- a/pixi-packages/freethreading/pixi.toml
+++ b/pixi-packages/freethreading/pixi.toml
@@ -24,7 +24,7 @@ python-freethreading = "*"
 # python.flags = ["freethreading"]
 # python.git = "https://github.com/python/cpython"
 # python.subdirectory = "Tools/pixi-packages"
-# python.rev = "abdd7aea18bde039fe35983b5c0d8036bc16f1a7"  # v3.15.0a8
+# python.rev = "847d099efa4785658ba9bd3163e35cb4ae742f6d"
 
 meson-python = "*"
 cython = "*"

--- a/pixi-packages/tsan_freethreading/pixi.toml
+++ b/pixi-packages/tsan_freethreading/pixi.toml
@@ -18,7 +18,7 @@ extra-args = ["-Csetup-args=-Db_sanitize=thread", "-Csetup-args=-Dbuildtype=debu
 python.flags = ["tsan_freethreading"]
 python.git = "https://github.com/python/cpython"
 python.subdirectory = "Tools/pixi-packages"
-python.rev = "abdd7aea18bde039fe35983b5c0d8036bc16f1a7"
+python.rev = "847d099efa4785658ba9bd3163e35cb4ae742f6d"
 
 meson-python = "*"
 cython = "*"


### PR DESCRIPTION
Support for this was backported to the 3.15 branch in cpython, so let's switch to it for hopefully more stability (and perhaps less trouble installing alongside other packages which break with changes in 3.16dev).

We can continuing inching towards a stable release as and when they arrive.

cc @ngoldbaum @charris 