### PR TITLE
DOC: clarify lazy loading of .npz arrays in np.load docstring

### DIFF
--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -399,12 +399,12 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
       block.
     - Data for each array in a ``.npz`` file is read from disk lazily,
       only when that array is actually accessed (e.g. via ``data['a']``),
-      not when `load` returns. The source file must therefore remain
-      unmodified and available until all needed arrays have been
-      accessed; replacing or deleting it first can raise ``BadZipFile``
-      or similar errors on later access. To decouple the result from the
-      file on disk, either access all needed keys first or convert it to
-      a plain ``dict``, e.g. ``dict(np.load('foo.npz'))``.
+      not when `load` returns. Overwriting the source file in place
+      before all needed arrays have been read can raise ``BadZipFile``
+      or similar errors; the effect of deleting or replacing the file
+      is platform- and filesystem-dependent. To decouple the result
+      from the file on disk, either access all needed keys first or
+      convert it to a plain ``dict``, e.g. ``dict(np.load('foo.npz'))``.
 
     Examples
     --------

--- a/numpy/lib/_npyio_impl.py
+++ b/numpy/lib/_npyio_impl.py
@@ -397,6 +397,14 @@ def load(file, mmap_mode=None, allow_pickle=False, fix_imports=True,
 
       The underlying file descriptor is closed when exiting the 'with'
       block.
+    - Data for each array in a ``.npz`` file is read from disk lazily,
+      only when that array is actually accessed (e.g. via ``data['a']``),
+      not when `load` returns. The source file must therefore remain
+      unmodified and available until all needed arrays have been
+      accessed; replacing or deleting it first can raise ``BadZipFile``
+      or similar errors on later access. To decouple the result from the
+      file on disk, either access all needed keys first or convert it to
+      a plain ``dict``, e.g. ``dict(np.load('foo.npz'))``.
 
     Examples
     --------


### PR DESCRIPTION
Add a note that data for each array in a .npz file is read from disk lazily, on first access, so the source file must remain available until all needed arrays have been accessed.

Closes gh-22435

### PR summary
`np.load`'s docstring didn't mention that data for each array in a
`.npz` file is read from disk lazily, only when that array is
actually accessed (e.g. via `data['a']`), not when `load` returns.
This means the source file must stay unmodified and available until
all needed arrays have been read; replacing or deleting it early can
raise `BadZipFile` or similar errors later, which is surprising and
not documented anywhere.

This PR adds a new bullet to the `Notes` section of the `load()`
docstring explaining this behavior and how to decouple the result
from the file on disk (access all keys up front, or wrap in
`dict(...)`).

### First time committer introduction
I'm Gajanan, and I'm a finance enthusiast! I have keen interest 
in data engineering. And that's what brought me to numpy's repo. 
Throughout my engineering studies, numpy has been an integral 
part of most of my classes, and now,
I seriously aspire to contribute to it. 

#### AI Disclosure
Claude Code was used to find relevant issues and understand the issue.
