### PR TITLE
BUG: fix `masked_object` mask shrinking and expand tests

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2320,7 +2320,7 @@ def masked_object(x, value, copy=True, shrink=True):
     else:
         condition = umath.equal(np.asarray(x), value)
         mask = nomask
-    mask = mask_or(mask, make_mask(condition, shrink=shrink))
+    mask = mask_or(mask, make_mask(condition, shrink=shrink), shrink=shrink)
     return masked_array(x, mask=mask, copy=copy, fill_value=value)
 
 

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -89,6 +89,7 @@ from numpy.ma.core import (
     masked_less,
     masked_less_equal,
     masked_not_equal,
+    masked_object,
     masked_outside,
     masked_print_option,
     masked_values,
@@ -5688,8 +5689,49 @@ class TestMaskedConstant:
 
 
 class TestMaskedWhereAliases:
+    def test_masked_greater(self):
+        assert_equal(masked_greater(np.arange(4), 2).mask,
+                     [False, False, False, True])
 
-    # TODO: Test masked_object, masked_equal, ...
+    def test_masked_greater_equal(self):
+        assert_equal(masked_greater_equal(np.arange(4), 2).mask,
+                     [False, False, True, True])
+
+    def test_masked_less(self):
+        assert_equal(masked_less(np.arange(4), 2).mask,
+                     [True, True, False, False])
+
+    def test_masked_less_equal(self):
+        assert_equal(masked_less_equal(np.arange(4), 2).mask,
+                     [True, True, True, False])
+
+    def test_masked_equal(self):
+        x = np.arange(4)
+        res = masked_equal(x, 2)
+        assert_equal(res.mask, [False, False, True, False])
+        assert_(res[2] is masked)
+        assert_equal(res.fill_value, 2)
+
+        res = masked_equal(x, 9)
+        assert_(res.mask is nomask)
+
+        xm = array([1, 2, 3], mask=[1, 0, 0])
+        res = masked_equal(xm, 3)
+        assert_equal(res.mask, [True, False, True])
+
+    def test_masked_object(self):
+        food = np.array(['green_eggs', 'ham'], dtype=object)
+        res = masked_object(food, 'green_eggs')
+        assert_equal(res.mask, [True, False])
+        assert_(res[0] is masked)
+        assert_equal(res.fill_value, 'green_eggs')
+
+        res = masked_object(food, 'cheese')
+        assert_(res.mask is nomask)
+
+        xm = array(['a', 'b', 'c'], mask=[1, 0, 0], dtype=object)
+        res = masked_object(xm, 'c')
+        assert_equal(res.mask, [True, False, True])
 
     def test_masked_values(self):
         res = masked_values(np.array([-32768.0]), np.int16(-32768))

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -5689,36 +5689,6 @@ class TestMaskedConstant:
 
 
 class TestMaskedWhereAliases:
-    def test_masked_greater(self):
-        assert_equal(masked_greater(np.arange(4), 2).mask,
-                     [False, False, False, True])
-
-    def test_masked_greater_equal(self):
-        assert_equal(masked_greater_equal(np.arange(4), 2).mask,
-                     [False, False, True, True])
-
-    def test_masked_less(self):
-        assert_equal(masked_less(np.arange(4), 2).mask,
-                     [True, True, False, False])
-
-    def test_masked_less_equal(self):
-        assert_equal(masked_less_equal(np.arange(4), 2).mask,
-                     [True, True, True, False])
-
-    def test_masked_equal(self):
-        x = np.arange(4)
-        res = masked_equal(x, 2)
-        assert_equal(res.mask, [False, False, True, False])
-        assert_(res[2] is masked)
-        assert_equal(res.fill_value, 2)
-
-        res = masked_equal(x, 9)
-        assert_(res.mask is nomask)
-
-        xm = array([1, 2, 3], mask=[1, 0, 0])
-        res = masked_equal(xm, 3)
-        assert_equal(res.mask, [True, False, True])
-
     def test_masked_object(self):
         food = np.array(['green_eggs', 'ham'], dtype=object)
         res = masked_object(food, 'green_eggs')
@@ -5728,6 +5698,9 @@ class TestMaskedWhereAliases:
 
         res = masked_object(food, 'cheese')
         assert_(res.mask is nomask)
+
+        res = masked_object(food, 'cheese', shrink=False)
+        assert_equal(res.mask, [False, False])
 
         xm = array(['a', 'b', 'c'], mask=[1, 0, 0], dtype=object)
         res = masked_object(xm, 'c')


### PR DESCRIPTION
### PR summary
Towards #32275 

Added test for masking function and removed `TODO` comment

- `masked_object`
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
I used to review this (got suggetion to add more tests but i think we are fine so haven't added)
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
