### PR TITLE
MAINT: Remove unused setting env variable in windows arm wheel build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,7 +69,6 @@ jobs:
       - name: win_arm64 - set environment variables
         if: ${{ matrix.buildplat[1] == 'win_arm64' }}
         run: |
-            echo "C:\Program Files\LLVM\bin" >> $env:GIHUB_PATH
             echo "CC=clang-cl" >> $env:GITHUB_ENV
             echo "CXX=clang-cl" >> $env:GITHUB_ENV
             echo "FC=flang" >> $env:GITHUB_ENV


### PR DESCRIPTION
### PR summary

Because of a typo in `echo "C:\Program Files\LLVM\bin" >> $env:GIHUB_PATH` (`GIHUB` in place of `GITHUB`) editing the PATH looks obsolete for the build wheel process. Maybe this directory is already on the path. 

Alternative to #32208
closes #32208

### First time committer introduction


#### AI Disclosure

No AI tools used
