### PR TITLE
BUG: fix a number of issues around iterators and StringDType (#32156)

### DIFF
--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -995,4 +995,3 @@ NPY_NO_EXPORT PyTypeObject PyBoundArrayMethod_Type = {
     .tp_methods = boundarraymethod_methods,
     .tp_getset = boundarraymethods_getters,
 };
-

--- a/numpy/_core/src/multiarray/arrayobject.c
+++ b/numpy/_core/src/multiarray/arrayobject.c
@@ -1203,6 +1203,12 @@ array_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
     }
     else {
         /* buffer given -- use it */
+        if (NPY_DT_has_finalize(NPY_DTYPE(descr))) {
+            PyErr_Format(PyExc_TypeError,
+                         "cannot create a %S array from a buffer",
+                         descr);
+            goto fail;
+        }
         if (dims.len == 1 && dims.ptr[0] == -1) {
             dims.ptr[0] = (buffer.len-(npy_intp)offset) / itemsize;
         }

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -394,7 +394,7 @@ arr_place(PyObject *NPY_UNUSED(self), PyObject *args, PyObject *kwdict)
     j = 0;
 
     copyswap = PyDataType_GetArrFuncs(PyArray_DESCR(array))->copyswap;
-    if (copyswap == NULL) {
+    if (copyswap == NULL || PyDataType_REFCHK(PyArray_DESCR(array))) {
         NPY_cast_info cast_info;
         NPY_ARRAYMETHOD_FLAGS flags;
         const npy_intp one = 1;

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1598,7 +1598,9 @@ _convert_from_type(PyObject *obj) {
     else {
         PyObject *DType = PyArray_DiscoverDTypeFromScalarType(typ);
         if (DType != NULL) {
-            return PyArray_GetDefaultDescr((PyArray_DTypeMeta *)DType);
+            PyArray_Descr *ret = PyArray_GetDefaultDescr((PyArray_DTypeMeta *)DType);
+            Py_DECREF(DType);
+            return ret;
         }
         PyArray_Descr *ret = _try_convert_from_dtype_attr(obj);
         if ((PyObject *)ret != Py_NotImplemented) {

--- a/numpy/_core/src/multiarray/dtype_transfer.h
+++ b/numpy/_core/src/multiarray/dtype_transfer.h
@@ -32,6 +32,7 @@ NPY_context_init(PyArrayMethod_Context *context, PyArray_Descr *descr[2])
     context->caller = NULL;
     context->_reserved = NULL;
     context->flags = 0;
+    context->parameters = NULL;
 }
 
 /*

--- a/numpy/_core/src/multiarray/dtypemeta.h
+++ b/numpy/_core/src/multiarray/dtypemeta.h
@@ -127,6 +127,9 @@ static inline int NPY_DT_is_user_defined(PyArray_DTypeMeta *dtype) {
     // New-style user defined dtypes have a type_num of -1 also on DType
     return dtype->type_num == -1;
 }
+static inline int NPY_DT_has_finalize(PyArray_DTypeMeta *dtype) {
+    return NPY_DT_SLOTS(dtype)->finalize_descr != NULL;
+}
 
 /*
  * Macros for convenient classmethod calls, since these require

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -2102,11 +2102,6 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
         if (PyArray_CopyObject(tmp_arr, op) < 0) {
              goto fail;
         }
-        /*
-         * In this branch we copy directly from a newly allocated array which
-         * may have a new descr:
-         */
-        descr = PyArray_DESCR(tmp_arr);
     }
 
     if (PyArray_MapIterCheckIndices(mit) < 0) {
@@ -2150,9 +2145,15 @@ array_assign_subscript(PyArrayObject *self, PyObject *ind, PyObject *op)
         /* May need a generic copy function (only for refs and odd sizes) */
         NPY_ARRAYMETHOD_FLAGS transfer_flags;
         npy_intp itemsize = PyArray_ITEMSIZE(self);
+        /*
+         * The value's descriptor may differ from `descr`: mit->outer can
+         * present it through a buffer or a temp copy whose descriptor
+         * `finalize_descr` replaced.
+         */
         if (PyArray_GetDTypeTransferFunction(
                 1, itemsize, itemsize,
-                descr, PyArray_DESCR(self),
+                NpyIter_GetDescrArray(mit->outer)[mit->num_fancy],
+                PyArray_DESCR(self),
                 0, &cast_info, &transfer_flags) != NPY_SUCCEED) {
             goto fail;
         }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -589,14 +589,18 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
 
         stride = descr->elsize;
 
-        /* Allocate the array for the result. This steals the 'dtype' reference. */
+        /*
+         * Allocate the array for the result. This steals the `descr`
+         * reference and may replace the descriptor via `finalize_descr`,
+         * so `descr` must not be used from here on.
+         */
         ret = (PyArrayObject *)PyArray_NewFromDescr_int(
                 subtype, descr,  1, &shape, &stride, NULL, 0, NULL,
                 NULL, _NPY_ARRAY_ALLOW_EMPTY_STRING);
+        descr = NULL;
         if (ret == NULL) {
             return NULL;
         }
-        assert(PyArray_DESCR(ret) == descr);
     }
 
     /*

--- a/numpy/_core/src/multiarray/nditer_constr.c
+++ b/numpy/_core/src/multiarray/nditer_constr.c
@@ -18,6 +18,7 @@
 #include "nditer_impl.h"
 #include "arrayobject.h"
 #include "array_coercion.h"
+#include "dtypemeta.h"
 #include "templ_common.h"
 #include "array_assign.h"
 #include "dtype_traversal.h"
@@ -626,13 +627,16 @@ NpyIter_Copy(NpyIter *iter)
             npyiter_goto_iterindex(newiter, NIT_ITERINDEX(newiter));
 
             /* Prepare the next buffers and set iterend/size */
-            npyiter_copy_to_buffers(newiter, NULL);
+            if (npyiter_copy_to_buffers(newiter, NULL) < 0) {
+                NpyIter_Deallocate(newiter);
+                return NULL;
+            }
         }
     }
 
     if (out_of_memory) {
-        NpyIter_Deallocate(newiter);
         PyErr_NoMemory();
+        NpyIter_Deallocate(newiter);
         return NULL;
     }
 
@@ -3069,6 +3073,21 @@ npyiter_new_temp_array(NpyIter *iter, PyTypeObject *subtype,
     return ret;
 }
 
+/*
+ * Replace an iterator-owned dtype when `finalize_descr` realized a different
+ * descriptor for its operand.  Other constructor changes, such as expanding a
+ * subarray dtype into the operand shape, must retain the requested dtype here.
+ */
+static inline void
+npyiter_sync_finalized_op_dtype(PyArray_Descr **op_dtype, PyArrayObject *op)
+{
+    if (*op_dtype != PyArray_DESCR(op) &&
+            NPY_DT_has_finalize(NPY_DTYPE(*op_dtype))) {
+        Py_INCREF(PyArray_DESCR(op));
+        Py_SETREF(*op_dtype, PyArray_DESCR(op));
+    }
+}
+
 static int
 npyiter_allocate_arrays(NpyIter *iter,
                         npy_uint32 flags,
@@ -3211,6 +3230,8 @@ npyiter_allocate_arrays(NpyIter *iter,
 
             op[iop] = out;
 
+            npyiter_sync_finalized_op_dtype(&op_dtype[iop], op[iop]);
+
             /*
              * Now we need to replace the pointers and strides with values
              * from the new array.
@@ -3245,6 +3266,8 @@ npyiter_allocate_arrays(NpyIter *iter,
             }
             Py_DECREF(op[iop]);
             op[iop] = temp;
+
+            npyiter_sync_finalized_op_dtype(&op_dtype[iop], op[iop]);
 
             /*
              * Now we need to replace the pointers and strides with values
@@ -3302,6 +3325,8 @@ npyiter_allocate_arrays(NpyIter *iter,
 
             Py_DECREF(op[iop]);
             op[iop] = temp;
+
+            npyiter_sync_finalized_op_dtype(&op_dtype[iop], op[iop]);
 
             /*
              * Now we need to replace the pointers and strides with values

--- a/numpy/_core/src/umath/reduction.c
+++ b/numpy/_core/src/umath/reduction.c
@@ -292,6 +292,27 @@ PyUFunc_ReduceWrapper(PyArrayMethod_Context *context,
         goto fail;
     }
 
+    /*
+     * Build the (nout + 1) -> nout reduction-loop descriptor layout:
+     * [accumulators..., stream, outputs...].  The accumulator and output
+     * slots both use the iterator's realized output descriptors.
+     *
+     * `op_dtypes` must track the same descriptors for initial-value buffers.
+     * All references are borrowed from `iter`, so this context must not
+     * outlive it.
+     */
+    PyArray_Descr *iter_context_descrs[NPY_MAXARGS];
+    PyArrayMethod_Context iter_context = *context;
+    PyArray_Descr **iter_descrs = NpyIter_GetDescrArray(iter);
+    for (int i = 0; i < nout; i++) {
+        iter_context_descrs[i] = iter_descrs[i];
+        iter_context_descrs[nout + 1 + i] = iter_descrs[i];
+        op_dtypes[i] = iter_descrs[i];
+    }
+    iter_context_descrs[nout] = iter_descrs[nout];
+    iter_context.descriptors = iter_context_descrs;
+    context = &iter_context;
+
     npy_bool empty_iteration = NpyIter_GetIterSize(iter) == 0;
     result = NpyIter_GetOperandArray(iter)[0];
 

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -886,6 +886,8 @@ try_trivial_single_output_loop(PyArrayMethod_Context *context,
     int operation_ndim = 0;
     npy_intp *operation_shape = NULL;
     npy_intp fixed_strides[NPY_MAXARGS];
+    PyArrayMethod_Context allocated_context;
+    PyArray_Descr *allocated_descrs[NPY_MAXARGS];
 
     for (int iop = 0; iop < nop; iop++) {
         if (op[iop] == NULL) {
@@ -943,6 +945,22 @@ try_trivial_single_output_loop(PyArrayMethod_Context *context,
                 NULL, NULL, operation_order==NPY_ARRAY_F_CONTIGUOUS, NULL);
         if (op[nin] == NULL) {
             return -1;
+        }
+        /*
+         * PyArray_NewFromDescr may replace the descriptor by calling
+         * `finalize_descr`.  The loop must use the replacement because it may
+         * own state referenced by the output data.
+         * Do not do this for every descriptor change: subarray dtypes also
+         * change PyArray_DESCR during creation, but their loop still uses the
+         * original subarray descriptor.
+         */
+        if (NPY_DT_has_finalize(NPY_DTYPE(context->descriptors[nin]))) {
+            memcpy(allocated_descrs, context->descriptors,
+                    nop * sizeof(*allocated_descrs));
+            allocated_descrs[nin] = PyArray_DESCR(op[nin]);
+            allocated_context = *context;
+            allocated_context.descriptors = allocated_descrs;
+            context = &allocated_context;
         }
         fixed_strides[nin] = context->descriptors[nin]->elsize;
     }
@@ -1122,6 +1140,10 @@ execute_ufunc_loop(PyArrayMethod_Context *context, int masked,
             Py_INCREF(op[nin + i]);
         }
     }
+
+    PyArrayMethod_Context iter_context = *context;
+    iter_context.descriptors = NpyIter_GetDescrArray(iter);
+    context = &iter_context;
 
     /* Only do the loop if the iteration size is non-zero */
     npy_intp full_size = NpyIter_GetIterSize(iter);
@@ -2107,9 +2129,9 @@ PyUFunc_GeneralizedFunctionInternal(PyUFuncObject *ufunc,
     memcpy(inner_strides, NpyIter_GetInnerStrideArray(iter),
                                     NPY_SIZEOF_INTP * nop);
 
-    /* Final preparation of the arraymethod call */
+    /* Final preparation of the arraymethod call. */
     PyArrayMethod_Context context;
-    NPY_context_init(&context, operation_descrs);
+    NPY_context_init(&context, NpyIter_GetDescrArray(iter));
     context.caller = (PyObject *)ufunc;
     context.method = ufuncimpl;
     PyArrayMethod_StridedLoop *strided_loop;
@@ -2863,6 +2885,11 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         }
     }
 
+    /* The loop descriptors borrow from the final iterator/array operands. */
+    PyArray_Descr *loop_descrs[3] = {
+            PyArray_DESCR(op[0]), PyArray_DESCR(op[1]), PyArray_DESCR(op[0])};
+    context.descriptors = loop_descrs;
+
     npy_intp fixed_strides[3];
     if (need_outer_iterator) {
         NpyIter_GetInnerFixedStrideArray(iter, fixed_strides);
@@ -2881,11 +2908,11 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         goto fail;
     }
     /* Set up function to copy the first element if it has references */
-    if (PyDataType_REFCHK(descrs[2])) {
+    if (PyDataType_REFCHK(loop_descrs[2])) {
         NPY_ARRAYMETHOD_FLAGS copy_flags;
         /* Setup guarantees aligned here. */
         if (PyArray_GetDTypeTransferFunction(
-                1, 0, 0, descrs[1], descrs[2], 0, &copy_info,
+                1, 0, 0, loop_descrs[1], loop_descrs[2], 0, &copy_info,
                 &copy_flags) == NPY_FAIL) {
             goto fail;
         }
@@ -2922,7 +2949,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         NpyIter_IterNextFunc *iternext;
         char **dataptr;
 
-        int itemsize = descrs[0]->elsize;
+        int itemsize = loop_descrs[0]->elsize;
 
         /* Get the variables needed for the loop */
         iternext = NpyIter_GetIterNext(iter, NULL);
@@ -2987,7 +3014,7 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
     else if (iter == NULL) {
         char *dataptr_copy[3];
 
-        int itemsize = descrs[0]->elsize;
+        int itemsize = loop_descrs[0]->elsize;
 
         /* Execute the loop with no iterators */
         npy_intp count = PyArray_DIM(op[1], axis);

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -724,6 +724,79 @@ def test_fancy_indexing(string_list):
         assert_array_equal(sarr[ind], uarr[ind])
 
 
+@pytest.mark.parametrize("value", ["Z" * 20, "Z" * 5])
+def test_fancy_index_assign_0d_value(value):
+    # a 0-d value assigned through multiple fancy indices broadcasts to
+    # every selected element (gh-32153)
+    a = np.array(["v0", "v1", "v2", "v3"], dtype="T").reshape(2, 2)
+    a[[0, 1], [0, 1]] = np.array(value, dtype="T")
+    assert_array_equal(a, [[value, "v1"], ["v2", value]])
+    # the value may carry the destination's own dtype instance
+    a[[0, 1], [0, 1]] = np.array(value + "x", dtype=a.dtype)
+    assert_array_equal(a, [[value + "x", "v1"], ["v2", value + "x"]])
+
+
+def test_fancy_index_assign_subspace_distinct_allocators():
+    # Fancy indexing only the first dimension leaves the second dimension as
+    # a subspace copied from an independently-owned StringDType descriptor.
+    a, b, a_obj, b_obj = _make_distinct_arena_arrays(6)
+    a, a_obj = a.reshape(3, 2), a_obj.reshape(3, 2)
+    rhs, rhs_obj = b[:4].reshape(2, 2), b_obj[:4].reshape(2, 2)
+
+    a[[0, 2], :] = rhs
+    a_obj[[0, 2], :] = rhs_obj
+    assert_array_equal(a, a_obj)
+
+
+@pytest.mark.parametrize("buffered", [True, False])
+@pytest.mark.parametrize("pass_op_dtypes", [True, False])
+def test_nditer_allocated_output(buffered, pass_op_dtypes):
+    # an iterator-allocated StringDType output round-trips the values
+    # written through the iterator, and it.dtypes reports the descriptor
+    # that owns the allocated operand's data (gh-32153)
+    a = np.array(["x" * 20, "y" * 20, "z" * 20], dtype="T")
+    flags = ["refs_ok"] + (["buffered"] if buffered else [])
+    op_dtypes = [a.dtype, a.dtype] if pass_op_dtypes else None
+    it = np.nditer([a, None], flags=flags,
+                   op_flags=[["readonly"], ["writeonly", "allocate"]],
+                   op_dtypes=op_dtypes)
+    with it:
+        for x, y in it:
+            y[...] = x
+        out = it.operands[1]
+        assert it.dtypes[1] is out.dtype
+    assert_array_equal(out, a)
+
+
+def test_nditer_copy_and_writeback():
+    # requesting a distinct StringDType instance forces the iterator to
+    # copy the operand; the copied values read back correctly and, with
+    # updateifcopy, write back to the original array (gh-32153)
+    v = np.array(["Z" * 20, "Y" * 25], dtype="T")
+    dt = np.dtypes.StringDType()
+    np.empty(1, dtype=dt)  # attach dt to an array so it is a distinct instance
+
+    it = np.nditer([v], flags=["refs_ok"], op_flags=[["readonly", "copy"]],
+                   op_dtypes=[dt], casting="unsafe")
+    assert [str(x) for x in it] == ["Z" * 20, "Y" * 25]
+    assert it.dtypes[0] is it.operands[0].dtype
+
+    it = np.nditer([v], flags=["refs_ok"],
+                   op_flags=[["readwrite", "updateifcopy"]],
+                   op_dtypes=[dt], casting="unsafe")
+    with it:
+        for x in it:
+            x[...] = str(x) + "q"
+    assert v.tolist() == ["Z" * 20 + "q", "Y" * 25 + "q"]
+
+
+def test_ndarray_from_buffer_rejected():
+    # StringDType entries reference a per-descriptor arena, so an array
+    # cannot be created over caller-supplied buffer memory (gh-32153)
+    with pytest.raises(TypeError, match="buffer"):
+        np.ndarray((2,), dtype="T", buffer=bytearray(32))
+
+
 def test_fromiter_reused_dtype():
     # Reusing the same StringDType instance across fromiter
     # calls used to write strings into the wrong arena, creating corrupted arrays
@@ -2335,6 +2408,9 @@ def test_concatenate_distinct_allocators():
     assert_array_equal(np.vstack([a, b]), np.vstack([a_obj, b_obj]))
     assert_array_equal(np.hstack([a, b]), expected)
 
+    # a single array with axis=None is returned unchanged
+    assert_array_equal(np.concatenate([a], axis=None), a_obj)
+
 
 def test_where_distinct_allocators():
     a, b, a_obj, b_obj = _make_distinct_arena_arrays(101)
@@ -2571,3 +2647,75 @@ def test_flat_assignment_distinct_allocators():
     d.flat = ["xy"]
     d_obj.flat = ["xy"]
     assert_array_equal(d, d_obj)
+
+
+def test_ufunc_overlapping_out_distinct_allocators():
+    a, _, a_obj, _ = _make_distinct_arena_arrays(20)
+    # out= overlapping an input (reversed view)
+    np.add(a, a, out=a[::-1])
+    np.add(a_obj, a_obj, out=a_obj[::-1])
+    assert_array_equal(a, a_obj)
+
+    # same through the masked (where=) loop
+    b, _, b_obj, _ = _make_distinct_arena_arrays(20, prefix_a="B")
+    mask = np.arange(10) % 2 == 0
+    np.add(b[:10], b[:10], out=b[5:15], where=mask)
+    np.add(b_obj[:10], b_obj[:10], out=b_obj[5:15], where=mask)
+    assert_array_equal(b, b_obj)
+
+
+def test_reduce_distinct_allocators():
+    a, acc_out, a_obj, acc_out_obj = _make_distinct_arena_arrays(50)
+    assert_array_equal(np.maximum.reduce(a), np.maximum.reduce(a_obj))
+    assert_array_equal(np.add.accumulate(a), np.add.accumulate(a_obj))
+
+    # no outer iterator, but the independently-allocated output still has a
+    # different descriptor from the input
+    np.add.accumulate(a, out=acc_out)
+    np.add.accumulate(a_obj, out=acc_out_obj)
+    assert_array_equal(acc_out, acc_out_obj)
+
+    # a multidimensional accumulate uses an outer iterator and allocates a
+    # finalized output descriptor
+    c, _, c_obj, _ = _make_distinct_arena_arrays(6, prefix_a="C")
+    c, c_obj = c.reshape(2, 3), c_obj.reshape(2, 3)
+    assert_array_equal(
+        np.add.accumulate(c, axis=1), np.add.accumulate(c_obj, axis=1)
+    )
+
+    # a long initial value exercises the finalized reduction descriptors used
+    # to create and populate the masked-reduction initial-value buffer
+    mask = np.array([[True, False, True], [False, True, True]])
+    assert_array_equal(
+        np.maximum.reduce(c, axis=1, where=mask, initial="initial" * 4),
+        np.maximum.reduce(c_obj, axis=1, where=mask, initial="initial" * 4),
+    )
+
+    # accumulate in place (out aliases the operand)
+    np.add.accumulate(a, out=a)
+    np.add.accumulate(a_obj, out=a_obj)
+    assert_array_equal(a, a_obj)
+
+    # reduce with out= overlapping the operand
+    b, _, b_obj, _ = _make_distinct_arena_arrays(6, prefix_a="B")
+    b, b_obj = b.reshape(2, 3), b_obj.reshape(2, 3)
+    np.maximum.reduce(b, axis=0, out=b[0])
+    np.maximum.reduce(b_obj, axis=0, out=b_obj[0])
+    assert_array_equal(b, b_obj)
+
+
+def test_nditer_distinct_allocators():
+    a, b, a_obj, _ = _make_distinct_arena_arrays(20)
+
+    # a 0-d readonly operand cast to a distinct instance reads back, and
+    # it.dtypes agrees with the operand the iterator actually uses
+    zero_d = np.array(a_obj[0], dtype="T")
+    it = np.nditer([zero_d], flags=["refs_ok"], op_dtypes=[b.dtype],
+                   casting="unsafe")
+    assert str(next(it)) == a_obj[0]
+    assert it.dtypes[0] is it.operands[0].dtype
+
+    # a buffered iterator and its copy read the same values
+    it = np.nditer([a], flags=["refs_ok", "buffered"], op_dtypes=[b.dtype],
+                   casting="unsafe")
+    assert_array_equal([str(x) for x in it.copy()], a_obj.tolist())


### PR DESCRIPTION
Backport of #32156.

### PR summary
Fixes #32153. Also fixes a number of other issues that are caused by the same problem: array creation can replace descriptors. The iterator code in particular had a number of spots that didn't handle this case.

I added a new `NPY_DT_has_finalize` predicate to branch based on whether or not there is a `finalize_descr` implementation, which might replace dtype instances.

I also added a new `npy_resync_finalized_descr`, which does the necessary reference bookkeeping when a descriptor has been replaced.

Also deletes an assert in the `np.concatenate` implementation that could trigger for `StringDType` if a descriptor is replaced.

There are also a few minor unrelated C error checking fixes included as well.


#### AI Disclosure
An AI model found the issue and I used it to help develop and debug the fix and new tests.
