### PR TITLE
ENH: add a `segmented_reduce` method to ufuncs

### DIFF
--- a/doc/release/upcoming_changes/32243.new_feature.rst
+++ b/doc/release/upcoming_changes/32243.new_feature.rst
@@ -15,5 +15,5 @@ clipped rather than an error.  Empty segments give the identity of the ufunc,
 or the ``initial`` value if one is passed (which is required for ufuncs
 without an identity, such as `numpy.maximum`).
 
-If ``stops`` is not given, each segment stops where the next one starts, as it
-does for `~numpy.ufunc.reduceat`.
+Consecutive segments, as given by the offsets of a CSR matrix for example,
+are expressed with ``starts=offsets[:-1]`` and ``stops=offsets[1:]``.

--- a/doc/release/upcoming_changes/32243.new_feature.rst
+++ b/doc/release/upcoming_changes/32243.new_feature.rst
@@ -15,5 +15,6 @@ clipped rather than an error.  Empty segments give the identity of the ufunc,
 or the ``initial`` value if one is passed (which is required for ufuncs
 without an identity, such as `numpy.maximum`).
 
-Consecutive segments, as given by the offsets of a CSR matrix for example,
-are expressed with ``starts=offsets[:-1]`` and ``stops=offsets[1:]``.
+Consecutive segments are commonly stored as a single array of offsets, with
+the i-th segment given by ``offsets[i]:offsets[i + 1]``.  Such an array is
+passed as ``starts=offsets[:-1]`` and ``stops=offsets[1:]``.

--- a/doc/release/upcoming_changes/XXXXX.new_feature.rst
+++ b/doc/release/upcoming_changes/XXXXX.new_feature.rst
@@ -1,0 +1,19 @@
+New ``ufunc.segmented_reduce`` method
+-------------------------------------
+Binary ufuncs have a new `~numpy.ufunc.segmented_reduce` method which reduces
+over segments (slices) of an axis given by their start and stop offsets::
+
+    >>> a = np.arange(8)
+    >>> np.add.segmented_reduce(a, starts=[0, 5], stops=[3, 8])
+    array([ 3, 18])
+
+It is a more flexible version of `~numpy.ufunc.reduceat`: segments may skip
+elements of the array, they may overlap, and they may be empty.  The offsets
+are interpreted like the start and stop of a slice, so that the i-th result is
+``ufunc.reduce(array[starts[i]:stops[i]])`` and out-of-bounds offsets are
+clipped rather than an error.  Empty segments give the identity of the ufunc,
+or the ``initial`` value if one is passed (which is required for ufuncs
+without an identity, such as `numpy.maximum`).
+
+If ``stops`` is not given, each segment stops where the next one starts, as it
+does for `~numpy.ufunc.reduceat`.

--- a/doc/source/reference/arrays.classes.rst
+++ b/doc/source/reference/arrays.classes.rst
@@ -59,7 +59,7 @@ NumPy provides several hooks that classes can customize:
    - *ufunc* is the ufunc object that was called.
    - *method* is a string indicating which Ufunc method was called
      (one of ``"__call__"``, ``"reduce"``, ``"reduceat"``,
-     ``"accumulate"``, ``"outer"``, ``"inner"``).
+     ``"segmented_reduce"``, ``"accumulate"``, ``"outer"``, ``"inner"``).
    - *inputs* is a tuple of the input arguments to the ``ufunc``.
    - *kwargs* is a dictionary containing the optional input arguments
      of the ufunc. If given, any ``out`` arguments, both positional

--- a/doc/source/reference/ufuncs.rst
+++ b/doc/source/reference/ufuncs.rst
@@ -224,6 +224,7 @@ Methods
    ufunc.reduce
    ufunc.accumulate
    ufunc.reduceat
+   ufunc.segmented_reduce
    ufunc.outer
    ufunc.at
 

--- a/doc/source/user/basics.subclassing.rst
+++ b/doc/source/user/basics.subclassing.rst
@@ -475,7 +475,7 @@ The signature of ``__array_ufunc__`` is::
 - *method* is a string indicating how the Ufunc was called, either
   ``"__call__"`` to indicate it was called directly, or one of its
   :ref:`methods<ufuncs.methods>`: ``"reduce"``, ``"accumulate"``,
-  ``"reduceat"``, ``"outer"``, or ``"at"``.
+  ``"reduceat"``, ``"segmented_reduce"``, ``"outer"``, or ``"at"``.
 - *inputs* is a tuple of the input arguments to the ``ufunc``
 - *kwargs* contains any optional or keyword arguments passed to the
   function. This includes any ``out`` arguments, which are always

--- a/doc/source/user/basics.ufuncs.rst
+++ b/doc/source/user/basics.ufuncs.rst
@@ -54,10 +54,11 @@ One can also produce custom :class:`numpy.ufunc` instances using the
 Ufunc methods
 =============
 
-All ufuncs have 5 methods. 4 reduce-like methods
+All ufuncs have 6 methods. 5 reduce-like methods
 (:meth:`~numpy.ufunc.reduce`, :meth:`~numpy.ufunc.accumulate`,
-:meth:`~numpy.ufunc.reduceat`, :meth:`~numpy.ufunc.outer`) and one
-for inplace operations (:meth:`~numpy.ufunc.at`).
+:meth:`~numpy.ufunc.reduceat`, :meth:`~numpy.ufunc.segmented_reduce`,
+:meth:`~numpy.ufunc.outer`) and one for inplace operations
+(:meth:`~numpy.ufunc.at`).
 See :ref:`ufuncs.methods` for more. However, these methods only make sense on
 ufuncs that take two input arguments and return one output argument (so-called
 "scalar" ufuncs since the inner loop operates on a single scalar value).

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -7649,7 +7649,7 @@ class ufunc:
         array: ArrayLike,
         /,
         starts: _ArrayLikeInt_co,
