### PR TITLE
BUG: Fix numpy.i0 overflow for large finite inputs (gh-32209)

### DIFF
--- a/doc/release/upcoming_changes/32209.improvement.rst
+++ b/doc/release/upcoming_changes/32209.improvement.rst
@@ -1,0 +1,7 @@
+`numpy.i0` no longer overflows for large finite inputs
+------------------------------------------------------
+`numpy.i0` could return ``inf`` for large but representable arguments
+such as ``713.0``, because ``exp(x)`` overflowed before it was scaled
+by the Chebyshev factor. The large-``x`` path now avoids that
+intermediate overflow, so the result stays finite when it fits in
+float64.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -46,6 +46,7 @@ from numpy._core.umath import (
     floor,
     frompyfunc,
     less_equal,
+    log,
     minimum,
     mod,
     not_equal,
@@ -3562,7 +3563,25 @@ def _i0_1(x):
 
 
 def _i0_2(x):
-    return exp(x) * _chbevl(32.0 / x - 2.0, _i0B) / sqrt(x)
+    # Cephes: I0(x) = exp(x) * y / sqrt(x) for x > 8, with y = chbevl(...).
+    # exp(x) overflows for x > log(dtype.max) (~709.78 for float64) even
+    # when the product is still finite (e.g. x = 713).  Keep the original
+    # formula below that threshold.  Above it, factor exp(x) = exp(x-s)*exp(s)
+    # with finite s so the Chebyshev factor is not logged (preserves accuracy).
+    y = _chbevl(32.0 / x - 2.0, _i0B)
+    overflow = log(np.finfo(x.dtype).max)
+    large = x > overflow
+    if not np.any(large):
+        return exp(x) * y / sqrt(x)
+    s = overflow - 1.0
+    if np.all(large):
+        return exp(x - s) * (exp(s) * y / sqrt(x))
+    out = empty(x.shape, dtype=x.dtype)
+    small = ~large
+    out[small] = exp(x[small]) * y[small] / sqrt(x[small])
+    xl = x[large]
+    out[large] = exp(xl - s) * (exp(s) * y[large] / sqrt(xl))
+    return out
 
 
 def _i0_dispatcher(x):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3016,6 +3016,17 @@ class Test_I0:
         assert_equal(i0_0.shape, (1,))
         assert_array_equal(np.i0([0.]), np.array([1.]))
 
+    def test_gh_32209_large_finite(self):
+        # exp(713) overflows float64, but I0(713) is still representable.
+        x = np.float64(713.0)
+        expected = np.float64(6.705128263670996e307)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            actual = i0(x)
+        assert np.isfinite(actual)
+        assert_allclose(actual, expected, rtol=1e-14, atol=0.0)
+        assert_allclose(i0(-x), actual, rtol=1e-14, atol=0.0)
+
     def test_non_array(self):
         a = np.arange(4)
 


### PR DESCRIPTION
`numpy.i0(x)` computes I0(x) as `exp(x) * chbevl(...) / sqrt(x)` for
x > 8. For x such as 713.0, `exp(x)` alone overflows to `inf` in
float64, even though the true I0(713.0) (~6.7e307) is finite and
representable.

This PR factors `exp(x)` as `exp(x - s) * exp(s)` with a finite `s`
chosen just below the overflow threshold (`log(finfo.max)`), so
neither factor overflows individually while the product stays
mathematically equivalent. The original formula is unchanged below
the threshold, so existing behavior (e.g. x=10) is untouched.

I also tried a log-space reformulation
(`exp(x + log(y) - 0.5*log(x))`) first, but it did not match the
reference value at rtol=1e-14 (off by ~6.7e-14). The scaled-exp
approach matches exactly, since it avoids an extra log/exp
round-trip.

Tested against the mpmath-derived reference value from the issue,
the x=8 boundary, the overflow threshold (~709.78), x=-713 (I0 is
even), true overflow at x=714+ (still correctly returns inf), and a
mixed array of small and large values, all with warnings-as-errors.

Closes #32209