### PR TITLE
CI: fix typo in the `typecheck` workflow `paths-ignore`

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -20,7 +20,7 @@ on:
     paths-ignore:
       - '**.md'
       - '**.rst'
-      - '.circlecl/**'
+      - '.circleci/**'
       - '.devcontainer/**'
       - '.spin/LICENSE'
       - 'benchmarks/**'


### PR DESCRIPTION
`.circlecl/**` -> `.circleci/**`

---

No AI.