### PR TITLE
MAINT, TST: Include subprocess coverage data

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     */numpy/conftest.py
 disable_warnings = include-ignored
 parallel = True
+patch = subprocess
 concurrency =
     multiprocessing
     thread

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,13 @@ omit =
     */tests/*
     */numpy/conftest.py
 disable_warnings = include-ignored
+parallel = True
+concurrency =
+    multiprocessing
+    thread
+
+[paths]
+source =
+    numpy/
+    */numpy/
+    */site-packages/numpy/

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ Thumbs.db
 # pytest generated files #
 ##########################
 /.pytest_cache
+.coverage
 
 # doc build generated files #
 #############################

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ Thumbs.db
 ##########################
 /.pytest_cache
 .coverage
+.coverage.*
 
 # doc build generated files #
 #############################

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -172,7 +172,6 @@ def test(*, parent_callback, pytest_args, tests, markexpr, parallel_threads, **k
     if kwargs.get('coverage'):
         coveragerc = curdir.parent / '.coveragerc'
         pytest_args = (f'--cov-config={coveragerc}',) + pytest_args
-        os.environ['COVERAGE_PROCESS_START'] = str(coveragerc)
         os.environ['COVERAGE_FILE'] = str(curdir.parent / '.coverage')
 
     kwargs['pytest_args'] = pytest_args

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -172,6 +172,8 @@ def test(*, parent_callback, pytest_args, tests, markexpr, parallel_threads, **k
     if kwargs.get('coverage'):
         coveragerc = curdir.parent / '.coveragerc'
         pytest_args = (f'--cov-config={coveragerc}',) + pytest_args
+        os.environ['COVERAGE_PROCESS_START'] = str(coveragerc)
+        os.environ['COVERAGE_FILE'] = str(curdir.parent / '.coverage')
 
     kwargs['pytest_args'] = pytest_args
     parent_callback(**{'pytest_args': pytest_args, 'tests': tests, **kwargs})


### PR DESCRIPTION
### PR summary

Include subprocess coverage data mainly for getting f2py test coverage data.

<details><summary>Before</summary>
<p>

```md
| Name                                           |    Stmts |     Miss |   Branch |   BrPart |   Cover |
|----------------------------------------------- | -------: | -------: | -------: | -------: | ------: |
| numpy/\_\_config\_\_.py                        |       32 |       20 |        6 |        0 |     42% |
| numpy/\_\_init\_\_.py                          |      191 |       54 |       66 |       17 |     68% |
| numpy/\_array\_api\_info.py                    |       39 |        9 |       24 |        0 |     86% |
| numpy/\_configtool.py                          |       20 |       20 |        8 |        0 |      0% |
| numpy/\_core/\_\_init\_\_.py                   |       88 |       82 |       18 |        0 |      8% |
| numpy/\_core/\_add\_newdocs.py                 |      235 |      235 |        4 |        0 |      0% |
| numpy/\_core/\_add\_newdocs\_scalars.py        |       68 |       68 |       12 |        0 |      0% |
| numpy/\_core/\_asarray.py                      |       31 |        9 |       16 |        1 |     79% |
| numpy/\_core/\_dtype.py                        |      174 |       23 |       96 |        2 |     91% |
| numpy/\_core/\_dtype\_ctypes.py                |       54 |        7 |       26 |        1 |     90% |
| numpy/\_core/\_exceptions.py                   |       84 |       34 |       12 |        0 |     65% |
| numpy/\_core/\_internal.py                     |      461 |      146 |      192 |       22 |     72% |
| numpy/\_core/\_methods.py                      |      142 |       36 |       72 |        1 |     82% |
| numpy/\_core/\_string\_helpers.py              |       15 |       15 |        2 |        0 |      0% |
| numpy/\_core/\_type\_aliases.py                |       51 |       51 |       24 |        0 |      0% |
| numpy/\_core/\_ufunc\_config.py                |       72 |       31 |        8 |        1 |     60% |
| numpy/\_core/arrayprint.py                     |      607 |      129 |      280 |       22 |     83% |
| numpy/\_core/cversions.py                      |        6 |        6 |        2 |        0 |      0% |
| numpy/\_core/defchararray.py                   |      223 |        5 |       50 |        6 |     96% |
| numpy/\_core/einsumfunc.py                     |      491 |       50 |      268 |       16 |     91% |
| numpy/\_core/fromnumeric.py                    |      450 |      156 |      114 |        5 |     71% |
| numpy/\_core/function\_base.py                 |      133 |       42 |       54 |        7 |     70% |
| numpy/\_core/getlimits.py                      |      171 |       68 |       42 |        6 |     62% |
| numpy/\_core/memmap.py                         |      101 |       23 |       38 |        5 |     80% |
| numpy/\_core/multiarray.py                     |      110 |       82 |        6 |        0 |     28% |
| numpy/\_core/numeric.py                        |      477 |      163 |      136 |        9 |     70% |
| numpy/\_core/numerictypes.py                   |      116 |       48 |       42 |        0 |     68% |
| numpy/\_core/overrides.py                      |       58 |       32 |       18 |        2 |     55% |
| numpy/\_core/printoptions.py                   |        5 |        5 |        0 |        0 |      0% |
| numpy/\_core/records.py                        |      359 |      130 |      166 |       33 |     64% |
| numpy/\_core/shape\_base.py                    |      191 |       47 |       74 |        3 |     81% |
| numpy/\_core/strings.py                        |      331 |       11 |       70 |        8 |     95% |
| numpy/\_core/umath.py                          |        5 |        5 |        0 |        0 |      0% |
| numpy/\_distributor\_init.py                   |        4 |        4 |        0 |        0 |      0% |
| numpy/\_expired\_attrs\_2\_0.py                |        1 |        1 |        0 |        0 |      0% |
| numpy/\_globals.py                             |       34 |       22 |       10 |        3 |     34% |
| numpy/\_pyinstaller/\_\_init\_\_.py            |        0 |        0 |        0 |        0 |    100% |
| numpy/\_pyinstaller/hook-numpy.py              |        8 |        8 |        2 |        0 |      0% |
| numpy/\_pytesttester.py                        |       43 |       41 |       16 |        0 |      3% |
| numpy/\_typing/\_\_init\_\_.py                 |        8 |        8 |        0 |        0 |      0% |
| numpy/\_typing/\_add\_docstring.py             |       32 |        0 |        8 |        0 |    100% |
| numpy/\_typing/\_array\_like.py                |       34 |       32 |        0 |        0 |      6% |
| numpy/\_typing/\_char\_codes.py                |       49 |       49 |        0 |        0 |      0% |
| numpy/\_typing/\_dtype\_like.py                |       32 |       31 |        0 |        0 |      3% |
| numpy/\_typing/\_nbit.py                       |       12 |       12 |        0 |        0 |      0% |
| numpy/\_typing/\_nbit\_base.py                 |       34 |       34 |        2 |        0 |      0% |
| numpy/\_typing/\_nested\_sequence.py           |       20 |       20 |        0 |        0 |      0% |
| numpy/\_typing/\_scalars.py                    |       12 |       12 |        0 |        0 |      0% |
| numpy/\_typing/\_shape.py                      |        5 |        5 |        0 |        0 |      0% |
| numpy/\_utils/\_\_init\_\_.py                  |       34 |       26 |       12 |        1 |     24% |
| numpy/\_utils/\_conversions.py                 |        9 |        3 |        4 |        0 |     77% |
| numpy/\_utils/\_inspect.py                     |       67 |       47 |       32 |        5 |     29% |
| numpy/\_utils/\_pep440.py                      |      198 |       97 |       60 |       10 |     43% |
| numpy/char/\_\_init\_\_.py                     |       13 |        0 |        4 |        0 |    100% |
| numpy/core/\_\_init\_\_.py                     |       10 |        0 |        0 |        0 |    100% |
| numpy/core/\_dtype.py                          |        8 |        8 |        2 |        0 |      0% |
| numpy/core/\_dtype\_ctypes.py                  |        8 |        8 |        2 |        0 |      0% |
| numpy/core/\_internal.py                       |       13 |        7 |        2 |        0 |     40% |
| numpy/core/\_multiarray\_umath.py              |       28 |       20 |       12 |        0 |     30% |
| numpy/core/\_utils.py                          |        8 |        0 |        2 |        0 |    100% |
| numpy/core/arrayprint.py                       |        8 |        0 |        2 |        0 |    100% |
| numpy/core/defchararray.py                     |        8 |        0 |        2 |        0 |    100% |
| numpy/core/einsumfunc.py                       |        8 |        0 |        2 |        0 |    100% |
| numpy/core/fromnumeric.py                      |        8 |        0 |        2 |        0 |    100% |
| numpy/core/function\_base.py                   |        8 |        0 |        2 |        0 |    100% |
| numpy/core/getlimits.py                        |        8 |        0 |        2 |        0 |    100% |
| numpy/core/multiarray.py                       |       13 |        0 |        4 |        0 |    100% |
| numpy/core/numeric.py                          |        9 |        0 |        2 |        0 |    100% |
| numpy/core/numerictypes.py                     |        8 |        0 |        2 |        0 |    100% |
| numpy/core/overrides.py                        |        8 |        0 |        2 |        0 |    100% |
| numpy/core/records.py                          |        8 |        0 |        2 |        0 |    100% |
| numpy/core/shape\_base.py                      |        8 |        0 |        2 |        0 |    100% |
| numpy/core/umath.py                            |        8 |        0 |        2 |        0 |    100% |
| numpy/ctypeslib/\_\_init\_\_.py                |        1 |        0 |        0 |        0 |    100% |
| numpy/ctypeslib/\_ctypeslib.py                 |      232 |       34 |       98 |       13 |     85% |
| numpy/dtypes.py                                |       12 |       10 |        2 |        0 |     14% |
| numpy/exceptions.py                            |       35 |       21 |        8 |        1 |     44% |
| numpy/f2py/\_\_init\_\_.py                     |       19 |        0 |        2 |        0 |    100% |
| numpy/f2py/\_\_main\_\_.py                     |        2 |        2 |        0 |        0 |      0% |
| numpy/f2py/\_\_version\_\_.py                  |        1 |        0 |        0 |        0 |    100% |
| numpy/f2py/\_backends/\_\_init\_\_.py          |        5 |        4 |        2 |        0 |     14% |
| numpy/f2py/\_backends/\_backend.py             |       22 |       17 |        0 |        0 |     23% |
| numpy/f2py/\_backends/\_meson.py               |      133 |       60 |       30 |        3 |     49% |
| numpy/f2py/\_isocbind.py                       |        7 |        0 |        4 |        0 |    100% |
| numpy/f2py/\_isofenv.py                        |        5 |        0 |        4 |        0 |    100% |
| numpy/f2py/\_src\_pyf.py                       |      148 |       28 |       52 |        6 |     77% |
| numpy/f2py/auxfuncs.py                         |      632 |      146 |      328 |       51 |     72% |
| numpy/f2py/capi\_maps.py                       |      500 |      256 |      306 |       57 |     45% |
| numpy/f2py/cb\_rules.py                        |      106 |       97 |       74 |        0 |      5% |
| numpy/f2py/cfuncs.py                           |      241 |       39 |       78 |       11 |     76% |
| numpy/f2py/common\_rules.py                    |      114 |       80 |       46 |        5 |     27% |
| numpy/f2py/crackfortran.py                     |     2584 |     1051 |     1620 |      250 |     55% |
| numpy/f2py/diagnose.py                         |       46 |       41 |        6 |        1 |     12% |
| numpy/f2py/f2py2e.py                           |      430 |      152 |      236 |       26 |     65% |
| numpy/f2py/f90mod\_rules.py                    |      183 |       69 |       68 |       19 |     59% |
| numpy/f2py/func2subr.py                        |      270 |      141 |      170 |       31 |     44% |
| numpy/f2py/rules.py                            |      275 |       36 |      146 |       22 |     86% |
| numpy/f2py/symbolic.py                         |     1006 |      562 |      564 |       93 |     39% |
| numpy/f2py/use\_rules.py                       |       41 |       35 |       22 |        0 |     10% |
| numpy/fft/\_\_init\_\_.py                      |        8 |        0 |        0 |        0 |    100% |
| numpy/fft/\_helper.py                          |       46 |        2 |       12 |        2 |     93% |
| numpy/fft/\_pocketfft.py                       |      154 |        4 |       52 |        2 |     97% |
| numpy/lib/\_\_init\_\_.py                      |       19 |       14 |        6 |        3 |     32% |
| numpy/lib/\_array\_utils\_impl.py              |       20 |        6 |        6 |        0 |     77% |
| numpy/lib/\_arraypad\_impl.py                  |      257 |       23 |      112 |        2 |     93% |
| numpy/lib/\_arraysetops\_impl.py               |      288 |       58 |      100 |        1 |     85% |
| numpy/lib/\_arrayterator\_impl.py              |       73 |       22 |       28 |        6 |     72% |
| numpy/lib/\_datasource.py                      |      177 |       62 |       54 |        7 |     66% |
| numpy/lib/\_format\_impl.py                    |      308 |       98 |      110 |       10 |     72% |
| numpy/lib/\_function\_base\_impl.py            |     1322 |      204 |      550 |       34 |     87% |
| numpy/lib/\_histograms\_impl.py                |      277 |       39 |      106 |        5 |     89% |
| numpy/lib/\_index\_tricks\_impl.py             |      260 |      100 |      100 |        7 |     69% |
| numpy/lib/\_iotools.py                         |      350 |       84 |      152 |       13 |     78% |
| numpy/lib/\_nanfunctions\_impl.py              |      346 |       76 |      160 |       15 |     82% |
| numpy/lib/\_npyio\_impl.py                     |      772 |      129 |      406 |       31 |     86% |
| numpy/lib/\_polynomial\_impl.py                |      434 |      147 |      174 |       39 |     69% |
| numpy/lib/\_scimath\_impl.py                   |       79 |       79 |        8 |        0 |      0% |
| numpy/lib/\_shape\_base\_impl.py               |      233 |       63 |       70 |        7 |     77% |
| numpy/lib/\_stride\_tricks\_impl.py            |      102 |       24 |       38 |        1 |     82% |
| numpy/lib/\_twodim\_base\_impl.py              |      196 |       66 |       52 |        6 |     69% |
| numpy/lib/\_type\_check\_impl.py               |      129 |       43 |       30 |        1 |     72% |
| numpy/lib/\_ufunclike\_impl.py                 |       28 |       11 |        0 |        0 |     61% |
| numpy/lib/\_user\_array\_impl.py               |      169 |      101 |       14 |        1 |     38% |
| numpy/lib/\_utils\_impl.py                     |      230 |      157 |      100 |       13 |     34% |
| numpy/lib/\_version.py                         |       76 |       23 |       38 |        5 |     75% |
| numpy/lib/array\_utils.py                      |        1 |        1 |        0 |        0 |      0% |
| numpy/lib/format.py                            |        1 |        1 |        0 |        0 |      0% |
| numpy/lib/introspect.py                        |       20 |       20 |       12 |        0 |      0% |
| numpy/lib/mixins.py                            |       60 |       48 |        4 |        0 |     25% |
| numpy/lib/npyio.py                             |        1 |        1 |        0 |        0 |      0% |
| numpy/lib/recfunctions.py                      |      597 |       41 |      290 |       29 |     92% |
| numpy/lib/scimath.py                           |        1 |        1 |        0 |        0 |      0% |
| numpy/lib/stride\_tricks.py                    |        1 |        1 |        0 |        0 |      0% |
| numpy/lib/user\_array.py                       |        1 |        0 |        0 |        0 |    100% |
| numpy/linalg/\_\_init\_\_.py                   |        6 |        6 |        0 |        0 |      0% |
| numpy/linalg/\_linalg.py                       |      713 |      168 |      234 |       11 |     81% |
| numpy/ma/\_\_init\_\_.py                       |        9 |        9 |        0 |        0 |      0% |
| numpy/ma/core.py                               |     2488 |      763 |      980 |       97 |     74% |
| numpy/ma/extras.py                             |      554 |      164 |      216 |       31 |     73% |
| numpy/ma/mrecords.py                           |      331 |       89 |      108 |       19 |     69% |
| numpy/ma/testutils.py                          |      125 |       28 |       54 |       12 |     73% |
| numpy/matlib.py                                |       45 |        4 |        8 |        4 |     85% |
| numpy/matrixlib/\_\_init\_\_.py                |        6 |        6 |        0 |        0 |      0% |
| numpy/matrixlib/defmatrix.py                   |      238 |       72 |       92 |       13 |     74% |
| numpy/polynomial/\_\_init\_\_.py               |       18 |        0 |        4 |        0 |    100% |
| numpy/polynomial/\_polybase.py                 |      435 |       61 |      120 |       19 |     86% |
| numpy/polynomial/chebyshev.py                  |      357 |       23 |      112 |        9 |     93% |
| numpy/polynomial/hermite.py                    |      269 |        6 |       86 |        6 |     97% |
| numpy/polynomial/hermite\_e.py                 |      264 |        6 |       86 |        6 |     97% |
| numpy/polynomial/laguerre.py                   |      254 |        5 |       80 |        5 |     97% |
| numpy/polynomial/legendre.py                   |      261 |        1 |       84 |        1 |     99% |
| numpy/polynomial/polynomial.py                 |      237 |        2 |       86 |        2 |     99% |
| numpy/polynomial/polyutils.py                  |      248 |        2 |      120 |        4 |     98% |
| numpy/random/\_\_init\_\_.py                   |       15 |        1 |        0 |        0 |     93% |
| numpy/random/\_examples/cffi/extending.py      |       20 |        0 |        2 |        0 |    100% |
| numpy/random/\_examples/cffi/parse.py          |       33 |        0 |       18 |        0 |    100% |
| numpy/random/\_pickle.py                       |       23 |        1 |        8 |        1 |     94% |
| numpy/rec/\_\_init\_\_.py                      |        2 |        0 |        0 |        0 |    100% |
| numpy/strings/\_\_init\_\_.py                  |        2 |        0 |        0 |        0 |    100% |
| numpy/testing/\_\_init\_\_.py                  |        9 |        9 |        0 |        0 |      0% |
| numpy/testing/\_private/\_\_init\_\_.py        |        0 |        0 |        0 |        0 |    100% |
| numpy/testing/\_private/extbuild.py            |       85 |       22 |       16 |        7 |     71% |
| numpy/testing/\_private/hypothesis\_helpers.py |       31 |       23 |        0 |        0 |     26% |
| numpy/testing/\_private/utils.py               |     1010 |      374 |      372 |       44 |     65% |
| numpy/testing/overrides.py                     |       13 |       11 |        0 |        0 |     15% |
| numpy/testing/print\_coercion\_tables.py       |      146 |      134 |       54 |        1 |      6% |
| numpy/typing/\_\_init\_\_.py                   |       22 |        4 |        6 |        3 |     75% |
| numpy/version.py                               |        6 |        6 |        0 |        0 |      0% |
| **TOTAL**                                      | **28786** | **8967** | **11740** | **1310** | **70%** |
```

</p>
</details> 

<details><summary>After</summary>
<p>

```md
| Name                                           |    Stmts |     Miss |   Branch |   BrPart |   Cover |
|----------------------------------------------- | -------: | -------: | -------: | -------: | ------: |
| numpy/\_\_config\_\_.py                        |       32 |        3 |        6 |        0 |     92% |
| numpy/\_\_init\_\_.py                          |      191 |       47 |       66 |       17 |     72% |
| numpy/\_array\_api\_info.py                    |       39 |        0 |       24 |        0 |    100% |
| numpy/\_configtool.py                          |       20 |       20 |        8 |        0 |      0% |
| numpy/\_core/\_\_init\_\_.py                   |       88 |       13 |       18 |        3 |     81% |
| numpy/\_core/\_add\_newdocs.py                 |      235 |        0 |        4 |        0 |    100% |
| numpy/\_core/\_add\_newdocs\_scalars.py        |       68 |        5 |       12 |        0 |     91% |
| numpy/\_core/\_asarray.py                      |       31 |        1 |       16 |        1 |     96% |
| numpy/\_core/\_dtype.py                        |      174 |        4 |       96 |        2 |     98% |
| numpy/\_core/\_dtype\_ctypes.py                |       54 |        1 |       26 |        1 |     98% |
| numpy/\_core/\_exceptions.py                   |       84 |        0 |       12 |        0 |    100% |
| numpy/\_core/\_internal.py                     |      461 |       69 |      192 |       23 |     83% |
| numpy/\_core/\_methods.py                      |      142 |        3 |       72 |        2 |     98% |
| numpy/\_core/\_string\_helpers.py              |       15 |        7 |        2 |        0 |     47% |
| numpy/\_core/\_type\_aliases.py                |       51 |        2 |       24 |        2 |     95% |
| numpy/\_core/\_ufunc\_config.py                |       72 |        5 |        8 |        1 |     92% |
| numpy/\_core/arrayprint.py                     |      607 |       25 |      280 |       22 |     94% |
| numpy/\_core/cversions.py                      |        6 |        6 |        2 |        0 |      0% |
| numpy/\_core/defchararray.py                   |      223 |        5 |       50 |        6 |     96% |
| numpy/\_core/einsumfunc.py                     |      491 |       20 |      268 |       16 |     95% |
| numpy/\_core/fromnumeric.py                    |      450 |        4 |      114 |        5 |     98% |
| numpy/\_core/function\_base.py                 |      133 |        9 |       54 |        5 |     89% |
| numpy/\_core/getlimits.py                      |      171 |       11 |       42 |        5 |     91% |
| numpy/\_core/memmap.py                         |      101 |        5 |       38 |        5 |     93% |
| numpy/\_core/multiarray.py                     |      110 |        0 |        6 |        0 |    100% |
| numpy/\_core/numeric.py                        |      477 |       29 |      136 |        9 |     92% |
| numpy/\_core/numerictypes.py                   |      116 |        3 |       42 |        0 |     98% |
| numpy/\_core/overrides.py                      |       58 |        1 |       18 |        1 |     97% |
| numpy/\_core/printoptions.py                   |        5 |        0 |        0 |        0 |    100% |
| numpy/\_core/records.py                        |      359 |       80 |      166 |       33 |     74% |
| numpy/\_core/shape\_base.py                    |      191 |        3 |       74 |        3 |     98% |
| numpy/\_core/strings.py                        |      331 |       11 |       70 |        8 |     95% |
| numpy/\_core/umath.py                          |        5 |        0 |        0 |        0 |    100% |
| numpy/\_distributor\_init.py                   |        4 |        0 |        0 |        0 |    100% |
| numpy/\_expired\_attrs\_2\_0.py                |        1 |        0 |        0 |        0 |    100% |
| numpy/\_globals.py                             |       34 |        6 |       10 |        1 |     75% |
| numpy/\_pyinstaller/\_\_init\_\_.py            |        0 |        0 |        0 |        0 |    100% |
| numpy/\_pyinstaller/hook-numpy.py              |        8 |        8 |        2 |        0 |      0% |
| numpy/\_pytesttester.py                        |       43 |       34 |       16 |        0 |     15% |
| numpy/\_typing/\_\_init\_\_.py                 |        8 |        0 |        0 |        0 |    100% |
| numpy/\_typing/\_add\_docstring.py             |       32 |        0 |        8 |        0 |    100% |
| numpy/\_typing/\_array\_like.py                |       34 |        0 |        0 |        0 |    100% |
| numpy/\_typing/\_char\_codes.py                |       49 |        0 |        0 |        0 |    100% |
| numpy/\_typing/\_dtype\_like.py                |       32 |        0 |        0 |        0 |    100% |
| numpy/\_typing/\_nbit.py                       |       12 |        0 |        0 |        0 |    100% |
| numpy/\_typing/\_nbit\_base.py                 |       34 |        1 |        2 |        1 |     94% |
| numpy/\_typing/\_nested\_sequence.py           |       20 |        7 |        0 |        0 |     65% |
| numpy/\_typing/\_scalars.py                    |       12 |        0 |        0 |        0 |    100% |
| numpy/\_typing/\_shape.py                      |        5 |        0 |        0 |        0 |    100% |
| numpy/\_utils/\_\_init\_\_.py                  |       34 |       21 |       12 |        1 |     35% |
| numpy/\_utils/\_conversions.py                 |        9 |        0 |        4 |        0 |    100% |
| numpy/\_utils/\_inspect.py                     |       67 |       33 |       32 |        4 |     44% |
| numpy/\_utils/\_pep440.py                      |      198 |       97 |       60 |       10 |     43% |
| numpy/char/\_\_init\_\_.py                     |       13 |        0 |        4 |        0 |    100% |
| numpy/core/\_\_init\_\_.py                     |       10 |        0 |        0 |        0 |    100% |
| numpy/core/\_dtype.py                          |        8 |        8 |        2 |        0 |      0% |
| numpy/core/\_dtype\_ctypes.py                  |        8 |        8 |        2 |        0 |      0% |
| numpy/core/\_internal.py                       |       13 |        7 |        2 |        0 |     40% |
| numpy/core/\_multiarray\_umath.py              |       28 |       20 |       12 |        0 |     30% |
| numpy/core/\_utils.py                          |        8 |        0 |        2 |        0 |    100% |
| numpy/core/arrayprint.py                       |        8 |        0 |        2 |        0 |    100% |
| numpy/core/defchararray.py                     |        8 |        0 |        2 |        0 |    100% |
| numpy/core/einsumfunc.py                       |        8 |        0 |        2 |        0 |    100% |
| numpy/core/fromnumeric.py                      |        8 |        0 |        2 |        0 |    100% |
| numpy/core/function\_base.py                   |        8 |        0 |        2 |        0 |    100% |
| numpy/core/getlimits.py                        |        8 |        0 |        2 |        0 |    100% |
| numpy/core/multiarray.py                       |       13 |        0 |        4 |        0 |    100% |
| numpy/core/numeric.py                          |        9 |        0 |        2 |        0 |    100% |
| numpy/core/numerictypes.py                     |        8 |        0 |        2 |        0 |    100% |
| numpy/core/overrides.py                        |        8 |        0 |        2 |        0 |    100% |
| numpy/core/records.py                          |        8 |        0 |        2 |        0 |    100% |
| numpy/core/shape\_base.py                      |        8 |        0 |        2 |        0 |    100% |
| numpy/core/umath.py                            |        8 |        0 |        2 |        0 |    100% |
| numpy/ctypeslib/\_\_init\_\_.py                |        1 |        0 |        0 |        0 |    100% |
| numpy/ctypeslib/\_ctypeslib.py                 |      232 |       34 |       98 |       13 |     85% |
| numpy/dtypes.py                                |       12 |        0 |        2 |        0 |    100% |
| numpy/exceptions.py                            |       35 |        2 |        8 |        2 |     91% |
| numpy/f2py/\_\_init\_\_.py                     |       19 |        0 |        2 |        0 |    100% |
| numpy/f2py/\_\_main\_\_.py                     |        2 |        0 |        0 |        0 |    100% |
| numpy/f2py/\_\_version\_\_.py                  |        1 |        0 |        0 |        0 |    100% |
| numpy/f2py/\_backends/\_\_init\_\_.py          |        5 |        1 |        2 |        1 |     71% |
| numpy/f2py/\_backends/\_backend.py             |       22 |        1 |        0 |        0 |     95% |
| numpy/f2py/\_backends/\_meson.py               |      133 |       11 |       30 |        7 |     87% |
| numpy/f2py/\_isocbind.py                       |        7 |        0 |        4 |        0 |    100% |
| numpy/f2py/\_isofenv.py                        |        5 |        0 |        4 |        0 |    100% |
| numpy/f2py/\_src\_pyf.py                       |      148 |       28 |       52 |        6 |     77% |
| numpy/f2py/auxfuncs.py                         |      632 |      118 |      328 |       61 |     77% |
| numpy/f2py/capi\_maps.py                       |      500 |      237 |      306 |       48 |     50% |
| numpy/f2py/cb\_rules.py                        |      106 |       97 |       74 |        0 |      5% |
| numpy/f2py/cfuncs.py                           |      241 |       39 |       78 |       11 |     76% |
| numpy/f2py/common\_rules.py                    |      114 |       80 |       46 |        5 |     27% |
| numpy/f2py/crackfortran.py                     |     2584 |      974 |     1620 |      241 |     59% |
| numpy/f2py/diagnose.py                         |       46 |       41 |        6 |        1 |     12% |
| numpy/f2py/f2py2e.py                           |      430 |       73 |      236 |       36 |     80% |
| numpy/f2py/f90mod\_rules.py                    |      183 |       36 |       68 |       14 |     78% |
| numpy/f2py/func2subr.py                        |      270 |       49 |      170 |       31 |     79% |
| numpy/f2py/rules.py                            |      275 |       28 |      146 |       18 |     89% |
| numpy/f2py/symbolic.py                         |     1006 |      433 |      564 |      105 |     53% |
| numpy/f2py/use\_rules.py                       |       41 |       35 |       22 |        0 |     10% |
| numpy/fft/\_\_init\_\_.py                      |        8 |        0 |        0 |        0 |    100% |
| numpy/fft/\_helper.py                          |       46 |        2 |       12 |        2 |     93% |
| numpy/fft/\_pocketfft.py                       |      154 |        4 |       52 |        2 |     97% |
| numpy/lib/\_\_init\_\_.py                      |       19 |        3 |        6 |        3 |     76% |
| numpy/lib/\_array\_utils\_impl.py              |       20 |        0 |        6 |        0 |    100% |
| numpy/lib/\_arraypad\_impl.py                  |      257 |        2 |      112 |        2 |     99% |
| numpy/lib/\_arraysetops\_impl.py               |      288 |        3 |      100 |        1 |     99% |
| numpy/lib/\_arrayterator\_impl.py              |       73 |        8 |       28 |        6 |     86% |
| numpy/lib/\_datasource.py                      |      177 |       25 |       54 |        7 |     82% |
| numpy/lib/\_format\_impl.py                    |      308 |       48 |      110 |       10 |     84% |
| numpy/lib/\_function\_base\_impl.py            |     1322 |       44 |      550 |       34 |     96% |
| numpy/lib/\_histograms\_impl.py                |      277 |        6 |      106 |        5 |     97% |
| numpy/lib/\_index\_tricks\_impl.py             |      260 |       21 |      100 |        7 |     91% |
| numpy/lib/\_iotools.py                         |      350 |       31 |      152 |       14 |     89% |
| numpy/lib/\_nanfunctions\_impl.py              |      346 |       14 |      160 |       15 |     94% |
| numpy/lib/\_npyio\_impl.py                     |      772 |       50 |      406 |       31 |     92% |
| numpy/lib/\_polynomial\_impl.py                |      434 |       59 |      174 |       39 |     83% |
| numpy/lib/\_scimath\_impl.py                   |       79 |       38 |        8 |        0 |     47% |
| numpy/lib/\_shape\_base\_impl.py               |      233 |        9 |       70 |        7 |     95% |
| numpy/lib/\_stride\_tricks\_impl.py            |      102 |        0 |       38 |        1 |     99% |
| numpy/lib/\_twodim\_base\_impl.py              |      196 |       11 |       52 |        6 |     92% |
| numpy/lib/\_type\_check\_impl.py               |      129 |        1 |       30 |        1 |     99% |
| numpy/lib/\_ufunclike\_impl.py                 |       28 |        0 |        0 |        0 |    100% |
| numpy/lib/\_user\_array\_impl.py               |      169 |      101 |       14 |        1 |     38% |
| numpy/lib/\_utils\_impl.py                     |      230 |      134 |      100 |       13 |     41% |
| numpy/lib/\_version.py                         |       76 |        8 |       38 |        5 |     89% |
| numpy/lib/array\_utils.py                      |        1 |        0 |        0 |        0 |    100% |
| numpy/lib/format.py                            |        1 |        0 |        0 |        0 |    100% |
| numpy/lib/introspect.py                        |       20 |       18 |       12 |        0 |      6% |
| numpy/lib/mixins.py                            |       60 |        0 |        4 |        0 |    100% |
| numpy/lib/npyio.py                             |        1 |        0 |        0 |        0 |    100% |
| numpy/lib/recfunctions.py                      |      597 |       41 |      290 |       29 |     92% |
| numpy/lib/scimath.py                           |        1 |        0 |        0 |        0 |    100% |
| numpy/lib/stride\_tricks.py                    |        1 |        0 |        0 |        0 |    100% |
| numpy/lib/user\_array.py                       |        1 |        0 |        0 |        0 |    100% |
| numpy/linalg/\_\_init\_\_.py                   |        6 |        0 |        0 |        0 |    100% |
| numpy/linalg/\_linalg.py                       |      713 |       22 |      234 |       11 |     97% |
| numpy/ma/\_\_init\_\_.py                       |        9 |        0 |        0 |        0 |    100% |
| numpy/ma/core.py                               |     2488 |      192 |      980 |      101 |     91% |
| numpy/ma/extras.py                             |      554 |       78 |      216 |       32 |     84% |
| numpy/ma/mrecords.py                           |      331 |       89 |      108 |       19 |     69% |
| numpy/ma/testutils.py                          |      125 |       28 |       54 |       12 |     73% |
| numpy/matlib.py                                |       45 |        4 |        8 |        4 |     85% |
| numpy/matrixlib/\_\_init\_\_.py                |        6 |        0 |        0 |        0 |    100% |
| numpy/matrixlib/defmatrix.py                   |      238 |       13 |       92 |       13 |     92% |
| numpy/polynomial/\_\_init\_\_.py               |       18 |        0 |        4 |        0 |    100% |
| numpy/polynomial/\_polybase.py                 |      435 |       61 |      120 |       19 |     86% |
| numpy/polynomial/chebyshev.py                  |      357 |       23 |      112 |        9 |     93% |
| numpy/polynomial/hermite.py                    |      269 |        6 |       86 |        6 |     97% |
| numpy/polynomial/hermite\_e.py                 |      264 |        6 |       86 |        6 |     97% |
| numpy/polynomial/laguerre.py                   |      254 |        5 |       80 |        5 |     97% |
| numpy/polynomial/legendre.py                   |      261 |        1 |       84 |        1 |     99% |
| numpy/polynomial/polynomial.py                 |      237 |        2 |       86 |        2 |     99% |
| numpy/polynomial/polyutils.py                  |      248 |        2 |      120 |        4 |     98% |
| numpy/random/\_\_init\_\_.py                   |       15 |        1 |        0 |        0 |     93% |
| numpy/random/\_examples/cffi/extending.py      |       20 |        0 |        2 |        0 |    100% |
| numpy/random/\_examples/cffi/parse.py          |       33 |        0 |       18 |        0 |    100% |
| numpy/random/\_pickle.py                       |       23 |        1 |        8 |        1 |     94% |
| numpy/rec/\_\_init\_\_.py                      |        2 |        0 |        0 |        0 |    100% |
| numpy/strings/\_\_init\_\_.py                  |        2 |        0 |        0 |        0 |    100% |
| numpy/testing/\_\_init\_\_.py                  |        9 |        0 |        0 |        0 |    100% |
| numpy/testing/\_private/\_\_init\_\_.py        |        0 |        0 |        0 |        0 |    100% |
| numpy/testing/\_private/extbuild.py            |       85 |        7 |       16 |        7 |     86% |
| numpy/testing/\_private/hypothesis\_helpers.py |       31 |       23 |        0 |        0 |     26% |
| numpy/testing/\_private/utils.py               |     1010 |      234 |      372 |       50 |     76% |
| numpy/testing/overrides.py                     |       13 |        4 |        0 |        0 |     69% |
| numpy/testing/print\_coercion\_tables.py       |      146 |      134 |       54 |        1 |      6% |
| numpy/typing/\_\_init\_\_.py                   |       22 |        4 |        6 |        3 |     75% |
| numpy/version.py                               |        6 |        0 |        0 |        0 |    100% |
| **TOTAL**                                      | **28786** | **4580** | **11740** | **1334** | **81%** |
```


</p>
</details> 

AI analyzed diff:

TOTAL 70% → 81%, missed statements 8,967 → 4,580 (−4,387).

  Biggest real recoveries:
  - numpy/ma/core.py: 74% → 91% (571 statements)
  - numpy/testing/_private/utils.py: 65% → 76% (140)
  - numpy/_core/fromnumeric.py: 71% → 98% (152)
  - numpy/f2py/*: the target modules — func2subr.py 44→79%, f2py2e.py 65→80%, symbolic.py 39→53%, crackfortran.py 55→59%
  - numpy/lib/_scimath_impl.py: 0% → 47% — this is Rec 1's np.emath module; the 0% was partly a measurement artifact, though 47% confirms there's still a genuine testing gap there.

#### AI Disclosure
I used Opus to root cause the issue

