### PR TITLE
BUG: fix segfault for reduce-like operations when the ufunc has no output

### DIFF
--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3920,6 +3920,13 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
                      _reduce_type[operation]);
         return NULL;
     }
+    if (ufunc->nout == 0) {
+        PyErr_Format(PyExc_ValueError,
+                     "%s not supported for functions "
+                     "returning no value",
+                     _reduce_type[operation]);
+        return NULL;
+    }
     if (operation != UFUNC_REDUCE && ufunc->nout != 1) {
         PyErr_Format(PyExc_ValueError,
                      "%s only supported for functions "

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2695,6 +2695,16 @@ class TestUfunc:
         np.add.accumulate(arr, out=out)
         assert_array_equal(expected, out)
 
+    @pytest.mark.parametrize("method", ["reduce", "accumulate", "reduceat"])
+    def test_reducelike_no_output_raises(self, method):
+        # A ufunc without outputs has nothing to accumulate into.  Reductions
+        # must reject it rather than resolving a nonexistent output loop.
+        # See gh-31816, which segfaulted here.
+        ufunc = np.frompyfunc(lambda a, b: None, 2, 0)
+        args = ([1, 2, 3], [0, 1]) if method == "reduceat" else ([1, 2, 3],)
+        with pytest.raises(ValueError, match="returning no value"):
+            getattr(ufunc, method)(*args)
+
     def test_reduce_noncontig_output(self):
         # Check that reduction deals with non-contiguous output arrays
         # appropriately.


### PR DESCRIPTION
### PR summary
Found by @ngoldbaum while reviewing https://github.com/numpy/numpy/pull/32212 (https://github.com/numpy/numpy/pull/32212#discussion_r3753197558) and introduced by me in https://github.com/numpy/numpy/pull/31816.
Fixes a segfault when a we ask for a reduce-like operation and the ufunc has no output.

#### AI Disclosure
No AI