### PR TITLE
BUG: don't assume strides are a multiple of itemsize in stringdtype casts

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -777,10 +777,10 @@ string_to_int(
 
     npy_intp N = dimensions[0];
     char *in = data[0];
-    NpyType *out = (NpyType *)data[1];
+    char *out = data[1];
 
     npy_intp in_stride = strides[0];
-    npy_intp out_stride = strides[1] / sizeof(NpyType);
+    npy_intp out_stride = strides[1];
 
     while (N--) {
         NpyLongType value;
@@ -788,10 +788,10 @@ string_to_int(
             npy_gil_error(PyExc_RuntimeError, "Encountered problem converting string dtype to integer dtype.");
             goto fail;
         }
-        *out = (NpyType)value;
+        *(NpyType *)out = (NpyType)value;
 
         // Cast back to NpyLongType to check for out-of-bounds errors
-        if (static_cast<NpyLongType>(*out) != value) {
+        if (static_cast<NpyLongType>(*(NpyType *)out) != value) {
             // out of bounds, raise error following NEP 50 behavior
             const char *errmsg = NULL;
             if constexpr (std::is_same_v<NpyLongType, npy_ulonglong>) {
@@ -901,10 +901,10 @@ type_to_string(
     NpyAuxData *NPY_UNUSED(auxdata)
 ) {
     npy_intp N = dimensions[0];
-    NpyType *in = (NpyType *)data[0];
+    char *in = data[0];
     char *out = data[1];
 
-    npy_intp in_stride = strides[0] / sizeof(NpyType);
+    npy_intp in_stride = strides[0];
     npy_intp out_stride = strides[1];
 
     PyArray_StringDTypeObject *descr =
@@ -913,7 +913,7 @@ type_to_string(
             NpyString_acquire_allocator(descr);
 
     while (N--) {
-        if (int_to_stringbuf((TClongType)*in, out, allocator) != 0) {
+        if (int_to_stringbuf((TClongType)*(NpyType *)in, out, allocator) != 0) {
             goto fail;
         }
 
@@ -1011,10 +1011,10 @@ string_to_float(
 
     npy_intp N = dimensions[0];
     char *in = data[0];
-    NpyType *out = (NpyType *)data[1];
+    char *out = data[1];
 
     npy_intp in_stride = strides[0];
-    npy_intp out_stride = strides[1] / sizeof(NpyType);
+    npy_intp out_stride = strides[1];
 
     while (N--) {
         PyObject *pyfloat_value = string_to_pyfloat(
@@ -1034,7 +1034,7 @@ string_to_float(
             }
         }
 
-        *out = fval;
+        *(NpyType *)out = fval;
 
         in += in_stride;
         out += out_stride;
@@ -1067,10 +1067,10 @@ string_to_float<npy_float64, NPY_DOUBLE>(
 
     npy_intp N = dimensions[0];
     char *in = data[0];
-    npy_float64 *out = (npy_float64 *)data[1];
+    char *out = data[1];
 
     npy_intp in_stride = strides[0];
-    npy_intp out_stride = strides[1] / sizeof(npy_float64);
+    npy_intp out_stride = strides[1];
 
     while (N--) {
         PyObject *pyfloat_value = string_to_pyfloat(
@@ -1079,7 +1079,7 @@ string_to_float<npy_float64, NPY_DOUBLE>(
         if (pyfloat_value == NULL) {
             goto fail;
         }
-        *out = (npy_float64)PyFloat_AS_DOUBLE(pyfloat_value);
+        *(npy_float64 *)out = (npy_float64)PyFloat_AS_DOUBLE(pyfloat_value);
         Py_DECREF(pyfloat_value);
 
         in += in_stride;
@@ -1110,10 +1110,10 @@ string_to_float<npy_longdouble, NPY_LONGDOUBLE>(
     const npy_static_string *default_string = &descr->default_string;
     npy_intp N = dimensions[0];
     char *in = data[0];
-    npy_longdouble *out = (npy_longdouble *)data[1];
+    char *out = data[1];
 
     npy_intp in_stride = strides[0];
-    npy_intp out_stride = strides[1] / sizeof(npy_longdouble);
+    npy_intp out_stride = strides[1];
 
     while (N--) {
         npy_static_string s = {0, NULL};
@@ -1159,7 +1159,7 @@ string_to_float<npy_longdouble, NPY_LONGDOUBLE>(
             }
         }
         PyMem_RawFree(buf);
-        *out = longdouble_value;
+        *(npy_longdouble *)out = longdouble_value;
 
         in += in_stride;
         out += out_stride;
@@ -1218,11 +1218,11 @@ float_to_string(
     NpyAuxData *NPY_UNUSED(auxdata)
 ) {
     npy_intp N = dimensions[0];
-    NpyType *in = (NpyType *)data[0];
+    char *in = data[0];
     char *out = data[1];
     PyArray_Descr *float_descr = context->descriptors[0];
 
-    npy_intp in_stride = strides[0] / sizeof(NpyType);
+    npy_intp in_stride = strides[0];
     npy_intp out_stride = strides[1];
 
     PyArray_StringDTypeObject *descr =
@@ -1316,10 +1316,10 @@ string_to_complex_float(
     const npy_static_string *default_string = &descr->default_string;
     npy_intp N = dimensions[0];
     char *in = data[0];
-    NpyComplexType *out = (NpyComplexType *)data[1];
+    char *out = data[1];
 
     npy_intp in_stride = strides[0];
-    npy_intp out_stride = strides[1] / sizeof(NpyComplexType);
+    npy_intp out_stride = strides[1];
 
     while (N--) {
         PyObject *pycomplex_value = string_to_pycomplex(
@@ -1336,8 +1336,8 @@ string_to_complex_float(
             goto fail;
         }
 
-        npy_csetrealfunc(out, (NpyFloatType) complex_value.real);
-        npy_csetimagfunc(out, (NpyFloatType) complex_value.imag);
+        npy_csetrealfunc((NpyComplexType *)out, (NpyFloatType) complex_value.real);
+        npy_csetimagfunc((NpyComplexType *)out, (NpyFloatType) complex_value.imag);
         in += in_stride;
         out += out_stride;
     }
@@ -1466,10 +1466,10 @@ string_to_datetime(PyArrayMethod_Context *context, char *const data[],
 
     npy_intp N = dimensions[0];
     char *in = data[0];
-    npy_datetime *out = (npy_datetime *)data[1];
+    char *out = data[1];
 
     npy_intp in_stride = strides[0];
-    npy_intp out_stride = strides[1] / sizeof(npy_datetime);
+    npy_intp out_stride = strides[1];
 
     npy_datetimestruct dts;
     NPY_DATETIMEUNIT in_unit = NPY_FR_ERROR;
@@ -1492,13 +1492,13 @@ string_to_datetime(PyArrayMethod_Context *context, char *const data[],
         }
         if (is_null) {
             if (has_null && !has_string_na) {
-                *out = NPY_DATETIME_NAT;
+                *(npy_datetime *)out = NPY_DATETIME_NAT;
                 goto next_step;
             }
             s = *default_string;
         }
         if (is_nat_string(&s)) {
-            *out = NPY_DATETIME_NAT;
+            *(npy_datetime *)out = NPY_DATETIME_NAT;
             goto next_step;
         }
 
@@ -1508,8 +1508,8 @@ string_to_datetime(PyArrayMethod_Context *context, char *const data[],
                     &dts, &in_meta.base, &out_special) < 0) {
             goto fail;
         }
-        if (NpyDatetime_ConvertDatetimeStructToDatetime64(dt_meta, &dts, out) <
-            0) {
+        if (NpyDatetime_ConvertDatetimeStructToDatetime64(
+                    dt_meta, &dts, (npy_datetime *)out) < 0) {
             goto fail;
         }
 
@@ -1540,10 +1540,10 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
                    NpyAuxData *NPY_UNUSED(auxdata))
 {
     npy_intp N = dimensions[0];
-    npy_datetime *in = (npy_datetime *)data[0];
+    char *in = data[0];
     char *out = data[1];
 
-    npy_intp in_stride = strides[0] / sizeof(npy_datetime);
+    npy_intp in_stride = strides[0];
     npy_intp out_stride = strides[1];
 
     _PyArray_LegacyDescr *dt_descr = (_PyArray_LegacyDescr *)context->descriptors[0];
@@ -1558,7 +1558,7 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
 
     while (N--) {
         npy_packed_static_string *out_pss = (npy_packed_static_string *)out;
-        if (*in == NPY_DATETIME_NAT)
+        if (*(npy_datetime *)in == NPY_DATETIME_NAT)
         {
             if (!has_null) {
                 npy_static_string os = {3, "NaT"};
@@ -1580,7 +1580,7 @@ datetime_to_string(PyArrayMethod_Context *context, char *const data[],
         else {
             npy_datetimestruct dts;
             if (NpyDatetime_ConvertDatetime64ToDatetimeStruct(
-                        dt_meta, *in, &dts) < 0) {
+                        dt_meta, *(npy_datetime *)in, &dts) < 0) {
                 goto fail;
             }
 
@@ -1635,10 +1635,10 @@ string_to_timedelta(PyArrayMethod_Context *context, char *const data[],
 
     npy_intp N = dimensions[0];
     char *in = data[0];
-    npy_timedelta *out = (npy_timedelta *)data[1];
+    char *out = data[1];
 
     npy_intp in_stride = strides[0];
-    npy_intp out_stride = strides[1] / sizeof(npy_timedelta);
+    npy_intp out_stride = strides[1];
 
     while (N--) {
         const npy_packed_static_string *ps = (npy_packed_static_string *)in;
@@ -1652,7 +1652,7 @@ string_to_timedelta(PyArrayMethod_Context *context, char *const data[],
         }
         if (is_null) {
             if (has_null && !has_string_na) {
-                *out = NPY_DATETIME_NAT;
+                *(npy_timedelta *)out = NPY_DATETIME_NAT;
                 in += in_stride;
                 out += out_stride;
                 continue;
@@ -1660,7 +1660,7 @@ string_to_timedelta(PyArrayMethod_Context *context, char *const data[],
             s = *default_string;
         }
         if (is_nat_string(&s)) {
-            *out = NPY_DATETIME_NAT;
+            *(npy_timedelta *)out = NPY_DATETIME_NAT;
             in += in_stride;
             out += out_stride;
             continue;
@@ -1684,7 +1684,7 @@ string_to_timedelta(PyArrayMethod_Context *context, char *const data[],
             goto fail;
         }
 
-        *out = (npy_timedelta)value;
+        *(npy_timedelta *)out = (npy_timedelta)value;
 
         in += in_stride;
         out += out_stride;
@@ -1712,10 +1712,10 @@ timedelta_to_string(PyArrayMethod_Context *context, char *const data[],
                    NpyAuxData *NPY_UNUSED(auxdata))
 {
     npy_intp N = dimensions[0];
-    npy_timedelta *in = (npy_timedelta *)data[0];
+    char *in = data[0];
     char *out = data[1];
 
-    npy_intp in_stride = strides[0] / sizeof(npy_timedelta);
+    npy_intp in_stride = strides[0];
     npy_intp out_stride = strides[1];
 
     PyArray_StringDTypeObject *sdescr = (PyArray_StringDTypeObject *)context->descriptors[1];
@@ -1724,7 +1724,7 @@ timedelta_to_string(PyArrayMethod_Context *context, char *const data[],
 
     while (N--) {
         npy_packed_static_string *out_pss = (npy_packed_static_string *)out;
-        if (*in == NPY_DATETIME_NAT)
+        if (*(npy_timedelta *)in == NPY_DATETIME_NAT)
         {
             if (!has_null) {
                 npy_static_string os = {3, "NaT"};
@@ -1743,7 +1743,7 @@ timedelta_to_string(PyArrayMethod_Context *context, char *const data[],
                 goto fail;
             }
         }
-        else if (int_to_stringbuf((long long)*in, out, allocator) < 0) {
+        else if (int_to_stringbuf((long long)*(npy_timedelta *)in, out, allocator) < 0) {
             goto fail;
         }
 

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1178,6 +1178,35 @@ def test_string_to_cfloat_cast_distinct_components(typename):
     assert_array_equal(inp.astype(typename), expected)
 
 
+def test_cast_structured_field_view_strides():
+    # the numeric cast loops used to truncate byte strides that are not a
+    # multiple of the itemsize, like a complex128 field view of 24-byte records
+    rec = np.zeros(3, dtype=[("c", "c16"), ("f", "f8")])
+    rec["c"] = [1 + 1j, 2 + 2j, 3 + 3j]
+    rec["f"] = [10.0, 20.0, 30.0]
+
+    assert_array_equal(
+        rec["c"].astype("T"),
+        np.array(["(1+1j)", "(2+2j)", "(3+3j)"], dtype="T"),
+    )
+
+    rec["c"] = np.array(["4+4j", "5+5j", "6-6j"], dtype="T")
+    assert_array_equal(rec["c"], np.array([4 + 4j, 5 + 5j, 6 - 6j]))
+    assert_array_equal(rec["f"], np.array([10.0, 20.0, 30.0]))
+
+    # the f8 loops only see a mismatched stride on 32-bit architectures,
+    # where 8-byte types have 4-byte alignment
+    rec2 = np.zeros(3, dtype=[("v", "f8"), ("pad", "u4")])
+    rec2["v"] = [1.5, 2.5, 3.5]
+    assert_array_equal(
+        rec2["v"].astype("T"),
+        np.array(["1.5", "2.5", "3.5"], dtype="T"),
+    )
+    rec2["v"] = np.array(["4.5", "5.5", "6.5"], dtype="T")
+    assert_array_equal(rec2["v"], np.array([4.5, 5.5, 6.5]))
+    assert_array_equal(rec2["pad"], np.zeros(3, dtype="u4"))
+
+
 def test_take(string_list):
     sarr = np.array(string_list, dtype="T")
     res = sarr.take(np.arange(len(string_list)))

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1206,6 +1206,20 @@ def test_cast_structured_field_view_strides():
     assert_array_equal(rec2["v"], np.array([4.5, 5.5, 6.5]))
     assert_array_equal(rec2["pad"], np.zeros(3, dtype="u4"))
 
+    # likewise the 8-byte datetime/timedelta loops only see a mismatched
+    # stride on 32-bit architectures
+    rec3 = np.zeros(3, dtype=[("t", "M8[D]"), ("td", "m8[s]"), ("pad", "u4")])
+    rec3["t"] = np.array(["2010-01-01", "NaT", "2015-02-03"], dtype="M8[D]")
+    rec3["td"] = np.array([12, "NaT", -34], dtype="m8[s]")
+    assert_array_equal(rec3["t"].astype("T"),
+                       np.array(["2010-01-01", "NaT", "2015-02-03"], dtype="T"))
+    assert_array_equal(rec3["td"].astype("T"),
+                       np.array(["12", "NaT", "-34"], dtype="T"))
+    rec3["t"] = np.array(["1993-06-05", "NaT", "2038-01-19"], dtype="T")
+    rec3["td"] = np.array(["-56", "NaT", "78"], dtype="T")
+    assert_array_equal(rec3["t"],
+                       np.array(["1993-06-05", "NaT", "2038-01-19"], dtype="M8[D]"))
+    assert_array_equal(rec3["td"], np.array([-56, "NaT", 78], dtype="m8[s]"))
 
 def test_take(string_list):
     sarr = np.array(string_list, dtype="T")


### PR DESCRIPTION
### PR summary
See the test I added. On NumPy 2.5.2 you can get a cast to generate garbage by casting from void to StringDType:

```pycon
>>> rec = np.zeros(3, dtype=[("c", "c16"), ("f", "f8")])
... rec["c"] = [1 + 1j, 2 + 2j, 3 + 3j]
... rec["f"] = [10.0, 20.0, 30.0]
...
>>> rec["c"].astype("T")
array(['(1+1j)', '(10+2j)', '(2+20j)'], dtype=StringDType())
>>> rec["c"]
array([1.+1.j, 2.+2.j, 3.+3.j])
>>> np.__version__
'2.5.2'
```

#### AI Disclosure
An AI model spotted this bug and helped me with the test case.