### PR TITLE
CI: fix ccache CC override, add CXX in mac Conda CI (#32285)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -92,7 +92,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda activate numpy-dev
-        CC="ccache $CC" spin build -j2 -- -Dallow-noblas=false
+        CC="ccache ${CC:-clang}" CXX="ccache ${CXX:-clang++}" spin build -j2 -- -Dallow-noblas=false
 
     - name: Run test suite (full)
       shell: bash -l {0}


### PR DESCRIPTION
Backport of #32285.

### PR summary
Fixes CI breakage seen here: https://github.com/numpy/numpy/actions/runs/31430422225/job/94558572825?pr=32232. Also adds ccache caching for C++ translation units.

This follows the pattern we use elsewhere: https://github.com/numpy/numpy/blob/761a03dfebf420e2c85332d30e861c5978675b14/.github/workflows/compiler_sanitizers.yml#L172

#### AI Disclosure
No AI used.
