### PR TITLE
DOC: document open PR limit

### DIFF
--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -268,6 +268,20 @@ messages (e.g., ``BUG:``, ``ENH:``, ``DOC:``). This enables automated labeling
 of your PR.
 
 
+.. _pull-request-limit:
+
+Open pull request limit
+=======================
+
+To keep the review queue manageable, GitHub is configured to allow only one
+open non-draft pull request per non-maintainer at a time. Draft pull requests
+do not count towards the limit. The maintainer team can, at its discretion,
+add contributors to the list of accounts allowed to open more pull requests
+at once. We liberally add contributors who attend the community and triage
+meetings, which alternate weekly on Wednesdays -- see the `community calendar
+<https://scientific-python.org/calendars/>`__ for times.
+
+
 .. _workflow_PR_timeline:
 
 Getting your PR reviewed
@@ -279,6 +293,9 @@ adding a comment on your PR (this will notify maintainers).
 
 If your PR is large or complicated, asking for input on the numpy-discussion
 mailing list may also be useful.
+
+Pull requests that go stale or do not meet our quality standards may be
+labeled by a triager and closed automatically by a bot.
 
 
 .. _rebasing-on-main:

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -107,6 +107,10 @@ Here's the short summary, complete TOC links are below:
      button. Make sure the title and message are clear, concise, and self-
      explanatory. Then click the button to submit it.
 
+   * Note that non-maintainers may only have one non-draft pull request
+     open for review at a time. See :ref:`pull-request-limit` for details
+     and how to be allowed more open pull requests.
+
    * If your commit introduces a new feature or changes functionality, post on
      the `mailing list`_ to explain your changes. For bug fixes, documentation
      updates, etc., this is generally not necessary, though if you do not get

--- a/doc/source/dev/reviewer_guidelines.rst
+++ b/doc/source/dev/reviewer_guidelines.rst
@@ -101,6 +101,10 @@ For maintainers
   If a PR becomes inactive, maintainers may make larger changes. 
   Remember, a PR is a collaboration between a contributor and a reviewer/s, 
   sometimes a direct push is the best way to finish it.
+- The maintainer team can add contributors to the list of accounts allowed
+  to have more than one non-draft PR open for review at a time (see
+  :ref:`pull-request-limit`). We liberally add contributors who attend the
+  community and triage meetings.
 
 API changes
 -----------


### PR DESCRIPTION
### PR summary

The maintainer mailing list had a discussion about this and decided to use the new open PR limits setting on GitHub. I'm sending an email to the mailing list with more info. This PR documents the new policy.


#### AI Disclosure
No AI use
