### PR TITLE
BUG: return 0 from empty object np.vdot

### DIFF
--- a/doc/release/upcoming_changes/32310.change.rst
+++ b/doc/release/upcoming_changes/32310.change.rst
@@ -1,0 +1,4 @@
+`np.vdot` of empty object arrays
+--------------------------------
+`np.vdot` on zero-length object arrays now returns ``0`` instead of
+``None``.

--- a/numpy/_core/src/multiarray/vdot.c
+++ b/numpy/_core/src/multiarray/vdot.c
@@ -145,6 +145,16 @@ OBJECT_vdot(char *ip1, npy_intp is1, char *ip2, npy_intp is2, char *op, npy_intp
     npy_intp i;
     PyObject *tmp0, *tmp1, *tmp2, *tmp = NULL;
     PyObject **tmp3;
+
+    if (n == 0) {
+        PyObject *zero = PyLong_FromLong(0);
+        if (zero == NULL) {
+            return;
+        }
+        Py_XSETREF(*((PyObject **)op), zero);
+        return;
+    }
+
     for (i = 0; i < n; i++, ip1 += is1, ip2 += is2) {
         if ((*((PyObject **)ip1) == NULL) || (*((PyObject **)ip2) == NULL)) {
             tmp1 = Py_False;

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -7839,6 +7839,19 @@ class TestVdot:
             assert_equal(np.vdot(a, b.copy('F')),
                          np.vdot(a.flatten(), b.flatten()))
 
+    def test_vdot_object_empty_is_zero(self):
+        # gh-31735: empty object vdot used to return None
+        cases = [
+            np.empty((0,), dtype=object),
+            np.empty((1, 0), dtype=object),
+            np.empty((0, 1), dtype=object),
+            np.empty((0, 0), dtype=object),
+        ]
+        for x in cases:
+            res = np.vdot(x, x)
+            assert_(np.isscalar(res))
+            assert_equal(res, 0)
+
 
 class TestDot:
     N = 7


### PR DESCRIPTION
## Description

`np.vdot` of a zero-length object array returned `None` instead of a zero-like result. `OBJECT_vdot` never wrote an identity value when `n == 0`, so the output pointer stayed `NULL` and `PyArray_Return` turned that into `None`.

This is the same empty-product case that `np.vecdot` hit in gh-31019. The fix matches gh-31033: store `0` when the contracted axis has length 0.

`vdot` flattens, so all of these now return the scalar `0`:

```python
>>> import numpy as np
>>> np.vdot(np.empty((0,), dtype=object), np.empty((0,), dtype=object))
0
>>> np.vdot(np.empty((1, 0), dtype=object), np.empty((1, 0), dtype=object))
0
```

Fixes #31735
