### PR TITLE
TYP: ``stack`` shape-typing

### DIFF
--- a/numpy/_core/shape_base.pyi
+++ b/numpy/_core/shape_base.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any, SupportsIndex, overload
+from typing import Any, Never, SupportsIndex, overload
 
 import numpy as np
 from numpy import _CastingKind
@@ -20,9 +20,12 @@ type _Array0D[ScalarT: np.generic] = np.ndarray[tuple[()], np.dtype[ScalarT]]
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
 type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
+type _Array4D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int, int], np.dtype[ScalarT]]
 
 # input only
 type _AtLeast2D = tuple[int, int, *tuple[Any, ...]]
+type _ToJustND[ScalarT: np.generic] = np.ndarray[tuple[Never, Never, Never, Never], np.dtype[ScalarT]]
+type _To0D[ScalarT: np.generic] = ScalarT | np.ndarray[tuple[()], np.dtype[ScalarT]]
 type _To1D[ScalarT: np.generic] = ScalarT | np.ndarray[tuple[()] | tuple[int], np.dtype[ScalarT]]
 type _To2D[ScalarT: np.generic] = ScalarT | np.ndarray[tuple[()] | tuple[int] | tuple[int, int], np.dtype[ScalarT]]
 
@@ -234,34 +237,169 @@ def hstack(
 ) -> NDArray[Any]: ...
 
 # keep in sync with `numpy.ma.extras.stack`
