### PR TITLE
MAINT: parse nditer flags as unicode directly (gh-15317)

### DIFF
--- a/doc/release/upcoming_changes/32232.improvement.rst
+++ b/doc/release/upcoming_changes/32232.improvement.rst
@@ -1,0 +1,3 @@
+Improved error for non-ASCII ``nditer`` flags
+---------------------------------------------
+`numpy.nditer` and `numpy.nested_iters` now read flag names from Python strings instead of encoding them to ASCII first. The flags containing non-ASCII character used to raise `UnicodeEncodeError`, but now it raises `ValueError`, which make it consistent with the error given for other unrecognized flag names.

--- a/doc/release/upcoming_changes/32232.improvement.rst
+++ b/doc/release/upcoming_changes/32232.improvement.rst
@@ -1,3 +1,3 @@
 Improved error for non-ASCII ``nditer`` flags
 ---------------------------------------------
-`numpy.nditer` and `numpy.nested_iters` now read flag names from Python strings instead of encoding them to ASCII first. The flags containing non-ASCII character used to raise `UnicodeEncodeError`, but now it raises `ValueError`, which make it consistent with the error given for other unrecognized flag names.
+``numpy.nditer`` and ``numpy.nested_iters`` now read flag names from Python strings instead of encoding them to ASCII first. Flags containing non-ASCII characters used to raise ``UnicodeEncodeError``, but now raise ``ValueError``, which makes it consistent with the error given for other unrecognized flag names.

--- a/numpy/_core/src/multiarray/nditer_pywrap.c
+++ b/numpy/_core/src/multiarray/nditer_pywrap.c
@@ -137,7 +137,7 @@ NpyIter_GlobalFlagsConverter(PyObject *flags_in, npy_uint32 *flags)
         if (PyUnicode_Check(f)) {
             /* accept unicode input */
             str = (char *)PyUnicode_AsUTF8AndSize(f, &length);
-            if(str == NULL) {
+            if (str == NULL) {
                 Py_DECREF(f);
                 return 0;
             }

--- a/numpy/_core/src/multiarray/nditer_pywrap.c
+++ b/numpy/_core/src/multiarray/nditer_pywrap.c
@@ -136,17 +136,13 @@ NpyIter_GlobalFlagsConverter(PyObject *flags_in, npy_uint32 *flags)
 
         if (PyUnicode_Check(f)) {
             /* accept unicode input */
-            PyObject *f_str;
-            f_str = PyUnicode_AsASCIIString(f);
-            if (f_str == NULL) {
+            str = (char *)PyUnicode_AsUTF8AndSize(f, &length);
+            if(str == NULL) {
                 Py_DECREF(f);
                 return 0;
             }
-            Py_DECREF(f);
-            f = f_str;
         }
-
-        if (PyBytes_AsStringAndSize(f, &str, &length) < 0) {
+        else if (PyBytes_AsStringAndSize(f, &str, &length) < 0) {
             Py_DECREF(f);
             return 0;
         }
@@ -268,17 +264,13 @@ NpyIter_OpFlagsConverter(PyObject *op_flags_in,
 
         if (PyUnicode_Check(f)) {
             /* accept unicode input */
-            PyObject *f_str;
-            f_str = PyUnicode_AsASCIIString(f);
-            if (f_str == NULL) {
+            str = (char *)PyUnicode_AsUTF8AndSize(f, &length);
+            if (str == NULL) {
                 Py_DECREF(f);
                 return 0;
             }
-            Py_DECREF(f);
-            f = f_str;
         }
-
-        if (PyBytes_AsStringAndSize(f, &str, &length) < 0) {
+        else if (PyBytes_AsStringAndSize(f, &str, &length) < 0) {
             PyErr_Clear();
             Py_DECREF(f);
             PyErr_SetString(PyExc_ValueError,

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -857,8 +857,6 @@ def test_iter_flags_errors():
     assert_raises(ValueError, nditer, [a], [], [['readonly', '☃']])
     # Non-string flag
     assert_raises(ValueError, nditer, [a], [], [['readonly', 3]])
-    # Non-string global flag
-    assert_raises(TypeError, nditer, [a], [3], [['readonly']])
     # Bad order parameter
     assert_raises(ValueError, nditer, [a], [], [['readonly']], order='G')
     # Bad casting parameter

--- a/numpy/_core/tests/test_nditer.py
+++ b/numpy/_core/tests/test_nditer.py
@@ -851,6 +851,14 @@ def test_iter_flags_errors():
     assert_raises(ValueError, nditer, [a], ['bad flag'], [['readonly']])
     # Bad op flag
     assert_raises(ValueError, nditer, [a], [], [['readonly', 'bad flag']])
+    # Non-ASCII global flag
+    assert_raises(ValueError, nditer, [a], ['☃'], [['readonly']])
+    # Non-ASCII op flag
+    assert_raises(ValueError, nditer, [a], [], [['readonly', '☃']])
+    # Non-string flag
+    assert_raises(ValueError, nditer, [a], [], [['readonly', 3]])
+    # Non-string global flag
+    assert_raises(TypeError, nditer, [a], [3], [['readonly']])
     # Bad order parameter
     assert_raises(ValueError, nditer, [a], [], [['readonly']], order='G')
     # Bad casting parameter
@@ -914,6 +922,14 @@ def test_iter_flags_errors():
     assert_raises(ValueError, assign_iterrange, i)
     # Can't iterate if size is zero
     assert_raises(ValueError, nditer, np.array([]))
+
+def test_iter_bytes_flags():
+    # bytes flags are accepted for backwards compatibility
+    a = arange(6)
+    i = nditer(a, [b'buffered'], [['readonly']])
+    assert_equal([int(x) for x in i], [0, 1, 2, 3, 4, 5])
+    i = nditer(a, [], [[b'readonly']])
+    assert_equal([int(x) for x in i], [0, 1, 2, 3, 4, 5])
 
 def test_iter_slice():
     a, b, c = np.arange(3), np.arange(3), np.arange(3.)


### PR DESCRIPTION
### PR summary
Part of gh-15317 (cleaning up internal callers of `PyUnicode_AsASCIIString`).

`NpyIter_GlobalFlagsConverter` and `NpyIter_OpFlagsConverter` encoded unicode flag strings to bytes with `PyUnicode_AsASCIIString` before inspecting them. That allocates a throwaway bytes object for every flag, and for non-ASCII input it raises `UnicodeEncodeError` — which doesn't describe what the user actually did wrong. This should be a value error instead of Unicode Encode Error.

I created the test cases to raise ValueErrors when flags are not correct Unicode or not strings. I have also added the positive test cases when byte strings are passed as well. 

### First time committer introduction
Hello! My name is Yuta Nakamura, and I'm a backend software engineer. It made me curious how NumPy was created, and realized it was open source, and now it's easier than ever to contribute, so I decided to contribute to the project. I did a Ph.D. in computer science at DePaul University (in Chicago) specializing in program analysis. I'm originally from Japan but spent half of my life in the US. 

#### AI Disclosure

I discussed the code with Claude to understand it and what changes need to be made, and I wrote the code myself to fix them. Tests are written by me (but discussed with claude where I should write and what I should write).