### PR TITLE
MAINT: use PyObject_ functions instead of raw PyArray_ ones (#32331)

### DIFF
--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -128,12 +128,10 @@ PyArray_IterNew(PyObject *obj)
         return NULL;
     }
 
-    it = (PyArrayIterObject *)PyArray_malloc(sizeof(PyArrayIterObject));
+    it = PyObject_New(PyArrayIterObject, &PyArrayIter_Type);
     if (it == NULL) {
-        PyErr_NoMemory();
         return NULL;
     }
-    PyObject_Init((PyObject *)it, &PyArrayIter_Type);
 
     Py_INCREF(ao);  /* PyArray_RawIterBaseInit steals a reference */
     PyArray_RawIterBaseInit(it, ao);
@@ -167,11 +165,10 @@ PyArray_BroadcastToShape(PyObject *obj, npy_intp *dims, int nd)
     if (!compat) {
         goto err;
     }
-    it = (PyArrayIterObject *)PyArray_malloc(sizeof(PyArrayIterObject));
+    it = PyObject_New(PyArrayIterObject, &PyArrayIter_Type);
     if (it == NULL) {
         return NULL;
     }
-    PyObject_Init((PyObject *)it, &PyArrayIter_Type);
 
     PyArray_UpdateFlags(ao, NPY_ARRAY_C_CONTIGUOUS);
     if (PyArray_ISCONTIGUOUS(ao)) {
@@ -345,7 +342,7 @@ arrayiter_dealloc(PyArrayIterObject *it)
      * which does not call this function.
      */
     array_iter_base_dealloc(it);
-    PyArray_free(it);
+    PyObject_Free(it);
 }
 
 static Py_ssize_t
