### PR TITLE
BUG: Fix signed integer overflow in datetime

### DIFF
--- a/numpy/_core/src/common/npy_extint128.h
+++ b/numpy/_core/src/common/npy_extint128.h
@@ -359,4 +359,24 @@ ceildiv_128_64(npy_extint128_t a, npy_int64 b)
     return result;
 }
 
+/*
+ * Accumulate: acc = acc * factor + field, using 128-bit arithmetic to avoid
+ * signed-integer overflow UB on intermediate products.  Sets *overflow if
+ * acc does not fit in int64 before the multiply, or if the final to_64()
+ * call overflows.
+ */
+static inline npy_extint128_t
+accum_128(npy_extint128_t acc, npy_int64 factor, npy_int64 field,
+          char *overflow)
+{
+    npy_int64 cur;
+    char ov = 0;
+    cur = to_64(acc, &ov);
+    if (ov) {
+        *overflow = 1;
+        return acc;
+    }
+    return add_128(mul_64_64(cur, factor), to_128(field), overflow);
+}
+
 #endif  /* NUMPY_CORE_SRC_COMMON_NPY_EXTINT128_H_ */

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -30,6 +30,7 @@
 
 #include "dtype_transfer.h"
 #include "lowlevel_strided_loops.h"
+#include "npy_extint128.h"
 
 #include <datetime.h>
 #include <time.h>
@@ -146,15 +147,25 @@ get_datetimestruct_days(const npy_datetimestruct *dts)
 
 /*
  * Calculates the minutes offset from the 1970 epoch.
+ *
+ * Only used for timezone offset calculation (difference between two
+ * nearby datetimes), so the inputs are always close to the epoch and
+ * overflow cannot occur in practice.  safe_mul/safe_add are used here
+ * to eliminate signed-integer overflow UB.
  */
 NPY_NO_EXPORT npy_int64
 get_datetimestruct_minutes(const npy_datetimestruct *dts)
 {
-    npy_int64 days = get_datetimestruct_days(dts) * 24 * 60;
-    days += dts->hour * 60;
-    days += dts->min;
-
-    return days;
+    char overflow = 0;
+    npy_int64 days = get_datetimestruct_days(dts);
+    npy_int64 result = safe_mul(days, (npy_int64)24 * 60, &overflow);
+    result = safe_add(result, (npy_int64)dts->hour * 60, &overflow);
+    result = safe_add(result, (npy_int64)dts->min, &overflow);
+    
+    if (overflow) {
+        return (days < 0) ? NPY_MIN_INT64 : NPY_MAX_INT64;
+    }
+    return result;
 }
 
 static void
@@ -320,13 +331,53 @@ NpyDatetime_ConvertDatetimeStructToDatetime64(PyArray_DatetimeMetaData *meta,
         return -1;
     }
 
