### PR TITLE
MAINT: Fix typo in environment variable name for build windows arm wheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,7 +69,7 @@ jobs:
       - name: win_arm64 - set environment variables
         if: ${{ matrix.buildplat[1] == 'win_arm64' }}
         run: |
-            echo "C:\Program Files\LLVM\bin" >> $env:GIHUB_PATH
+            echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
             echo "CC=clang-cl" >> $env:GITHUB_ENV
             echo "CXX=clang-cl" >> $env:GITHUB_ENV
             echo "FC=flang" >> $env:GITHUB_ENV


### PR DESCRIPTION
### PR summary

This PR changes the env name from GIHUB_PATH to GITHUB_PATH in the wheel build workflow. 

It looks like a typo was made in this commit during the refactor: 

https://github.com/numpy/numpy/commit/e9827645c55b13d2f1cd98be751939fbc95bd4a3

Both in my PR and in this repository, the workflow with the typo looks like it is working, so maybe a better solution is to remove this line? 

### First time committer introduction

I was trying to enable building Python 3.15 wheels, and my CI was failing on Windows 11 ARM runners, so I checked how it is solved in the NumPy repository. I found this steep to properly configure compilers. 

https://github.com/napari/bermuda/pull/206

I'm one of [napari](napari.org) maintainers. 

