### PR TITLE
BUG: validate UTF-8 and harden StringDType bounds handling

### DIFF
--- a/doc/release/upcoming_changes/32296.change.rst
+++ b/doc/release/upcoming_changes/32296.change.rst
@@ -1,0 +1,4 @@
+* Casting a fixed-width byte string array (``np.bytes_``) to ``StringDType``
+  now raises ``TypeError`` when the bytes are not valid UTF-8. Previously the
+  invalid bytes were stored as-is and later caused undefined behavior in
+  string operations.

--- a/doc/source/reference/c-api/strings.rst
+++ b/doc/source/reference/c-api/strings.rst
@@ -267,3 +267,6 @@ Functions
 
    Copy and pack the first ``size`` entries of the buffer pointed to by ``buf``
    into the ``packed_string``. Returns 0 on success and -1 on failure.
+
+   The ``buf`` pointer must store valid, complete UTF-8. The ``NpyString_pack``
+   function does not validate it.

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -2040,17 +2040,19 @@ bytes_to_string(PyArrayMethod_Context *context, char *const data[],
     npy_intp out_stride = strides[1];
 
     while(N--) {
-        size_t out_num_bytes = max_in_size;
-
-        // ignore trailing nulls
-        while (out_num_bytes > 0 && in[out_num_bytes - 1] == 0) {
-            out_num_bytes--;
+        // reject non-UTF-8 input; readers of the stored bytes assume validity
+        Py_ssize_t out_num_bytes = utf8_buffer_size(in, max_in_size);
+        if (out_num_bytes < 0) {
+            npy_gil_error(PyExc_TypeError,
+                          "Invalid UTF-8 bytes found, cannot convert to "
+                          "StringDType");
+            goto fail;
         }
 
         npy_static_string out_ss = {0, NULL};
         if (load_new_string((npy_packed_static_string *)out,
-                            &out_ss, out_num_bytes, allocator,
-                            "void to string cast") == -1) {
+                            &out_ss, (size_t)out_num_bytes, allocator,
+                            "bytes to string cast") == -1) {
             goto fail;
         }
 

--- a/numpy/_core/src/multiarray/stringdtype/static_string.c
+++ b/numpy/_core/src/multiarray/stringdtype/static_string.c
@@ -813,6 +813,10 @@ NpyString_size(const npy_packed_static_string *packed_string)
  *
  * Copy and pack the first *size* entries of the buffer pointed to by *buf*
  * into the *packed_string*. Returns 0 on success and -1 on failure.
+ *
+ * *buf* must be valid, complete UTF-8: StringDType readers decode the stored
+ * bytes without validating them, so malformed input can make them stall or
+ * read out of bounds. This function does not validate *buf*.
 */
 NPY_NO_EXPORT int
 NpyString_pack(npy_string_allocator *allocator,

--- a/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
+++ b/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
@@ -210,8 +210,9 @@ utf8_decode(uint32_t* state, uint32_t* codep, uint32_t byte) {
 
 /*******************************************************************************/
 
-// calculate the size in bytes required to store a UTF-8 encoded version of the
-// UTF-32 encoded string stored in **s**, which is **max_bytes** long.
+// calculate the number of bytes, excluding trailing null bytes, needed to
+// store the UTF-8 encoded buffer **s**, which is **max_bytes** long. Returns
+// -1 if **s** is not valid, complete UTF-8.
 NPY_NO_EXPORT Py_ssize_t
 utf8_buffer_size(const uint8_t *s, size_t max_bytes)
 {

--- a/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
+++ b/numpy/_core/src/multiarray/stringdtype/utf8_utils.c
@@ -295,7 +295,8 @@ find_start_end_locs(char* buf, size_t buffer_size, npy_int64 start_index, npy_in
         *end_loc = buf;
     }
     while (bytes_consumed < buffer_size && num_codepoints < (size_t) end_index) {
-        size_t num_bytes = num_bytes_for_utf8_character((const unsigned char*)buf);
+        size_t num_bytes = num_bytes_for_utf8_character_bounded(
+                (const unsigned char*)buf, buffer_size - bytes_consumed);
         num_codepoints += 1;
         bytes_consumed += num_bytes;
         buf += num_bytes;
@@ -318,7 +319,8 @@ utf8_character_index(
     size_t bytes_consumed = 0;
     size_t cur_index = start_index;
     while (bytes_consumed < buffer_size && bytes_consumed < search_byte_offset) {
-        size_t num_bytes = num_bytes_for_utf8_character((const unsigned char*)start_loc);
+        size_t num_bytes = num_bytes_for_utf8_character_bounded(
+                (const unsigned char*)start_loc, buffer_size - bytes_consumed);
         cur_index += 1;
         bytes_consumed += num_bytes;
         start_loc += num_bytes;

--- a/numpy/_core/src/multiarray/stringdtype/utf8_utils.h
+++ b/numpy/_core/src/multiarray/stringdtype/utf8_utils.h
@@ -19,6 +19,25 @@ static inline int num_bytes_for_utf8_character(const unsigned char *c)
     return LENGTHS_LUT[c[0] >> 3];
 }
 
+// like num_bytes_for_utf8_character, but clamps the result to [1, max_bytes]
+// (0 if max_bytes is 0) so a walk over invalid UTF-8 cannot stall on a
+// malformed lead byte or advance past the end of the buffer
+static inline int
+num_bytes_for_utf8_character_bounded(const unsigned char *c, size_t max_bytes)
+{
+    if (max_bytes == 0) {
+        return 0;
+    }
+    int num_bytes = num_bytes_for_utf8_character(c);
+    if (num_bytes < 1) {
+        num_bytes = 1;
+    }
+    if ((size_t)num_bytes > max_bytes) {
+        num_bytes = (int)max_bytes;
+    }
+    return num_bytes;
+}
+
 NPY_NO_EXPORT const unsigned char*
 find_previous_utf8_character(const unsigned char *c, size_t nchar);
 

--- a/numpy/_core/src/umath/string_buffer.h
+++ b/numpy/_core/src/umath/string_buffer.h
@@ -320,7 +320,7 @@ struct Buffer {
             buf += rhs;
             break;
         case ENCODING::UTF32:
-            buf += rhs * sizeof(npy_ucs4);
+            buf += rhs * (npy_int64)sizeof(npy_ucs4);
             break;
         case ENCODING::UTF8:
             for (npy_int64 i = 0; i < rhs && buf < after; i++) {
@@ -340,7 +340,7 @@ struct Buffer {
             buf -= rhs;
             break;
         case ENCODING::UTF32:
-            buf -= rhs * sizeof(npy_ucs4);
+            buf -= rhs * (npy_int64)sizeof(npy_ucs4);
             break;
         case ENCODING::UTF8:
             buf = (char *) find_previous_utf8_character((unsigned char *)buf, (size_t) rhs);
@@ -722,8 +722,8 @@ operator+(Buffer<enc> lhs, npy_int64 rhs)
         case ENCODING::ASCII:
             return Buffer<enc>(lhs.buf + rhs, lhs.after - lhs.buf - rhs);
         case ENCODING::UTF32:
-            return Buffer<enc>(lhs.buf + rhs * sizeof(npy_ucs4),
-                          lhs.after - lhs.buf - rhs * sizeof(npy_ucs4));
+            return Buffer<enc>(lhs.buf + rhs * (npy_int64)sizeof(npy_ucs4),
+                          lhs.after - lhs.buf - rhs * (npy_int64)sizeof(npy_ucs4));
         case ENCODING::UTF8:
             char* buf = lhs.buf;
             for (npy_int64 i = 0; i < rhs && buf < lhs.after; i++) {
@@ -759,8 +759,8 @@ operator-(Buffer<enc> lhs, npy_int64 rhs)
         case ENCODING::ASCII:
             return Buffer<enc>(lhs.buf - rhs, lhs.after - lhs.buf + rhs);
         case ENCODING::UTF32:
-            return Buffer<enc>(lhs.buf - rhs * sizeof(npy_ucs4),
-                          lhs.after - lhs.buf + rhs * sizeof(npy_ucs4));
+            return Buffer<enc>(lhs.buf - rhs * (npy_int64)sizeof(npy_ucs4),
+                          lhs.after - lhs.buf + rhs * (npy_int64)sizeof(npy_ucs4));
         case ENCODING::UTF8:
             char* buf = lhs.buf;
             buf = (char *)find_previous_utf8_character((unsigned char *)buf, rhs);

--- a/numpy/_core/src/umath/string_buffer.h
+++ b/numpy/_core/src/umath/string_buffer.h
@@ -1635,13 +1635,18 @@ string_zfill(Buffer<enc> buf, npy_int64 width, Buffer<enc> out)
         return -1;
     }
 
-    size_t offset = final_width - buf.num_codepoints();
-    Buffer<enc> tmp = out + offset;
+    // when no padding was added there is no sign to move, and the sign
+    // position below would be out of bounds
+    size_t len = buf.num_codepoints();
+    if (len > 0 && final_width > len) {
+        size_t offset = final_width - len;
+        Buffer<enc> tmp = out + offset;
 
-    npy_ucs4 c = *tmp;
-    if (c == '+' || c == '-') {
-        tmp.buffer_memset(fill, 1);
-        out.buffer_memset(c, 1);
+        npy_ucs4 c = *tmp;
+        if (c == '+' || c == '-') {
+            tmp.buffer_memset(fill, 1);
+            out.buffer_memset(c, 1);
+        }
     }
 
     return new_len;

--- a/numpy/_core/src/umath/string_buffer.h
+++ b/numpy/_core/src/umath/string_buffer.h
@@ -323,8 +323,9 @@ struct Buffer {
             buf += rhs * sizeof(npy_ucs4);
             break;
         case ENCODING::UTF8:
-            for (int i=0; i<rhs; i++) {
-                buf += num_bytes_for_utf8_character((unsigned char *)buf);
+            for (npy_int64 i = 0; i < rhs && buf < after; i++) {
+                buf += num_bytes_for_utf8_character_bounded(
+                        (unsigned char *)buf, (size_t)(after - buf));
             }
             break;
         }
@@ -482,7 +483,8 @@ struct Buffer {
             case ENCODING::UTF32:
                 return 4;
             case ENCODING::UTF8:
-                return num_bytes_for_utf8_character((unsigned char *)(*this).buf);
+                return num_bytes_for_utf8_character_bounded(
+                        (unsigned char *)buf, (size_t)(after - buf));
         }
     }
 
@@ -724,8 +726,9 @@ operator+(Buffer<enc> lhs, npy_int64 rhs)
                           lhs.after - lhs.buf - rhs * sizeof(npy_ucs4));
         case ENCODING::UTF8:
             char* buf = lhs.buf;
-            for (int i=0; i<rhs; i++) {
-                buf += num_bytes_for_utf8_character((unsigned char *)buf);
+            for (npy_int64 i = 0; i < rhs && buf < lhs.after; i++) {
+                buf += num_bytes_for_utf8_character_bounded(
+                        (unsigned char *)buf, (size_t)(lhs.after - buf));
             }
             return Buffer<enc>(buf, (npy_int64)(lhs.after - buf));
     }

--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -698,11 +698,13 @@ string_slice_loop(PyArrayMethod_Context *context,
             // copy one codepoint
             inbuf.buffer_memcpy(outbuf, 1);
 
-            // Move in inbuf by step.
-            inbuf += step;
-
             // Move in outbuf by the number of chars or bytes written
             outbuf.advance_chars_or_bytes(1);
+
+            // an extreme step overflows the pointer on the final advance
+            if (i + 1 < slice_length) {
+                inbuf += step;
+            }
         }
 
         // fill remaining outbuf with zero bytes

--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -689,7 +689,8 @@ string_slice_loop(PyArrayMethod_Context *context,
         // adjust slice to string length in codepoints
         // and handle negative indices
         size_t num_codepoints = inbuf.num_codepoints();
-        npy_intp slice_length = PySlice_AdjustIndices(num_codepoints, &start, &stop, step);
+        npy_intp slice_length = PySlice_AdjustIndices(num_codepoints, &start, &stop,
+                                                      step < -NPY_MAX_INTP ? -NPY_MAX_INTP : step);
 
         // iterate over slice and copy each character of the string
         inbuf.advance_chars_or_bytes(start);

--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -686,6 +686,11 @@ string_slice_loop(PyArrayMethod_Context *context,
         npy_intp stop = *(npy_intp*)stop_ptr;
         npy_intp step = *(npy_intp*)step_ptr;
 
+        if (step == 0) {
+            npy_gil_error(PyExc_ValueError, "slice step cannot be zero");
+            return -1;
+        }
+
         // adjust slice to string length in codepoints
         // and handle negative indices
         size_t num_codepoints = inbuf.num_codepoints();

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2301,8 +2301,8 @@ slice_strided_loop(PyArrayMethod_Context *context, char *const data[],
 
         // adjust slice to string length in codepoints
         // and handle negative indices
-        npy_intp slice_length =
-                PySlice_AdjustIndices(num_codepoints, &start, &stop, step);
+        npy_intp slice_length = PySlice_AdjustIndices(num_codepoints, &start, &stop,
+                                                      step < -NPY_MAX_INTP ? -NPY_MAX_INTP : step);
 
         if (step == 1) {
             // step == 1 is the easy case, we can just use memcpy

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2263,6 +2263,11 @@ slice_strided_loop(PyArrayMethod_Context *context, char *const data[],
         npy_intp stop = *(npy_intp *)stop_ptr;
         npy_intp step = *(npy_intp *)step_ptr;
 
+        if (step == 0) {
+            npy_gil_error(PyExc_ValueError, "slice step cannot be zero");
+            goto fail;
+        }
+
         npy_static_string is = {0, NULL};
         const npy_packed_static_string *ips = (npy_packed_static_string *)iptr;
         npy_static_string os = {0, NULL};

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -135,6 +135,11 @@ static int multiply_loop_core(
         }
         T factor = *(T *)iin;
         size_t cursize = is.size;
+        // the overflow check below passes for an empty input regardless of
+        // factor, but the copy loop still runs factor times
+        if (factor < 1 || cursize == 0) {
+            factor = 0;
+        }
         size_t newsize;
         int overflowed = npy_mul_with_overflow_size_t(
                 &newsize, cursize, factor);

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -181,6 +181,7 @@ static int multiply_loop_core(
             if (NpyString_pack(oallocator, ops, buf, newsize) < 0) {
                 npy_gil_error(PyExc_MemoryError,
                               "Failed to pack string in multiply");
+                PyMem_RawFree(buf);
                 goto fail;
             }
 
@@ -376,6 +377,7 @@ add_strided_loop(PyArrayMethod_Context *context, char *const data[],
             if (NpyString_pack(oallocator, ops, buf, newsize) < 0) {
                 npy_gil_error(PyExc_MemoryError,
                           "Failed to pack output string in add");
+                PyMem_RawFree(buf);
                 goto fail;
             }
 

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -1762,9 +1762,12 @@ center_ljust_rjust_strided_loop(PyArrayMethod_Context *context,
 
             char *buf = NULL;
             char overflowed = 0;
+            // size the pad with the same encoded length buffer_memset writes
+            char fill_utf8[4];
+            npy_int64 fill_nbytes =
+                    (npy_int64)ucs4_code_to_utf8_char(*fill, fill_utf8);
             npy_int64 pad_nbytes = safe_mul(
-                    (npy_int64)num_bytes_for_utf8_character((unsigned char *)s2.buf),
-                    width - (npy_int64)num_codepoints, &overflowed);
+                    fill_nbytes, width - (npy_int64)num_codepoints, &overflowed);
             npy_int64 newsize = safe_add(pad_nbytes, (npy_int64)s1.size,
                                          &overflowed);
             // also bounds width: the fill is at least one byte per pad

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -1783,8 +1783,9 @@ center_ljust_rjust_strided_loop(PyArrayMethod_Context *context,
                 goto fail;
             }
 
-            if (context->descriptors[0] == context->descriptors[3]) {
-                // in-place
+            int in_place = context->descriptors[0] == context->descriptors[3] ||
+                           context->descriptors[2] == context->descriptors[3];
+            if (in_place) {
                 buf = (char *)PyMem_RawMalloc(newsize);
                 if (buf == NULL) {
                     npy_gil_error(PyExc_MemoryError,
@@ -1805,14 +1806,14 @@ center_ljust_rjust_strided_loop(PyArrayMethod_Context *context,
             npy_intp len = string_pad(inbuf, width, *fill, pos, outbuf);
 
             if (len < 0) {
-                if (context->descriptors[0] == context->descriptors[3]) {
+                if (in_place) {
                     PyMem_RawFree(buf);
                 }
                 goto fail;
             }
 
             // in-place operations need to clean up temp buffer
-            if (context->descriptors[0] == context->descriptors[3]) {
+            if (in_place) {
                 if (NpyString_pack(oallocator, ops, buf, newsize) < 0) {
                     npy_gil_error(PyExc_MemoryError,
                                   "Failed to pack string in %s", ufunc_name);

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -140,6 +140,12 @@ static int multiply_loop_core(
         if (factor < 1 || cursize == 0) {
             factor = 0;
         }
+        // on 32-bit platforms size_t truncates a 64-bit factor
+        else if ((npy_uint64)factor > (npy_uint64)PY_SSIZE_T_MAX) {
+            npy_gil_error(PyExc_OverflowError,
+                      "Overflow encountered in string multiply");
+            goto fail;
+        }
         size_t newsize;
         int overflowed = npy_mul_with_overflow_size_t(
                 &newsize, cursize, factor);

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -21,6 +21,7 @@
 #include "string_buffer.h"
 #include "string_fastsearch.h"
 #include "templ_common.h" /* for npy_mul_size_with_overflow_size_t */
+#include "npy_extint128.h" /* for safe_add, safe_mul */
 
 #include "stringdtype/static_string.h"
 #include "stringdtype/dtype.h"
@@ -1753,21 +1754,22 @@ center_ljust_rjust_strided_loop(PyArrayMethod_Context *context,
             Buffer<ENCODING::UTF8> fill((char *)s2.buf, s2.size);
 
             size_t num_codepoints = inbuf.num_codepoints();
-            npy_intp width = (npy_intp)*(npy_int64*)in2;
+            npy_int64 width = *(npy_int64 *)in2;
 
-            if ((npy_intp)num_codepoints > width) {
-                width = num_codepoints;
+            if ((npy_int64)num_codepoints > width) {
+                width = (npy_int64)num_codepoints;
             }
 
             char *buf = NULL;
-            npy_intp newsize;
-            int overflowed = npy_mul_sizes_with_overflow(
-                    &(newsize),
-                    (npy_intp)num_bytes_for_utf8_character((unsigned char *)s2.buf),
-                    width - num_codepoints);
-            newsize += s1.size;
-
-            if (overflowed || newsize > PY_SSIZE_T_MAX) {
+            char overflowed = 0;
+            npy_int64 pad_nbytes = safe_mul(
+                    (npy_int64)num_bytes_for_utf8_character((unsigned char *)s2.buf),
+                    width - (npy_int64)num_codepoints, &overflowed);
+            npy_int64 newsize = safe_add(pad_nbytes, (npy_int64)s1.size,
+                                         &overflowed);
+            // also bounds width: the fill is at least one byte per pad
+            // character and s1.size >= num_codepoints, so width <= newsize
+            if (overflowed || newsize > NPY_MAX_INTP) {
                 npy_gil_error(PyExc_OverflowError,
                               "Overflow encountered in %s", ufunc_name);
                 goto fail;
@@ -1792,10 +1794,13 @@ center_ljust_rjust_strided_loop(PyArrayMethod_Context *context,
 
             Buffer<ENCODING::UTF8> outbuf(buf, newsize);
 
-            npy_intp len = string_pad(inbuf, *(npy_int64*)in2, *fill, pos, outbuf);
+            npy_intp len = string_pad(inbuf, width, *fill, pos, outbuf);
 
             if (len < 0) {
-                return -1;
+                if (context->descriptors[0] == context->descriptors[3]) {
+                    PyMem_RawFree(buf);
+                }
+                goto fail;
             }
 
             // in-place operations need to clean up temp buffer
@@ -1803,6 +1808,7 @@ center_ljust_rjust_strided_loop(PyArrayMethod_Context *context,
                 if (NpyString_pack(oallocator, ops, buf, newsize) < 0) {
                     npy_gil_error(PyExc_MemoryError,
                                   "Failed to pack string in %s", ufunc_name);
+                    PyMem_RawFree(buf);
                     goto fail;
                 }
 
@@ -1885,13 +1891,21 @@ zfill_strided_loop(PyArrayMethod_Context *context,
         {
             Buffer<ENCODING::UTF8> inbuf((char *)is.buf, is.size);
             size_t in_codepoints = inbuf.num_codepoints();
-            npy_intp width = (npy_intp)*(npy_int64*)in2;
-            if ((npy_intp)in_codepoints > width) {
-                width = in_codepoints;
+            npy_int64 width = *(npy_int64 *)in2;
+            if ((npy_int64)in_codepoints > width) {
+                width = (npy_int64)in_codepoints;
             }
             // number of leading one-byte characters plus the size of the
             // original string
-            size_t outsize = (width - in_codepoints) + is.size;
+            char overflowed = 0;
+            npy_int64 outsize = safe_add(width - (npy_int64)in_codepoints,
+                                         (npy_int64)is.size, &overflowed);
+            // also bounds width: is.size >= in_codepoints, so width <= outsize
+            if (overflowed || outsize > NPY_MAX_INTP) {
+                npy_gil_error(PyExc_OverflowError,
+                              "Overflow encountered in zfill");
+                goto fail;
+            }
             char *buf = NULL;
             if (context->descriptors[0] == context->descriptors[2]) {
                 // in-place
@@ -1911,7 +1925,10 @@ zfill_strided_loop(PyArrayMethod_Context *context,
             }
 
             Buffer<ENCODING::UTF8> outbuf(buf, outsize);
-            if (string_zfill(inbuf, (npy_int64)width, outbuf) < 0) {
+            if (string_zfill(inbuf, width, outbuf) < 0) {
+                if (context->descriptors[0] == context->descriptors[2]) {
+                    PyMem_RawFree(buf);
+                }
                 goto fail;
             }
 
@@ -1920,6 +1937,7 @@ zfill_strided_loop(PyArrayMethod_Context *context,
                 if (NpyString_pack(oallocator, ops, buf, outsize) < 0) {
                     npy_gil_error(PyExc_MemoryError,
                                   "Failed to pack string in zfill");
+                    PyMem_RawFree(buf);
                     goto fail;
                 }
 
@@ -2264,9 +2282,21 @@ slice_strided_loop(PyArrayMethod_Context *context, char *const data[],
                 num_codepoints++;
                 int num_bytes = num_bytes_for_utf8_character(
                         ((unsigned char *)inbuf_ptr));
+                // num_bytes is 0 for a malformed lead byte
+                if (num_bytes < 1) {
+                    // keep forward progress
+                    num_bytes = 1;
+                }
+                // never advance past the end
+                if (num_bytes > inbuf_ptr_end - inbuf_ptr) {
+                    num_bytes = (int)(inbuf_ptr_end - inbuf_ptr);
+                }
                 codepoint_offsets.push_back((unsigned char *)inbuf_ptr);
                 inbuf_ptr += num_bytes;
             }
+            // trailing offset so offsets[i + 1] - offsets[i] is codepoint i's
+            // byte length below, including for the last codepoint
+            codepoint_offsets.push_back((unsigned char *)inbuf_ptr_end);
         }
 
         // adjust slice to string length in codepoints
@@ -2276,12 +2306,8 @@ slice_strided_loop(PyArrayMethod_Context *context, char *const data[],
 
         if (step == 1) {
             // step == 1 is the easy case, we can just use memcpy
-            unsigned char *start_bounded = ((size_t)start < num_codepoints
-                                            ? codepoint_offsets[start]
-                                            : (unsigned char *)is.buf + is.size);
-            unsigned char *stop_bounded = ((size_t)stop < num_codepoints
-                                           ? codepoint_offsets[stop]
-                                           : (unsigned char *)is.buf + is.size);
+            unsigned char *start_bounded = codepoint_offsets[start];
+            unsigned char *stop_bounded = codepoint_offsets[stop];
             npy_intp outsize = stop_bounded - start_bounded;
             outsize = outsize < 0 ? 0 : outsize;
 
@@ -2295,11 +2321,16 @@ slice_strided_loop(PyArrayMethod_Context *context, char *const data[],
             memcpy(buf, start_bounded, outsize);
         }
         else {
-            // handle step != 1
-            // compute outsize
+            // step != 1. Only add step when another iteration remains: for an
+            // extreme step the final i_idx += step would overflow npy_intp and
+            // index codepoint_offsets out of bounds.
             npy_intp outsize = 0;
-            for (int i = start; step > 0 ? i < stop : i > stop; i += step) {
-                outsize += num_bytes_for_utf8_character(codepoint_offsets[i]);
+            npy_intp i_idx = start;
+            for (npy_intp o_idx = 0; o_idx < slice_length; o_idx++) {
+                outsize += codepoint_offsets[i_idx + 1] - codepoint_offsets[i_idx];
+                if (o_idx + 1 < slice_length) {
+                    i_idx += step;
+                }
             }
 
             if (outsize > 0) {
@@ -2310,10 +2341,15 @@ slice_strided_loop(PyArrayMethod_Context *context, char *const data[],
                 /* explicitly discard const; initializing new buffer */
                 char *buf = (char *)os.buf;
 
-                for (npy_intp i_idx = start, o_idx = 0; o_idx < slice_length; o_idx++, i_idx += step) {
-                    int num_bytes = num_bytes_for_utf8_character(codepoint_offsets[i_idx]);
+                i_idx = start;
+                for (npy_intp o_idx = 0; o_idx < slice_length; o_idx++) {
+                    npy_intp num_bytes =
+                            codepoint_offsets[i_idx + 1] - codepoint_offsets[i_idx];
                     memcpy(buf, codepoint_offsets[i_idx], num_bytes);
                     buf += num_bytes;
+                    if (o_idx + 1 < slice_length) {
+                        i_idx += step;
+                    }
                 }
             }
         }

--- a/numpy/_core/tests/examples/cython/checks.pyx
+++ b/numpy/_core/tests/examples/cython/checks.pyx
@@ -296,6 +296,21 @@ def npystring_pack(arr):
     return ret
 
 
+def npystring_pack_invalid_utf8(arr, bytes data):
+    # NpyString_pack does not validate its input, so pack raw bytes into arr[0]
+    cdef const char *buf = data
+    cdef size_t size = len(data)
+
+    allocator = cnp.NpyString_acquire_allocator(
+        <cnp.PyArray_StringDTypeObject *>cnp.PyArray_DESCR(arr)
+    )
+    ret = cnp.NpyString_pack(
+        allocator, <cnp.npy_packed_static_string *>cnp.PyArray_DATA(arr), buf, size,
+    )
+    cnp.NpyString_release_allocator(allocator)
+    return ret
+
+
 def npystring_load(arr):
     allocator = cnp.NpyString_acquire_allocator(
         <cnp.PyArray_StringDTypeObject *>cnp.PyArray_DESCR(arr)

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -354,6 +354,27 @@ def test_npystring_allocators_other_dtype(install_temp):
     assert checks.npystring_allocators_other_types(arr1, arr2) == 0
 
 
+def test_npystring_pack_invalid_utf8(install_temp):
+    """Check StringDType stays safe on stored bytes that aren't valid UTF-8."""
+    import checks
+
+    from numpy._core.umath import _center, _ljust, _rjust
+
+    sdt = np.dtypes.StringDType()
+
+    # the raw ufuncs skip the wrapper's one-character fill check
+    fill = np.array(["x"], dtype=sdt)
+    assert checks.npystring_pack_invalid_utf8(fill, b"\x80") == 0
+    src = np.array(["hello"], dtype=sdt)
+    for pad in (_center, _ljust, _rjust):
+        pad(src, 100_000, fill)
+
+    bad = np.array(["placeholder"], dtype=sdt)
+    assert checks.npystring_pack_invalid_utf8(bad, b"\x80" * 12) == 0
+    assert np.strings.find(bad, "z")[0] == -1
+    assert np.strings.count(bad, "z")[0] == 0
+
+
 @pytest.mark.skipif(sysconfig.get_platform() == 'win-arm64',
                     reason='no checks module on win-arm64')
 def test_npy_uintp_type_enum(install_temp):

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -579,6 +579,20 @@ def test_pad_extreme_width_overflow():
             pad(arr, imax)
 
 
+def test_pad_out_aliases_fill():
+    from numpy._core.umath import _center, _ljust, _rjust
+    dt = StringDType()
+    for pad, expected in [(_center, "***abc***"), (_ljust, "abc******"),
+                          (_rjust, "******abc")]:
+        a = np.array(["abc"], dtype=dt)
+        fill = np.array(["*"], dtype=dt)
+        assert pad(a, 9, fill, out=fill).tolist() == [expected]
+    # a fill longer than 15 bytes is stored in the arena, not the packed struct
+    a = np.array(["abc"], dtype=dt)
+    fill = np.array(["*" * 300], dtype=dt)
+    assert _center(a, 9, fill, out=fill).tolist() == ["***abc***"]
+
+
 def test_zfill_no_padding_no_oob():
     # no padding is added for an empty input or a width <= the input length
     dt = StringDType()

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1591,6 +1591,16 @@ def test_multiply_two_string_raises():
         np.multiply(arr, arr)
 
 
+def test_multiply_nonpositive_factor_or_empty():
+    # a non-positive factor or an empty input yields an empty string
+    dt = StringDType()
+    for factor in (0, -1, -100):
+        assert (np.array(["ab", ""], dtype=dt) * factor).tolist() == ["", ""]
+    assert (np.array([""], dtype=dt) * np.uint64(2**63)).tolist() == [""]
+    with pytest.raises(OverflowError):
+        np.array(["ab"], dtype=dt) * np.uint64(2**63)
+
+
 @pytest.mark.parametrize("use_out", [True, False])
 @pytest.mark.parametrize("other", [2, [2, 1, 3, 4, 1, 3]])
 @pytest.mark.parametrize(

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -579,6 +579,19 @@ def test_pad_extreme_width_overflow():
             pad(arr, imax)
 
 
+def test_zfill_no_padding_no_oob():
+    # no padding is added for an empty input or a width <= the input length
+    dt = StringDType()
+    assert np.strings.zfill(np.array([""], dtype=dt), 20).tolist() == ["0" * 20]
+    assert np.strings.zfill(np.array([""], dtype=dt), 0).tolist() == [""]
+    assert np.strings.zfill(np.array(["42"], dtype=dt), 1).tolist() == ["42"]
+    assert np.strings.zfill(np.array(["-7"], dtype=dt), 5).tolist() == ["-0007"]
+    # the in-place path writes into a heap buffer the sanitizer can bounds-check
+    from numpy._core.umath import _zfill
+    a = np.array([""], dtype=dt)
+    assert _zfill(a, 20, out=a).tolist() == ["0" * 20]
+
+
 def test_additional_unicode_cast(dtype):
     string_list = random_unicode_string_list()
     arr = np.array(string_list, dtype=dtype)

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -508,6 +508,77 @@ class TestStringLikeCasts:
                 sarr.astype("S20")
 
 
+# malformed UTF-8, one sequence per distinct failure class; every bytes-like
+# -> StringDType ingress must reject these (gh-32287, gh-32288)
+INVALID_UTF8 = [
+    b"\x80AAAA",  # gh-32287: continuation byte as lead (0-length)
+    b"\xF8AAAA",  # 0xF8-0xFF lead (0-length)
+    b"\xFC\x80",  # 5-/6-byte lead, disallowed since RFC 3629
+    b"A" * 15 + b"\xF0",  # gh-32288: truncated 4-byte lead at the buffer end
+    b"A\xC3",  # truncated 2-byte lead
+    b"A\xE2\x82",  # truncated 3-byte lead
+    b"\xE2\x28\xA1",  # non-continuation byte inside a 3-byte sequence
+    b"\xC0\xAF",  # overlong 2-byte encoding of '/'
+    b"\xE0\x80\xAF",  # overlong 3-byte encoding of '/'
+    b"\xF0\x80\x80\xAF",  # overlong 4-byte encoding of '/'
+    b"\xED\xA0\x80",  # UTF-16 surrogate
+    b"\xF4\x90\x80\x80",  # code point above U+10FFFF
+    b"\xF5\x80\x80\x80",  # 0xF5-0xF7 lead, always above U+10FFFF
+]
+
+
+@pytest.mark.parametrize("bad", INVALID_UTF8)
+def test_bytes_cast_rejects_invalid_utf8(bad):
+    arr = np.array([bad], dtype=f"S{len(bad)}")
+    with pytest.raises(TypeError, match="Invalid UTF-8"):
+        arr.astype(StringDType())
+
+
+@pytest.mark.parametrize("bad", INVALID_UTF8)
+def test_void_cast_rejects_invalid_utf8(bad):
+    # the void ('V') -> StringDType cast validates the same way as bytes
+    arr = np.array([bad], dtype=f"V{len(bad)}")
+    with pytest.raises(TypeError, match="Invalid UTF-8"):
+        arr.astype(StringDType())
+
+
+def test_bytes_cast_roundtrips_valid_utf8():
+    # boundary code points adjacent to the reject cases above: largest 2-byte,
+    # U+D7FF below the surrogates, max code point
+    strings = ["héllo", "naïve", "😀 e", "über\x00embedded",
+               "߿퟿", "\U0010FFFF"]
+    barr = np.array([s.encode() for s in strings], dtype="S16")
+    sarr = barr.astype(StringDType())
+    assert list(sarr) == strings
+    assert list(sarr.astype("U16")) == strings
+
+
+def test_slice_extreme_step_no_overflow():
+    # an extreme step must not overflow the slice index and read out of bounds
+    arr = np.array(["abcd"], dtype=StringDType())
+    imax = np.iinfo(np.intp).max
+    assert np.strings.slice(arr, 1, None, imax).tolist() == ["b"]
+    assert np.strings.slice(arr, None, None, imax).tolist() == ["a"]
+    assert np.strings.slice(arr, None, None, -imax).tolist() == ["d"]
+    assert np.strings.slice(arr, 2, None, -imax).tolist() == ["c"]
+    mb = np.array(["a😀cd"], dtype=StringDType())
+    assert np.strings.slice(mb, 1, None, imax).tolist() == ["😀"]
+    imin = np.iinfo(np.intp).min
+    assert np.strings.slice(arr, None, None, imin).tolist() == ["d"]
+    assert np.strings.slice(mb, None, None, imin).tolist() == ["d"]
+
+
+def test_pad_extreme_width_overflow():
+    # width near the npy_intp max must raise OverflowError, not wrap the output
+    # size past the check (which surfaced as a MemoryError)
+    arr = np.array(["😀"], dtype=StringDType())
+    imax = np.iinfo(np.intp).max
+    for pad in (np.strings.ljust, np.strings.rjust, np.strings.center,
+                np.strings.zfill):
+        with pytest.raises(OverflowError):
+            pad(arr, imax)
+
+
 def test_additional_unicode_cast(dtype):
     string_list = random_unicode_string_list()
     arr = np.array(string_list, dtype=dtype)

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -1076,6 +1076,13 @@ class TestMethods:
                        dtype=dt)
         assert_array_equal(act, res)
 
+    def test_slice_extreme_step(self, dt):
+        buf = np.array(["abcd"], dtype=dt)
+        imax, imin = np.iinfo(np.intp).max, np.iinfo(np.intp).min
+        for step, expected in [(imax, "a"), (-imax, "d"), (imin, "d")]:
+            assert_array_equal(np.strings.slice(buf, None, None, step),
+                               np.array([expected], dtype=dt))
+
     def test_slice_unsupported(self, dt):
         with pytest.raises(TypeError, match="did not contain a loop"):
             np.strings.slice(np.array([1, 2, 3]), 4)

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -1083,6 +1083,11 @@ class TestMethods:
             assert_array_equal(np.strings.slice(buf, None, None, step),
                                np.array([expected], dtype=dt))
 
+    def test_slice_zero_step_raises(self, dt):
+        from numpy._core.umath import _slice
+        with pytest.raises(ValueError, match="slice step cannot be zero"):
+            _slice(np.array(["abcd"], dtype=dt), 0, 4, 0)
+
     def test_slice_unsupported(self, dt):
         with pytest.raises(TypeError, match="did not contain a loop"):
             np.strings.slice(np.array([1, 2, 3]), 4)

--- a/tools/ci/ubsan_suppressions_arm64.txt
+++ b/tools/ci/ubsan_suppressions_arm64.txt
@@ -25,7 +25,6 @@ pointer-overflow:_core/src/umath/loops_arithm_fp.dispatch.c.src
 pointer-overflow:_core/src/umath/loops_unary.dispatch.c.src
 pointer-overflow:_core/src/umath/loops_unary_complex.dispatch.c.src
 pointer-overflow:_core/src/umath/loops_unary_fp_le.dispatch.c.src
-pointer-overflow:_core/src/umath/string_buffer.h
 pointer-overflow:linalg/umath_linalg.cpp
 pointer-overflow:numpy/random/bit_generator.pyx.c
 


### PR DESCRIPTION
### PR summary
Fixes #32287, Fixes #32288

Both issues relied on injecting invalid UTF-8 via the bytes to string cast, which did not validate UTF-8.

This led to hangs and UB, which I've defensively hardened in a few spots but the main bugfix is adding UTF-8 validation to the bytes to string cast. I also saw a spot to avoid unnecessary re-scanning in the np.strings.slice loop, which is fixed to avoid possible UTF-8 validation issues.

Also documents that `NpyString_Pack` doesn't do UTF-8 validation, so input data must be validated as UTF-8 by users of the C API.

Additionally, fixes signed integer overflow issues and issues on 32-bit builds caused by using `npy_intp` internally but still accepting 64-bit data in the Python API.

#### AI Disclosure
I used an AI to do code review, address corner cases, and spot UB sites.