### PR TITLE
BUG: fix two error handling mistakes in stringdtype replace loop (#32355)

### DIFF
--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -1409,6 +1409,7 @@ string_replace_strided_loop(
                         npy_gil_error(PyExc_ValueError,
                                       "Only string or NaN-like null strings can "
                                       "be used as search strings for replace");
+                        goto fail;
                     }
                 }
             }
@@ -1430,7 +1431,7 @@ string_replace_strided_loop(
             Buffer<ENCODING::UTF8> buf2((char *)i2s.buf, i2s.size);
 
             npy_int64 in_count = *(npy_int64*)in4;
-            if (in_count == -1) {
+            if (in_count < 0) {
                 in_count = NPY_MAX_INT64;
             }
 

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1878,6 +1878,14 @@ def test_replace_non_default_repeat(count):
     assert_array_equal(result, np.array(["🐍--", "🦜†🦜†"], "T"))
 
 
+@pytest.mark.parametrize("count", [-1, -2, -2**63])
+def test_replace_negative_count_replaces_all(count):
+    # any negative count means "replace all", matching str.replace
+    arr = np.array(["aaa"], dtype="T")
+    assert_array_equal(np.strings.replace(arr, "a", "X", count),
+                       np.array(["XXX"], dtype="T"))
+
+
 def test_trailing_null_is_not_padding():
     arr = np.array(["x\0", "\0", "x\0y\0", "abc"], dtype=StringDType())
     nul = np.array("\0", dtype=StringDType())


### PR DESCRIPTION
Backport of #32355.

### PR summary
Two error paths in the `StringDType` replace implementation had bugs. One one is user-visible via a public API:

```
In [1]: arr = np.array(["aaa"], dtype="T")

In [2]: np.strings.replace(arr, "X", count=-12)
Out[2]: array(['aaa'], dtype=StringDType())
```

This should be `array(['XXX'], dtype=StringDType())`, for any negative `count`. Right now it only happens if `count == -1`. This follows python strings:

```
In [3]: "aaa".replace('a', 'X', count=-12)
Out[3]: 'XXX'
```

The other one requires passing `out` to the private `_replace` ufunc directly to have a user-visible impact. Still, seems worth  adding the `goto fail` that's missing.


#### AI Disclosure
An AI model spotted both issues.
