### PR TITLE
MAINT: Update ml_dtypes pin to 8/21/2026.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -333,7 +333,7 @@ jobs:
       with:
         repository: jax-ml/ml_dtypes
         # Current ml_dtypes main, should be updated occasionally:
-        ref: '9b8b2471a5ec5fd4c223693f677fcc2416847970'  # main as of 2026-05-11
+        ref: 'b793a6e2864ce20b6680df2fd480a5cd2a75fa82'  # main as of 2026-08-21
         submodules: 'true'
         path: 'ml_dtypes'
         persist-credentials: false


### PR DESCRIPTION
Update ml_dtypes used for testing user dtypes.

No AI.


