### PR TITLE
MAINT: Handle overflow in i0 for large inputs like 713.0

### DIFF
--- a/doc/release/upcoming_changes/32223.improvement.rst
+++ b/doc/release/upcoming_changes/32223.improvement.rst
@@ -1,2 +1,3 @@
-`numpy.i0` no longer returns ``inf`` for large inputs such as ``np.i0(713.0)``.
-The function now avoids intermediate overflow and returns the correct finite value.
+* `numpy.i0` no longer returns ``inf`` for large inputs such as ``np.i0(713.0)``.
+  The function now avoids intermediate overflow and returns the correct finite value.
+* `numpy.i0(np.inf)` no longer triggers a spurious ``RuntimeWarning`` due to divide-by-zero in the implementation and returns `np.inf` rather than `np.nan`.

--- a/doc/release/upcoming_changes/32223.improvement.rst
+++ b/doc/release/upcoming_changes/32223.improvement.rst
@@ -1,0 +1,2 @@
+`numpy.i0` no longer returns ``inf`` for large inputs such as ``np.i0(713.0)``.
+The function now avoids intermediate overflow and returns the correct finite value.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3628,7 +3628,7 @@ def i0(x):
     if x.dtype.kind != 'f':
         x = x.astype(float)
     x = np.abs(x)
-    return piecewise(x, [x <= 8.0], [_i0_1, _i0_2])
+    return piecewise(x, [x <= 8.0, np.isinf(x)], [_i0_1, lambda x: x, _i0_2])
 
 ## End of cephes code for i0
 

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3563,7 +3563,8 @@ def _i0_1(x):
 
 
 def _i0_2(x):
