### PR TITLE
TST: avoid allocating huge tuple of arrays in concatenate test

### DIFF
--- a/numpy/_core/tests/test_shape_base.py
+++ b/numpy/_core/tests/test_shape_base.py
@@ -30,7 +30,6 @@ from numpy.testing import (
     assert_raises,
     assert_raises_regex,
 )
-from numpy.testing._private.utils import requires_memory
 
 
 class TestAtleast1d:
@@ -292,21 +291,27 @@ class TestConcatenate:
         # No arrays to concatenate raises ValueError
         assert_raises(ValueError, concatenate, ())
 
-    @pytest.mark.slow
     @pytest.mark.skipif(
         sys.maxsize < 2**32,
         reason="only problematic on 64bit platforms"
     )
-    @requires_memory(2 * np.iinfo(np.intc).max)
-    @pytest.mark.thread_unsafe(reason="crashes with low memory")
     def test_huge_list_error(self):
-        a = np.array([1])
         max_int = np.iinfo(np.intc).max
-        arrs = (a,) * (max_int + 1)
+
+        class HugeSequence:
+            def __len__(self):
+                return max_int + 1
+
+            def __getitem__(self, index):
+                raise RuntimeError(
+                    "concatenate must raise before accessing any item")
+
         msg = (fr"concatenate\(\) only supports up to {max_int} arrays"
                f" but got {max_int + 1}.")
         with pytest.raises(ValueError, match=msg):
-            np.concatenate(arrs)
+            # the __array_function__ dispatcher would iterate all entries
+            # before the length check, so call the implementation directly
+            np.concatenate._implementation(HugeSequence())
 
     def test_concatenate_axis_None(self):
         a = np.arange(4, dtype=np.float64).reshape((2, 2))


### PR DESCRIPTION
### PR summary
This test is causing flaky CI: https://github.com/numpy/numpy/actions/runs/31394421923/job/93475396840?pr=32239

Given that the test is mostly there to make sure the error path fires, I think it's OK to call `_implementation` directly. As a bonus I can remove all the slow, thread-unsafe, and requires lots of RAM pytest markers.

#### AI Disclosure
I used an AI to understand why this test was so slow on CI (it's causing the CI runners to swap).