### PR TITLE
MAINT: soft-deprecate PyArray_malloc/realloc/free in favor of PyMem_Raw APIs

### DIFF
--- a/doc/release/upcoming_changes/32334.c_api.rst
+++ b/doc/release/upcoming_changes/32334.c_api.rst
@@ -1,0 +1,15 @@
+``PyArray`` allocator helpers are now deprecated
+------------------------------------------------
+
+The following macro and C API helper functions for allocating data are now
+`soft-deprecated
+<https://docs.python.org/3/glossary.html#term-soft-deprecated>`_:
+
+* ``NPY_USE_PYMEM``
+* ``PyArray_malloc``
+* ``PyArray_realloc``
+* ``PyArray_free``
+
+If you are using these in your extensions, we suggest migrating to use `the
+Python Raw Memory Interface instead
+<https://docs.python.org/3/c-api/memory.html#raw-memory-interface>`_.

--- a/doc/source/reference/c-api/array.rst
+++ b/doc/source/reference/c-api/array.rst
@@ -3055,12 +3055,12 @@ an element copier function as a primitive.
         eldoubler_aux_data *d = (eldoubler_aux_data *)data;
         /* Free the memory owned by this auxdata */
         NPY_AUXDATA_FREE(d->funcdata);
-        PyArray_free(d);
+        PyMem_RawFree(d);
     }
 
     NpyAuxData *clone_element_doubler_aux_data(NpyAuxData *data)
     {
-        eldoubler_aux_data *ret = PyArray_malloc(sizeof(eldoubler_aux_data));
+        eldoubler_aux_data *ret = PyMem_RawMalloc(sizeof(eldoubler_aux_data));
         if (ret == NULL) {
             return NULL;
         }
@@ -3071,7 +3071,7 @@ an element copier function as a primitive.
         /* Fix up the owned auxdata so we have our own copy */
         ret->funcdata = NPY_AUXDATA_CLONE(ret->funcdata);
         if (ret->funcdata == NULL) {
-            PyArray_free(ret);
+            PyMem_RawFree(ret);
             return NULL;
         }
 
@@ -3082,7 +3082,7 @@ an element copier function as a primitive.
                                 ElementCopier_Func *func,
                                 NpyAuxData *funcdata)
     {
-        eldoubler_aux_data *ret = PyArray_malloc(sizeof(eldoubler_aux_data));
+        eldoubler_aux_data *ret = PyMem_RawMalloc(sizeof(eldoubler_aux_data));
         if (ret == NULL) {
             PyErr_NoMemory();
             return NULL;
@@ -4488,12 +4488,15 @@ Memory management
 
 .. c:function:: void* PyArray_realloc(npy_intp* ptr, size_t nbytes)
 
-    These macros use different memory allocators, depending on the
-    constant :c:data:`NPY_USE_PYMEM`. The system malloc is used when
-    :c:data:`NPY_USE_PYMEM` is 0, if :c:data:`NPY_USE_PYMEM` is 1, then
-    the Python memory allocator is used.
+    These macros are aliases for ``PyMem_RawMalloc``, ``PyMem_RawFree``, and
+    ``PyMem_RawRealloc``. They exist to maintain backward compatibility for code
+    written against older versions of NumPy's C API. For new code, we recommend
+    using the `CPython Raw Memory Interface
+    <https://docs.python.org/3/c-api/memory.html#raw-memory-interface>`_.
 
-    .. c:macro:: NPY_USE_PYMEM
+.. c:macro:: NPY_USE_PYMEM
+
+   Always defined to be ``1`` and present in the API for backward compatibility.
 
 .. c:function:: int PyArray_ResolveWritebackIfCopy(PyArrayObject* obj)
 

--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -392,32 +392,24 @@ struct NpyAuxData_tag {
 #define NPY_ERR2(str) fprintf(stderr, str); fflush(stderr);
 
 /*
-* Macros to define how array, and dimension/strides data is
-* allocated. These should be made private
-*/
+ * These are soft-deprecated but are left for backward compatibility.
+ * Use PyMem_Raw APIs directly instead.
+ */
 
 #define NPY_USE_PYMEM 1
 
-
-#if NPY_USE_PYMEM == 1
-/* use the Raw versions which are safe to call with the GIL released */
 #define PyArray_malloc PyMem_RawMalloc
 #define PyArray_free PyMem_RawFree
 #define PyArray_realloc PyMem_RawRealloc
-#else
-#define PyArray_malloc malloc
-#define PyArray_free free
-#define PyArray_realloc realloc
-#endif
 
 /* Dimensions and strides */
 #define PyDimMem_NEW(size)                                         \
-    ((npy_intp *)PyArray_malloc(size*sizeof(npy_intp)))
+    ((npy_intp *)PyMem_RawMalloc(size*sizeof(npy_intp)))
 
-#define PyDimMem_FREE(ptr) PyArray_free(ptr)
+#define PyDimMem_FREE(ptr) PyMem_RawFree(ptr)
 
 #define PyDimMem_RENEW(ptr,size)                                   \
-        ((npy_intp *)PyArray_realloc(ptr,size*sizeof(npy_intp)))
+        ((npy_intp *)PyMem_RawRealloc(ptr,size*sizeof(npy_intp)))
 
 /* forward declaration */
 struct _PyArray_Descr;

--- a/numpy/_core/src/multiarray/alloc.c
+++ b/numpy/_core/src/multiarray/alloc.c
@@ -231,7 +231,7 @@ npy_free_cache_dim(void * p, npy_uintp sz)
         sz = 2;
     }
     _npy_free_cache(p, sz, NBUCKETS_DIM, dimcache,
-                    &PyArray_free);
+                    &PyMem_RawFree);
 }
 
 /* Similar to array_dealloc in arrayobject.c */

