### PR TITLE
ENH: pilot where= support on MaskedArray.sum 32126

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -5217,13 +5217,26 @@ class MaskedArray(ndarray):
         """
         return dot(self, b, out=out, strict=strict)
 
-    def sum(self, axis=None, dtype=None, out=None, keepdims=np._NoValue):
+    def sum(self, axis=None, dtype=None, out=None, keepdims=np._NoValue,
+            where=np._NoValue):
         """
         Return the sum of the array elements over the given axis.
 
-        Masked elements are set to 0 internally.
+        Masked elements are set to 0 internally. If ``where`` is provided,
+        only elements for which ``where`` is True (and which are not masked)
+        contribute to the sum. When both a mask and ``where`` apply to the
+        same element, the element is excluded (intersection semantics).
 
         Refer to `numpy.sum` for full documentation.
+
+        Parameters
+        ----------
+        axis, dtype, out, keepdims : see `numpy.sum`
+        where : array_like of bool, optional
+            Elements to include in the sum. See `numpy.ufunc.reduce`
+            for details. An output element is masked when no input element
+            along the reduction axis contributes (i.e. every input is either
+            masked or has ``where=False``).
 
         See Also
         --------
@@ -5256,14 +5269,33 @@ class MaskedArray(ndarray):
         >>> print(type(x.sum(axis=0, dtype=np.int64)[0]))
         <class 'numpy.int64'>
 
