### PR TITLE
gh-31382: Fix the return dtype from np.vectorize

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -27,6 +27,8 @@ from numpy._core.numeric import (
     concatenate,
     dot,
     empty,
+    empty_like,
+    fromiter,
     integer,
     intp,
     isscalar,
@@ -2303,6 +2305,29 @@ def _get_vectorize_dtype(dtype):
     return dtype
 
 
+def _as_object_array(a):
+    """Convert `a` to an object array without unboxing NumPy scalars.
+
+    ``asanyarray(a, dtype=object)`` converts each element through the dtype's
+    ``getitem``.  For datetime64/timedelta64 that yields ``datetime.date``,
+    ``datetime.datetime``, ``int`` or ``None`` depending on both the unit and
+    the values, which loses the unit and makes the type passed to the user's
+    function unpredictable (gh-31382).  Boxing the elements instead preserves
+    the NumPy scalars, matching what `_get_ufunc_and_otypes` already passes
+    when it probes for the output type.
+    """
+    if isinstance(a, ndarray) and a.dtype.kind in "Mm":
+        boxed = fromiter(asarray(a).flat, dtype=object, count=a.size)
+        if type(a) is ndarray:
+            return boxed.reshape(a.shape)
+        # ndarray subclass: `empty_like` keeps the subclass and any mask,
+        # without doing the elementwise conversion we are about to overwrite.
+        out = empty_like(a, dtype=object)
+        asarray(out).flat = boxed
+        return out
+    return asanyarray(a, dtype=object)
+
+
 @set_module('numpy')
 class vectorize:
     """
@@ -2634,7 +2659,7 @@ class vectorize:
         else:
             ufunc, otypes = self._get_ufunc_and_otypes(func=func, args=args)
             # gh-29196: `dtype=object` should eventually be removed
-            args = [asanyarray(a, dtype=object) for a in args]
+            args = [_as_object_array(a) for a in args]
             outputs = ufunc(*args, out=...)
 
             if ufunc.nout == 1:

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2108,6 +2108,85 @@ class TestVectorize:
         assert_array_equal(np.vectorize(lambda x: x, signature="(i)->(j)",
                                         otypes=[otype])(arr), arr)
 
+    @pytest.mark.parametrize("unit", ["Y", "M", "D", "h", "s", "ms", "us",
+                                      "ns", "ps", "fs", "as"])
+    def test_datetime64_roundtrip(self, unit):
+        # gh-31382: the unit was silently changed (M8[Y] -> M8[D],
+        # M8[h] -> M8[us]) and M8[ns] raised ValueError, because elements
+        # were unboxed to datetime.date/datetime.datetime/int on the way
+        # to the pyfunc, losing the unit.
+        arr = np.arange(0, 3, dtype=f"M8[{unit}]")
+        res = vectorize(lambda x: x)(arr)
+        assert_equal(res.dtype, arr.dtype)
+        assert_array_equal(res, arr)
+
+    @pytest.mark.parametrize("unit", ["D", "h", "s", "us", "ns"])
+    def test_timedelta64_roundtrip(self, unit):
+        # gh-31382, as above but for timedelta64.
+        arr = np.arange(0, 3, dtype=f"m8[{unit}]")
+        res = vectorize(lambda x: x)(arr)
+        assert_equal(res.dtype, arr.dtype)
+        assert_array_equal(res, arr)
+
+    @pytest.mark.parametrize("dtype", ["M8[Y]", "M8[us]", "M8[ns]", "m8[s]"])
+    def test_datetime64_argument_type(self, dtype):
+        # gh-31382: every call must see the same type.  The output-type
+        # probe in _get_ufunc_and_otypes passes a NumPy scalar, so the
+        # vectorized loop has to as well.
+        arr = np.arange(0, 3, dtype=dtype)
+        seen = []
+        vectorize(lambda x: seen.append(type(x)) or x)(arr)
+        assert_equal(set(seen), {type(arr[0])})
+
+    def test_datetime64_argument_type_nat_and_out_of_range(self):
+        # gh-31382: NaT reached the pyfunc as None, and years outside
+        # 1..9999 as int, even at us resolution.
+        arr = np.array(['NaT', '0000-06-01', '2011-01-02'], dtype="M8[us]")
+        seen = []
+        vectorize(lambda x: seen.append(type(x)) or x, otypes=[object])(arr)
+        assert_equal(set(seen), {np.datetime64})
+
+    def test_datetime64_preserves_shape(self):
+        # The datetime path rebuilds the object array, so shape and
+        # non-contiguous input must survive.
+        arr = np.arange(0, 6, dtype="M8[s]").reshape(2, 3)
+        assert_array_equal(vectorize(lambda x: x)(arr), arr)
+        assert_array_equal(vectorize(lambda x: x)(arr.T), arr.T)
+
+    def test_datetime64_masked_array(self):
+        # gh-31382: the mask and the MaskedArray type must survive, and
+        # the pyfunc must not receive np.ma.masked for masked positions.
+        arr = ma.array(np.arange(0, 4, dtype="M8[s]"), mask=[0, 1, 0, 1])
+        seen = []
+        res = vectorize(lambda x: seen.append(type(x)) or x,
+                        otypes=[object])(arr)
+        assert_equal(set(seen), {np.datetime64})
+        assert_(isinstance(res, ma.MaskedArray))
+        assert_array_equal(res.mask, arr.mask)
+
+    def test_datetime64_ndarray_subclass(self):
+        # gh-31382: the datetime path must not downgrade a subclass.
+        class MyArray(np.ndarray):
+            pass
+
+        arr = np.arange(0, 4, dtype="M8[s]").view(MyArray)
+        res = vectorize(lambda x: x)(arr)
+        assert_(isinstance(res, MyArray))
+        assert_array_equal(res, arr)
+
+    @pytest.mark.parametrize("arr,expected", [
+        (np.arange(2, dtype="int64"), int),
+        (np.arange(2, dtype="float64"), float),
+        (np.array([True, False]), bool),
+        (np.array(["ab", "cd"]), str),
+    ])
+    def test_non_datetime_arguments_unchanged(self, arr, expected):
+        # The gh-31382 fix is limited to datetime64/timedelta64; every
+        # other dtype keeps passing plain Python scalars to the pyfunc.
+        seen = []
+        vectorize(lambda x: seen.append(type(x)) or x, otypes=[object])(arr)
+        assert_equal(set(seen), {expected})
+
 
 class TestLeaks:
     class A:


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

--> Fixed #31382 . The fix now return the correct dtype of the np.datetime64 array under np.vectorize.



#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
--> Claude Code was used to understand the codebase. However, all the implementation was done after discussing on the main thread. Further, Claude Code was used to generate the function docstring and write the tests. I manually verified all of them and ran the tests myself. 
