### PR TITLE
BUG: fix file descriptor leak in npy_PyFile_Dup2 when fdopen fails [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/numpy/_core/include/numpy/npy_3kcompat.h
+++ b/numpy/_core/include/numpy/npy_3kcompat.h
@@ -119,6 +119,11 @@ npy_PyFile_Dup2(PyObject *file, char *mode, npy_off_t *orig_pos)
     handle = fdopen(fd2, mode);
 #endif
     if (handle == NULL) {
+#ifdef _WIN32
+        _close(fd2);
+#else
+        close(fd2);
+#endif
         PyErr_SetString(PyExc_IOError,
                         "Getting a FILE* from a Python file object via "
                         "_fdopen failed. If you built NumPy, you probably "


### PR DESCRIPTION
## Description

Fixes #32373

When `os.dup()` succeeds but `fdopen`/`_fdopen` fails inside `npy_PyFile_Dup2`, the duplicated file descriptor `fd2` is leaked. This is the only error path in the function that does not properly close the file descriptor before returning `NULL`.

## Fix

Added `close(fd2)` (POSIX) / `_close(fd2)` (Windows) before the error return, matching the pattern used by all other error paths in the function.

## Verification

- All other error paths after `fdopen` succeeds properly call `fclose(handle)`
- The `fd2` variable is only leaked on this one path
- `npy_common.h` already includes `<unistd.h>` (POSIX) and `<io.h>` (Windows), so `close`/`_close` are available

Signed-off-by: waterWang <waterwang@proton.me>