-    return exp(x + log(_chbevl(32.0 / x - 2.0, _i0B)) - 0.5 * log(x))
+    half_exp = exp(0.5 * x)
+    return half_exp * (_chbevl(32.0 / x - 2.0, _i0B) / sqrt(x)) * half_exp
 
 
 def _i0_dispatcher(x):

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -43,6 +43,7 @@ from numpy._core.umath import (
     arctan2,
     cos,
     exp,
+    log,
     floor,
     frompyfunc,
     less_equal,
@@ -3562,7 +3563,7 @@ def _i0_1(x):
 
 
 def _i0_2(x):
-    return exp(x) * _chbevl(32.0 / x - 2.0, _i0B) / sqrt(x)
+    return exp(x + log(_chbevl(32.0 / x - 2.0, _i0B)) - 0.5 * log(x))
 
 
 def _i0_dispatcher(x):

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -43,7 +43,6 @@ from numpy._core.umath import (
     arctan2,
     cos,
     exp,
-    log,
     floor,
     frompyfunc,
     less_equal,

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3037,10 +3037,8 @@ class Test_I0:
         x = np.float64(713.0)
         expected = np.float64(6.705128263670996e307)
         actual = np.i0(x)
-        
         # Should be finite (not inf)
         assert np.isfinite(actual), f"i0({x}) returned inf, expected finite value"
-        
         # Should be close to expected value
         np.testing.assert_allclose(actual, expected, rtol=1e-13)
     
@@ -3050,7 +3048,7 @@ class Test_I0:
         result = np.i0(np.inf)
         assert np.isinf(result), f"i0(inf) returned {result}, expected inf"
         assert result > 0, "i0(inf) should be positive infinity"
-
+        
     def test_complex(self):
         a = np.array([0, 1 + 2j])
         with pytest.raises(TypeError, match="i0 not supported for complex values"):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -5094,3 +5094,4 @@ class TestSortComplex:
         actual = np.sort_complex(a)
         assert_equal(actual, expected)
         assert_equal(actual.dtype, expected.dtype)
+        

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3032,6 +3032,18 @@ class Test_I0:
 
         assert_array_equal(exp, res)
 
+    def test_i0_large_input(self):
+        """Test that i0 returns finite values for large inputs like 713.0"""
+        x = np.float64(713.0)
+        expected = np.float64(6.705128263670996e307)
+        actual = np.i0(x)
+        
+        # Should be finite (not inf)
+        assert np.isfinite(actual), f"i0({x}) returned inf, expected finite value"
+        
+        # Should be close to expected value
+        np.testing.assert_allclose(actual, expected, rtol=1e-13)
+
     def test_complex(self):
         a = np.array([0, 1 + 2j])
         with pytest.raises(TypeError, match="i0 not supported for complex values"):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -5094,4 +5094,3 @@ class TestSortComplex:
         actual = np.sort_complex(a)
         assert_equal(actual, expected)
         assert_equal(actual.dtype, expected.dtype)
-        

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3037,7 +3037,7 @@ class Test_I0:
         x = np.float64(713.0)
         expected = np.float64(6.705128263670996e307)
         actual = np.i0(x)
-        
+
         # Should be finite (not inf)
         assert np.isfinite(actual), f"i0({x}) returned inf, expected finite value"
         # Should be close to expected value

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3037,10 +3037,10 @@ class Test_I0:
         x = np.float64(713.0)
         expected = np.float64(6.705128263670996e307)
         actual = np.i0(x)
-        
+
         # Should be finite (not inf)
         assert np.isfinite(actual), f"i0({x}) returned inf, expected finite value"
-        
+
         # Should be close to expected value
         np.testing.assert_allclose(actual, expected, rtol=1e-13)
 
@@ -5094,4 +5094,3 @@ class TestSortComplex:
         actual = np.sort_complex(a)
         assert_equal(actual, expected)
         assert_equal(actual.dtype, expected.dtype)
-        

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3041,7 +3041,7 @@ class Test_I0:
         assert np.isfinite(actual), f"i0({x}) returned inf, expected finite value"
         # Should be close to expected value
         np.testing.assert_allclose(actual, expected, rtol=1e-13)
-    
+
     def test_i0_inf(self):
         """Test that i0 handles infinity correctly"""
         # i0(inf) should return inf

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3043,6 +3043,13 @@ class Test_I0:
         
         # Should be close to expected value
         np.testing.assert_allclose(actual, expected, rtol=1e-13)
+    
+    def test_i0_inf(self):
+        """Test that i0 handles infinity correctly"""
+        # i0(inf) should return inf
+        result = np.i0(np.inf)
+        assert np.isinf(result), f"i0(inf) returned {result}, expected inf"
+        assert result > 0, "i0(inf) should be positive infinity"
 
     def test_complex(self):
         a = np.array([0, 1 + 2j])

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3049,7 +3049,7 @@ class Test_I0:
         result = np.i0(np.inf)
         assert np.isinf(result), f"i0(inf) returned {result}, expected inf"
         assert result > 0, "i0(inf) should be positive infinity"
-        
+
     def test_complex(self):
         a = np.array([0, 1 + 2j])
         with pytest.raises(TypeError, match="i0 not supported for complex values"):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3037,15 +3037,9 @@ class Test_I0:
         x = np.float64(713.0)
         expected = np.float64(6.705128263670996e307)
         actual = np.i0(x)
-<<<<<<< HEAD
-
+        
         # Should be finite (not inf)
         assert np.isfinite(actual), f"i0({x}) returned inf, expected finite value"
-
-=======
-        # Should be finite (not inf)
-        assert np.isfinite(actual), f"i0({x}) returned inf, expected finite value"
->>>>>>> 2726b1e8211a172ecb893a4b9f28a60f8091a058
         # Should be close to expected value
         np.testing.assert_allclose(actual, expected, rtol=1e-13)
 


### PR DESCRIPTION
Using math log this overflow problem is solved
 issue #32209

### PR summary
This is the fix to an overflow issuse 
np.i0(713.0) returns inf instead of a finite value

```
def _i0_2(x):
return exp(x) * _chbevl(32.0 / x - 2.0, _i0B) / sqrt(x)
```
changed to this 
```
def _i0_2(x):
return exp(x + log(_chbevl(32.0 / x - 2.0, _i0B)) - 0.5 * log(x))
```

this is in file : _lib\_function_base_impl.py_

THE MATH 
using logs we can control the overflow of exp so that it will return and finite value and not inf
new math formula for function is 
exp(x + log(val) - 0.5 * log(x))


### First time committer introduction
Hi  I'm Hariom Lohar (@hariomlohardev). I'm a Python developer interested in AI/AGI and right knwo learning basics in neural network and probability and statistics

I found this issue through exploring NumPy's codebase and noticed the i0() Bessel function had a numerical stability problem with large inputs. Since I have a math background and experience with numerical methods, I decided to fix it.


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
