### PR TITLE
BUG: avoid segfaults when legacy copyswap slot is not defined (#32151)

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1013,10 +1013,26 @@ _copy_and_return_void_setitem(_PyArray_LegacyDescr *dstdescr, char *dstdata,
             if (_setup_field(i, dstdescr, dummy_arr, &offset, dstdata)) {
                 return -1;
             }
-            PyDataType_GetArrFuncs(PyArray_DESCR(dummy_arr))->copyswap(dstdata + offset,
-                    srcdata + offset, 0, dummy_arr);
+            PyArray_CopySwapFunc *copyswap =
+                    PyDataType_GetArrFuncs(PyArray_DESCR(dummy_arr))->copyswap;
+            if (copyswap == NULL) {
+                /* a field dtype without the legacy copyswap slot; the
+                   casting path below handles it correctly */
+                break;
+            }
+            copyswap(dstdata + offset, srcdata + offset, 0, dummy_arr);
+            if (PyErr_Occurred()) {
+                /*
+                 * Clear the error and use the casting path, which
+                 * handles it and overwrites any partially copied fields.
+                 */
+                PyErr_Clear();
+                break;
+            }
         }
-        return 0;
+        if (i == names_size) {
+            return 0;
+        }
     }
 
     /* Slow path */
@@ -2259,6 +2275,17 @@ STRING_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
 }
 
 
+/* See common.h for the contract of this helper. */
+NPY_NO_EXPORT int
+raise_missing_copyswap(PyArray_Descr *dtype, int inplace_swap)
+{
+    (void)inplace_swap;
+    npy_gil_error(PyExc_TypeError,
+            "dtype %S does not implement copyswap",
+            (PyObject *)dtype);
+    return -1;
+}
+
 /* */
 static void
 VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
@@ -2289,9 +2316,14 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
             }
 
             dummy_fields.descr = new;
-            PyDataType_GetArrFuncs(new)->copyswapn(dst+offset, dstride,
-                    (src != NULL ? src+offset : NULL),
-                    sstride, n, swap, dummy_arr);
+            PyArray_CopySwapNFunc *copyswapn =
+                    PyDataType_GetArrFuncs(new)->copyswapn;
+            if (copyswapn == NULL && raise_missing_copyswap(new, src == NULL) < 0) {
+                return;
+            }
+            copyswapn(dst+offset, dstride,
+                      (src != NULL ? src+offset : NULL),
+                      sstride, n, swap, dummy_arr);
         }
         return;
     }
@@ -2330,10 +2362,15 @@ VOID_copyswapn (char *dst, npy_intp dstride, char *src, npy_intp sstride,
         PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
         ((PyArrayObject_fields *)dummy_arr)->descr = new;
 
+        PyArray_CopySwapNFunc *copyswapn =
+                PyDataType_GetArrFuncs(new)->copyswapn;
+        if (copyswapn == NULL && raise_missing_copyswap(new, src == NULL) < 0) {
+            return;
+        }
         num = descr->elsize / subitemsize;
         for (i = 0; i < n; i++) {
-            PyDataType_GetArrFuncs(new)->copyswapn(dstptr, subitemsize, srcptr,
-                    subitemsize, num, swap, dummy_arr);
+            copyswapn(dstptr, subitemsize, srcptr,
+                      subitemsize, num, swap, dummy_arr);
             dstptr += dstride;
             if (srcptr) {
                 srcptr += sstride;
@@ -2374,9 +2411,14 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
                 return;
             }
             dummy_fields.descr = new;
-            PyDataType_GetArrFuncs(new)->copyswap(dst+offset,
-                    (src != NULL ? src+offset : NULL),
-                    swap, dummy_arr);
+            PyArray_CopySwapFunc *copyswap =
+                    PyDataType_GetArrFuncs(new)->copyswap;
+            if (copyswap == NULL && raise_missing_copyswap(new, src == NULL) < 0) {
+                return;
+            }
+            copyswap(dst+offset,
+                     (src != NULL ? src+offset : NULL),
+                     swap, dummy_arr);
         }
         return;
     }
