### PR TITLE
TYP: ``np.column_stack`` shape-typing

### DIFF
--- a/numpy/lib/_shape_base_impl.pyi
+++ b/numpy/lib/_shape_base_impl.pyi
@@ -188,10 +188,16 @@ def expand_dims[ScalarT: np.generic](
 def expand_dims(a: ArrayLike, axis: int | tuple[int, ...]) -> NDArray[Any]: ...
 
 # keep in sync with `numpy.ma.extras.column_stack`
-@overload
+@overload  # >=2d, known dtype
+def column_stack[ShapeT: _Min2D, DTypeT: np.dtype](
+    tup: Sequence[np.ndarray[ShapeT, DTypeT]],
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # <=2d, known dtype
+def column_stack[ScalarT: np.generic](tup: Sequence[_To2D[ScalarT]]) -> _Array2D[ScalarT]: ...
+@overload  # ?d, known dtype
 def column_stack[ScalarT: np.generic](tup: Sequence[_ArrayLike[ScalarT]]) -> NDArray[ScalarT]: ...
-@overload
-def column_stack(tup: Sequence[ArrayLike]) -> NDArray[Incomplete]: ...
+@overload  # fallback
+def column_stack(tup: Sequence[ArrayLike]) -> NDArray[Any]: ...
 
 # keep in sync with `numpy.ma.extras.dstack`
 @overload

--- a/numpy/ma/extras.pyi
+++ b/numpy/ma/extras.pyi
@@ -318,10 +318,16 @@ def hstack(
     casting: _CastingKind = "same_kind"
 ) -> _MArray[Incomplete]: ...
 
-# keep in sync with `numpy._core.shape_base_impl.column_stack`
-@overload
+# keep in sync with `numpy.lib._shape_base_impl.column_stack`
+@overload  # >=2d, known dtype
+def column_stack[ShapeT: _AtLeast2D, DTypeT: np.dtype](
+    tup: Sequence[np.ndarray[ShapeT, DTypeT]],
+) -> MaskedArray[ShapeT, DTypeT]: ...
+@overload  # <=2d, known dtype
+def column_stack[ScalarT: np.generic](tup: Sequence[_To2D[ScalarT]]) -> _MArray2D[ScalarT]: ...
+@overload  # ?d, known dtype
 def column_stack[ScalarT: np.generic](tup: Sequence[_ArrayLike[ScalarT]]) -> _MArray[ScalarT]: ...
-@overload
+@overload  # fallback
 def column_stack(tup: Sequence[ArrayLike]) -> _MArray[Incomplete]: ...
 
 # keep in sync with `numpy._core.shape_base_impl.dstack`

--- a/numpy/typing/tests/data/reveal/ma.pyi
+++ b/numpy/typing/tests/data/reveal/ma.pyi
@@ -61,6 +61,7 @@ MAR_into_subclass: IntoMaskedArraySubClass[np.float32]
 
 MAR_1d: np.ma.MaskedArray[tuple[int], np.dtype]
 AR_2d_f4: np.ndarray[tuple[int, int], np.dtype[np.float32]]
+MAR_0d_f4: np.ma.MaskedArray[tuple[()], np.dtype[np.float32]]
 MAR_1d_f4: np.ma.MaskedArray[tuple[int], np.dtype[np.float32]]
 MAR_2d_f4: np.ma.MaskedArray[tuple[int, int], np.dtype[np.float32]]
 MAR_3d_f4: np.ma.MaskedArray[tuple[int, int, int], np.dtype[np.float32]]
@@ -1134,6 +1135,13 @@ assert_type(np.ma.hstack([MAR_2d_f4, MAR_2d_f4]), _MArray2D[np.float32])
 assert_type(np.ma.hstack([MAR_3d_f4, MAR_3d_f4]), _MArray3D[np.float32])
 assert_type(np.ma.hstack([MAR_3d_f4, MAR_3d_f4], dtype=np.int8), _MArray3D[np.int8])
 assert_type(np.ma.hstack([AR_LIKE_f, AR_LIKE_f]), MaskedArray[Any])
+
+assert_type(np.ma.column_stack([MAR_f4, MAR_f4]), MaskedArray[np.float32])
+assert_type(np.ma.column_stack([AR_LIKE_f, AR_LIKE_f]), MaskedArray[Any])
+assert_type(np.ma.column_stack([MAR_0d_f4, MAR_0d_f4]), _MArray2D[np.float32])
+assert_type(np.ma.column_stack([MAR_1d_f4, MAR_1d_f4]), _MArray2D[np.float32])
+assert_type(np.ma.column_stack([MAR_2d_f4, MAR_2d_f4]), _MArray2D[np.float32])
+assert_type(np.ma.column_stack([MAR_3d_f4, MAR_3d_f4]), _MArray3D[np.float32])
 
 assert_type(np.ma.stack([MAR_f4, MAR_f4]), MaskedArray[np.float32])
 assert_type(np.ma.stack([AR_f4, AR_f4]), MaskedArray[np.float32])

--- a/numpy/typing/tests/data/reveal/shape_base.pyi
+++ b/numpy/typing/tests/data/reveal/shape_base.pyi
@@ -55,6 +55,10 @@ assert_type(np.expand_dims(AR_i8_2d, (0, 1)), np.ndarray[tuple[int, int, int, in
 
 assert_type(np.column_stack([AR_i8]), npt.NDArray[np.int64])
 assert_type(np.column_stack([AR_LIKE_f8]), npt.NDArray[Any])
+assert_type(np.column_stack([AR_i8_0d, AR_i8_0d]), _Array2D[np.int64])
+assert_type(np.column_stack([AR_i8_1d, AR_i8_1d]), _Array2D[np.int64])
+assert_type(np.column_stack([AR_i8_2d, AR_i8_2d]), _Array2D[np.int64])
+assert_type(np.column_stack([AR_i8_3d, AR_i8_3d]), _Array3D[np.int64])
 
 assert_type(np.dstack([AR_i8]), npt.NDArray[np.int64])
 assert_type(np.dstack([AR_LIKE_f8]), npt.NDArray[Any])


### PR DESCRIPTION
This ports the `vstack`/`hstack` shape-typing improvements from #32238 to `np.column_stack` (surjectively, because there's no `dtype` param).
This also does the same for the `np.ma.column_stack` masked dual (with near-identical signature) 

---

Mostly mechanical, so I used AI to copy over the overloads, which this time it actually did right this time.