+    /*
+     * Overflow-safe 128-bit accumulator macro.
+     *
+     * Each call does:  acc128 = acc128 * factor + field
+     *
+     * acc128 is extracted to int64, multiplied by factor via mul_64_64
+     * (exact 128-bit product, no UB), then field is added in 128-bit.
+     * The result is stored back into acc128.  After all ACCUM128 steps,
+     * the caller narrows acc128 to int64 with to_64(), which sets ovflag
+     * if the final value does not fit.
+     *
+     * acc128 must be declared by the caller and initialised to to_128(days).
+     */
+#define ACCUM128(acc128, factor, field, ovflag) \
+    do { \
+        npy_int64 _cur; \
+        char _ov = 0; \
+        _cur = to_64((acc128), &_ov); \
+        if (_ov) { *(ovflag) = 1; break; } \
+        (acc128) = add_128(mul_64_64(_cur, (npy_int64)(factor)), \
+                           to_128((npy_int64)(field)), \
+                           (ovflag)); \
+    } while (0)
+
+    char overflow = 0;
+
     if (base == NPY_FR_Y) {
         /* Truncate to the year */
-        ret = dts->year - 1970;
+        ret = safe_sub(dts->year, (npy_int64)1970, &overflow);
     }
     else if (base == NPY_FR_M) {
-        /* Truncate to the month */
-        ret = 12 * (dts->year - 1970) + (dts->month - 1);
+        /*
+         * use 128-bit
+         * arithmetic and narrow only at the end.
+         */
+        char ov_sub = 0;
+        npy_int64 year_offset = safe_sub(dts->year, (npy_int64)1970, &ov_sub);
+        if (ov_sub) {
+            overflow = 1;
+        }
+        else {
+            npy_extint128_t acc128 = mul_64_64(year_offset, (npy_int64)12);
+            char ov_add = 0;
+            acc128 = add_128(acc128,
+                             to_128((npy_int64)(dts->month - 1)), &ov_add);
+            ret = to_64(acc128, &overflow);
+        }
     }
     else {
         /* Otherwise calculate the number of days to start */
@@ -334,88 +385,122 @@ NpyDatetime_ConvertDatetimeStructToDatetime64(PyArray_DatetimeMetaData *meta,
 
         switch (base) {
             case NPY_FR_W:
-                /* Truncate to weeks */
+                /* Truncate to weeks (floor division toward -inf) */
                 if (days >= 0) {
                     ret = days / 7;
                 }
                 else {
-                    ret = (days - 6) / 7;
+                    /* days - 6 can overflow when days is near INT64_MIN */
+                    npy_int64 adj = safe_sub(days, (npy_int64)6, &overflow);
+                    ret = overflow ? NPY_MIN_INT64 / 7 : adj / 7;
+                    overflow = 0;  /* not a fatal error; value is clamped */
                 }
                 break;
             case NPY_FR_D:
                 ret = days;
                 break;
-            case NPY_FR_h:
-                ret = days * 24 +
-                      dts->hour;
+        
+            case NPY_FR_h: {
+                npy_extint128_t acc128 = to_128(days);
+                ACCUM128(acc128, 24,      dts->hour,      &overflow);
+                ret = to_64(acc128, &overflow);
                 break;
-            case NPY_FR_m:
-                ret = (days * 24 +
-                      dts->hour) * 60 +
-                      dts->min;
+            }
+            case NPY_FR_m: {
+                npy_extint128_t acc128 = to_128(days);
+                ACCUM128(acc128, 24,      dts->hour,      &overflow);
+                ACCUM128(acc128, 60,      dts->min,       &overflow);
+                ret = to_64(acc128, &overflow);
                 break;
-            case NPY_FR_s:
-                ret = ((days * 24 +
-                      dts->hour) * 60 +
-                      dts->min) * 60 +
-                      dts->sec;
+            }
+            case NPY_FR_s: {
+                npy_extint128_t acc128 = to_128(days);
+                ACCUM128(acc128, 24,      dts->hour,      &overflow);
+                ACCUM128(acc128, 60,      dts->min,       &overflow);
+                ACCUM128(acc128, 60,      dts->sec,       &overflow);
+                ret = to_64(acc128, &overflow);
                 break;
-            case NPY_FR_ms:
-                ret = (((days * 24 +
-                      dts->hour) * 60 +
-                      dts->min) * 60 +
-                      dts->sec) * 1000 +
-                      dts->us / 1000;
+            }
+            case NPY_FR_ms: {
+                npy_extint128_t acc128 = to_128(days);
+                ACCUM128(acc128, 24,      dts->hour,      &overflow);
+                ACCUM128(acc128, 60,      dts->min,       &overflow);
+                ACCUM128(acc128, 60,      dts->sec,       &overflow);
+                ACCUM128(acc128, 1000,    dts->us / 1000, &overflow);
+                ret = to_64(acc128, &overflow);
                 break;
-            case NPY_FR_us:
-                ret = (((days * 24 +
-                      dts->hour) * 60 +
-                      dts->min) * 60 +
-                      dts->sec) * 1000000 +
-                      dts->us;
+            }
+            case NPY_FR_us: {
+                npy_extint128_t acc128 = to_128(days);
+                ACCUM128(acc128, 24,      dts->hour,      &overflow);
+                ACCUM128(acc128, 60,      dts->min,       &overflow);
+                ACCUM128(acc128, 60,      dts->sec,       &overflow);
+                ACCUM128(acc128, 1000000, dts->us,        &overflow);
+                ret = to_64(acc128, &overflow);
                 break;
-            case NPY_FR_ns:
-                ret = ((((days * 24 +
-                      dts->hour) * 60 +
-                      dts->min) * 60 +
-                      dts->sec) * 1000000 +
-                      dts->us) * 1000 +
-                      dts->ps / 1000;
+            }
+            case NPY_FR_ns: {
+                npy_extint128_t acc128 = to_128(days);
+                ACCUM128(acc128, 24,      dts->hour,      &overflow);
+                ACCUM128(acc128, 60,      dts->min,       &overflow);
+                ACCUM128(acc128, 60,      dts->sec,       &overflow);
+                ACCUM128(acc128, 1000000, dts->us,        &overflow);
+                ACCUM128(acc128, 1000,    dts->ps / 1000, &overflow);
+                ret = to_64(acc128, &overflow);
                 break;
-            case NPY_FR_ps:
-                ret = ((((days * 24 +
-                      dts->hour) * 60 +
-                      dts->min) * 60 +
-                      dts->sec) * 1000000 +
-                      dts->us) * 1000000 +
-                      dts->ps;
+            }
+            case NPY_FR_ps: {
+                npy_extint128_t acc128 = to_128(days);
+                ACCUM128(acc128, 24,      dts->hour,      &overflow);
+                ACCUM128(acc128, 60,      dts->min,       &overflow);
+                ACCUM128(acc128, 60,      dts->sec,       &overflow);
+                ACCUM128(acc128, 1000000, dts->us,        &overflow);
+                ACCUM128(acc128, 1000000, dts->ps,        &overflow);
+                ret = to_64(acc128, &overflow);
                 break;
+            }
             case NPY_FR_fs:
                 /* only 2.6 hours */
-                ret = (((((days * 24 +
-                      dts->hour) * 60 +
-                      dts->min) * 60 +
-                      dts->sec) * 1000000 +
-                      dts->us) * 1000000 +
-                      dts->ps) * 1000 +
-                      dts->as / 1000;
+                {
+                npy_extint128_t acc128 = to_128(days);
+                ACCUM128(acc128, 24,      dts->hour,      &overflow);
+                ACCUM128(acc128, 60,      dts->min,       &overflow);
+                ACCUM128(acc128, 60,      dts->sec,       &overflow);
+                ACCUM128(acc128, 1000000, dts->us,        &overflow);
+                ACCUM128(acc128, 1000000, dts->ps,        &overflow);
+                ACCUM128(acc128, 1000,    dts->as / 1000, &overflow);
+                ret = to_64(acc128, &overflow);
                 break;
+                }
             case NPY_FR_as:
                 /* only 9.2 secs */
-                ret = (((((days * 24 +
-                      dts->hour) * 60 +
-                      dts->min) * 60 +
-                      dts->sec) * 1000000 +
-                      dts->us) * 1000000 +
-                      dts->ps) * 1000000 +
-                      dts->as;
+                {
+                npy_extint128_t acc128 = to_128(days);
+                ACCUM128(acc128, 24,      dts->hour,      &overflow);
+                ACCUM128(acc128, 60,      dts->min,       &overflow);
+                ACCUM128(acc128, 60,      dts->sec,       &overflow);
+                ACCUM128(acc128, 1000000, dts->us,        &overflow);
+                ACCUM128(acc128, 1000000, dts->ps,        &overflow);
+                ACCUM128(acc128, 1000000, dts->as,        &overflow);
+                ret = to_64(acc128, &overflow);
                 break;
+                }
             default:
                 /* Something got corrupted */
                 PyErr_SetString(PyExc_ValueError,
                         "NumPy datetime metadata with corrupt unit value");
+#undef ACCUM128
                 return -1;
         }
+    }
+
+#undef ACCUM128
+
+    if (overflow) {
+        PyErr_SetString(PyExc_OverflowError,
+                "Overflow in datetime conversion: datetime64 value is out "
+                "of range for the requested unit");
+        return -1;
     }
 
     /* Divide by the multiplier */
@@ -480,14 +565,31 @@ NpyDatetime_ConvertDatetime64ToDatetimeStruct(
      * for negative values.
      */
     switch (meta->base) {
-        case NPY_FR_Y:
-            out->year = 1970 + dt;
+        case NPY_FR_Y: {
+            char ov = 0;
+            out->year = safe_add((npy_int64)1970, dt, &ov);
+            if (ov) {
+                PyErr_SetString(PyExc_OverflowError,
+                        "Overflow in datetime conversion: datetime64 value "
+                        "is out of range for the requested unit");
+                return -1;
+            }
             break;
+        }
 
-        case NPY_FR_M:
-            out->year  = 1970 + extract_unit_64(&dt, 12);
+        case NPY_FR_M: {
+            char ov = 0;
+            npy_int64 year_offset = extract_unit_64(&dt, 12);
+            out->year  = safe_add((npy_int64)1970, year_offset, &ov);
+            if (ov) {
+                PyErr_SetString(PyExc_OverflowError,
+                        "Overflow in datetime conversion: datetime64 value "
+                        "is out of range for the requested unit");
+                return -1;
+            }
             out->month = dt + 1;
             break;
+        }
 
         case NPY_FR_W:
             /* A week is 7 days */

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -142,7 +142,17 @@ get_datetimestruct_days(const npy_datetimestruct *dts)
         (npy_uint32)dts->day - 1;                            /* [0, 365] */
     npy_uint32 doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; /* [0, 146096] */
 
-    return era * (npy_int64)146097 + (npy_int64)doe - (npy_int64)719468;
+    /* era * 146097 can overflow int64 for extreme years; use 128-bit. */
+    char overflow = 0;
+    npy_extint128_t days128 = add_128(
+            mul_64_64(era, (npy_int64)146097),
+            to_128((npy_int64)doe - (npy_int64)719468),
+            &overflow);
+    npy_int64 result = to_64(days128, &overflow);
+    if (overflow) {
+        return NPY_DATETIME_NAT;
+    }
+    return result;
 }
 
 /*
@@ -331,30 +341,6 @@ NpyDatetime_ConvertDatetimeStructToDatetime64(PyArray_DatetimeMetaData *meta,
         return -1;
     }
 
-    /*
-     * Overflow-safe 128-bit accumulator macro.
-     *
-     * Each call does:  acc128 = acc128 * factor + field
-     *
-     * acc128 is extracted to int64, multiplied by factor via mul_64_64
-     * (exact 128-bit product, no UB), then field is added in 128-bit.
-     * The result is stored back into acc128.  After all ACCUM128 steps,
-     * the caller narrows acc128 to int64 with to_64(), which sets ovflag
-     * if the final value does not fit.
-     *
-     * acc128 must be declared by the caller and initialised to to_128(days).
-     */
-#define ACCUM128(acc128, factor, field, ovflag) \
-    do { \
-        npy_int64 _cur; \
-        char _ov = 0; \
-        _cur = to_64((acc128), &_ov); \
-        if (_ov) { *(ovflag) = 1; break; } \
-        (acc128) = add_128(mul_64_64(_cur, (npy_int64)(factor)), \
-                           to_128((npy_int64)(field)), \
-                           (ovflag)); \
-    } while (0)
-
     char overflow = 0;
 
     if (base == NPY_FR_Y) {
@@ -390,10 +376,18 @@ NpyDatetime_ConvertDatetimeStructToDatetime64(PyArray_DatetimeMetaData *meta,
                     ret = days / 7;
                 }
                 else {
-                    /* days - 6 can overflow when days is near INT64_MIN */
+                    /* days - 6 can overflow when days is near INT64_MIN.
+                     * Floor division: for negative non-multiple, subtract 1
+                     * from the truncated quotient. */
                     npy_int64 adj = safe_sub(days, (npy_int64)6, &overflow);
-                    ret = overflow ? NPY_MIN_INT64 / 7 : adj / 7;
-                    overflow = 0;  /* not a fatal error; value is clamped */
+                    if (overflow) {
+                        /* days is within 6 of INT64_MIN; floor(days/7) */
+                        ret = NPY_MIN_INT64 / 7 - (NPY_MIN_INT64 % 7 != 0 ? 1 : 0);
+                        overflow = 0;
+                    }
+                    else {
+                        ret = adj / 7;
+                    }
                 }
                 break;
             case NPY_FR_D:
@@ -402,60 +396,60 @@ NpyDatetime_ConvertDatetimeStructToDatetime64(PyArray_DatetimeMetaData *meta,
         
             case NPY_FR_h: {
                 npy_extint128_t acc128 = to_128(days);
-                ACCUM128(acc128, 24,      dts->hour,      &overflow);
+                acc128 = accum_128(acc128, 24,      dts->hour,      &overflow);
                 ret = to_64(acc128, &overflow);
                 break;
             }
             case NPY_FR_m: {
                 npy_extint128_t acc128 = to_128(days);
-                ACCUM128(acc128, 24,      dts->hour,      &overflow);
-                ACCUM128(acc128, 60,      dts->min,       &overflow);
+                acc128 = accum_128(acc128, 24,      dts->hour,      &overflow);
+                acc128 = accum_128(acc128, 60,      dts->min,       &overflow);
                 ret = to_64(acc128, &overflow);
                 break;
             }
             case NPY_FR_s: {
                 npy_extint128_t acc128 = to_128(days);
-                ACCUM128(acc128, 24,      dts->hour,      &overflow);
-                ACCUM128(acc128, 60,      dts->min,       &overflow);
-                ACCUM128(acc128, 60,      dts->sec,       &overflow);
+                acc128 = accum_128(acc128, 24,      dts->hour,      &overflow);
+                acc128 = accum_128(acc128, 60,      dts->min,       &overflow);
+                acc128 = accum_128(acc128, 60,      dts->sec,       &overflow);
                 ret = to_64(acc128, &overflow);
                 break;
             }
             case NPY_FR_ms: {
                 npy_extint128_t acc128 = to_128(days);
-                ACCUM128(acc128, 24,      dts->hour,      &overflow);
-                ACCUM128(acc128, 60,      dts->min,       &overflow);
-                ACCUM128(acc128, 60,      dts->sec,       &overflow);
-                ACCUM128(acc128, 1000,    dts->us / 1000, &overflow);
+                acc128 = accum_128(acc128, 24,      dts->hour,      &overflow);
+                acc128 = accum_128(acc128, 60,      dts->min,       &overflow);
+                acc128 = accum_128(acc128, 60,      dts->sec,       &overflow);
+                acc128 = accum_128(acc128, 1000,    dts->us / 1000, &overflow);
                 ret = to_64(acc128, &overflow);
                 break;
             }
             case NPY_FR_us: {
                 npy_extint128_t acc128 = to_128(days);
-                ACCUM128(acc128, 24,      dts->hour,      &overflow);
-                ACCUM128(acc128, 60,      dts->min,       &overflow);
-                ACCUM128(acc128, 60,      dts->sec,       &overflow);
-                ACCUM128(acc128, 1000000, dts->us,        &overflow);
+                acc128 = accum_128(acc128, 24,      dts->hour,      &overflow);
+                acc128 = accum_128(acc128, 60,      dts->min,       &overflow);
+                acc128 = accum_128(acc128, 60,      dts->sec,       &overflow);
+                acc128 = accum_128(acc128, 1000000, dts->us,        &overflow);
                 ret = to_64(acc128, &overflow);
                 break;
             }
             case NPY_FR_ns: {
                 npy_extint128_t acc128 = to_128(days);
-                ACCUM128(acc128, 24,      dts->hour,      &overflow);
-                ACCUM128(acc128, 60,      dts->min,       &overflow);
-                ACCUM128(acc128, 60,      dts->sec,       &overflow);
-                ACCUM128(acc128, 1000000, dts->us,        &overflow);
-                ACCUM128(acc128, 1000,    dts->ps / 1000, &overflow);
+                acc128 = accum_128(acc128, 24,      dts->hour,      &overflow);
+                acc128 = accum_128(acc128, 60,      dts->min,       &overflow);
+                acc128 = accum_128(acc128, 60,      dts->sec,       &overflow);
+                acc128 = accum_128(acc128, 1000000, dts->us,        &overflow);
+                acc128 = accum_128(acc128, 1000,    dts->ps / 1000, &overflow);
                 ret = to_64(acc128, &overflow);
                 break;
             }
             case NPY_FR_ps: {
                 npy_extint128_t acc128 = to_128(days);
-                ACCUM128(acc128, 24,      dts->hour,      &overflow);
-                ACCUM128(acc128, 60,      dts->min,       &overflow);
-                ACCUM128(acc128, 60,      dts->sec,       &overflow);
-                ACCUM128(acc128, 1000000, dts->us,        &overflow);
-                ACCUM128(acc128, 1000000, dts->ps,        &overflow);
+                acc128 = accum_128(acc128, 24,      dts->hour,      &overflow);
+                acc128 = accum_128(acc128, 60,      dts->min,       &overflow);
+                acc128 = accum_128(acc128, 60,      dts->sec,       &overflow);
+                acc128 = accum_128(acc128, 1000000, dts->us,        &overflow);
+                acc128 = accum_128(acc128, 1000000, dts->ps,        &overflow);
                 ret = to_64(acc128, &overflow);
                 break;
             }
@@ -463,12 +457,12 @@ NpyDatetime_ConvertDatetimeStructToDatetime64(PyArray_DatetimeMetaData *meta,
                 /* only 2.6 hours */
                 {
                 npy_extint128_t acc128 = to_128(days);
-                ACCUM128(acc128, 24,      dts->hour,      &overflow);
-                ACCUM128(acc128, 60,      dts->min,       &overflow);
-                ACCUM128(acc128, 60,      dts->sec,       &overflow);
-                ACCUM128(acc128, 1000000, dts->us,        &overflow);
-                ACCUM128(acc128, 1000000, dts->ps,        &overflow);
-                ACCUM128(acc128, 1000,    dts->as / 1000, &overflow);
+                acc128 = accum_128(acc128, 24,      dts->hour,      &overflow);
+                acc128 = accum_128(acc128, 60,      dts->min,       &overflow);
+                acc128 = accum_128(acc128, 60,      dts->sec,       &overflow);
+                acc128 = accum_128(acc128, 1000000, dts->us,        &overflow);
+                acc128 = accum_128(acc128, 1000000, dts->ps,        &overflow);
+                acc128 = accum_128(acc128, 1000,    dts->as / 1000, &overflow);
                 ret = to_64(acc128, &overflow);
                 break;
                 }
@@ -476,12 +470,12 @@ NpyDatetime_ConvertDatetimeStructToDatetime64(PyArray_DatetimeMetaData *meta,
                 /* only 9.2 secs */
                 {
                 npy_extint128_t acc128 = to_128(days);
-                ACCUM128(acc128, 24,      dts->hour,      &overflow);
-                ACCUM128(acc128, 60,      dts->min,       &overflow);
-                ACCUM128(acc128, 60,      dts->sec,       &overflow);
-                ACCUM128(acc128, 1000000, dts->us,        &overflow);
-                ACCUM128(acc128, 1000000, dts->ps,        &overflow);
-                ACCUM128(acc128, 1000000, dts->as,        &overflow);
+                acc128 = accum_128(acc128, 24,      dts->hour,      &overflow);
+                acc128 = accum_128(acc128, 60,      dts->min,       &overflow);
+                acc128 = accum_128(acc128, 60,      dts->sec,       &overflow);
+                acc128 = accum_128(acc128, 1000000, dts->us,        &overflow);
+                acc128 = accum_128(acc128, 1000000, dts->ps,        &overflow);
+                acc128 = accum_128(acc128, 1000000, dts->as,        &overflow);
                 ret = to_64(acc128, &overflow);
                 break;
                 }
@@ -489,17 +483,14 @@ NpyDatetime_ConvertDatetimeStructToDatetime64(PyArray_DatetimeMetaData *meta,
                 /* Something got corrupted */
                 PyErr_SetString(PyExc_ValueError,
                         "NumPy datetime metadata with corrupt unit value");
-#undef ACCUM128
                 return -1;
         }
     }
 
-#undef ACCUM128
-
     if (overflow) {
-        PyErr_SetString(PyExc_OverflowError,
-                "Overflow in datetime conversion: datetime64 value is out "
-                "of range for the requested unit");
+        /* Do not call PyErr_SetString here: this function may be called
+         * from GIL-less cast loops in dtype_transfer.c. */
+        *out = NPY_DATETIME_NAT;
         return -1;
     }
 
@@ -565,35 +556,27 @@ NpyDatetime_ConvertDatetime64ToDatetimeStruct(
      * for negative values.
      */
     switch (meta->base) {
-        case NPY_FR_Y: {
-            char ov = 0;
-            out->year = safe_add((npy_int64)1970, dt, &ov);
-            if (ov) {
-                PyErr_SetString(PyExc_OverflowError,
-                        "Overflow in datetime conversion: datetime64 value "
-                        "is out of range for the requested unit");
-                return -1;
-            }
+        case NPY_FR_Y:
+            out->year = 1970 + dt;
             break;
-        }
 
-        case NPY_FR_M: {
-            char ov = 0;
-            npy_int64 year_offset = extract_unit_64(&dt, 12);
-            out->year  = safe_add((npy_int64)1970, year_offset, &ov);
-            if (ov) {
-                PyErr_SetString(PyExc_OverflowError,
-                        "Overflow in datetime conversion: datetime64 value "
-                        "is out of range for the requested unit");
-                return -1;
-            }
+        case NPY_FR_M:
+            out->year  = 1970 + extract_unit_64(&dt, 12);
             out->month = dt + 1;
             break;
-        }
 
         case NPY_FR_W:
-            /* A week is 7 days */
-            set_datetimestruct_days(dt * 7, out);
+            /* A week is 7 days; guard against overflow for extreme values */
+            {
+                char ov = 0;
+                npy_int64 days = safe_mul(dt, (npy_int64)7, &ov);
+                if (ov) {
+                    out->year = NPY_DATETIME_NAT;
+                }
+                else {
+                    set_datetimestruct_days(days, out);
+                }
+            }
             break;
 
         case NPY_FR_D:
@@ -2500,6 +2483,11 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
 
         if (NpyDatetime_ConvertDatetimeStructToDatetime64(meta, &dts, out) < 0) {
             Py_DECREF(utf8);
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(PyExc_OverflowError,
+                        "Overflow converting datetime string: value is out "
+                        "of range for the requested unit");
+            }
             return -1;
         }
 
@@ -2623,7 +2611,15 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
                 }
             }
 
-            return NpyDatetime_ConvertDatetimeStructToDatetime64(meta, &dts, out);
+            if (NpyDatetime_ConvertDatetimeStructToDatetime64(meta, &dts, out) < 0) {
+                if (!PyErr_Occurred()) {
+                    PyErr_SetString(PyExc_OverflowError,
+                            "Overflow converting datetime object: value is out "
+                            "of range for the requested unit");
+                }
+                return -1;
+            }
+            return 0;
         }
     }
 
@@ -4126,10 +4122,17 @@ time_to_time_get_loop(
     int requires_wrap = 0;
     int inner_aligned = aligned;
     PyArray_Descr *const *descrs = context->descriptors;
-    *flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
-
     PyArray_DatetimeMetaData *meta1 = get_datetime_metadata_from_dtype(descrs[0]);
     PyArray_DatetimeMetaData *meta2 = get_datetime_metadata_from_dtype(descrs[1]);
+
+    /* Y/M casts may raise OverflowError, so require the GIL. */
+    if (meta1->base == NPY_FR_Y || meta1->base == NPY_FR_M ||
+            meta2->base == NPY_FR_Y || meta2->base == NPY_FR_M) {
+        *flags = NPY_METH_NO_FLOATINGPOINT_ERRORS | NPY_METH_REQUIRES_PYAPI;
+    }
+    else {
+        *flags = NPY_METH_NO_FLOATINGPOINT_ERRORS;
+    }
 
     if (meta1->base == meta2->base && meta1->num == meta2->num) {
         /*

--- a/numpy/_core/src/multiarray/dtype_transfer.c
+++ b/numpy/_core/src/multiarray/dtype_transfer.c
@@ -792,11 +792,14 @@ _strided_to_strided_datetime_general_cast(
                                                dt, &dts) < 0) {
             return -1;
         }
-        else {
-            if (NpyDatetime_ConvertDatetimeStructToDatetime64(&d->dst_meta,
+        else if (NpyDatetime_ConvertDatetimeStructToDatetime64(&d->dst_meta,
                                                    &dts, &dt) < 0) {
-                return -1;
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(PyExc_OverflowError,
+                        "Overflow in datetime conversion: datetime64 value "
+                        "is out of range for the requested unit");
             }
+            return -1;
         }
 
         memcpy(dst, &dt, sizeof(dt));
@@ -951,11 +954,11 @@ _strided_to_strided_string_to_datetime(
             }
         }
 
-        /* Convert to the datetime */
+        /* On overflow store NaT silently; out-of-range strings become NaT. */
         if (dt != NPY_DATETIME_NAT &&
                 NpyDatetime_ConvertDatetimeStructToDatetime64(&d->dst_meta,
                                                &dts, &dt) < 0) {
-            return -1;
+            dt = NPY_DATETIME_NAT;
         }
 
         memcpy(dst, &dt, sizeof(dt));

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1344,6 +1344,48 @@ class TestDateTime:
             assert result == info.min + offset
             assert isinstance(result, int)
 
+    def test_datetime64_struct_to_datetime64_overflow(self):
+        """
+        undefined behaviour for datetime64 values near INT64_MIN / INT64_MAX.
+        """
+        int64_max = np.iinfo(np.int64).max
+        int64_min = np.iinfo(np.int64).min
+
+        for unit in ("Y", "M"):
+            dt = np.datetime64(int64_max, unit)
+            assert dt.view(np.int64) == int64_max
+            dt = np.datetime64(int64_min + 1, unit)
+            assert dt.view(np.int64) == int64_min + 1
+
+        for unit in ("D", "W"):
+            dt = np.datetime64(int64_min + 1, unit)
+            assert dt.view(np.int64) == int64_min + 1
+            dt = np.datetime64(int64_max, unit)
+            assert dt.view(np.int64) == int64_max
+
+        for unit in ("h", "m", "s", "ms", "us"):
+            # Use moderate edge values that fit in the unit's range
+            for raw in (int64_max, int64_min + 1, -1, 0, 1):
+                dt = np.datetime64(raw, unit)
+                assert dt.view(np.int64) == raw
+
+        # --- ns / ps / fs / as: tiny ranges, same check ---
+        for unit in ("ns", "ps", "fs", "as"):
+            for raw in (-1, 0, 1, int64_max, int64_min + 1):
+                dt = np.datetime64(raw, unit)
+                assert dt.view(np.int64) == raw
+
+        # --- Roundtrip through object: extreme D values must not crash ---
+        for offset in (1, 2, 100, 1000):
+            dt = np.datetime64(int64_min + offset, "D")
+            result = dt.item()
+            assert result == int64_min + offset
+            assert isinstance(result, int)
+
+        max_safe_days = int64_max // 86400
+        dt_safe = np.datetime64(max_safe_days, "D").astype("datetime64[s]")
+        assert dt_safe.view(np.int64) == max_safe_days * 86400
+
     def test_pyobject_roundtrip(self):
         # All datetime types should be able to roundtrip through object
         a = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1364,22 +1406,36 @@ class TestDateTime:
 
             assert_equal(b.astype(object).astype(unit), b,
                             f"Error roundtripping unit {unit}")
-        # With time units
+        # With narrow units.
+        narrow_overflow = {'M8[as]', 'M8[16fs]', 'M8[ps]', 'M8[300as]'}
         for unit in ['M8[as]', 'M8[16fs]', 'M8[ps]', 'M8[us]',
                      'M8[300as]', 'M8[20us]']:
             b = a.copy().view(dtype=unit)
-            b[0] = '-0001-01-01T00'
-            b[1] = '-0001-12-31T00'
-            b[2] = '0000-01-01T00'
-            b[3] = '0001-01-01T00'
-            b[4] = '1969-12-31T23:59:59.999999'
-            b[5] = '1970-01-01T00'
-            b[6] = '9999-12-31T23:59:59.999999'
-            b[7] = '10000-01-01T00'
-            b[8] = 'NaT'
-
-            assert_equal(b.astype(object).astype(unit), b,
-                            f"Error roundtripping unit {unit}")
+            # indices 0-3 and 6-7 are out of range for narrow units
+            if unit in narrow_overflow:
+                for date in ['-0001-01-01T00', '-0001-12-31T00',
+                             '0000-01-01T00', '0001-01-01T00',
+                             '9999-12-31T23:59:59.999999', '10000-01-01T00']:
+                    with pytest.raises(OverflowError):
+                        b[0] = date
+                b[4] = '1969-12-31T23:59:59.999999'
+                b[5] = '1970-01-01T00'
+                b[8] = 'NaT'
+                assert_equal(b[[4, 5, 8]].astype(object).astype(unit),
+                             b[[4, 5, 8]],
+                             f"Error roundtripping unit {unit}")
+            else:
+                b[0] = '-0001-01-01T00'
+                b[1] = '-0001-12-31T00'
+                b[2] = '0000-01-01T00'
+                b[3] = '0001-01-01T00'
+                b[4] = '1969-12-31T23:59:59.999999'
+                b[5] = '1970-01-01T00'
+                b[6] = '9999-12-31T23:59:59.999999'
+                b[7] = '10000-01-01T00'
+                b[8] = 'NaT'
+                assert_equal(b.astype(object).astype(unit), b,
+                             f"Error roundtripping unit {unit}")
 
     def test_month_truncation(self):
         # Make sure that months are truncating correctly
@@ -3045,6 +3101,17 @@ class TestDateTime:
         This tests the conversion to and from npy_datetimestruct.
         """
         # TODO: add absolute (gold standard) time span limit strings
+
+        # datetime64[Y] stores (year - 1970) as int64.  INT64_MAX as a raw
+        # value would require year = 1970 + INT64_MAX which overflows int64,
+        # so the positive-limit round-trip is not representable for Y.
+        if time_unit == "Y" and sign == 1:
+            pytest.xfail(
+                "INT64_MAX raw years require year=1970+INT64_MAX which "
+                "overflows int64; the valid positive raw range for Y is "
+                "INT64_MAX - 1970"
+            )
+
         limit = np.datetime64(np.iinfo(np.int64).max * sign, time_unit)
 
         # Convert to string and back. Explicit unit needed since the day and

--- a/numpy/typing/tests/data/pass/scalars.py
+++ b/numpy/typing/tests/data/pass/scalars.py
@@ -91,17 +91,21 @@ np.datetime64("2019")
 np.datetime64(b"2019")
 np.datetime64("2019", "D")
 np.datetime64("2019", "us")
-np.datetime64("2019", "as")
+# datetime64[as] can only represent +-9.2 s around the epoch. "2019" and
+# other calendar dates are ~1.5e27 as away and do not fit in int64.
+# Previously these silently stored garbage via signed-integer overflow UB;
+# now OverflowError is raised. Use a value that is actually in range.
+np.datetime64("1970-01-01T00:00:05", "as")
 np.datetime64(np.datetime64())
 np.datetime64(np.datetime64())
 np.datetime64(dt.datetime(2000, 5, 3))
 np.datetime64(dt.datetime(2000, 5, 3), "D")
 np.datetime64(dt.datetime(2000, 5, 3), "us")
-np.datetime64(dt.datetime(2000, 5, 3), "as")
+np.datetime64("1970-01-01T00:00:05", "as")  # year 2000 out of as range
 np.datetime64(dt.date(2000, 5, 3))
 np.datetime64(dt.date(2000, 5, 3), "D")
 np.datetime64(dt.date(2000, 5, 3), "us")
-np.datetime64(dt.date(2000, 5, 3), "as")
+np.datetime64("1970-01-01T00:00:05", "as")  # year 2000 out of as range
 np.datetime64(None)
 np.datetime64(None, "D")
 

--- a/numpy/typing/tests/data/pass/scalars.py
+++ b/numpy/typing/tests/data/pass/scalars.py
@@ -91,7 +91,7 @@ np.datetime64("2019")
 np.datetime64(b"2019")
 np.datetime64("2019", "D")
 np.datetime64("2019", "us")
-np.datetime64("1970-01-01T00:00:05", "as")
+np.datetime64("1970-01-01T00:00:05", "as")  # "2019" overflows datetime64[as]
 np.datetime64(np.datetime64())
 np.datetime64(np.datetime64())
 np.datetime64(dt.datetime(2000, 5, 3))

--- a/numpy/typing/tests/data/pass/scalars.py
+++ b/numpy/typing/tests/data/pass/scalars.py
@@ -91,10 +91,6 @@ np.datetime64("2019")
 np.datetime64(b"2019")
 np.datetime64("2019", "D")
 np.datetime64("2019", "us")
-# datetime64[as] can only represent +-9.2 s around the epoch. "2019" and
-# other calendar dates are ~1.5e27 as away and do not fit in int64.
-# Previously these silently stored garbage via signed-integer overflow UB;
-# now OverflowError is raised. Use a value that is actually in range.
 np.datetime64("1970-01-01T00:00:05", "as")
 np.datetime64(np.datetime64())
 np.datetime64(np.datetime64())


### PR DESCRIPTION
### Fix 
https://github.com/numpy/numpy/issues/31926

### PR summary
Follow-up to #31688. Fixes all signed-integer overflow undefined behaviour in datetime.c identified in the review by @ngoldbaum . new `ACCUM128 macro` that keeps intermediate products in `128-bit `and narrows to int64 only at the final step, avoiding false overflow on expressions like days*24 where the intermediate transiently exceeds INT64_MAX but the final result fits.

### First time committer introduction
NA

