### PR TITLE
BUG: restore RandomState multinomial stream compatibility

### DIFF
--- a/numpy/random/src/legacy/legacy-distributions.c
+++ b/numpy/random/src/legacy/legacy-distributions.c
@@ -618,19 +618,43 @@ int64_t legacy_random_geometric(bitgen_t *bitgen_state, double p) {
   }
 }
 
+static RAND_INT_TYPE legacy_random_binomial_for_multinomial(
+    bitgen_t *bitgen_state, double p, RAND_INT_TYPE n, binomial_t *binomial) {
+  double q;
+
+  if ((n == 0LL) || (p == 0.0f)) {
+    return 0;
+  }
+
+  if (p <= 0.5) {
+    if (p * n <= 30.0) {
+      return random_binomial_inversion(bitgen_state, n, p, binomial);
+    } else {
+      return legacy_random_binomial_btpe(bitgen_state, n, p, binomial);
+    }
+  } else {
+    q = 1.0 - p;
+    if (q * n <= 30.0) {
+      return n - random_binomial_inversion(bitgen_state, n, q, binomial);
+    } else {
+      return n - legacy_random_binomial_btpe(bitgen_state, n, q, binomial);
+    }
+  }
+}
+
 void legacy_random_multinomial(bitgen_t *bitgen_state, RAND_INT_TYPE n,
                                RAND_INT_TYPE *mnix, double *pix, npy_intp d,
                                binomial_t *binomial) {
   /*
-   * Mirrors random_multinomial but dispatches to legacy_random_binomial,
-   * since bug fixes to random_binomial would otherwise change the
-   * RandomState stream.
+   * Mirrors the random_multinomial path used by RandomState before gh-31238.
+   * It retains the current inversion and early returns, while preserving the
+   * legacy BTPE implementation.
    */
   double remaining_p = 1.0;
   npy_intp j;
   RAND_INT_TYPE dn = n;
   for (j = 0; j < (d - 1); j++) {
-    mnix[j] = (RAND_INT_TYPE)legacy_random_binomial(
+    mnix[j] = legacy_random_binomial_for_multinomial(
         bitgen_state, pix[j] / remaining_p, dn, binomial);
     dn = dn - mnix[j];
     if (dn <= 0) {

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -4,7 +4,7 @@ import pytest
 
 import numpy as np
 from numpy import random
-from numpy.testing import assert_, assert_array_equal, assert_raises
+from numpy.testing import assert_, assert_array_equal, assert_equal, assert_raises
 
 
 class TestRegression:
@@ -225,6 +225,44 @@ class TestRegression:
         bg.state = state
         rs = random.RandomState(bg)
         assert_array_equal(rs.multinomial(500, [0.5, 0.5]), [227, 273])
+
+    def test_multinomial_zero_probability_stream(self):
+        # gh-32299: zero probabilities must not consume random draws.
+        rng = random.RandomState(1234)
+        pvals = [0.5, 0.0, 0.5, 0.0, 0.0, 0.0]
+        expected = np.array([
+            [0, 0, 2, 0, 0, 0],
+            [1, 0, 1, 0, 0, 0],
+            [2, 0, 0, 0, 0, 0],
+            [1, 0, 1, 0, 0, 0],
+            [2, 0, 0, 0, 0, 0],
+        ])
+
+        assert_array_equal(rng.multinomial(2, pvals, 5), expected)
+        assert_equal(rng.random_sample(), 0.9581393536837052)
+
+    def test_multinomial_zero_count_stream(self):
+        rng = random.RandomState(1234)
+
+        assert_array_equal(rng.multinomial(0, [0.5, 0.5], 5), np.zeros((5, 2)))
+        assert_equal(rng.random_sample(), 0.1915194503788923)
+
+    def test_multinomial_small_p_uses_current_inversion(self):
+        state = {
+            'bit_generator': 'PCG64',
+            'state': {
+                'state': 169755515854538203297949045700863217783,
+                'inc': 87136372517582989555478159403783844777,
+            },
+            'has_uint32': 0,
+            'uinteger': 0,
+        }
+        bg = random.PCG64()
+        bg.state = state
+        rng = random.RandomState(bg)
+
+        actual = rng.multinomial(2_000_000_000, [5e-17, 1.0])
+        assert_array_equal(actual, [1, 1_999_999_999])
 
     def test_n_zero_stream(self):
         # Regression test for gh-14522.  Ensure that future versions


### PR DESCRIPTION
### PR summary

Fixes #32299.

This restores the pre-2.5 random stream behavior of `RandomState.multinomial` without reverting the `Generator.multinomial` fix from #31238.

The regression was caused by routing `RandomState.multinomial` through `legacy_random_binomial`, which changed both zero-probability RNG consumption and the inversion path. This PR adds a multinomial-specific legacy helper that preserves the previous behavior while retaining the corrected Generator behavior.

Regression tests cover the reported sequence, RNG stream consumption, the inversion path, and the existing BTPE behavior.

### First time committer introduction

Hi, I'm Kirill. This is my first contribution to NumPy.

I came across #32299 while looking for a small bug I could help with. I was interested in it because the change affects reproducibility of the legacy RandomState API. I reproduced the issue on different NumPy versions and worked through the regression to understand what had changed.

I'm still getting familiar with the NumPy codebase, so feedback is very welcome.

### AI Disclosure

I used OpenAI Codex as a development assistant for repository exploration, reproducing the issue, tracing the relevant code paths, implementing the fix, and running tests and validation.

I reviewed and understood the resulting changes and verified the behavior and test results myself. The pull request is being submitted and all project communication is being handled by me.
