### PR TITLE
BLD: skip unsupported floating-point builtins with MSVC

### DIFF
--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -471,6 +471,12 @@ optional_intrinsics = [
 ]
 foreach intrin: optional_intrinsics
   func = intrin[0]
+  # MSVC does not support these builtins in C mode (gh-32229).
+  if (compiler_id == 'msvc' and
+      func in ['__builtin_isnan', '__builtin_isinf', '__builtin_isfinite']
+    )
+    continue
+  endif
   func_args = intrin[1]
   header = intrin[2]
   define = intrin[3]


### PR DESCRIPTION
## Summary

MSVC 19.51 accepts `__builtin_isnan`, `__builtin_isinf` and `__builtin_isfinite` in C mode, but optimized builds silently miscompile and unoptimized builds hit an internal compiler error. The Meson probes in `numpy/_core/meson.build` only check that each builtin *links*, so those MSVC releases define `HAVE___BUILTIN_ISNAN` / `_ISINF` / `_ISFINITE` and `npy_math.h` is routed through builtins MSVC does not actually support.

This skips those three classification builtins when the C compiler ID is `msvc`, so the macros stay unset and the existing `<math.h>` fallbacks are used.

## Why this matters

gh-32229 reports NumPy built with MSVC 19.51 breaking silently at `/O2` and hitting an ICE at `/Od`. Microsoft has clarified that these builtins are not supported in MSVC C mode. The effect is visible through existing behaviour — `np.arange`, `np.linspace` and finite-array formatting — so a build that looks successful produces wrong results.

## Notes on the approach

- Uses the Meson compiler ID rather than `_MSC_VER`, so `clang-cl` keeps its working builtin path.
- Scoped to the three unsupported builtins; every other optional intrinsic probe is unchanged.
- Stays compile/link-only rather than becoming a runtime probe, so cross compilation is unaffected.

## Testing

I do not have an MSVC toolchain available, so I have not built NumPy with MSVC 19.51 to confirm the macros are now unset or that the reported miscompilation goes away. That verification is still needed. What I did check is that `numpy/_core/meson.build` parses cleanly with Meson's own parser, and that the guard is placed after `func` is assigned and after `compiler_id = cc.get_id()` (line 449), so it is in scope where used.

Existing Windows coverage that exercises the affected paths: `numpy/_core/tests/test_arrayprint.py`, `numpy/_core/tests/test_function_base.py`, and the `arange` call sites in `numpy/_core/tests/test_multiarray.py`.

#### AI Disclosure

This patch was drafted with AI assistance (Claude, via an automated contribution pipeline). The diff is six lines in `numpy/_core/meson.build`; I have reviewed it and am submitting it myself in line with NumPy's AI policy. The PR description above was written with AI assistance and edited by me.

Fixes #32229
