### PR TITLE
TYP: ``ndarray.getfield`` shape-typing

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -4072,12 +4072,26 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     @overload  # (dtype: ?, type: T)
     def view[ArrayT: ndarray](self, /, dtype: DTypeLike, type: type[ArrayT]) -> ArrayT: ...
 
+    #
     def setfield(self, val: ArrayLike, /, dtype: DTypeLike, offset: SupportsIndex = 0) -> None: ...
-    @overload
-    def getfield[ScalarT: generic](self, /, dtype: _DTypeLike[ScalarT], offset: SupportsIndex = 0) -> NDArray[ScalarT]: ...
-    @overload
-    def getfield(self, /, dtype: DTypeLike, offset: SupportsIndex = 0) -> NDArray[Any]: ...
 
+    #
+    @overload
+    def getfield[ScalarT: generic](
+        self,
+        /,
+        dtype: _DTypeLike[ScalarT],
+        offset: SupportsIndex = 0,
+    ) -> ndarray[_ShapeT_co, dtype[ScalarT]]: ...
+    @overload
+    def getfield(
+        self,
+        /,
+        dtype: DTypeLike,
+        offset: SupportsIndex = 0,
+    ) -> ndarray[_ShapeT_co, dtype[Any]]: ...
+
+    #
     def __index__(self: NDArray[integer], /) -> int: ...
     def __complex__(self: NDArray[number | bool_ | object_], /) -> complex: ...
 

--- a/numpy/typing/tests/data/reveal/ndarray_conversion.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_conversion.pyi
@@ -78,6 +78,8 @@ assert_type(i0_nd.getfield("float"), npt.NDArray[Any])
 assert_type(i0_nd.getfield(float), npt.NDArray[Any])
 assert_type(i0_nd.getfield(np.float64), npt.NDArray[np.float64])
 assert_type(i0_nd.getfield(np.float64, 8), npt.NDArray[np.float64])
+assert_type(u2_1d.getfield("f"), np.ndarray[tuple[int]])
+assert_type(u2_1d.getfield(np.float64), np.ndarray[tuple[int], np.dtype[np.float64]])
 
 # setflags does not return a value
 # fill does not return a value


### PR DESCRIPTION
`ndarray.getfield` always returns an array with same shape as the original, so this was an easy one.

---

No AI.