### PR TITLE
DOC: clarify nan_to_num copy= semantics

### DIFF
--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -389,10 +389,10 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     x : scalar or array_like
         Input data.
     copy : bool, optional
-        Whether to create a copy of `x` (True) or to replace values
-        in-place (False). The in-place operation only occurs if
-        casting to an array does not require a copy.
-        Default is True.
+        If ``True`` (default), always copy `x` before replacing values.
+        If ``False``, never copy; a ``ValueError`` is raised if a copy
+        is required (for example if `x` is a Python list). If ``None``,
+        copy only if needed. Has the same meaning as in `numpy.array`.
     nan : int, float, or bool or array_like of int, float, or bool, optional
         Values to be used to fill NaN values. If no values are passed
         then NaN values will be replaced with 0.0.
@@ -408,8 +408,8 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     Returns
     -------
     out : ndarray
-        `x`, with the non-finite values replaced. If `copy` is False, this may
-        be `x` itself.
+        `x`, with the non-finite values replaced. If `copy` is False or
+        None, this may be `x` itself.
 
     See Also
     --------


### PR DESCRIPTION
## Summary
Docs-only fix for https://github.com/numpy/numpy/issues/29045.

`nan_to_num(..., copy=)` is passed through to `np.array`, so `True` always copies, `False` never copies (`ValueError` if a copy is required), and `None` copies only if needed. The current docstring still describes 1.x semantics.

## Test plan
- [ ] Docs render; no code change.