### PR TITLE
TYP: ``isclose`` shape-typing fix for 2d array-likes

### DIFF
--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -1282,58 +1282,58 @@ def allclose(
 def isclose(
     a: _NumberLike_co,
     b: _NumberLike_co,
-    rtol: ArrayLike = 1e-5,
-    atol: ArrayLike = 1e-8,
+    rtol: _ScalarLike_co = 1e-5,
+    atol: _ScalarLike_co = 1e-8,
     equal_nan: py_bool = False,
 ) -> np.bool: ...
 @overload  # known shape, same shape or scalar
 def isclose[ShapeT: _Shape](
     a: np.ndarray[ShapeT],
     b: np.ndarray[ShapeT] | _NumberLike_co,
-    rtol: ArrayLike = 1e-5,
-    atol: ArrayLike = 1e-8,
+    rtol: _ScalarLike_co = 1e-5,
+    atol: _ScalarLike_co = 1e-8,
     equal_nan: py_bool = False,
 ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
 @overload  # same shape or scalar, known shape
 def isclose[ShapeT: _Shape](
     a: np.ndarray[ShapeT] | _NumberLike_co,
     b: np.ndarray[ShapeT],
-    rtol: ArrayLike = 1e-5,
-    atol: ArrayLike = 1e-8,
+    rtol: _ScalarLike_co = 1e-5,
+    atol: _ScalarLike_co = 1e-8,
     equal_nan: py_bool = False,
 ) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
 @overload  # 1d sequence, <=1d array-like
 def isclose(
     a: Sequence[_NumberLike_co],
     b: Sequence[_NumberLike_co] | _NumberLike_co | np.ndarray[tuple[int]],
-    rtol: ArrayLike = 1e-5,
-    atol: ArrayLike = 1e-8,
+    rtol: _ScalarLike_co = 1e-5,
+    atol: _ScalarLike_co = 1e-8,
     equal_nan: py_bool = False,
 ) -> np.ndarray[tuple[int], np.dtype[np.bool]]: ...
 @overload  # <=1d array-like, 1d sequence
 def isclose(
     a: Sequence[_NumberLike_co] | _NumberLike_co | np.ndarray[tuple[int]],
     b: Sequence[_NumberLike_co],
-    rtol: ArrayLike = 1e-5,
-    atol: ArrayLike = 1e-8,
+    rtol: _ScalarLike_co = 1e-5,
+    atol: _ScalarLike_co = 1e-8,
     equal_nan: py_bool = False,
 ) -> np.ndarray[tuple[int], np.dtype[np.bool]]: ...
 @overload  # 2d sequence, <=2d array-like
 def isclose(
     a: Sequence[Sequence[_NumberLike_co]],
     b: Sequence[Sequence[_NumberLike_co]] | Sequence[_NumberLike_co] | _NumberLike_co | np.ndarray[tuple[int] | tuple[int, int]],
-    rtol: ArrayLike = 1e-5,
-    atol: ArrayLike = 1e-8,
+    rtol: _ScalarLike_co = 1e-5,
+    atol: _ScalarLike_co = 1e-8,
     equal_nan: py_bool = False,
-) -> np.ndarray[tuple[int], np.dtype[np.bool]]: ...
+) -> np.ndarray[tuple[int, int], np.dtype[np.bool]]: ...
 @overload  # <=2d array-like, 2d sequence
 def isclose(
     b: Sequence[Sequence[_NumberLike_co]] | Sequence[_NumberLike_co] | _NumberLike_co | np.ndarray[tuple[int] | tuple[int, int]],
     a: Sequence[Sequence[_NumberLike_co]],
-    rtol: ArrayLike = 1e-5,
-    atol: ArrayLike = 1e-8,
+    rtol: _ScalarLike_co = 1e-5,
+    atol: _ScalarLike_co = 1e-8,
     equal_nan: py_bool = False,
-) -> np.ndarray[tuple[int], np.dtype[np.bool]]: ...
+) -> np.ndarray[tuple[int, int], np.dtype[np.bool]]: ...
 @overload  # unknown shape, unknown shape
 def isclose(
     a: ArrayLike,

--- a/numpy/typing/tests/data/reveal/numeric.pyi
+++ b/numpy/typing/tests/data/reveal/numeric.pyi
@@ -27,6 +27,7 @@ _sub_nd_i8: SubClass
 _to_1d_bool: list[bool]
 _to_1d_int: list[int]
 _to_1d_float: list[float]
+_to_2d_float: list[list[float]]
 _to_1d_complex: list[complex]
 
 ###
@@ -161,6 +162,9 @@ assert_type(np.allclose(AR_i8, AR_i8), bool)
 assert_type(np.isclose(i8, i8), np.bool)
 assert_type(np.isclose(i8, AR_i8), npt.NDArray[np.bool])
 assert_type(np.isclose(_to_1d_int, _to_1d_int), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.isclose(_to_1d_int, _to_2d_float), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isclose(_to_2d_float, _to_1d_int), np.ndarray[tuple[int, int], np.dtype[np.bool]])
+assert_type(np.isclose(_to_2d_float, _to_2d_float), np.ndarray[tuple[int, int], np.dtype[np.bool]])
 assert_type(np.isclose(AR_i8, AR_i8), npt.NDArray[np.bool])
 
 assert_type(np.array_equal(i8, AR_i8), bool)


### PR DESCRIPTION
This fixes two shape-typing issues in `np.isclose`:

- 2d nested sequences returned a 1d array (copy-paste gone bad)
- &gt;0d `rtol` / `atol` are broadcasted against `a` and `b` and could therefore result in wrong output shape-type (rare in practice though ~2-3% of code search hits)

---

Fully written by me, audited as kinda-high-value shape-typing fix / improvement by AI (see https://gist.github.com/jorenham/36c78602a7ca866ddb2a917de48ccdd0).