### PR TITLE
MAINT: Skip limited_api tests on some platforms.

### DIFF
--- a/numpy/_core/tests/examples/limited_api/meson.build
+++ b/numpy/_core/tests/examples/limited_api/meson.build
@@ -76,7 +76,10 @@ if py.get_variable('Py_GIL_DISABLED', 0) == 0
   endforeach
 endif
 
-if py.language_version().version_compare('>=3.15')
+if (
+     py.language_version().version_compare('>=3.15') and
+     (host_machine.system() != 'windows' or (py.get_variable('Py_GIL_DISABLED', 0) == 1))
+)
   py.extension_module(
       'limited_api_opaque',
       'limited_api.c',

--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -200,15 +200,17 @@ def limited_api_cython_module_names():
     return _module_names("limited_api_cython", _PY_ABI3_VERSIONS)
 
 
-@pytest.mark.skipif(IS_WASM, reason="Can't start subprocess")
-@pytest.mark.xfail(
+@pytest.mark.skipif(
+    IS_WASM, reason="platform cannot start subprocesses"
+)
+@pytest.mark.skipif(
     sysconfig.get_config_var("Py_DEBUG"),
     reason=(
         "Py_LIMITED_API is incompatible with Py_DEBUG, Py_TRACE_REFS, "
         "and Py_REF_DEBUG"
     ),
 )
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     NOGIL_BUILD,
     reason="Py_GIL_DISABLED builds do not support abi3",
 )
@@ -218,15 +220,17 @@ def test_limited_api_abi3(install_temp, module_name):
     _check_api_module(mod)
 
 
-@pytest.mark.skipif(IS_WASM, reason="Can't start subprocess")
-@pytest.mark.xfail(
+@pytest.mark.skipif(
+    IS_WASM, reason="platform cannot start subprocesses"
+)
+@pytest.mark.skipif(
     sysconfig.get_config_var("Py_DEBUG"),
     reason=(
         "Py_LIMITED_API is incompatible with Py_DEBUG, Py_TRACE_REFS, "
         "and Py_REF_DEBUG"
     ),
 )
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     NOGIL_BUILD,
     reason="Py_GIL_DISABLED builds do not support abi3",
 )


### PR DESCRIPTION
Attempt to fix wheel builds in `numpy-release` for Python 3.15.

No AI.
