### PR TITLE
TYP: ``argsort`` improved shape-typing

### DIFF
--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -520,7 +520,7 @@ def sort(
 ) -> _Array1D[Any]: ...
 
 #
-@overload
+@overload  # known shape, axis=<given> (default)
 def argsort[ShapeT: _Shape](
     a: np.ndarray[ShapeT],
     axis: SupportsIndex = -1,
@@ -530,7 +530,37 @@ def argsort[ShapeT: _Shape](
     stable: bool | None = None,
     descending: bool | _NoValueType = ...,
 ) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...
-@overload
+@overload  # 1d, axis=<given> (default)
+def argsort(
+    a: Sequence[_ScalarLike_co],
+    axis: SupportsIndex = -1,
+    kind: _SortKind | None = None,
+    order: str | Sequence[str] | None = None,
+    *,
+    stable: bool | None = None,
+    descending: bool | _NoValueType = ...,
+) -> _Array1D[np.intp]: ...
+@overload  # 2d, axis=<given> (default)
+def argsort(
+    a: Sequence[Sequence[_ScalarLike_co]],
+    axis: SupportsIndex = -1,
+    kind: _SortKind | None = None,
+    order: str | Sequence[str] | None = None,
+    *,
+    stable: bool | None = None,
+    descending: bool | _NoValueType = ...,
+) -> _Array2D[np.intp]: ...
+@overload  # 3d, axis=<given> (default)
+def argsort(
+    a: Sequence[Sequence[Sequence[_ScalarLike_co]]],
+    axis: SupportsIndex = -1,
+    kind: _SortKind | None = None,
+    order: str | Sequence[str] | None = None,
+    *,
+    stable: bool | None = None,
+    descending: bool | _NoValueType = ...,
+) -> _Array3D[np.intp]: ...
+@overload  # ?d, axis=<given> (default)
 def argsort(
     a: ArrayLike,
     axis: SupportsIndex = -1,
@@ -540,7 +570,7 @@ def argsort(
     stable: bool | None = None,
     descending: bool | _NoValueType = ...,
 ) -> NDArray[np.intp]: ...
-@overload
+@overload  # axis=None
 def argsort(
     a: ArrayLike,
     axis: None,

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -36,6 +36,8 @@ f: float
 _py_list_1d: list[int]
 _py_list_2d: list[list[int]]
 _py_list_3d: list[list[list[int]]]
+_py_str_1d: list[str]
+_py_str_2d: list[list[str]]
 
 _dtype_list: list[np.dtype]
 _any_list: list[Any]
@@ -43,6 +45,10 @@ _any_list: list[Any]
 # integer‑dtype subclass for argmin/argmax
 class NDArrayIntSubclass(np.ndarray[tuple[Any, ...], np.dtype[np.intp]]): ...
 AR_sub_i: NDArrayIntSubclass
+
+type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
+type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
 
 assert_type(np.take(b, 0), np.bool)
 assert_type(np.take(f4, 0), np.float32)
@@ -117,7 +123,11 @@ assert_type(np.sort(AR_f4, axis=None), np.ndarray[tuple[int], np.dtype[np.float3
 assert_type(np.sort(AR_f4_1d, axis=None), np.ndarray[tuple[int], np.dtype[np.float32]])
 assert_type(np.sort(AR_f4_2d, axis=None), np.ndarray[tuple[int], np.dtype[np.float32]])
 
-assert_type(np.argsort([2, 1]), npt.NDArray[np.intp])
+assert_type(np.argsort(_py_list_1d), _Array1D[np.intp])
+assert_type(np.argsort(_py_list_2d), _Array2D[np.intp])
+assert_type(np.argsort(_py_list_3d), _Array3D[np.intp])
+assert_type(np.argsort(_py_str_1d), _Array1D[np.intp])
+assert_type(np.argsort(_py_str_2d), _Array2D[np.intp])
 assert_type(np.argsort(AR_b), npt.NDArray[np.intp])
 assert_type(np.argsort(AR_f4), npt.NDArray[np.intp])
 assert_type(np.argsort(AR_f4_1d), np.ndarray[tuple[int], np.dtype[np.intp]])


### PR DESCRIPTION
`np.argsort` is now also shape-type-aware in case of (nested) sequences for the 1-3d cases.

---

Fully written by me, audited as kinda-high-value shape-typing improvement by AI (see https://gist.github.com/jorenham/36c78602a7ca866ddb2a917de48ccdd0).