### PR TITLE
TYP: Add ``object_.__class_getitem__``

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -5982,6 +5982,10 @@ bool_ = bool
 # `object_` cannot exists (at runtime).
 @final
 class object_(generic[_ItemT_co], Generic[_ItemT_co]):
+    @classmethod   # `object_` is (also) subscriptable at runtime
+    def __class_getitem__[T](cls: T, type_arg: type | object, /) -> T: ...
+
+    #
     @overload
     def __new__(cls, value: None = None, /) -> None: ...  # type: ignore[misc]
     @overload

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -5983,7 +5983,7 @@ bool_ = bool
 @final
 class object_(generic[_ItemT_co], Generic[_ItemT_co]):
     @classmethod   # `object_` is (also) subscriptable at runtime
-    def __class_getitem__[T](cls: T, type_arg: type | object, /) -> T: ...
+    def __class_getitem__[T](cls: T, item: type | object, /) -> T: ...
 
     #
     @overload

--- a/numpy/_core/_add_newdocs.py
+++ b/numpy/_core/_add_newdocs.py
@@ -6989,6 +6989,15 @@ add_newdoc('numpy._core.numerictypes', 'number', ('__class_getitem__',
 
     """))
 
+add_newdoc('numpy._core.numerictypes', 'object_', ('__class_getitem__',
+    """
+    __class_getitem__($cls, item, /)
+    --
+
+    Return `~numpy.object_` itself, so that it remains usable as a dtype.
+
+    """))
+
 ##############################################################################
 #
 # Documentation for scalar type abstract base classes in type hierarchy

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2512,6 +2512,13 @@ numbertype_class_getitem(PyObject *cls, PyObject *args)
     return NULL;
 }
 
+/* Returns `np.object_` itself, so that e.g. `np.object_[str]` stays dtype-like */
+static PyObject *
+objecttype_class_getitem(PyObject *cls, PyObject *NPY_UNUSED(args))
+{
+    return Py_NewRef(cls);
+}
+
 /*
  * casting complex numbers (that don't inherit from Python complex)
  * to Python complex
@@ -2918,6 +2925,14 @@ static PyMethodDef @name@type_methods[] = {
     {NULL, NULL, 0, NULL} /* sentinel */
 };
 /**end repeat**/
+
+static PyMethodDef objecttype_methods[] = {
+    /* for typing */
+    {"__class_getitem__",
+        (PyCFunction)objecttype_class_getitem,
+        METH_CLASS | METH_O, NULL},
+    {NULL, NULL, 0, NULL} /* sentinel */
+};
 
 /**begin repeat
  * #name = cfloat,clongdouble#
@@ -4517,6 +4532,8 @@ initialize_numeric_types(void)
     PyVoidArrType_Type.tp_as_sequence = &voidtype_as_sequence;
     PyVoidArrType_Type.tp_repr = voidtype_repr;
     PyVoidArrType_Type.tp_str = voidtype_str;
+
+    PyObjectArrType_Type.tp_methods = objecttype_methods;
 
     PyIntegerArrType_Type.tp_getset = inttype_getsets;
 

--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -173,12 +173,16 @@ class TestClassGetItem:
     @pytest.mark.parametrize("code", np.typecodes["All"])
     def test_concrete(self, code: str) -> None:
         cls = np.dtype(code).type
-        if cls in {np.bool, np.datetime64}:
+        if cls in {np.bool, np.datetime64, np.object_}:
             # these are intentionally subscriptable
             assert cls[Any]
         else:
             with pytest.raises(TypeError):
                 cls[Any]
+
+    def test_object(self) -> None:
+        # returns itself, not a generic alias, so it stays dtype-like
+        assert np.object_[int] is np.object_
 
     @pytest.mark.parametrize("arg_len", range(4))
     def test_subscript_tuple(self, arg_len: int) -> None:


### PR DESCRIPTION
#32075 turned `numpy.object_` into a generic type in the stubs. But at runtime, it wasn't yet possible to write e.g. `object_[int]` (not everywhere, at least).

This adds a `__class_getitem__` classmethod to `numpy.object_` that returns the class itself.
It doesn't return a `types.GenericAlias` like the other generic types, because that would mean that e.g. `dtype=np.object_[int]` wouldn't work anymore (`GenericAlias` isn't a dtype-like). 

```
In [1]: np.object_.__class_getitem__?
Signature: np.object_.__class_getitem__(item, /)
Docstring: Return `~numpy.object_` itself, so that it remains usable as a dtype.
Type:      builtin_function_or_method
```

I didn't add a release note because then we'd just be repeating the relnote from #32075.

---

AI was used for the C bits, but it was a bit too sloppy for my taste, so I rewrote most of it.