### PR TITLE
DOC: fix typo in lapack_lite (wether -> whether)

### DIFF
--- a/numpy/linalg/lapack_lite/f2c_d_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_d_lapack.c
@@ -28481,7 +28481,7 @@ L100:
 
     UPLO  (input) CHARACTER*1
           On entry, UPLO specifies whether the input bidiagonal matrix
-          is upper or lower bidiagonal, and wether it is square are
+          is upper or lower bidiagonal, and whether it is square are
           not.
              UPLO = 'U' or 'u'   B is upper bidiagonal.
              UPLO = 'L' or 'l'   B is lower bidiagonal.

--- a/numpy/linalg/lapack_lite/f2c_s_lapack.c
+++ b/numpy/linalg/lapack_lite/f2c_s_lapack.c
@@ -28373,7 +28373,7 @@ L100:
 
     UPLO  (input) CHARACTER*1
           On entry, UPLO specifies whether the input bidiagonal matrix
-          is upper or lower bidiagonal, and wether it is square are
+          is upper or lower bidiagonal, and whether it is square are
           not.
              UPLO = 'U' or 'u'   B is upper bidiagonal.
              UPLO = 'L' or 'l'   B is lower bidiagonal.


### PR DESCRIPTION
Fix a spelling typo in the generated LAPACK doc comments: `wether` -> `whether` (two occurrences, in f2c_d_lapack.c and f2c_s_lapack.c).