### PR TITLE
MAINT: Update cibuildwheel to v4.2.0

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
           fetch-tags: true
           persist-credentials: false
-      - uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c  # v4.1.1
+      - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074  # v4.2.0
         env:
           CIBW_PLATFORM: pyodide
           CIBW_BUILD: cp314-pyodide_wasm32

--- a/.github/workflows/linux_riscv64.yml
+++ b/.github/workflows/linux_riscv64.yml
@@ -58,7 +58,7 @@ jobs:
             ccache-wheels-manylinux_riscv64-${{ matrix.python }}-
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c  # v4.1.1
+      - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074  # v4.2.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-manylinux_riscv64
           CIBW_BEFORE_ALL_LINUX: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -121,7 +121,7 @@ jobs:
           fi
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c  # v4.1.1
+      - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074  # v4.2.0
         with:
           only: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 


### PR DESCRIPTION
This has Python 3.15.0rc1, which we want for the upcoming NumPy 2.5.2 release.

No AI.