### PR TITLE
BUG: preserve input masks in ma.in1d and ma.isin

### DIFF
--- a/numpy/ma/extras.py
+++ b/numpy/ma/extras.py
@@ -1551,27 +1551,23 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
            fill_value=True)
 
     """
-    if not assume_unique:
-        ar1, rev_idx = unique(ar1, return_inverse=True)
-        ar2 = unique(ar2)
+    ar1 = ma.asarray(ar1).ravel()
+    ar2 = ma.asarray(ar2).ravel()
+    ar1_mask = getmask(ar1)
+    result = ma.empty_like(ar1, dtype=bool)
 
-    ar = ma.concatenate((ar1, ar2))
-    # We need this to be a stable sort, so always use 'mergesort'
-    # here. The values from the first array should always come before
-    # the values from the second array.
-    order = ar.argsort(kind='mergesort')
-    sar = ar[order]
-    if invert:
-        bool_ar = (sar[1:] != sar[:-1])
-    else:
-        bool_ar = (sar[1:] == sar[:-1])
-    flag = ma.concatenate((bool_ar, [invert]))
-    indx = order.argsort(kind='mergesort')[:len(ar1)]
+    if ar1_mask is not nomask:
+        ar1 = ar1[~ar1_mask]
+    ar2_mask = getmask(ar2)
+    if ar2_mask is not nomask:
+        ar2 = ar2[~ar2_mask]
 
-    if assume_unique:
-        return flag[indx]
+    output = np.isin(ar1, ar2, assume_unique=assume_unique, invert=invert)
+    if ar1_mask is nomask:
+        result[...] = output
     else:
-        return flag[indx][rev_idx]
+        result[~ar1_mask] = output
+    return result
 
 
 def isin(element, test_elements, assume_unique=False, invert=False):

--- a/numpy/ma/tests/test_extras.py
+++ b/numpy/ma/tests/test_extras.py
@@ -1695,6 +1695,38 @@ class TestArraySetOps:
         d = np.isin(a, b[~b.mask]) & ~a.mask
         assert_array_equal(c, d)
 
+    @pytest.mark.parametrize(
+        "test_elements, expected_data",
+        [
+            ([], [False, False, False, False, False]),
+            ([2], [False, False, True, False, False]),
+            ([2, 3, 4], [False, False, True, True, True]),
+        ],
+    )
+    def test_isin_preserves_input_mask(self, test_elements, expected_data):
+        values = masked_array(np.arange(5), mask=[0, 1, 0, 0, 1])
+        expected = masked_array(expected_data, mask=values.mask)
+
+        for func in (in1d, isin):
+            result = func(values, test_elements)
+            assert_equal(result, expected)
+            assert_array_equal(getmaskarray(result), values.mask)
+
+    def test_in1d_flattens_multidimensional_input(self):
+        values = masked_array(
+            np.arange(8).reshape(2, 4),
+            mask=[[0, 1, 0, 0], [0, 0, 0, 0]],
+        )
+        expected = masked_array(
+            [True, False, True, True, False, False, False, False],
+            mask=values.mask.ravel(),
+        )
+
+        result = in1d(values, [0, 2, 3])
+
+        assert_equal(result, expected)
+        assert result.shape == (8,)
+
     def test_in1d(self):
         # Test in1d
         a = array([1, 2, 5, 7, -1], mask=[0, 0, 0, 0, 1])


### PR DESCRIPTION
## Description

  `ma.in1d` and `ma.isin` did not preserve the mask of the first input at its original positions. The previous implementation sorted combined masked arrays, causing the result mask to correspond to the sorted
  positions instead of the original input.

  This change excludes masked values from membership comparisons, computes membership for the unmasked elements, and places the results back into an array carrying the original mask of the first input.

  `ma.in1d` continues to return a flattened result for multidimensional inputs.

  Closes #19877.

  ## Tests

  Added regression coverage for:

  - empty, single-value, and multiple-value membership sets;
  - both `ma.in1d` and `ma.isin`;
  - multidimensional input flattening in `ma.in1d`.

  Validation results:

  - `numpy/ma/tests/test_extras.py`: 150 passed
  - `numpy/ma`: 4426 passed, 2 existing expected xfails
  - Ruff: passed
  - C API borrowed-reference lint: passed (555 files)
  - Cython lint: passed
  - `git diff --check`: passed