### PR TITLE
TYP: ``copy`` improved shape-typing

### DIFF
--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -541,13 +541,23 @@ def select(
 ) -> np.ndarray: ...
 
 # keep roughly in sync with `ma.core.copy`
-@overload
+@overload  # known array, subok=True (positional)
 def copy[ArrayT: np.ndarray](a: ArrayT, order: _OrderKACF, subok: L[True]) -> ArrayT: ...
-@overload
+@overload  # known array, subok=True (keyword)
 def copy[ArrayT: np.ndarray](a: ArrayT, order: _OrderKACF = "K", *, subok: L[True]) -> ArrayT: ...
-@overload
-def copy[ScalarT: np.generic](a: _ArrayLike[ScalarT], order: _OrderKACF = "K", subok: L[False] = False) -> NDArray[ScalarT]: ...
-@overload
+@overload  # known array, subok=False (default)
+def copy[ShapeT: _Shape, DTypeT: np.dtype](
+    a: np.ndarray[ShapeT, DTypeT],
+    order: _OrderKACF = "K",
+    subok: L[False] = False,
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # known array-like dtype
+def copy[ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    order: _OrderKACF = "K",
+    subok: bool = False,
+) -> NDArray[ScalarT]: ...
+@overload  # fallback
 def copy(a: ArrayLike, order: _OrderKACF = "K", subok: L[False] = False) -> NDArray[Incomplete]: ...
 
 #

--- a/numpy/typing/tests/data/reveal/lib_function_base.pyi
+++ b/numpy/typing/tests/data/reveal/lib_function_base.pyi
@@ -26,7 +26,7 @@ AR_M: npt.NDArray[np.datetime64]
 AR_O: npt.NDArray[np.object_]
 AR_b: npt.NDArray[np.bool]
 AR_U: npt.NDArray[np.str_]
-CHAR_AR_U: np.char.chararray[tuple[Any, ...], np.dtype[np.str_]]  # type: ignore[deprecated]
+CHAR_AR_U: np.char.chararray[tuple[int], np.dtype[np.str_]]  # type: ignore[deprecated]
 
 AR_f8_1d: np.ndarray[tuple[int], np.dtype[np.float64]]
 AR_f8_2d: np.ndarray[tuple[int, int], np.dtype[np.float64]]
@@ -131,10 +131,9 @@ assert_type(np.place(AR_f8, mask=AR_i8, vals=5.0), None)
 # copy
 assert_type(np.copy(AR_LIKE_f8), np.ndarray)
 assert_type(np.copy(AR_U), npt.NDArray[np.str_])
-assert_type(np.copy(CHAR_AR_U, "K", subok=True), np.char.chararray[tuple[Any, ...], np.dtype[np.str_]])  # type: ignore[deprecated]
-assert_type(np.copy(CHAR_AR_U, subok=True), np.char.chararray[tuple[Any, ...], np.dtype[np.str_]])  # type: ignore[deprecated]
-# pyright correctly infers `NDArray[str_]` here
-assert_type(np.copy(CHAR_AR_U), np.ndarray[Any, Any])  # pyright: ignore[reportAssertTypeFailure]
+assert_type(np.copy(CHAR_AR_U, "K", subok=True), np.char.chararray[tuple[int], np.dtype[np.str_]])  # type: ignore[deprecated]
+assert_type(np.copy(CHAR_AR_U, subok=True), np.char.chararray[tuple[int], np.dtype[np.str_]])  # type: ignore[deprecated]
+assert_type(np.copy(CHAR_AR_U), np.ndarray[tuple[int], np.dtype[np.str_]])
 
 # gradient
 assert_type(np.gradient(AR_f8_1d, 1), np.ndarray[tuple[int], np.dtype[np.float64]])


### PR DESCRIPTION
`np.copy` now also propagates the input shape-type in when `subok=False` (the default).

---

Fully written by me, audited as kinda-high-value shape-typing improvement by AI (see https://gist.github.com/jorenham/36c78602a7ca866ddb2a917de48ccdd0).