### PR TITLE
MAINT, TST: Exclude test files from coverage reports and make spin pick up ``.coveragerc``

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,7 @@
 [run]
 branch = True
 include = */numpy/*
+omit =
+    */tests/*
+    */numpy/conftest.py
 disable_warnings = include-ignored

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -169,6 +169,10 @@ def test(*, parent_callback, pytest_args, tests, markexpr, parallel_threads, **k
     if parallel_threads != "1":
         pytest_args = ('--parallel-threads', parallel_threads) + pytest_args
 
+    if kwargs.get('coverage'):
+        coveragerc = curdir.parent / '.coveragerc'
+        pytest_args = (f'--cov-config={coveragerc}',) + pytest_args
+
     kwargs['pytest_args'] = pytest_args
     parent_callback(**{'pytest_args': pytest_args, 'tests': tests, **kwargs})
 


### PR DESCRIPTION
### PR summary

Coverage reports generated via `spin test --coverage` currently include the test files themselves and ignore the repo's `.coveragerc` entirely. This PR fixes both:

  1. Adds an omit section to `.coveragerc` so test files are excluded from coverage.
  2. Makes `spin test --coverage` actually load the repo `.coveragerc`.

<details><summary>Before</summary>
<p>

```md
| Name                                                        |    Stmts |     Miss |   Cover |
|------------------------------------------------------------ | -------: | -------: | ------: |
| numpy/\_\_config\_\_.py                                     |       32 |       20 |     38% |
| numpy/\_\_init\_\_.py                                       |      191 |       54 |     72% |
| numpy/\_array\_api\_info.py                                 |       39 |        9 |     77% |
| numpy/\_configtool.py                                       |       20 |       20 |      0% |
| numpy/\_core/\_\_init\_\_.py                                |       88 |       82 |      7% |
| numpy/\_core/\_add\_newdocs.py                              |      235 |      235 |      0% |
| numpy/\_core/\_add\_newdocs\_scalars.py                     |       68 |       68 |      0% |
| numpy/\_core/\_asarray.py                                   |       31 |        9 |     71% |
| numpy/\_core/\_dtype.py                                     |      174 |       23 |     87% |
| numpy/\_core/\_dtype\_ctypes.py                             |       54 |        7 |     87% |
| numpy/\_core/\_exceptions.py                                |       84 |       34 |     60% |
| numpy/\_core/\_internal.py                                  |      461 |      146 |     68% |
| numpy/\_core/\_methods.py                                   |      142 |       36 |     75% |
| numpy/\_core/\_string\_helpers.py                           |       15 |       15 |      0% |
| numpy/\_core/\_type\_aliases.py                             |       51 |       51 |      0% |
| numpy/\_core/\_ufunc\_config.py                             |       72 |       31 |     57% |
| numpy/\_core/arrayprint.py                                  |      607 |      129 |     79% |
| numpy/\_core/cversions.py                                   |        6 |        6 |      0% |
| numpy/\_core/defchararray.py                                |      223 |        5 |     98% |
| numpy/\_core/einsumfunc.py                                  |      491 |       50 |     90% |
| numpy/\_core/fromnumeric.py                                 |      450 |      156 |     65% |
| numpy/\_core/function\_base.py                              |      133 |       42 |     68% |
| numpy/\_core/getlimits.py                                   |      171 |       68 |     60% |
| numpy/\_core/memmap.py                                      |      101 |       23 |     77% |
| numpy/\_core/multiarray.py                                  |      110 |       82 |     25% |
| numpy/\_core/numeric.py                                     |      477 |      163 |     66% |
| numpy/\_core/numerictypes.py                                |      116 |       48 |     59% |
| numpy/\_core/overrides.py                                   |       58 |       32 |     45% |
| numpy/\_core/printoptions.py                                |        5 |        5 |      0% |
| numpy/\_core/records.py                                     |      359 |      130 |     64% |
| numpy/\_core/shape\_base.py                                 |      191 |       47 |     75% |
| numpy/\_core/strings.py                                     |      331 |       11 |     97% |
| numpy/\_core/tests/\_locales.py                             |       34 |        5 |     85% |
| numpy/\_core/tests/\_natype.py                              |       92 |       30 |     67% |
| numpy/\_core/tests/test\_\_exceptions.py                    |       56 |        0 |    100% |
| numpy/\_core/tests/test\_abc.py                             |       33 |        0 |    100% |
| numpy/\_core/tests/test\_api.py                             |      430 |        0 |    100% |
| numpy/\_core/tests/test\_argparse.py                        |       43 |        0 |    100% |
| numpy/\_core/tests/test\_array\_api\_info.py                |       38 |        0 |    100% |
| numpy/\_core/tests/test\_array\_coercion.py                 |      559 |       18 |     97% |
| numpy/\_core/tests/test\_array\_interface.py                |       64 |        5 |     92% |
| numpy/\_core/tests/test\_arraymethod.py                     |       32 |        0 |    100% |
| numpy/\_core/tests/test\_arrayobject.py                     |      126 |        0 |    100% |
| numpy/\_core/tests/test\_arrayprint.py                      |      667 |       26 |     96% |
| numpy/\_core/tests/test\_casting\_floatingpoint\_errors.py  |       95 |        1 |     99% |
| numpy/\_core/tests/test\_casting\_unittests.py              |      556 |       14 |     97% |
| numpy/\_core/tests/test\_conversion\_utils.py               |      147 |        4 |     97% |
| numpy/\_core/tests/test\_cpu\_dispatcher.py                 |       25 |        2 |     92% |
| numpy/\_core/tests/test\_cpu\_features.py                   |      260 |       94 |     64% |
| numpy/\_core/tests/test\_custom\_dtypes.py                  |      315 |        0 |    100% |
| numpy/\_core/tests/test\_cython.py                          |      203 |       13 |     94% |
| numpy/\_core/tests/test\_datetime.py                        |     1663 |        4 |     99% |
| numpy/\_core/tests/test\_defchararray.py                    |      555 |        0 |    100% |
| numpy/\_core/tests/test\_deprecations.py                    |      297 |        8 |     97% |
| numpy/\_core/tests/test\_dlpack.py                          |      231 |        0 |    100% |
| numpy/\_core/tests/test\_dtype.py                           |     1163 |       34 |     97% |
| numpy/\_core/tests/test\_einsum.py                          |      810 |        4 |     99% |
| numpy/\_core/tests/test\_errstate.py                        |       84 |        1 |     99% |
| numpy/\_core/tests/test\_extint128.py                       |      139 |       16 |     88% |
| numpy/\_core/tests/test\_finfo.py                           |       38 |        0 |    100% |
| numpy/\_core/tests/test\_function\_base.py                  |      414 |       17 |     96% |
| numpy/\_core/tests/test\_getlimits.py                       |      119 |        0 |    100% |
| numpy/\_core/tests/test\_half.py                            |      357 |        5 |     99% |
| numpy/\_core/tests/test\_hashtable.py                       |      117 |        0 |    100% |
| numpy/\_core/tests/test\_indexerrors.py                     |       89 |        0 |    100% |
| numpy/\_core/tests/test\_indexing.py                        |     1030 |       17 |     98% |
| numpy/\_core/tests/test\_item\_selection.py                 |      121 |        0 |    100% |
| numpy/\_core/tests/test\_limited\_api.py                    |      140 |       11 |     92% |
| numpy/\_core/tests/test\_longdouble.py                      |      216 |        5 |     98% |
| numpy/\_core/tests/test\_mem\_overlap.py                    |      555 |       10 |     98% |
| numpy/\_core/tests/test\_mem\_policy.py                     |      154 |       21 |     86% |
| numpy/\_core/tests/test\_memmap.py                          |      200 |       10 |     95% |
| numpy/\_core/tests/test\_multiarray.py                      |     7723 |       78 |     99% |
| numpy/\_core/tests/test\_multiprocessing.py                 |       34 |       13 |     62% |
| numpy/\_core/tests/test\_multithreading.py                  |      465 |      135 |     71% |
| numpy/\_core/tests/test\_nditer.py                          |     2046 |       24 |     99% |
| numpy/\_core/tests/test\_nep50\_promotions.py               |      191 |        2 |     99% |
| numpy/\_core/tests/test\_numeric.py                         |     2760 |       13 |     99% |
| numpy/\_core/tests/test\_numerictypes.py                    |      322 |        3 |     99% |
| numpy/\_core/tests/test\_overrides.py                       |      540 |       15 |     97% |
| numpy/\_core/tests/test\_print.py                           |       85 |        2 |     98% |
| numpy/\_core/tests/test\_protocols.py                       |       30 |        4 |     87% |
| numpy/\_core/tests/test\_records.py                         |      388 |        8 |     98% |
| numpy/\_core/tests/test\_reduction\_loop.py                 |      321 |        0 |    100% |
| numpy/\_core/tests/test\_regression.py                      |     1719 |       42 |     98% |
| numpy/\_core/tests/test\_scalar\_ctors.py                   |      142 |        0 |    100% |
| numpy/\_core/tests/test\_scalar\_methods.py                 |      178 |        9 |     95% |
| numpy/\_core/tests/test\_scalarbuffer.py                    |       86 |        0 |    100% |
| numpy/\_core/tests/test\_scalarinherit.py                   |       75 |        1 |     99% |
| numpy/\_core/tests/test\_scalarmath.py                      |      718 |       14 |     98% |
| numpy/\_core/tests/test\_scalarprint.py                     |      171 |       19 |     89% |
| numpy/\_core/tests/test\_shape\_base.py                     |      574 |        7 |     99% |
| numpy/\_core/tests/test\_simd.py                            |      868 |       11 |     99% |
| numpy/\_core/tests/test\_simd\_module.py                    |       82 |        5 |     94% |
| numpy/\_core/tests/test\_stringdtype.py                     |     1404 |        3 |     99% |
| numpy/\_core/tests/test\_strings.py                         |      586 |       27 |     95% |
| numpy/\_core/tests/test\_ufunc.py                           |     2140 |       34 |     98% |
| numpy/\_core/tests/test\_umath.py                           |     3380 |       68 |     98% |
| numpy/\_core/tests/test\_umath\_accuracy.py                 |       58 |       30 |     48% |
| numpy/\_core/tests/test\_umath\_complex.py                  |      358 |      176 |     51% |
| numpy/\_core/tests/test\_unicode.py                         |      192 |        1 |     99% |
| numpy/\_core/umath.py                                       |        5 |        5 |      0% |
| numpy/\_distributor\_init.py                                |        4 |        4 |      0% |
| numpy/\_expired\_attrs\_2\_0.py                             |        1 |        1 |      0% |
| numpy/\_globals.py                                          |       34 |       22 |     35% |
| numpy/\_pyinstaller/\_\_init\_\_.py                         |        0 |        0 |    100% |
| numpy/\_pyinstaller/hook-numpy.py                           |        8 |        8 |      0% |
| numpy/\_pyinstaller/tests/\_\_init\_\_.py                   |        6 |        2 |     67% |
| numpy/\_pyinstaller/tests/pyinstaller-smoke.py              |       15 |       15 |      0% |
| numpy/\_pyinstaller/tests/test\_pyinstaller.py              |       17 |       17 |      0% |
| numpy/\_pytesttester.py                                     |       43 |       41 |      5% |
| numpy/\_typing/\_\_init\_\_.py                              |        8 |        8 |      0% |
| numpy/\_typing/\_add\_docstring.py                          |       32 |        0 |    100% |
| numpy/\_typing/\_array\_like.py                             |       34 |       32 |      6% |
| numpy/\_typing/\_char\_codes.py                             |       49 |       49 |      0% |
| numpy/\_typing/\_dtype\_like.py                             |       32 |       31 |      3% |
| numpy/\_typing/\_nbit.py                                    |       12 |       12 |      0% |
| numpy/\_typing/\_nbit\_base.py                              |       34 |       34 |      0% |
| numpy/\_typing/\_nested\_sequence.py                        |       20 |       20 |      0% |
| numpy/\_typing/\_scalars.py                                 |       12 |       12 |      0% |
| numpy/\_typing/\_shape.py                                   |        5 |        5 |      0% |
| numpy/\_utils/\_\_init\_\_.py                               |       34 |       26 |     24% |
| numpy/\_utils/\_conversions.py                              |        9 |        3 |     67% |
| numpy/\_utils/\_inspect.py                                  |       67 |       47 |     30% |
| numpy/\_utils/\_pep440.py                                   |      198 |       97 |     51% |
| numpy/char/\_\_init\_\_.py                                  |       13 |        0 |    100% |
| numpy/conftest.py                                           |      108 |       35 |     68% |
| numpy/core/\_\_init\_\_.py                                  |       10 |        0 |    100% |
| numpy/core/\_dtype.py                                       |        8 |        8 |      0% |
| numpy/core/\_dtype\_ctypes.py                               |        8 |        8 |      0% |
| numpy/core/\_internal.py                                    |       13 |        7 |     46% |
| numpy/core/\_multiarray\_umath.py                           |       28 |       20 |     29% |
| numpy/core/\_utils.py                                       |        8 |        0 |    100% |
| numpy/core/arrayprint.py                                    |        8 |        0 |    100% |
| numpy/core/defchararray.py                                  |        8 |        0 |    100% |
| numpy/core/einsumfunc.py                                    |        8 |        0 |    100% |
| numpy/core/fromnumeric.py                                   |        8 |        0 |    100% |
| numpy/core/function\_base.py                                |        8 |        0 |    100% |
| numpy/core/getlimits.py                                     |        8 |        0 |    100% |
| numpy/core/multiarray.py                                    |       13 |        0 |    100% |
| numpy/core/numeric.py                                       |        9 |        0 |    100% |
| numpy/core/numerictypes.py                                  |        8 |        0 |    100% |
| numpy/core/overrides.py                                     |        8 |        0 |    100% |
| numpy/core/records.py                                       |        8 |        0 |    100% |
| numpy/core/shape\_base.py                                   |        8 |        0 |    100% |
| numpy/core/umath.py                                         |        8 |        0 |    100% |
| numpy/ctypeslib/\_\_init\_\_.py                             |        1 |        0 |    100% |
| numpy/ctypeslib/\_ctypeslib.py                              |      232 |       34 |     85% |
| numpy/dtypes.py                                             |       12 |       10 |     17% |
| numpy/exceptions.py                                         |       35 |       21 |     40% |
| numpy/f2py/\_\_init\_\_.py                                  |       19 |        0 |    100% |
| numpy/f2py/\_\_main\_\_.py                                  |        2 |        2 |      0% |
| numpy/f2py/\_\_version\_\_.py                               |        1 |        0 |    100% |
| numpy/f2py/\_backends/\_\_init\_\_.py                       |        5 |        1 |     80% |
| numpy/f2py/\_backends/\_backend.py                          |       22 |        1 |     95% |
| numpy/f2py/\_backends/\_meson.py                            |      133 |       11 |     92% |
| numpy/f2py/\_isocbind.py                                    |        7 |        0 |    100% |
| numpy/f2py/\_isofenv.py                                     |        5 |        0 |    100% |
| numpy/f2py/\_src\_pyf.py                                    |      148 |       28 |     81% |
| numpy/f2py/auxfuncs.py                                      |      632 |      142 |     78% |
| numpy/f2py/capi\_maps.py                                    |      500 |      256 |     49% |
| numpy/f2py/cb\_rules.py                                     |      106 |       97 |      8% |
| numpy/f2py/cfuncs.py                                        |      241 |       39 |     84% |
| numpy/f2py/common\_rules.py                                 |      114 |       80 |     30% |
| numpy/f2py/crackfortran.py                                  |     2584 |      975 |     62% |
| numpy/f2py/diagnose.py                                      |       46 |       41 |     11% |
| numpy/f2py/f2py2e.py                                        |      430 |       65 |     85% |
| numpy/f2py/f90mod\_rules.py                                 |      183 |       69 |     62% |
| numpy/f2py/func2subr.py                                     |      270 |      141 |     48% |
| numpy/f2py/rules.py                                         |      275 |       36 |     87% |
| numpy/f2py/symbolic.py                                      |     1006 |      131 |     87% |
| numpy/f2py/tests/\_\_init\_\_.py                            |        6 |        2 |     67% |
| numpy/f2py/tests/test\_abstract\_interface.py               |       17 |        0 |    100% |
| numpy/f2py/tests/test\_array\_from\_pyobj.py                |      482 |       46 |     90% |
| numpy/f2py/tests/test\_assumed\_shape.py                    |       31 |        0 |    100% |
| numpy/f2py/tests/test\_block\_docstring.py                  |       10 |        0 |    100% |
| numpy/f2py/tests/test\_callback.py                          |      161 |       10 |     94% |
| numpy/f2py/tests/test\_capi\_maps.py                        |        6 |        0 |    100% |
| numpy/f2py/tests/test\_character.py                         |      270 |       13 |     95% |
| numpy/f2py/tests/test\_common.py                            |       16 |        0 |    100% |
| numpy/f2py/tests/test\_crackfortran.py                      |      272 |        2 |     99% |
| numpy/f2py/tests/test\_data.py                              |       55 |        0 |    100% |
| numpy/f2py/tests/test\_docs.py                              |       40 |        3 |     92% |
| numpy/f2py/tests/test\_f2cmap.py                            |       11 |        0 |    100% |
| numpy/f2py/tests/test\_f2py2e.py                            |      508 |       75 |     85% |
| numpy/f2py/tests/test\_inplace.py                           |       38 |        0 |    100% |
| numpy/f2py/tests/test\_isoc.py                              |       44 |        0 |    100% |
| numpy/f2py/tests/test\_isof.py                              |       41 |        0 |    100% |
| numpy/f2py/tests/test\_kind.py                              |       23 |        0 |    100% |
| numpy/f2py/tests/test\_mixed.py                             |       13 |        0 |    100% |
| numpy/f2py/tests/test\_modules.py                           |       51 |        0 |    100% |
| numpy/f2py/tests/test\_parameter.py                         |       72 |        0 |    100% |
| numpy/f2py/tests/test\_pyf\_src.py                          |       11 |        0 |    100% |
| numpy/f2py/tests/test\_quoted\_character.py                 |        8 |        0 |    100% |
| numpy/f2py/tests/test\_regression.py                        |      186 |        2 |     99% |
| numpy/f2py/tests/test\_return\_character.py                 |       34 |        1 |     97% |
| numpy/f2py/tests/test\_return\_complex.py                   |       47 |        1 |     98% |
| numpy/f2py/tests/test\_return\_integer.py                   |       36 |        0 |    100% |
| numpy/f2py/tests/test\_return\_logical.py                   |       54 |        0 |    100% |
| numpy/f2py/tests/test\_return\_real.py                      |       55 |        2 |     96% |
| numpy/f2py/tests/test\_routines.py                          |       16 |        0 |    100% |
| numpy/f2py/tests/test\_semicolon\_split.py                  |       22 |        2 |     91% |
| numpy/f2py/tests/test\_size.py                              |       27 |        0 |    100% |
| numpy/f2py/tests/test\_string.py                            |       76 |        0 |    100% |
| numpy/f2py/tests/test\_symbolic.py                          |      358 |        1 |     99% |
| numpy/f2py/tests/test\_usercode.py                          |        7 |        0 |    100% |
| numpy/f2py/tests/test\_value\_attrspec.py                   |       10 |        0 |    100% |
| numpy/f2py/tests/util.py                                    |      228 |       35 |     85% |
| numpy/f2py/use\_rules.py                                    |       41 |       35 |     15% |
| numpy/fft/\_\_init\_\_.py                                   |        8 |        0 |    100% |
| numpy/fft/\_helper.py                                       |       46 |        2 |     96% |
| numpy/fft/\_pocketfft.py                                    |      154 |        4 |     97% |
| numpy/fft/tests/\_\_init\_\_.py                             |        0 |        0 |    100% |
| numpy/fft/tests/test\_helper.py                             |      103 |        0 |    100% |
| numpy/fft/tests/test\_pocketfft.py                          |      416 |        1 |     99% |
| numpy/lib/\_\_init\_\_.py                                   |       19 |       14 |     26% |
| numpy/lib/\_array\_utils\_impl.py                           |       20 |        6 |     70% |
| numpy/lib/\_arraypad\_impl.py                               |      257 |       23 |     91% |
| numpy/lib/\_arraysetops\_impl.py                            |      288 |       58 |     80% |
| numpy/lib/\_arrayterator\_impl.py                           |       73 |       22 |     70% |
| numpy/lib/\_datasource.py                                   |      177 |       62 |     65% |
| numpy/lib/\_format\_impl.py                                 |      308 |       98 |     68% |
| numpy/lib/\_function\_base\_impl.py                         |     1322 |      204 |     85% |
| numpy/lib/\_histograms\_impl.py                             |      277 |       39 |     86% |
| numpy/lib/\_index\_tricks\_impl.py                          |      260 |      100 |     62% |
| numpy/lib/\_iotools.py                                      |      350 |       84 |     76% |
| numpy/lib/\_nanfunctions\_impl.py                           |      346 |       76 |     78% |
| numpy/lib/\_npyio\_impl.py                                  |      772 |      129 |     83% |
| numpy/lib/\_polynomial\_impl.py                             |      434 |      147 |     66% |
| numpy/lib/\_scimath\_impl.py                                |       79 |       79 |      0% |
| numpy/lib/\_shape\_base\_impl.py                            |      233 |       63 |     73% |
| numpy/lib/\_stride\_tricks\_impl.py                         |      102 |       24 |     76% |
| numpy/lib/\_twodim\_base\_impl.py                           |      196 |       66 |     66% |
| numpy/lib/\_type\_check\_impl.py                            |      129 |       43 |     67% |
| numpy/lib/\_ufunclike\_impl.py                              |       28 |       11 |     61% |
| numpy/lib/\_user\_array\_impl.py                            |      169 |      101 |     40% |
| numpy/lib/\_utils\_impl.py                                  |      230 |      157 |     32% |
| numpy/lib/\_version.py                                      |       76 |       23 |     70% |
| numpy/lib/array\_utils.py                                   |        1 |        1 |      0% |
| numpy/lib/format.py                                         |        1 |        1 |      0% |
| numpy/lib/introspect.py                                     |       20 |       20 |      0% |
| numpy/lib/mixins.py                                         |       60 |       48 |     20% |
| numpy/lib/npyio.py                                          |        1 |        1 |      0% |
| numpy/lib/recfunctions.py                                   |      597 |       41 |     93% |
| numpy/lib/scimath.py                                        |        1 |        1 |      0% |
| numpy/lib/stride\_tricks.py                                 |        1 |        1 |      0% |
| numpy/lib/tests/\_\_init\_\_.py                             |        0 |        0 |    100% |
| numpy/lib/tests/test\_\_datasource.py                       |      260 |        6 |     98% |
| numpy/lib/tests/test\_\_iotools.py                          |      219 |        0 |    100% |
| numpy/lib/tests/test\_\_version.py                          |       39 |        0 |    100% |
| numpy/lib/tests/test\_array\_utils.py                       |       23 |        0 |    100% |
| numpy/lib/tests/test\_arraypad.py                           |      576 |        0 |    100% |
| numpy/lib/tests/test\_arraysetops.py                        |      755 |        0 |    100% |
| numpy/lib/tests/test\_arrayterator.py                       |       27 |        1 |     96% |
| numpy/lib/tests/test\_format.py                             |      372 |       16 |     96% |
| numpy/lib/tests/test\_function\_base.py                     |     3323 |       27 |     99% |
| numpy/lib/tests/test\_histograms.py                         |      499 |        6 |     99% |
| numpy/lib/tests/test\_index\_tricks.py                      |      386 |        0 |    100% |
| numpy/lib/tests/test\_io.py                                 |     1836 |       31 |     98% |
| numpy/lib/tests/test\_loadtxt.py                            |      573 |        1 |     99% |
| numpy/lib/tests/test\_mixins.py                             |      123 |        0 |    100% |
| numpy/lib/tests/test\_nanfunctions.py                       |      980 |        0 |    100% |
| numpy/lib/tests/test\_packbits.py                           |      166 |        0 |    100% |
| numpy/lib/tests/test\_polynomial.py                         |      216 |        0 |    100% |
| numpy/lib/tests/test\_recfunctions.py                       |      555 |        0 |    100% |
| numpy/lib/tests/test\_regression.py                         |      133 |        4 |     97% |
| numpy/lib/tests/test\_shape\_base.py                        |      530 |        4 |     99% |
| numpy/lib/tests/test\_stride\_tricks.py                     |      397 |       11 |     97% |
| numpy/lib/tests/test\_twodim\_base.py                       |      291 |        0 |    100% |
| numpy/lib/tests/test\_type\_check.py                        |      346 |        0 |    100% |
| numpy/lib/tests/test\_ufunclike.py                          |       95 |        0 |    100% |
| numpy/lib/tests/test\_utils.py                              |       46 |        1 |     98% |
| numpy/lib/user\_array.py                                    |        1 |        0 |    100% |
| numpy/linalg/\_\_init\_\_.py                                |        6 |        6 |      0% |
| numpy/linalg/\_linalg.py                                    |      713 |      168 |     76% |
| numpy/linalg/tests/\_\_init\_\_.py                          |        0 |        0 |    100% |
| numpy/linalg/tests/test\_deprecations.py                    |       12 |        0 |    100% |
| numpy/linalg/tests/test\_linalg.py                          |     1448 |       61 |     96% |
| numpy/linalg/tests/test\_regression.py                      |      115 |        1 |     99% |
| numpy/ma/\_\_init\_\_.py                                    |        9 |        9 |      0% |
| numpy/ma/core.py                                            |     2488 |      763 |     69% |
| numpy/ma/extras.py                                          |      554 |      164 |     70% |
| numpy/ma/mrecords.py                                        |      331 |       89 |     73% |
| numpy/ma/tests/\_\_init\_\_.py                              |        0 |        0 |    100% |
| numpy/ma/tests/test\_arrayobject.py                         |       23 |        0 |    100% |
| numpy/ma/tests/test\_core.py                                |     4153 |       16 |     99% |
| numpy/ma/tests/test\_deprecations.py                        |       42 |        0 |    100% |
| numpy/ma/tests/test\_extras.py                              |     1443 |        3 |     99% |
| numpy/ma/tests/test\_mrecords.py                            |      342 |       10 |     97% |
| numpy/ma/tests/test\_old\_ma.py                             |      701 |        9 |     99% |
| numpy/ma/tests/test\_regression.py                          |       53 |        0 |    100% |
| numpy/ma/tests/test\_subclassing.py                         |      297 |       10 |     97% |
| numpy/ma/testutils.py                                       |      125 |       28 |     78% |
| numpy/matlib.py                                             |       45 |        4 |     91% |
| numpy/matrixlib/\_\_init\_\_.py                             |        6 |        6 |      0% |
| numpy/matrixlib/defmatrix.py                                |      238 |       72 |     70% |
| numpy/matrixlib/tests/\_\_init\_\_.py                       |        0 |        0 |    100% |
| numpy/matrixlib/tests/test\_defmatrix.py                    |      339 |        4 |     99% |
| numpy/matrixlib/tests/test\_interaction.py                  |      216 |        6 |     97% |
| numpy/matrixlib/tests/test\_masked\_matrix.py               |      169 |        3 |     98% |
| numpy/matrixlib/tests/test\_matrix\_linalg.py               |       37 |        0 |    100% |
| numpy/matrixlib/tests/test\_multiarray.py                   |       12 |        0 |    100% |
| numpy/matrixlib/tests/test\_numeric.py                      |       13 |        0 |    100% |
| numpy/matrixlib/tests/test\_regression.py                   |       21 |        0 |    100% |
| numpy/polynomial/\_\_init\_\_.py                            |       18 |        0 |    100% |
| numpy/polynomial/\_polybase.py                              |      435 |       61 |     86% |
| numpy/polynomial/chebyshev.py                               |      357 |       23 |     94% |
| numpy/polynomial/hermite.py                                 |      269 |        6 |     98% |
| numpy/polynomial/hermite\_e.py                              |      264 |        6 |     98% |
| numpy/polynomial/laguerre.py                                |      254 |        5 |     98% |
| numpy/polynomial/legendre.py                                |      261 |        1 |     99% |
| numpy/polynomial/polynomial.py                              |      237 |        2 |     99% |
| numpy/polynomial/polyutils.py                               |      248 |        2 |     99% |
| numpy/polynomial/tests/\_\_init\_\_.py                      |        0 |        0 |    100% |
| numpy/polynomial/tests/test\_chebyshev.py                   |      454 |        0 |    100% |
| numpy/polynomial/tests/test\_classes.py                     |      451 |        3 |     99% |
| numpy/polynomial/tests/test\_hermite.py                     |      409 |        0 |    100% |
| numpy/polynomial/tests/test\_hermite\_e.py                  |      409 |        0 |    100% |
| numpy/polynomial/tests/test\_laguerre.py                    |      394 |        0 |    100% |
| numpy/polynomial/tests/test\_legendre.py                    |      419 |        0 |    100% |
| numpy/polynomial/tests/test\_polynomial.py                  |      499 |        0 |    100% |
| numpy/polynomial/tests/test\_polyutils.py                   |       84 |        0 |    100% |
| numpy/polynomial/tests/test\_printing.py                    |      259 |        0 |    100% |
| numpy/polynomial/tests/test\_symbol.py                      |      121 |        0 |    100% |
| numpy/random/\_\_init\_\_.py                                |       15 |        1 |     93% |
| numpy/random/\_examples/cffi/extending.py                   |       20 |        0 |    100% |
| numpy/random/\_examples/cffi/parse.py                       |       33 |        0 |    100% |
| numpy/random/\_pickle.py                                    |       23 |        1 |     96% |
| numpy/random/tests/\_\_init\_\_.py                          |        0 |        0 |    100% |
| numpy/random/tests/data/\_\_init\_\_.py                     |        0 |        0 |    100% |
| numpy/random/tests/test\_direct.py                          |      449 |       18 |     96% |
| numpy/random/tests/test\_extending.py                       |       81 |        9 |     89% |
| numpy/random/tests/test\_generator\_mt19937.py              |     1878 |        9 |     99% |
| numpy/random/tests/test\_generator\_mt19937\_regressions.py |      134 |        0 |    100% |
| numpy/random/tests/test\_random.py                          |     1133 |        4 |     99% |
| numpy/random/tests/test\_randomstate.py                     |     1400 |        9 |     99% |
| numpy/random/tests/test\_randomstate\_regression.py         |      141 |        0 |    100% |
| numpy/random/tests/test\_regression.py                      |      100 |        2 |     98% |
| numpy/random/tests/test\_seed\_sequence.py                  |       31 |        0 |    100% |
| numpy/random/tests/test\_smoke.py                           |      733 |       10 |     99% |
| numpy/rec/\_\_init\_\_.py                                   |        2 |        0 |    100% |
| numpy/strings/\_\_init\_\_.py                               |        2 |        0 |    100% |
| numpy/testing/\_\_init\_\_.py                               |        9 |        9 |      0% |
| numpy/testing/\_private/\_\_init\_\_.py                     |        0 |        0 |    100% |
| numpy/testing/\_private/extbuild.py                         |       85 |       22 |     74% |
| numpy/testing/\_private/hypothesis\_helpers.py              |       31 |       23 |     26% |
| numpy/testing/\_private/utils.py                            |     1010 |      349 |     65% |
| numpy/testing/overrides.py                                  |       13 |       11 |     15% |
| numpy/testing/print\_coercion\_tables.py                    |      146 |      134 |      8% |
| numpy/testing/tests/\_\_init\_\_.py                         |        0 |        0 |    100% |
| numpy/testing/tests/test\_utils.py                          |     1279 |       12 |     99% |
| numpy/tests/\_\_init\_\_.py                                 |        0 |        0 |    100% |
| numpy/tests/test\_\_all\_\_.py                              |        5 |        0 |    100% |
| numpy/tests/test\_configtool.py                             |       35 |       12 |     66% |
| numpy/tests/test\_ctypeslib.py                              |      236 |       14 |     94% |
| numpy/tests/test\_lazyloading.py                            |        9 |        0 |    100% |
| numpy/tests/test\_matlib.py                                 |       36 |        0 |    100% |
| numpy/tests/test\_numpy\_config.py                          |       21 |        0 |    100% |
| numpy/tests/test\_numpy\_version.py                         |       16 |        1 |     94% |
| numpy/tests/test\_public\_api.py                            |      246 |       33 |     87% |
| numpy/tests/test\_reloading.py                              |       35 |        0 |    100% |
| numpy/tests/test\_scripts.py                                |       26 |        4 |     85% |
| numpy/tests/test\_warnings.py                               |       51 |        4 |     92% |
| numpy/typing/\_\_init\_\_.py                                |       22 |        4 |     82% |
| numpy/typing/tests/\_\_init\_\_.py                          |        0 |        0 |    100% |
| numpy/typing/tests/test\_isfile.py                          |       12 |        0 |    100% |
| numpy/typing/tests/test\_runtime.py                         |       51 |        0 |    100% |
| numpy/typing/tests/test\_typing.py                          |      117 |       63 |     46% |
| numpy/version.py                                            |        6 |        6 |      0% |
| **TOTAL**                                                   | **106652** | **10098** | **91%** |
```

</p>
</details> 

<details><summary>After</summary>
<p>

```md
| Name                                           |    Stmts |     Miss |   Branch |   BrPart |   Cover |
|----------------------------------------------- | -------: | -------: | -------: | -------: | ------: |
| numpy/\_\_config\_\_.py                        |       32 |       20 |        6 |        0 |     42% |
| numpy/\_\_init\_\_.py                          |      191 |       54 |       66 |       17 |     68% |
| numpy/\_array\_api\_info.py                    |       39 |        9 |       24 |        0 |     86% |
| numpy/\_configtool.py                          |       20 |       20 |        8 |        0 |      0% |
| numpy/\_core/\_\_init\_\_.py                   |       88 |       82 |       18 |        0 |      8% |
| numpy/\_core/\_add\_newdocs.py                 |      235 |      235 |        4 |        0 |      0% |
| numpy/\_core/\_add\_newdocs\_scalars.py        |       68 |       68 |       12 |        0 |      0% |
| numpy/\_core/\_asarray.py                      |       31 |        9 |       16 |        1 |     79% |
| numpy/\_core/\_dtype.py                        |      174 |       23 |       96 |        2 |     91% |
| numpy/\_core/\_dtype\_ctypes.py                |       54 |        7 |       26 |        1 |     90% |
| numpy/\_core/\_exceptions.py                   |       84 |       34 |       12 |        0 |     65% |
| numpy/\_core/\_internal.py                     |      461 |      146 |      192 |       22 |     72% |
| numpy/\_core/\_methods.py                      |      142 |       36 |       72 |        1 |     82% |
| numpy/\_core/\_string\_helpers.py              |       15 |       15 |        2 |        0 |      0% |
| numpy/\_core/\_type\_aliases.py                |       51 |       51 |       24 |        0 |      0% |
| numpy/\_core/\_ufunc\_config.py                |       72 |       31 |        8 |        1 |     60% |
| numpy/\_core/arrayprint.py                     |      607 |      129 |      280 |       22 |     83% |
| numpy/\_core/cversions.py                      |        6 |        6 |        2 |        0 |      0% |
| numpy/\_core/defchararray.py                   |      223 |        5 |       50 |        6 |     96% |
| numpy/\_core/einsumfunc.py                     |      491 |       50 |      268 |       16 |     91% |
| numpy/\_core/fromnumeric.py                    |      450 |      156 |      114 |        5 |     71% |
| numpy/\_core/function\_base.py                 |      133 |       42 |       54 |        7 |     70% |
| numpy/\_core/getlimits.py                      |      171 |       68 |       42 |        6 |     62% |
| numpy/\_core/memmap.py                         |      101 |       23 |       38 |        5 |     80% |
| numpy/\_core/multiarray.py                     |      110 |       82 |        6 |        0 |     28% |
| numpy/\_core/numeric.py                        |      477 |      163 |      136 |        9 |     70% |
| numpy/\_core/numerictypes.py                   |      116 |       48 |       42 |        0 |     68% |
| numpy/\_core/overrides.py                      |       58 |       32 |       18 |        2 |     55% |
| numpy/\_core/printoptions.py                   |        5 |        5 |        0 |        0 |      0% |
| numpy/\_core/records.py                        |      359 |      130 |      166 |       33 |     64% |
| numpy/\_core/shape\_base.py                    |      191 |       47 |       74 |        3 |     81% |
| numpy/\_core/strings.py                        |      331 |       11 |       70 |        8 |     95% |
| numpy/\_core/umath.py                          |        5 |        5 |        0 |        0 |      0% |
| numpy/\_distributor\_init.py                   |        4 |        4 |        0 |        0 |      0% |
| numpy/\_expired\_attrs\_2\_0.py                |        1 |        1 |        0 |        0 |      0% |
| numpy/\_globals.py                             |       34 |       22 |       10 |        3 |     34% |
| numpy/\_pyinstaller/\_\_init\_\_.py            |        0 |        0 |        0 |        0 |    100% |
| numpy/\_pyinstaller/hook-numpy.py              |        8 |        8 |        2 |        0 |      0% |
| numpy/\_pytesttester.py                        |       43 |       41 |       16 |        0 |      3% |
| numpy/\_typing/\_\_init\_\_.py                 |        8 |        8 |        0 |        0 |      0% |
| numpy/\_typing/\_add\_docstring.py             |       32 |        0 |        8 |        0 |    100% |
| numpy/\_typing/\_array\_like.py                |       34 |       32 |        0 |        0 |      6% |
| numpy/\_typing/\_char\_codes.py                |       49 |       49 |        0 |        0 |      0% |
| numpy/\_typing/\_dtype\_like.py                |       32 |       31 |        0 |        0 |      3% |
| numpy/\_typing/\_nbit.py                       |       12 |       12 |        0 |        0 |      0% |
| numpy/\_typing/\_nbit\_base.py                 |       34 |       34 |        2 |        0 |      0% |
| numpy/\_typing/\_nested\_sequence.py           |       20 |       20 |        0 |        0 |      0% |
| numpy/\_typing/\_scalars.py                    |       12 |       12 |        0 |        0 |      0% |
| numpy/\_typing/\_shape.py                      |        5 |        5 |        0 |        0 |      0% |
| numpy/\_utils/\_\_init\_\_.py                  |       34 |       26 |       12 |        1 |     24% |
| numpy/\_utils/\_conversions.py                 |        9 |        3 |        4 |        0 |     77% |
| numpy/\_utils/\_inspect.py                     |       67 |       47 |       32 |        5 |     29% |
| numpy/\_utils/\_pep440.py                      |      198 |       97 |       60 |       10 |     43% |
| numpy/char/\_\_init\_\_.py                     |       13 |        0 |        4 |        0 |    100% |
| numpy/core/\_\_init\_\_.py                     |       10 |        0 |        0 |        0 |    100% |
| numpy/core/\_dtype.py                          |        8 |        8 |        2 |        0 |      0% |
| numpy/core/\_dtype\_ctypes.py                  |        8 |        8 |        2 |        0 |      0% |
| numpy/core/\_internal.py                       |       13 |        7 |        2 |        0 |     40% |
| numpy/core/\_multiarray\_umath.py              |       28 |       20 |       12 |        0 |     30% |
| numpy/core/\_utils.py                          |        8 |        0 |        2 |        0 |    100% |
| numpy/core/arrayprint.py                       |        8 |        0 |        2 |        0 |    100% |
| numpy/core/defchararray.py                     |        8 |        0 |        2 |        0 |    100% |
| numpy/core/einsumfunc.py                       |        8 |        0 |        2 |        0 |    100% |
| numpy/core/fromnumeric.py                      |        8 |        0 |        2 |        0 |    100% |
| numpy/core/function\_base.py                   |        8 |        0 |        2 |        0 |    100% |
| numpy/core/getlimits.py                        |        8 |        0 |        2 |        0 |    100% |
| numpy/core/multiarray.py                       |       13 |        0 |        4 |        0 |    100% |
| numpy/core/numeric.py                          |        9 |        0 |        2 |        0 |    100% |
| numpy/core/numerictypes.py                     |        8 |        0 |        2 |        0 |    100% |
| numpy/core/overrides.py                        |        8 |        0 |        2 |        0 |    100% |
| numpy/core/records.py                          |        8 |        0 |        2 |        0 |    100% |
| numpy/core/shape\_base.py                      |        8 |        0 |        2 |        0 |    100% |
| numpy/core/umath.py                            |        8 |        0 |        2 |        0 |    100% |
| numpy/ctypeslib/\_\_init\_\_.py                |        1 |        0 |        0 |        0 |    100% |
| numpy/ctypeslib/\_ctypeslib.py                 |      232 |       34 |       98 |       13 |     85% |
| numpy/dtypes.py                                |       12 |       10 |        2 |        0 |     14% |
| numpy/exceptions.py                            |       35 |       21 |        8 |        1 |     44% |
| numpy/f2py/\_\_init\_\_.py                     |       19 |        0 |        2 |        0 |    100% |
| numpy/f2py/\_\_main\_\_.py                     |        2 |        2 |        0 |        0 |      0% |
| numpy/f2py/\_\_version\_\_.py                  |        1 |        0 |        0 |        0 |    100% |
| numpy/f2py/\_backends/\_\_init\_\_.py          |        5 |        4 |        2 |        0 |     14% |
| numpy/f2py/\_backends/\_backend.py             |       22 |       17 |        0 |        0 |     23% |
| numpy/f2py/\_backends/\_meson.py               |      133 |       60 |       30 |        3 |     49% |
| numpy/f2py/\_isocbind.py                       |        7 |        0 |        4 |        0 |    100% |
| numpy/f2py/\_isofenv.py                        |        5 |        0 |        4 |        0 |    100% |
| numpy/f2py/\_src\_pyf.py                       |      148 |       28 |       52 |        6 |     77% |
| numpy/f2py/auxfuncs.py                         |      632 |      146 |      328 |       51 |     72% |
| numpy/f2py/capi\_maps.py                       |      500 |      256 |      306 |       57 |     45% |
| numpy/f2py/cb\_rules.py                        |      106 |       97 |       74 |        0 |      5% |
| numpy/f2py/cfuncs.py                           |      241 |       39 |       78 |       11 |     76% |
| numpy/f2py/common\_rules.py                    |      114 |       80 |       46 |        5 |     27% |
| numpy/f2py/crackfortran.py                     |     2584 |     1051 |     1620 |      250 |     55% |
| numpy/f2py/diagnose.py                         |       46 |       41 |        6 |        1 |     12% |
| numpy/f2py/f2py2e.py                           |      430 |      152 |      236 |       26 |     65% |
| numpy/f2py/f90mod\_rules.py                    |      183 |       69 |       68 |       19 |     59% |
| numpy/f2py/func2subr.py                        |      270 |      141 |      170 |       31 |     44% |
| numpy/f2py/rules.py                            |      275 |       36 |      146 |       22 |     86% |
| numpy/f2py/symbolic.py                         |     1006 |      562 |      564 |       93 |     39% |
| numpy/f2py/use\_rules.py                       |       41 |       35 |       22 |        0 |     10% |
| numpy/fft/\_\_init\_\_.py                      |        8 |        0 |        0 |        0 |    100% |
| numpy/fft/\_helper.py                          |       46 |        2 |       12 |        2 |     93% |
| numpy/fft/\_pocketfft.py                       |      154 |        4 |       52 |        2 |     97% |
| numpy/lib/\_\_init\_\_.py                      |       19 |       14 |        6 |        3 |     32% |
| numpy/lib/\_array\_utils\_impl.py              |       20 |        6 |        6 |        0 |     77% |
| numpy/lib/\_arraypad\_impl.py                  |      257 |       23 |      112 |        2 |     93% |
| numpy/lib/\_arraysetops\_impl.py               |      288 |       58 |      100 |        1 |     85% |
| numpy/lib/\_arrayterator\_impl.py              |       73 |       22 |       28 |        6 |     72% |
| numpy/lib/\_datasource.py                      |      177 |       62 |       54 |        7 |     66% |
| numpy/lib/\_format\_impl.py                    |      308 |       98 |      110 |       10 |     72% |
| numpy/lib/\_function\_base\_impl.py            |     1322 |      204 |      550 |       34 |     87% |
| numpy/lib/\_histograms\_impl.py                |      277 |       39 |      106 |        5 |     89% |
| numpy/lib/\_index\_tricks\_impl.py             |      260 |      100 |      100 |        7 |     69% |
| numpy/lib/\_iotools.py                         |      350 |       84 |      152 |       13 |     78% |
| numpy/lib/\_nanfunctions\_impl.py              |      346 |       76 |      160 |       15 |     82% |
| numpy/lib/\_npyio\_impl.py                     |      772 |      129 |      406 |       31 |     86% |
| numpy/lib/\_polynomial\_impl.py                |      434 |      147 |      174 |       39 |     69% |
| numpy/lib/\_scimath\_impl.py                   |       79 |       79 |        8 |        0 |      0% |
| numpy/lib/\_shape\_base\_impl.py               |      233 |       63 |       70 |        7 |     77% |
| numpy/lib/\_stride\_tricks\_impl.py            |      102 |       24 |       38 |        1 |     82% |
| numpy/lib/\_twodim\_base\_impl.py              |      196 |       66 |       52 |        6 |     69% |
| numpy/lib/\_type\_check\_impl.py               |      129 |       43 |       30 |        1 |     72% |
| numpy/lib/\_ufunclike\_impl.py                 |       28 |       11 |        0 |        0 |     61% |
| numpy/lib/\_user\_array\_impl.py               |      169 |      101 |       14 |        1 |     38% |
| numpy/lib/\_utils\_impl.py                     |      230 |      157 |      100 |       13 |     34% |
| numpy/lib/\_version.py                         |       76 |       23 |       38 |        5 |     75% |
| numpy/lib/array\_utils.py                      |        1 |        1 |        0 |        0 |      0% |
| numpy/lib/format.py                            |        1 |        1 |        0 |        0 |      0% |
| numpy/lib/introspect.py                        |       20 |       20 |       12 |        0 |      0% |
| numpy/lib/mixins.py                            |       60 |       48 |        4 |        0 |     25% |
| numpy/lib/npyio.py                             |        1 |        1 |        0 |        0 |      0% |
| numpy/lib/recfunctions.py                      |      597 |       41 |      290 |       29 |     92% |
| numpy/lib/scimath.py                           |        1 |        1 |        0 |        0 |      0% |
| numpy/lib/stride\_tricks.py                    |        1 |        1 |        0 |        0 |      0% |
| numpy/lib/user\_array.py                       |        1 |        0 |        0 |        0 |    100% |
| numpy/linalg/\_\_init\_\_.py                   |        6 |        6 |        0 |        0 |      0% |
| numpy/linalg/\_linalg.py                       |      713 |      168 |      234 |       11 |     81% |
| numpy/ma/\_\_init\_\_.py                       |        9 |        9 |        0 |        0 |      0% |
| numpy/ma/core.py                               |     2488 |      763 |      980 |       97 |     74% |
| numpy/ma/extras.py                             |      554 |      164 |      216 |       31 |     73% |
| numpy/ma/mrecords.py                           |      331 |       89 |      108 |       19 |     69% |
| numpy/ma/testutils.py                          |      125 |       28 |       54 |       12 |     73% |
| numpy/matlib.py                                |       45 |        4 |        8 |        4 |     85% |
| numpy/matrixlib/\_\_init\_\_.py                |        6 |        6 |        0 |        0 |      0% |
| numpy/matrixlib/defmatrix.py                   |      238 |       72 |       92 |       13 |     74% |
| numpy/polynomial/\_\_init\_\_.py               |       18 |        0 |        4 |        0 |    100% |
| numpy/polynomial/\_polybase.py                 |      435 |       61 |      120 |       19 |     86% |
| numpy/polynomial/chebyshev.py                  |      357 |       23 |      112 |        9 |     93% |
| numpy/polynomial/hermite.py                    |      269 |        6 |       86 |        6 |     97% |
| numpy/polynomial/hermite\_e.py                 |      264 |        6 |       86 |        6 |     97% |
| numpy/polynomial/laguerre.py                   |      254 |        5 |       80 |        5 |     97% |
| numpy/polynomial/legendre.py                   |      261 |        1 |       84 |        1 |     99% |
| numpy/polynomial/polynomial.py                 |      237 |        2 |       86 |        2 |     99% |
| numpy/polynomial/polyutils.py                  |      248 |        2 |      120 |        4 |     98% |
| numpy/random/\_\_init\_\_.py                   |       15 |        1 |        0 |        0 |     93% |
| numpy/random/\_examples/cffi/extending.py      |       20 |        0 |        2 |        0 |    100% |
| numpy/random/\_examples/cffi/parse.py          |       33 |        0 |       18 |        0 |    100% |
| numpy/random/\_pickle.py                       |       23 |        1 |        8 |        1 |     94% |
| numpy/rec/\_\_init\_\_.py                      |        2 |        0 |        0 |        0 |    100% |
| numpy/strings/\_\_init\_\_.py                  |        2 |        0 |        0 |        0 |    100% |
| numpy/testing/\_\_init\_\_.py                  |        9 |        9 |        0 |        0 |      0% |
| numpy/testing/\_private/\_\_init\_\_.py        |        0 |        0 |        0 |        0 |    100% |
| numpy/testing/\_private/extbuild.py            |       85 |       22 |       16 |        7 |     71% |
| numpy/testing/\_private/hypothesis\_helpers.py |       31 |       23 |        0 |        0 |     26% |
| numpy/testing/\_private/utils.py               |     1010 |      374 |      372 |       44 |     65% |
| numpy/testing/overrides.py                     |       13 |       11 |        0 |        0 |     15% |
| numpy/testing/print\_coercion\_tables.py       |      146 |      134 |       54 |        1 |      6% |
| numpy/typing/\_\_init\_\_.py                   |       22 |        4 |        6 |        3 |     75% |
| numpy/version.py                               |        6 |        6 |        0 |        0 |      0% |
| **TOTAL**                                      | **28786** | **8967** | **11740** | **1310** | **70%** |
```


</p>
</details> 

### Note
Post this, I'm planning on opening a tracking issue to improve code coverage that can be used in NumPy sprints and hopefully will attract out the AI generated pull requests and IMHO, adding UT would be a good use of AI without too much maintainer review burden. 

#### AI Disclosure
No AI tools used
