### PR TITLE
CI: fix workflow syntax

### DIFF
--- a/.github/workflows/linux_riscv64.yml
+++ b/.github/workflows/linux_riscv64.yml
@@ -58,7 +58,7 @@ jobs:
             ccache-wheels-manylinux_riscv64-${{ matrix.python }}-
 
       - name: Build wheels
-      - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074  # v4.2.0
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074  # v4.2.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-manylinux_riscv64
           CIBW_BEFORE_ALL_LINUX: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -121,7 +121,7 @@ jobs:
           fi
 
       - name: Build wheels
-      - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074  # v4.2.0
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074  # v4.2.0
         with:
           only: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 


### PR DESCRIPTION
I merged https://github.com/numpy/numpy/pull/32200 too soon apparently, because there were some stray dashes that broke these workflows

https://github.com/numpy/numpy/commit/56e77e0cea232ca8add53c5b804db149ca9c6488

cc @charris