### PR TITLE
TYP: ``ndarray.compress`` shape-typing

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -3718,6 +3718,50 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     ) -> ArrayT: ...
 
     #
+    @override  # type:ignore[override]  # false positive
+    @overload  # axis=None (default)
+    def compress(
+        self,
+        /,
+        condition: _ArrayLikeInt_co,
+        axis: None = None,
+        out: None = None,
+    ) -> ndarray[tuple[int], _DTypeT_co]: ...
+    @overload  # >=1d, axis=<given>
+    def compress[DTypeT: dtype, ShapeT: tuple[int, *tuple[int, ...]]](
+        self: ndarray[ShapeT, DTypeT],
+        /,
+        condition: _ArrayLikeInt_co,
+        axis: SupportsIndex,
+        out: None = None,
+    ) -> ndarray[ShapeT, DTypeT]: ...
+    @overload  # 0d, axis=<given>
+    def compress[DTypeT: dtype](
+        self: ndarray[tuple[()], DTypeT],
+        /,
+        condition: _ArrayLikeInt_co,
+        axis: SupportsIndex,
+        out: None = None,
+    ) -> ndarray[tuple[int], DTypeT]: ...
+    @overload  # out=<given>  (positional)
+    def compress[ArrayT: ndarray](
+        self,
+        /,
+        condition: _ArrayLikeInt_co,
+        axis: SupportsIndex | None,
+        out: ArrayT,
+    ) -> ArrayT: ...
+    @overload  # out=<given>  (keyword)
+    def compress[ArrayT: ndarray](
+        self,
+        /,
+        condition: _ArrayLikeInt_co,
+        axis: SupportsIndex | None = None,
+        *,
+        out: ArrayT,
+    ) -> ArrayT: ...
+
+    #
     @overload
     def partition(
         self,

--- a/numpy/typing/tests/data/reveal/ndarray_misc.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_misc.pyi
@@ -109,8 +109,12 @@ assert_type(AR_f8.clip(1, out=B), SubClass)
 assert_type(AR_f8.clip(None, 1, out=B), SubClass)
 
 assert_type(f8.compress([0]), npt.NDArray[Any])
-assert_type(AR_f8.compress([0]), npt.NDArray[Any])
+assert_type(AR_f8.compress([0]), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(AR_f8.compress([0], axis=0), npt.NDArray[np.float64])
 assert_type(AR_f8.compress([0], out=B), SubClass)
+assert_type(AR_f8_1d.compress([0]), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(AR_f8_1d.compress([0], axis=0), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(AR_f8_2d.compress([0], axis=0), np.ndarray[tuple[int, int], np.dtype[np.float64]])
 
 assert_type(f8.conj(), np.float64)
 assert_type(AR_f8.conj(), npt.NDArray[np.float64])


### PR DESCRIPTION
`ndarray.compress` now also propagates its shape-type when `axis` is given and >=1d, or returns the 1d shape-type when 0d.

---

Fully written by me, pre-reviewed and audited by AI (see [gist](https://gist.github.com/jorenham/36c78602a7ca866ddb2a917de48ccdd0)).