@@ -2411,9 +2453,14 @@ VOID_copyswap (char *dst, char *src, int swap, PyArrayObject *arr)
         PyArrayObject *dummy_arr = (PyArrayObject *)&dummy_fields;
         dummy_fields.descr = new;
 
+        PyArray_CopySwapNFunc *copyswapn =
+                PyDataType_GetArrFuncs(new)->copyswapn;
+        if (copyswapn == NULL && raise_missing_copyswap(new, src == NULL) < 0) {
+            return;
+        }
         num = descr->elsize / subitemsize;
-        PyDataType_GetArrFuncs(new)->copyswapn(dst, subitemsize, src,
-                subitemsize, num, swap, dummy_arr);
+        copyswapn(dst, subitemsize, src,
+                  subitemsize, num, swap, dummy_arr);
         return;
     }
     /* Must be a naive Void type (e.g. a "V8") so simple copy is sufficient. */
@@ -3049,6 +3096,13 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         /* Set the fields needed by compare or copyswap */
         dummy_struct.descr = new;
 
+        if (PyDataType_GetArrFuncs(new)->compare == NULL) {
+            npy_gil_error(PyExc_TypeError,
+                    "dtype %S does not support comparison",
+                    (PyObject *)new);
+            /* res is 0, so the caller sees equality alongside the error */
+            goto finish;
+        }
         swap = PyArray_ISBYTESWAPPED(dummy);
         nip1 = ip1 + offset;
         nip2 = ip2 + offset;

--- a/numpy/_core/src/multiarray/common.h
+++ b/numpy/_core/src/multiarray/common.h
@@ -59,6 +59,30 @@ _array_find_python_scalar_type(PyObject *op);
 NPY_NO_EXPORT npy_bool
 _IsWriteable(PyArrayObject *ap);
 
+/*
+ * Raise a TypeError for a dtype whose legacy copyswap slot is missing
+ * (e.g. a dtype written using the new DType API).  This never succeeds:
+ * it always returns -1, so that it can be chained onto the NULL test at
+ * the call site.  `inplace_swap` marks a request that only swaps bytes
+ * in place (no data copy); it is unused for now, but is passed so that
+ * such requests can become a no-op (returning 0) when byte order does
+ * not apply to the dtype (see gh-32150).
+ *
+ * WARNING: every call site is written as
+ *
+ *     if (copyswap == NULL && raise_missing_copyswap(...) < 0) {
+ *         <error return>;
+ *     }
+ *     copyswap(...);
+ *
+ * which calls through the NULL slot if this function returns 0.  This is
+ * safe only while it unconditionally returns -1: before changing it to
+ * return 0, every call site must first be restructured to skip the
+ * copyswap call on success.
+ */
+NPY_NO_EXPORT int
+raise_missing_copyswap(PyArray_Descr *dtype, int inplace_swap);
+
 NPY_NO_EXPORT PyObject *
 convert_shape_to_string(npy_intp n, npy_intp const *vals, char *ending);
 

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -433,6 +433,7 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
         NPY_cast_info_xfree(&cast_info);
     }
     else {
+        int needs_api = PyDataType_FLAGCHK(PyArray_DESCR(array), NPY_NEEDS_PYAPI);
         NPY_BEGIN_THREADS_DESCR(PyArray_DESCR(array));
         for (i = 0; i < ni; i++) {
             if (mask_data[i]) {
@@ -441,10 +442,17 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
                 }
 
                 copyswap(dest + i*chunk, src + j*chunk, 0, array);
+                if (needs_api && PyErr_Occurred()) {
+                    /* e.g. a structured dtype field that does not support copyswap */
+                    break;
+                }
                 j++;
             }
         }
         NPY_END_THREADS;
