### PR TITLE
ENH: add NEP-50-style string promotion outside ufuncs

### DIFF
--- a/doc/release/upcoming_changes/32356.improvement.rst
+++ b/doc/release/upcoming_changes/32356.improvement.rst
@@ -1,0 +1,6 @@
+* `np.copyto`, `np.full`, `np.where`, `np.concatenate` with ``axis=None``, and
+  `np.choose` now convert an exact Python ``str`` scalar directly with the
+  resolved dtype instead of through a fixed-width unicode intermediate, so a
+  trailing null is no longer lost for ``StringDType`` or ``object``. For example,
+  ``np.full(2, "x\0", dtype=np.dtypes.StringDType())[0]`` now gives ``"x\0"``
+  rather than ``"x"``.

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -403,6 +403,29 @@ npy_update_operand_for_scalar(
 
 
 /*
+ * Convert an operand marked with NPY_ARRAY_WAS_PYTHON_STR again from the
+ * original str once the operation's target descriptor is known, so that the
+ * fixed-width unicode temporary cannot lose trailing nulls.  A no-op when
+ * the str's DType has no common DType with the target's.
+ */
+NPY_NO_EXPORT int
+npy_update_operand_for_pystr(
+    PyArrayObject **operand, PyObject *scalar, PyArray_Descr *target,
+    NPY_CASTING casting)
+{
+    PyArray_Descr *descr = npy_find_descr_for_scalar(
+            scalar, PyArray_DESCR(*operand),
+            NPY_DTYPE(PyArray_DESCR(*operand)), NPY_DTYPE(target));
+    if (descr == NULL) {
+        return -1;
+    }
+    int res = npy_update_operand_for_scalar(operand, scalar, descr, casting);
+    Py_DECREF(descr);
+    return res;
+}
+
+
+/*
  * When a user passed a Python literal (int, float, complex), special promotion
  * rules mean that we don't know the exact descriptor that should be used.
  *

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -390,10 +390,10 @@ npy_update_operand_for_scalar(
     Py_INCREF(descr);
     PyArrayObject *new = (PyArrayObject *)PyArray_NewFromDescr(
             &PyArray_Type, descr, 0, NULL, NULL, NULL, 0, NULL);
-    Py_SETREF(*operand, new);
-    if (*operand == NULL) {
+    if (new == NULL) {
         return -1;
     }
+    Py_SETREF(*operand, new);
     if (scalar == NULL) {
         /* The ufunc.resolve_dtypes paths can go here.  Anything should go. */
         return 0;
@@ -411,7 +411,7 @@ npy_update_operand_for_scalar(
 NPY_NO_EXPORT int
 npy_update_operand_if_pystr(
     PyArrayObject **operand, PyObject *op, Py_ssize_t i,
-    PyArray_Descr *target, NPY_CASTING casting)
+    PyArray_Descr *target)
 {
     if (!(PyArray_FLAGS(*operand) & NPY_ARRAY_WAS_PYTHON_STR)) {
         return 0;
@@ -427,7 +427,8 @@ npy_update_operand_if_pystr(
         Py_DECREF(scalar);
         return -1;
     }
-    int res = npy_update_operand_for_scalar(operand, scalar, descr, casting);
+    int res = npy_update_operand_for_scalar(
+            operand, scalar, descr, NPY_SAFE_CASTING);
     Py_DECREF(scalar);
     Py_DECREF(descr);
     return res;

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -403,23 +403,32 @@ npy_update_operand_for_scalar(
 
 
 /*
- * Convert an operand marked with NPY_ARRAY_WAS_PYTHON_STR again from the
- * original str once the operation's target descriptor is known, so that the
- * fixed-width unicode temporary cannot lose trailing nulls.  A no-op when
- * the str's DType has no common DType with the target's.
+ * If `*operand` (converted from item `i` of sequence `op`) is marked with
+ * NPY_ARRAY_WAS_PYTHON_STR, convert it again from the original str once the
+ * operation's target descriptor is known, so that the fixed-width unicode
+ * temporary cannot lose trailing nulls.
  */
 NPY_NO_EXPORT int
-npy_update_operand_for_pystr(
-    PyArrayObject **operand, PyObject *scalar, PyArray_Descr *target,
-    NPY_CASTING casting)
+npy_update_operand_if_pystr(
+    PyArrayObject **operand, PyObject *op, Py_ssize_t i,
+    PyArray_Descr *target, NPY_CASTING casting)
 {
+    if (!(PyArray_FLAGS(*operand) & NPY_ARRAY_WAS_PYTHON_STR)) {
+        return 0;
+    }
+    PyObject *scalar = PySequence_GetItem(op, i);
+    if (scalar == NULL) {
+        return -1;
+    }
     PyArray_Descr *descr = npy_find_descr_for_scalar(
             scalar, PyArray_DESCR(*operand),
             NPY_DTYPE(PyArray_DESCR(*operand)), NPY_DTYPE(target));
     if (descr == NULL) {
+        Py_DECREF(scalar);
         return -1;
     }
     int res = npy_update_operand_for_scalar(operand, scalar, descr, casting);
+    Py_DECREF(scalar);
     Py_DECREF(descr);
     return res;
 }

--- a/numpy/_core/src/multiarray/abstractdtypes.h
+++ b/numpy/_core/src/multiarray/abstractdtypes.h
@@ -102,6 +102,12 @@ npy_update_operand_for_scalar(
     NPY_CASTING casting);
 
 
+NPY_NO_EXPORT int
+npy_update_operand_for_pystr(
+    PyArrayObject **operand, PyObject *scalar, PyArray_Descr *target,
+    NPY_CASTING casting);
+
+
 NPY_NO_EXPORT PyArray_Descr *
 npy_find_descr_for_scalar(
     PyObject *scalar, PyArray_Descr *original_descr,

--- a/numpy/_core/src/multiarray/abstractdtypes.h
+++ b/numpy/_core/src/multiarray/abstractdtypes.h
@@ -103,9 +103,9 @@ npy_update_operand_for_scalar(
 
 
 NPY_NO_EXPORT int
-npy_update_operand_for_pystr(
-    PyArrayObject **operand, PyObject *scalar, PyArray_Descr *target,
-    NPY_CASTING casting);
+npy_update_operand_if_pystr(
+    PyArrayObject **operand, PyObject *op, Py_ssize_t i,
+    PyArray_Descr *target, NPY_CASTING casting);
 
 
 NPY_NO_EXPORT PyArray_Descr *

--- a/numpy/_core/src/multiarray/abstractdtypes.h
+++ b/numpy/_core/src/multiarray/abstractdtypes.h
@@ -105,7 +105,7 @@ npy_update_operand_for_scalar(
 NPY_NO_EXPORT int
 npy_update_operand_if_pystr(
     PyArrayObject **operand, PyObject *op, Py_ssize_t i,
-    PyArray_Descr *target, NPY_CASTING casting);
+    PyArray_Descr *target);
 
 
 NPY_NO_EXPORT PyArray_Descr *

--- a/numpy/_core/src/multiarray/arrayobject.h
+++ b/numpy/_core/src/multiarray/arrayobject.h
@@ -63,9 +63,10 @@ static const int NPY_ARRAY_WAS_PYTHON_LITERAL = (1 << 30 | 1 << 29 | 1 << 28);
 /*
  * Mark an array converted from an exact Python str.  Unlike the flags above
  * it does not participate in promotion (the array keeps its discovered
- * dtype); it only lets the ufunc machinery convert the operand again from
- * the original object once the loop's descriptors are resolved.  Not part
- * of NPY_ARRAY_WAS_PYTHON_LITERAL, whose consumers assume a numeric scalar.
+ * dtype); it only lets scalar-aware paths (ufuncs, copyto, where) convert
+ * the operand again from the original object once the operation's
+ * descriptors are resolved.  Not part of NPY_ARRAY_WAS_PYTHON_LITERAL,
+ * whose consumers assume a numeric scalar.
  */
 static const int NPY_ARRAY_WAS_PYTHON_STR = (1 << 25);
 

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2019,6 +2019,7 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
             goto fail;
         }
         npy_mark_tmp_array_if_pyscalar(tmp, mps[i], NULL);
+        npy_mark_tmp_array_if_pystr(tmp, mps[i]);
         Py_DECREF(tmp);
     }
 
@@ -2030,8 +2031,18 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
     /* Make sure all arrays are contiguous and have the correct dtype. */
     for (i = 0; i < n; i++) {
         int flags = NPY_ARRAY_CARRAY;
-        PyArrayObject *tmp = mps[i];
 
+        if (PyArray_FLAGS(mps[i]) & NPY_ARRAY_WAS_PYTHON_STR) {
+            PyObject *item = PySequence_GetItem(op, i);
+            if (item == NULL || npy_update_operand_for_pystr(
+                    &mps[i], item, common_descr, NPY_SAFE_CASTING) < 0) {
+                Py_XDECREF(item);
+                goto fail;
+            }
+            Py_DECREF(item);
+        }
+
+        PyArrayObject *tmp = mps[i];
         Py_INCREF(common_descr);
         mps[i] = (PyArrayObject *)PyArray_FromArray(tmp, common_descr, flags);
         Py_DECREF(tmp);

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2032,14 +2032,9 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
     for (i = 0; i < n; i++) {
         int flags = NPY_ARRAY_CARRAY;
 
-        if (PyArray_FLAGS(mps[i]) & NPY_ARRAY_WAS_PYTHON_STR) {
-            PyObject *item = PySequence_GetItem(op, i);
-            if (item == NULL || npy_update_operand_for_pystr(
-                    &mps[i], item, common_descr, NPY_SAFE_CASTING) < 0) {
-                Py_XDECREF(item);
-                goto fail;
-            }
-            Py_DECREF(item);
+        if (npy_update_operand_if_pystr(&mps[i], op, i,
+                                        common_descr, NPY_SAFE_CASTING) < 0) {
+            goto fail;
         }
 
         PyArrayObject *tmp = mps[i];

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2032,8 +2032,7 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
     for (i = 0; i < n; i++) {
         int flags = NPY_ARRAY_CARRAY;
 
-        if (npy_update_operand_if_pystr(&mps[i], op, i,
-                                        common_descr, NPY_SAFE_CASTING) < 0) {
+        if (npy_update_operand_if_pystr(&mps[i], op, i, common_descr) < 0) {
             goto fail;
         }
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -692,6 +692,7 @@ PyArray_ConcatenateInto(PyObject *op,
         PyErr_NoMemory();
         return NULL;
     }
+    int any_pystr = 0;
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
         PyObject *item = PySequence_GetItem(op, iarrays);
         if (item == NULL) {
@@ -705,7 +706,31 @@ PyArray_ConcatenateInto(PyObject *op,
             goto fail;
         }
         npy_mark_tmp_array_if_pyscalar(item, arrays[iarrays], NULL);
+        any_pystr |= npy_mark_tmp_array_if_pystr(item, arrays[iarrays]);
         Py_DECREF(item);
+    }
+
+    /* Explicit axes reject the 0-d str before resolving a descriptor */
+    if (any_pystr && axis == NPY_RAVEL_AXIS) {
+        PyArray_Descr *target = PyArray_FindConcatenationDescriptor(
+                narrays, arrays, ret != NULL ? PyArray_DESCR(ret) : dtype);
+        if (target == NULL) {
+            goto fail;
+        }
+        for (iarrays = 0; iarrays < narrays; ++iarrays) {
+            if (!(PyArray_FLAGS(arrays[iarrays]) & NPY_ARRAY_WAS_PYTHON_STR)) {
+                continue;
+            }
+            PyObject *item = PySequence_GetItem(op, iarrays);
+            if (item == NULL || npy_update_operand_for_pystr(
+                    &arrays[iarrays], item, target, casting) < 0) {
+                Py_XDECREF(item);
+                Py_DECREF(target);
+                goto fail;
+            }
+            Py_DECREF(item);
+        }
+        Py_DECREF(target);
     }
 
     if (axis == NPY_RAVEL_AXIS) {
@@ -728,7 +753,7 @@ PyArray_ConcatenateInto(PyObject *op,
 fail:
     /* 'narrays' was set to how far we got in the conversion */
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
-        Py_DECREF(arrays[iarrays]);
+        Py_XDECREF(arrays[iarrays]);
     }
     PyMem_RawFree(arrays);
 
@@ -1981,13 +2006,14 @@ array_copyto(PyObject *NPY_UNUSED(ignored),
     }
     PyArray_DTypeMeta *DType = NPY_DTYPE(PyArray_DESCR(src));
     Py_INCREF(DType);
-    if (npy_mark_tmp_array_if_pyscalar(src_obj, src, &DType)) {
-        /* The user passed a Python scalar */
+    int is_pyscalar = npy_mark_tmp_array_if_pyscalar(src_obj, src, &DType);
+    if (is_pyscalar || npy_mark_tmp_array_if_pystr(src_obj, src)) {
         PyArray_Descr *descr;
         PyArray_DTypeMeta *dst_DType = NPY_DTYPE(PyArray_DESCR(dst));
         bool is_npy_nan = PyFloat_Check(src_obj) && npy_isnan(PyFloat_AsDouble(src_obj));
-        if (!is_npy_nan && (dst_DType->type_num == NPY_TIMEDELTA ||
-                            dst_DType->type_num == NPY_DATETIME)) {
+        if (is_pyscalar && !is_npy_nan &&
+                (dst_DType->type_num == NPY_TIMEDELTA ||
+                 dst_DType->type_num == NPY_DATETIME)) {
             descr = PyArray_DESCR(dst);
             Py_INCREF(descr);
         }
@@ -3274,6 +3300,8 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
     }
     npy_mark_tmp_array_if_pyscalar(x, ax, NULL);
     npy_mark_tmp_array_if_pyscalar(y, ay, NULL);
+    npy_mark_tmp_array_if_pystr(x, ax);
+    npy_mark_tmp_array_if_pystr(y, ay);
 
     npy_uint32 flags = NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED |
                         NPY_ITER_REFS_OK | NPY_ITER_ZEROSIZE_OK;
@@ -3292,14 +3320,14 @@ PyArray_Where(PyObject *condition, PyObject *x, PyObject *y)
         goto fail;
     }
 
-    if (PyArray_FLAGS(ax) & NPY_ARRAY_WAS_PYTHON_LITERAL) {
+    if (PyArray_FLAGS(ax) & (NPY_ARRAY_WAS_PYTHON_LITERAL | NPY_ARRAY_WAS_PYTHON_STR)) {
         if (npy_update_operand_for_scalar(&ax, x, common_dt, NPY_SAFE_CASTING) < 0) {
             goto fail;
         }
         op_in[2] = ax;
     }
 
-    if (PyArray_FLAGS(ay) & NPY_ARRAY_WAS_PYTHON_LITERAL) {
+    if (PyArray_FLAGS(ay) & (NPY_ARRAY_WAS_PYTHON_LITERAL | NPY_ARRAY_WAS_PYTHON_STR)) {
         if (npy_update_operand_for_scalar(&ay, y, common_dt, NPY_SAFE_CASTING) < 0) {
             goto fail;
         }

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -620,7 +620,7 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
 
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
         if (npy_update_operand_if_pystr(&arrays[iarrays], op, iarrays,
-                                        PyArray_DESCR(ret), casting) < 0) {
+                                        PyArray_DESCR(ret)) < 0) {
             Py_DECREF(sliding_view);
             Py_DECREF(ret);
             return NULL;
@@ -731,7 +731,7 @@ PyArray_ConcatenateInto(PyObject *op,
     }
 
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
-        Py_XDECREF(arrays[iarrays]);
+        Py_DECREF(arrays[iarrays]);
     }
     PyMem_RawFree(arrays);
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -530,9 +530,9 @@ PyArray_ConcatenateArrays(int narrays, PyArrayObject **arrays, int axis,
 
 /*
  * Concatenates a list of ndarrays, flattening each in the specified order.
- * If `op`, the sequence `arrays` were converted from, is given, any exact
- * Python str in it is converted again with the result descriptor so that
- * trailing nulls survive.
+ * `op` is the sequence `arrays` were converted from; any exact Python str in
+ * it is converted again with the result descriptor so that trailing nulls
+ * survive.
  */
 NPY_NO_EXPORT PyArrayObject *
 PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
@@ -607,16 +607,6 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
         }
     }
 
-    if (op != NULL) {
-        for (iarrays = 0; iarrays < narrays; ++iarrays) {
-            if (npy_update_operand_if_pystr(&arrays[iarrays], op, iarrays,
-                                            PyArray_DESCR(ret), casting) < 0) {
-                Py_DECREF(ret);
-                return NULL;
-            }
-        }
-    }
-
     /*
      * Create a view which slides through ret for assigning the
      * successive input arrays.
@@ -629,6 +619,13 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
     }
 
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
+        if (npy_update_operand_if_pystr(&arrays[iarrays], op, iarrays,
+                                        PyArray_DESCR(ret), casting) < 0) {
+            Py_DECREF(sliding_view);
+            Py_DECREF(ret);
+            return NULL;
+        }
+
         /* Adjust the window dimensions for this array */
         sliding_view->dimensions[0] = PyArray_SIZE(arrays[iarrays]);
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -530,10 +530,14 @@ PyArray_ConcatenateArrays(int narrays, PyArrayObject **arrays, int axis,
 
 /*
  * Concatenates a list of ndarrays, flattening each in the specified order.
+ * If `op`, the sequence `arrays` were converted from, is given, any exact
+ * Python str in it is converted again with the result descriptor so that
+ * trailing nulls survive.
  */
 NPY_NO_EXPORT PyArrayObject *
 PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
-                                   NPY_ORDER order, PyArrayObject *ret,
+                                   NPY_ORDER order, PyObject *op,
+                                   PyArrayObject *ret,
                                    PyArray_Descr *dtype, NPY_CASTING casting)
 {
     int iarrays;
@@ -600,6 +604,16 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
         descr = NULL;
         if (ret == NULL) {
             return NULL;
+        }
+    }
+
+    if (op != NULL) {
+        for (iarrays = 0; iarrays < narrays; ++iarrays) {
+            if (npy_update_operand_if_pystr(&arrays[iarrays], op, iarrays,
+                                            PyArray_DESCR(ret), casting) < 0) {
+                Py_DECREF(ret);
+                return NULL;
+            }
         }
     }
 
@@ -692,7 +706,6 @@ PyArray_ConcatenateInto(PyObject *op,
         PyErr_NoMemory();
         return NULL;
     }
-    int any_pystr = 0;
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
         PyObject *item = PySequence_GetItem(op, iarrays);
         if (item == NULL) {
@@ -706,36 +719,13 @@ PyArray_ConcatenateInto(PyObject *op,
             goto fail;
         }
         npy_mark_tmp_array_if_pyscalar(item, arrays[iarrays], NULL);
-        any_pystr |= npy_mark_tmp_array_if_pystr(item, arrays[iarrays]);
+        npy_mark_tmp_array_if_pystr(item, arrays[iarrays]);
         Py_DECREF(item);
-    }
-
-    /* Explicit axes reject the 0-d str before resolving a descriptor */
-    if (any_pystr && axis == NPY_RAVEL_AXIS) {
-        PyArray_Descr *target = PyArray_FindConcatenationDescriptor(
-                narrays, arrays, ret != NULL ? PyArray_DESCR(ret) : dtype);
-        if (target == NULL) {
-            goto fail;
-        }
-        for (iarrays = 0; iarrays < narrays; ++iarrays) {
-            if (!(PyArray_FLAGS(arrays[iarrays]) & NPY_ARRAY_WAS_PYTHON_STR)) {
-                continue;
-            }
-            PyObject *item = PySequence_GetItem(op, iarrays);
-            if (item == NULL || npy_update_operand_for_pystr(
-                    &arrays[iarrays], item, target, casting) < 0) {
-                Py_XDECREF(item);
-                Py_DECREF(target);
-                goto fail;
-            }
-            Py_DECREF(item);
-        }
-        Py_DECREF(target);
     }
 
     if (axis == NPY_RAVEL_AXIS) {
         ret = PyArray_ConcatenateFlattenedArrays(
-                narrays, arrays, NPY_CORDER, ret, dtype,
+                narrays, arrays, NPY_CORDER, op, ret, dtype,
                 casting);
     }
     else {
@@ -744,7 +734,7 @@ PyArray_ConcatenateInto(PyObject *op,
     }
 
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
-        Py_DECREF(arrays[iarrays]);
+        Py_XDECREF(arrays[iarrays]);
     }
     PyMem_RawFree(arrays);
 
@@ -753,7 +743,7 @@ PyArray_ConcatenateInto(PyObject *op,
 fail:
     /* 'narrays' was set to how far we got in the conversion */
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
-        Py_XDECREF(arrays[iarrays]);
+        Py_DECREF(arrays[iarrays]);
     }
     PyMem_RawFree(arrays);
 

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -479,6 +479,14 @@ def test_copyto_cast_safety():
     # As a special thing, object is equiv currently:
     np.copyto(np.arange(3, dtype=object), 3, casting="equiv")
 
+    # A Python str adopts a StringDType's semantics in the same way
+    np.copyto(np.empty(3, dtype=np.dtypes.StringDType()), "x", casting="no")
+    with pytest.raises(TypeError):
+        np.copyto(np.empty(3, dtype=np.dtypes.StringDType()), "x",
+                  casting="equiv")
+    # and object is equiv for a str, too:
+    np.copyto(np.empty(3, dtype=object), "x", casting="equiv")
+
     # The following raises an overflow error/gives a warning but not
     # type error (due to casting), though:
     with pytest.raises(OverflowError):

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -480,7 +480,7 @@ def test_copyto_cast_safety():
     np.copyto(np.arange(3, dtype=object), 3, casting="equiv")
 
     # A Python str adopts a StringDType's semantics in the same way
-    np.copyto(np.empty(3, dtype=np.dtypes.StringDType()), "x", casting="no")
+    np.copyto(np.empty(3, dtype=np.dtypes.StringDType()), "x", casting="safe")
     with pytest.raises(TypeError):
         np.copyto(np.empty(3, dtype=np.dtypes.StringDType()), "x",
                   casting="equiv")

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -346,8 +346,10 @@ def test_pystr_scalar_concatenate_preserves_nulls(dtype):
     res = np.concatenate((scalar,), axis=None, dtype=dtype)
     assert res[0] == scalar
 
-    res = np.concatenate((arr, "z"), axis=None, casting="no")
-    assert res[1] == "z"
+    # like a Python int, the str is not cast, so any casting rule allows it
+    for casting in ["no", "equiv", "safe", "same_kind", "unsafe"]:
+        res = np.concatenate((arr, "z"), axis=None, casting=casting)
+        assert res[1] == "z"
 
 
 def test_pystr_scalar_choose_preserves_nulls(dtype):

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -304,19 +304,14 @@ def test_pystr_scalar_full_copyto_where_preserve_nulls(dtype):
 
     dst = np.empty(2, dtype=dtype)
     np.copyto(dst, scalar)
-    assert dst[0] == scalar
-    np.copyto(dst, scalar, casting="unsafe")
-    assert dst[1] == scalar
+    assert dst.tolist() == [scalar, scalar]
 
     cond = np.array([True, False])
     arr = np.array(["y", "y"], dtype=dtype)
-    res = np.where(cond, scalar, arr)
-    assert res.dtype == dtype
-    assert res[0] == scalar
-    assert res[1] == "y"
-    res = np.where(cond, arr, scalar)
-    assert res[0] == "y"
-    assert res[1] == scalar
+    assert_array_equal(np.where(cond, scalar, arr),
+                       np.array([scalar, "y"], dtype=dtype), strict=True)
+    assert_array_equal(np.where(cond, arr, scalar),
+                       np.array(["y", scalar], dtype=dtype), strict=True)
 
 
 def test_pystr_scalar_full_copyto_where_object_preserve_nulls():
@@ -336,8 +331,7 @@ def test_pystr_scalar_concatenate_preserves_nulls(dtype):
     arr = np.array(["y"], dtype=dtype)
 
     res = np.concatenate((arr, scalar), axis=None)
-    assert res.dtype == dtype
-    assert_array_equal(res, np.array(["y", scalar], dtype=dtype))
+    assert_array_equal(res, np.array(["y", scalar], dtype=dtype), strict=True)
 
     res = np.concatenate((scalar, arr), axis=None)
     assert res[0] == scalar
@@ -361,8 +355,7 @@ def test_pystr_scalar_choose_preserves_nulls(dtype):
     arr = np.array(["y"], dtype=dtype)
 
     res = np.choose(np.array([1]), (arr, scalar))
-    assert res.dtype == dtype
-    assert res[0] == scalar
+    assert_array_equal(res, np.array([scalar], dtype=dtype), strict=True)
 
     res = np.choose(np.array([0]), (arr, scalar))
     assert res[0] == "y"

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -297,6 +297,84 @@ def test_pystr_scalar_ufunc_operand_any_instance(dtype):
     assert (arr + "x\0")[0] == "abc\0x\0"
 
 
+def test_pystr_scalar_full_copyto_where_preserve_nulls(dtype):
+    scalar = "x\0"
+
+    assert np.full(2, scalar, dtype=dtype)[0] == scalar
+
+    dst = np.empty(2, dtype=dtype)
+    np.copyto(dst, scalar)
+    assert dst[0] == scalar
+    np.copyto(dst, scalar, casting="unsafe")
+    assert dst[1] == scalar
+
+    cond = np.array([True, False])
+    arr = np.array(["y", "y"], dtype=dtype)
+    res = np.where(cond, scalar, arr)
+    assert res.dtype == dtype
+    assert res[0] == scalar
+    assert res[1] == "y"
+    res = np.where(cond, arr, scalar)
+    assert res[0] == "y"
+    assert res[1] == scalar
+
+
+def test_pystr_scalar_full_copyto_where_object_preserve_nulls():
+    scalar = "x\0"
+
+    assert np.full(1, scalar, dtype=object)[0] == scalar
+
+    dst = np.empty(1, dtype=object)
+    np.copyto(dst, scalar)
+    assert dst[0] == scalar
+
+    assert np.where([True], scalar, np.array(["y"], dtype=object))[0] == scalar
+
+
+def test_pystr_scalar_concatenate_preserves_nulls(dtype):
+    scalar = "x\0"
+    arr = np.array(["y"], dtype=dtype)
+
+    res = np.concatenate((arr, scalar), axis=None)
+    assert res.dtype == dtype
+    assert_array_equal(res, np.array(["y", scalar], dtype=dtype))
+
+    res = np.concatenate((scalar, arr), axis=None)
+    assert res[0] == scalar
+
+    out = np.empty(2, dtype=dtype)
+    np.concatenate((arr, scalar), axis=None, out=out)
+    assert out[1] == scalar
+
+    res = np.concatenate((["y"], scalar), axis=None, dtype=dtype)
+    assert res[1] == scalar
+
+    res = np.concatenate((scalar,), axis=None, dtype=dtype)
+    assert res[0] == scalar
+
+    res = np.concatenate((arr, "z"), axis=None, casting="no")
+    assert res[1] == "z"
+
+
+def test_pystr_scalar_choose_preserves_nulls(dtype):
+    scalar = "x\0"
+    arr = np.array(["y"], dtype=dtype)
+
+    res = np.choose(np.array([1]), (arr, scalar))
+    assert res.dtype == dtype
+    assert res[0] == scalar
+
+    res = np.choose(np.array([0]), (arr, scalar))
+    assert res[0] == "y"
+
+
+def test_pystr_scalar_concatenate_choose_object_preserve_nulls():
+    scalar = "x\0"
+    arr = np.array(["y"], dtype=object)
+    assert np.concatenate((arr, scalar), axis=None)[1] == scalar
+    assert np.choose(np.array([1]), (arr, scalar))[0] == scalar
+
+
 def test_partition_str_sep():
     arr = np.array(["a-b\0c", "nosep"], dtype="T")
 


### PR DESCRIPTION
### PR summary
Followup for #32040 

This adds NEP-50 style promotion for strings to `copyto` and `where`, which have explicit handling for numeric scalars. It also adds new promotion handling for `concatenate` and `choose`. These weren't needed before in `concatenate` and `choose` because numeric scalars don't need to do anything the the scalar value, only type metadata. Concatenate and choose correctly propagate that metadata but don't correctly propagate trailing NULLs.

The net effect is that trailing NULLs are now preserved for `StringDType` in all four operations, see tests.

#### AI Disclosure
I iterated on this with an AI model.