### PR TITLE
TYP: ``searchsorted`` shape-typing

### DIFF
--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -145,6 +145,13 @@ class _CanGE(Protocol):
 
 type _Orderable = _CanLE | _CanGE
 
+@type_check_only
+class _CanArray[ArrayT: np.ndarray](Protocol):
+    def __array__(self, /) -> ArrayT: ...
+
+type _ArrayLike1D = _CanArray[_Array1D[Any]] | Sequence[_ScalarLike_co]
+type _ArrayLikeInt1D = _CanArray[_Array1D[np.integer]] | Sequence[int | np.integer]
+
 ###
 
 # TODO: Fix overlapping overloads: https://github.com/numpy/numpy/issues/27032
@@ -662,21 +669,49 @@ def argmin[ArrayT: NDArray[np.intp]](
     keepdims: bool | _NoValueType = ...,
 ) -> ArrayT: ...
 
-# TODO: Fix overlapping overloads: https://github.com/numpy/numpy/issues/27032
-@overload
-def searchsorted(
-    a: ArrayLike,
-    v: _ScalarLike_co,
+#
+@overload  # Nd
+def searchsorted[ShapeT: _Shape](
+    a: _ArrayLike1D,
+    v: np.ndarray[ShapeT, np.dtype[Any]],
     side: _SortSide = "left",
-    sorter: _ArrayLikeInt_co | None = None,  # 1D int array
-) -> intp: ...
-@overload
+    sorter: _ArrayLikeInt1D | None = None,
+) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...
+@overload  # 0d
 def searchsorted(
-    a: ArrayLike,
+    a: _ArrayLike1D,
+    v: complex | str | np.generic,
+    side: _SortSide = "left",
+    sorter: _ArrayLikeInt1D | None = None,
+) -> np.intp: ...
+@overload  # 1d  (`str <; Sequence[str]`, hence the `list[str]`)
+def searchsorted(
+    a: _ArrayLike1D,
+    v: Sequence[complex | np.generic] | list[str],
+    side: _SortSide = "left",
+    sorter: _ArrayLikeInt1D | None = None,
+) -> _Array1D[np.intp]: ...
+@overload  # 2d
+def searchsorted(
+    a: _ArrayLike1D,
+    v: Sequence[Sequence[complex | np.generic]] | Sequence[list[str]],
+    side: _SortSide = "left",
+    sorter: _ArrayLikeInt1D | None = None,
+) -> _Array2D[np.intp]: ...
+@overload  # 3d
+def searchsorted(
+    a: _ArrayLike1D,
+    v: Sequence[Sequence[Sequence[complex | np.generic]]] | Sequence[Sequence[list[str]]],
+    side: _SortSide = "left",
+    sorter: _ArrayLikeInt1D | None = None,
+) -> _Array3D[np.intp]: ...
+@overload  # fallback  (overlaps with 1st overload)
+def searchsorted(
+    a: _ArrayLike1D,
     v: ArrayLike,
     side: _SortSide = "left",
-    sorter: _ArrayLikeInt_co | None = None,  # 1D int array
-) -> NDArray[intp]: ...
+    sorter: _ArrayLikeInt1D | None = None,
+) -> NDArray[np.intp] | Any: ...
 
 # keep in sync with `ma.core.resize`
 @overload

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -156,10 +156,14 @@ assert_type(np.argmin(AR_f4_2d, keepdims=True), np.ndarray[tuple[int, int], np.d
 assert_type(np.argmin(AR_f4_3d, keepdims=True), np.ndarray[tuple[int, int, int], np.dtype[np.intp]])
 assert_type(np.argmin(AR_f4, out=AR_sub_i), NDArrayIntSubclass)
 
-assert_type(np.searchsorted(AR_b[0], 0), np.intp)
-assert_type(np.searchsorted(AR_f4[0], 0), np.intp)
-assert_type(np.searchsorted(AR_b[0], [0]), npt.NDArray[np.intp])
-assert_type(np.searchsorted(AR_f4[0], [0]), npt.NDArray[np.intp])
+assert_type(np.searchsorted(AR_f4, 0), np.intp)
+assert_type(np.searchsorted(AR_f4, _py_list_1d), _Array1D[np.intp])
+assert_type(np.searchsorted(AR_f4, _py_list_2d), _Array2D[np.intp])
+assert_type(np.searchsorted(AR_f4, _py_list_3d), _Array3D[np.intp])
+assert_type(np.searchsorted(AR_f4, f4), np.intp)
+assert_type(np.searchsorted(AR_f4, AR_f4_1d), _Array1D[np.intp])
+assert_type(np.searchsorted(AR_f4, AR_f4_2d), _Array2D[np.intp])
+assert_type(np.searchsorted(AR_f4, AR_f4_3d), _Array3D[np.intp])
 
 assert_type(np.resize(b, (5, 5)), np.ndarray[tuple[int, int], np.dtype[np.bool]])
 assert_type(np.resize(f4, (5, 5)), np.ndarray[tuple[int, int], np.dtype[np.float32]])


### PR DESCRIPTION
This improves `np.searchsorted` so that it returns an accurate shape-type in the most common usage patterns.

---

Fully written by me, pre-reviewed and audited by AI (see https://gist.github.com/jorenham/36c78602a7ca866ddb2a917de48ccdd0).