### PR TITLE
DOC: Correct integration formula in docstring

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4956,7 +4956,7 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     Integrate `y` (`x`) along each 1d slice on the given axis, compute
     :math:`\int y(x) dx`.
     When `x` is specified, this integrates along the parametric curve,
-    computing :math:`\int_t y(t) dt =
+    computing :math:`\int_x y(x(t)) dx =
     \int_t y(t) \left.\frac{dx}{dt}\right|_{x=x(t)} dt`.
 
     .. versionadded:: 2.0.0

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4956,9 +4956,9 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
     Integrate `y` (`x`) along each 1d slice on the given axis, compute
     :math:`\int y(x) dx`.
     When `x` is specified, this integrates along the parametric curve
-    :math:`C` given by :math:`(x(t), y(t))`, computing the line integral 
-    :math:`\int_C y dx = \int_t y(t) \left.\frac{dx}{dt}\right|_{x=x(t)} dt.
-    
+    :math:`C` given by :math:`(x(t), y(t))`, computing the line integral
+    :math:`\int_C y \, dx = \int y(t) \frac{dx}{dt} \, dt`.
+
     .. versionadded:: 2.0.0
 
     Parameters

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -4955,10 +4955,10 @@ def trapezoid(y, x=None, dx=1.0, axis=-1):
 
     Integrate `y` (`x`) along each 1d slice on the given axis, compute
     :math:`\int y(x) dx`.
-    When `x` is specified, this integrates along the parametric curve,
-    computing :math:`\int_x y(x(t)) dx =
-    \int_t y(t) \left.\frac{dx}{dt}\right|_{x=x(t)} dt`.
-
+    When `x` is specified, this integrates along the parametric curve
+    :math:`C` given by :math:`(x(t), y(t))`, computing the line integral 
+    :math:`\int_C y dx = \int_t y(t) \left.\frac{dx}{dt}\right|_{x=x(t)} dt.
+    
     .. versionadded:: 2.0.0
 
     Parameters


### PR DESCRIPTION
### PR summary
In the current docstring for `np.trapezoid`, I believe this equation
$\int_t y(t) dt = \int_t y(t) \left.\frac{dx}{dt}\right|_{x=x(t)} dt$
is mathematically inaccurate, or at least very misleading.

I think this equation is meant to illustrate how a change of variable (from $x$ to $t$) can be used to get the integration formula purely in the parametric variable $t$. To be accurate, reintroducing integration bounds, the change of variable can be written
$\int_{x_i}^{x_f} y(x) dx = \int_{x(t_i)}^{x(t_f)} y(x(t)) dx = \int_{t_i}^{t_f} y(t) \left.\frac{dx}{dt}\right|_{x=x(t)} dt$

with the subscripts " $\cdot_i$" and " $\cdot_f$" denoting initial and final values.
Simplifying back to how the original equations in the docstring are currently written, I propose to rewrite the first equation
$\int_x y(x(t)) dx = \int_t y(t) \left.\frac{dx}{dt}\right|_{x=x(t)} dt$
as a satisfactory trade-off between conciseness and clarity.

#### AI Disclosure
Github automatically created the PR's title and commit message using Copilot.