### PR TITLE
MAINT: parse ndarray.flags keys as unicode directly (gh-15317) 

### DIFF
--- a/numpy/_core/src/multiarray/flagsobject.c
+++ b/numpy/_core/src/multiarray/flagsobject.c
@@ -460,24 +460,16 @@ static PyGetSetDef arrayflags_getsets[] = {
 static PyObject *
 arrayflags_getitem(PyArrayFlagsObject *self, PyObject *ind)
 {
-    char *key = NULL;
-    char buf[16];
-    int n;
+    char const *key = NULL;
+    Py_ssize_t n;
     if (PyUnicode_Check(ind)) {
-        PyObject *tmp_str;
-        tmp_str = PyUnicode_AsASCIIString(ind);
-        if (tmp_str == NULL) {
-            return NULL;
-        }
-        key = PyBytes_AS_STRING(tmp_str);
-        n = PyBytes_GET_SIZE(tmp_str);
-        if (n > 16) {
-            Py_DECREF(tmp_str);
+        if (!PyUnicode_IS_ASCII(ind)) {
             goto fail;
         }
-        memcpy(buf, key, n);
-        Py_DECREF(tmp_str);
-        key = buf;
+        key = PyUnicode_AsUTF8AndSize(ind, &n);
+        if (key == NULL) {
+            return NULL;
+        }
     }
     else if (PyBytes_Check(ind)) {
         key = PyBytes_AS_STRING(ind);
@@ -580,21 +572,16 @@ arrayflags_getitem(PyArrayFlagsObject *self, PyObject *ind)
 static int
 arrayflags_setitem(PyArrayFlagsObject *self, PyObject *ind, PyObject *item)
 {
-    char *key;
-    char buf[16];
-    int n;
+    char const *key;
+    Py_ssize_t n;
     if (PyUnicode_Check(ind)) {
-        PyObject *tmp_str;
-        tmp_str = PyUnicode_AsASCIIString(ind);
-        if (tmp_str == NULL) {
+        if (!PyUnicode_IS_ASCII(ind)) {
             goto fail;
         }
-        key = PyBytes_AS_STRING(tmp_str);
-        n = PyBytes_GET_SIZE(tmp_str);
-        if (n > 16) n = 16;
-        memcpy(buf, key, n);
-        Py_DECREF(tmp_str);
-        key = buf;
+        key = PyUnicode_AsUTF8AndSize(ind, &n);
+        if (key == NULL) {
+            return -1;
+        }
     }
     else if (PyBytes_Check(ind)) {
         key = PyBytes_AS_STRING(ind);

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -277,6 +277,23 @@ class TestFlags:
         with pytest.raises(KeyError, match="Unknown flag"):
             arr.flags["\N{MICRO SIGN}"] = True
 
+    @pytest.mark.parametrize("key", ["\N{MICRO SIGN}", "\N{SNOWMAN}",
+                                     "\ud800", "WRITEABLE" * 3, ""])
+    def test_bad_flag_key_raises_keyerror(self, key):
+        arr = np.arange(10)
+        with pytest.raises(KeyError, match="Unknown flag"):
+            arr.flags[key]
+        with pytest.raises(KeyError, match="Unknown flag"):
+            arr.flags[key] = True
+
+    def test_bytes_flag_key(self):
+        # bytes keys are accepted for backwards compatibility
+        arr = np.arange(10)
+        assert_equal(arr.flags[b'WRITEABLE'], True)
+        assert_equal(arr.flags[b'W'], True)
+        arr.flags[b'WRITEABLE'] = False
+        assert_equal(arr.flags['WRITEABLE'], False)
+
     def test_string_align(self):
         a = np.zeros(4, dtype=np.dtype('|S4'))
         assert_(a.flags.aligned)


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
This is one of the code that's trying to resolve [numpy#15317](https://github.com/numpy/numpy/issues/15317) which is to take out the code as below
```
if (PyUnicode_Check(obj)) {
    PyObject *obj_bytes = PyUnicode_AsASCIIString(obj);   /* encode first */
    ...
}
PyBytes_AsStringAndSize(obj, &str, &length);              /* then work with bytes */
```
which is all over this repo. This is problematic as `PyUnicode_AsASCIIString(obj);` could throw UnicodeEncodeError, which does not describe the issue accurately. In this PR, I'm replacing one for the function getitem to have simply key errors instead of encoding errors. For the function setitem, it would have the exact same behavior, but we're removing the `PyUnicode_AsASCIIString` function in the code and simplifying the code. 

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI-generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

Code, tests, and release notes are AI-generated (Claude model Opus). PR summaries and comments are mine. I've looked into the code extensively, so I should know what's going on fully. 