@@ -1101,6 +1098,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayIter_Type = {
     .tp_name = "numpy.flatiter",
     .tp_basicsize = sizeof(PyArrayIterObject),
     .tp_dealloc = (destructor)arrayiter_dealloc,
+    .tp_free = PyObject_Free,
     .tp_as_mapping = &iter_as_mapping,
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_richcompare = (richcmpfunc)iter_richcompare,
@@ -1245,11 +1243,10 @@ multiiter_new_impl(int n_args, PyObject **args)
     PyArrayMultiIterObject *multi;
     int i;
 
-    multi = PyArray_malloc(sizeof(PyArrayMultiIterObject));
+    multi = PyObject_New(PyArrayMultiIterObject, &PyArrayMultiIter_Type);
     if (multi == NULL) {
-        return PyErr_NoMemory();
+        return NULL;
     }
-    PyObject_Init((PyObject *)multi, &PyArrayMultiIter_Type);
     multi->numiter = 0;
 
     for (i = 0; i < n_args; ++i) {
@@ -1525,6 +1522,7 @@ NPY_NO_EXPORT PyTypeObject PyArrayMultiIter_Type = {
     .tp_name = "numpy.broadcast",
     .tp_basicsize = sizeof(PyArrayMultiIterObject),
     .tp_dealloc = (destructor)arraymultiter_dealloc,
+    .tp_free = PyObject_Free,
     .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_iternext = (iternextfunc)arraymultiter_next,
     .tp_methods = arraymultiter_methods,
@@ -1696,11 +1694,10 @@ PyArray_NeighborhoodIterNew(PyArrayIterObject *x, const npy_intp *bounds,
     int i;
     PyArrayNeighborhoodIterObject *ret;
 
-    ret = PyArray_malloc(sizeof(*ret));
+    ret = PyObject_New(PyArrayNeighborhoodIterObject, &PyArrayNeighborhoodIter_Type);
     if (ret == NULL) {
         return NULL;
     }
-    PyObject_Init((PyObject *)ret, &PyArrayNeighborhoodIter_Type);
 
     Py_INCREF(x->ao);  /* PyArray_RawIterBaseInit steals a reference */
     PyArray_RawIterBaseInit((PyArrayIterObject*)ret, x->ao);
@@ -1785,7 +1782,7 @@ PyArray_NeighborhoodIterNew(PyArrayIterObject *x, const npy_intp *bounds,
 clean_x:
     Py_DECREF(ret->_internal_iter);
     array_iter_base_dealloc((PyArrayIterObject*)ret);
-    PyArray_free((PyArrayObject*)ret);
+    PyObject_Free(ret);
     return NULL;
 }
 
@@ -1800,7 +1797,7 @@ static void neighiter_dealloc(PyArrayNeighborhoodIterObject* iter)
     Py_DECREF(iter->_internal_iter);
 
     array_iter_base_dealloc((PyArrayIterObject*)iter);
-    PyArray_free((PyArrayObject*)iter);
+    PyObject_Free(iter);
 }
 
 NPY_NO_EXPORT PyTypeObject PyArrayNeighborhoodIter_Type = {
@@ -1808,5 +1805,6 @@ NPY_NO_EXPORT PyTypeObject PyArrayNeighborhoodIter_Type = {
     .tp_name = "numpy.neigh_internal_iter",
     .tp_basicsize = sizeof(PyArrayNeighborhoodIterObject),
     .tp_dealloc = (destructor)neighiter_dealloc,
+    .tp_free = PyObject_Free,
     .tp_flags = Py_TPFLAGS_DEFAULT,
 };

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -2813,7 +2813,7 @@ PyArray_MapIterNew(npy_index_info *indices , int index_num, int index_type,
     }
 
     /* create new MapIter object */
-    mit = (PyArrayMapIterObject *)PyArray_malloc(
+    mit = (PyArrayMapIterObject *)PyObject_Malloc(
             sizeof(PyArrayMapIterObject) + sizeof(NPY_cast_info));
     if (mit == NULL) {
         Py_DECREF(intp_descr);
@@ -3463,7 +3463,7 @@ arraymapiter_dealloc(PyArrayMapIterObject *mit)
     if (mit->extra_op_iter != NULL) {
         NpyIter_Deallocate(mit->extra_op_iter);
     }
-    PyArray_free(mit);
+    PyObject_Free(mit);
 }
 
 /*
@@ -3482,5 +3482,6 @@ NPY_NO_EXPORT PyTypeObject PyArrayMapIter_Type = {
     .tp_name = "numpy.mapiter",
     .tp_basicsize = sizeof(PyArrayMapIterObject),
     .tp_dealloc = (destructor)arraymapiter_dealloc,
+    .tp_free = PyObject_Free,
     .tp_flags = Py_TPFLAGS_DEFAULT,
 };

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -5132,7 +5132,6 @@ _multiarray_umath_exec(PyObject *m) {
     PyArrayIter_Type.tp_iter = PyObject_SelfIter;
     NpyIter_Type.tp_iter = PyObject_SelfIter;
     PyArrayMultiIter_Type.tp_iter = PyObject_SelfIter;
-    PyArrayMultiIter_Type.tp_free = PyArray_free;
     if (PyType_Ready(&PyArrayIter_Type) < 0) {
         return -1;
     }


### PR DESCRIPTION



Backport of #32331.

### PR summary
In preparation for PyPy 3.12 support, I discovered this pattern of using `PyArray_malloc` + `PyObject_Init` / `PyArray_free` for allocating python objects. While not per-se wrong, this is a little non-standard. It is much more accepted to use `PyObject_Malloc` and `PyObject_New`, paired with `PyObject_Free`. These are the only such uses inside NumPy. Cython and other wrapper libraries use the `PyObject_New` style exclusively. This is entirely a refactor, it should not affect performance or have any user-facing implications. In fact, I think this is a bit of a clean up since it removes the need for `PyErr_NoMemory` which may have been missing in some allocations.

For those who want the whole story:

PyPy 3.12 will be adopting a strategy of complete PyObject compatibility, and will be (ab)using allocation of PyObjects with a prefix, where we hide the link to the RPython w_obj. So PyObject_New/PyObject_Alloc actually allocate 16 bytes more than requested, and return the address 16 bytes after the actual allocation. CPython has this a previous art, it does this in `PyGC_Head` and `_PyObject_HEAD_EXTRA`. We will have an escape hatch when we see a "foreign" PyObject without the prefix, but it is much more complicated to handle these.

AI was used to identify the problem and pinpoint where to change the code, I made the actual changes. 

It might be nice to backport this so PyPy3.12 can run with a released version of NumPy before the current dev version goes out, assuming I release PyPy3.12 before December.