### PR TITLE
MAINT: parse dtype endian as unicode directly (gh-15317)

### DIFF
--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -3061,30 +3061,25 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
 
     /* Parse endian */
     if (PyUnicode_Check(endian_obj) || PyBytes_Check(endian_obj)) {
-        PyObject *tmp = NULL;
-        char *str;
+        char const *str;
         Py_ssize_t len;
 
         if (PyUnicode_Check(endian_obj)) {
-            tmp = PyUnicode_AsASCIIString(endian_obj);
-            if (tmp == NULL) {
+            str = PyUnicode_AsUTF8AndSize(endian_obj, &len);
+            if (str == NULL) {
                 return NULL;
             }
-            endian_obj = tmp;
         }
-
-        if (PyBytes_AsStringAndSize(endian_obj, &str, &len) < 0) {
-            Py_XDECREF(tmp);
-            return NULL;
+        else {
+            str = PyBytes_AS_STRING(endian_obj);
+            len = PyBytes_GET_SIZE(endian_obj);
         }
         if (len != 1) {
             PyErr_SetString(PyExc_ValueError,
                             "endian is not 1-char string in Numpy dtype unpickling");
-            Py_XDECREF(tmp);
             return NULL;
         }
         endian = str[0];
-        Py_XDECREF(tmp);
     }
     else {
         PyErr_SetString(PyExc_ValueError,

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -3065,9 +3065,15 @@ arraydescr_setstate(_PyArray_LegacyDescr *self, PyObject *args)
         Py_ssize_t len;
 
         if (PyUnicode_Check(endian_obj)) {
-            str = PyUnicode_AsUTF8AndSize(endian_obj, &len);
-            if (str == NULL) {
-                return NULL;
+            if (!PyUnicode_IS_ASCII(endian_obj)) {
+                str = NULL;
+                len = 0;
+            }
+            else {
+                str = PyUnicode_AsUTF8AndSize(endian_obj, &len);
+                if (str == NULL) {
+                    return NULL;
+                }
             }
         }
         else {

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1452,7 +1452,8 @@ class TestPickling:
         dt.__setstate__(state_with_endian(swapped))
         assert dt.byteorder == swapped
 
-        for endian in ['\N{MICRO SIGN}', '\N{SNOWMAN}', '', '>>', b'', b'>>']:
+        for endian in ['\N{MICRO SIGN}', '\N{SNOWMAN}', '\ud800', '', '>>',
+                       b'', b'>>']:
             with pytest.raises(
                 ValueError, match="endian is not 1-char string"
             ):

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1431,6 +1431,36 @@ class TestPickling:
             ):
                 dt.__setstate__(extended)
 
+    @pytest.mark.parametrize('dt', [
+        np.dtype([('a', 'i4'), ('b', 'f8')]),
+        np.dtype('i4, i1', align=True),
+    ])
+    def test_setstate_endian(self, dt):
+        valid_state = list(dt.__reduce__()[2])
+
+        def state_with_endian(endian):
+            state = list(valid_state)
+            state[1] = endian
+            return tuple(state)
+
+        # a non-native byte order is stored as given, a native one as '='
+        swapped = '>' if sys.byteorder == 'little' else '<'
+
+        # bytes are accepted for backwards compatibility with old pickles
+        dt.__setstate__(state_with_endian(swapped.encode()))
+        assert dt.byteorder == swapped
+        dt.__setstate__(state_with_endian(swapped))
+        assert dt.byteorder == swapped
+
+        for endian in ['\N{MICRO SIGN}', '\N{SNOWMAN}', '', '>>', b'', b'>>']:
+            with pytest.raises(
+                ValueError, match="endian is not 1-char string"
+            ):
+                dt.__setstate__(state_with_endian(endian))
+
+        with pytest.raises(ValueError, match="endian is not a string"):
+            dt.__setstate__(state_with_endian(42))
+
 
 class TestPromotion:
     """Test cases related to more complex DType promotions.  Further promotion

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1431,11 +1431,12 @@ class TestPickling:
             ):
                 dt.__setstate__(extended)
 
-    @pytest.mark.parametrize('dt', [
-        np.dtype([('a', 'i4'), ('b', 'f8')]),
-        np.dtype('i4, i1', align=True),
+    @pytest.mark.parametrize('spec, align', [
+        ([('a', 'i4'), ('b', 'f8')], False),
+        ('i4, i1', True),
     ])
-    def test_setstate_endian(self, dt):
+    def test_setstate_endian(self, spec, align):
+        dt = np.dtype(spec, align=align)
         valid_state = list(dt.__reduce__()[2])
 
         def state_with_endian(endian):


### PR DESCRIPTION
Part of gh-15317, following #32232 (nditer flags) and #32305 (ndarray.flags keys).
(I realized that the issue is already closed, but I think we can still work on this one as the last one of the issue)

We are trying to replace PyUnicode_AsASCIIString which throws UnicodeEncodeError, but should rather be ValueError (or something that better describes the error in each context). This function also have a side effect of needing to allocate temporary memory for python string objects. In this pr, we're working on arraydescr_setstate, which looks into the byte order (e.g. little endian) when we are depickling (i.e. from byte to obj) and parses them . We change whenever the non ASCII is passed to give a ValueError instead of UnicodeEncodeError. 

We added the tests to verify that it still reads the byte string correctly, throws the right error (i.e. ValueError) with correct error messages. 

The release note will be bundled together for the same issue (with multiple PRs) as discussed in the previous PR.

### AI Disclosure
Code, tests are AI-generated (Claude model Opus). PR summaries and comments are mine. I've looked into the code extensively, so I should know what's going on fully. 