### PR TITLE
TYP: fix binary ufunc ``float`` scalar co-promotion

### DIFF
--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -6038,7 +6038,7 @@ class _ufunc_21_f[IdT](_ufunc_21[IdT]):  # type: ignore[misc]
     def __call__(
         self,
         x1: np.float64 | _as_f64,
-        x2: _to_f64,
+        x2: float | _to_f64,
         /,
         *,
         out: None = None,
@@ -6048,7 +6048,7 @@ class _ufunc_21_f[IdT](_ufunc_21[IdT]):  # type: ignore[misc]
     @overload  # 0d +f64, 0d ~f64
     def __call__(
         self,
-        x1: _to_f64,
+        x1: float | _to_f64,
         x2: np.float64 | _as_f64,
         /,
         *,
@@ -6360,7 +6360,7 @@ class _ufunc_21_f[IdT](_ufunc_21[IdT]):  # type: ignore[misc]
     def outer(
         self,
         x1: np.float64 | _as_f64,
-        x2: _to_f64,
+        x2: float | _to_f64,
         /,
         *,
         out: None = None,
@@ -6370,7 +6370,7 @@ class _ufunc_21_f[IdT](_ufunc_21[IdT]):  # type: ignore[misc]
     @overload  # 0d +f64, 0d ~f64
     def outer(
         self,
-        x1: _to_f64,
+        x1: float | _to_f64,
         x2: np.float64 | _as_f64,
         /,
         *,


### PR DESCRIPTION
The scalar overloads for `_ufunc_21_f` were missing  `float` cases which caused e.g. `np.copysign(np.int32(1), True) ` to be inferred as `NDArray[float64]` instead of `float64`.

---

Discovered by an AI ([details](https://gist.github.com/jorenham/79eb6178aef97f7b4e6aeafd6a48b088)), fixed by a human (me!).