### PR TITLE
TYP: ``random.Generator.permutation`` shape-typing

### DIFF
--- a/numpy/random/_generator.pyi
+++ b/numpy/random/_generator.pyi
@@ -1,6 +1,6 @@
 # Alias for builtin shadowed by classes to avoid annotations resolving to class members by ty
 from builtins import bytes as py_bytes
-from collections.abc import Callable, MutableSequence
+from collections.abc import Callable, MutableSequence, Sequence
 from typing import Any, Literal, Self, SupportsIndex, overload
 
 import numpy as np
@@ -27,6 +27,7 @@ from .mtrand import RandomState
 ###
 
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
 
 type _ArrayF32 = NDArray[np.float32]
 type _ArrayF64 = NDArray[np.float64]
@@ -807,10 +808,30 @@ class Generator:
     def shuffle(self, /, x: MutableSequence[Any], axis: Literal[0] = 0) -> None: ...
 
     #
-    @overload
-    def permutation(self, /, x: int, axis: int = 0) -> NDArray[np.int64]: ...
-    @overload
-    def permutation(self, /, x: ArrayLike, axis: int = 0) -> np.ndarray: ...
+    @overload  # int -> 1d
+    def permutation(self, /, x: int, axis: int = 0) -> _Array1D[np.int64]: ...
+    @overload  # known array
+    def permutation[ArrayT: np.ndarray](self, /, x: ArrayT, axis: int = 0) -> ArrayT: ...
+    @overload  # 1d bool
+    def permutation(self, /, x: list[bool], axis: int = 0) -> _Array1D[np.bool]: ...
+    @overload  # 1d int
+    def permutation(self, /, x: list[int], axis: int = 0) -> _Array1D[np.int_]: ...
+    @overload  # 1d float
+    def permutation(self, /, x: list[float], axis: int = 0) -> _Array1D[np.float64]: ...
+    @overload  # 1d complex
+    def permutation(self, /, x: list[complex], axis: int = 0) -> _Array1D[np.complex128]: ...
+    @overload  # 2d bool
+    def permutation(self, /, x: Sequence[list[bool]], axis: int = 0) -> _Array2D[np.bool]: ...
+    @overload  # 2d int
+    def permutation(self, /, x: Sequence[list[int]], axis: int = 0) -> _Array2D[np.int_]: ...
+    @overload  # 2d float
+    def permutation(self, /, x: Sequence[list[float]], axis: int = 0) -> _Array2D[np.float64]: ...
+    @overload  # 2d complex
+    def permutation(self, /, x: Sequence[list[complex]], axis: int = 0) -> _Array2D[np.complex128]: ...
+    @overload  # ?d known dtype
+    def permutation[ScalarT: np.generic](self, /, x: _ArrayLike[ScalarT], axis: int = 0) -> NDArray[ScalarT]: ...
+    @overload  # ?d unknown dtype
+    def permutation(self, /, x: ArrayLike, axis: int = 0) -> NDArray[Any]: ...
 
     #
     @overload  # does not preserve `ndarray` subtypes

--- a/numpy/typing/tests/data/reveal/random.pyi
+++ b/numpy/typing/tests/data/reveal/random.pyi
@@ -750,10 +750,19 @@ assert_type(def_gen.multivariate_normal([0.0], np.array([[1.0]])), npt.NDArray[n
 assert_type(def_gen.multivariate_normal(np.array([0.0]), [[1.0]]), npt.NDArray[np.float64])
 assert_type(def_gen.multivariate_normal([0.0], np.array([[1.0]])), npt.NDArray[np.float64])
 
-assert_type(def_gen.permutation(10), npt.NDArray[np.int64])
-assert_type(def_gen.permutation([1, 2, 3, 4]), npt.NDArray[Any])
-assert_type(def_gen.permutation(np.array([1, 2, 3, 4])), npt.NDArray[Any])
-assert_type(def_gen.permutation(D_2D, axis=1), npt.NDArray[Any])
+_f32_2d: _Array2D[np.float32]
+
+assert_type(def_gen.permutation(10), _Array1D[np.int64])
+assert_type(def_gen.permutation([True]), _Array1D[np.bool])
+assert_type(def_gen.permutation([1]), _Array1D[np.int_])
+assert_type(def_gen.permutation([1.0]), _Array1D[np.float64])
+assert_type(def_gen.permutation([1j]), _Array1D[np.complex128])
+assert_type(def_gen.permutation([[True]]), _Array2D[np.bool])
+assert_type(def_gen.permutation([[1]]), _Array2D[np.int_])
+assert_type(def_gen.permutation([[1.0]]), _Array2D[np.float64])
+assert_type(def_gen.permutation([[1j]]), _Array2D[np.complex128])
+assert_type(def_gen.permutation(_f32_2d), _Array2D[np.float32])
+
 assert_type(def_gen.permuted(D_2D), npt.NDArray[np.float64])
 assert_type(def_gen.permuted(D_2D_like), npt.NDArray[Any])
 assert_type(def_gen.permuted(D_2D, axis=1), npt.NDArray[np.float64])


### PR DESCRIPTION
For >0d input, `np.random.Generator.permutation` outputs the same shape as the input, so it's pretty straightforward to type this.

related: #32258

---

Fully written by me, pre-reviewed and audited by AI (see https://gist.github.com/jorenham/36c78602a7ca866ddb2a917de48ccdd0).