### PR TITLE
BUG: immortalize heap-allocated dtypes to avoid refcount contention (gh-32298)

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -2058,6 +2058,25 @@ PyArray_DescrNew(PyArray_Descr *base_descr)
     Py_XINCREF(newdescr->metadata);
     newdescr->hash = -1;
 
+    /*
+     * Make heap-allocated descriptors immortal (gh-32298).
+     *
+     * Builtin, unparametrized dtype singletons are immortal, so refcounting
+     * them is a no-op.  A descriptor created here is an ordinary mortal object,
+     * and every array operation takes a reference on its operands' dtype.  On
+     * free-threaded builds, when one such descriptor is shared across threads
+     * (e.g. an array from unpickling, copy.deepcopy, newbyteorder, or any
+     * parametrized dtype such as datetime64[ns] / fixed-width strings /
+     * structured dtypes) those atomic refcount updates contend on a single
+     * cache line and the workload anti-scales.
+     *
+     * Immortalizing the descriptor removes it from refcounting entirely, giving
+     * these dtypes the same threading behavior as the builtin singletons.  This
+     * mirrors the treatment of casting impls in array_method.c, which are made
+     * immortal for the same reason.
+     */
+    PyUnstable_SetImmortal((PyObject *)newdescr);
+
     return (PyArray_Descr *)newdescr;
 }
 

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 import ctypes
 import inspect
 import operator
@@ -1430,6 +1431,45 @@ class TestPickling:
                 ValueError, match="Invalid state while unpickling"
             ):
                 dt.__setstate__(extended)
+
+
+class TestImmortalHeapDtypes:
+    # gh-32298: heap-allocated descriptors are immortalized so that dtype
+    # instances shared across threads (from unpickling, deepcopy, newbyteorder,
+    # or parametrized dtypes) do not cause refcount contention on free-threaded
+    # builds, matching the builtin singletons.
+
+    @staticmethod
+    def assert_immortal(dtype):
+        # Immortal objects are excluded from refcounting: getrefcount reports
+        # the special immortal value (2**32 - 1 on CPython 3.13) rather than a
+        # small per-object count.  Guard well below that so the check is robust
+        # to the exact sentinel.
+        assert sys.getrefcount(dtype) > 2**30, (
+            f"{dtype!r} is mortal; heap descriptors must be immortal"
+        )
+
+    def test_unpickled_dtype_is_immortal(self):
+        dt = pickle.loads(pickle.dumps(np.dtype("float64")))
+        assert dt == np.dtype("float64")
+        assert dt is not np.dtype("float64")  # a fresh heap descriptor
+        self.assert_immortal(dt)
+
+    def test_deepcopy_dtype_is_immortal(self):
+        self.assert_immortal(copy.deepcopy(np.dtype("float64")))
+
+    def test_newbyteorder_dtype_is_immortal(self):
+        self.assert_immortal(np.dtype("float64").newbyteorder("="))
+
+    @pytest.mark.parametrize(
+        "spec",
+        ["datetime64[ns]", "timedelta64[s]", "U5", "S3", "V12",
+         [("a", "f8"), ("b", "i4")]],
+    )
+    def test_parametrized_dtype_is_immortal(self, spec):
+        # These dtypes are not cached singletons, so a freshly created instance
+        # is shared across threads with no user-side workaround available.
+        self.assert_immortal(np.dtype(spec))
 
 
 class TestPromotion:


### PR DESCRIPTION
## Summary

Fixes gh-32298. On free-threaded builds, an array whose dtype is a *fresh, mortal* descriptor — from unpickling, `copy.deepcopy`, `dtype.newbyteorder('=')`, or any parametrized dtype (`datetime64[ns]`, fixed-width strings, void, structured) — anti-scales under threads: every operation takes a reference on its operands' dtype, and when one descriptor is shared across threads those atomic refcount RMWs contend on a single cache line.

Builtin, unparametrized dtype singletons avoid this because they are immortal, so refcounting them is a no-op. This PR gives the same treatment to heap-allocated descriptors by immortalizing them in `PyArray_DescrNew`, using `PyUnstable_SetImmortal` — the same technique already applied to casting impls in `array_method.c` for the same reason.

## Benchmark

Reproduction script from the issue, CPython 3.13 free-threaded build, 8 threads:

```
                            nt=1     nt=8    scaling
np.load (immortal dtype)    0.25s    0.40s    0.63x
pickle  (mortal dtype)      0.26s    1.31s    0.20x   <- anti-scales
pickle + view(canonical)    0.23s    0.38s    0.61x
```

After this change the `pickle` array's dtype is immortal (`sys.getrefcount` reports the immortal sentinel), and it matches `np.load`:

```
                            nt=1     nt=8    scaling
np.load                     0.23s    0.39s    0.59x
pickle                      0.24s    0.38s    0.62x
pickle + view(canonical)    0.24s    0.39s    0.61x
```

8-thread pickle time: **1.31s -> 0.38s (~3.4x)**, and the anti-scaling is gone. A single call site covers every path listed in the issue (pickle, deepcopy, newbyteorder, and all parametrized dtypes), since they all route through `PyArray_DescrNew`.

## Tests

New `TestImmortalHeapDtypes` in `test_dtype.py` asserts the invariant — descriptors from each of these paths are immortal. These tests fail on `main` and pass with this change. Existing `test_dtype`, `test_multithreading`, and `test_casting_unittests` suites pass.

## Open question for reviewers

This immortalizes **all** heap-allocated descriptors, so they are never freed. For the overwhelmingly common case (a bounded set of distinct dtypes) the memory cost is negligible, and this matches the direction suggested in the issue. The tradeoff is a program that intentionally creates a very large number of *distinct* parametrized dtypes (e.g. many unique structured dtypes) will retain them for the process lifetime.

If that is a concern, the alternative is to *intern* parametrized descriptors into a canonical cache (as builtins effectively are) rather than immortalize unconditionally. That is a larger change; happy to go that route if preferred. `PyArray_DescrNew` also only handles legacy descriptors — new-style user DTypes take a different path and are out of scope here, but none of the reported cases need them.

Note: the original report was written with LLM assistance; this PR independently reproduces the bug on a free-threaded build and verifies the fix and its regression tests.
