### PR TITLE
TYP: ``expand_dims`` improved shape-typing

### DIFF
--- a/numpy/lib/_shape_base_impl.pyi
+++ b/numpy/lib/_shape_base_impl.pyi
@@ -151,34 +151,54 @@ def expand_dims[DTypeT: np.dtype](
 ) -> np.ndarray[_AnyShape, DTypeT]: ...
 @overload  # 0d -> 1d
 def expand_dims[ScalarT: np.generic](
-    a: ScalarT | np.ndarray[tuple[()], np.dtype[ScalarT]],
+    a: ScalarT | np.ndarray[_0d, np.dtype[ScalarT]],
     axis: int | tuple[int],
-) -> np.ndarray[tuple[int], np.dtype[ScalarT]]: ...
+) -> np.ndarray[_1d, np.dtype[ScalarT]]: ...
 @overload  # 0d -> 2d
 def expand_dims[ScalarT: np.generic](
-    a: ScalarT | np.ndarray[tuple[()], np.dtype[ScalarT]],
+    a: ScalarT | np.ndarray[_0d, np.dtype[ScalarT]],
     axis: tuple[int, int],
-) -> np.ndarray[tuple[int, int], np.dtype[ScalarT]]: ...
+) -> np.ndarray[_2d, np.dtype[ScalarT]]: ...
 @overload  # 1d -> 2d
 def expand_dims[DTypeT: np.dtype](
-    a: np.ndarray[tuple[int], DTypeT],
+    a: np.ndarray[_1d, DTypeT],
     axis: int | tuple[int],
-) -> np.ndarray[tuple[int, int], DTypeT]: ...
+) -> np.ndarray[_2d, DTypeT]: ...
 @overload  # 1d -> 3d
 def expand_dims[DTypeT: np.dtype](
-    a: np.ndarray[tuple[int], DTypeT],
+    a: np.ndarray[_1d, DTypeT],
     axis: tuple[int, int],
-) -> np.ndarray[tuple[int, int, int], DTypeT]: ...
+) -> np.ndarray[_3d, DTypeT]: ...
 @overload  # 2d -> 3d
 def expand_dims[DTypeT: np.dtype](
-    a: np.ndarray[tuple[int, int], DTypeT],
+    a: np.ndarray[_2d, DTypeT],
     axis: int | tuple[int],
-) -> np.ndarray[tuple[int, int, int], DTypeT]: ...
+) -> np.ndarray[_3d, DTypeT]: ...
 @overload  # 2d -> 4d
 def expand_dims[DTypeT: np.dtype](
-    a: np.ndarray[tuple[int, int], DTypeT],
+    a: np.ndarray[_2d, DTypeT],
     axis: tuple[int, int],
-) -> np.ndarray[tuple[int, int, int, int], DTypeT]: ...
+) -> np.ndarray[_4d, DTypeT]: ...
+@overload  # 3d -> 4d
+def expand_dims[DTypeT: np.dtype](
+    a: np.ndarray[_3d, DTypeT],
+    axis: int | tuple[int],
+) -> np.ndarray[_4d, DTypeT]: ...
+@overload  # 3d -> 5d
+def expand_dims[DTypeT: np.dtype](
+    a: np.ndarray[_3d, DTypeT],
+    axis: tuple[int, int],
+) -> np.ndarray[_5d, DTypeT]: ...
+@overload  # 4d -> 5d
+def expand_dims[DTypeT: np.dtype](
+    a: np.ndarray[_4d, DTypeT],
+    axis: int | tuple[int],
+) -> np.ndarray[_5d, DTypeT]: ...
+@overload  # 4d -> 6d
+def expand_dims[DTypeT: np.dtype](
+    a: np.ndarray[_4d, DTypeT],
+    axis: tuple[int, int],
+) -> np.ndarray[_6d, DTypeT]: ...
 @overload  # Nd -> ?d
 def expand_dims[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],

--- a/numpy/typing/tests/data/reveal/shape_base.pyi
+++ b/numpy/typing/tests/data/reveal/shape_base.pyi
@@ -3,20 +3,24 @@ from typing import Any, Self, assert_type
 import numpy as np
 import numpy.typing as npt
 
+type _Array0D[ScalarT: np.generic] = np.ndarray[tuple[()], np.dtype[ScalarT]]
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
 type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
 type _Array4D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int, int], np.dtype[ScalarT]]
+type _Array5D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int, int, int], np.dtype[ScalarT]]
+type _Array6D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int, int, int, int], np.dtype[ScalarT]]
 
 i8: np.int64
 f8: np.float64
 
 AR_b: npt.NDArray[np.bool]
 AR_i8: npt.NDArray[np.int64]
