### PR TITLE
CI: skip circleci on stubs-only changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ _defaults: &defaults
     - image: cimg/python:3.12.12
   working_directory: ~/repo
 
+# PRs changing only paths matching this regex skip the build job
+_paths_ignore_re: &paths_ignore_re '\.pyi$|^tools/stubtest/'
+
 
 jobs:
   build:
@@ -33,6 +36,24 @@ jobs:
               echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
               circleci-agent step halt;
             fi
+
+      - run:
+          name: check ignored paths
+          # CircleCI has no `paths-ignore` equivalent
+          environment:
+            PATHS_IGNORE_RE: *paths_ignore_re
+          command: |
+            [[ -v CIRCLE_PULL_REQUEST ]] || exit 0
+            # parent 1 of the merge ref is the tip of the target branch
+            git fetch --quiet origin "refs/pull/${CIRCLE_PULL_REQUEST##*/}/merge" || exit 0
+            # --no-renames so that a `foo.py` -> `foo.pyi` rename reports both paths
+            changed=$(git diff --name-only --no-renames "FETCH_HEAD^1...HEAD") || exit 0
+            if ! grep -qvE "${PATHS_IGNORE_RE}" \<<< "${changed}"; then
+              echo "Only ignored paths changed, exiting job ${CIRCLE_JOB}:"
+              echo "${changed}"
+              circleci-agent step halt
+            fi
+
       - run:
           name: pull changes from merge
           command: |


### PR DESCRIPTION
The .pyi stubs and docs are fully disjoint as far as I can tell. So there is no utility in running circleci when only `.pyi` files changed, and it's currently even the CI bottleneck (i.e. circleci takes longest). 

Circleci doens't seem to have something like the `paths-ignore` that github actions has, so I asked Opus 5 (xhigh) to write this custom regex-based skip step.

It should be easy to extend the regex to skip other paths as well.

---

Yup, I used AI (it required 8 iterations or something to get here though, so it's not really "vibe coding" I guess).