+        if (PyErr_Occurred()) {
+            goto fail;
+        }
     }
 
     Py_XDECREF(values);

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -713,6 +713,11 @@ array_flat_set(PyArrayObject *self, PyObject *val, void *NPY_UNUSED(ignored))
     swap = PyArray_ISNOTSWAPPED(self) != PyArray_ISNOTSWAPPED(arr);
     while(selfit->index < selfit->size) {
         copyswap(selfit->dataptr, arrit->dataptr, swap, self);
+        if (PyErr_Occurred()) {
+            /* e.g. a structured dtype field that does not support copyswap;
+               stop writing as soon as the error is visible */
+            goto exit;
+        }
         PyArray_ITER_NEXT(selfit);
         PyArray_ITER_NEXT(arrit);
         if (arrit->index == arrit->size) {

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -533,10 +533,13 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
     PyArrayIterObject *it;
 
     copyswapn = PyDataType_GetArrFuncs(PyArray_DESCR(self))->copyswapn;
+    if (inplace && PyArray_FailUnlessWriteable(self, "array to be byte-swapped") < 0) {
+        return NULL;
+    }
+    if (copyswapn == NULL && raise_missing_copyswap(PyArray_DESCR(self), 1) < 0) {
+        return NULL;
+    }
     if (inplace) {
-        if (PyArray_FailUnlessWriteable(self, "array to be byte-swapped") < 0) {
-            return NULL;
-        }
         size = PyArray_SIZE(self);
         if (PyArray_ISONESEGMENT(self)) {
             copyswapn(PyArray_DATA(self), PyArray_ITEMSIZE(self), NULL, -1, size, 1, self);
@@ -554,6 +557,10 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
             }
             Py_DECREF(it);
         }
+        if (PyErr_Occurred()) {
+            /* e.g. a structured dtype field that does not support copyswap */
+            return NULL;
+        }
 
         Py_INCREF(self);
         return (PyObject *)self;
@@ -564,6 +571,10 @@ PyArray_Byteswap(PyArrayObject *self, npy_bool inplace)
             return NULL;
         }
         new = PyArray_Byteswap(ret, NPY_TRUE);
+        if (new == NULL) {
+            Py_DECREF(ret);
+            return NULL;
+        }
         Py_DECREF(new);
         return (PyObject *)ret;
     }

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2177,13 +2177,19 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
         descr = PyArray_DescrFromScalar(self);
         data = (void *)scalar_value(self, descr);
 
+        PyArray_CopySwapFunc *copyswap =
+                PyDataType_GetArrFuncs(descr)->copyswap;
+        if (copyswap == NULL && raise_missing_copyswap(descr, 1) < 0) {
+            Py_DECREF(descr);
+            return NULL;
+        }
         newmem = PyMem_Malloc(descr->elsize);
         if (newmem == NULL) {
             Py_DECREF(descr);
             return PyErr_NoMemory();
         }
         else {
-            PyDataType_GetArrFuncs(descr)->copyswap(newmem, data, 1, NULL);
+            copyswap(newmem, data, 1, NULL);
         }
         new = PyArray_Scalar(newmem, descr, NULL);
         PyMem_Free(newmem);

--- a/numpy/_core/tests/test_custom_dtypes.py
+++ b/numpy/_core/tests/test_custom_dtypes.py
@@ -44,6 +44,98 @@ class TestSFloat:
         assert a.dtype.get_scaling() == scaling
         assert_array_equal(scaling * a.view(np.float64), [1., 2., 3.])
 
