### PR TITLE
MAINT: define timeout for apt uses in github actions

### DIFF
--- a/.github/workflows/compiler_sanitizers.yml
+++ b/.github/workflows/compiler_sanitizers.yml
@@ -29,6 +29,9 @@ concurrency:
 permissions:
   contents: read # to fetch code (actions/checkout)
 
+env:
+  APT_TIMEOUT_MINUTES: 15
+
 jobs:
   clang_ASAN_UBSAN:
     # To enable this workflow on a fork, comment out:
@@ -112,6 +115,7 @@ jobs:
         run: pip install -U spin
 
       - name: Install ccache
+        timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
         run: |
           apt-get update && apt-get install -y ccache
           echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> "$GITHUB_ENV"

--- a/.github/workflows/linux-ibm.yml
+++ b/.github/workflows/linux-ibm.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  APT_TIMEOUT_MINUTES: 15
+
 jobs:
   native_ibm:
     # These jobs runs only in the main NumPy repository.
@@ -64,6 +67,7 @@ jobs:
         fetch-tags: true
 
     - name: Install dependencies
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         sudo apt update
         sudo apt install -y python3.12 python3-pip python3-dev ninja-build gfortran \
@@ -74,6 +78,7 @@ jobs:
 
     - name: Install clang
       if: matrix.config.compiler == 'clang'
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         sudo apt install -y clang-20
         echo CC=clang-20 >> $GITHUB_ENV

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,6 +31,9 @@ concurrency:
 permissions:
   contents: read # to fetch code (actions/checkout)
 
+env:
+  APT_TIMEOUT_MINUTES: 15
+
 jobs:
   smoke_test:
     # To enable this job on a fork, comment out:
@@ -121,6 +124,7 @@ jobs:
         pip install -r requirements/build_requirements.txt
         pip install -r requirements/test_requirements.txt -r requirements/hypothesis_requirements.txt
     - name: Install gfortran and setup OpenBLAS (MacPython build)
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         set -xe
         sudo apt update
@@ -157,6 +161,7 @@ jobs:
         persist-credentials: false
 
     - name: Creates new container
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         docker run --name the_container --interactive \
           -v $(pwd):/numpy arm32v7/ubuntu:24.04 /bin/linux32 /bin/bash -c "
@@ -204,6 +209,7 @@ jobs:
       with:
         python-version: '3.12'
     - name: Install build and benchmarking dependencies
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         sudo apt-get update
         sudo apt-get install libopenblas-dev ninja-build
@@ -263,6 +269,7 @@ jobs:
         cd tools
         pytest --pyargs numpy -m "not slow"
     - name: Test SWIG binding
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         sudo apt update
         sudo apt install make swig

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -57,6 +57,9 @@ concurrency:
 permissions:
   contents: read # to fetch code (actions/checkout)
 
+env:
+  APT_TIMEOUT_MINUTES: 15
+
 jobs:
   openblas32_stable_nightly:
     # To enable this workflow on a fork, comment out:
@@ -203,6 +206,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install dependencies
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         sudo apt-get update
@@ -231,6 +235,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install dependencies
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
         sudo apt-get update
@@ -359,6 +364,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install dependencies
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         pip install -r requirements/build_requirements.txt
         pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
@@ -396,6 +402,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install dependencies
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         pip install -r requirements/build_requirements.txt
         pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt

--- a/.github/workflows/linux_qemu.yml
+++ b/.github/workflows/linux_qemu.yml
@@ -37,6 +37,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  APT_TIMEOUT_MINUTES: 15
+
 jobs:
   linux_qemu:
     # Only workflow_dispatch is enabled on forks.
@@ -77,6 +80,7 @@ jobs:
         docker run --rm --privileged tonistiigi/binfmt:qemu-v9.2.2-52@sha256:1b804311fe87047a4c96d38b4b3ef6f62fca8cd125265917a9e3dc3c996c39e6 --install all
 
     - name: Install GCC cross-compilers
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         sudo apt update
         sudo apt install -y ninja-build gcc-${TOOLCHAIN_NAME} g++-${TOOLCHAIN_NAME} gfortran-${TOOLCHAIN_NAME}
@@ -93,8 +97,9 @@ jobs:
       run: |
         docker run --platform=linux/${ARCH} --name the_container --interactive \
           -v /:/host -v $(pwd):/numpy ${DOCKER_CONTAINER} /bin/bash -c "
-          apt update &&
-          apt install -y cmake git curl ca-certificates &&
+          # timeout-minutes can't reach inside 'docker run', so bound apt directly
+          timeout ${APT_TIMEOUT_MINUTES}m apt update &&
+          timeout ${APT_TIMEOUT_MINUTES}m apt install -y cmake git curl ca-certificates &&
           # Fix expired Microsoft/azure-cli repo key (affects riscv64/ubuntu:22.04)
           mkdir -p /etc/apt/keyrings &&
           curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
@@ -194,6 +199,7 @@ jobs:
           docker run --rm --privileged tonistiigi/binfmt:qemu-v10.0.4-56@sha256:30cc9a4d03765acac9be2ed0afc23af1ad018aed2c28ea4be8c2eb9afe03fbd1 --install all
 
     - name: Install GCC cross-compilers
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         sudo apt update
         sudo apt install -y ninja-build gcc-14-${TOOLCHAIN_NAME} g++-14-${TOOLCHAIN_NAME} gfortran-14-${TOOLCHAIN_NAME}

--- a/.github/workflows/linux_simd.yml
+++ b/.github/workflows/linux_simd.yml
@@ -46,6 +46,7 @@ defaults:
 
 env:
   TERM: xterm-256color
+  APT_TIMEOUT_MINUTES: 15
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -90,6 +91,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install GCC10
+      timeout-minutes: ${{ fromJSON(env.APT_TIMEOUT_MINUTES) }}
       run: |
         echo "deb http://archive.ubuntu.com/ubuntu focal main universe" | sudo tee /etc/apt/sources.list.d/focal.list
         sudo apt update


### PR DESCRIPTION
### PR summary

I've been noticing 6 hour timeouts, stalling on apt invocations. For example:

https://github.com/numpy/numpy/actions/runs/32302817294/job/96230801905
https://github.com/numpy/numpy/actions/runs/32302817294/job/96230801759

Rather than wasting CI resources spinning, let's add a timeout. 15 minutes seems generous to catch any truly recoverable network issue.

#### AI Disclosure
I asked an AI to double-check I caught all apt uses.