### PR TITLE
TYP: fix ``[true_]divide`` downcasting of ``longdouble``

### DIFF
--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -7154,7 +7154,7 @@ class _ufunc_21_divide(_ufunc_21[None]):  # type: ignore[misc]
     def __call__(
         self,
         x1: np.float64 | _as_f64,
-        x2: float | _to_floating,
+        x2: float | _to_f64,
         /,
         *,
         out: None = None,
@@ -7164,7 +7164,7 @@ class _ufunc_21_divide(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # 0d +f64, 0d ~f64
     def __call__(
         self,
-        x1: float | _to_floating,
+        x1: float | _to_f64,
         x2: np.float64 | _as_f64,
         /,
         *,
@@ -7341,7 +7341,7 @@ class _ufunc_21_divide(_ufunc_21[None]):  # type: ignore[misc]
     def __call__(
         self,
         x1: _ArrayLike[np.float64 | _as_f64],
-        x2: _DualArrayLike[np.dtype[_to_floating], float],
+        x2: _DualArrayLike[np.dtype[_to_f64], float],
         /,
         *,
         out: EllipsisType | None = None,
@@ -7351,7 +7351,7 @@ class _ufunc_21_divide(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # ?d +f64, ?d ~f64
     def __call__(
         self,
-        x1: _DualArrayLike[np.dtype[_to_floating], float],
+        x1: _DualArrayLike[np.dtype[_to_f64], float],
         x2: _ArrayLike[np.float64 | _as_f64],
         /,
         *,
@@ -7597,7 +7597,7 @@ class _ufunc_21_divide(_ufunc_21[None]):  # type: ignore[misc]
     def outer(
         self,
         x1: np.float64 | _as_f64,
-        x2: float | _to_floating,
+        x2: float | _to_f64,
         /,
         *,
         out: None = None,
@@ -7607,7 +7607,7 @@ class _ufunc_21_divide(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # 0d +f64, 0d ~f64
     def outer(
         self,
-        x1: float | _to_floating,
+        x1: float | _to_f64,
         x2: np.float64 | _as_f64,
         /,
         *,
@@ -7784,7 +7784,7 @@ class _ufunc_21_divide(_ufunc_21[None]):  # type: ignore[misc]
     def outer(
         self,
         x1: _ArrayLike[np.float64 | _as_f64],
-        x2: _DualArrayLike[np.dtype[_to_floating], float],
+        x2: _DualArrayLike[np.dtype[_to_f64], float],
         /,
         *,
         out: EllipsisType | None = None,
@@ -7794,7 +7794,7 @@ class _ufunc_21_divide(_ufunc_21[None]):  # type: ignore[misc]
     @overload  # ?d +f64, ?d ~f64
     def outer(
         self,
-        x1: _DualArrayLike[np.dtype[_to_floating], float],
+        x1: _DualArrayLike[np.dtype[_to_f64], float],
         x2: _ArrayLike[np.float64 | _as_f64],
         /,
         *,


### PR DESCRIPTION
`divide` and `true_divide` had something like a typo in some `__call__` and `outer` overloads, causing it to use `float64` as output dtype for `longdouble` input.

---

Discovered by an AI ([details](https://gist.github.com/jorenham/117846488e6d2dd65c6f44f29e981e97)), fixed by a human (me!).