### PR TITLE
BUG: avoid uninitialized memory access / NULL-pointer deref in scalar byteswap

### DIFF
--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2173,10 +2173,25 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
         char *data;
         PyArray_Descr *descr;
         PyObject *new;
-        char *newmem;
 
         descr = PyArray_DescrFromScalar(self);
         data = (void *)scalar_value(self, descr);
+        if (data == NULL) {
+            if (PyErr_Occurred()) {
+                /* e.g. allocating the unicode scalar's UCS4 buffer failed */
+                Py_DECREF(descr);
+                return NULL;
+            }
+            /*
+             * Zero-sized void scalars have no data to swap; return an
+             * equivalent empty scalar.  PyArray_Scalar does not read data
+             * when descr->elsize is 0.
+             */
+            assert(descr->elsize == 0);
+            PyObject *ret = PyArray_Scalar(data, descr, NULL);
+            Py_DECREF(descr);
+            return ret;
+        }
 
         PyArray_CopySwapFunc *copyswap =
                 PyDataType_GetArrFuncs(descr)->copyswap;
@@ -2184,16 +2199,50 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
             Py_DECREF(descr);
             return NULL;
         }
-        newmem = PyMem_Malloc(descr->elsize);
-        if (newmem == NULL) {
-            Py_DECREF(descr);
-            return PyErr_NoMemory();
+
+        if (PyDataType_FLAGCHK(descr, NPY_NEEDS_INIT)) {
+            /*
+             * NPY_NEEDS_INIT means copyswap reads the destination before it
+             * writes it so the buffer cannot be a bare malloc.  This is
+             * equivalent to np.array([scalar]).byteswap()[0].
+             */
+            Py_INCREF(descr);
+            PyArrayObject *tmp = (PyArrayObject *)PyArray_NewFromDescr_int(
+                    &PyArray_Type, descr, 0, NULL, NULL, NULL, 0, NULL, NULL,
+                    _NPY_ARRAY_ENSURE_DTYPE_IDENTITY);
+            if (tmp == NULL) {
+                Py_DECREF(descr);
+                return NULL;
+            }
+            copyswap(PyArray_DATA(tmp), data, 1, tmp);
+            new = PyArray_Scalar(PyArray_DATA(tmp), descr, (PyObject *)tmp);
+            Py_DECREF(tmp);
         }
         else {
-            copyswap(newmem, data, 1, NULL);
+            char *newmem = PyMem_Malloc(descr->elsize);
+            if (newmem == NULL) {
+                Py_DECREF(descr);
+                return PyErr_NoMemory();
+            }
+            if (PyDataType_ISFLEXIBLE(descr)) {
+                /*
+                 * Need a dummy array because these types use it to access the
+                 * descriptor. This is much faster than the heap-allocated
+                 * temp array path that dtypes with embedded objects need.
+                 */
+                PyArrayObject_fields dummy_fields;
+                memset(&dummy_fields, 0, sizeof(dummy_fields));
+                dummy_fields.descr = descr;
+                dummy_fields.flags = NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS |
+                                     NPY_ARRAY_F_CONTIGUOUS;
+                copyswap(newmem, data, 1, (PyArrayObject *)&dummy_fields);
+            }
+            else {
+                copyswap(newmem, data, 1, NULL);
+            }
+            new = PyArray_Scalar(newmem, descr, NULL);
+            PyMem_Free(newmem);
         }
-        new = PyArray_Scalar(newmem, descr, NULL);
-        PyMem_Free(newmem);
         Py_DECREF(descr);
         return new;
     }

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -2219,7 +2219,7 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
             Py_DECREF(tmp);
         }
         else {
-            char *newmem = PyMem_Malloc(descr->elsize);
+            char *newmem = PyMem_Calloc(1, descr->elsize);
             if (newmem == NULL) {
                 Py_DECREF(descr);
                 return PyErr_NoMemory();

--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -238,7 +238,9 @@ class TestDevice:
 class TestByteswap:
     @pytest.mark.parametrize("scalar", [
         np.bytes_(b"abcd"),
-        np.str_("abcd"),
+        # pick characters that are valid UCS-4 after being byteswapped
+        # otherwise we trip a sanity check in debug Python builds
+        np.str_("\u0100\u0200\u0300"),
         np.void(b"\x01\x02\x03\x04"),
         np.array([(1, 2.5)], dtype="i4,f8")[0],
         np.array([([1, 2], b"xy")], dtype=[("a", "i4", (2,)), ("b", "S2")])[0],

--- a/numpy/_core/tests/test_scalar_methods.py
+++ b/numpy/_core/tests/test_scalar_methods.py
@@ -235,6 +235,42 @@ class TestDevice:
         assert scalar.__array_namespace__() is np
 
 
+class TestByteswap:
+    @pytest.mark.parametrize("scalar", [
+        np.bytes_(b"abcd"),
+        np.str_("abcd"),
+        np.void(b"\x01\x02\x03\x04"),
+        np.array([(1, 2.5)], dtype="i4,f8")[0],
+        np.array([([1, 2], b"xy")], dtype=[("a", "i4", (2,)), ("b", "S2")])[0],
+    ])
+    def test_matches_array_byteswap(self, scalar):
+        arr = np.array([scalar], dtype=scalar.dtype)
+        assert scalar.byteswap().tobytes() == arr.byteswap()[0].tobytes()
+        assert scalar.byteswap().byteswap().tobytes() == scalar.tobytes()
+
+    def test_object_field(self):
+        sentinel = object()
+        scalar = np.array([(1, sentinel)], dtype=[("a", "i4"), ("b", "O")])[0]
+        swapped = scalar.byteswap()
+        assert swapped["b"] is sentinel
+        assert swapped["a"] == np.int32(1).byteswap()
+
+        count = sys.getrefcount(sentinel)
+        scalar.byteswap()
+        assert sys.getrefcount(sentinel) == count
+
+    @pytest.mark.parametrize("scalar", [
+        np.bytes_(b""),
+        np.str_(""),
+        np.void(b""),
+        np.zeros(1, dtype=[])[0],
+    ])
+    def test_empty(self, scalar):
+        swapped = scalar.byteswap()
+        assert swapped == scalar
+        assert swapped.dtype == scalar.dtype
+
+
 @pytest.mark.parametrize("scalar", [np.bool(True), np.int8(1), np.float64(1)])
 def test_array_wrap(scalar):
     # Test scalars array wrap as long as it exists.  NumPy itself should


### PR DESCRIPTION
### PR summary

Fixes #24694

The current scalar byteswap implementation assumes copyswap doesn't need the last argument for the copyswap function, which is an array object. That is incorrect for flexible descriptors (string, void) and for descriptors that request array initialization like object dtype or void dtypes with embedded object dtypes.

For flexible descriptors this allows access to unitialized heap memory on release builds of NumPy or an assert on a debug build:

```
>>> np.bytes_(b"1234").byteswap()
np.bytes_(b'\xb0\xf5D\x01')
>>> np.array([b"1234"]).byteswap()
array([b'1234'], dtype='|S4')
```

The first result is uninitialized heap garbage. With a debug build:

```
>>> import numpy as np
>>> np.bytes_(b"1234").byteswap()
Assertion failed: (arr != NULL), function STRING_copyswap, file arraytypes.c.src, line 2507.
[1]    84175 abort      spin python
```

If there are object dtypes involved, this bug can also lead to a segfault:

```
>>> import numpy as np
... o = object()
... s = np.array([(o,)], dtype=[("x", "O")])[0]
... print(s.byteswap()["x"])
...
[1]    84728 segmentation fault  python
```

(this is also an assert in `VOID_copyswap` in debug builds).

I could make this less branchy by forcing all dtypes to go through the object dtype path or making e.g. ints, floats, and other simple data dtypes use the stack-allocated array path. I did find leaving the fast-path, even with all the branches, was still worth it. Scalar byteswaps probably aren't performance critical though so I'm open to simplifying this if anyone wants that.

This was originally noticed by @ikrommyd during review of #32150: https://github.com/numpy/numpy/pull/32150#discussion_r3739682641


#### AI Disclosure
I used an AI for review and to help identify corner cases.
