### PR TITLE
MAINT: Pin Cython to <3.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12 # need to pin to avoid issues with builds
-  - cython>=3.0
+  - cython>=3.0,<3.3
   - compilers
   - openblas
   - nomkl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "mesonpy"
 requires = [
     "meson-python>=0.20.0",
-    "Cython>=3.1.0",  # keep in sync with version check in meson.build
+    "Cython>=3.1.0,<3.3",  # keep in sync with version check in meson.build
 ]
 
 [project]

--- a/requirements/build_requirements.txt
+++ b/requirements/build_requirements.txt
@@ -1,5 +1,5 @@
 meson-python>=0.18.0
-Cython>=3.1.0
+Cython>=3.1.0,<3.3
 ninja
 spin
 build

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -2,7 +2,7 @@
 # kept in sync.
 # Note: hypothesis is an optional test dependency, see hypothesis_requirements.txt
 
-Cython
+Cython>=3.1.0,<3.3
 pytest==9.1.1
 pytest-cov==7.1.0
 meson


### PR DESCRIPTION

### PR summary

Cython 3.3.0 changed the limited-API CyFunction layout per abi3 target without updating the shared-type ABI key, so importing extensions built for different targets fails with "Shared Cython type cython_function_or_method has the wrong size". This breaks `test_limited_api`. Upstream report is cython/cython#7914.

<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->



#### AI Disclosure

Claude was used to investigate the issue. 

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
