### PR TITLE
TST: add tests for `numpy.lib.introspect.opt_func_info`

### DIFF
--- a/numpy/lib/tests/test_introspect.py
+++ b/numpy/lib/tests/test_introspect.py
@@ -1,0 +1,47 @@
+from numpy._core._multiarray_umath import __cpu_targets_info__ as _targets, dtype
+from numpy.lib.introspect import opt_func_info
+
+
+class TestOptFuncInfo:
+    def test_returns_dict(self):
+        assert isinstance(opt_func_info(), dict)
+
+    def test_no_arguments_returns_all(self):
+        assert opt_func_info() == dict(_targets)
+
+    def test_filter_by_func_name(self):
+        # Every returned name matches the filter.
+        info = opt_func_info(func_name="add")
+        assert all("add" in name for name in info)
+        assert set(info).issubset(opt_func_info())
+
+    def test_func_name_is_regex(self):
+        combined = opt_func_info(func_name="add|absolute")
+        assert set(opt_func_info(func_name="add")).issubset(combined)
+        assert set(opt_func_info(func_name="absolute")).issubset(combined)
+
+    def test_func_name_no_match(self):
+        assert opt_func_info(func_name="_no_such_ufunc_") == {}
+
+    def test_filter_by_signature_char(self):
+        # 'd' matches a signature letter directly.
+        info = opt_func_info(signature="d")
+        assert set(info).issubset(opt_func_info())
+
+    def test_filter_by_signature_dtype_name(self):
+        # 'float64' matches by type name, so it keeps codes named 'float64'
+        info = opt_func_info(signature="float64")
+        for sigs in info.values():
+            assert all(
+                any(dtype(c).name == "float64" for c in chars)
+                for chars in sigs
+            )
+
+    def test_filter_by_func_name_and_signature(self):
+        info = opt_func_info(func_name="add", signature="float64")
+        assert all("add" in name for name in info)
+        assert set(info).issubset(opt_func_info(func_name="add"))
+
+    def test_signature_no_match_drops_func(self):
+        # A filter that matches no type returns an empty dict.
+        assert opt_func_info(signature="_no_such_dtype_") == {}

--- a/numpy/lib/tests/test_introspect.py
+++ b/numpy/lib/tests/test_introspect.py
@@ -1,11 +1,9 @@
-from numpy._core._multiarray_umath import __cpu_targets_info__ as _targets, dtype
+import numpy as np
+from numpy._core._multiarray_umath import __cpu_targets_info__ as _targets
 from numpy.lib.introspect import opt_func_info
 
 
 class TestOptFuncInfo:
-    def test_returns_dict(self):
-        assert isinstance(opt_func_info(), dict)
-
     def test_no_arguments_returns_all(self):
         assert opt_func_info() == dict(_targets)
 
@@ -24,23 +22,19 @@ class TestOptFuncInfo:
         assert opt_func_info(func_name="_no_such_ufunc_") == {}
 
     def test_filter_by_signature_char(self):
-        # 'd' matches a signature letter directly.
-        info = opt_func_info(signature="d")
-        assert set(info).issubset(opt_func_info())
+        # Match the exact code 'd', not names containing 'd' like 'timedelta64'.
+        info = opt_func_info(signature="^d$")
+        for sigs in info.values():
+            assert all("d" in chars for chars in sigs)
 
     def test_filter_by_signature_dtype_name(self):
-        # 'float64' matches by type name, so it keeps codes named 'float64'
+        # 'float64' matches by type name, so it keeps codes named 'float64'.
         info = opt_func_info(signature="float64")
         for sigs in info.values():
             assert all(
-                any(dtype(c).name == "float64" for c in chars)
+                any(np.dtype(c).name == "float64" for c in chars)
                 for chars in sigs
             )
-
-    def test_filter_by_func_name_and_signature(self):
-        info = opt_func_info(func_name="add", signature="float64")
-        assert all("add" in name for name in info)
-        assert set(info).issubset(opt_func_info(func_name="add"))
 
     def test_signature_no_match_drops_func(self):
         # A filter that matches no type returns an empty dict.


### PR DESCRIPTION
### PR summary
Towards #32275 

- add tests for `numpy.lib.introspect.opt_func_info`

### Coverage report

- `numpy\lib\introspect.py       20    0   12   0  100%`  

<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
- i asked to review, and then got some improvements 

So lets call this work done by Semi-human

cc @ganesh-k13
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