-        stops: _ArrayLikeInt_co | None = None,
+        stops: _ArrayLikeInt_co,
         axis: SupportsIndex = 0,
         dtype: DTypeLike | None = None,
         out: ndarray | EllipsisType | None = None,

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -2206,7 +2206,7 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def __array_ufunc__(
         self,
         ufunc: ufunc,
-        method: L["__call__", "reduce", "reduceat", "accumulate", "outer", "at"],
+        method: L["__call__", "reduce", "reduceat", "segmented_reduce", "accumulate", "outer", "at"],
         /,
         *inputs: Any,
         **kwargs: Any,
@@ -7614,7 +7614,7 @@ class ufunc:
 
     def __call__(self, /, *args: Any, **kwargs: Any) -> Any: ...
 
-    # The next four methods will always exist, but they will just
+    # The next five methods will always exist, but they will just
     # raise a ValueError ufuncs with that don't accept two input
     # arguments and return one output argument. Because of that we
     # can't type them very precisely.
@@ -7643,6 +7643,18 @@ class ufunc:
         axis: SupportsIndex = 0,
         dtype: DTypeLike | None = None,
         out: ndarray | EllipsisType | None = None,
+    ) -> NDArray[Incomplete]: ...
+    def segmented_reduce(
+        self,
+        array: ArrayLike,
+        /,
+        starts: _ArrayLikeInt_co,
+        stops: _ArrayLikeInt_co | None = None,
+        axis: SupportsIndex = 0,
+        dtype: DTypeLike | None = None,
+        out: ndarray | EllipsisType | None = None,
+        # `initial` is passed through `kwargs` (like it is for `reduce`)
+        **kwargs: Incomplete,
     ) -> NDArray[Incomplete]: ...
     def outer(self, A: ArrayLike, B: ArrayLike, /, **kwargs: Incomplete) -> NDArray[Incomplete]: ...
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5634,6 +5634,11 @@ add_newdoc('numpy._core', 'ufunc', ('reduceat',
         The reduced values. If `out` was supplied, `r` is a reference to
         `out`.
 
+    See Also
+    --------
+    ufunc.segmented_reduce : Reduce over segments given by start and stop
+        offsets, which may skip elements, overlap, or be empty.
+
     Notes
     -----
     A descriptive example:
@@ -5691,6 +5696,138 @@ add_newdoc('numpy._core', 'ufunc', ('reduceat',
            [ 120.,     7.],
            [ 720.,    11.],
            [2184.,    15.]])
+
+    """))
+
+add_newdoc('numpy._core', 'ufunc', ('segmented_reduce',
+    """
+    segmented_reduce($self, array, /, starts, stops=None, axis=0, dtype=None, out=None, **kwargs)
+    --
+
+    segmented_reduce(array, starts, stops=None, axis=0, dtype=None, out=None, initial=<no value>)
+
+    Reduce over segments (slices) of a single axis.
+
+    For i in ``range(len(starts))``, `segmented_reduce` computes
+    ``ufunc.reduce(array[starts[i]:stops[i]], initial=initial)``, which
+    becomes the i-th generalized "row" parallel to `axis` in the final result
+    (i.e., in a 2-D array, for example, if ``axis = 0``, it becomes the i-th
+    row, but if ``axis = 1``, it becomes the i-th column).
+
+    The offsets are interpreted like the start and stop of a slice: negative
+    offsets count from the end of the axis and out-of-bounds offsets are
+    clipped.  Consequently segments may overlap, they may skip elements of
+    `array`, and they may be empty, in which case the result of the segment
+    is `initial` (or the identity of the ufunc, see the Notes).
+
+    .. versionadded:: 2.6.0
+
+    Parameters
+    ----------
+    array : array_like
+        The array to act on.
+    starts : array_like
+        1-D array of offsets at which the segments start.  Its length is the
+        length of the result along `axis`.
+    stops : array_like, optional
+        1-D array of offsets at which the segments stop, must have the same
+        length as `starts`.  If not given, each segment stops where the next
+        one starts and the last one stops at the end of the axis (which is
+        the segmentation `ufunc.reduceat` uses).
+    axis : int, optional
+        The axis along which to apply the segmented reduction.
+    dtype : data-type code, optional
+        The data type used to perform the operation. Defaults to that of
+        ``out`` if given, and the data type of ``array`` otherwise (though
+        upcast to conserve precision for some cases, such as
+        ``numpy.add.reduce`` for integer or boolean input).
+    out : ndarray, None, or tuple of ndarray and None, optional
+        Location into which the result is stored.
+        If not provided or None, a freshly-allocated array is returned.
+        For consistency with ``ufunc.__call__``, if passed as a keyword
+        argument, can be Ellipses (``out=...``, which has the same effect
+        as None as an array is always returned), or a 1-element tuple.
+    initial : scalar, optional
+        The value with which to start each segment reduction.  If the ufunc
+        has no identity, it is required when any segment may be empty.
+
+    Returns
+    -------
+    r : ndarray
+        The reduced values. If `out` was supplied, `r` is a reference to
+        `out`.
+
+    See Also
+    --------
+    ufunc.reduce : Reduce over a whole axis.
+    ufunc.reduceat : Reduce over consecutive slices given by single indices.
+
+    Notes
+    -----
+    If `initial` is not given, the identity of the ufunc is used (e.g. ``0``
+    for `numpy.add` and ``1`` for `numpy.multiply`), exactly as `ufunc.reduce`
+    does.  For a ufunc without an identity, such as `numpy.maximum`, empty
+    segments then raise a ``ValueError`` and `initial` has to be passed to
+    define their result.  Passing ``initial=None`` explicitly disables the
+    use of an identity.
+
+    For arrays of ``object`` dtype the identity is only used for the empty
+    segments, just as `ufunc.reduce` only uses it for an empty reduction.
+
+    If the result is empty, for example because a dimension that is not
+    reduced over has length zero, no reduction is performed at all and no
+    identity is required.
+
+    Unlike `ufunc.reduceat`, offsets are never an error and empty segments
+    have a well defined result, so that ``starts`` and ``stops`` can be
+    computed without clipping them first.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> a = np.arange(8)
+
+    Reduce over two segments of four elements each:
+
+    >>> np.add.segmented_reduce(a, [0, 4], [4, 8])
+    array([ 6, 22])
+
+    The segments may skip elements or overlap:
+
+    >>> np.add.segmented_reduce(a, [1, 5], [3, 7])
+    array([ 3, 11])
+    >>> np.add.segmented_reduce(a, [0, 2], [5, 4])
+    array([10,  5])
+
+    If ``stops`` is not given, each segment stops where the next one starts,
+    just like `ufunc.reduceat` (but empty segments are still allowed):
+
+    >>> np.add.segmented_reduce(a, [0, 4])
+    array([ 6, 22])
+
+    Empty segments give the identity of the ufunc, or ``initial`` if given:
+
+    >>> np.add.segmented_reduce(a, [0, 4], [0, 4])
+    array([0, 0])
+    >>> np.add.segmented_reduce(a, [0, 4], [4, 8], initial=100)
+    array([106, 122])
+
+    A ufunc without an identity requires ``initial`` for empty segments:
+
+    >>> np.maximum.segmented_reduce(a, [0, 4], [0, 8])
+    Traceback (most recent call last):
+    ...
+    ValueError: zero-size segment in reduction operation 'maximum' which ...
+    >>> np.maximum.segmented_reduce(a, [0, 4], [0, 8], initial=-1)
+    array([-1,  7])
+
+    A 2-D example, reducing over segments of each row:
+
+    >>> x = np.arange(12).reshape(3, 4)
+    >>> np.add.segmented_reduce(x, [0, 2], [2, 4], axis=1)
+    array([[ 1,  5],
+           [ 9, 13],
+           [17, 21]])
 
     """))
 

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5790,8 +5790,8 @@ add_newdoc('numpy._core', 'ufunc', ('segmented_reduce',
     >>> np.add.segmented_reduce(a, [0, 4], [4, 8])
     array([ 6, 22])
 
-    Consecutive segments are given by an array of offsets, such as the
-    ``indptr`` of a CSR matrix:
+    Consecutive segments are commonly stored as a single array of offsets,
+    with the i-th segment given by ``offsets[i]:offsets[i + 1]``:
 
     >>> offsets = np.array([0, 4, 8])
     >>> np.add.segmented_reduce(a, offsets[:-1], offsets[1:])

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -5701,10 +5701,10 @@ add_newdoc('numpy._core', 'ufunc', ('reduceat',
 
 add_newdoc('numpy._core', 'ufunc', ('segmented_reduce',
     """
-    segmented_reduce($self, array, /, starts, stops=None, axis=0, dtype=None, out=None, **kwargs)
+    segmented_reduce($self, array, /, starts, stops, axis=0, dtype=None, out=None, **kwargs)
     --
 
-    segmented_reduce(array, starts, stops=None, axis=0, dtype=None, out=None, initial=<no value>)
+    segmented_reduce(array, starts, stops, axis=0, dtype=None, out=None, initial=<no value>)
 
     Reduce over segments (slices) of a single axis.
 
@@ -5729,11 +5729,9 @@ add_newdoc('numpy._core', 'ufunc', ('segmented_reduce',
     starts : array_like
         1-D array of offsets at which the segments start.  Its length is the
         length of the result along `axis`.
-    stops : array_like, optional
+    stops : array_like
         1-D array of offsets at which the segments stop, must have the same
-        length as `starts`.  If not given, each segment stops where the next
-        one starts and the last one stops at the end of the axis (which is
-        the segmentation `ufunc.reduceat` uses).
+        length as `starts`.
     axis : int, optional
         The axis along which to apply the segmented reduction.
     dtype : data-type code, optional
@@ -5792,18 +5790,19 @@ add_newdoc('numpy._core', 'ufunc', ('segmented_reduce',
     >>> np.add.segmented_reduce(a, [0, 4], [4, 8])
     array([ 6, 22])
 
+    Consecutive segments are given by an array of offsets, such as the
+    ``indptr`` of a CSR matrix:
+
+    >>> offsets = np.array([0, 4, 8])
+    >>> np.add.segmented_reduce(a, offsets[:-1], offsets[1:])
+    array([ 6, 22])
+
     The segments may skip elements or overlap:
 
     >>> np.add.segmented_reduce(a, [1, 5], [3, 7])
     array([ 3, 11])
     >>> np.add.segmented_reduce(a, [0, 2], [5, 4])
     array([10,  5])
-
-    If ``stops`` is not given, each segment stops where the next one starts,
-    just like `ufunc.reduceat` (but empty segments are still allowed):
-
-    >>> np.add.segmented_reduce(a, [0, 4])
-    array([ 6, 22])
 
     Empty segments give the identity of the ufunc, or ``initial`` if given:
 

--- a/numpy/_core/src/umath/override.c
+++ b/numpy/_core/src/umath/override.c
@@ -172,12 +172,8 @@ copy_positional_args_to_kwargs(const char **keywords,
             /* keyword argument is either input or output and not set here */
             continue;
         }
-        if (NPY_UNLIKELY(i == 5)) {
-            /*
-             * This is only relevant for reduce, which is the only one with
-             * 5 keyword arguments.
-             */
-            assert(strcmp(keywords[i], "initial") == 0);
+        if (NPY_UNLIKELY(strcmp(keywords[i], "initial") == 0)) {
+            /* `initial` is not passed on when it was not given */
             if (args[i] == npy_static_pydata._NoValue) {
                 continue;
             }
@@ -276,6 +272,13 @@ PyUFunc_CheckOverride(PyUFuncObject *ufunc, char *method,
     else if (strcmp(method, "reduceat") == 0) {
         static const char *keywords[] = {
                 NULL, NULL, "axis", "dtype", NULL};
+        status = copy_positional_args_to_kwargs(keywords,
+                args, len_args, normal_kwds);
+    }
+    /* ufunc.segmented_reduce */
+    else if (strcmp(method, "segmented_reduce") == 0) {
+        static const char *keywords[] = {
+                NULL, NULL, NULL, "axis", "dtype", NULL, "initial"};
         status = copy_positional_args_to_kwargs(keywords,
                 args, len_args, normal_kwds);
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3420,7 +3420,7 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
     PyArray_Descr *descrs[3];
     PyArrayMethodObject *ufuncimpl = reducelike_promote_and_resolve(ufunc,
             arr, &out, signature, NPY_TRUE, descrs, NPY_UNSAFE_CASTING,
-            "reduceat");
+            opname);
     if (ufuncimpl == NULL) {
         Py_XDECREF(out);
         return NULL;
@@ -3435,16 +3435,16 @@ PyUFunc_Reduceat(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *ind,
 
     if (PyDataType_REFCHK(descrs[2]) && descrs[2]->type_num != NPY_OBJECT) {
         /* This can be removed, but the initial element copy needs fixing */
-        PyErr_SetString(PyExc_TypeError,
-                "reduceat currently only supports `object` dtype with "
-                "references");
+        PyErr_Format(PyExc_TypeError,
+                "%s currently only supports `object` dtype with references",
+                opname);
         goto fail;
     }
 
     PyArrayMethod_Context context;
     NPY_context_init(&context, descrs);
-    context.caller = (PyObject *)ufunc,
-    context.method = ufuncimpl,
+    context.caller = (PyObject *)ufunc;
+    context.method = ufuncimpl;
     ndim = PyArray_NDIM(arr);
 
 #if NPY_UF_DBG_TRACING
@@ -3735,7 +3735,7 @@ finish:
 
     if (res == 0 && !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
         /* NOTE: We could check float errors even when `res < 0` */
-        res = _check_ufunc_fperr(errormask, "reduceat");
+        res = _check_ufunc_fperr(errormask, opname);
     }
 
     if (res < 0) {
@@ -3816,7 +3816,7 @@ PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
     PyArrayMethod_StridedLoop *strided_loop;
     NpyAuxData *auxdata = NULL;
 
-    /* The segment offsets - starts and stops must be copies (see below) */
+    /* The segment offsets - starts and stops must be copies (clipped below) */
     npy_intp *start_offsets, *stop_offsets;
     npy_intp i, ind_size, red_axis_size;
 
@@ -3869,9 +3869,9 @@ PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
 
     if (PyDataType_REFCHK(descrs[2]) && descrs[2]->type_num != NPY_OBJECT) {
         /* This can be removed, but the initial element copy needs fixing */
-        PyErr_SetString(PyExc_TypeError,
-                "segmented_reduce currently only supports `object` dtype with "
-                "references");
+        PyErr_Format(PyExc_TypeError,
+                "%s currently only supports `object` dtype with references",
+                opname);
         goto fail;
     }
 
@@ -4121,8 +4121,9 @@ PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
 
         do {
             for (i = 0; i < ind_size; ++i) {
-                npy_intp start = start_offsets[i];
-                npy_intp count = stop_offsets[i] - start;
+                npy_intp start = start_offsets[i],
+                        end = stop_offsets[i];
+                npy_intp count = end - start;
                 char *first_element;
 
                 dataptr_copy[0] = dataptr[0] + stride0_ind*i;
@@ -4198,8 +4199,9 @@ PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
         }
 
         for (i = 0; i < ind_size; ++i) {
-            npy_intp start = start_offsets[i];
-            npy_intp count = stop_offsets[i] - start;
+            npy_intp start = start_offsets[i],
+                    end = stop_offsets[i];
+            npy_intp count = end - start;
             char *first_element;
 
             dataptr_copy[0] = PyArray_BYTES(op[0]) + stride0_ind*i;
@@ -4276,7 +4278,7 @@ finish:
 
     if (res == 0 && !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
         /* NOTE: We could check float errors even when `res < 0` */
-        res = _check_ufunc_fperr(errormask, "segmented_reduce");
+        res = _check_ufunc_fperr(errormask, opname);
     }
 
     if (res < 0) {

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -65,6 +65,7 @@
 #include "mapping.h"
 #include "npy_static_data.h"
 #include "multiarraymodule.h"
+#include "refcount.h"  // for PyArray_ClearBuffer
 #include "number.h"
 #include "scalartypes.h"  // for is_anyscalar_exact and scalar_value
 
@@ -3757,6 +3758,569 @@ fail:
     return NULL;
 }
 
+/*
+ * Normalize segment offsets in-place the way slices do, negative offsets
+ * count from the end of the axis and out-of-bounds ones are clipped.
+ */
+static inline void
+clip_segment_offsets(npy_intp *offsets, npy_intp n, npy_intp axis_size)
+{
+    for (npy_intp i = 0; i < n; ++i) {
+        npy_intp offset = offsets[i];
+        if (offset < 0) {
+            offset += axis_size;
+            offsets[i] = offset < 0 ? 0 : offset;
+        }
+        else if (offset > axis_size) {
+            offsets[i] = axis_size;
+        }
+    }
+}
+
+/*
+ * Segmented_reduce performs a reduce over an axis using start and stop
+ * offsets as a guide
+ *
+ * op.segmented_reduce(array, starts, stops) computes
+ * op.reduce(array[starts[i]:stops[i]])
+ * for i=0..len(starts)-1.  The offsets use slice semantics, i.e. negative
+ * offsets count from the end of the axis and out-of-bounds offsets are
+ * clipped.  If `stops` is NULL, the stop of a segment is the start of the
+ * next one (and the end of the axis for the last segment).
+ *
+ * Contrary to reduceat, empty segments are well defined, they give the
+ * `initial` value or the identity of the ufunc, exactly like `ufunc.reduce`
+ * does for an empty array.
+ *
+ * output shape is based on the size of starts
+ *
+ * TODO: Segmented_reduce duplicates too much code from reduceat!
+ */
+static PyObject *
+PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
+                        PyArrayObject *starts, PyArrayObject *stops,
+                        PyArrayObject *out, int axis,
+                        PyArray_DTypeMeta *signature[3], PyObject *initial)
+{
+    PyArrayObject *op[3];
+    int op_axes_arrays[3][NPY_MAXDIMS];
+    int *op_axes[3] = {op_axes_arrays[0], op_axes_arrays[1],
+                            op_axes_arrays[2]};
+    npy_uint32 op_flags[3];
+    int idim, ndim;
+    int need_outer_iterator = 0;
+
+    int res = 0;
+
+    NpyIter *iter = NULL;
+
+    PyArrayMethod_StridedLoop *strided_loop;
+    NpyAuxData *auxdata = NULL;
+
+    /* The segment offsets - starts and stops must be copies (see below) */
+    npy_intp *start_offsets, *stop_offsets = NULL;
+    npy_intp i, ind_size, red_axis_size;
+
+    /* Buffer to use when we need an initial value, and views into it */
+    char *initial_buf = NULL;
+    /* Value that starts every segment, and the result of an empty one */
+    char *segment_initial = NULL, *empty_initial = NULL;
+
+    const char *ufunc_name = ufunc_get_name_cstr(ufunc);
+    char *opname = "segmented_reduce";
+
+    /* These parameters come from a TLS global */
+    int buffersize = 0, errormask = 0;
+
+    NPY_BEGIN_THREADS_DEF;
+
+    start_offsets = (npy_intp *)PyArray_DATA(starts);
+    if (stops != NULL) {
+        stop_offsets = (npy_intp *)PyArray_DATA(stops);
+    }
+    ind_size = PyArray_DIM(starts, 0);
+    red_axis_size = PyArray_DIM(arr, axis);
+
+    /* Out-of-bounds offsets are not an error, they are clipped in-place */
+    clip_segment_offsets(start_offsets, ind_size, red_axis_size);
+    if (stop_offsets != NULL) {
+        clip_segment_offsets(stop_offsets, ind_size, red_axis_size);
+    }
+
+    NPY_UF_DBG_PRINT2("\nEvaluating ufunc %s.%s\n", ufunc_name, opname);
+
+    if (_get_bufsize_errmask(&buffersize, &errormask) < 0) {
+        return NULL;
+    }
+
+    /* Take a reference to out for later returning */
+    Py_XINCREF(out);
+
+    PyArray_Descr *descrs[3];
+    PyArrayMethodObject *ufuncimpl = reducelike_promote_and_resolve(ufunc,
+            arr, &out, signature, NPY_TRUE, descrs, NPY_UNSAFE_CASTING,
+            opname);
+    if (ufuncimpl == NULL) {
+        Py_XDECREF(out);
+        return NULL;
+    }
+
+    /*
+     * The below code assumes that all descriptors are interchangeable, we
+     * allow them to not be strictly identical (but they typically should be)
+     */
+    assert(PyArray_EquivTypes(descrs[0], descrs[1])
+           && PyArray_EquivTypes(descrs[0], descrs[2]));
+
+    if (PyDataType_REFCHK(descrs[2]) && descrs[2]->type_num != NPY_OBJECT) {
+        /* This can be removed, but the initial element copy needs fixing */
+        PyErr_SetString(PyExc_TypeError,
+                "segmented_reduce currently only supports `object` dtype with "
+                "references");
+        goto fail;
+    }
+
+    PyArrayMethod_Context context;
+    NPY_context_init(&context, descrs);
+    context.caller = (PyObject *)ufunc;
+    context.method = ufuncimpl;
+    ndim = PyArray_NDIM(arr);
+
+#if NPY_UF_DBG_TRACING
+    printf("Found %s.%s inner loop with dtype :  ", ufunc_name, opname);
+    PyObject_Print((PyObject *)descrs[0], stdout, 0);
+    printf("\n");
+#endif
+
+    /*
+     * The number of segments defines the length of the output along `axis`,
+     * the iterator would broadcast `starts` up to a longer one.
+     */
+    if (out != NULL && PyArray_NDIM(out) != ndim) {
+        PyErr_Format(PyExc_ValueError,
+                "output parameter for reduction operation %s has the wrong "
+                "number of dimensions: Found %d but expected %d",
+                ufunc_name, PyArray_NDIM(out), ndim);
+        goto fail;
+    }
+    if (out != NULL && PyArray_DIM(out, axis) != ind_size) {
+        PyErr_Format(PyExc_ValueError,
+                "output parameter for reduction operation %s has the wrong "
+                "length along axis %d: Found %" NPY_INTP_FMT " but expected "
+                "%" NPY_INTP_FMT " (the number of segments)",
+                ufunc_name, axis, PyArray_DIM(out, axis), ind_size);
+        goto fail;
+    }
+
+    /* Set up the op_axes for the outer loop */
+    for (idim = 0; idim < ndim; ++idim) {
+        /* Use the i-th iteration dimension to match up starts */
+        if (idim == axis) {
+            op_axes_arrays[0][idim] = axis;
+            op_axes_arrays[1][idim] = -1;
+            op_axes_arrays[2][idim] = 0;
+        }
+        else {
+            op_axes_arrays[0][idim] = idim;
+            op_axes_arrays[1][idim] = idim;
+            op_axes_arrays[2][idim] = -1;
+        }
+    }
+
+    op[0] = out;
+    op[1] = arr;
+    op[2] = starts;
+
+    if (out != NULL || ndim > 1 || !PyArray_ISALIGNED(arr) ||
+            !PyArray_EquivTypes(descrs[0], PyArray_DESCR(arr))) {
+        need_outer_iterator = 1;
+    }
+
+    if (need_outer_iterator) {
+        PyArray_Descr *op_dtypes[3] = {descrs[0], descrs[1], NULL};
+
+        npy_uint32 flags = NPY_ITER_ZEROSIZE_OK|
+                           NPY_ITER_REFS_OK|
+                           NPY_ITER_MULTI_INDEX|
+                           NPY_ITER_COPY_IF_OVERLAP;
+
+        /*
+         * The way segmented_reduce is set up, we can't do buffering,
+         * so make a copy instead when necessary using
+         * the UPDATEIFCOPY flag
+         */
+
+        /* The per-operand flags for the outer loop */
+        op_flags[0] = NPY_ITER_READWRITE|
+                      NPY_ITER_NO_BROADCAST|
+                      NPY_ITER_ALLOCATE|
+                      NPY_ITER_NO_SUBTYPE|
+                      NPY_ITER_UPDATEIFCOPY|
+                      NPY_ITER_ALIGNED;
+        op_flags[1] = NPY_ITER_READONLY|
+                      NPY_ITER_COPY|
+                      NPY_ITER_ALIGNED;
+        op_flags[2] = NPY_ITER_READONLY;
+
+        op_dtypes[1] = op_dtypes[0];
+
+        NPY_UF_DBG_PRINT("Allocating outer iterator\n");
+        iter = NpyIter_AdvancedNew(3, op, flags,
+                                   NPY_KEEPORDER, NPY_UNSAFE_CASTING,
+                                   op_flags, op_dtypes,
+                                   ndim, op_axes, NULL, 0);
+        if (iter == NULL) {
+            goto fail;
+        }
+
+        /* Remove the inner loop axis from the outer iterator */
+        if (NpyIter_RemoveAxis(iter, axis) != NPY_SUCCEED) {
+            goto fail;
+        }
+        if (NpyIter_RemoveMultiIndex(iter) != NPY_SUCCEED) {
+            goto fail;
+        }
+
+        /* In case COPY or UPDATEIFCOPY occurred */
+        op[0] = NpyIter_GetOperandArray(iter)[0];
+        op[1] = NpyIter_GetOperandArray(iter)[1];
+        op[2] = NpyIter_GetOperandArray(iter)[2];
+
+        if (out == NULL) {
+            out = op[0];
+            Py_INCREF(out);
+        }
+    }
+    else {
+        /*
+         * Allocate the output for when there's no outer iterator, we always
+         * use the outer_iteration path when `out` is passed.
+         */
+        assert(out == NULL);
+        Py_INCREF(descrs[0]);
+        op[0] = out = (PyArrayObject *)PyArray_NewFromDescr(
+                                    &PyArray_Type, descrs[0],
+                                    1, &ind_size, NULL, NULL,
+                                    0, NULL);
+        if (out == NULL) {
+            goto fail;
+        }
+    }
+
+    npy_intp fixed_strides[3];
+    if (need_outer_iterator) {
+        NpyIter_GetInnerFixedStrideArray(iter, fixed_strides);
+    }
+    else {
+        fixed_strides[1] = PyArray_STRIDES(op[1])[axis];
+    }
+    /* The reduce axis does not advance here in the strided-loop */
+    fixed_strides[0] = 0;
+    fixed_strides[2] = 0;
+
+    NPY_ARRAYMETHOD_FLAGS flags = 0;
+    if (ufuncimpl->get_strided_loop(&context,
+            1, 0, fixed_strides, &strided_loop, &auxdata, &flags) < 0) {
+        goto fail;
+    }
+    if (iter != NULL) {
+        flags = PyArrayMethod_COMBINED_FLAGS(flags, NpyIter_GetTransferFlags(iter));
+    }
+
+    int needs_api = (flags & NPY_METH_REQUIRES_PYAPI) != 0;
+    if (!(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
+        /* Start with the floating-point exception flags cleared */
+        npy_clear_floatstatus_barrier((char*)&iter);
+    }
+
+    /*
+     * Get the initial value (if it exists).  Without one, the first element
+     * of each segment starts the reduction and empty segments are an error.
+     */
+    if (initial != Py_None) {
+        /* Not all functions will need initialization, but init always: */
+        initial_buf = PyMem_Calloc(1, descrs[0]->elsize);
+        if (initial_buf == NULL) {
+            PyErr_NoMemory();
+            goto fail;
+        }
+        if (initial != NULL) {
+            /* must use user provided initial value */
+            if (PyArray_Pack(descrs[0], initial_buf, initial) < 0) {
+                goto fail;
+            }
+            segment_initial = empty_initial = initial_buf;
+        }
+        else {
+            void *initials[1] = {initial_buf};
+            int has_initial = reduction_get_initial(
+                    &context, /* reduction_is_empty */ NPY_FALSE, initials);
+            if (has_initial < 0) {
+                goto fail;
+            }
+            if (has_initial) {
+                segment_initial = empty_initial = initial_buf;
+            }
+            else {
+                /*
+                 * The method may still have an identity for an empty
+                 * reduction (for `object` dtype it is not used when the
+                 * reduction has elements), it then only defines the result
+                 * of the empty segments.
+                 */
+                has_initial = reduction_get_initial(
+                        &context, /* reduction_is_empty */ NPY_TRUE, initials);
+                if (has_initial < 0) {
+                    goto fail;
+                }
+                if (has_initial) {
+                    empty_initial = initial_buf;
+                }
+                else {
+                    /* No initial value available, free the buffer */
+                    PyMem_FREE(initial_buf);
+                    initial_buf = NULL;
+                }
+            }
+        }
+    }
+
+    /*
+     * If the output has zero elements, return now.
+     */
+    if (PyArray_SIZE(op[0]) == 0) {
+        goto finish;
+    }
+
+    if (iter && NpyIter_GetIterSize(iter) != 0) {
+        char *dataptr_copy[3];
+        npy_intp stride_copy[3];
+
+        NpyIter_IterNextFunc *iternext;
+        char **dataptr;
+        npy_intp stride0, stride1;
+        npy_intp stride0_ind = PyArray_STRIDE(op[0], axis);
+
+        int itemsize = descrs[0]->elsize;
+
+        /* Get the variables needed for the loop */
+        iternext = NpyIter_GetIterNext(iter, NULL);
+        if (iternext == NULL) {
+            goto fail;
+        }
+        dataptr = NpyIter_GetDataPtrArray(iter);
+
+        /* Execute the loop with just the outer iterator */
+        stride0 = 0;
+        stride1 = PyArray_STRIDE(op[1], axis);
+
+        NPY_UF_DBG_PRINT("UFunc: Reduce loop with just outer iterator\n");
+
+        stride_copy[0] = stride0;
+        stride_copy[1] = stride1;
+        stride_copy[2] = stride0;
+
+        if (!needs_api) {
+            NPY_BEGIN_THREADS_THRESHOLDED(NpyIter_GetIterSize(iter));
+        }
+
+        do {
+            for (i = 0; i < ind_size; ++i) {
+                npy_intp start = start_offsets[i];
+                npy_intp end = stop_offsets != NULL ? stop_offsets[i] :
+                        ((i == ind_size-1) ? red_axis_size :
+                                             start_offsets[i+1]);
+                npy_intp count = end - start;
+                char *first_element;
+
+                dataptr_copy[0] = dataptr[0] + stride0_ind*i;
+                dataptr_copy[1] = dataptr[1] + stride1*start;
+                dataptr_copy[2] = dataptr[0] + stride0_ind*i;
+
+                /* Start from the initial value or the first element */
+                if (segment_initial != NULL) {
+                    first_element = segment_initial;
+                }
+                else if (count > 0) {
+                    first_element = dataptr_copy[1];
+                    --count;
+                    dataptr_copy[1] += stride1;
+                }
+                else if (empty_initial != NULL) {
+                    first_element = empty_initial;
+                }
+                else {
+                    /* Empty segment and no identity, error out below */
+                    res = -2;
+                    break;
+                }
+
+                /*
+                 * Copy the first value to start the reduction.
+                 *
+                 * Output (dataptr[0]) and input (dataptr[1]) may point
+                 * to the same memory, e.g.
+                 * np.add.segmented_reduce(a, starts, stops, out=a).
+                 */
+                if (descrs[2]->type_num == NPY_OBJECT) {
+                    /*
+                     * Incref before decref to avoid the possibility of
+                     * the reference count being zero temporarily.
+                     */
+                    Py_XINCREF(*(PyObject **)first_element);
+                    Py_XDECREF(*(PyObject **)dataptr_copy[0]);
+                    *(PyObject **)dataptr_copy[0] =
+                                        *(PyObject **)first_element;
+                }
+                else {
+                    memmove(dataptr_copy[0], first_element, itemsize);
+                }
+
+                if (count > 0) {
+                    /* Inner loop like REDUCE */
+                    NPY_UF_DBG_PRINT1("iterator loop count %d\n",
+                                                    (int)count);
+                    res = strided_loop(&context,
+                            dataptr_copy, &count, stride_copy, auxdata);
+                    if (res != 0) {
+                        break;
+                    }
+                }
+            }
+        } while (res == 0 && iternext(iter));
+
+        NPY_END_THREADS;
+    }
+    else if (iter == NULL) {
+        char *dataptr_copy[3];
+
+        int itemsize = descrs[0]->elsize;
+
+        npy_intp stride0_ind = PyArray_STRIDE(op[0], axis);
+        npy_intp stride1 = PyArray_STRIDE(op[1], axis);
+
+        NPY_UF_DBG_PRINT("UFunc: Reduce loop with no iterators\n");
+
+        if (!needs_api) {
+            NPY_BEGIN_THREADS;
+        }
+
+        for (i = 0; i < ind_size; ++i) {
+            npy_intp start = start_offsets[i];
+            npy_intp end = stop_offsets != NULL ? stop_offsets[i] :
+                    ((i == ind_size-1) ? red_axis_size :
+                                         start_offsets[i+1]);
+            npy_intp count = end - start;
+            char *first_element;
+
+            dataptr_copy[0] = PyArray_BYTES(op[0]) + stride0_ind*i;
+            dataptr_copy[1] = PyArray_BYTES(op[1]) + stride1*start;
+            dataptr_copy[2] = PyArray_BYTES(op[0]) + stride0_ind*i;
+
+            /* Start from the initial value or the first element */
+            if (segment_initial != NULL) {
+                first_element = segment_initial;
+            }
+            else if (count > 0) {
+                first_element = dataptr_copy[1];
+                --count;
+                dataptr_copy[1] += stride1;
+            }
+            else if (empty_initial != NULL) {
+                first_element = empty_initial;
+            }
+            else {
+                /* Empty segment and no identity, error out below */
+                res = -2;
+                break;
+            }
+
+            /*
+             * Copy the first value to start the reduction.
+             *
+             * Output (dataptr[0]) and input (dataptr[1]) may point to
+             * the same memory, e.g.
+             * np.add.segmented_reduce(a, starts, stops, out=a).
+             */
+            if (descrs[2]->type_num == NPY_OBJECT) {
+                /*
+                 * Incref before decref to avoid the possibility of the
+                 * reference count being zero temporarily.
+                 */
+                Py_XINCREF(*(PyObject **)first_element);
+                Py_XDECREF(*(PyObject **)dataptr_copy[0]);
+                *(PyObject **)dataptr_copy[0] =
+                                    *(PyObject **)first_element;
+            }
+            else {
+                memmove(dataptr_copy[0], first_element, itemsize);
+            }
+
+            if (count > 0) {
+                /* Inner loop like REDUCE */
+                NPY_UF_DBG_PRINT1("iterator loop count %d\n",
+                                                (int)count);
+                res = strided_loop(&context,
+                        dataptr_copy, &count, fixed_strides, auxdata);
+                if (res != 0) {
+                    break;
+                }
+            }
+        }
+
+        NPY_END_THREADS;
+    }
+
+finish:
+    if (initial_buf != NULL && PyDataType_REFCHK(descrs[0])) {
+        PyArray_ClearBuffer(descrs[0], initial_buf, 0, 1, 1);
+    }
+    PyMem_FREE(initial_buf);
+    NPY_AUXDATA_FREE(auxdata);
+    Py_DECREF(descrs[0]);
+    Py_DECREF(descrs[1]);
+    Py_DECREF(descrs[2]);
+
+    if (!NpyIter_Deallocate(iter)) {
+        res = -1;
+    }
+
+    if (res == 0 && !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
+        /* NOTE: We could check float errors even when `res < 0` */
+        res = _check_ufunc_fperr(errormask, "segmented_reduce");
+    }
+
+    if (res < 0) {
+        if (res == -2) {
+            PyErr_Format(PyExc_ValueError,
+                    "zero-size segment in reduction operation '%s' which does "
+                    "not have an identity, so to allow empty segments one has "
+                    "to specify 'initial'", ufunc_name);
+        }
+        Py_DECREF(out);
+        return NULL;
+    }
+
+    return (PyObject *)out;
+
+fail:
+    if (initial_buf != NULL && PyDataType_REFCHK(descrs[0])) {
+        PyArray_ClearBuffer(descrs[0], initial_buf, 0, 1, 1);
+    }
+    PyMem_FREE(initial_buf);
+
+    Py_XDECREF(out);
+
+    NPY_AUXDATA_FREE(auxdata);
+    Py_XDECREF(descrs[0]);
+    Py_XDECREF(descrs[1]);
+    Py_XDECREF(descrs[2]);
+
+    NpyIter_Deallocate(iter);
+
+    return NULL;
+}
+
 
 static npy_bool
 tuple_all_none(PyObject *tup) {
@@ -3879,7 +4443,14 @@ _parse_axis(PyObject *axes_obj, int ndim, int *axes)
 static PyArray_DTypeMeta * _get_dtype(PyObject *dtype_obj);
 
 /*
- * This code handles reduce, reduceat, and accumulate
+ * Identifier for `segmented_reduce`, continuing the `UFUNC_REDUCE`,
+ * `UFUNC_ACCUMULATE`, ... defines of `ufuncobject.h` (`UFUNC_OUTER` is 3 and
+ * not handled by `PyUFunc_GenericReduction`).
+ */
+#define UFUNC_SEGMENTED_REDUCE 4
+
+/*
+ * This code handles reduce, reduceat, segmented_reduce, and accumulate
  * (accumulate and reduce are special cases of the more general reduceat
  * but they are handled separately for speed)
  */
@@ -3896,6 +4467,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
     PyObject *op = NULL;
     PyObject *ret = NULL;
     PyArrayObject *indices = NULL;
+    PyArrayObject *starts = NULL, *stops = NULL;
     PyArray_DTypeMeta *signature[NPY_MAXARGS] = {NULL};
     PyArrayObject *out[NPY_MAXARGS] = {NULL};
     int keepdims = 0;
@@ -3903,7 +4475,8 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
     npy_bool out_is_passed_by_position;
 
 
-    static char *_reduce_type[] = {"reduce", "accumulate", "reduceat", NULL};
+    static char *_reduce_type[] = {"reduce", "accumulate", "reduceat",
+                                   "outer", "segmented_reduce", NULL};
 
     if (ufunc == NULL) {
         PyErr_SetString(PyExc_ValueError, "function not supported");
@@ -3935,6 +4508,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
      * certain parameters.
      */
     PyObject *otype_obj = NULL, *out_obj = NULL, *indices_obj = NULL;
+    PyObject *starts_obj = NULL, *stops_obj = NULL;
     PyObject *keepdims_obj = NULL, *wheremask_obj = NULL;
     npy_bool return_scalar = NPY_TRUE;  /* scalar return is disabled for out=... */
     if (operation == UFUNC_REDUCEAT) {
@@ -3955,6 +4529,28 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             goto fail;
         }
         out_is_passed_by_position = len_args >= 5;
+    }
+    else if (operation == UFUNC_SEGMENTED_REDUCE) {
+        NPY_PREPARE_ARGPARSER;
+
+        if (npy_parse_arguments("segmented_reduce", args, len_args, kwnames,
+                {"array", NULL, &op},
+                {"starts", NULL, &starts_obj},
+                {"|stops", NULL, &stops_obj},
+                {"|axis", NULL, &axes_obj},
+                {"|dtype", NULL, &otype_obj},
+                {"|out", NULL, &out_obj},
+                {"|initial", &_not_NoValue, &initial}) < 0) {
+            goto fail;
+        }
+        /* Prepare inputs for PyUfunc_CheckOverride */
+        PyObject *reduce_in[] = {op, starts_obj, stops_obj};
+        npy_bool has_stops = stops_obj != NULL && stops_obj != Py_None;
+        full_args.in = PyTuple_FromArray(reduce_in, has_stops ? 3 : 2);
+        if (full_args.in == NULL) {
+            goto fail;
+        }
+        out_is_passed_by_position = len_args >= 6;
     }
     else if (operation == UFUNC_ACCUMULATE) {
         NPY_PREPARE_ARGPARSER;
@@ -4039,6 +4635,38 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             goto fail;
         }
     }
+    if (starts_obj) {
+        PyArray_Descr *indtype = PyArray_DescrFromType(NPY_INTP);
+
+        /*
+         * Ensure copies, since the offsets are clipped in-place.  Each
+         * `PyArray_FromAny` steals a reference to indtype.
+         */
+        Py_INCREF(indtype);
+        starts = (PyArrayObject *)PyArray_FromAny(starts_obj, indtype, 1, 1,
+                NPY_ARRAY_CARRAY | NPY_ARRAY_ENSURECOPY, NULL);
+        if (starts == NULL) {
+            Py_DECREF(indtype);
+            goto fail;
+        }
+        if (stops_obj != NULL && stops_obj != Py_None) {
+            stops = (PyArrayObject *)PyArray_FromAny(stops_obj, indtype, 1, 1,
+                    NPY_ARRAY_CARRAY | NPY_ARRAY_ENSURECOPY, NULL);
+            if (stops == NULL) {
+                goto fail;
+            }
+            if (PyArray_DIM(stops, 0) != PyArray_DIM(starts, 0)) {
+                PyErr_Format(PyExc_ValueError,
+                        "'starts' and 'stops' must have the same length, got "
+                        "%" NPY_INTP_FMT " and %" NPY_INTP_FMT,
+                        PyArray_DIM(starts, 0), PyArray_DIM(stops, 0));
+                goto fail;
+            }
+        }
+        else {
+            Py_DECREF(indtype);
+        }
+    }
     if (otype_obj && otype_obj != Py_None) {
         /* Use `_get_dtype` because `dtype` is a DType and not the instance */
         signature[0] = _get_dtype(otype_obj);
@@ -4106,6 +4734,22 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         ret = PyUFunc_Reduceat(ufunc,
                 mp, indices, out[0], axes[0], signature);
         Py_SETREF(indices, NULL);
+        break;
+    case UFUNC_SEGMENTED_REDUCE:
+        if (ndim == 0) {
+            PyErr_SetString(PyExc_TypeError,
+                        "cannot segmented_reduce on a scalar");
+            goto fail;
+        }
+        if (naxes != 1) {
+            PyErr_SetString(PyExc_ValueError,
+                        "segmented_reduce does not allow multiple axes");
+            goto fail;
+        }
+        ret = PyUFunc_SegmentedReduce(ufunc,
+                mp, starts, stops, out[0], axes[0], signature, initial);
+        Py_SETREF(starts, NULL);
+        Py_XSETREF(stops, NULL);
         break;
     }
     if (ret == NULL) {
@@ -4187,6 +4831,8 @@ fail:
     Py_XDECREF(mp);
     Py_XDECREF(wheremask);
     Py_XDECREF(indices);
+    Py_XDECREF(starts);
+    Py_XDECREF(stops);
     Py_XDECREF(full_args.in);
     Py_XDECREF(full_args.out);
     return NULL;
@@ -6079,6 +6725,14 @@ ufunc_reduceat(PyUFuncObject *ufunc,
             ufunc, args, len_args, kwnames, UFUNC_REDUCEAT);
 }
 
+static PyObject *
+ufunc_segmented_reduce(PyUFuncObject *ufunc,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+{
+    return PyUFunc_GenericReduction(
+            ufunc, args, len_args, kwnames, UFUNC_SEGMENTED_REDUCE);
+}
+
 /* Helper for ufunc_at, below */
 static inline PyArrayObject *
 new_array_op(PyArrayObject *op_array, char *data)
@@ -7111,6 +7765,9 @@ static struct PyMethodDef ufunc_methods[] = {
         METH_FASTCALL | METH_KEYWORDS, NULL },
     {"reduceat",
         (PyCFunction)ufunc_reduceat,
+        METH_FASTCALL | METH_KEYWORDS, NULL },
+    {"segmented_reduce",
+        (PyCFunction)ufunc_segmented_reduce,
         METH_FASTCALL | METH_KEYWORDS, NULL },
     {"outer",
         (PyCFunction)ufunc_outer,

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -4087,6 +4087,22 @@ PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
         goto finish;
     }
 
+    if (empty_initial == NULL) {
+        /*
+         * Without an initial value an empty segment has no result.  Check
+         * for one here, the loops below may run without holding the GIL.
+         */
+        for (i = 0; i < ind_size; ++i) {
+            if (stop_offsets[i] <= start_offsets[i]) {
+                PyErr_Format(PyExc_ValueError,
+                        "zero-size segment in reduction operation '%s' which "
+                        "does not have an identity, so to allow empty "
+                        "segments one has to specify 'initial'", ufunc_name);
+                goto fail;
+            }
+        }
+    }
+
     if (iter && NpyIter_GetIterSize(iter) != 0) {
         char *dataptr_copy[3];
         npy_intp stride_copy[3];
@@ -4139,13 +4155,9 @@ PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
                     --count;
                     dataptr_copy[1] += stride1;
                 }
-                else if (empty_initial != NULL) {
-                    first_element = empty_initial;
-                }
                 else {
-                    /* Empty segment and no identity, error out below */
-                    res = -2;
-                    break;
+                    /* An empty segment, checked to have a result above */
+                    first_element = empty_initial;
                 }
 
                 /*
@@ -4217,13 +4229,9 @@ PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
                 --count;
                 dataptr_copy[1] += stride1;
             }
-            else if (empty_initial != NULL) {
-                first_element = empty_initial;
-            }
             else {
-                /* Empty segment and no identity, error out below */
-                res = -2;
-                break;
+                /* An empty segment, checked to have a result above */
+                first_element = empty_initial;
             }
 
             /*
@@ -4282,12 +4290,6 @@ finish:
     }
 
     if (res < 0) {
-        if (res == -2) {
-            PyErr_Format(PyExc_ValueError,
-                    "zero-size segment in reduction operation '%s' which does "
-                    "not have an identity, so to allow empty segments one has "
-                    "to specify 'initial'", ufunc_name);
-        }
         Py_DECREF(out);
         return NULL;
     }

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3785,8 +3785,7 @@ clip_segment_offsets(npy_intp *offsets, npy_intp n, npy_intp axis_size)
  * op.reduce(array[starts[i]:stops[i]])
  * for i=0..len(starts)-1.  The offsets use slice semantics, i.e. negative
  * offsets count from the end of the axis and out-of-bounds offsets are
- * clipped.  If `stops` is NULL, the stop of a segment is the start of the
- * next one (and the end of the axis for the last segment).
+ * clipped.
  *
  * Contrary to reduceat, empty segments are well defined, they give the
  * `initial` value or the identity of the ufunc, exactly like `ufunc.reduce`
@@ -3818,7 +3817,7 @@ PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
     NpyAuxData *auxdata = NULL;
 
     /* The segment offsets - starts and stops must be copies (see below) */
-    npy_intp *start_offsets, *stop_offsets = NULL;
+    npy_intp *start_offsets, *stop_offsets;
     npy_intp i, ind_size, red_axis_size;
 
     /* Buffer to use when we need an initial value, and views into it */
@@ -3835,17 +3834,13 @@ PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
     NPY_BEGIN_THREADS_DEF;
 
     start_offsets = (npy_intp *)PyArray_DATA(starts);
-    if (stops != NULL) {
-        stop_offsets = (npy_intp *)PyArray_DATA(stops);
-    }
+    stop_offsets = (npy_intp *)PyArray_DATA(stops);
     ind_size = PyArray_DIM(starts, 0);
     red_axis_size = PyArray_DIM(arr, axis);
 
     /* Out-of-bounds offsets are not an error, they are clipped in-place */
     clip_segment_offsets(start_offsets, ind_size, red_axis_size);
-    if (stop_offsets != NULL) {
-        clip_segment_offsets(stop_offsets, ind_size, red_axis_size);
-    }
+    clip_segment_offsets(stop_offsets, ind_size, red_axis_size);
 
     NPY_UF_DBG_PRINT2("\nEvaluating ufunc %s.%s\n", ufunc_name, opname);
 
@@ -4127,10 +4122,7 @@ PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
         do {
             for (i = 0; i < ind_size; ++i) {
                 npy_intp start = start_offsets[i];
-                npy_intp end = stop_offsets != NULL ? stop_offsets[i] :
-                        ((i == ind_size-1) ? red_axis_size :
-                                             start_offsets[i+1]);
-                npy_intp count = end - start;
+                npy_intp count = stop_offsets[i] - start;
                 char *first_element;
 
                 dataptr_copy[0] = dataptr[0] + stride0_ind*i;
@@ -4207,10 +4199,7 @@ PyUFunc_SegmentedReduce(PyUFuncObject *ufunc, PyArrayObject *arr,
 
         for (i = 0; i < ind_size; ++i) {
             npy_intp start = start_offsets[i];
-            npy_intp end = stop_offsets != NULL ? stop_offsets[i] :
-                    ((i == ind_size-1) ? red_axis_size :
-                                         start_offsets[i+1]);
-            npy_intp count = end - start;
+            npy_intp count = stop_offsets[i] - start;
             char *first_element;
 
             dataptr_copy[0] = PyArray_BYTES(op[0]) + stride0_ind*i;
@@ -4536,7 +4525,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         if (npy_parse_arguments("segmented_reduce", args, len_args, kwnames,
                 {"array", NULL, &op},
                 {"starts", NULL, &starts_obj},
-                {"|stops", NULL, &stops_obj},
+                {"stops", NULL, &stops_obj},
                 {"|axis", NULL, &axes_obj},
                 {"|dtype", NULL, &otype_obj},
                 {"|out", NULL, &out_obj},
@@ -4545,8 +4534,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         }
         /* Prepare inputs for PyUfunc_CheckOverride */
         PyObject *reduce_in[] = {op, starts_obj, stops_obj};
-        npy_bool has_stops = stops_obj != NULL && stops_obj != Py_None;
-        full_args.in = PyTuple_FromArray(reduce_in, has_stops ? 3 : 2);
+        full_args.in = PyTuple_FromArray(reduce_in, 3);
         if (full_args.in == NULL) {
             goto fail;
         }
@@ -4649,22 +4637,17 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
             Py_DECREF(indtype);
             goto fail;
         }
-        if (stops_obj != NULL && stops_obj != Py_None) {
-            stops = (PyArrayObject *)PyArray_FromAny(stops_obj, indtype, 1, 1,
-                    NPY_ARRAY_CARRAY | NPY_ARRAY_ENSURECOPY, NULL);
-            if (stops == NULL) {
-                goto fail;
-            }
-            if (PyArray_DIM(stops, 0) != PyArray_DIM(starts, 0)) {
-                PyErr_Format(PyExc_ValueError,
-                        "'starts' and 'stops' must have the same length, got "
-                        "%" NPY_INTP_FMT " and %" NPY_INTP_FMT,
-                        PyArray_DIM(starts, 0), PyArray_DIM(stops, 0));
-                goto fail;
-            }
+        stops = (PyArrayObject *)PyArray_FromAny(stops_obj, indtype, 1, 1,
+                NPY_ARRAY_CARRAY | NPY_ARRAY_ENSURECOPY, NULL);
+        if (stops == NULL) {
+            goto fail;
         }
-        else {
-            Py_DECREF(indtype);
+        if (PyArray_DIM(stops, 0) != PyArray_DIM(starts, 0)) {
+            PyErr_Format(PyExc_ValueError,
+                    "'starts' and 'stops' must have the same length, got "
+                    "%" NPY_INTP_FMT " and %" NPY_INTP_FMT,
+                    PyArray_DIM(starts, 0), PyArray_DIM(stops, 0));
+            goto fail;
         }
     }
     if (otype_obj && otype_obj != Py_None) {
@@ -4749,7 +4732,7 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         ret = PyUFunc_SegmentedReduce(ufunc,
                 mp, starts, stops, out[0], axes[0], signature, initial);
         Py_SETREF(starts, NULL);
-        Py_XSETREF(stops, NULL);
+        Py_SETREF(stops, NULL);
         break;
     }
     if (ret == NULL) {

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -2574,6 +2574,9 @@ class TestDateTime:
         with pytest.raises(TypeError, match=msg):
             np.subtract.reduceat(arr, [0])
 
+        with pytest.raises(TypeError, match=msg):
+            np.subtract.segmented_reduce(arr, [0], [2])
+
     def test_datetime_busday_offset(self):
         # First Monday in June
         assert_equal(

--- a/numpy/_core/tests/test_mem_overlap.py
+++ b/numpy/_core/tests/test_mem_overlap.py
@@ -748,7 +748,8 @@ class TestUFunc:
                 size = a.shape[axis]
                 step = a.shape[axis] // out.shape[axis]
             starts = np.arange(0, size, step)
-            return np.add.segmented_reduce(a, starts, out=out, axis=axis)
+            stops = np.concatenate([starts[1:], [size]])
+            return np.add.segmented_reduce(a, starts, stops, out=out, axis=axis)
 
         self.check_unary_fuzz(do_segmented_reduce, get_out_axis_size,
                               dtype=np.int16, count=500)

--- a/numpy/_core/tests/test_mem_overlap.py
+++ b/numpy/_core/tests/test_mem_overlap.py
@@ -730,6 +730,44 @@ class TestUFunc:
         a = np.arange(10000, dtype=np.int16)
         check(np.add, a, a[::-1], a)
 
+    def test_binary_ufunc_segmented_reduce_fuzz(self):
+        def get_out_axis_size(a, b, axis):
+            if axis is None:
+                if a.ndim == 1:
+                    return a.size, False
+                else:
+                    return 'skip', False  # segmented_reduce doesn't support this
+            else:
+                return a.shape[axis], False
+
+        def do_segmented_reduce(a, out, axis):
+            if axis is None:
+                size = len(a)
+                step = size // len(out)
+            else:
+                size = a.shape[axis]
+                step = a.shape[axis] // out.shape[axis]
+            starts = np.arange(0, size, step)
+            return np.add.segmented_reduce(a, starts, out=out, axis=axis)
+
+        self.check_unary_fuzz(do_segmented_reduce, get_out_axis_size,
+                              dtype=np.int16, count=500)
+
+    def test_binary_ufunc_segmented_reduce_manual(self):
+        def check(ufunc, a, starts, stops, out):
+            c1 = ufunc.segmented_reduce(a.copy(), starts.copy(), stops.copy(),
+                                        out=out.copy())
+            c2 = ufunc.segmented_reduce(a, starts, stops, out=out)
+            assert_array_equal(c1, c2)
+
+        # Exactly same input/output arrays
+        a = np.arange(10000, dtype=np.int16)
+        check(np.add, a, a[::-1].copy(), a.copy(), a)
+
+        # Overlap with the offsets
+        a = np.arange(10000, dtype=np.int16)
+        check(np.add, a, a[::-1], a, a)
+
     @pytest.mark.slow
     def test_unary_gufunc_fuzz(self):
         shapes = [7, 13, 8, 21, 29, 32]

--- a/numpy/_core/tests/test_reduction_loop.py
+++ b/numpy/_core/tests/test_reduction_loop.py
@@ -389,6 +389,12 @@ class TestReductionLoop:
                 ValueError, match="only supported for functions returning a single"):
             mm.reduceat(a, [0, 2])
 
+    def test_segmented_reduce_raises(self):
+        a = make_array((4,), seed=25)
+        with pytest.raises(
+                ValueError, match="only supported for functions returning a single"):
+            mm.segmented_reduce(a, [0, 2], [2, 4])
+
     def test_at_raises(self):
         a = make_array((4,), seed=22)
         with pytest.raises(ValueError, match="single output"):

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2846,13 +2846,10 @@ class TestSegmentedReduce:
     ufuncs_integer = [np.bitwise_or, np.bitwise_and, np.gcd, np.left_shift]
 
     @staticmethod
-    def reference(ufunc, arr, starts, stops=None, axis=0, **kwargs):
+    def reference(ufunc, arr, starts, stops, axis=0, **kwargs):
         """Reference implementation using plain slicing and `ufunc.reduce`."""
         arr = np.asarray(arr)
         axis = axis % arr.ndim
-        starts = list(starts)
-        if stops is None:
-            stops = starts[1:] + [arr.shape[axis]]
 
         results = []
         for start, stop in zip(starts, stops):
@@ -2934,21 +2931,14 @@ class TestSegmentedReduce:
         for i, (start, stop) in enumerate(zip(starts, stops)):
             assert res[i] == np.add.reduce(arr[start:stop], initial=0.)
 
-    def test_implicit_stops(self):
-        # Without `stops`, a segment ends where the next one starts, which is
-        # the same segmentation `reduceat` uses.
+    def test_matches_reduceat(self):
+        # Consecutive segments are the segmentation `reduceat` uses
         arr = np.arange(10.)
-        starts = [0, 3, 3, 7]
+        offsets = [0, 3, 7]
+        stops = offsets[1:] + [len(arr)]
 
-        res = np.add.segmented_reduce(arr, starts)
-        assert_array_equal(res, self.reference(np.add, arr, starts))
-        assert_array_equal(res, [3, 0, 18, 24])
-        # `stops=None` is the same as not passing it at all
-        assert_array_equal(np.add.segmented_reduce(arr, starts, None), res)
-
-        # It matches reduceat where the segments are not empty
-        res = np.add.segmented_reduce(arr, [0, 3, 7])
-        assert_array_equal(res, np.add.reduceat(arr, [0, 3, 7]))
+        assert_array_equal(np.add.segmented_reduce(arr, offsets, stops),
+                           np.add.reduceat(arr, offsets))
 
     def test_slice_semantics(self):
         arr = np.arange(10.)
@@ -2961,8 +2951,6 @@ class TestSegmentedReduce:
             np.add.segmented_reduce(arr, [-100, 8], [100, 100]), [45, 17])
         # A stop before the start gives an empty segment
         assert_array_equal(np.add.segmented_reduce(arr, [5], [2]), [0])
-        # Including for the implicit stops of decreasing starts
-        assert_array_equal(np.add.segmented_reduce(arr, [5, 2]), [0, 44])
 
     def test_offsets_are_not_modified(self):
         # The offsets are normalized internally, but must not be modified
@@ -3028,7 +3016,6 @@ class TestSegmentedReduce:
         res = np.add.segmented_reduce(np.arange(10.), [], [])
         assert res.shape == (0,)
         assert res.dtype == np.float64
-        assert_array_equal(np.add.segmented_reduce(np.arange(10.), []), res)
 
         # An empty reduction axis (all segments must be empty)
         assert_array_equal(
@@ -3138,6 +3125,8 @@ class TestSegmentedReduce:
 
     def test_bad_offsets(self):
         arr = np.arange(10.)
+        with pytest.raises(TypeError):
+            np.add.segmented_reduce(arr, [0, 5])
         with pytest.raises(ValueError, match="same length"):
             np.add.segmented_reduce(arr, [0, 5], [5])
         with pytest.raises(ValueError, match="same length"):
@@ -3167,6 +3156,8 @@ class TestSegmentedReduce:
                 arr, starts=[0, 5], stops=[5, 10], axis=0, dtype=None,
                 out=None, initial=np._NoValue),
             expected)
+        with pytest.raises(TypeError):
+            np.add.segmented_reduce(arr, [0, 5])
         # ... and by position
         assert_array_equal(
             np.add.segmented_reduce(arr, [0, 5], [5, 10], 0, None, None,
@@ -3318,15 +3309,7 @@ class TestSegmentedReduce:
         assert res[3] == {"axis": "axis0", "dtype": "dtype0",
                           "out": ("out0",)}
 
-        # `stops` may be left out entirely or passed as None
-        res = np.add.segmented_reduce(arr, [0, 2])
-        assert res[2] == (arr, [0, 2])
-        res = np.add.segmented_reduce(arr, [0, 2], None)
-        assert res[2] == (arr, [0, 2])
-        res = np.add.segmented_reduce(arr, [0, 2], stops=None)
-        assert res[2] == (arr, [0, 2])
-
-        # And `initial` is only passed on when it is given
+        # `initial` is only passed on when it is given
         res = np.add.segmented_reduce(arr, [0], [1], 0, None, None,
                                       np._NoValue)
         assert res[3] == {"axis": 0, "dtype": None}

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2898,6 +2898,12 @@ class TestSegmentedReduce:
         with pytest.raises(ValueError, match="zero-size segment"):
             ufunc.segmented_reduce(arr, [0, 3], [4, 3])
 
+        # The error is raised before anything is written into `out`
+        out = np.full(2, 42.)
+        with pytest.raises(ValueError, match="zero-size segment"):
+            ufunc.segmented_reduce(arr, [0, 3], [4, 3], out=out)
+        assert_array_equal(out, [42., 42.])
+
         # But passing an initial value defines the result:
         res = ufunc.segmented_reduce(arr, [0, 3], [4, 3], initial=42)
         assert_array_equal(

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2963,8 +2963,8 @@ class TestSegmentedReduce:
         assert_array_equal(starts, starts_copy)
         assert_array_equal(stops, stops_copy)
 
-    @pytest.mark.parametrize("offset_dtype", [np.int8, np.int32, np.intp,
-                                              np.uint8, np.uint32])
+    @pytest.mark.parametrize("offset_dtype", [np.int8, np.int16, np.int32,
+                                              np.intp, np.uint8, np.uint16])
     def test_offset_dtypes(self, offset_dtype):
         arr = np.arange(10.)
         starts = np.array([0, 5], dtype=offset_dtype)

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2651,6 +2651,9 @@ class TestUfunc:
         assert_array_equal(np.add.accumulate(arr_be), np.add.accumulate(arr_le))
         assert_array_equal(
             np.add.reduceat(arr_be, [1]), np.add.reduceat(arr_le, [1]))
+        assert_array_equal(
+            np.add.segmented_reduce(arr_be, [1], [10]),
+            np.add.segmented_reduce(arr_le, [1], [10]))
 
     def test_reducelike_out_promotes(self):
         # Check that the out argument to reductions is considered for
@@ -2688,6 +2691,11 @@ class TestUfunc:
         out = np.empty(2, dtype=arr.dtype.newbyteorder())
         expected = np.add.reduceat(arr, [0, 1])
         np.add.reduceat(arr, [0, 1], out=out)
+        assert_array_equal(expected, out)
+        # And segmented_reduce:
+        out = np.empty(2, dtype=arr.dtype.newbyteorder())
+        expected = np.add.segmented_reduce(arr, [0, 1], [1, 20])
+        np.add.segmented_reduce(arr, [0, 1], [1, 20], out=out)
         assert_array_equal(expected, out)
         # And accumulate:
         out = np.empty(arr.shape, dtype=arr.dtype.newbyteorder())
@@ -2740,6 +2748,9 @@ class TestUfunc:
 
         with pytest.raises(np._core._exceptions._UFuncNoLoopError):
             np.add.reduceat(arr, [0, 1, 2], out=out)
+
+        with pytest.raises(np._core._exceptions._UFuncNoLoopError):
+            np.add.segmented_reduce(arr, [0, 1, 2], [1, 2, 3], out=out)
 
         with pytest.raises(np._core._exceptions._UFuncNoLoopError):
             np.add.accumulate(arr, out=out)
@@ -2822,6 +2833,523 @@ class TestUfunc:
             assert not np.isinf(nat)
         except TypeError:
             pass  # ok, just not implemented
+
+
+class TestSegmentedReduce:
+    # Ufuncs with an identity, so that empty segments are well defined
+    ufuncs_with_identity = [np.add, np.multiply, np.logical_and,
+                            np.logical_or, np.hypot]
+    # Ufuncs without an identity, empty segments require `initial`
+    ufuncs_without_identity = [np.maximum, np.minimum, np.subtract,
+                               np.arctan2]
+    # Ufuncs that only have integer (or boolean) loops
+    ufuncs_integer = [np.bitwise_or, np.bitwise_and, np.gcd, np.left_shift]
+
+    @staticmethod
+    def reference(ufunc, arr, starts, stops=None, axis=0, **kwargs):
+        """Reference implementation using plain slicing and `ufunc.reduce`."""
+        arr = np.asarray(arr)
+        axis = axis % arr.ndim
+        starts = list(starts)
+        if stops is None:
+            stops = starts[1:] + [arr.shape[axis]]
+
+        results = []
+        for start, stop in zip(starts, stops):
+            # NOTE: slicing defines the start/stop semantics we implement
+            index = (slice(None),) * axis + (slice(start, stop),)
+            results.append(ufunc.reduce(arr[index], axis=axis, **kwargs))
+
+        if not results:
+            shape = list(arr.shape)
+            shape[axis] = 0
+            return np.empty(shape, dtype=ufunc.reduce(arr, axis=axis).dtype)
+        return np.stack(results, axis=axis)
+
+    @pytest.mark.parametrize("ufunc",
+            ufuncs_with_identity + ufuncs_without_identity + ufuncs_integer)
+    def test_basic(self, ufunc):
+        if ufunc in self.ufuncs_integer:
+            arr = np.arange(1, 11)
+        else:
+            arr = np.arange(1, 11).astype(np.float64)
+        # Segments that overlap, skip elements, and are given out of order
+        starts = [0, 2, 5, 3, 9]
+        stops = [4, 3, 10, 9, 10]
+
+        res = ufunc.segmented_reduce(arr, starts, stops)
+        assert_array_equal(res, self.reference(ufunc, arr, starts, stops))
+
+    @pytest.mark.parametrize("ufunc",
+            ufuncs_with_identity + [np.bitwise_or, np.bitwise_and])
+    def test_empty_segments_use_identity(self, ufunc):
+        if ufunc in self.ufuncs_integer:
+            arr = np.arange(1, 11)
+        else:
+            arr = np.arange(1, 11).astype(np.float64)
+        starts = [0, 3, 5, 10]
+        stops = [4, 3, 5, 10]  # last three segments are empty
+
+        res = ufunc.segmented_reduce(arr, starts, stops)
+        assert_array_equal(res, self.reference(ufunc, arr, starts, stops))
+        assert_array_equal(res[1:], [ufunc.identity] * 3)
+
+    @pytest.mark.parametrize("ufunc", ufuncs_without_identity)
+    def test_empty_segments_without_identity(self, ufunc):
+        arr = np.arange(1, 11).astype(np.float64)
+
+        with pytest.raises(ValueError, match="zero-size segment"):
+            ufunc.segmented_reduce(arr, [0, 3], [4, 3])
+
+        # But passing an initial value defines the result:
+        res = ufunc.segmented_reduce(arr, [0, 3], [4, 3], initial=42)
+        assert_array_equal(
+            res, self.reference(ufunc, arr, [0, 3], [4, 3], initial=42))
+        assert res[1] == 42
+
+    def test_initial(self):
+        arr = np.arange(10.)
+        res = np.add.segmented_reduce(arr, [0, 5], [5, 10], initial=100)
+        assert_array_equal(res, [110, 135])
+
+        # `initial=None` means that there is explicitly no initial value
+        # (and thus no identity), just as it does for `reduce`.
+        res = np.add.segmented_reduce(arr, [0, 5], [5, 10], initial=None)
+        assert_array_equal(res, [10, 35])
+        with pytest.raises(ValueError, match="zero-size segment"):
+            np.add.segmented_reduce(arr, [0], [0], initial=None)
+
+        # An initial value that cannot be cast is an error
+        with pytest.raises(ValueError):
+            np.add.segmented_reduce(arr, [0], [5], initial="spam")
+
+    def test_matches_reduce_exactly(self):
+        # The result of a segment must be identical to reducing the slice
+        rng = np.random.RandomState(1234)
+        arr = rng.uniform(-1e10, 1e10, size=100)
+        starts = rng.randint(-120, 120, size=30)
+        stops = rng.randint(-120, 120, size=30)
+
+        res = np.add.segmented_reduce(arr, starts, stops, initial=0.)
+        for i, (start, stop) in enumerate(zip(starts, stops)):
+            assert res[i] == np.add.reduce(arr[start:stop], initial=0.)
+
+    def test_implicit_stops(self):
+        # Without `stops`, a segment ends where the next one starts, which is
+        # the same segmentation `reduceat` uses.
+        arr = np.arange(10.)
+        starts = [0, 3, 3, 7]
+
+        res = np.add.segmented_reduce(arr, starts)
+        assert_array_equal(res, self.reference(np.add, arr, starts))
+        assert_array_equal(res, [3, 0, 18, 24])
+        # `stops=None` is the same as not passing it at all
+        assert_array_equal(np.add.segmented_reduce(arr, starts, None), res)
+
+        # It matches reduceat where the segments are not empty
+        res = np.add.segmented_reduce(arr, [0, 3, 7])
+        assert_array_equal(res, np.add.reduceat(arr, [0, 3, 7]))
+
+    def test_slice_semantics(self):
+        arr = np.arange(10.)
+
+        # Negative offsets count from the end
+        assert_array_equal(
+            np.add.segmented_reduce(arr, [-3, -10], [-1, 3]), [15, 3])
+        # Out-of-bounds offsets are clipped (and not an error)
+        assert_array_equal(
+            np.add.segmented_reduce(arr, [-100, 8], [100, 100]), [45, 17])
+        # A stop before the start gives an empty segment
+        assert_array_equal(np.add.segmented_reduce(arr, [5], [2]), [0])
+        # Including for the implicit stops of decreasing starts
+        assert_array_equal(np.add.segmented_reduce(arr, [5, 2]), [0, 44])
+
+    def test_offsets_are_not_modified(self):
+        # The offsets are normalized internally, but must not be modified
+        arr = np.arange(10.)
+        starts = np.array([-5, 3, 100])
+        stops = np.array([100, -20, 3])
+        starts_copy, stops_copy = starts.copy(), stops.copy()
+
+        np.add.segmented_reduce(arr, starts, stops)
+        assert_array_equal(starts, starts_copy)
+        assert_array_equal(stops, stops_copy)
+
+    @pytest.mark.parametrize("offset_dtype", [np.int8, np.int32, np.intp,
+                                              np.uint8, np.uint32])
+    def test_offset_dtypes(self, offset_dtype):
+        arr = np.arange(10.)
+        starts = np.array([0, 5], dtype=offset_dtype)
+        stops = np.array([5, 10], dtype=offset_dtype)
+        assert_array_equal(
+            np.add.segmented_reduce(arr, starts, stops), [10, 35])
+
+    def test_float_offsets_rejected(self):
+        # Just as for reduceat, offsets must be safely castable to intp
+        arr = np.arange(10.)
+        with pytest.raises(TypeError, match="Cannot cast array data"):
+            np.add.segmented_reduce(arr, np.array([0., 5.]), [5, 10])
+        with pytest.raises(TypeError, match="Cannot cast array data"):
+            np.add.segmented_reduce(arr, [0, 5], np.array([5., 10.]))
+
+    def test_offsets_as_sequences(self):
+        arr = np.arange(10.)
+        expected = [10, 35]
+        assert_array_equal(np.add.segmented_reduce(arr, [0, 5], [5, 10]),
+                           expected)
+        assert_array_equal(np.add.segmented_reduce(arr, (0, 5), (5, 10)),
+                           expected)
+        assert_array_equal(
+            np.add.segmented_reduce(arr, np.array([0, 5]), np.array([5, 10])),
+            expected)
+
+    @pytest.mark.parametrize("axis", [0, 1, 2, -1, -2, -3])
+    def test_axis(self, axis):
+        arr = np.arange(2 * 3 * 4).reshape(2, 3, 4).astype(np.float64)
+        starts = [0, 1]
+        stops = [1, arr.shape[axis]]
+
+        res = np.add.segmented_reduce(arr, starts, stops, axis=axis)
+        assert_array_equal(res, self.reference(
+            np.add, arr, starts, stops, axis=axis))
+        assert res.shape[axis] == 2
+
+    def test_axis_errors(self):
+        arr = np.arange(12.).reshape(3, 4)
+        with pytest.raises(AxisError):
+            np.add.segmented_reduce(arr, [0], [1], axis=2)
+        with pytest.raises(ValueError, match="does not allow multiple axes"):
+            np.add.segmented_reduce(arr, [0], [1], axis=(0, 1))
+        with pytest.raises(TypeError, match="cannot segmented_reduce"):
+            np.add.segmented_reduce(np.float64(1.), [0], [1])
+
+    def test_zero_sized(self):
+        # No segments at all
+        res = np.add.segmented_reduce(np.arange(10.), [], [])
+        assert res.shape == (0,)
+        assert res.dtype == np.float64
+        assert_array_equal(np.add.segmented_reduce(np.arange(10.), []), res)
+
+        # An empty reduction axis (all segments must be empty)
+        assert_array_equal(
+            np.add.segmented_reduce(np.zeros(0), [0, 5], [10, 20]), [0, 0])
+        with pytest.raises(ValueError, match="zero-size segment"):
+            np.maximum.segmented_reduce(np.zeros(0), [0], [1])
+
+        # An empty dimension that is not reduced over
+        arr = np.zeros((0, 5))
+        res = np.add.segmented_reduce(arr, [0, 2], [2, 5], axis=1)
+        assert res.shape == (0, 2)
+
+        # If the result is empty, no reduction happens and thus no identity
+        # is needed, even for empty segments
+        res = np.maximum.segmented_reduce(arr, [0, 2], [0, 5], axis=1)
+        assert res.shape == (0, 2)
+        res = np.maximum.segmented_reduce(np.zeros((0, 0)), [0, 2], [0, 5])
+        assert res.shape == (2, 0)
+
+    def test_out(self):
+        arr = np.arange(10.)
+        out = np.zeros(2)
+        res = np.add.segmented_reduce(arr, [0, 5], [5, 10], out=out)
+        assert res is out
+        assert_array_equal(out, [10, 35])
+
+        # `out=` may also be passed as a 1-element tuple or by position
+        out = np.zeros(2)
+        assert_array_equal(
+            np.add.segmented_reduce(arr, [0, 5], [5, 10], out=(out,)),
+            [10, 35])
+        out = np.zeros(2)
+        np.add.segmented_reduce(arr, [0, 5], [5, 10], 0, None, out)
+        assert_array_equal(out, [10, 35])
+
+        # `out=...` is accepted as a keyword and returns an array
+        res = np.add.segmented_reduce(arr, [0, 5], [5, 10], out=...)
+        assert_array_equal(res, [10, 35])
+        with pytest.raises(TypeError, match="only allowed as a keyword"):
+            np.add.segmented_reduce(arr, [0, 5], [5, 10], 0, None, ...)
+
+        # A cast on the output is fine
+        out = np.zeros(2, dtype=np.int64)
+        np.add.segmented_reduce(arr, [0, 5], [5, 10], out=out)
+        assert_array_equal(out, [10, 35])
+
+    def test_out_shape_mismatch(self):
+        arr = np.arange(10.)
+        for out in [np.zeros(1), np.zeros(3), np.zeros((2, 2))]:
+            with pytest.raises(ValueError, match="(length|dimensions)"):
+                np.add.segmented_reduce(arr, [0, 5], [5, 10], out=out)
+
+        arr = np.arange(12.).reshape(3, 4)
+        with pytest.raises(ValueError, match="(length|dimensions)"):
+            np.add.segmented_reduce(arr, [0], [2], axis=1, out=np.zeros((3, 2)))
+
+    def test_out_aliasing_offsets(self):
+        # The offsets are copied, so writing the result into them is fine
+        arr = np.arange(10)
+        starts = np.array([0, 5])
+        stops = np.array([5, 10])
+
+        res = np.add.segmented_reduce(arr, starts, stops, out=starts)
+        assert res is starts
+        assert_array_equal(starts, [10, 35])
+
+    def test_non_contiguous_offsets(self):
+        arr = np.arange(10.)
+        starts = np.array([0, -1, 5, -1])[::2]
+        stops = np.array([5, -1, 10, -1])[::2]
+        assert_array_equal(
+            np.add.segmented_reduce(arr, starts, stops), [10, 35])
+
+    def test_frompyfunc(self):
+        # A ufunc using the object loop and without an identity
+        ufunc = np.frompyfunc(lambda x, y: x + y, 2, 1)
+        arr = np.arange(6)
+
+        assert_array_equal(ufunc.segmented_reduce(arr, [0, 3], [3, 6]), [3, 12])
+        with pytest.raises(ValueError, match="zero-size segment"):
+            ufunc.segmented_reduce(arr, [0], [0])
+        assert_array_equal(
+            ufunc.segmented_reduce(arr, [0, 3], [0, 6], initial=100),
+            [100, 112])
+
+    def test_out_overlapping_input(self):
+        # Writing into the array that is reduced must give the same result
+        arr = np.arange(20., dtype=np.float64)
+        starts = np.arange(0, 20, 2)
+        stops = starts + 2
+
+        expected = np.add.segmented_reduce(arr, starts, stops)
+        res = np.add.segmented_reduce(arr, starts, stops, out=arr[:10])
+        assert_array_equal(res, expected)
+
+    def test_dtype(self):
+        arr = np.arange(10, dtype=np.int8)
+        res = np.add.segmented_reduce(arr, [0], [10], dtype=np.int8)
+        assert res.dtype == np.int8
+        assert_array_equal(res, [45])
+
+        # The default upcasts small integers, just like `reduce` does
+        assert np.add.segmented_reduce(arr, [0], [10]).dtype == np.intp
+
+        res = np.add.segmented_reduce(arr, [0], [10], dtype=np.float64)
+        assert res.dtype == np.float64
+
+    def test_bad_offsets(self):
+        arr = np.arange(10.)
+        with pytest.raises(ValueError, match="same length"):
+            np.add.segmented_reduce(arr, [0, 5], [5])
+        with pytest.raises(ValueError, match="same length"):
+            np.add.segmented_reduce(arr, [0], [5, 10])
+        with pytest.raises(ValueError, match="dimension"):
+            np.add.segmented_reduce(arr, [[0, 5]], [[5, 10]])
+        with pytest.raises(ValueError, match="depth"):
+            np.add.segmented_reduce(arr, 0, 5)
+        with pytest.raises((ValueError, TypeError)):
+            np.add.segmented_reduce(arr, ["a"], [1])
+
+    def test_bad_ufuncs(self):
+        arr = np.arange(10.)
+        with pytest.raises(ValueError, match="binary functions"):
+            np.sin.segmented_reduce(arr, [0], [1])
+        with pytest.raises(ValueError, match="single value"):
+            np.divmod.segmented_reduce(arr, [0], [1])
+        with pytest.raises(RuntimeError, match="Reduction not defined"):
+            umt.inner1d.segmented_reduce(arr, [0], [1])
+
+    def test_signature(self):
+        arr = np.arange(10.)
+        expected = [10, 35]
+        # All parameters may be passed by keyword
+        assert_array_equal(
+            np.add.segmented_reduce(
+                arr, starts=[0, 5], stops=[5, 10], axis=0, dtype=None,
+                out=None, initial=np._NoValue),
+            expected)
+        # ... and by position
+        assert_array_equal(
+            np.add.segmented_reduce(arr, [0, 5], [5, 10], 0, None, None,
+                                    np._NoValue),
+            expected)
+        with pytest.raises(TypeError):
+            np.add.segmented_reduce(arr, [0], [1], invalid_kwarg=1)
+        with pytest.raises(TypeError):
+            np.add.segmented_reduce(arr)
+        with pytest.raises(TypeError):
+            np.add.segmented_reduce()
+
+    @pytest.mark.parametrize("dtype", ["f8", "f4", "i8", "i4", "u1", "m8[s]",
+                                       "c16", "e"])
+    def test_dtypes(self, dtype):
+        arr = np.arange(1, 11).astype(dtype)
+        starts, stops = [0, 3, 8, 5], [5, 3, 10, 10]
+
+        res = np.add.segmented_reduce(arr, starts, stops)
+        assert_array_equal(res, self.reference(np.add, arr, starts, stops))
+
+    def test_non_contiguous(self):
+        arr = np.arange(40.)[::4]
+        starts, stops = [0, 5], [5, 10]
+        assert_array_equal(np.add.segmented_reduce(arr, starts, stops),
+                           self.reference(np.add, arr, starts, stops))
+
+        # Byte-swapped (non-native) input
+        arr = np.arange(10.).astype(np.dtype("f8").newbyteorder())
+        assert_array_equal(np.add.segmented_reduce(arr, starts, stops),
+                           [10, 35])
+
+        # Non-contiguous output
+        out = np.zeros(4)[::2]
+        np.add.segmented_reduce(np.arange(10.), starts, stops, out=out)
+        assert_array_equal(out, [10, 35])
+
+    def test_object_dtype(self):
+        arr = np.array([1, 2, 3, 4], dtype=object)
+        assert_array_equal(
+            np.add.segmented_reduce(arr, [0, 2], [2, 4]), [3, 7])
+
+        # As for `reduce`, the identity is only used for empty segments and
+        # not to start a non-empty one (`sum` of objects must not add a 0)
+        assert_array_equal(
+            np.add.segmented_reduce(arr, [0, 2], [0, 4]), [0, 7])
+        assert_array_equal(
+            np.multiply.segmented_reduce(arr, [0, 2], [0, 4]), [1, 12])
+        arr = np.array(["a", "b", "c"], dtype=object)
+        assert_array_equal(
+            np.add.segmented_reduce(arr, [0, 1], [2, 3]), ["ab", "bc"])
+
+        # A ufunc without an identity still requires `initial`
+        with pytest.raises(ValueError, match="zero-size segment"):
+            np.maximum.segmented_reduce(arr, [0], [0])
+        assert_array_equal(
+            np.maximum.segmented_reduce(arr, [0, 1], [0, 3], initial="a"),
+            ["a", "c"])
+
+    def test_object_dtype_inplace(self):
+        # Checks that in-place segmented reductions work, see also gh-7465
+        arr = np.empty(4, dtype=object)
+        arr[:] = [[1] for i in range(4)]
+        out = np.empty(4, dtype=object)
+        out[:] = [[1] for i in range(4)]
+        np.add.segmented_reduce(arr, np.arange(4), np.arange(1, 5), out=arr)
+        np.add.segmented_reduce(arr, np.arange(4), np.arange(1, 5), out=arr)
+        assert_array_equal(arr, out)
+
+        # And the same if the axis argument is used
+        arr = np.ones((2, 4), dtype=object)
+        arr[0, :] = [[2] for i in range(4)]
+        out = np.ones((2, 4), dtype=object)
+        out[0, :] = [[2] for i in range(4)]
+        np.add.segmented_reduce(arr, np.arange(4), np.arange(1, 5),
+                                out=arr, axis=-1)
+        np.add.segmented_reduce(arr, np.arange(4), np.arange(1, 5),
+                                out=arr, axis=-1)
+        assert_array_equal(arr, out)
+
+    def test_object_dtype_cleanup_on_failure(self):
+        # Failing in the middle must not leak the initial value or result
+        arr = np.array([1, 2, None], dtype=object)
+        with pytest.raises(TypeError):
+            np.add.segmented_reduce(arr, [0], [3], initial=4)
+        with pytest.raises(TypeError):
+            np.add.segmented_reduce(arr, [0], [3])
+
+    @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+    def test_no_reference_leak(self):
+        arr = np.array([1, 2, 3], dtype=np.int32)
+        starts = np.array([0, 1])
+        stops = np.array([1, 3])
+        out = np.empty(2, dtype=np.int32)
+        initial = np.int32(0)
+        counts = [sys.getrefcount(o)
+                  for o in (arr, starts, stops, out, initial)]
+
+        for _ in range(5):
+            np.add.segmented_reduce(arr, starts, stops, dtype=np.int32)
+            np.add.segmented_reduce(arr, starts, stops, dtype=np.int32,
+                                    initial=initial)
+            np.add.segmented_reduce(arr, starts, stops, dtype=np.int32,
+                                    out=out)
+            with pytest.raises(ValueError):
+                np.maximum.segmented_reduce(arr, [0], [0])
+
+        assert counts == [sys.getrefcount(o)
+                          for o in (arr, starts, stops, out, initial)]
+
+    @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
+    def test_object_no_reference_leak(self):
+        # An object `initial` is used for the empty segment (and released)
+        obj = 12345678901234567890
+        arr = np.empty(2, dtype=object)
+        arr[...] = obj
+        count = sys.getrefcount(obj)
+
+        for _ in range(5):
+            res = np.add.segmented_reduce(arr, [0, 2], [2, 2], initial=obj)
+            assert res[1] is obj
+            del res
+            # The identity used for the empty segment must be released too
+            res = np.add.segmented_reduce(arr, [0, 2], [2, 2])
+            del res
+
+        assert count == sys.getrefcount(obj)
+
+    def test_dtypes_with_references_not_supported(self):
+        # Only object dtype is supported for dtypes holding references
+        arr = np.array(["a", "b", "c"], dtype="T")
+        with pytest.raises(TypeError, match="segmented_reduce"):
+            np.add.segmented_reduce(arr, [0], [3])
+
+    def test_array_ufunc_override(self):
+        class MyArray:
+            def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+                return (ufunc, method, inputs, kwargs)
+
+        arr = MyArray()
+        res = np.add.segmented_reduce(arr, [0, 2], [2, 4], axis=1, initial=3)
+        assert res[0] is np.add
+        assert res[1] == "segmented_reduce"
+        assert res[2] == (arr, [0, 2], [2, 4])
+        assert res[3] == {"axis": 1, "initial": 3}
+
+        # Arguments passed by position are normalized into the kwargs
+        res = np.add.segmented_reduce(arr, [0], [1], "axis0", "dtype0", "out0")
+        assert res[3] == {"axis": "axis0", "dtype": "dtype0",
+                          "out": ("out0",)}
+
+        # `stops` may be left out entirely or passed as None
+        res = np.add.segmented_reduce(arr, [0, 2])
+        assert res[2] == (arr, [0, 2])
+        res = np.add.segmented_reduce(arr, [0, 2], None)
+        assert res[2] == (arr, [0, 2])
+        res = np.add.segmented_reduce(arr, [0, 2], stops=None)
+        assert res[2] == (arr, [0, 2])
+
+        # And `initial` is only passed on when it is given
+        res = np.add.segmented_reduce(arr, [0], [1], 0, None, None,
+                                      np._NoValue)
+        assert res[3] == {"axis": 0, "dtype": None}
+
+    @pytest.mark.parametrize("ndim", [1, 2, 3])
+    @pytest.mark.parametrize("ufunc", [np.add, np.multiply, np.minimum])
+    def test_fuzz_against_reference(self, ndim, ufunc):
+        rng = np.random.RandomState(4321)
+        shape = rng.randint(1, 6, size=ndim)
+        arr = rng.randint(1, 10, size=shape).astype(np.float64)
+
+        for axis in range(-ndim, ndim):
+            n = arr.shape[axis]
+            for _ in range(10):
+                num = rng.randint(0, 5)
+                starts = rng.randint(-n - 2, n + 2, size=num)
+                stops = rng.randint(-n - 2, n + 2, size=num)
+
+                res = ufunc.segmented_reduce(
+                        arr, starts, stops, axis=axis, initial=1.)
+                expected = self.reference(
+                        ufunc, arr, starts, stops, axis=axis, initial=1.)
+                assert_array_equal(res, expected)
 
 
 class TestGUFuncProcessCoreDims:
@@ -3021,7 +3549,8 @@ def test_ufunc_input_floatingpoint_error(bad_offset):
 @pytest.mark.skipif(sys.flags.optimize == 2, reason="Python running -OO")
 @pytest.mark.parametrize(
     "methodname",
-    ["__call__", "accumulate", "at", "outer", "reduce", "reduceat", "resolve_dtypes"],
+    ["__call__", "accumulate", "at", "outer", "reduce", "reduceat",
+     "segmented_reduce", "resolve_dtypes"],
 )
 def test_ufunc_method_signatures(methodname: str):
     method = getattr(np.ufunc, methodname)
@@ -3085,6 +3614,9 @@ def test_reduction_no_reference_leak():
     np.add.reduceat(arr, [0, 1], dtype=np.int32)
     assert count == sys.getrefcount(arr)
 
+    np.add.segmented_reduce(arr, [0, 1], [1, 3], dtype=np.int32, initial=0)
+    assert count == sys.getrefcount(arr)
+
     # with `out=` the reference count is not changed
     out = np.empty((), dtype=np.int32)
     out_count = sys.getrefcount(out)
@@ -3107,6 +3639,10 @@ def test_reduction_no_reference_leak():
     assert count == sys.getrefcount(arr)
     assert out_count == sys.getrefcount(out)
 
+    np.add.segmented_reduce(arr, [0, 1], [1, 3], dtype=np.int32, out=out)
+    assert count == sys.getrefcount(arr)
+    assert out_count == sys.getrefcount(out)
+
 
 def test_object_reduce_cleanup_on_failure():
     # Test cleanup, including of the initial value (manually provided or not)
@@ -3121,6 +3657,8 @@ def test_object_reduce_cleanup_on_failure():
 @pytest.mark.parametrize("method",
         [np.add.accumulate, np.add.reduce,
          pytest.param(lambda x: np.add.reduceat(x, [0]), id="reduceat"),
+         pytest.param(lambda x: np.add.segmented_reduce(x, [0], [3]),
+                      id="segmented_reduce"),
          pytest.param(lambda x: np.log.at(x, [2]), id="at")])
 def test_ufunc_methods_floaterrors(method):
     # adding inf and -inf (or log(-inf) creates an invalid float and warns

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -3798,9 +3798,9 @@ class TestSpecialMethods:
                               'axis': 'axis0',
                               'initial': 'initial0'})
 
-        # segmented_reduce, stops and initial are optional
-        res = np.multiply.segmented_reduce(a, [4, 2])
-        assert_equal(res[3], (a, [4, 2]))
+        # segmented_reduce, initial is optional
+        res = np.multiply.segmented_reduce(a, [4, 2], [6, 4])
+        assert_equal(res[3], (a, [4, 2], [6, 4]))
         assert_equal(res[4], {})
 
         # segmented_reduce, output equal to None removed.

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -3773,6 +3773,54 @@ class TestSpecialMethods:
         assert_raises(TypeError, np.multiply.reduce, a, [4, 2],
                       'axis0', axis='axis0')
 
+        # segmented_reduce, pos args
+        res = np.multiply.segmented_reduce(a, [4, 2], [6, 4], 'axis0',
+                                           'dtype0', 'out0', 'initial0')
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], 'segmented_reduce')
+        assert_equal(res[3], (a, [4, 2], [6, 4]))
+        assert_equal(res[4], {'dtype': 'dtype0',
+                              'out': ('out0',),
+                              'axis': 'axis0',
+                              'initial': 'initial0'})
+
+        # segmented_reduce, kwargs
+        res = np.multiply.segmented_reduce(a, [4, 2], [6, 4], axis='axis0',
+                                           dtype='dtype0', out='out0',
+                                           initial='initial0')
+        assert_equal(res[0], a)
+        assert_equal(res[1], np.multiply)
+        assert_equal(res[2], 'segmented_reduce')
+        assert_equal(res[3], (a, [4, 2], [6, 4]))
+        assert_equal(res[4], {'dtype': 'dtype0',
+                              'out': ('out0',),
+                              'axis': 'axis0',
+                              'initial': 'initial0'})
+
+        # segmented_reduce, stops and initial are optional
+        res = np.multiply.segmented_reduce(a, [4, 2])
+        assert_equal(res[3], (a, [4, 2]))
+        assert_equal(res[4], {})
+
+        # segmented_reduce, output equal to None removed.
+        res = np.multiply.segmented_reduce(a, [4, 2], [6, 4], 0, None, None)
+        assert_equal(res[4], {'axis': 0, 'dtype': None})
+        res = np.multiply.segmented_reduce(a, [4, 2], [6, 4], axis=None,
+                                           out=None, dtype='dt')
+        assert_equal(res[4], {'axis': None, 'dtype': 'dt'})
+        res = np.multiply.segmented_reduce(a, [4, 2], [6, 4], None, None,
+                                           out=(None,))
+        assert_equal(res[4], {'axis': None, 'dtype': None})
+
+        # segmented_reduce, wrong args
+        assert_raises(ValueError, np.multiply.segmented_reduce, a, [4, 2],
+                      [6, 4], out=())
+        assert_raises(ValueError, np.multiply.segmented_reduce, a, [4, 2],
+                      [6, 4], out=('out0', 'out1'))
+        assert_raises(TypeError, np.multiply.segmented_reduce, a, [4, 2],
+                      [6, 4], 'axis0', axis='axis0')
+
         # outer
         res = np.multiply.outer(a, 42)
         assert_equal(res[0], a)
@@ -3975,6 +4023,7 @@ class TestSpecialMethods:
         assert_raises(TypeError, np.add.reduce, a)
         assert_raises(TypeError, np.add.accumulate, a)
         assert_raises(TypeError, np.add.reduceat, a, [0])
+        assert_raises(TypeError, np.add.segmented_reduce, a, [0], [1])
 
     def test_ufunc_override_disabled(self):
 
@@ -4192,6 +4241,16 @@ class TestSpecialMethods:
         assert_(c.info, {'inputs': [0]})
         b = np.zeros_like(c)
         c = np.add.reduceat(a, indices, 1, None, b)
+        assert_equal(c, check)
+        assert_(c is b)
+        assert_(c.info, {'inputs': [0], 'outputs': [0]})
+        starts, stops = [0, 2, 1], [2, 3, 3]
+        check = np.add.segmented_reduce(d, starts, stops, axis=1)
+        c = np.add.segmented_reduce(a, starts, stops, axis=1)
+        assert_equal(c, check)
+        assert_(c.info, {'inputs': [0]})
+        b = np.zeros_like(c)
+        c = np.add.segmented_reduce(a, starts, stops, 1, None, b)
         assert_equal(c, check)
         assert_(c is b)
         assert_(c.info, {'inputs': [0], 'outputs': [0]})
@@ -4982,6 +5041,29 @@ def test_reduceat():
     # test no buffer
     np.setbufsize(32)
     h1 = np.add.reduceat(a['value'], indx)
+    np.setbufsize(ncu.UFUNC_BUFSIZE_DEFAULT)
+    assert_array_almost_equal(h1, h2)
+
+def test_segmented_reduce():
+    """Test segmented_reduce when structured arrays are not copied."""
+    db = np.dtype([('name', 'S11'), ('time', np.int64), ('value', np.float32)])
+    a = np.empty([100], dtype=db)
+    a['name'] = 'Simple'
+    a['time'] = 10
+    a['value'] = 100
+    starts = [0, 7, 15, 25]
+    stops = [7, 15, 25, 100]
+
+    h2 = np.array([np.add.reduce(a['value'][i:j])
+                   for i, j in zip(starts, stops)])
+
+    # test buffered
+    h1 = np.add.segmented_reduce(a['value'], starts, stops)
+    assert_array_almost_equal(h1, h2)
+
+    # test no buffer
+    np.setbufsize(32)
+    h1 = np.add.segmented_reduce(a['value'], starts, stops)
     np.setbufsize(ncu.UFUNC_BUFSIZE_DEFAULT)
     assert_array_almost_equal(h1, h2)
 

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -347,7 +347,7 @@ class _ufunc_11(np.ufunc, Generic[_IdT_co]):  # type: ignore[misc]
     @override
     def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
     @override
-    def segmented_reduce(self, array: Never, /, starts: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    def segmented_reduce(self, array: Never, /, starts: Never, stops: Never) -> Never: ...  # pyrefly:ignore[bad-override]
     @override
     def outer(self, A: Never, B: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
 
@@ -384,7 +384,7 @@ class _ufunc_12(np.ufunc):  # type: ignore[misc]
     def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
     @final
     @override
-    def segmented_reduce(self, array: Never, /, starts: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    def segmented_reduce(self, array: Never, /, starts: Never, stops: Never) -> Never: ...  # pyrefly:ignore[bad-override]
     @final
     @override
     def outer(self, A: Never, B: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
@@ -443,7 +443,7 @@ class _gufunc_21(np.ufunc):  # type: ignore[misc]
     def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
     @final
     @override
-    def segmented_reduce(self, array: Never, /, starts: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    def segmented_reduce(self, array: Never, /, starts: Never, stops: Never) -> Never: ...  # pyrefly:ignore[bad-override]
 
 @type_check_only
 class _ufunc_22(np.ufunc):  # type: ignore[misc]
@@ -478,7 +478,7 @@ class _ufunc_22(np.ufunc):  # type: ignore[misc]
     def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
     @final
     @override
-    def segmented_reduce(self, array: Never, /, starts: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    def segmented_reduce(self, array: Never, /, starts: Never, stops: Never) -> Never: ...  # pyrefly:ignore[bad-override]
 
 # Mm => ?
 @type_check_only
@@ -5055,7 +5055,7 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
     @override
     def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
     @override
-    def segmented_reduce(self, array: Never, /, starts: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    def segmented_reduce(self, array: Never, /, starts: Never, stops: Never) -> Never: ...  # pyrefly:ignore[bad-override]
     @override
     def accumulate(self, array: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
 

--- a/numpy/_core/umath.pyi
+++ b/numpy/_core/umath.pyi
@@ -347,6 +347,8 @@ class _ufunc_11(np.ufunc, Generic[_IdT_co]):  # type: ignore[misc]
     @override
     def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
     @override
+    def segmented_reduce(self, array: Never, /, starts: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    @override
     def outer(self, A: Never, B: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
 
 @type_check_only
@@ -380,6 +382,9 @@ class _ufunc_12(np.ufunc):  # type: ignore[misc]
     @final
     @override
     def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    @final
+    @override
+    def segmented_reduce(self, array: Never, /, starts: Never) -> Never: ...  # pyrefly:ignore[bad-override]
     @final
     @override
     def outer(self, A: Never, B: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
@@ -436,6 +441,9 @@ class _gufunc_21(np.ufunc):  # type: ignore[misc]
     @final
     @override
     def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    @final
+    @override
+    def segmented_reduce(self, array: Never, /, starts: Never) -> Never: ...  # pyrefly:ignore[bad-override]
 
 @type_check_only
 class _ufunc_22(np.ufunc):  # type: ignore[misc]
@@ -468,6 +476,9 @@ class _ufunc_22(np.ufunc):  # type: ignore[misc]
     @final
     @override
     def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    @final
+    @override
+    def segmented_reduce(self, array: Never, /, starts: Never) -> Never: ...  # pyrefly:ignore[bad-override]
 
 # Mm => ?
 @type_check_only
@@ -5043,6 +5054,8 @@ class _ufunc_21_ldexp(_ufunc_21[None]):  # type: ignore[misc]
 
     @override
     def reduceat(self, array: Never, /, indices: Never) -> Never: ...  # pyrefly:ignore[bad-override]
+    @override
+    def segmented_reduce(self, array: Never, /, starts: Never) -> Never: ...  # pyrefly:ignore[bad-override]
     @override
     def accumulate(self, array: Never, /) -> Never: ...  # pyrefly:ignore[bad-override]
 

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -24,13 +24,13 @@ def test_matmul_reduceat_invalid() -> None:
     assert_type(np.matmul.reduceat(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
 
 def test_absolute_segmented_reduce_invalid() -> None:
-    assert_type(np.absolute.segmented_reduce(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
+    assert_type(np.absolute.segmented_reduce(AR_f8, AR_i8, AR_i8), NoReturn)  # type: ignore[arg-type]
 def test_frexp_segmented_reduce_invalid() -> None:
-    assert_type(np.frexp.segmented_reduce(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
+    assert_type(np.frexp.segmented_reduce(AR_f8, AR_i8, AR_i8), NoReturn)  # type: ignore[arg-type]
 def test_divmod_segmented_reduce_invalid() -> None:
-    assert_type(np.divmod.segmented_reduce(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
+    assert_type(np.divmod.segmented_reduce(AR_f8, AR_i8, AR_i8), NoReturn)  # type: ignore[arg-type]
 def test_matmul_segmented_reduce_invalid() -> None:
-    assert_type(np.matmul.segmented_reduce(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
+    assert_type(np.matmul.segmented_reduce(AR_f8, AR_i8, AR_i8), NoReturn)  # type: ignore[arg-type]
 
 def test_absolute_reduce_invalid() -> None:
     assert_type(np.absolute.reduce(AR_f8), NoReturn)  # type: ignore[arg-type]

--- a/numpy/typing/tests/data/reveal/ufuncs.pyi
+++ b/numpy/typing/tests/data/reveal/ufuncs.pyi
@@ -23,6 +23,15 @@ def test_divmod_reduceat_invalid() -> None:
 def test_matmul_reduceat_invalid() -> None:
     assert_type(np.matmul.reduceat(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
 
+def test_absolute_segmented_reduce_invalid() -> None:
+    assert_type(np.absolute.segmented_reduce(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
+def test_frexp_segmented_reduce_invalid() -> None:
+    assert_type(np.frexp.segmented_reduce(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
+def test_divmod_segmented_reduce_invalid() -> None:
+    assert_type(np.divmod.segmented_reduce(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
+def test_matmul_segmented_reduce_invalid() -> None:
+    assert_type(np.matmul.segmented_reduce(AR_f8, AR_i8), NoReturn)  # type: ignore[arg-type]
+
 def test_absolute_reduce_invalid() -> None:
     assert_type(np.absolute.reduce(AR_f8), NoReturn)  # type: ignore[arg-type]
 def test_frexp_reduce_invalid() -> None:


### PR DESCRIPTION
### PR summary
Taking over https://github.com/numpy/numpy/pull/25476.
Implements a new `segmented_reduce` method to ufuncs as it was discussed on that PR instead of enhancing the `reduceat` interface.
In its current state, this was mostly developed within the weekend by starting over by copying the whole `reduceat` code into a new `segmented_reduce` method, adding all the boilerplate for it and iterating with AI on making the necessary changes to it to support starts and stops offsets while considering the changes from Marten's PR. This is obviously not in a ready state and I have only skimmed through the code while iterating with AI. I just wanted a proof of concept over the weekend. I'm opening it as draft for visibility and because I wanted a CI run. I will be iterating over it in the next few days to get it in a ready to review state.
 
### First time committer introduction
N/A

#### AI Disclosure
See above for the AI usage in the current state. Will update later.

cc @mhvk since the previous PR was yours