### PR TITLE
BUG: raise ValueError when reading into record array with references

### DIFF
--- a/numpy/_core/records.py
+++ b/numpy/_core/records.py
@@ -815,7 +815,10 @@ def fromstring(datastring, dtype=None, shape=None, offset=0, formats=None,
         descr = format_parser(formats, names, titles, aligned, byteorder).dtype
 
     if descr.hasobject:
-        raise ValueError("Cannot read into array with references")
+        raise ValueError(
+            f"Cannot create record array for dtype {descr}. "
+             "Arrays containing references are not supported."
+        )
 
     itemsize = descr.itemsize
 
@@ -916,7 +919,10 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
             ).dtype
 
         if descr.hasobject:
-            raise ValueError("Cannot read into array with references")
+            raise ValueError(
+                f"Cannot create record array for dtype {descr}. "
+                "Arrays containing references are not supported."
+            )
 
         itemsize = descr.itemsize
 

--- a/numpy/_core/records.py
+++ b/numpy/_core/records.py
@@ -814,6 +814,9 @@ def fromstring(datastring, dtype=None, shape=None, offset=0, formats=None,
     else:
         descr = format_parser(formats, names, titles, aligned, byteorder).dtype
 
+    if descr.hasobject:
+        raise ValueError("Cannot read into array with references")
+
     itemsize = descr.itemsize
 
     # NumPy 1.19.0, 2020-01-01
@@ -911,6 +914,9 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
             descr = format_parser(
                 formats, names, titles, aligned, byteorder
             ).dtype
+
+        if descr.hasobject:
+            raise ValueError("Cannot read into array with references")
 
         itemsize = descr.itemsize
 

--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -108,6 +108,18 @@ class TestFromrecords:
         assert_equal(r1, r2)
         assert_equal(r2, r3)
 
+    def test_recarray_read_with_references_raises(self):
+        with temppath(suffix=".bin") as path:
+            with open(path, "wb") as fd:
+                fd.write(b"dummy data")
+            with pytest.raises(
+                ValueError, match="Cannot read into array with references"
+            ):
+                np.rec.fromfile(path, formats="O", shape=1)
+
+        with pytest.raises(ValueError, match="Cannot read into array with references"):
+            np.rec.fromstring(b"dummy data", formats="O", shape=1)
+
     def test_recarray_from_obj(self):
         count = 10
         a = np.zeros(count, dtype='O')

--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -113,11 +113,13 @@ class TestFromrecords:
             with open(path, "wb") as fd:
                 fd.write(b"dummy data")
             with pytest.raises(
-                ValueError, match="Cannot read into array with references"
+                ValueError, match="Arrays containing references are not supported"
             ):
                 np.rec.fromfile(path, formats="O", shape=1)
 
-        with pytest.raises(ValueError, match="Cannot read into array with references"):
+        with pytest.raises(
+            ValueError, match="Arrays containing references are not supported"
+        ):
             np.rec.fromstring(b"dummy data", formats="O", shape=1)
 
     def test_recarray_from_obj(self):


### PR DESCRIPTION
Fixes a bug with `numpy.rec.fromfile` and `numpy.rec.fromstring` where attempting to read into dtypes with references, including object and structured dtypes, would be unsafely accepted and could lead to segfaults. We already guard against this in `PyArray_FromFile` and related functions:

https://github.com/numpy/numpy/blob/73d14198a7e98ece82fdd1e3554e6c3d7060ae7b/numpy/_core/src/multiarray/ctors.c#L3659-L3664

The test in this PR would lead to a segfault on `main`. This bug was reported privately, cc @rgommers 

#### AI Disclosure

I used line completion with GitHub copilot. No other AI used.