-AR_i8_0d: np.ndarray[tuple[()], np.dtype[np.int64]]
+AR_i8_0d: _Array0D[np.int64]
 AR_i8_1d: _Array1D[np.int64]
 AR_i8_2d: _Array2D[np.int64]
 AR_i8_3d: _Array3D[np.int64]
+AR_i8_4d: _Array4D[np.int64]
 AR_f8: npt.NDArray[np.float64]
 
 AR_LIKE_f8: list[float]
@@ -40,18 +44,26 @@ assert_type(np.expand_dims(AR_i8, ()), npt.NDArray[np.int64])
 assert_type(np.expand_dims(AR_i8, 0), npt.NDArray[np.int64])
 assert_type(np.expand_dims(AR_i8, (0,)), npt.NDArray[np.int64])
 assert_type(np.expand_dims(AR_i8, (0, 1)), npt.NDArray[np.int64])
-assert_type(np.expand_dims(AR_i8_0d, ()), np.ndarray[tuple[()], np.dtype[np.int64]])
-assert_type(np.expand_dims(AR_i8_0d, 0), np.ndarray[tuple[int], np.dtype[np.int64]])
-assert_type(np.expand_dims(AR_i8_0d, (0,)), np.ndarray[tuple[int], np.dtype[np.int64]])
-assert_type(np.expand_dims(AR_i8_0d, (0, 1)), np.ndarray[tuple[int, int], np.dtype[np.int64]])
-assert_type(np.expand_dims(AR_i8_1d, ()), np.ndarray[tuple[int], np.dtype[np.int64]])
-assert_type(np.expand_dims(AR_i8_1d, 0), np.ndarray[tuple[int, int], np.dtype[np.int64]])
-assert_type(np.expand_dims(AR_i8_1d, (0,)), np.ndarray[tuple[int, int], np.dtype[np.int64]])
-assert_type(np.expand_dims(AR_i8_1d, (0, 1)), np.ndarray[tuple[int, int, int], np.dtype[np.int64]])
-assert_type(np.expand_dims(AR_i8_2d, ()), np.ndarray[tuple[int, int], np.dtype[np.int64]])
-assert_type(np.expand_dims(AR_i8_2d, 0), np.ndarray[tuple[int, int, int], np.dtype[np.int64]])
-assert_type(np.expand_dims(AR_i8_2d, (0,)), np.ndarray[tuple[int, int, int], np.dtype[np.int64]])
-assert_type(np.expand_dims(AR_i8_2d, (0, 1)), np.ndarray[tuple[int, int, int, int], np.dtype[np.int64]])
+assert_type(np.expand_dims(AR_i8_0d, ()), _Array0D[np.int64])
+assert_type(np.expand_dims(AR_i8_0d, 0), _Array1D[np.int64])
+assert_type(np.expand_dims(AR_i8_0d, (0,)), _Array1D[np.int64])
+assert_type(np.expand_dims(AR_i8_0d, (0, 1)), _Array2D[np.int64])
+assert_type(np.expand_dims(AR_i8_1d, ()), _Array1D[np.int64])
+assert_type(np.expand_dims(AR_i8_1d, 0), _Array2D[np.int64])
+assert_type(np.expand_dims(AR_i8_1d, (0,)), _Array2D[np.int64])
+assert_type(np.expand_dims(AR_i8_1d, (0, 1)), _Array3D[np.int64])
+assert_type(np.expand_dims(AR_i8_2d, ()), _Array2D[np.int64])
+assert_type(np.expand_dims(AR_i8_2d, 0), _Array3D[np.int64])
+assert_type(np.expand_dims(AR_i8_2d, (0,)), _Array3D[np.int64])
+assert_type(np.expand_dims(AR_i8_2d, (0, 1)), _Array4D[np.int64])
+assert_type(np.expand_dims(AR_i8_3d, ()), _Array3D[np.int64])
+assert_type(np.expand_dims(AR_i8_3d, 0), _Array4D[np.int64])
+assert_type(np.expand_dims(AR_i8_3d, (0,)), _Array4D[np.int64])
+assert_type(np.expand_dims(AR_i8_3d, (0, 1)), _Array5D[np.int64])
+assert_type(np.expand_dims(AR_i8_4d, ()), _Array4D[np.int64])
+assert_type(np.expand_dims(AR_i8_4d, 0), _Array5D[np.int64])
+assert_type(np.expand_dims(AR_i8_4d, (0,)), _Array5D[np.int64])
+assert_type(np.expand_dims(AR_i8_4d, (0, 1)), _Array6D[np.int64])
 
 assert_type(np.column_stack([AR_i8]), npt.NDArray[np.int64])
 assert_type(np.column_stack([AR_LIKE_f8]), npt.NDArray[Any])


### PR DESCRIPTION
The shape-typing support added to `expand_dims` in #31220 only went up to <=2+2d. This expands the `expand_dims` dims so that it goes up to <=4+2d now.

---

Purely mechanical, so I had AI do most of this.