### PR TITLE
FIX: Handle overflow in i0 for large inputs (issue #32209)

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -42,6 +42,7 @@ from numpy._core.umath import (
     add,
     arctan2,
     cos,
+    log,
     exp,
     floor,
     frompyfunc,
@@ -3562,7 +3563,7 @@ def _i0_1(x):
 
 
 def _i0_2(x):
-    return exp(x) * _chbevl(32.0 / x - 2.0, _i0B) / sqrt(x)
+    return exp(x + log(_chbevl(32.0 / x - 2.0, _i0B) ) - 0.5 * log(x))
 
 
 def _i0_dispatcher(x):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3037,6 +3037,18 @@ class Test_I0:
         with pytest.raises(TypeError, match="i0 not supported for complex values"):
             res = i0(a)
 
+    def test_i0_large_input(self):
+        """Test that i0 returns finite values for large inputs like 713.0"""
+        x = np.float64(713.0)
+        expected = np.float64(6.705128263670996e307)
+        actual = np.i0(x)
+        
+        # Should be finite (not inf)
+        assert np.isfinite(actual), f"i0({x}) returned inf, expected finite value"
+        
+        # Should be close to expected value
+        np.testing.assert_allclose(actual, expected, rtol=1e-13)
+
 
 class TestKaiser:
 


### PR DESCRIPTION
Fixes issue #32209

### PR summary
## Description
Fixes issue #32209 where np.i0(713.0) returns inf instead of a finite value.

## Problem
The current implementation uses: exp(x) * chbevl(...) / sqrt(x)
For x=713.0, exp(713.0) overflows to inf before being divided.

## Solution
Use logarithmic form to avoid intermediate overflow:
exp(x + log(chbevl(...)) - 0.5*log(x))

This computes the same mathematical result without overflow.

## Testing
- Added test case for large input (713.0)
- Result is now finite and matches mpmath reference
- Relative error: ~1e-13 (acceptable for float64)

Closes #32209

### First time committer introduction
Hi! I'm Hariom Lohar (@hariomlohardev). I'm a Python developer interested in AI/AGI and numerical computing. I've been learning about neural networks and mathematical foundations of machine learning.

I found this issue through exploring NumPy's codebase and noticed the i0() Bessel function had a numerical stability problem with large inputs. Since I have a math background and experience with numerical methods, I decided to fix it.

I'm excited to contribute to NumPy and learn from the community!