+        Restricting the sum with ``where``:
+
+        >>> x.sum(where=[[True, True, False],
+        ...              [True, True, True],
+        ...              [False, True, True]])
+        15
+
         """
         kwargs = {} if keepdims is np._NoValue else {'keepdims': keepdims}
+        where_kwarg = {} if where is np._NoValue else {'where': where}
 
         _mask = self._mask
-        newmask = _check_mask_axis(_mask, axis, **kwargs)
+        # Combine mask with ~where so an output position is masked iff no
+        # element along the axis contributed (either masked or excluded).
+        if where is np._NoValue or where is True:
+            effective_mask = _mask
+        else:
+            where_arr = np.asarray(where)
+            if _mask is nomask:
+                effective_mask = ~where_arr
+            else:
+                effective_mask = _mask | ~where_arr
+        newmask = _check_mask_axis(effective_mask, axis, **kwargs)
         # No explicit output
         if out is None:
-            result = self.filled(0).sum(axis, dtype=dtype, **kwargs)
+            result = self.filled(0).sum(
+                axis, dtype=dtype, **kwargs, **where_kwarg)
             rndim = getattr(result, 'ndim', 0)
             if rndim:
                 result = result.view(type(self))
@@ -5272,7 +5304,8 @@ class MaskedArray(ndarray):
                 result = masked
             return result
         # Explicit output
-        result = self.filled(0).sum(axis, dtype=dtype, out=out, **kwargs)
+        result = self.filled(0).sum(
+            axis, dtype=dtype, out=out, **kwargs, **where_kwarg)
         if isinstance(out, MaskedArray):
             outmask = getmask(out)
             if outmask is nomask:

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -2040,6 +2040,7 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         dtype: DTypeLike | None = None,
         out: None = None,
         keepdims: bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> Any: ...
     @overload
     def sum[ArrayT: np.ndarray](
@@ -2049,6 +2050,7 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         dtype: DTypeLike | None,
         out: ArrayT,
         keepdims: bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> ArrayT: ...
     @overload
     def sum[ArrayT: np.ndarray](
@@ -2059,6 +2061,7 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
         *,
         out: ArrayT,
         keepdims: bool | _NoValueType = ...,
+        where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> ArrayT: ...
 
     # Keep in sync with `ma.core.prod`
@@ -3349,6 +3352,7 @@ def sum(
     dtype: DTypeLike | None = None,
     out: None = None,
     keepdims: bool | _NoValueType = ...,
+    where: _ArrayLikeBool_co | _NoValueType = ...,
 ) -> Incomplete: ...
 @overload
 def sum[ArrayT: np.ndarray](
@@ -3357,6 +3361,7 @@ def sum[ArrayT: np.ndarray](
     dtype: DTypeLike | None,
     out: ArrayT,
     keepdims: bool | _NoValueType = ...,
+    where: _ArrayLikeBool_co | _NoValueType = ...,
 ) -> ArrayT: ...
 @overload
 def sum[ArrayT: np.ndarray](
@@ -3366,6 +3371,7 @@ def sum[ArrayT: np.ndarray](
     *,
     out: ArrayT,
     keepdims: bool | _NoValueType = ...,
+    where: _ArrayLikeBool_co | _NoValueType = ...,
 ) -> ArrayT: ...
 
 # Keep in sync with `product` and `MaskedArray.prod`

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -4442,6 +4442,89 @@ class TestMaskedArrayMathMethods:
         assert_(np.ma.allequal(a, diff))
 
 
+class TestMaskedArraySumWhere:
+    # Pilot for gh-32126: `where=` keyword on MaskedArray reductions.
+    # Intersection semantics: an element contributes to the sum iff
+    # (not masked) AND (where=True). An output position is masked iff no
+    # element along the axis contributes.
+    def setup_method(self):
+        self.data = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        self.mask = np.array([[False, True, False],
+                              [True, False, True],
+                              [False, True, False]])
+        self.arr = np.ma.array(self.data, mask=self.mask)
+
+    def test_no_where_matches_default(self):
+        # sum() unchanged when where= is not provided
+        assert_equal(self.arr.sum(), 25)
+
+    def test_where_scalar_true_matches_default(self):
+        assert_equal(self.arr.sum(where=True), self.arr.sum())
+
+    def test_where_scalar_false_returns_masked(self):
+        # No element contributes anywhere -> result is masked scalar
+        assert_(self.arr.sum(where=False) is np.ma.masked)
+
+    def test_where_all_true_array_matches_default(self):
+        where = np.ones_like(self.data, dtype=bool)
+        assert_equal(self.arr.sum(where=where), self.arr.sum())
+
+    def test_where_diagonal_all_unmasked(self):
+        # Diagonal selection: (0,0)=1, (1,1)=5, (2,2)=9 — all unmasked
+        # under the setup_method mask pattern (alternating rows).
+        where = np.eye(3, dtype=bool)
+        assert_equal(self.arr.sum(where=where), 1 + 5 + 9)
+
+    def test_where_targets_only_masked_positions(self):
+        # Verify the intersection semantic: if where=True lands only on
+        # already-masked positions, no element contributes and the
+        # result is masked.
+        where = self.mask.copy()  # True exactly where elements are masked
+        assert_(self.arr.sum(where=where) is np.ma.masked)
+
+    def test_where_overlaps_mask(self):
+        # where=True on all positions collapses to default sum
+        where = np.ones_like(self.data, dtype=bool)
+        assert_equal(self.arr.sum(where=where), 25)
+
+    def test_where_fully_excludes_row_on_axis(self):
+        where = np.array([[True, True, True],
+                          [False, False, False],
+                          [True, True, True]])
+        result = self.arr.sum(axis=1, where=where)
+        # Row 0: 1+3=4 (col 1 masked). Row 1: fully excluded -> masked.
+        # Row 2: 7+9=16 (col 1 masked).
+        assert_equal(result[0], 4)
+        assert_(result[1] is np.ma.masked)
+        assert_equal(result[2], 16)
+
+    def test_where_with_axis(self):
+        where = np.ones_like(self.data, dtype=bool)
+        assert_equal(self.arr.sum(axis=0, where=where),
+                     self.arr.sum(axis=0))
+        assert_equal(self.arr.sum(axis=1, where=where),
+                     self.arr.sum(axis=1))
+
+    def test_where_with_keepdims(self):
+        where = np.ones_like(self.data, dtype=bool)
+        result = self.arr.sum(axis=0, keepdims=True, where=where)
+        assert_equal(result.shape, (1, 3))
+
+    def test_where_broadcasts(self):
+        # 1-D where broadcasts across rows; excludes column 1 entirely
+        where = np.array([True, False, True])
+        # Contributing (unmasked AND where): (0,0)=1, (0,2)=3,
+        # (2,0)=7, (2,2)=9 -> 20
+        assert_equal(self.arr.sum(where=where), 20)
+
+    def test_where_with_out_parameter(self):
+        where = np.ones_like(self.data, dtype=bool)
+        out = np.ma.zeros(3, dtype=self.data.dtype)
+        self.arr.sum(axis=1, out=out, where=where)
+        # Row sums honoring mask: 1+3=4, 5=5, 7+9=16
+        assert_equal(out, [4, 5, 16])
+
+
 class TestMaskedArrayMathMethodsComplex:
     # Test class for miscellaneous MaskedArrays methods.
     def _create_data(self):


### PR DESCRIPTION
### PR summary

Following the ENH created https://github.com/numpy/numpy/issues/32126 this Draft PR is created to add `where=` keyword to `MaskedArray.sum` only. Other reductions (`mean`, `prod`, `std`, `var`, `min`, `max`, `any`, `all`) intentionally excluded from this PR 


### First time committer introduction
No

#### AI Disclosure
Claude AI desktop agent to code review & test cases verification