### PR TITLE
TYP: ``np.array`` improved shape-typing

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -700,6 +700,54 @@ def array[ScalarT: np.generic](
     ndmax: int = 0,
     like: _SupportsArrayFunc | None = None,
 ) -> NDArray[ScalarT]: ...
+@overload  # 0d bool
+def array(
+    object: bool,
+    dtype: None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array0D[np.bool]: ...
+@overload  # 0d int  (overlaps with bool)
+def array(
+    object: int,
+    dtype: None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array0D[np.int_ | Any]: ...
+@overload  # 0d float  (overlaps with int)
+def array(
+    object: float,
+    dtype: None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array0D[np.float64 | Any]: ...
+@overload  # 0d complex  (overlaps with float)
+def array(
+    object: complex,
+    dtype: None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array0D[np.complex128 | Any]: ...
 @overload  # 1d float  (must go first to capture empty lists)
 def array(
     object: list[float] | Sequence[Never],
@@ -796,6 +844,54 @@ def array(
     ndmax: int = 0,
     like: _SupportsArrayFunc | None = None,
 ) -> _Array2D[np.complex128]: ...
+@overload  # 3d float
+def array(
+    object: Sequence[Sequence[list[float]]],
+    dtype: None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0, 1, 2, 3] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array3D[np.float64]: ...
+@overload  # 3d bool
+def array(
+    object: Sequence[Sequence[Sequence[bool]]],
+    dtype: None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0, 1, 2, 3] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array3D[np.bool]: ...
+@overload  # 2d int
+def array(
+    object: Sequence[Sequence[list[int]]],
+    dtype: None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0, 1, 2, 3] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array3D[np.int_]: ...
+@overload  # 3d complex
+def array(
+    object: Sequence[Sequence[list[complex]]],
+    dtype: None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0, 1, 2, 3] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array3D[np.complex128]: ...
 @overload  # scalar, dtype=object_
 def array[ItemT](
     object: np.generic[ItemT],
@@ -856,7 +952,55 @@ def array[ItemT: _ObjItemT](
     ndmax: int = 0,
     like: _SupportsArrayFunc | None = None,
 ) -> NDArray[np.object_[ItemT | Any]]: ...  # `| Any` because it might be ragged
-@overload  # ?, dtype=<known>
+@overload  # 0d, dtype=<known>
+def array[ScalarT: _ScalarNotObject](
+    object: _ScalarLike_co,
+    dtype: _DTypeLike[ScalarT],
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array0D[ScalarT]: ...
+@overload  # 1d, dtype=<known>
+def array[ScalarT: _ScalarNotObject](
+    object: Sequence[_ScalarLike_co],
+    dtype: _DTypeLike[ScalarT],
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0, 1] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[ScalarT]: ...
+@overload  # 2d, dtype=<known>
+def array[ScalarT: _ScalarNotObject](
+    object: Sequence[Sequence[_ScalarLike_co]],
+    dtype: _DTypeLike[ScalarT],
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0, 1, 2] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array2D[ScalarT]: ...
+@overload  # 3d, dtype=<known>
+def array[ScalarT: _ScalarNotObject](
+    object: Sequence[Sequence[Sequence[_ScalarLike_co]]],
+    dtype: _DTypeLike[ScalarT],
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0, 1, 2, 3] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array3D[ScalarT]: ...
+@overload  # ?d, dtype=<known>
 def array[ScalarT: np.generic](
     object: Any,
     dtype: _DTypeLike[ScalarT],
@@ -868,6 +1012,54 @@ def array[ScalarT: np.generic](
     ndmax: int = 0,
     like: _SupportsArrayFunc | None = None,
 ) -> NDArray[ScalarT]: ...
+@overload  # 0d, dtype=<unknown>
+def array(
+    object: _ScalarLike_co,
+    dtype: DTypeLike | None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array0D[Any]: ...
+@overload  # 1d, dtype=<unknown>
+def array(
+    object: Sequence[_ScalarLike_co],
+    dtype: DTypeLike | None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0, 1] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array1D[Any]: ...
+@overload  # 2d, dtype=<unknown>
+def array(
+    object: Sequence[Sequence[_ScalarLike_co]],
+    dtype: DTypeLike | None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0, 1, 2] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array2D[Any]: ...
+@overload  # 3d, dtype=<unknown>
+def array(
+    object: Sequence[Sequence[Sequence[_ScalarLike_co]]],
+    dtype: DTypeLike | None = None,
+    *,
+    copy: bool | _CopyMode | None = True,
+    order: _OrderKACF = "K",
+    subok: bool = False,
+    ndmin: L[0, 1, 2, 3] = 0,
+    ndmax: int = 0,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array3D[Any]: ...
 @overload  # fallback
 def array(
     object: Any,

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -32,12 +32,16 @@ _obj_str_1d: _Array1D[np.object_[str]]
 
 _py_b_1d: list[bool]
 _py_b_2d: list[list[bool]]
+_py_b_3d: list[list[list[bool]]]
 _py_i_1d: list[int]
 _py_i_2d: list[list[int]]
+_py_i_3d: list[list[list[int]]]
 _py_f_1d: list[float]
 _py_f_2d: list[list[float]]
+_py_f_3d: list[list[list[float]]]
 _py_c_1d: list[complex]
 _py_c_2d: list[list[complex]]
+_py_c_3d: list[list[list[complex]]]
 
 mixed_shape: tuple[int, np.int64]
 
@@ -45,12 +49,23 @@ def func(i: int, j: int, **kwargs: Any) -> SubClass[np.float64]: ...
 
 assert_type(np.array(_py_b_1d), _Array1D[np.bool])
 assert_type(np.array(_py_b_2d), _Array2D[np.bool])
+assert_type(np.array(_py_b_3d), _Array3D[np.bool])
 assert_type(np.array(_py_i_1d), _Array1D[np.int_])
 assert_type(np.array(_py_i_2d), _Array2D[np.int_])
+assert_type(np.array(_py_i_3d), _Array3D[np.int_])
 assert_type(np.array(_py_f_1d), _Array1D[np.float64])
 assert_type(np.array(_py_f_2d), _Array2D[np.float64])
+assert_type(np.array(_py_f_3d), _Array3D[np.float64])
 assert_type(np.array(_py_c_1d), _Array1D[np.complex128])
 assert_type(np.array(_py_c_2d), _Array2D[np.complex128])
+assert_type(np.array(_py_c_3d), _Array3D[np.complex128])
+assert_type(np.array(_py_i_1d, dtype=np.float32), _Array1D[np.float32])
+assert_type(np.array(_py_i_2d, dtype=np.float32), _Array2D[np.float32])
+assert_type(np.array(_py_i_3d, dtype=np.float32), _Array3D[np.float32])
+assert_type(np.array(_py_i_1d, dtype="f"), _Array1D[Any])
+assert_type(np.array(_py_i_2d, dtype="f"), _Array2D[Any])
+assert_type(np.array(_py_i_3d, dtype="f"), _Array3D[Any])
+assert_type(np.array(_f32_0d), _Array0D[np.float32])
 assert_type(np.array(_f32_1d), _Array1D[np.float32])
 assert_type(np.array(_f32_2d), _Array2D[np.float32])
 assert_type(np.array(A), npt.NDArray[np.float64])
@@ -67,7 +82,7 @@ assert_type(np.array(B, subok=True, ndmin=1), npt.NDArray[np.float64])  # subtyp
 assert_type(np.array(D), npt.NDArray[np.float64 | np.int64])
 assert_type(np.array(E, subok=True), SubClass[np.float64 | np.int64])
 # https://github.com/numpy/numpy/issues/29245
-assert_type(np.array([], dtype=np.bool), npt.NDArray[np.bool[Any]])
+assert_type(np.array([], dtype=np.bool), _Array1D[np.bool[Any]])
 assert_type(np.array(None, dtype=np.object_), _Array0D[np.object_[None]])
 assert_type(np.array(1, dtype=np.object_), _Array0D[np.object_[int]])
 assert_type(np.array(_py_i_1d, dtype=np.object_), _Array1D[np.object_[int]])
@@ -76,6 +91,12 @@ assert_type(np.array(_py_i_2d, dtype=np.object_), npt.NDArray[np.object_[Any]])
 assert_type(np.array(_f32_0d, dtype=np.object_), _Array0D[np.object_[float]])
 assert_type(np.array(_f32_1d, dtype=np.object_), _Array1D[np.object_[float]])
 assert_type(np.array(_f32_2d, dtype=np.object_), _Array2D[np.object_[float]])
+assert_type(np.array(True), _Array0D[np.bool])
+assert_type(np.array(1), _Array0D[np.int_ | Any])
+assert_type(np.array(1.0), _Array0D[np.float64 | Any])
+assert_type(np.array(1j), _Array0D[np.complex128 | Any])
+assert_type(np.array(1, dtype=np.float32), _Array0D[np.float32])
+assert_type(np.array(1, dtype="f"), _Array0D[Any])
 
 assert_type(np.zeros([1, 5, 6]), npt.NDArray[np.float64])
 assert_type(np.zeros([1, 5, 6], dtype=np.int64), npt.NDArray[np.int64])


### PR DESCRIPTION
There were still some shape-typing gaps left for `np.array` (the most popular numpy function) after #32081:

- 0d builtin scalars (`bool`/`int`/`float`/`complex`)
- 3d nested sequences of builtin scalars (only 1d and 2d sequences were covered)
- 0d-3d nested sequences with `dtype=` given

There are some things that still aren't shape-typed, such as `ndmin` larger than the input, and >=4d  nested sequences. I don't think adding overloads for that is worth it though, because code search shows that those patterns aren't used very often

---

Fully written by me, pre-reviewed by AI.