### PR TITLE
BUG: raise ValueError when reading into record array with references (#32227)

### DIFF
--- a/numpy/_core/records.py
+++ b/numpy/_core/records.py
@@ -814,6 +814,12 @@ def fromstring(datastring, dtype=None, shape=None, offset=0, formats=None,
     else:
         descr = format_parser(formats, names, titles, aligned, byteorder).dtype
 
+    if descr.hasobject:
+        raise ValueError(
+            f"Cannot create record array for dtype {descr}. "
+             "Arrays containing references are not supported."
+        )
+
     itemsize = descr.itemsize
 
     # NumPy 1.19.0, 2020-01-01
@@ -911,6 +917,12 @@ def fromfile(fd, dtype=None, shape=None, offset=0, formats=None,
             descr = format_parser(
                 formats, names, titles, aligned, byteorder
             ).dtype
+
+        if descr.hasobject:
+            raise ValueError(
+                f"Cannot create record array for dtype {descr}. "
+                "Arrays containing references are not supported."
+            )
 
         itemsize = descr.itemsize
 

--- a/numpy/_core/tests/test_records.py
+++ b/numpy/_core/tests/test_records.py
@@ -108,6 +108,20 @@ class TestFromrecords:
         assert_equal(r1, r2)
         assert_equal(r2, r3)
 
+    def test_recarray_read_with_references_raises(self):
+        with temppath(suffix=".bin") as path:
+            with open(path, "wb") as fd:
+                fd.write(b"dummy data")
+            with pytest.raises(
+                ValueError, match="Arrays containing references are not supported"
+            ):
+                np.rec.fromfile(path, formats="O", shape=1)
+
+        with pytest.raises(
+            ValueError, match="Arrays containing references are not supported"
+        ):
+            np.rec.fromstring(b"dummy data", formats="O", shape=1)
+
     def test_recarray_from_obj(self):
         count = 10
         a = np.zeros(count, dtype='O')


### PR DESCRIPTION
Backport of #32227.

Fixes a bug with `numpy.rec.fromfile` and `numpy.rec.fromstring` where attempting to read into dtypes with references, including object and structured dtypes, would be unsafely accepted and could lead to segfaults. We already guard against this in `PyArray_FromFile` and related functions:

https://github.com/numpy/numpy/blob/73d14198a7e98ece82fdd1e3554e6c3d7060ae7b/numpy/_core/src/multiarray/ctors.c#L3659-L3664

The test in this PR would lead to a segfault on `main`. This bug was reported privately, cc @rgommers 

#### AI Disclosure

I used line completion with GitHub copilot. No other AI used.