### PR TITLE
TYP/DOC: release note for the ufunc typing improvements

### DIFF
--- a/doc/release/upcoming_changes/32198.typing.rst
+++ b/doc/release/upcoming_changes/32198.typing.rst
@@ -1,0 +1,25 @@
+Promotion-aware ufunc return types
+----------------------------------
+All ufuncs in the main namespace are now individually annotated, instead of sharing one
+generic ``numpy.ufunc`` type. Their ``__call__``, ``reduce``, ``accumulate``,
+``reduceat``, ``outer``, and ``at`` methods now follow NumPy's promotion rules, so that
+the output dtype is inferred instead of ``Any``.
+
+.. code-block:: python
+
+    import numpy as np
+    import numpy.typing as npt
+
+    x: npt.NDArray[np.float32]
+    y: npt.NDArray[np.int16]
+
+    reveal_type(np.sqrt(y))
+    # before: npt.NDArray[Any]
+    # after:  npt.NDArray[np.float32]
+
+    reveal_type(np.multiply(x, y))
+    # before: npt.NDArray[Any]
+    # after:  npt.NDArray[np.float32]
+
+This took 44 pull requests and over 20,000 lines of *hand-written* code, spread over
+1,905 overloads.


### PR DESCRIPTION
Here's the promised release note for the recent ufunc typing improvements. 

For reference, here's the full list of (44) PRs:

- #31716
- #31730
- #31741
- #31742
- #31749
- #31760
- #31761
- #31793
- #31797
- #31806
- #31813
- #31824
- #31851
- #31873
- #31896
- #31903
- #31924
- #31935
- #31941
- #31989
- #31991
- #31995
- #32003
- #32004
- #32019
- #32021
- #32047
- #32048
- #32052
- #32072
- #32113
- #32118
- #32129
- #32149
- #32173
- #32175
- #32176
- #32177
- #32178
- #32179
- #32181
- #32185
- #32189
- #32190

---

I had AI write the initial draft, then rephrased and fixed the example myself.