-@overload
+@overload  # ?d  (workaround overload)
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_ToJustND[ScalarT]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: None = None,
+    casting: _CastingKind = "same_kind",
+) -> NDArray[ScalarT]: ...
+@overload  # ?d, dtype=<known>  (workaround overload)
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_ToJustND[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    casting: _CastingKind = "same_kind",
+) -> NDArray[ScalarT]: ...
+@overload  # ?d, dtype=<unknown>  (workaround overload)
+def stack(
+    arrays: Sequence[_ToJustND[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: DTypeLike,
+    casting: _CastingKind = "same_kind",
+) -> NDArray[Any]: ...
+@overload  # 0d -> 1d
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_To0D[ScalarT]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: None = None,
+    casting: _CastingKind = "same_kind",
+) -> _Array1D[ScalarT]: ...
+@overload  # 0d -> 1d, dtype=<known>
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_To0D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    casting: _CastingKind = "same_kind",
+) -> _Array1D[ScalarT]: ...
+@overload  # 0d -> 1d, dtype=<unknown>
+def stack(
+    arrays: Sequence[_To0D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: DTypeLike,
+    casting: _CastingKind = "same_kind",
+) -> _Array1D[Any]: ...
+@overload  # 1d -> 2d
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array1D[ScalarT]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: None = None,
+    casting: _CastingKind = "same_kind",
+) -> _Array2D[ScalarT]: ...
+@overload  # 1d -> 2d, dtype=<known>
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array1D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    casting: _CastingKind = "same_kind",
+) -> _Array2D[ScalarT]: ...
+@overload  # 1d -> 2d, dtype=<unknown>
+def stack(
+    arrays: Sequence[_Array1D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: DTypeLike,
+    casting: _CastingKind = "same_kind",
+) -> _Array2D[Any]: ...
+@overload  # 2d -> 3d
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array2D[ScalarT]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: None = None,
+    casting: _CastingKind = "same_kind",
+) -> _Array3D[ScalarT]: ...
+@overload  # 2d -> 3d, dtype=<known>
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array2D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    casting: _CastingKind = "same_kind",
+) -> _Array3D[ScalarT]: ...
+@overload  # 2d -> 3d, dtype=<unknown>
+def stack(
+    arrays: Sequence[_Array2D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: DTypeLike,
+    casting: _CastingKind = "same_kind",
+) -> _Array3D[Any]: ...
+@overload  # 3d -> 4d
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array3D[ScalarT]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: None = None,
+    casting: _CastingKind = "same_kind",
+) -> _Array4D[ScalarT]: ...
+@overload  # 3d -> 4d, dtype=<known>
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array3D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    casting: _CastingKind = "same_kind",
+) -> _Array4D[ScalarT]: ...
+@overload  # 3d -> 4d, dtype=<unknown>
+def stack(
+    arrays: Sequence[_Array3D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: DTypeLike,
+    casting: _CastingKind = "same_kind",
+) -> _Array4D[Any]: ...
+@overload  # ?d
 def stack[ScalarT: np.generic](
     arrays: Sequence[_ArrayLike[ScalarT]],
     axis: SupportsIndex = 0,
     out: None = None,
     *,
     dtype: None = None,
-    casting: _CastingKind = "same_kind"
+    casting: _CastingKind = "same_kind",
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # ?d, dtype=<known>
 def stack[ScalarT: np.generic](
     arrays: Sequence[ArrayLike],
     axis: SupportsIndex = 0,
     out: None = None,
     *,
     dtype: _DTypeLike[ScalarT],
-    casting: _CastingKind = "same_kind"
+    casting: _CastingKind = "same_kind",
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # fallback
 def stack(
     arrays: Sequence[ArrayLike],
     axis: SupportsIndex = 0,
     out: None = None,
     *,
     dtype: DTypeLike | None = None,
-    casting: _CastingKind = "same_kind"
+    casting: _CastingKind = "same_kind",
 ) -> NDArray[Any]: ...
-@overload
+@overload  # out=<given>  (positional)
 def stack[OutT: np.ndarray](
     arrays: Sequence[ArrayLike],
     axis: SupportsIndex,
@@ -270,7 +408,7 @@ def stack[OutT: np.ndarray](
     dtype: DTypeLike | None = None,
     casting: _CastingKind = "same_kind",
 ) -> OutT: ...
-@overload
+@overload  # out=<given> (keyword)
 def stack[OutT: np.ndarray](
     arrays: Sequence[ArrayLike],
     axis: SupportsIndex = 0,

--- a/numpy/ma/extras.pyi
+++ b/numpy/ma/extras.pyi
@@ -5,6 +5,7 @@ from typing import (
     Concatenate,
     Final,
     Literal as L,
+    Never,
     SupportsIndex,
     TypeVar,
     overload,
@@ -89,11 +90,17 @@ __all__ = [
 type _MArray[ScalarT: np.generic] = MaskedArray[_AnyShape, np.dtype[ScalarT]]
 type _MArray1D[ScalarT: np.generic] = MaskedArray[tuple[int], np.dtype[ScalarT]]
 type _MArray2D[ScalarT: np.generic] = MaskedArray[tuple[int, int], np.dtype[ScalarT]]
+type _MArray3D[ScalarT: np.generic] = MaskedArray[tuple[int, int, int], np.dtype[ScalarT]]
+type _MArray4D[ScalarT: np.generic] = MaskedArray[tuple[int, int, int, int], np.dtype[ScalarT]]
+
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
+type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
 
 # input only; keep in sync with `numpy._core.shape_base`
 type _AtLeast2D = tuple[int, int, *tuple[Any, ...]]
+type _ArrayJustND[ScalarT: np.generic] = np.ndarray[tuple[Never, Never, Never, Never], np.dtype[ScalarT]]
+type _To0D[ScalarT: np.generic] = ScalarT | np.ndarray[tuple[()], np.dtype[ScalarT]]
 type _To1D[ScalarT: np.generic] = ScalarT | np.ndarray[tuple[()] | tuple[int], np.dtype[ScalarT]]
 type _To2D[ScalarT: np.generic] = ScalarT | np.ndarray[tuple[()] | tuple[int] | tuple[int, int], np.dtype[ScalarT]]
 
@@ -324,7 +331,142 @@ def dstack[ScalarT: np.generic](tup: Sequence[_ArrayLike[ScalarT]]) -> _MArray[S
 def dstack(tup: Sequence[ArrayLike]) -> _MArray[Incomplete]: ...
 
 # keep in sync with `numpy._core.shape_base.stack`
-@overload
+@overload  # ?d  (workaround overload)
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_ArrayJustND[ScalarT]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: None = None,
+    casting: _CastingKind = "same_kind"
+) -> _MArray[ScalarT]: ...
+@overload  # ?d, dtype=<known>  (workaround overload)
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_ArrayJustND[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    casting: _CastingKind = "same_kind"
+) -> _MArray[ScalarT]: ...
+@overload  # ?d, dtype=<unknown>  (workaround overload)
+def stack(
+    arrays: Sequence[_ArrayJustND[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: DTypeLike,
+    casting: _CastingKind = "same_kind"
+) -> _MArray[Incomplete]: ...
+@overload  # 0d -> 1d
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_To0D[ScalarT]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: None = None,
+    casting: _CastingKind = "same_kind"
+) -> _MArray1D[ScalarT]: ...
+@overload  # 0d -> 1d, dtype=<known>
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_To0D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    casting: _CastingKind = "same_kind"
+) -> _MArray1D[ScalarT]: ...
+@overload  # 0d -> 1d, dtype=<unknown>
+def stack(
+    arrays: Sequence[_To0D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: DTypeLike,
+    casting: _CastingKind = "same_kind"
+) -> _MArray1D[Incomplete]: ...
+@overload  # 1d -> 2d
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array1D[ScalarT]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: None = None,
+    casting: _CastingKind = "same_kind"
+) -> _MArray2D[ScalarT]: ...
+@overload  # 1d -> 2d, dtype=<known>
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array1D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    casting: _CastingKind = "same_kind"
+) -> _MArray2D[ScalarT]: ...
+@overload  # 1d -> 2d, dtype=<unknown>
+def stack(
+    arrays: Sequence[_Array1D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: DTypeLike,
+    casting: _CastingKind = "same_kind"
+) -> _MArray2D[Incomplete]: ...
+@overload  # 2d -> 3d
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array2D[ScalarT]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: None = None,
+    casting: _CastingKind = "same_kind"
+) -> _MArray3D[ScalarT]: ...
+@overload  # 2d -> 3d, dtype=<known>
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array2D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    casting: _CastingKind = "same_kind"
+) -> _MArray3D[ScalarT]: ...
+@overload  # 2d -> 3d, dtype=<unknown>
+def stack(
+    arrays: Sequence[_Array2D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: DTypeLike,
+    casting: _CastingKind = "same_kind"
+) -> _MArray3D[Incomplete]: ...
+@overload  # 3d -> 4d
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array3D[ScalarT]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: None = None,
+    casting: _CastingKind = "same_kind"
+) -> _MArray4D[ScalarT]: ...
+@overload  # 3d -> 4d, dtype=<known>
+def stack[ScalarT: np.generic](
+    arrays: Sequence[_Array3D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    casting: _CastingKind = "same_kind"
+) -> _MArray4D[ScalarT]: ...
+@overload  # 3d -> 4d, dtype=<unknown>
+def stack(
+    arrays: Sequence[_Array3D[np.generic]],
+    axis: SupportsIndex = 0,
+    out: None = None,
+    *,
+    dtype: DTypeLike,
+    casting: _CastingKind = "same_kind"
+) -> _MArray4D[Incomplete]: ...
+@overload  # ?d
 def stack[ScalarT: np.generic](
     arrays: Sequence[_ArrayLike[ScalarT]],
     axis: SupportsIndex = 0,
@@ -333,7 +475,7 @@ def stack[ScalarT: np.generic](
     dtype: None = None,
     casting: _CastingKind = "same_kind"
 ) -> _MArray[ScalarT]: ...
-@overload
+@overload  # ?d, dtype=<known>
 def stack[ScalarT: np.generic](
     arrays: Sequence[ArrayLike],
     axis: SupportsIndex = 0,
@@ -342,7 +484,7 @@ def stack[ScalarT: np.generic](
     dtype: _DTypeLike[ScalarT],
     casting: _CastingKind = "same_kind"
 ) -> _MArray[ScalarT]: ...
-@overload
+@overload  # fallback
 def stack(
     arrays: Sequence[ArrayLike],
     axis: SupportsIndex = 0,
@@ -351,24 +493,24 @@ def stack(
     dtype: DTypeLike | None = None,
     casting: _CastingKind = "same_kind"
 ) -> _MArray[Incomplete]: ...
-@overload
-def stack[MArrayT: MaskedArray](
+@overload  # out=<given>  (positional)
+def stack[ShapeT: _Shape, DTypeT: np.dtype](
     arrays: Sequence[ArrayLike],
     axis: SupportsIndex,
-    out: MArrayT,
+    out: np.ndarray[ShapeT, DTypeT],
     *,
     dtype: DTypeLike | None = None,
     casting: _CastingKind = "same_kind",
-) -> MArrayT: ...
-@overload
-def stack[MArrayT: MaskedArray](
+) -> MaskedArray[ShapeT, DTypeT]: ...
+@overload  # out=<given>  (keyword)
+def stack[ShapeT: _Shape, DTypeT: np.dtype](
     arrays: Sequence[ArrayLike],
     axis: SupportsIndex = 0,
     *,
-    out: MArrayT,
+    out: np.ndarray[ShapeT, DTypeT],
     dtype: DTypeLike | None = None,
     casting: _CastingKind = "same_kind",
-) -> MArrayT: ...
+) -> MaskedArray[ShapeT, DTypeT]: ...
 
 # keep in sync with `numpy._core.shape_base_impl.hsplit`
 @overload

--- a/numpy/typing/tests/data/reveal/array_constructors.pyi
+++ b/numpy/typing/tests/data/reveal/array_constructors.pyi
@@ -10,6 +10,7 @@ type _Array0D[ScalarT: np.generic] = np.ndarray[tuple[()], np.dtype[ScalarT]]
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
 type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
+type _Array4D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int, int], np.dtype[ScalarT]]
 
 class SubClass[ScalarT: np.generic](np.ndarray[_AnyShape, np.dtype[ScalarT]]): ...
 
@@ -379,6 +380,13 @@ assert_type(np.stack([A, C]), npt.NDArray[Any])
 assert_type(np.stack([C, C]), npt.NDArray[Any])
 assert_type(np.stack([A, A], axis=0), npt.NDArray[np.float64])
 assert_type(np.stack([A, A], out=B), SubClass[np.float64])
+assert_type(np.stack([_f32_0d, _f32_0d]), _Array1D[np.float32])
+assert_type(np.stack([_f32_1d, _f32_1d]), _Array2D[np.float32])
+assert_type(np.stack([_f32_2d, _f32_2d]), _Array3D[np.float32])
+assert_type(np.stack([_f32_3d, _f32_3d]), _Array4D[np.float32])
+assert_type(np.stack([_f32_2d, _f32_2d], axis=-1), _Array3D[np.float32])
+assert_type(np.stack([_f32_2d, _f32_2d], dtype=np.int8), _Array3D[np.int8])
+assert_type(np.stack([_f32_2d, _f32_2d], dtype="i1"), _Array3D[Any])
 
 assert_type(np.block([[A, A], [A, A]]), npt.NDArray[Any])  # pyright correctly infers this as NDArray[float64]
 assert_type(np.block(C), npt.NDArray[Any])

--- a/numpy/typing/tests/data/reveal/ma.pyi
+++ b/numpy/typing/tests/data/reveal/ma.pyi
@@ -9,6 +9,7 @@ type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 type _MArray1D[ScalarT: np.generic] = np.ma.MaskedArray[tuple[int], np.dtype[ScalarT]]
 type _MArray2D[ScalarT: np.generic] = np.ma.MaskedArray[tuple[int, int], np.dtype[ScalarT]]
 type _MArray3D[ScalarT: np.generic] = np.ma.MaskedArray[tuple[int, int, int], np.dtype[ScalarT]]
+type _MArray4D[ScalarT: np.generic] = np.ma.MaskedArray[tuple[int, int, int, int], np.dtype[ScalarT]]
 
 ###
 
@@ -59,6 +60,7 @@ MAR_subclass_i: MaskedArraySubclassI
 MAR_into_subclass: IntoMaskedArraySubClass[np.float32]
 
 MAR_1d: np.ma.MaskedArray[tuple[int], np.dtype]
+AR_2d_f4: np.ndarray[tuple[int, int], np.dtype[np.float32]]
 MAR_1d_f4: np.ma.MaskedArray[tuple[int], np.dtype[np.float32]]
 MAR_2d_f4: np.ma.MaskedArray[tuple[int, int], np.dtype[np.float32]]
 MAR_3d_f4: np.ma.MaskedArray[tuple[int, int, int], np.dtype[np.float32]]
@@ -1132,3 +1134,14 @@ assert_type(np.ma.hstack([MAR_2d_f4, MAR_2d_f4]), _MArray2D[np.float32])
 assert_type(np.ma.hstack([MAR_3d_f4, MAR_3d_f4]), _MArray3D[np.float32])
 assert_type(np.ma.hstack([MAR_3d_f4, MAR_3d_f4], dtype=np.int8), _MArray3D[np.int8])
 assert_type(np.ma.hstack([AR_LIKE_f, AR_LIKE_f]), MaskedArray[Any])
+
+assert_type(np.ma.stack([MAR_f4, MAR_f4]), MaskedArray[np.float32])
+assert_type(np.ma.stack([AR_f4, AR_f4]), MaskedArray[np.float32])
+assert_type(np.ma.stack([MAR_1d_f4, MAR_1d_f4]), _MArray2D[np.float32])
+assert_type(np.ma.stack([MAR_2d_f4, MAR_2d_f4]), _MArray3D[np.float32])
+assert_type(np.ma.stack([MAR_3d_f4, MAR_3d_f4]), _MArray4D[np.float32])
+assert_type(np.ma.stack([MAR_2d_f4, MAR_2d_f4], axis=-1), _MArray3D[np.float32])
+assert_type(np.ma.stack([MAR_2d_f4, MAR_2d_f4], dtype=np.int8), _MArray3D[np.int8])
+assert_type(np.ma.stack([MAR_f4, MAR_f4], out=AR_f4), MaskedArray[np.float32])
+assert_type(np.ma.stack([MAR_1d_f4, MAR_1d_f4], out=AR_2d_f4), _MArray2D[np.float32])
+assert_type(np.ma.stack([MAR_f4, MAR_f4], 0, AR_2d_f4), _MArray2D[np.float32])


### PR DESCRIPTION
Same story as #32238

---

Mechanical work done by AI (these `stack` overloads are very similar to `vstack`/`hstack`). It messed up here and there, so I changed some stuff myself afterwards.