### PR TITLE
TYP: preserve array shape in `isposinf` and `isneginf`

### DIFF
--- a/numpy/lib/_ufunclike_impl.pyi
+++ b/numpy/lib/_ufunclike_impl.pyi
@@ -7,6 +7,7 @@ from numpy._typing import (
     _ArrayLikeFloat_co,
     _ArrayLikeObject_co,
     _FloatLike_co,
+    _Shape,
 )
 
 __all__ = ["fix", "isneginf", "isposinf"]
@@ -28,6 +29,8 @@ def fix[ArrayT: np.ndarray](x: _ArrayLikeFloat_co | _ArrayLikeObject_co, out: Ar
 @overload
 def isposinf(x: _FloatLike_co, out: None = None) -> np.bool: ...
 @overload
+def isposinf[ShapeT: _Shape](x: np.ndarray[ShapeT, np.dtype[np.floating | np.integer | np.bool]], out: None = None) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
+@overload
 def isposinf(x: _ArrayLikeFloat_co, out: None = None) -> NDArray[np.bool]: ...
 @overload
 def isposinf[ArrayT: np.ndarray](x: _ArrayLikeFloat_co, out: ArrayT) -> ArrayT: ...
@@ -35,6 +38,8 @@ def isposinf[ArrayT: np.ndarray](x: _ArrayLikeFloat_co, out: ArrayT) -> ArrayT: 
 #
 @overload
 def isneginf(x: _FloatLike_co, out: None = None) -> np.bool: ...
+@overload
+def isneginf[ShapeT: _Shape](x: np.ndarray[ShapeT, np.dtype[np.floating | np.integer | np.bool]], out: None = None) -> np.ndarray[ShapeT, np.dtype[np.bool]]: ...
 @overload
 def isneginf(x: _ArrayLikeFloat_co, out: None = None) -> NDArray[np.bool]: ...
 @overload

--- a/numpy/typing/tests/data/reveal/ufunclike.pyi
+++ b/numpy/typing/tests/data/reveal/ufunclike.pyi
@@ -11,6 +11,9 @@ AR_LIKE_O: list[np.object_]
 
 AR_U: npt.NDArray[np.str_]
 
+AR_f8_1d: np.ndarray[tuple[int], np.dtype[np.float64]]
+AR_f8_2d: np.ndarray[tuple[int, int], np.dtype[np.float64]]
+
 assert_type(np.fix(AR_LIKE_b), npt.NDArray[np.floating])  # type: ignore[deprecated]
 assert_type(np.fix(AR_LIKE_u), npt.NDArray[np.floating])  # type: ignore[deprecated]
 assert_type(np.fix(AR_LIKE_i), npt.NDArray[np.floating])  # type: ignore[deprecated]
@@ -23,9 +26,13 @@ assert_type(np.isposinf(AR_LIKE_u), npt.NDArray[np.bool])
 assert_type(np.isposinf(AR_LIKE_i), npt.NDArray[np.bool])
 assert_type(np.isposinf(AR_LIKE_f), npt.NDArray[np.bool])
 assert_type(np.isposinf(AR_LIKE_f, out=AR_U), npt.NDArray[np.str_])
+assert_type(np.isposinf(AR_f8_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.isposinf(AR_f8_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])
 
 assert_type(np.isneginf(AR_LIKE_b), npt.NDArray[np.bool])
 assert_type(np.isneginf(AR_LIKE_u), npt.NDArray[np.bool])
 assert_type(np.isneginf(AR_LIKE_i), npt.NDArray[np.bool])
 assert_type(np.isneginf(AR_LIKE_f), npt.NDArray[np.bool])
 assert_type(np.isneginf(AR_LIKE_f, out=AR_U), npt.NDArray[np.str_])
+assert_type(np.isneginf(AR_f8_1d), np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(np.isneginf(AR_f8_2d), np.ndarray[tuple[int, int], np.dtype[np.bool]])


### PR DESCRIPTION
### PR summary
- previously, the typing of `isposinf` and `isneginf` did not preserve the input array's shape.
- This PR updates the typing so the returned boolean array keeps the same shape as the input array.
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction

<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
- took help to verify runtime behaviour
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
