### PR TITLE
BUG: make np.split accept array-like input with integer sections

### DIFF
--- a/numpy/lib/_shape_base_impl.py
+++ b/numpy/lib/_shape_base_impl.py
@@ -849,7 +849,10 @@ def split(ary, indices_or_sections, axis=0):
         len(indices_or_sections)
     except TypeError:
         sections = indices_or_sections
-        N = ary.shape[axis]
+        try:
+            N = ary.shape[axis]
+        except AttributeError:
+            N = len(ary)
         if N % sections:
             raise ValueError(
                 'array split does not result in an equal division') from None

--- a/numpy/lib/tests/test_shape_base.py
+++ b/numpy/lib/tests/test_shape_base.py
@@ -495,6 +495,20 @@ class TestSplit:
         a = np.arange(10)
         assert_raises(ValueError, split, a, 3)
 
+    def test_integer_split_list_and_tuple(self):
+        # gh-17463: `split` with an integer number of sections must accept
+        # array-like input (list/tuple), consistent with `array_split`.
+        desired = [np.array([1, 2]), np.array([3, 4])]
+
+        res = split([1, 2, 3, 4], 2)
+        compare_results(res, desired)
+
+        res = split((1, 2, 3, 4), 2)
+        compare_results(res, desired)
+
+        # An unequal division must still raise (rather than AttributeError).
+        assert_raises(ValueError, split, [1, 2, 3, 4], 3)
+
 
 class TestColumnStack:
     def test_non_iterable(self):


### PR DESCRIPTION
Fixes #17463

`np.split` raised `AttributeError: 'list' object has no attribute 'shape'` when given a list/tuple input together with an integer number of sections, whereas `np.array_split` (which `split` delegates to) accepts array-likes. `array_split` already falls back to `len(ary)` when `ary.shape` is unavailable; `split`'s equal-division check did not.

This mirrors that fallback in `split` so the two functions behave consistently for array-like inputs. An unequal division still raises `ValueError` as before, and the ndarray code path is unchanged.

Added a regression test (`TestSplit.test_integer_split_list_and_tuple`) covering list and tuple inputs and the unequal-division `ValueError`.