### PR TITLE
TYP: ``ndarray.view`` improved shape-typing

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -680,6 +680,7 @@ from numpy.lib._utils_impl import (
     show_runtime,
 )
 
+from numpy.ma import MaskedArray as _marray  # type-check-only
 from numpy.matrixlib import (
     asmatrix,
     bmat,
@@ -4478,20 +4479,33 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
         copy: py_bool | _CopyMode = ...,
     ) -> ndarray[_ShapeT_co, _dtype]: ...
 
-    #
-    @overload  # ()
+    # NOTE: Python has no support for higher-kinded types, so we special-case some known
+    # array subclasses to avoid erasing the shape-type and dtype.
+    @overload  # /
     def view(self, /) -> Self: ...
-    @overload  # (dtype: T)
+    @overload  # dtype=<known dtype>
     def view[DTypeT: _dtype](self, /, dtype: DTypeT | _HasDType[DTypeT]) -> ndarray[_ShapeT_co, DTypeT]: ...
-    @overload  # (dtype: dtype[T])
+    @overload  # dtype=<known scalar type>
     def view[ScalarT: generic](self, /, dtype: _DTypeLike[ScalarT]) -> ndarray[_ShapeT_co, _dtype[ScalarT]]: ...
-    @overload  # (type: T)
+    @overload  # type=memmap (keyword)
+    def view(self, /, *, type: type[memmap]) -> memmap[_ShapeT_co, _DTypeT_co]: ...
+    @overload  # type=memmap (positional)
+    def view(self, /, dtype: type[memmap]) -> memmap[_ShapeT_co, _DTypeT_co]: ...
+    @overload  # type=recarray (keyword)
+    def view(self, /, *, type: type[recarray]) -> recarray[_ShapeT_co, _DTypeT_co]: ...
+    @overload  # type=recarray (positional)
+    def view(self, /, dtype: type[recarray]) -> recarray[_ShapeT_co, _DTypeT_co]: ...
+    @overload  # type=ma.MaskedArray (keyword)
+    def view(self, /, *, type: type[_marray]) -> _marray[_ShapeT_co, _DTypeT_co]: ...
+    @overload  # type=ma.MaskedArray (positional)
+    def view(self, /, dtype: type[_marray]) -> _marray[_ShapeT_co, _DTypeT_co]: ...
+    @overload  # type=<given> (keyword)
     def view[ArrayT: ndarray](self, /, *, type: type[ArrayT]) -> ArrayT: ...
-    @overload  # (_: T)
+    @overload  # type=<given> (positional)
     def view[ArrayT: ndarray](self, /, dtype: type[ArrayT]) -> ArrayT: ...
-    @overload  # (dtype: ?)
+    @overload  # dtype=<unknown>
     def view(self, /, dtype: DTypeLike) -> ndarray[_ShapeT_co, _dtype]: ...
-    @overload  # (dtype: ?, type: T)
+    @overload  # dtype=<unknown>, type=<given>
     def view[ArrayT: ndarray](self, /, dtype: DTypeLike, type: type[ArrayT]) -> ArrayT: ...
 
     #

--- a/numpy/typing/tests/data/reveal/ndarray_conversion.pyi
+++ b/numpy/typing/tests/data/reveal/ndarray_conversion.pyi
@@ -68,10 +68,13 @@ assert_type(i0_nd.byteswap(True), npt.NDArray[np.int_])
 assert_type(i0_nd.copy(), npt.NDArray[np.int_])
 assert_type(i0_nd.copy("C"), npt.NDArray[np.int_])
 
-assert_type(i0_nd.view(), npt.NDArray[np.int_])
-assert_type(i0_nd.view(np.float64), npt.NDArray[np.float64])
-assert_type(i0_nd.view(float), npt.NDArray[Any])
-assert_type(i0_nd.view(np.float64, np.matrix), np.matrix[Any, Any])
+assert_type(u2_1d.view(), np.ndarray[tuple[int], np.dtype[np.uint16]])
+assert_type(i4_2d.view(np.float64), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(f8_3d.view(float), np.ndarray[tuple[int, int, int], np.dtype[Any]])
+assert_type(u2_1d.view(np.memmap), np.memmap[tuple[int], np.dtype[np.uint16]])
+assert_type(u2_1d.view(type=np.memmap), np.memmap[tuple[int], np.dtype[np.uint16]])
+assert_type(i4_2d.view(np.ma.MaskedArray), np.ma.MaskedArray[tuple[int, int], np.dtype[np.int32]])
+assert_type(i4_2d.view(type=np.ma.MaskedArray), np.ma.MaskedArray[tuple[int, int], np.dtype[np.int32]])
 
 # getfield
 assert_type(i0_nd.getfield("float"), npt.NDArray[Any])


### PR DESCRIPTION
This adds special-cased `ndarray.view` overloads for `recarray`, `ma.MaskedArray`, and `memmap`, so that for those types the dtype and shape-type will be preserved. Special casing is needed because Python has currently no support for higher-kinded types (see https://github.com/jorenham/hkt-survey and https://github.com/python/typing/issues/548 for details).

---

Fully written by me, pre-reviewed and audited by AI (see [gist](https://gist.github.com/jorenham/36c78602a7ca866ddb2a917de48ccdd0)).