### PR TITLE
ENH: dtype argument `fft.fftfreq` & `fft.rfftfreq`

### DIFF
--- a/numpy/fft/_helper.py
+++ b/numpy/fft/_helper.py
@@ -2,7 +2,7 @@
 Discrete Fourier Transforms - _helper.py
 
 """
-from numpy._core import arange, asarray, empty, integer, roll
+from numpy._core import arange, asarray, empty, float64, floating, integer, roll
 from numpy._core.overrides import array_function_dispatch, set_module
 
 # Created by Pearu Peterson, September 2002
@@ -123,7 +123,7 @@ def ifftshift(x, axes=None):
 
 
 @set_module('numpy.fft')
-def fftfreq(n, d=1.0, device=None):
+def fftfreq(n, d=1.0, device=None, dtype=None):
     """
     Return the Discrete Fourier Transform sample frequencies.
 
@@ -147,6 +147,11 @@ def fftfreq(n, d=1.0, device=None):
         For Array-API interoperability only, so must be ``"cpu"`` if passed.
 
         .. versionadded:: 2.0.0
+    dtype : dtype, optional
+        The type of the output array. Must be a real-valued floating-point type.
+        Default is `numpy.float64`.
+
+        .. versionadded:: 2.6.0
 
     Returns
     -------
@@ -167,18 +172,22 @@ def fftfreq(n, d=1.0, device=None):
     """
     if not isinstance(n, integer_types):
         raise ValueError("n should be an integer")
+    dtype = dtype or float64
+    if not issubclass(dtype, floating):
+        raise ValueError(f"`dtype` must be a real floating-point type. Got {dtype=}.")
     val = 1.0 / (n * d)
-    results = empty(n, int, device=device)
+    results = empty(n, dtype, device=device)
     N = (n - 1) // 2 + 1
-    p1 = arange(0, N, dtype=int, device=device)
+    p1 = arange(0, N, dtype=dtype, device=device)
     results[:N] = p1
-    p2 = arange(-(n // 2), 0, dtype=int, device=device)
+    p2 = arange(-(n // 2), 0, dtype=dtype, device=device)
     results[N:] = p2
-    return results * val
+    results *= val
+    return results
 
 
 @set_module('numpy.fft')
-def rfftfreq(n, d=1.0, device=None):
+def rfftfreq(n, d=1.0, device=None, dtype=None):
     """
     Return the Discrete Fourier Transform sample frequencies
     (for usage with rfft, irfft).
@@ -206,6 +215,11 @@ def rfftfreq(n, d=1.0, device=None):
         For Array-API interoperability only, so must be ``"cpu"`` if passed.
 
         .. versionadded:: 2.0.0
+    dtype : dtype, optional
+        The type of the output array. Must be a real-valued floating-point type.
+        Default is `numpy.float64`.
+
+        ..versionadded:: 2.6.0
 
     Returns
     -------
@@ -229,7 +243,11 @@ def rfftfreq(n, d=1.0, device=None):
     """
     if not isinstance(n, integer_types):
         raise ValueError("n should be an integer")
+    dtype = dtype or float64
+    if not issubclass(dtype, floating):
+        raise ValueError(f"`dtype` must be a real floating-point type. Got {dtype=}.")
     val = 1.0 / (n * d)
     N = n // 2 + 1
-    results = arange(0, N, dtype=int, device=device)
-    return results * val
+    results = arange(0, N, dtype=dtype, device=device)
+    results *= val
+    return results

--- a/numpy/fft/_helper.py
+++ b/numpy/fft/_helper.py
@@ -2,7 +2,17 @@
 Discrete Fourier Transforms - _helper.py
 
 """
-from numpy._core import arange, asarray, empty, float64, floating, integer, roll
+from numpy._core import (
+    arange,
+    asarray,
+    empty,
+    float64,
+    inexact,
+    integer,
+    issubdtype,
+    result_type,
+    roll,
+)
 from numpy._core.overrides import array_function_dispatch, set_module
 
 # Created by Pearu Peterson, September 2002
@@ -148,8 +158,8 @@ def fftfreq(n, d=1.0, device=None, dtype=None):
 
         .. versionadded:: 2.0.0
     dtype : dtype, optional
-        The type of the output array. Must be a real-valued floating-point type.
-        Default is `numpy.float64`.
+        The type of the output array. Must be an inexact type.
+        Default is ``numpy.result_type(numpy.float64, d)``.
 
         .. versionadded:: 2.6.0
 
