### PR TITLE
BUG: fix `trim_zeros` for multi-dimensional sequences

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2072,7 +2072,9 @@ def trim_zeros(filt, trim='fb', axis=None):
         # filt is 1D -> avoid multi-dimensional slicing to preserve
         # non-array input types
         return filt[sl[0]]
-    return filt[sl]
+    if isinstance(filt, np.ndarray):
+        return filt[sl]
+    return filt_[sl]
 
 
 def _extract_dispatcher(condition, arr):

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -2002,8 +2002,10 @@ def trim_zeros(filt, trim='fb', axis=None):
     Returns
     -------
     trimmed : ndarray or sequence
-        The result of trimming the input. The number of dimensions and the
-        input data type are preserved.
+        The result of trimming the input. The number of dimensions is
+        preserved, and so is the input type where possible: arrays and
+        1-D sequences keep their type, while nested sequences (such as a
+        list of lists) are returned as an ``ndarray``.
 
     Notes
     -----
@@ -2072,9 +2074,12 @@ def trim_zeros(filt, trim='fb', axis=None):
         # filt is 1D -> avoid multi-dimensional slicing to preserve
         # non-array input types
         return filt[sl[0]]
-    if isinstance(filt, np.ndarray):
+    try:
+        # Index the input directly to preserve its type (ndarray subclasses
+        # and duck arrays that support multi-dimensional indexing).
         return filt[sl]
-    return filt_[sl]
+    except TypeError:
+        return filt_[sl]
 
 
 def _extract_dispatcher(condition, arr):

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1541,6 +1541,12 @@ class TestTrimZeros:
         data, expected = self.construct_input_output(rng, shape, axis, trim)
         assert_array_equal(trim_zeros(data, axis=axis, trim=trim), expected)
 
+    @pytest.mark.parametrize("seq", ([[0, 1], [0, 0]], ((0, 1), (0, 0))))
+    def test_nested_sequence(self, seq):
+        res = np.trim_zeros(seq)
+        assert isinstance(res, np.ndarray)
+        assert_array_equal(res, [[1]])
+
 
 class TestExtins:
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -1543,9 +1543,38 @@ class TestTrimZeros:
 
     @pytest.mark.parametrize("seq", ([[0, 1], [0, 0]], ((0, 1), (0, 0))))
     def test_nested_sequence(self, seq):
-        res = np.trim_zeros(seq)
+        res = trim_zeros(seq)
         assert isinstance(res, np.ndarray)
         assert_array_equal(res, [[1]])
+
+        res = trim_zeros(seq, axis=0)
+        assert_array_equal(res, [[0, 1]])
+
+        res = trim_zeros(seq, axis=1)
+        assert_array_equal(res, [[1], [0]])
+
+    def test_nested_sequence_all_zero(self):
+        res = trim_zeros([[0, 0], [0, 0]])
+        assert_array_equal(res, np.zeros((0, 0)))
+
+    def test_duck_array(self):
+        # gh-32394: an ndarray duck type that is not an ndarray instance
+        # (e.g. xarray.DataArray) but supports multi-dimensional indexing
+        # must be sliced directly so that its type is preserved
+        class DuckArray:
+            def __init__(self, arr):
+                self.arr = np.asarray(arr)
+
+            def __array__(self, dtype=None, copy=None):
+                return np.array(self.arr, dtype=dtype, copy=copy)
+
+            def __getitem__(self, index):
+                return DuckArray(self.arr[index])
+
+        duck = DuckArray([[0, 0, 0], [0, 1, 0], [0, 0, 0]])
+        res = trim_zeros(duck)
+        assert isinstance(res, DuckArray)
+        assert_array_equal(res.arr, [[1]])
 
 
 class TestExtins:


### PR DESCRIPTION
### PR summary
fixes #32394

- Fix the handling of multi-dimensional sequences.

```
>>> import numpy as np
>>> print("1-D list :", np.trim_zeros([0, 1, 2, 0]))
1-D list : [1, 2]
>>> print("1-D tuple:", np.trim_zeros((0, 1, 2, 0)))
1-D tuple: (1, 2)
>>> print("2-D array:", np.trim_zeros(np.array([[0, 1], [0, 0]])).tolist())
2-D array: [[1]]
>>> for label, seq in [("2-D list ", [[0, 1], [0, 0]]),
...                     ("2-D tuple", ((0, 1), (0, 0)))]:
...     try:
...         print(label, ":", np.trim_zeros(seq))
...     except TypeError as e:
...         print(label, ": TypeError:", e)
...
2-D list  : [[1]]
2-D tuple : [[1]]
>>> try:
...     np.trim_zeros([[0, 1], [0, 0]], axis=0)
... except TypeError as e:
...     print("2-D list, axis=0 : TypeError:", e)
...
array([[0, 1]])
```


<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
- took help for test and review
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
