### PR TITLE
MAINT/TYP: Bump ``mypy`` to ``2.3.1``

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - pytest-xdist
   - hypothesis
   # For type annotations
-  - mypy==2.3.0
+  - mypy==2.3.1
   - orjson # makes mypy faster
   # For building docs
   - sphinx>=8.0

--- a/requirements/typing_requirements.txt
+++ b/requirements/typing_requirements.txt
@@ -3,5 +3,5 @@
 -r test_requirements.txt
 -r hypothesis_requirements.txt
 
-mypy==2.3.0
+mypy==2.3.1
 pyrefly==1.2.0


### PR DESCRIPTION
As kindly noted by @wangenau in https://github.com/numpy/numpy/pull/32316#issuecomment-5319158892, this should fix the mypy_primer internal error for optuna.

---

No AI