### PR TITLE
TYP: ``ndarray.repeat`` shape-typing

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3933,10 +3933,27 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     ) -> ArrayT: ...
 
     # keep in sync with `ma.MaskedArray.repeat`
-    @overload
-    def repeat(self, repeats: _ArrayLikeInt_co, /, axis: None = None) -> ndarray[tuple[int], _DTypeT_co]: ...
-    @overload
-    def repeat(self, repeats: _ArrayLikeInt_co, /, axis: SupportsIndex) -> ndarray[_AnyShape, _DTypeT_co]: ...
+    @overload  # axis=None  (default)
+    def repeat(
+        self,
+        repeats: _ArrayLikeInt_co,
+        /,
+        axis: None = None,
+    ) -> ndarray[tuple[int], _DTypeT_co]: ...
+    @overload  # >=1d, axis=<given>
+    def repeat[DTypeT: dtype, ShapeT: tuple[int, *tuple[int, ...]]](
+        self: ndarray[ShapeT, DTypeT],
+        repeats: _ArrayLikeInt_co,
+        /,
+        axis: SupportsIndex,
+    ) -> ndarray[ShapeT, DTypeT]: ...
+    @overload  # 0d, axis=<given>
+    def repeat[DTypeT: dtype](
+        self: ndarray[tuple[()], DTypeT],
+        repeats: _ArrayLikeInt_co,
+        /,
+        axis: SupportsIndex,
+    ) -> ndarray[tuple[int], DTypeT]: ...
 
     # keep in sync with `ma.MaskedArray.flatten` and `ma.MaskedArray.ravel`
     def flatten(self, /, order: _OrderKACF = "C") -> ndarray[tuple[int], _DTypeT_co]: ...

--- a/numpy/ma/core.pyi
+++ b/numpy/ma/core.pyi
@@ -2743,20 +2743,27 @@ class MaskedArray(ndarray[_ShapeT_co, _DTypeT_co]):
 
     # keep in sync with `ndarray.repeat`
     @override
-    @overload
+    @overload  # axis=None  (default)
     def repeat(
         self,
-        /,
         repeats: _ArrayLikeInt_co,
+        /,
         axis: None = None,
     ) -> MaskedArray[tuple[int], _DTypeT_co]: ...
-    @overload
-    def repeat(
-        self,
-        /,
+    @overload  # >=1d, axis=<given>
+    def repeat[DTypeT: dtype, ShapeT: tuple[int, *tuple[int, ...]]](
+        self: MaskedArray[ShapeT, DTypeT],
         repeats: _ArrayLikeInt_co,
+        /,
         axis: SupportsIndex,
-    ) -> MaskedArray[_AnyShape, _DTypeT_co]: ...
+    ) -> MaskedArray[ShapeT, DTypeT]: ...
+    @overload  # 0d, axis=<given>
+    def repeat[DTypeT: dtype](
+        self: MaskedArray[tuple[()], DTypeT],
+        repeats: _ArrayLikeInt_co,
+        /,
+        axis: SupportsIndex,
+    ) -> MaskedArray[tuple[int], DTypeT]: ...
 
     # keep in sync with `ndarray.flatten` and `ndarray.ravel`
     @override

--- a/numpy/typing/tests/data/reveal/ma.pyi
+++ b/numpy/typing/tests/data/reveal/ma.pyi
@@ -351,7 +351,7 @@ assert_type(np.ma.filled(MAR_1d), np.ndarray[tuple[int], np.dtype])  # type: ign
 assert_type(MAR_b.repeat(3), np.ma.MaskedArray[tuple[int], np.dtype[np.bool]])
 assert_type(MAR_2d_f4.repeat(MAR_i8), np.ma.MaskedArray[tuple[int], np.dtype[np.float32]])
 assert_type(MAR_2d_f4.repeat(MAR_i8, axis=None), np.ma.MaskedArray[tuple[int], np.dtype[np.float32]])
-assert_type(MAR_2d_f4.repeat(MAR_i8, axis=0), MaskedArray[np.float32])
+assert_type(MAR_2d_f4.repeat(MAR_i8, axis=0), np.ma.MaskedArray[tuple[int, int], np.dtype[np.float32]])
 
 assert_type(np.ma.allequal(AR_f4, MAR_f4), bool)
 assert_type(np.ma.allequal(AR_f4, MAR_f4, fill_value=False), bool)

--- a/numpy/typing/tests/data/reveal/ndarray_misc.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.pyi
@@ -325,6 +325,8 @@ assert_type(f8.repeat(1), np.ndarray[tuple[int], np.dtype[np.float64]])
 assert_type(f8.repeat(1, axis=0), np.ndarray[tuple[int], np.dtype[np.float64]])
 assert_type(AR_f8.repeat(1), np.ndarray[tuple[int], np.dtype[np.float64]])
 assert_type(AR_f8.repeat(1, axis=0), npt.NDArray[np.float64])
+assert_type(AR_f8_1d.repeat(1, axis=0), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(AR_f8_2d.repeat(1, axis=0), np.ndarray[tuple[int, int], np.dtype[np.float64]])
 assert_type(B.repeat(1), np.ndarray[tuple[int], np.dtype[np.object_]])
 assert_type(B.repeat(1, axis=0), npt.NDArray[np.object_])
 


### PR DESCRIPTION
`ndarray.repeat` (and `ma.MaskedArray.repeat`) now propagates its shape-type when `axis` is given and >=1d, or returns the 1d shape-type when 0d.

---

Fully written by me, pre-reviewed and audited by AI (see [gist](https://gist.github.com/jorenham/36c78602a7ca866ddb2a917de48ccdd0)).