### PR TITLE
BUG: avoid intermediate overflow in numpy.i0 for large x

### DIFF
--- a/doc/release/upcoming_changes/32209.improvement.rst
+++ b/doc/release/upcoming_changes/32209.improvement.rst
@@ -1,0 +1,7 @@
+`numpy.i0` no longer overflows for large finite inputs
+------------------------------------------------------
+`numpy.i0` could return ``inf`` for large but representable arguments
+such as ``713.0``, because ``exp(x)`` overflowed before it was scaled
+by the Chebyshev factor. The large-``x`` path now avoids that
+intermediate overflow, so the result stays finite when it fits in
+float64.

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -46,6 +46,7 @@ from numpy._core.umath import (
     floor,
     frompyfunc,
     less_equal,
+    log,
     minimum,
     mod,
     not_equal,
@@ -3562,7 +3563,25 @@ def _i0_1(x):
 
 
 def _i0_2(x):
-    return exp(x) * _chbevl(32.0 / x - 2.0, _i0B) / sqrt(x)
+    # Cephes: I0(x) = exp(x) * y / sqrt(x) for x > 8, with y = chbevl(...).
+    # exp(x) overflows for x > log(dtype.max) (~709.78 for float64) even
+    # when the product is still finite (e.g. x = 713).  Keep the original
+    # formula below that threshold.  Above it, factor exp(x) = exp(x-s)*exp(s)
+    # with finite s so the Chebyshev factor is not logged (preserves accuracy).
+    y = _chbevl(32.0 / x - 2.0, _i0B)
+    overflow = log(np.finfo(x.dtype).max)
+    large = x > overflow
+    if not np.any(large):
+        return exp(x) * y / sqrt(x)
+    s = overflow - 1.0
+    if np.all(large):
+        return exp(x - s) * (exp(s) * y / sqrt(x))
+    out = empty(x.shape, dtype=x.dtype)
+    small = ~large
+    out[small] = exp(x[small]) * y[small] / sqrt(x[small])
+    xl = x[large]
+    out[large] = exp(xl - s) * (exp(s) * y[large] / sqrt(xl))
+    return out
 
 
 def _i0_dispatcher(x):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -3016,6 +3016,17 @@ class Test_I0:
         assert_equal(i0_0.shape, (1,))
         assert_array_equal(np.i0([0.]), np.array([1.]))
 
+    def test_gh_32209_large_finite(self):
+        # exp(713) overflows float64, but I0(713) is still representable.
+        x = np.float64(713.0)
+        expected = np.float64(6.705128263670996e307)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            actual = i0(x)
+        assert np.isfinite(actual)
+        assert_allclose(actual, expected, rtol=1e-14, atol=0.0)
+        assert_allclose(i0(-x), actual, rtol=1e-14, atol=0.0)
+
     def test_non_array(self):
         a = np.arange(4)
 


### PR DESCRIPTION
exp(x) overflows for values such as 713.0 even though the corresponding I0(x) value is still finite and representable in float64.

This change scales the exponential calculation on the large-x path so that the intermediate exp() call does not overflow before the remaining factors are applied. The existing calculation is kept unchanged for values below the overflow threshold.

### PR summary

#### What does this PR do?

Fixes an intermediate overflow in `numpy.i0` for large finite inputs.

For example, `np.i0(713.0)` currently encounters an overflow in the intermediate `exp(713.0)` calculation, even though the final I0 value is approximately `6.7e307` and is still representable as a float64.

The exponential is therefore split into two finite factors on the large-x path. This allows the calculation to produce the correct finite result instead of returning `inf` because of an intermediate overflow.

#### How was this tested?

I tested the change with:

* A large finite input such as `713.0`.
* The boundary around the existing `x > 8` path.
* Values around the float64 exponential overflow threshold.
* Negative large inputs, since `I0(x)` is an even function.
* Values above the range where the actual result should overflow.
* Arrays containing a mixture of small and large inputs.
* Tests with warnings treated as errors.

The reference value for the large finite case was also checked against a higher-precision calculation.

#### First time committer introduction

This is my first contribution to NumPy. I came across the issue while looking at numerical behavior in `numpy.i0` for large finite inputs. I wanted to understand why a finite result was becoming `inf` and worked on a fix that avoids the intermediate overflow while keeping the existing calculation unchanged for normal inputs.

#### AI Disclosure

No AI tools used.