+    def test_structured_field_byteswap_raises(self):
+        # a field (or subarray field) whose dtype lacks the legacy copyswap
+        # slot cannot be byteswapped; previously this segfaulted via the
+        # unguarded field copyswap calls in VOID_copyswapn
+        arr = np.zeros(2, dtype=[("a", "i4"), ("v", SF(1.))])
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            arr.byteswap()
+
+        subarr = np.zeros(2, dtype=[("v", SF(1.), (2,))])
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            subarr.byteswap()
+
+    def test_byteswap_raises(self):
+        # a top-level DType without the legacy copyswap slot does not
+        # support byteswapping
+        arr = np.zeros(2, dtype=SF(1.))
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            arr.byteswap()
+
+        # the in-place writeability check fires before the missing-slot
+        # check, matching the behavior for dtypes that fill the slot
+        arr.flags.writeable = False
+        with pytest.raises(ValueError, match="array to be byte-swapped"):
+            arr.byteswap(inplace=True)
+
+    def test_structured_field_place_and_flat_raise(self):
+        # requests that need to copy through the missing legacy copyswap
+        # slot raise instead of crashing
+        arr = np.zeros(2, dtype=[("v", SF(1.))])
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            np.place(arr, [True, False], arr[:1])
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            arr.flat = arr[:1]
+
+        # both stop copying as soon as the error is detected, so elements
+        # after the first (failing) one keep their values, even for fields
+        # that could have been copied
+        marr = np.zeros(3, dtype=[("a", "i4"), ("v", SF(1.))])
+        marr["a"] = [5, 6, 7]
+        src = marr[:1].copy()
+        src["a"] = 1
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            marr.flat = src
+        assert marr["a"].tolist()[1:] == [6, 7]
+        with pytest.raises(TypeError, match="does not implement copyswap"):
+            np.place(marr, [True, True, True], src)
+        assert marr["a"].tolist()[1:] == [6, 7]
+
+    def test_structured_field_sort_raises(self):
+        # VOID_compare called the field's legacy compare slot, which
+        # new-style DTypes do not fill
+        arr = np.zeros(3, dtype=[("v", SF(1.))])
+        with pytest.raises(TypeError, match="does not support comparison"):
+            np.sort(arr, order="v")
+
+        # packed fields are misaligned; the compare == NULL check fires
+        # before VOID_compare's alignment handling, so this exits through
+        # the same guard as the aligned case above and never reaches the
+        # misaligned buffer path (which would call the missing copyswap
+        # slot); it checks that the guard keeps covering that layout
+        packed_dt = np.dtype({"names": ["a", "v"],
+                              "formats": ["u1", SF(1.)],
+                              "offsets": [0, 1], "itemsize": 17})
+        with pytest.raises(TypeError, match="does not support comparison"):
+            np.sort(np.zeros(3, dtype=packed_dt), order="v")
+
+    def test_structured_setitem_uses_cast_path(self):
+        # scalar assignment between equivalent structured dtypes used to
+        # segfault in the copyswap fast path; it now falls back to casting
+        arr = np.zeros(2, dtype=[("v", SF(1.))])
+        arr["v"] = np.array([1., 2.]).view(SF(1.))
+        arr[0] = arr[1]
+        assert arr["v"].view(np.float64).tolist() == [2., 2.]
+
+    def test_structured_setitem_nested_uses_cast_path(self):
+        # for a nested field the copyswap slot is VOID_copyswap, which
+        # fails on the inner sfloat field only after it is called; the
+        # error must not leak out of a successful-looking assignment and
+        # the copy falls back to the casting path like the flat case
+        arr = np.zeros(2, dtype=[("a", "i4"), ("nested", [("v", SF(1.))])])
+        arr["a"] = [1, 2]
+        arr["nested"]["v"] = np.array([1., 2.]).view(SF(1.))
+        arr[0] = arr[1]
+        assert arr["a"].tolist() == [2, 2]
+        assert arr["nested"]["v"].view(np.float64).tolist() == [2., 2.]
+
+        # same for a subarray field of an sfloat dtype
+        arr = np.zeros(2, dtype=[("sub", SF(1.), (2,))])
+        arr["sub"] = np.array([[1., 2.], [3., 4.]]).view(SF(1.))
+        arr[0] = arr[1]
+        assert arr["sub"].view(np.float64).tolist() == [[3., 4.], [3., 4.]]
+
     def test_repr(self):
         # Check the repr, mainly to cover the code paths:
         assert repr(SF(scaling=1.)) == "_ScaledFloatTestDType(scaling=1.0)"


### PR DESCRIPTION
Backport of #32151.

### PR summary
Towards addressing #24859 (see also #30795 ping @SwayamInSync). This avoids segfaults in many operations if `copyswap` or `copyswapn` isn't defined. Also see #32150 which does the same thing along with a small behavior change in `np.byteswap`.


#### AI Disclosure
I used an AI model to search the codebase and debug/test the fixes.