--- a/numpy/_core/src/multiarray/array_assign_scalar.c
+++ b/numpy/_core/src/multiarray/array_assign_scalar.c
@@ -281,7 +281,7 @@ PyArray_AssignRawScalar(PyArrayObject *dst,
             tmp_src_data = (char *)&scalarbuffer[0];
         }
         else {
-            tmp_src_data = PyArray_malloc(PyArray_ITEMSIZE(dst));
+            tmp_src_data = PyMem_RawMalloc(PyArray_ITEMSIZE(dst));
             if (tmp_src_data == NULL) {
                 PyErr_NoMemory();
                 goto fail;
@@ -336,14 +336,14 @@ PyArray_AssignRawScalar(PyArrayObject *dst,
     }
 
     if (allocated_src_data) {
-        PyArray_free(src_data);
+        PyMem_RawFree(src_data);
     }
 
     return 0;
 
 fail:
     if (allocated_src_data) {
-        PyArray_free(src_data);
+        PyMem_RawFree(src_data);
     }
 
     return -1;

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -719,7 +719,7 @@ UNICODE_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
     char *buffer;
     int aligned = npy_is_aligned(ov, NPY_ALIGNOF(Py_UCS4));
     if (!aligned) {
-        buffer = PyArray_malloc(num_bytes);
+        buffer = PyMem_RawMalloc(num_bytes);
         if (buffer == NULL) {
             Py_DECREF(temp);
             PyErr_NoMemory();
@@ -730,14 +730,14 @@ UNICODE_setitem(PyArray_Descr *descr, PyObject *op, char *ov)
         buffer = ov;
     }
     if (PyUnicode_AsUCS4(temp, (Py_UCS4 *)buffer, actual_len, 0) == NULL) {
-        PyArray_free(buffer);
+        PyMem_RawFree(buffer);
         Py_DECREF(temp);
         return -1;
     }
 
     if (!aligned) {
         memcpy(ov, buffer, num_bytes);
-        PyArray_free(buffer);
+        PyMem_RawFree(buffer);
     }
 
     /* Fill in the rest of the space with 0 */
@@ -3448,7 +3448,7 @@ static int
 {
     npy_intp i;
     int elsize = PyArray_ITEMSIZE(aip);
-    @type@ *mp = (@type@ *)PyArray_malloc(elsize);
+    @type@ *mp = (@type@ *)PyMem_RawMalloc(elsize);
 
     if (mp == NULL) {
         return 0;
@@ -3462,7 +3462,7 @@ static int
             *max_ind = i;
         }
     }
-    PyArray_free(mp);
+    PyMem_RawFree(mp);
     return 0;
 }
 
@@ -3512,7 +3512,7 @@ static int
 {
     npy_intp i;
     int elsize = PyArray_ITEMSIZE(aip);
-    @type@ *mp = (@type@ *)PyArray_malloc(elsize);
+    @type@ *mp = (@type@ *)PyMem_RawMalloc(elsize);
 
     if (mp==NULL) return 0;
     memcpy(mp, ip, elsize);
@@ -3524,7 +3524,7 @@ static int
             *min_ind=i;
         }
     }
-    PyArray_free(mp);
+    PyMem_RawFree(mp);
     return 0;
 }
 
