### PR TITLE
MAINT: update openblas

### DIFF
--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.34.160.0
+scipy-openblas32==0.3.34.106.0

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.34.0.0
+scipy-openblas32==0.3.34.160.0

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.34.0.0
-scipy-openblas64==0.3.34.0.0
+scipy-openblas32==0.3.34.160.0
+scipy-openblas64==0.3.34.160.0

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.34.160.0
-scipy-openblas64==0.3.34.160.0
+scipy-openblas32==0.3.34.106.0
+scipy-openblas64==0.3.34.106.0


### PR DESCRIPTION
Update OpenBLAS to 0.3.34.106.0

~Fixes~ Towards #32168

Will need a companion numpy-release PR to be merged in order to pass all CI.

No AI used.