### PR TITLE
TYP: ``{zeros,ones,empty,full}_like`` improved shape-typing

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -497,21 +497,65 @@ def zeros(
     like: _SupportsArrayFunc | None = None,
 ) -> NDArray[Incomplete]: ...
 
-#
-@overload
+# keep in sync with `zeros_like` in core/numeric.pyi
+@overload  # known array, subok=True
 def empty_like[ArrayT: np.ndarray](
-    prototype: ArrayT,
+    a: ArrayT,
+    /,
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    subok: L[True] = True,
+    shape: None = None,
+    *,
+    device: L["cpu"] | None = None,
+) -> ArrayT: ...
+@overload  # known array, subok=False (default)
+def empty_like[ShapeT: _Shape, DTypeT: np.dtype](
+    a: np.ndarray[ShapeT, DTypeT],
+    /,
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    *,
+    subok: L[False],
+    shape: None = None,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # known array, dtype=<known>
+def empty_like[ShapeT: _Shape, ScalarT: np.generic](
+    a: np.ndarray[ShapeT],
+    /,
+    dtype: _DTypeLike[ScalarT],
+    order: _OrderKACF = "K",
+    subok: bool = True,
+    shape: None = None,
+    *,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+@overload  # known array, dtype=<unknown>
+def empty_like[ShapeT: _Shape](
+    a: np.ndarray[ShapeT],
+    /,
+    dtype: DTypeLike,
+    order: _OrderKACF = "K",
+    subok: bool = True,
+    shape: None = None,
+    *,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, np.dtype[Any]]: ...
+@overload  # known array-like, shape=<known>
+def empty_like[ShapeT: _Shape, ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
     /,
     dtype: None = None,
     order: _OrderKACF = "K",
     subok: bool = True,
-    shape: _ShapeLike | None = None,
     *,
+    shape: ShapeT,
     device: L["cpu"] | None = None,
-) -> ArrayT: ...
-@overload
+) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+@overload  # known array-like
 def empty_like[ScalarT: np.generic](
-    prototype: _ArrayLike[ScalarT],
+    a: _ArrayLike[ScalarT],
     /,
     dtype: None = None,
     order: _OrderKACF = "K",
@@ -520,9 +564,9 @@ def empty_like[ScalarT: np.generic](
     *,
     device: L["cpu"] | None = None,
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # unknown, dtype=<known>
 def empty_like[ScalarT: np.generic](
-    prototype: Incomplete,
+    a: object,
     /,
     dtype: _DTypeLike[ScalarT],
     order: _OrderKACF = "K",
@@ -531,9 +575,9 @@ def empty_like[ScalarT: np.generic](
     *,
     device: L["cpu"] | None = None,
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # fallback
 def empty_like(
-    prototype: Incomplete,
+    a: object,
     /,
     dtype: DTypeLike | None = None,
     order: _OrderKACF = "K",
@@ -541,7 +585,7 @@ def empty_like(
     shape: _ShapeLike | None = None,
     *,
     device: L["cpu"] | None = None,
-) -> NDArray[Incomplete]: ...
+) -> NDArray[Any]: ...
 
 #
 @overload  # ndarray, subok=True

--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -498,7 +498,7 @@ def zeros(
 ) -> NDArray[Incomplete]: ...
 
 # keep in sync with `zeros_like` in core/numeric.pyi
-@overload  # known array, subok=True
+@overload  # known array, subok=True (default)
 def empty_like[ArrayT: np.ndarray](
     a: ArrayT,
     /,
@@ -509,7 +509,7 @@ def empty_like[ArrayT: np.ndarray](
     *,
     device: L["cpu"] | None = None,
 ) -> ArrayT: ...
-@overload  # known array, subok=False (default)
+@overload  # known array, subok=False
 def empty_like[ShapeT: _Shape, DTypeT: np.dtype](
     a: np.ndarray[ShapeT, DTypeT],
     /,

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -665,8 +665,8 @@ type _DTypeLikeComplex128 = type[complex] | _Complex128Codes
 
 ###
 
-# keep in sync with `ones_like`
-@overload
+# keep in sync with `ones_like` and empty_like in `core/multiarray.pyi`
+@overload  # known array, subok=True
 def zeros_like[ArrayT: np.ndarray](
     a: ArrayT,
     dtype: None = None,
@@ -676,7 +676,47 @@ def zeros_like[ArrayT: np.ndarray](
     *,
     device: L["cpu"] | None = None,
 ) -> ArrayT: ...
-@overload
+@overload  # known array, subok=False (default)
+def zeros_like[ShapeT: _Shape, DTypeT: np.dtype](
+    a: np.ndarray[ShapeT, DTypeT],
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    *,
+    subok: L[False],
+    shape: None = None,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # known array, dtype=<known>
+def zeros_like[ShapeT: _Shape, ScalarT: np.generic](
+    a: np.ndarray[ShapeT],
+    dtype: _DTypeLike[ScalarT],
+    order: _OrderKACF = "K",
+    subok: py_bool = True,
+    shape: None = None,
+    *,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+@overload  # known array, dtype=<unknown>
+def zeros_like[ShapeT: _Shape](
+    a: np.ndarray[ShapeT],
+    dtype: DTypeLike,
+    order: _OrderKACF = "K",
+    subok: py_bool = True,
+    shape: None = None,
+    *,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, np.dtype[Any]]: ...
+@overload  # known array-like, shape=<known>
+def zeros_like[ShapeT: _Shape, ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    subok: py_bool = True,
+    *,
+    shape: ShapeT,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+@overload  # known array-like
 def zeros_like[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
     dtype: None = None,
@@ -686,7 +726,7 @@ def zeros_like[ScalarT: np.generic](
     *,
     device: L["cpu"] | None = None,
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # unknown, dtype=<known>
 def zeros_like[ScalarT: np.generic](
     a: object,
     dtype: _DTypeLike[ScalarT],
@@ -696,7 +736,7 @@ def zeros_like[ScalarT: np.generic](
     *,
     device: L["cpu"] | None = None,
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # fallback
 def zeros_like(
     a: object,
     dtype: DTypeLike | None = None,
@@ -818,7 +858,7 @@ def ones(
 ) -> NDArray[Incomplete]: ...
 
 # keep in sync with `zeros_like`
-@overload
+@overload  # known array, subok=True
 def ones_like[ArrayT: np.ndarray](
     a: ArrayT,
     dtype: None = None,
@@ -828,7 +868,47 @@ def ones_like[ArrayT: np.ndarray](
     *,
     device: L["cpu"] | None = None,
 ) -> ArrayT: ...
-@overload
+@overload  # known array, subok=False (default)
+def ones_like[ShapeT: _Shape, DTypeT: np.dtype](
+    a: np.ndarray[ShapeT, DTypeT],
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    *,
+    subok: L[False],
+    shape: None = None,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # known array, dtype=<known>
+def ones_like[ShapeT: _Shape, ScalarT: np.generic](
+    a: np.ndarray[ShapeT],
+    dtype: _DTypeLike[ScalarT],
+    order: _OrderKACF = "K",
+    subok: py_bool = True,
+    shape: None = None,
+    *,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+@overload  # known array, dtype=<unknown>
+def ones_like[ShapeT: _Shape](
+    a: np.ndarray[ShapeT],
+    dtype: DTypeLike,
+    order: _OrderKACF = "K",
+    subok: py_bool = True,
+    shape: None = None,
+    *,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, np.dtype[Any]]: ...
+@overload  # known array-like, shape=<known>
+def ones_like[ShapeT: _Shape, ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    subok: py_bool = True,
+    *,
+    shape: ShapeT,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+@overload  # known array-like
 def ones_like[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
     dtype: None = None,
@@ -838,7 +918,7 @@ def ones_like[ScalarT: np.generic](
     *,
     device: L["cpu"] | None = None,
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # unknown, dtype=<known>
 def ones_like[ScalarT: np.generic](
     a: object,
     dtype: _DTypeLike[ScalarT],
@@ -848,7 +928,7 @@ def ones_like[ScalarT: np.generic](
     *,
     device: L["cpu"] | None = None,
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # fallback
 def ones_like(
     a: object,
     dtype: DTypeLike | None = None,
@@ -984,7 +1064,8 @@ def full(
     like: _SupportsArrayFunc | None = None,
 ) -> NDArray[Any]: ...
 
-@overload
+# keep in sync with `zeros_like` and `ones_like` (modulo `fill_value`)
+@overload  # known array, subok=True
 def full_like[ArrayT: np.ndarray](
     a: ArrayT,
     fill_value: object,
@@ -995,7 +1076,51 @@ def full_like[ArrayT: np.ndarray](
     *,
     device: L["cpu"] | None = None,
 ) -> ArrayT: ...
-@overload
+@overload  # known array, subok=False (default)
+def full_like[ShapeT: _Shape, DTypeT: np.dtype](
+    a: np.ndarray[ShapeT, DTypeT],
+    fill_value: object,
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    *,
+    subok: L[False],
+    shape: None = None,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # known array, dtype=<known>
+def full_like[ShapeT: _Shape, ScalarT: np.generic](
+    a: np.ndarray[ShapeT],
+    fill_value: object,
+    dtype: _DTypeLike[ScalarT],
+    order: _OrderKACF = "K",
+    subok: py_bool = True,
+    shape: None = None,
+    *,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+@overload  # known array, dtype=<unknown>
+def full_like[ShapeT: _Shape](
+    a: np.ndarray[ShapeT],
+    fill_value: object,
+    dtype: DTypeLike,
+    order: _OrderKACF = "K",
+    subok: py_bool = True,
+    shape: None = None,
+    *,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, np.dtype[Any]]: ...
+@overload  # known array-like, shape=<known>
+def full_like[ShapeT: _Shape, ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    fill_value: object,
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    subok: py_bool = True,
+    *,
+    shape: ShapeT,
+    device: L["cpu"] | None = None,
+) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+@overload  # known array-like
 def full_like[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
     fill_value: object,
@@ -1006,7 +1131,7 @@ def full_like[ScalarT: np.generic](
     *,
     device: L["cpu"] | None = None,
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # unknown, dtype=<known>
 def full_like[ScalarT: np.generic](
     a: object,
     fill_value: object,
@@ -1017,7 +1142,7 @@ def full_like[ScalarT: np.generic](
     *,
     device: L["cpu"] | None = None,
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # fallback
 def full_like(
     a: object,
     fill_value: object,

--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -666,7 +666,7 @@ type _DTypeLikeComplex128 = type[complex] | _Complex128Codes
 ###
 
 # keep in sync with `ones_like` and empty_like in `core/multiarray.pyi`
-@overload  # known array, subok=True
+@overload  # known array, subok=True (default)
 def zeros_like[ArrayT: np.ndarray](
     a: ArrayT,
     dtype: None = None,
@@ -676,7 +676,7 @@ def zeros_like[ArrayT: np.ndarray](
     *,
     device: L["cpu"] | None = None,
 ) -> ArrayT: ...
-@overload  # known array, subok=False (default)
+@overload  # known array, subok=False
 def zeros_like[ShapeT: _Shape, DTypeT: np.dtype](
     a: np.ndarray[ShapeT, DTypeT],
     dtype: None = None,
@@ -858,7 +858,7 @@ def ones(
 ) -> NDArray[Incomplete]: ...
 
 # keep in sync with `zeros_like`
-@overload  # known array, subok=True
+@overload  # known array, subok=True (default)
 def ones_like[ArrayT: np.ndarray](
     a: ArrayT,
     dtype: None = None,
@@ -868,7 +868,7 @@ def ones_like[ArrayT: np.ndarray](
     *,
     device: L["cpu"] | None = None,
 ) -> ArrayT: ...
-@overload  # known array, subok=False (default)
+@overload  # known array, subok=False
 def ones_like[ShapeT: _Shape, DTypeT: np.dtype](
     a: np.ndarray[ShapeT, DTypeT],
     dtype: None = None,
@@ -1065,7 +1065,7 @@ def full(
 ) -> NDArray[Any]: ...
 
 # keep in sync with `zeros_like` and `ones_like` (modulo `fill_value`)
-@overload  # known array, subok=True
+@overload  # known array, subok=True (default)
 def full_like[ArrayT: np.ndarray](
     a: ArrayT,
     fill_value: object,
@@ -1076,7 +1076,7 @@ def full_like[ArrayT: np.ndarray](
     *,
     device: L["cpu"] | None = None,
 ) -> ArrayT: ...
-@overload  # known array, subok=False (default)
+@overload  # known array, subok=False
 def full_like[ShapeT: _Shape, DTypeT: np.dtype](
     a: np.ndarray[ShapeT, DTypeT],
     fill_value: object,

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -41,12 +41,6 @@ mixed_shape: tuple[int, np.int64]
 
 def func(i: int, j: int, **kwargs: Any) -> SubClass[np.float64]: ...
 
-assert_type(np.empty_like(A), npt.NDArray[np.float64])
-assert_type(np.empty_like(B), SubClass[np.float64])
-assert_type(np.empty_like([1, 1.0]), npt.NDArray[Any])
-assert_type(np.empty_like(A, dtype=np.int64), npt.NDArray[np.int64])
-assert_type(np.empty_like(A, dtype="c16"), npt.NDArray[Any])
-
 assert_type(np.array(_py_b_1d), _Array1D[np.bool])
 assert_type(np.array(_py_b_2d), _Array2D[np.bool])
 assert_type(np.array(_py_i_1d), _Array1D[np.int_])
@@ -222,18 +216,44 @@ assert_type(np.zeros_like(C), npt.NDArray[Any])
 assert_type(np.zeros_like(A, dtype=float), npt.NDArray[Any])
 assert_type(np.zeros_like(B), SubClass[np.float64])
 assert_type(np.zeros_like(B, dtype=np.int64), npt.NDArray[np.int64])
+assert_type(np.zeros_like(_f32_1d), _Array1D[np.float32])
+assert_type(np.zeros_like(_f32_1d, dtype=np.int64), _Array1D[np.int64])
+assert_type(np.zeros_like(_f32_1d, dtype=int), _Array1D[Any])
+assert_type(np.zeros_like(_f32_1d, shape=_shape_2d), _Array2D[np.float32])
+assert_type(np.zeros_like(_f32_1d, shape=_shape_like), npt.NDArray[np.float32])
 
 assert_type(np.ones_like(A), npt.NDArray[np.float64])
 assert_type(np.ones_like(C), npt.NDArray[Any])
 assert_type(np.ones_like(A, dtype=float), npt.NDArray[Any])
 assert_type(np.ones_like(B), SubClass[np.float64])
 assert_type(np.ones_like(B, dtype=np.int64), npt.NDArray[np.int64])
+assert_type(np.ones_like(_f32_1d), _Array1D[np.float32])
+assert_type(np.ones_like(_f32_1d, dtype=np.int64), _Array1D[np.int64])
+assert_type(np.ones_like(_f32_1d, dtype=int), _Array1D[Any])
+assert_type(np.ones_like(_f32_1d, shape=_shape_2d), _Array2D[np.float32])
+assert_type(np.ones_like(_f32_1d, shape=_shape_like), npt.NDArray[np.float32])
+
+assert_type(np.empty_like(A), npt.NDArray[np.float64])
+assert_type(np.empty_like(C), npt.NDArray[Any])
+assert_type(np.empty_like(A, dtype=float), npt.NDArray[Any])
+assert_type(np.empty_like(B), SubClass[np.float64])
+assert_type(np.empty_like(B, dtype=np.int64), npt.NDArray[np.int64])
+assert_type(np.empty_like(_f32_1d), _Array1D[np.float32])
+assert_type(np.empty_like(_f32_1d, dtype=np.int64), _Array1D[np.int64])
+assert_type(np.empty_like(_f32_1d, dtype=int), _Array1D[Any])
+assert_type(np.empty_like(_f32_1d, shape=_shape_2d), _Array2D[np.float32])
+assert_type(np.empty_like(_f32_1d, shape=_shape_like), npt.NDArray[np.float32])
 
 assert_type(np.full_like(A, i8), npt.NDArray[np.float64])
 assert_type(np.full_like(C, i8), npt.NDArray[Any])
 assert_type(np.full_like(A, i8, dtype=int), npt.NDArray[Any])
 assert_type(np.full_like(B, i8), SubClass[np.float64])
 assert_type(np.full_like(B, i8, dtype=np.int64), npt.NDArray[np.int64])
+assert_type(np.full_like(_f32_1d, i8), _Array1D[np.float32])
+assert_type(np.full_like(_f32_1d, i8, dtype=np.int64), _Array1D[np.int64])
+assert_type(np.full_like(_f32_1d, i8, dtype=int), _Array1D[Any])
+assert_type(np.full_like(_f32_1d, i8, shape=_shape_2d), _Array2D[np.float32])
+assert_type(np.full_like(_f32_1d, i8, shape=_shape_like), npt.NDArray[np.float32])
 
 _size: int
 _shape_0d: tuple[()]


### PR DESCRIPTION
The `full_like`, `ones_like`, `empty_like`, and `zeros_like` functions are used very frequently according to code search (https://gist.github.com/jorenham/36c78602a7ca866ddb2a917de48ccdd0), but had suboptimal shape-typing support. This improves it by -- yes you guessed right -- adding a bunch of overloads :)

Towards #16544 I guess

---

Fully written by me, pre-reviewed & audited as high-value shape-typing improvement by AI (see https://gist.github.com/jorenham/36c78602a7ca866ddb2a917de48ccdd0).