### PR TITLE
ENH: Distinct signature mismatch error code in npy_parse_arguments

### DIFF
--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -232,7 +232,7 @@ raise_incorrect_number_of_positional_args(const char *funcname,
                 funcname, cache->nrequired, cache->npositional,
                 len_args, verb);
     }
-    return -1;
+    return NPY_ARGPARSE_MISMATCH;
 }
 
 static void
@@ -266,7 +266,7 @@ raise_missing_argument(const char *funcname,
  * @param specs Array of argument specifications
  * @param nspecs Number of argument specifications
  *
- * @return Returns 0 on success and -1 on failure.
+ * @return 0 on success, NPY_ARGPARSE_MISMATCH on mismatch, and -1 on failure.
  */
 NPY_NO_EXPORT int
 _npy_parse_arguments(const char *funcname,
@@ -339,7 +339,7 @@ _npy_parse_arguments(const char *funcname,
                     PyErr_Format(PyExc_TypeError,
                             "%s() got an unexpected keyword argument '%S'",
                             funcname, key);
-                    return -1;
+                    return NPY_ARGPARSE_MISMATCH;
                 }
             }
 
@@ -351,7 +351,7 @@ _npy_parse_arguments(const char *funcname,
                 PyErr_Format(PyExc_TypeError,
                         "argument for %s() given by name ('%S') and position "
                         "(position %zd)", funcname, key, param_pos);
-                return -1;
+                return NPY_ARGPARSE_MISMATCH;
             }
 
             all_arguments[param_pos] = value;
@@ -401,12 +401,12 @@ _npy_parse_arguments(const char *funcname,
         /* (PyArg_* also does this after the actual parsing is finished) */
         if (NPY_UNLIKELY(max_nargs < cache->nrequired)) {
             raise_missing_argument(funcname, cache, max_nargs);
-            return -1;
+            return NPY_ARGPARSE_MISMATCH;
         }
         for (int i = 0; i < cache->nrequired; i++) {
             if (NPY_UNLIKELY(all_arguments[i] == NULL)) {
                 raise_missing_argument(funcname, cache, i);
-                return -1;
+                return NPY_ARGPARSE_MISMATCH;
             }
         }
     }

--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -336,9 +336,14 @@ _npy_parse_arguments(const char *funcname,
                 }
                 if (NPY_UNLIKELY(*name == NULL)) {
                     /* Invalid keyword argument. */
-                    PyErr_Format(PyExc_TypeError,
+                    PyObject *message = PyUnicode_FromFormat(
                             "%s() got an unexpected keyword argument '%S'",
                             funcname, key);
+                    if (message == NULL) {
+                        return -1;
+                    }
+                    PyErr_SetObject(PyExc_TypeError, message);
+                    Py_DECREF(message);
                     return NPY_ARGPARSE_MISMATCH;
                 }
             }
@@ -348,9 +353,14 @@ _npy_parse_arguments(const char *funcname,
 
             /* There could be an identical positional argument */
             if (NPY_UNLIKELY(all_arguments[param_pos] != NULL)) {
-                PyErr_Format(PyExc_TypeError,
+                PyObject *message = PyUnicode_FromFormat(
                         "argument for %s() given by name ('%S') and position "
                         "(position %zd)", funcname, key, param_pos);
+                if (message == NULL) {
+                    return -1;
+                }
+                PyErr_SetObject(PyExc_TypeError, message);
+                Py_DECREF(message);
                 return NPY_ARGPARSE_MISMATCH;
             }
 

--- a/numpy/_core/src/common/npy_argparse.h
+++ b/numpy/_core/src/common/npy_argparse.h
@@ -25,9 +25,7 @@ PyArray_PythonPyIntFromInt(PyObject *obj, int *value);
 /*
  * Returned instead of -1 when the call does not match the signature (wrong
  * number of positional arguments, unknown/duplicate keyword, or a missing
- * required argument).  A TypeError is set as usual and the value is negative,
- * so plain `< 0` error checks remain correct; callers that only want to test a
- * signature can check for this code and clear the error.
+ * required argument).
  */
 #define NPY_ARGPARSE_MISMATCH (-2)
 

--- a/numpy/_core/src/common/npy_argparse.h
+++ b/numpy/_core/src/common/npy_argparse.h
@@ -22,6 +22,15 @@ PyArray_PythonPyIntFromInt(PyObject *obj, int *value);
 
 #define _NPY_MAX_KWARGS 14
 
+/*
+ * Returned instead of -1 when the call does not match the signature (wrong
+ * number of positional arguments, unknown/duplicate keyword, or a missing
+ * required argument).  A TypeError is set as usual and the value is negative,
+ * so plain `< 0` error checks remain correct; callers that only want to test a
+ * signature can check for this code and clear the error.
+ */
+#define NPY_ARGPARSE_MISMATCH (-2)
+
 typedef int (*npy_arg_converter)(PyObject *, void *);
 
 typedef struct {
@@ -86,7 +95,8 @@ NPY_NO_EXPORT int init_argparse_mutex(void);
  *            passed to the converter (holding the converted data or a
  *            borrowed reference if converter is NULL).
  *
- * @return Returns 0 on success and -1 on failure.
+ * @return Returns 0 on success, `NPY_ARGPARSE_MISMATCH` if the arguments do
+ *         not match the signature, and -1 on any other failure.
  */
 NPY_NO_EXPORT int
 _npy_parse_arguments(const char *funcname,

--- a/numpy/_core/src/multiarray/arrayfunction_override.c
+++ b/numpy/_core/src/multiarray/arrayfunction_override.c
@@ -479,16 +479,8 @@ try_reduction(PyArray_ArrayFunctionDispatcherObject *self,
             return 0;
     }
 
-    /*
-     * These parsers use no explicit argument converters, so a TypeError here
-     * means that the call does not match this fast-path signature. Clear it
-     * and fall back to normal dispatch; other parser errors are propagated later.
-     *
-     * TODO: Add an npy_parse_arguments probe mode that returns a distinct mismatch
-     * status instead of relying on exception-class matching here. See
-     * https://github.com/numpy/numpy/pull/32041#discussion_r3638882974
-     */
-    if (parsed < 0 && PyErr_ExceptionMatches(PyExc_TypeError)) {
+    /* The call does not match this fast-path signature, use normal dispatch. */
+    if (parsed == NPY_ARGPARSE_MISMATCH) {
         PyErr_Clear();
         return 0;
     }

--- a/numpy/_core/tests/test_overrides.py
+++ b/numpy/_core/tests/test_overrides.py
@@ -459,6 +459,8 @@ class TestArrayFunctionImplementation:
             (np.sum, (np.ones(1),), {"out": object()}),
             (np.max, (np.ones(1),), {"dtype": np.float64}),
             (np.any, (np.ones(1),), {"dtype": np.bool_, "initial": False}),
+            (np.sum, (np.ones(1), 0), {"axis": 0}),  # name and position
+            (np.any, (np.ones(1), 0, None, False, True), {}),  # too many pos.
         ],
     )
     def test_reduction_error_message(self, func, args, kwargs):

--- a/numpy/_core/tests/test_overrides.py
+++ b/numpy/_core/tests/test_overrides.py
@@ -472,6 +472,32 @@ class TestArrayFunctionImplementation:
 
         assert actual.value.args == expected.value.args
 
+    @pytest.mark.parametrize(
+        "args, name",
+        [
+            ((np.ones(1),), "bad"),  # unknown keyword
+            ((np.ones(1), 0), "axis"),  # name and position
+        ],
+    )
+    def test_reduction_signature_format_error(self, args, name):
+        # Formatting the signature mismatch message calls `str()` on the
+        # keyword, which can run arbitrary Python code.  If that raises, the
+        # error must propagate instead of being cleared as a mismatch.
+        class K(str):
+            calls = 0
+
+            def __str__(self):
+                K.calls += 1
+                if K.calls == 1:
+                    raise RuntimeError
+                return super().__str__()
+
+        with pytest.raises(RuntimeError):
+            np.sum(*args, **{K(name): 1})
+
+        # The failure must happen while formatting, not somewhere later.
+        assert K.calls == 1
+
     @pytest.mark.parametrize("value", [234, "this func is not replaced"])
     def test_dispatcher_error(self, value):
         # If the dispatcher raises an error, we must not attempt to mutate it


### PR DESCRIPTION
### PR summary

Follow up on the TODO from #32041, originally raised [here](https://github.com/numpy/numpy/pull/32041#discussion_r3638882974). `npy_parse_arguments` now returns `NPY_ARGPARSE_MISMATCH` (`-2`) when the arguments do not match the signature. This covers too many positional arguments, unknown keywords, arguments passed both by position and by name, and missing required arguments. These cases still raise the same `TypeError`.

The reduction fast path in `try_reduction` now checks this return value instead of treating every `TypeError` as a signature mismatch. This avoids hiding a `TypeError` or subclass raised while parsing an argument.

Existing callers are unaffected because no caller checks specifically for `-1` equality.

Two cases were added to `test_reduction_error_message` to test the mismatch paths that were not already covered.

#### AI Disclosure

`opencode` was used for development/review of the code changes. Human verified.