@@ -4060,7 +4060,7 @@ static NpyAuxData *
 _datetime_dtype_metadata_clone(NpyAuxData *data)
 {
     PyArray_DatetimeDTypeMetaData *newdata =
-        (PyArray_DatetimeDTypeMetaData *)PyArray_malloc(
+        (PyArray_DatetimeDTypeMetaData *)PyMem_RawMalloc(
                         sizeof(*newdata));
     if (newdata == NULL) {
         PyErr_NoMemory();
@@ -4081,7 +4081,7 @@ _create_datetime_metadata(NPY_DATETIMEUNIT base, int num)
     PyArray_DatetimeDTypeMetaData *data;
 
     /* Allocate memory for the metadata */
-    data = PyArray_malloc(sizeof(*data));
+    data = PyMem_RawMalloc(sizeof(*data));
     if (data == NULL) {
         PyErr_NoMemory();
         return NULL;
@@ -4089,7 +4089,7 @@ _create_datetime_metadata(NPY_DATETIMEUNIT base, int num)
 
     /* Initialize the base aux data */
     memset(data, 0, sizeof(PyArray_DatetimeDTypeMetaData));
-    data->base.free = (NpyAuxData_FreeFunc *)PyArray_free;
+    data->base.free = (NpyAuxData_FreeFunc *)PyMem_RawFree;
     data->base.clone = _datetime_dtype_metadata_clone;
 
     data->meta.base = base;

--- a/numpy/_core/src/multiarray/compiled_base.c
+++ b/numpy/_core/src/multiarray/compiled_base.c
@@ -685,7 +685,7 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t len_arg
 
         /* only pre-calculate slopes if there are relatively few of them. */
         if (lenxp <= lenx) {
-            slopes = PyArray_malloc((lenxp - 1) * sizeof(npy_double));
+            slopes = PyMem_RawMalloc((lenxp - 1) * sizeof(npy_double));
             if (slopes == NULL) {
                 PyErr_NoMemory();
                 goto fail;
@@ -741,7 +741,7 @@ arr_interp(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t len_arg
         NPY_END_THREADS;
     }
 
-    PyArray_free(slopes);
+    PyMem_RawFree(slopes);
 
 finish:
     Py_DECREF(afp);
@@ -873,7 +873,7 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t
 
         /* only pre-calculate slopes if there are relatively few of them. */
         if (lenxp <= lenx) {
-            slopes = PyArray_malloc((lenxp - 1) * sizeof(npy_cdouble));
+            slopes = PyMem_RawMalloc((lenxp - 1) * sizeof(npy_cdouble));
             if (slopes == NULL) {
                 PyErr_NoMemory();
                 goto fail;
@@ -946,7 +946,7 @@ arr_interp_complex(PyObject *NPY_UNUSED(self), PyObject *const *args, Py_ssize_t
 
         NPY_END_THREADS;
     }
-    PyArray_free(slopes);
+    PyMem_RawFree(slopes);
 
 finish:
     Py_DECREF(afp);

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -3362,7 +3362,7 @@ convert_pyobjects_to_datetimes(int count,
     /* Use the inputs to resolve the unit metadata if requested */
     if (inout_meta->base == NPY_FR_ERROR) {
         /* Allocate an array of metadata corresponding to the objects */
-        meta = PyArray_malloc(count * sizeof(PyArray_DatetimeMetaData));
+        meta = PyMem_RawMalloc(count * sizeof(PyArray_DatetimeMetaData));
         if (meta == NULL) {
             PyErr_NoMemory();
             return -1;
@@ -3381,14 +3381,14 @@ convert_pyobjects_to_datetimes(int count,
             else if (type_nums[i] == NPY_DATETIME) {
                 if (convert_pyobject_to_datetime(&meta[i], objs[i],
                                             casting, &out_values[i]) < 0) {
-                    PyArray_free(meta);
+                    PyMem_RawFree(meta);
                     return -1;
                 }
             }
             else if (type_nums[i] == NPY_TIMEDELTA) {
                 if (convert_pyobject_to_timedelta(&meta[i], objs[i],
                                             casting, &out_values[i]) < 0) {
-                    PyArray_free(meta);
+                    PyMem_RawFree(meta);
                     return -1;
                 }
             }
@@ -3396,7 +3396,7 @@ convert_pyobjects_to_datetimes(int count,
                 PyErr_SetString(PyExc_ValueError,
                         "convert_pyobjects_to_datetimes requires that "
                         "all the type_nums provided be datetime or timedelta");
-                PyArray_free(meta);
+                PyMem_RawFree(meta);
                 return -1;
             }
         }
@@ -3410,7 +3410,7 @@ convert_pyobjects_to_datetimes(int count,
                                     &meta[i], inout_meta, inout_meta,
                                     type_nums[i] == NPY_TIMEDELTA,
                                     is_out_strict) < 0) {
-                PyArray_free(meta);
+                PyMem_RawFree(meta);
                 return -1;
             }
             is_out_strict = is_out_strict || (type_nums[i] == NPY_TIMEDELTA);
@@ -3421,20 +3421,20 @@ convert_pyobjects_to_datetimes(int count,
             if (type_nums[i] == NPY_DATETIME) {
                 if (cast_datetime_to_datetime(&meta[i], inout_meta,
                                          out_values[i], &out_values[i]) < 0) {
-                    PyArray_free(meta);
+                    PyMem_RawFree(meta);
                     return -1;
                 }
             }
             else if (type_nums[i] == NPY_TIMEDELTA) {
                 if (cast_timedelta_to_timedelta(&meta[i], inout_meta,
                                          out_values[i], &out_values[i]) < 0) {
-                    PyArray_free(meta);
+                    PyMem_RawFree(meta);
                     return -1;
                 }
             }
         }
 
-        PyArray_free(meta);
+        PyMem_RawFree(meta);
     }
     /* Otherwise convert to the provided unit metadata */
     else {
@@ -3721,7 +3721,7 @@ find_string_array_datetime64_type(PyArrayObject *arr,
     maxlen = NpyIter_GetDescrArray(iter)[0]->elsize;
 
     /* Allocate a buffer for strings which fill the buffer completely */
-    tmp_buffer = PyArray_malloc(maxlen+1);
+    tmp_buffer = PyMem_RawMalloc(maxlen+1);
     if (tmp_buffer == NULL) {
         PyErr_NoMemory();
         NpyIter_Deallocate(iter);
@@ -3777,13 +3777,13 @@ find_string_array_datetime64_type(PyArrayObject *arr,
         }
     } while(iternext(iter));
 
-    PyArray_free(tmp_buffer);
+    PyMem_RawFree(tmp_buffer);
     NpyIter_Deallocate(iter);
 
     return 0;
 
 fail:
-    PyArray_free(tmp_buffer);
+    PyMem_RawFree(tmp_buffer);
     NpyIter_Deallocate(iter);
 
     return -1;

--- a/numpy/_core/src/multiarray/datetime_busday.c
+++ b/numpy/_core/src/multiarray/datetime_busday.c
@@ -1047,7 +1047,7 @@ array_busday_offset(PyObject *NPY_UNUSED(self),
     Py_DECREF(dates);
     Py_DECREF(offsets);
     if (allocated_holidays && holidays.begin != NULL) {
-        PyArray_free(holidays.begin);
+        PyMem_RawFree(holidays.begin);
     }
 
     return out == NULL ? PyArray_Return(ret) : (PyObject *)ret;
@@ -1056,7 +1056,7 @@ fail:
     Py_XDECREF(dates);
     Py_XDECREF(offsets);
     if (allocated_holidays && holidays.begin != NULL) {
-        PyArray_free(holidays.begin);
+        PyMem_RawFree(holidays.begin);
     }
 
     return NULL;
@@ -1192,7 +1192,7 @@ array_busday_count(PyObject *NPY_UNUSED(self),
     Py_DECREF(dates_begin);
     Py_DECREF(dates_end);
     if (allocated_holidays && holidays.begin != NULL) {
-        PyArray_free(holidays.begin);
+        PyMem_RawFree(holidays.begin);
     }
 
     return out == NULL ? PyArray_Return(ret) : (PyObject *)ret;
@@ -1201,7 +1201,7 @@ fail:
     Py_XDECREF(dates_begin);
     Py_XDECREF(dates_end);
     if (allocated_holidays && holidays.begin != NULL) {
-        PyArray_free(holidays.begin);
+        PyMem_RawFree(holidays.begin);
     }
 
     return NULL;
@@ -1311,7 +1311,7 @@ array_is_busday(PyObject *NPY_UNUSED(self),
 
     Py_DECREF(dates);
     if (allocated_holidays && holidays.begin != NULL) {
-        PyArray_free(holidays.begin);
+        PyMem_RawFree(holidays.begin);
     }
 
     return out == NULL ? PyArray_Return(ret) : (PyObject *)ret;
@@ -1319,7 +1319,7 @@ array_is_busday(PyObject *NPY_UNUSED(self),
 fail:
     Py_XDECREF(dates);
     if (allocated_holidays && holidays.begin != NULL) {
-        PyArray_free(holidays.begin);
+        PyMem_RawFree(holidays.begin);
     }
 
     return NULL;

--- a/numpy/_core/src/multiarray/datetime_busdaycal.c
+++ b/numpy/_core/src/multiarray/datetime_busdaycal.c
@@ -315,7 +315,7 @@ PyArray_HolidaysConverter(PyObject *dates_in, npy_holidayslist *holidays)
 
     /* Allocate the memory for the dates */
     count = PyArray_DIM(dates, 0);
-    holidays->begin = PyArray_malloc(sizeof(npy_datetime) * count);
+    holidays->begin = PyMem_RawMalloc(sizeof(npy_datetime) * count);
     if (holidays->begin == NULL) {
         PyErr_NoMemory();
         goto fail;
@@ -376,7 +376,7 @@ busdaycalendar_init(NpyBusDayCalendar *self, PyObject *args, PyObject *kwds)
 
     /* Clear the holidays if necessary */
     if (self->holidays.begin != NULL) {
-        PyArray_free(self->holidays.begin);
+        PyMem_RawFree(self->holidays.begin);
         self->holidays.begin = NULL;
         self->holidays.end = NULL;
     }
@@ -424,7 +424,7 @@ busdaycalendar_dealloc(NpyBusDayCalendar *self)
 {
     /* Clear the holidays */
     if (self->holidays.begin != NULL) {
-        PyArray_free(self->holidays.begin);
+        PyMem_RawFree(self->holidays.begin);
         self->holidays.begin = NULL;
         self->holidays.end = NULL;
     }

--- a/numpy/_core/src/multiarray/datetime_busdaycal.h
+++ b/numpy/_core/src/multiarray/datetime_busdaycal.h
@@ -6,7 +6,7 @@
  * duplicates or NaTs, and not include any days already excluded
  * by the associated weekmask.
  *
- * The data is manually managed with PyArray_malloc/PyArray_free.
+ * The data is manually managed with PyMem_RawMalloc/PyMem_RawFree.
  */
 typedef struct {
     npy_datetime *begin, *end;

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -356,7 +356,7 @@ _convert_from_tuple(PyObject *obj, int align)
             goto fail;
         }
         newdescr->elsize = nbytes;
-        newdescr->subarray = PyArray_malloc(sizeof(PyArray_ArrayDescr));
+        newdescr->subarray = PyMem_RawMalloc(sizeof(PyArray_ArrayDescr));
         if (newdescr->subarray == NULL) {
             Py_DECREF(newdescr);
             PyErr_NoMemory();
@@ -2045,7 +2045,7 @@ PyArray_DescrNew(PyArray_Descr *base_descr)
     Py_XINCREF(newdescr->fields);
     Py_XINCREF(newdescr->names);
     if (newdescr->subarray) {
-        newdescr->subarray = PyArray_malloc(sizeof(PyArray_ArrayDescr));
+        newdescr->subarray = PyMem_RawMalloc(sizeof(PyArray_ArrayDescr));
         if (newdescr->subarray == NULL) {
             Py_DECREF(newdescr);
             return (PyArray_Descr *)PyErr_NoMemory();
@@ -2103,7 +2103,7 @@ arraydescr_dealloc(PyArray_Descr *self)
          * instead.
          */
         PyArray_Descr *base = lself->subarray->base;
-        PyArray_free(lself->subarray);
+        PyMem_RawFree(lself->subarray);
         /*
          * The Py_REFCNT(..) == 1 check is intentional. This happens in
          * a deallocator for a type that doesn't support weakrefs and
@@ -3118,7 +3118,7 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
     if (self->subarray) {
         Py_XDECREF(self->subarray->base);
         Py_XDECREF(self->subarray->shape);
-        PyArray_free(self->subarray);
+        PyMem_RawFree(self->subarray);
     }
     self->subarray = NULL;
 
@@ -3158,7 +3158,7 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
             return NULL;
         }
 
-        self->subarray = PyArray_malloc(sizeof(PyArray_ArrayDescr));
+        self->subarray = PyMem_RawMalloc(sizeof(PyArray_ArrayDescr));
         if (self->subarray == NULL) {
             return PyErr_NoMemory();
         }

--- a/numpy/_core/src/multiarray/getset.c
+++ b/numpy/_core/src/multiarray/getset.c
@@ -408,7 +408,7 @@ array_struct_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
 {
     PyArrayInterface *inter;
 
-    inter = (PyArrayInterface *)PyArray_malloc(sizeof(PyArrayInterface));
+    inter = (PyArrayInterface *)PyMem_RawMalloc(sizeof(PyArrayInterface));
     if (inter==NULL) {
         return PyErr_NoMemory();
     }
@@ -430,9 +430,9 @@ array_struct_get(PyArrayObject *self, void *NPY_UNUSED(ignored))
      *when the array is "reshaped".
      */
     if (PyArray_NDIM(self) > 0) {
-        inter->shape = (npy_intp *)PyArray_malloc(2*sizeof(npy_intp)*PyArray_NDIM(self));
+        inter->shape = (npy_intp *)PyMem_RawMalloc(2*sizeof(npy_intp)*PyArray_NDIM(self));
         if (inter->shape == NULL) {
-            PyArray_free(inter);
+            PyMem_RawFree(inter);
             return PyErr_NoMemory();
         }
         inter->strides = inter->shape + PyArray_NDIM(self);

--- a/numpy/_core/src/multiarray/item_selection.c
+++ b/numpy/_core/src/multiarray/item_selection.c
@@ -1940,13 +1940,13 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
                 "need sequence of keys with len > 0 in lexsort");
         return NULL;
     }
-    mps = (PyArrayObject **) PyArray_malloc(n * sizeof(PyArrayObject *));
+    mps = (PyArrayObject **) PyMem_RawMalloc(n * sizeof(PyArrayObject *));
     if (mps == NULL) {
         return PyErr_NoMemory();
     }
-    its = (PyArrayIterObject **) PyArray_malloc(n * sizeof(PyArrayIterObject *));
+    its = (PyArrayIterObject **) PyMem_RawMalloc(n * sizeof(PyArrayIterObject *));
     if (its == NULL) {
-        PyArray_free(mps);
+        PyMem_RawFree(mps);
         return PyErr_NoMemory();
     }
     for (i = 0; i < n; i++) {
@@ -2151,8 +2151,8 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
         Py_XDECREF(its[i]);
     }
     Py_XDECREF(rit);
-    PyArray_free(mps);
-    PyArray_free(its);
+    PyMem_RawFree(mps);
+    PyMem_RawFree(its);
     return (PyObject *)ret;
 
  fail:
@@ -2167,8 +2167,8 @@ PyArray_LexSort(PyObject *sort_keys, int axis)
         Py_XDECREF(mps[i]);
         Py_XDECREF(its[i]);
     }
-    PyArray_free(mps);
-    PyArray_free(its);
+    PyMem_RawFree(mps);
+    PyMem_RawFree(its);
     return NULL;
 }
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -302,7 +302,7 @@ PyArray_AsCArray(PyObject **op, void *ptr, npy_intp *dims, int nd,
         break;
     case 2:
         n = PyArray_DIMS(ap)[0];
-        ptr2 = (char **)PyArray_malloc(n * sizeof(char *));
+        ptr2 = (char **)PyMem_RawMalloc(n * sizeof(char *));
         if (!ptr2) {
             Py_DECREF(ap);
             PyErr_NoMemory();
@@ -316,7 +316,7 @@ PyArray_AsCArray(PyObject **op, void *ptr, npy_intp *dims, int nd,
     case 3:
         n = PyArray_DIMS(ap)[0];
         m = PyArray_DIMS(ap)[1];
-        ptr3 = (char ***)PyArray_malloc(n*(m+1) * sizeof(char *));
+        ptr3 = (char ***)PyMem_RawMalloc(n*(m+1) * sizeof(char *));
         if (!ptr3) {
             Py_DECREF(ap);
             PyErr_NoMemory();
@@ -350,7 +350,7 @@ PyArray_Free(PyObject *op, void *ptr)
         return -1;
     }
     if (PyArray_NDIM(ap) >= 2) {
-        PyArray_free(ptr);
+        PyMem_RawFree(ptr);
     }
     Py_DECREF(ap);
     return 0;
@@ -687,7 +687,7 @@ PyArray_ConcatenateInto(PyObject *op,
         return NULL;
     }
     narrays = (int)narrays_true;
-    arrays = PyArray_malloc(narrays * sizeof(arrays[0]));
+    arrays = PyMem_RawMalloc(narrays * sizeof(arrays[0]));
     if (arrays == NULL) {
         PyErr_NoMemory();
         return NULL;
@@ -721,7 +721,7 @@ PyArray_ConcatenateInto(PyObject *op,
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
         Py_DECREF(arrays[iarrays]);
     }
-    PyArray_free(arrays);
+    PyMem_RawFree(arrays);
 
     return (PyObject *)ret;
 
@@ -730,7 +730,7 @@ fail:
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
         Py_DECREF(arrays[iarrays]);
     }
-    PyArray_free(arrays);
+    PyMem_RawFree(arrays);
 
     return NULL;
 }
@@ -1295,7 +1295,7 @@ _pyarray_revert(PyArrayObject *ret)
         copyswapn(op, os, NULL, 0, length, 1, NULL);
     }
     else {
-        char *tmp = PyArray_malloc(PyArray_ITEMSIZE(ret));
+        char *tmp = PyMem_RawMalloc(PyArray_ITEMSIZE(ret));
         if (tmp == NULL) {
             PyErr_NoMemory();
             return -1;
@@ -1308,7 +1308,7 @@ _pyarray_revert(PyArrayObject *ret)
             sw1 += os;
             sw2 -= os;
         }
-        PyArray_free(tmp);
+        PyMem_RawFree(tmp);
     }
 
     return 0;
@@ -2194,7 +2194,7 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
             if (typecode->elsize == 0) {
                 typecode->elsize = 1;
             }
-            dptr = PyArray_malloc(typecode->elsize);
+            dptr = PyMem_RawMalloc(typecode->elsize);
             if (dptr == NULL) {
                 return PyErr_NoMemory();
             }
@@ -2234,7 +2234,7 @@ array_scalar(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
 
     /* free dptr which contains zeros */
     if (alloc) {
-        PyArray_free(dptr);
+        PyMem_RawFree(dptr);
     }
     Py_XDECREF(tmpobj);
     return ret;

--- a/numpy/_core/src/multiarray/nditer_api.c
+++ b/numpy/_core/src/multiarray/nditer_api.c
@@ -1742,7 +1742,7 @@ npyiter_allocate_buffers(NpyIter *iter, char **errmsg)
             buffer = NULL;
             if (!npy_mul_sizes_with_overflow(
                         &alloc_size, itemsize, buffersize)) {
-                buffer = PyArray_malloc(alloc_size);
+                buffer = PyMem_RawMalloc(alloc_size);
             }
             if (buffer == NULL) {
                 if (errmsg == NULL) {
@@ -1765,7 +1765,7 @@ npyiter_allocate_buffers(NpyIter *iter, char **errmsg)
 fail:
     for (i = 0; i < iop; ++i) {
         if (buffers[i] != NULL) {
-            PyArray_free(buffers[i]);
+            PyMem_RawFree(buffers[i]);
             buffers[i] = NULL;
         }
     }

--- a/numpy/_core/src/multiarray/nditer_constr.c
+++ b/numpy/_core/src/multiarray/nditer_constr.c
@@ -573,7 +573,7 @@ NpyIter_Copy(NpyIter *iter)
                 }
                 else {
                     itemsize = dtypes[iop]->elsize;
-                    buffers[iop] = PyArray_malloc(itemsize*buffersize);
+                    buffers[iop] = PyMem_RawMalloc(itemsize*buffersize);
                     if (buffers[iop] == NULL) {
                         out_of_memory = 1;
                     }
@@ -691,7 +691,7 @@ NpyIter_Deallocate(NpyIter *iter)
         /* buffers */
         buffers = NBF_BUFFERS(bufferdata);
         for (iop = 0; iop < nop; ++iop, ++buffers) {
-            PyArray_free(*buffers);
+            PyMem_RawFree(*buffers);
         }
 
         NpyIter_TransferInfo *transferinfo = NBF_TRANSFERINFO(bufferdata);

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -501,7 +501,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
     if (type_num == NPY_UNICODE) {
         /* we need the full string length here, else copyswap will write too
            many bytes */
-        void *buff = PyArray_malloc(descr->elsize);
+        void *buff = PyMem_RawMalloc(descr->elsize);
         if (buff == NULL) {
             return PyErr_NoMemory();
         }
@@ -512,7 +512,7 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
 
         /* truncation occurs here */
         PyObject *u = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, buff, itemsize / 4);
-        PyArray_free(buff);
+        PyMem_RawFree(buff);
         if (u == NULL) {
             return NULL;
         }

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -1747,8 +1747,8 @@ gentype_struct_free(PyObject *ptr)
     }
     Py_XDECREF(context);
     Py_XDECREF(arrif->descr);
-    PyArray_free(arrif->shape);
-    PyArray_free(arrif);
+    PyMem_RawFree(arrif->shape);
+    PyMem_RawFree(arrif);
 }
 
 static PyObject *
@@ -1759,7 +1759,7 @@ gentype_struct_get(PyObject *self, void *NPY_UNUSED(ignored))
     PyObject *ret;
 
     arr = (PyArrayObject *)PyArray_FromScalar(self, NULL);
-    inter = (PyArrayInterface *)PyArray_malloc(sizeof(PyArrayInterface));
+    inter = (PyArrayInterface *)PyMem_RawMalloc(sizeof(PyArrayInterface));
     inter->two = 2;
     inter->nd = 0;
     inter->flags = PyArray_FLAGS(arr);

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -304,7 +304,7 @@ _is_same_name(const char* s1, const char* s2)
  *
  * The function assumes that the values that are arrays have not
  * been set already, and sets these pointers to memory allocated
- * with PyArray_malloc.  These are freed when the ufunc dealloc
+ * with PyMem_RawMalloc.  These are freed when the ufunc dealloc
  * method is called.
  *
  * Returns 0 unless an error occurred.
@@ -326,14 +326,14 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
         return -1;
     }
     len = strlen(signature);
-    ufunc->core_signature = PyArray_malloc(sizeof(char) * (len+1));
+    ufunc->core_signature = PyMem_RawMalloc(sizeof(char) * (len+1));
     if (ufunc->core_signature == NULL) {
         PyErr_NoMemory();
         return -1;
     }
     strcpy(ufunc->core_signature, signature);
     /* Allocate sufficient memory to store pointers to all dimension names */
-    var_names = PyArray_malloc(sizeof(char const*) * len);
+    var_names = PyMem_RawMalloc(sizeof(char const*) * len);
     if (var_names == NULL) {
         PyErr_NoMemory();
         return -1;
@@ -341,12 +341,12 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
 
     ufunc->core_enabled = 1;
     ufunc->core_num_dim_ix = 0;
-    ufunc->core_num_dims = PyArray_malloc(sizeof(int) * ufunc->nargs);
-    ufunc->core_offsets = PyArray_malloc(sizeof(int) * ufunc->nargs);
+    ufunc->core_num_dims = PyMem_RawMalloc(sizeof(int) * ufunc->nargs);
+    ufunc->core_offsets = PyMem_RawMalloc(sizeof(int) * ufunc->nargs);
     /* The next three items will be shrunk later */
-    ufunc->core_dim_ixs = PyArray_malloc(sizeof(int) * len);
-    ufunc->core_dim_sizes = PyArray_malloc(sizeof(npy_intp) * len);
-    ufunc->core_dim_flags = PyArray_malloc(sizeof(npy_uint32) * len);
+    ufunc->core_dim_ixs = PyMem_RawMalloc(sizeof(int) * len);
+    ufunc->core_dim_sizes = PyMem_RawMalloc(sizeof(npy_intp) * len);
+    ufunc->core_dim_flags = PyMem_RawMalloc(sizeof(npy_uint32) * len);
 
     if (ufunc->core_num_dims == NULL || ufunc->core_dim_ixs == NULL ||
         ufunc->core_offsets == NULL ||
@@ -482,21 +482,21 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
         goto fail;
     }
     void *tmp;
-    tmp = PyArray_realloc(ufunc->core_dim_ixs,
+    tmp = PyMem_RawRealloc(ufunc->core_dim_ixs,
             sizeof(int) * cur_core_dim);
     if (tmp == NULL) {
         PyErr_NoMemory();
         goto fail;
     }
     ufunc->core_dim_ixs = tmp;
-    tmp = PyArray_realloc(ufunc->core_dim_sizes,
+    tmp = PyMem_RawRealloc(ufunc->core_dim_sizes,
             sizeof(npy_intp) * ufunc->core_num_dim_ix);
     if (tmp == NULL) {
         PyErr_NoMemory();
         goto fail;
     }
     ufunc->core_dim_sizes = tmp;
-    tmp = PyArray_realloc(ufunc->core_dim_flags,
+    tmp = PyMem_RawRealloc(ufunc->core_dim_flags,
             sizeof(npy_uint32) * ufunc->core_num_dim_ix);
     if (tmp == NULL) {
         PyErr_NoMemory();
@@ -508,11 +508,11 @@ _parse_signature(PyUFuncObject *ufunc, const char *signature)
     if (cur_core_dim == 0) {
         ufunc->core_enabled = 0;
     }
-    PyArray_free((void*)var_names);
+    PyMem_RawFree((void*)var_names);
     return 0;
 
 fail:
-    PyArray_free((void*)var_names);
+    PyMem_RawFree((void*)var_names);
     if (parse_error) {
         PyErr_Format(PyExc_ValueError,
                      "%s at position %d in \"%s\"",
@@ -1870,8 +1870,8 @@ PyUFunc_GeneralizedFunctionInternal(PyUFuncObject *ufunc,
     if (axes != NULL || axis != NULL) {
         assert(!(axes != NULL && axis != NULL));
 
-        remap_axis = PyArray_malloc(sizeof(remap_axis[0]) * nop);
-        remap_axis_memory = PyArray_malloc(sizeof(remap_axis_memory[0]) *
+        remap_axis = PyMem_RawMalloc(sizeof(remap_axis[0]) * nop);
+        remap_axis_memory = PyMem_RawMalloc(sizeof(remap_axis_memory[0]) *
                                                   nop * NPY_MAXDIMS);
         if (remap_axis == NULL || remap_axis_memory == NULL) {
             PyErr_NoMemory();
@@ -2058,7 +2058,7 @@ PyUFunc_GeneralizedFunctionInternal(PyUFuncObject *ufunc,
     for (i = 0; i < nop; ++i) {
         core_dim_ixs_size += ufunc->core_num_dims[i];
     }
-    inner_strides = (npy_intp *)PyArray_malloc(
+    inner_strides = (npy_intp *)PyMem_RawMalloc(
                         NPY_SIZEOF_INTP * (nop+core_dim_ixs_size));
     if (inner_strides == NULL) {
         PyErr_NoMemory();
@@ -2198,14 +2198,14 @@ PyUFunc_GeneralizedFunctionInternal(PyUFuncObject *ufunc,
         retval = _check_ufunc_fperr(errormask, ufunc_name);
     }
 
-    PyArray_free(inner_strides);
+    PyMem_RawFree(inner_strides);
     NPY_AUXDATA_FREE(auxdata);
     if (!NpyIter_Deallocate(iter)) {
         retval = -1;
     }
 
-    PyArray_free(remap_axis_memory);
-    PyArray_free(remap_axis);
+    PyMem_RawFree(remap_axis_memory);
+    PyMem_RawFree(remap_axis);
 
     NPY_UF_DBG_PRINT1("Returning code %d\n", retval);
 
@@ -2213,11 +2213,11 @@ PyUFunc_GeneralizedFunctionInternal(PyUFuncObject *ufunc,
 
 fail:
     NPY_UF_DBG_PRINT1("Returning failure code %d\n", retval);
-    PyArray_free(inner_strides);
+    PyMem_RawFree(inner_strides);
     NPY_AUXDATA_FREE(auxdata);
     NpyIter_Deallocate(iter);
-    PyArray_free(remap_axis_memory);
-    PyArray_free(remap_axis);
+    PyMem_RawFree(remap_axis_memory);
+    PyMem_RawFree(remap_axis);
     return retval;
 }
 
@@ -5410,7 +5410,7 @@ PyUFunc_FromFuncAndDataAndSignatureAndIdentity(PyUFuncGenericFunction *func, voi
     }
     ufunc->doc = doc;
 
-    ufunc->op_flags = PyArray_malloc(sizeof(npy_uint32)*ufunc->nargs);
+    ufunc->op_flags = PyMem_RawMalloc(sizeof(npy_uint32)*ufunc->nargs);
     if (ufunc->op_flags == NULL) {
         Py_DECREF(ufunc);
         return PyErr_NoMemory();
@@ -5511,16 +5511,16 @@ _free_loop1d_list(PyUFunc_Loop1d *data)
 
     while (data != NULL) {
         PyUFunc_Loop1d *next = data->next;
-        PyArray_free(data->arg_types);
+        PyMem_RawFree(data->arg_types);
 
         if (data->arg_dtypes != NULL) {
             for (i = 0; i < data->nargs; i++) {
                 Py_DECREF(data->arg_dtypes[i]);
             }
-            PyArray_free(data->arg_dtypes);
+            PyMem_RawFree(data->arg_dtypes);
         }
 
-        PyArray_free(data);
+        PyMem_RawFree(data);
         data = next;
     }
 }
@@ -5573,7 +5573,7 @@ PyUFunc_RegisterLoopForDescr(PyUFuncObject *ufunc,
         return -1;
     }
 
-    arg_typenums = PyArray_malloc(ufunc->nargs * sizeof(int));
+    arg_typenums = PyMem_RawMalloc(ufunc->nargs * sizeof(int));
     if (arg_typenums == NULL) {
         Py_DECREF(key);
         PyErr_NoMemory();
@@ -5619,7 +5619,7 @@ PyUFunc_RegisterLoopForDescr(PyUFuncObject *ufunc,
                 current = current->next;
             }
             if (cmp == 0 && current != NULL && current->arg_dtypes == NULL) {
-                current->arg_dtypes = PyArray_malloc(ufunc->nargs *
+                current->arg_dtypes = PyMem_RawMalloc(ufunc->nargs *
                     sizeof(PyArray_Descr*));
                 if (current->arg_dtypes == NULL) {
                     PyErr_NoMemory();
@@ -5649,7 +5649,7 @@ PyUFunc_RegisterLoopForDescr(PyUFuncObject *ufunc,
     }
 
 done:
-    PyArray_free(arg_typenums);
+    PyMem_RawFree(arg_typenums);
 
     Py_DECREF(key);
 
@@ -5687,11 +5687,11 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
     if (key == NULL) {
         return -1;
     }
-    funcdata = PyArray_malloc(sizeof(PyUFunc_Loop1d));
+    funcdata = PyMem_RawMalloc(sizeof(PyUFunc_Loop1d));
     if (funcdata == NULL) {
         goto fail;
     }
-    newtypes = PyArray_malloc(sizeof(int)*ufunc->nargs);
+    newtypes = PyMem_RawMalloc(sizeof(int)*ufunc->nargs);
     if (newtypes == NULL) {
         goto fail;
     }
@@ -5821,8 +5821,8 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
             /* just replace it with new function */
             current->func = function;
             current->data = data;
-            PyArray_free(newtypes);
-            PyArray_free(funcdata);
+            PyMem_RawFree(newtypes);
+            PyMem_RawFree(funcdata);
         }
         else {
             /*
@@ -5856,8 +5856,8 @@ PyUFunc_RegisterLoopForType(PyUFuncObject *ufunc,
     Py_DECREF(key);
     Py_XDECREF(signature_tuple);
     Py_XDECREF(info);
-    PyArray_free(funcdata);
-    PyArray_free(newtypes);
+    PyMem_RawFree(funcdata);
+    PyMem_RawFree(newtypes);
     if (!PyErr_Occurred()) PyErr_NoMemory();
     return -1;
 }
@@ -5878,14 +5878,14 @@ static void
 ufunc_dealloc(PyUFuncObject *ufunc)
 {
     PyObject_GC_UnTrack((PyObject *)ufunc);
-    PyArray_free(ufunc->core_num_dims);
-    PyArray_free(ufunc->core_dim_ixs);
-    PyArray_free(ufunc->core_dim_sizes);
-    PyArray_free(ufunc->core_dim_flags);
-    PyArray_free(ufunc->core_offsets);
-    PyArray_free(ufunc->core_signature);
-    PyArray_free(ufunc->ptr);
-    PyArray_free(ufunc->op_flags);
+    PyMem_RawFree(ufunc->core_num_dims);
+    PyMem_RawFree(ufunc->core_dim_ixs);
+    PyMem_RawFree(ufunc->core_dim_sizes);
+    PyMem_RawFree(ufunc->core_dim_flags);
+    PyMem_RawFree(ufunc->core_offsets);
+    PyMem_RawFree(ufunc->core_signature);
+    PyMem_RawFree(ufunc->ptr);
+    PyMem_RawFree(ufunc->op_flags);
     Py_XDECREF(ufunc->userloops);
     if (ufunc->identity == PyUFunc_IdentityValue) {
         Py_DECREF(ufunc->identity_value);
@@ -7258,7 +7258,7 @@ ufunc_get_types(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
     if (list == NULL) {
         return NULL;
     }
-    t = PyArray_malloc(no+ni+2);
+    t = PyMem_RawMalloc(no+ni+2);
     if (t == NULL) {
         Py_DECREF(list);
         return PyErr_NoMemory();
@@ -7278,7 +7278,7 @@ ufunc_get_types(PyUFuncObject *ufunc, void *NPY_UNUSED(ignored))
         str = PyUnicode_FromStringAndSize(t, no + ni + 2);
         PyList_SET_ITEM(list, k, str);
     }
-    PyArray_free(t);
+    PyMem_RawFree(t);
     return list;
 }
 

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -121,7 +121,7 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds) {
     if (i) {
         offset[1] += (sizeof(void *)-i);
     }
-    ptr = PyArray_malloc(offset[0] + offset[1] + sizeof(void *) +
+    ptr = PyMem_RawMalloc(offset[0] + offset[1] + sizeof(void *) +
                             (fname_len + 14));
     if (ptr == NULL) {
         Py_XDECREF(pyname);
@@ -152,7 +152,7 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds) {
             str, doc, /* unused */ 0, NULL, identity);
 
     if (self == NULL) {
-        PyArray_free(ptr);
+        PyMem_RawFree(ptr);
         return NULL;
     }
     Py_INCREF(function);


### PR DESCRIPTION
### PR summary
Followup from #32331 (ping @mattip).

From what I can tell, `NPY_USE_PYMEM` has been unconditionally defined to be 1 since August 19, 2006 (almost exactly 20 years ago!!) and the `#else` branch for when it's not defined has been dead code since then. See https://github.com/numpy/numpy/blob/b9ce9390471f4f0989c6e4605d04ef0e5d1f5494/numpy/core/include/numpy/ndarrayobject.h#L690 which was the last commit that changed this with the commit message "Fix white-space issues."

Let's soft-deprecate these but leave behind the define and aliases in case anyone is using them. Leaving these behind forever is free but managing a deprecation cycle isn't free.

#### AI Disclosure
An AI model did a code review pass