@@ -172,9 +182,9 @@ def fftfreq(n, d=1.0, device=None, dtype=None):
     """
     if not isinstance(n, integer_types):
         raise ValueError("n should be an integer")
-    dtype = dtype or float64
-    if not issubclass(dtype, floating):
-        raise ValueError(f"`dtype` must be a real floating-point type. Got {dtype=}.")
+    dtype = result_type(d, float64) if dtype is None else dtype
+    if not issubdtype(dtype, inexact):
+        raise ValueError(f"`dtype` must be an inexact type. Got {dtype=}.")
     val = 1.0 / (n * d)
     results = empty(n, dtype, device=device)
     N = (n - 1) // 2 + 1
@@ -216,10 +226,10 @@ def rfftfreq(n, d=1.0, device=None, dtype=None):
 
         .. versionadded:: 2.0.0
     dtype : dtype, optional
-        The type of the output array. Must be a real-valued floating-point type.
-        Default is `numpy.float64`.
+        The type of the output array. Must be an inexact type.
+        Default is ``numpy.result_type(numpy.float64, d)``.
 
-        ..versionadded:: 2.6.0
+        .. versionadded:: 2.6.0
 
     Returns
     -------
@@ -243,9 +253,9 @@ def rfftfreq(n, d=1.0, device=None, dtype=None):
     """
     if not isinstance(n, integer_types):
         raise ValueError("n should be an integer")
-    dtype = dtype or float64
-    if not issubclass(dtype, floating):
-        raise ValueError(f"`dtype` must be a real floating-point type. Got {dtype=}.")
+    dtype = result_type(d, float64) if dtype is None else dtype
+    if not issubdtype(dtype, inexact):
+        raise ValueError(f"`dtype` must be an inexact type. Got {dtype=}.")
     val = 1.0 / (n * d)
     N = n // 2 + 1
     results = arange(0, N, dtype=dtype, device=device)

--- a/numpy/fft/tests/test_helper.py
+++ b/numpy/fft/tests/test_helper.py
@@ -3,6 +3,9 @@
 Copied from fftpack.helper by Pearu Peterson, October 2005
 
 """
+
+import pytest
+
 import numpy as np
 from numpy import fft, pi
 from numpy.testing import assert_array_almost_equal
@@ -143,6 +146,21 @@ class TestFFTFreq:
         assert_array_almost_equal(10 * fft.fftfreq(10), x)
         assert_array_almost_equal(10 * pi * fft.fftfreq(10, pi), x)
 
+    @pytest.mark.parametrize("dtype", "efFdDgG")
+    def test_valid_dtype(self, dtype):
+        assert fft.fftfreq(10, dtype=dtype).dtype == dtype
+
+    @pytest.mark.parametrize("dtype", "?bBhHiIlLqQOSUV")
+    def test_invalid_dtype(self, dtype):
+        msg = f"`dtype` must be an inexact type. Got {dtype=}."
+        with pytest.raises(ValueError, match=msg):
+            fft.fftfreq(10, dtype=dtype)
+
+    @pytest.mark.parametrize("d_dtype", "efFdDgG?bBhHiIlLqQ")
+    def test_default_dtype(self, d_dtype):
+        d = np.dtype(d_dtype).type(1.0)
+        assert fft.fftfreq(10, d).dtype == np.result_type(np.float64, d_dtype)
+
 
 class TestRFFTFreq:
 
@@ -153,6 +171,21 @@ class TestRFFTFreq:
         x = [0, 1, 2, 3, 4, 5]
         assert_array_almost_equal(10 * fft.rfftfreq(10), x)
         assert_array_almost_equal(10 * pi * fft.rfftfreq(10, pi), x)
+
+    @pytest.mark.parametrize("dtype", "efFdDgG")
+    def test_valid_dtype(self, dtype):
+        assert fft.rfftfreq(10, dtype=dtype).dtype == dtype
+
+    @pytest.mark.parametrize("dtype", "?bBhHiIlLqQOSUV")
+    def test_invalid_dtype(self, dtype):
+        msg = f"`dtype` must be an inexact type. Got {dtype=}."
+        with pytest.raises(ValueError, match=msg):
+            fft.rfftfreq(10, dtype=dtype)
+
+    @pytest.mark.parametrize("d_dtype", "efFdDgG?bBhHiIlLqQ")
+    def test_default_dtype(self, d_dtype):
+        d = np.dtype(d_dtype).type(1.0)
+        assert fft.rfftfreq(10, d).dtype == np.result_type(np.float64, d_dtype)
 
 
 class TestIRFFTN:


### PR DESCRIPTION
### PR summary

Add a dtype argument to `fft.fftfreq` and `fft.rfftfreq`: closes https://github.com/numpy/numpy/issues/9126

#### AI Disclosure
No AI used.