### PR TITLE
BUG: Fix ref leak in _convert_from_type for custom scalar types (#31750)

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1598,7 +1598,9 @@ _convert_from_type(PyObject *obj) {
     else {
         PyObject *DType = PyArray_DiscoverDTypeFromScalarType(typ);
         if (DType != NULL) {
-            return PyArray_GetDefaultDescr((PyArray_DTypeMeta *)DType);
+            PyArray_Descr *ret = PyArray_GetDefaultDescr((PyArray_DTypeMeta *)DType);
+            Py_DECREF(DType);
+            return ret;
         }
         PyArray_Descr *ret = _try_convert_from_dtype_attr(obj);
         if ((PyObject *)ret != Py_NotImplemented) {


### PR DESCRIPTION
Backport of https://github.com/numpy/numpy/pull/31750

### PR summary
This PR is from issue https://github.com/numpy/numpy/issues/31676 addressing a memory leakage in descriptor.c at line 1598 to 1604 and I have checked and hit all guidlines to the best of my knowledge

### First time committer introduction
I am michael cogan I am a physics student I have used numpy numerously throughout research and classes I chose this fix because I am trying to build up my resume and also thought it would be cool to help open source and I believed this was an easy enough fix for me to tackle as my first commit 

#### AI Disclosure
I used Gemini pro to help me with understanding the scope of the file and I used to run personal tests to make sure the memory leak was fixed all code entered is mine 