### PR TITLE
TYP: Apply `@disjoint_base` (PEP 800)

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -156,7 +156,7 @@ from typing import (
 # library include `typing_extensions` stubs:
 # https://github.com/python/typeshed/blob/main/stdlib/typing_extensions.pyi
 from _typeshed import Incomplete, StrOrBytesPath, SupportsFlush, SupportsLenAndGetItem, SupportsWrite
-from typing_extensions import CapsuleType, TypeVar, deprecated
+from typing_extensions import CapsuleType, TypeVar, deprecated, disjoint_base
 
 from numpy import (
     char,
@@ -2185,6 +2185,7 @@ class _ArrayOrScalarCommon:
         correction: float | _NoValueType = ...,
     ) -> ArrayT: ...
 
+@disjoint_base
 class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     __hash__: ClassVar[None]  # type: ignore[assignment]  # pyright: ignore[reportIncompatibleMethodOverride]
     @property
@@ -5586,6 +5587,7 @@ class number(generic[_NumberItemT_co], Generic[_NBitT, _NumberItemT_co]):
         where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> ArrayT: ...
 
+@disjoint_base
 class bool(generic[_BoolItemT_co], Generic[_BoolItemT_co]):
     @property
     def itemsize(self) -> L[1]: ...
@@ -6708,6 +6710,7 @@ float16 = floating[_16Bit]
 float32 = floating[_32Bit]
 
 # either a C `double`, `float`, or `longdouble`
+@disjoint_base
 class float64(floating[_64Bit], float):  # type: ignore[misc]
     @property
     def itemsize(self) -> L[8]: ...
@@ -6966,6 +6969,7 @@ class complexfloating(inexact[_NBitT1, complex], Generic[_NBitT1, _NBitT2]):
 
 complex64 = complexfloating[_32Bit]
 
+@disjoint_base
 class complex128(complexfloating[_64Bit, _64Bit], complex):
     @property
     def itemsize(self) -> L[16]: ...
@@ -7019,6 +7023,7 @@ csingle = complex64
 cdouble = complex128
 clongdouble = complexfloating[_NBitLongDouble]
 
+@disjoint_base
 class timedelta64(_IntegralMixin, generic[_TD64ItemT_co], Generic[_TD64ItemT_co]):
     @property
     def itemsize(self) -> L[8]: ...
@@ -7383,6 +7388,7 @@ class timedelta64(_IntegralMixin, generic[_TD64ItemT_co], Generic[_TD64ItemT_co]
         where: _ArrayLikeBool_co | _NoValueType = ...,
     ) -> ArrayT: ...
 
+@disjoint_base
 class datetime64(_RealMixin, generic[_DT64ItemT_co], Generic[_DT64ItemT_co]):
     @property
     def itemsize(self) -> L[8]: ...
@@ -7526,6 +7532,7 @@ class datetime64(_RealMixin, generic[_DT64ItemT_co], Generic[_DT64ItemT_co]):
 @final  # cannot be subclassed at runtime
 class flexible(_RealMixin, generic[_FlexibleItemT_co], Generic[_FlexibleItemT_co]): ...  # type: ignore[misc]
 
+@disjoint_base
 class void(flexible[bytes | tuple[Any, ...]]):  # type: ignore[misc]
     @overload
     def __new__(cls, length_or_data: _IntLike_co | bytes, /, dtype: None = None) -> Self: ...
@@ -7569,6 +7576,7 @@ class character(flexible[_CharacterItemT_co], Generic[_CharacterItemT_co]):  # t
 
 # NOTE: Most `np.bytes_` / `np.str_` methods return their builtin `bytes` / `str` counterpart
 
+@disjoint_base
 class bytes_(character[bytes], bytes):  # type: ignore[misc]
     @overload
     def __new__(cls, value: object = b"", /) -> Self: ...
@@ -7589,6 +7597,7 @@ class bytes_(character[bytes], bytes):  # type: ignore[misc]
     #
     def __bytes__(self, /) -> bytes: ...
 
+@disjoint_base
 class str_(character[str], str):  # type: ignore[misc]
     @overload
     def __new__(cls, value: object = "", /) -> Self: ...

--- a/numpy/random/_generator.pyi
+++ b/numpy/random/_generator.pyi
@@ -2,6 +2,7 @@
 from builtins import bytes as py_bytes
 from collections.abc import Callable, MutableSequence, Sequence
 from typing import Any, Literal, Self, SupportsIndex, overload
+from typing_extensions import disjoint_base
 
 import numpy as np
 from numpy._typing import (
@@ -46,6 +47,7 @@ type _MethodExp = Literal["zig", "inv"]
 
 ###
 
+@disjoint_base
 class Generator:
     def __init__(self, bit_generator: BitGenerator) -> None: ...
     def __setstate__(self, state: dict[str, Any] | None) -> None: ...

--- a/numpy/random/_mt19937.pyi
+++ b/numpy/random/_mt19937.pyi
@@ -1,4 +1,5 @@
 from typing import TypedDict, type_check_only
+from typing_extensions import disjoint_base
 
 from numpy import uint32
 from numpy._typing import _ArrayLikeInt_co
@@ -17,6 +18,7 @@ class _MT19937State(TypedDict):
     bit_generator: str
     state: _MT19937Internal
 
+@disjoint_base
 class MT19937(BitGenerator):
     def __init__(self, seed: _ArrayLikeInt_co | SeedSequence | None = ...) -> None: ...
     def _legacy_seeding(self, seed: _ArrayLikeInt_co) -> None: ...

--- a/numpy/random/_pcg64.pyi
+++ b/numpy/random/_pcg64.pyi
@@ -1,4 +1,5 @@
 from typing import TypedDict, type_check_only
+from typing_extensions import disjoint_base
 
 from numpy._typing import _ArrayLikeInt_co
 from numpy.random.bit_generator import BitGenerator, SeedSequence
@@ -17,6 +18,7 @@ class _PCG64State(TypedDict):
     has_uint32: int
     uinteger: int
 
+@disjoint_base
 class PCG64(BitGenerator):
     def __init__(self, seed: _ArrayLikeInt_co | SeedSequence | None = ...) -> None: ...
     def jumped(self, jumps: int = 1) -> PCG64: ...
@@ -26,6 +28,7 @@ class PCG64(BitGenerator):
     def state(self, value: _PCG64State) -> None: ...
     def advance(self, delta: int) -> PCG64: ...
 
+@disjoint_base
 class PCG64DXSM(BitGenerator):
     def __init__(self, seed: _ArrayLikeInt_co | SeedSequence | None = ...) -> None: ...
     def jumped(self, jumps: int = 1) -> PCG64DXSM: ...

--- a/numpy/random/_philox.pyi
+++ b/numpy/random/_philox.pyi
@@ -1,4 +1,5 @@
 from typing import TypedDict, type_check_only
+from typing_extensions import disjoint_base
 
 from numpy import uint64
 from numpy._typing import _ArrayLikeInt_co
@@ -21,6 +22,7 @@ class _PhiloxState(TypedDict):
     has_uint32: int
     uinteger: int
 
+@disjoint_base
 class Philox(BitGenerator):
     def __init__(
         self,

--- a/numpy/random/_sfc64.pyi
+++ b/numpy/random/_sfc64.pyi
@@ -1,4 +1,5 @@
 from typing import TypedDict, type_check_only
+from typing_extensions import disjoint_base
 
 from numpy import uint64
 from numpy._typing import NDArray, _ArrayLikeInt_co
@@ -17,6 +18,7 @@ class _SFC64State(TypedDict):
     has_uint32: int
     uinteger: int
 
+@disjoint_base
 class SFC64(BitGenerator):
     def __init__(self, seed: _ArrayLikeInt_co | SeedSequence | None = ...) -> None: ...
     @property  # type: ignore[override]

--- a/numpy/random/bit_generator.pyi
+++ b/numpy/random/bit_generator.pyi
@@ -12,7 +12,7 @@ from typing import (
     overload,
     type_check_only,
 )
-from typing_extensions import CapsuleType
+from typing_extensions import CapsuleType, disjoint_base
 
 import numpy as np
 from numpy._typing import (
@@ -68,6 +68,7 @@ class ISpawnableSeedSequence(ISeedSequence, abc.ABC):
 class SeedlessSeedSequence(_GenerateStateMixin, ISpawnableSeedSequence):
     def spawn(self, /, n_children: int) -> list[Self]: ...
 
+@disjoint_base
 class SeedSequence(_GenerateStateMixin, ISpawnableSeedSequence):
     __pyx_vtable__: ClassVar[CapsuleType] = ...
 
@@ -90,6 +91,7 @@ class SeedSequence(_GenerateStateMixin, ISpawnableSeedSequence):
     @property
     def state(self) -> _SeedSeqState: ...
 
+@disjoint_base
 class BitGenerator(_CythonMixin, abc.ABC):
     lock: Lock
     @property

--- a/numpy/random/mtrand.pyi
+++ b/numpy/random/mtrand.pyi
@@ -1,6 +1,7 @@
 from builtins import bytes as py_bytes
 from collections.abc import Callable
 from typing import Any, Literal, overload
+from typing_extensions import disjoint_base
 
 import numpy as np
 from numpy._typing import (
@@ -82,6 +83,7 @@ __all__ = [
     "zipf",
 ]
 
+@disjoint_base
 class RandomState:
     _bit_generator: BitGenerator
 


### PR DESCRIPTION
`spin stubtest` currently runs `stubtest` with the `--ignore-disjoint-bases` flag. Disabling this will show a bunch of classes that should be decorated with the new [PEP 800](https://peps.python.org/pep-0800/) `@disjoint_base` class decorator. 

All concrete (viz. non-abstract) scalar types are also disjoint bases. However, we're currently not able to mark all of these as such, because there are still quite a lot that aren't defined as proper concrete subclasses. For example `float32` is defined as `floating[_32Bit]` in the stubs, which isn't something we can decorate. My plan is to eventually fix all of these by declaring them as proper subclasses (e.g. `class float32(floating)`), but for now this means that we can't remove stubtest's `--ignore-disjoint-bases` flag yet.

---

No AI.