### PR TITLE
TYP: ``linalg.tensorsolve`` shape-typing

### DIFF
--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -212,35 +212,183 @@ class SlogdetResult(NamedTuple, Generic[_FloatingOrArrayT_co, _InexactOrArrayT_c
     sign: _InexactOrArrayT_co
     logabsdet: _FloatingOrArrayT_co
 
-# keep in sync with `solve`
-@overload  # ~float64, +float64
-def tensorsolve(a: _ToArrayF64, b: _ArrayLikeFloat_co, axes: Iterable[int] | None = None) -> NDArray[np.float64]: ...
-@overload  # +float64, ~float64
-def tensorsolve(a: _ArrayLikeFloat_co, b: _ToArrayF64, axes: Iterable[int] | None = None) -> NDArray[np.float64]: ...
-@overload  # ~float32, ~float32
+#
+@overload  # ?d +f64, ?d +f64 (workaround)
 def tensorsolve(
-    a: _ArrayLike[np.float32], b: _ArrayLike[np.float32], axes: Iterable[int] | None = None
+    a: _ArrayJustND[_to_float64],
+    b: _ToArrayF64,
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.float64]: ...
+@overload  # ?d +f64, ?d +f64 (workaround)
+def tensorsolve(
+    a: _ToArrayF64,
+    b: _ArrayJustND[_to_float64],
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.float64]: ...
+@overload  # ?d ~c128, ?d +c128 (workaround)
+def tensorsolve(
+    a: _ArrayJustND[np.complex128],
+    b: _ToArrayC128,
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # ?d +c128, ?d ~c128 (workaround)
+def tensorsolve(
+    a: _ToArrayC128,
+    b: _ArrayJustND[np.complex128],
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # ?d ~f32, ?d ~f32 (workaround)
+def tensorsolve(
+    a: _ArrayJustND[np.float32],
+    b: _ArrayLike[np.float32],
+    axes: Iterable[int] | None = None,
 ) -> NDArray[np.float32]: ...
-@overload  # +float, +float
-def tensorsolve(a: _ArrayLikeFloat_co, b: _ArrayLikeFloat_co, axes: Iterable[int] | None = None) -> NDArray[np.float64 | Any]: ...
-@overload  # ~complex128, +complex128
-def tensorsolve(a: _AsArrayC128, b: _ArrayLikeComplex_co, axes: Iterable[int] | None = None) -> NDArray[np.complex128]: ...
-@overload  # +complex128, ~complex128
-def tensorsolve(a: _ArrayLikeComplex_co, b: _AsArrayC128, axes: Iterable[int] | None = None) -> NDArray[np.complex128]: ...
-@overload  # ~complex64, +complex64
+@overload  # ?d ~f32, ?d ~f32 (workaround)
 def tensorsolve(
-    a: _ArrayLike[np.complex64], b: _ArrayLike[_inexact32], axes: Iterable[int] | None = None
+    a: _ArrayLike[np.float32],
+    b: _ArrayJustND[np.float32],
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.float32]: ...
+@overload  # ?d ~c64, ?d +c64 (workaround)
+def tensorsolve(
+    a: _ArrayJustND[np.complex64],
+    b: _ArrayLike[_inexact32],
+    axes: Iterable[int] | None = None,
 ) -> NDArray[np.complex64]: ...
-@overload  # +complex64, ~complex64
+@overload  # ?d +c64, ?d ~c64 (workaround)
 def tensorsolve(
-    a: _ArrayLike[_inexact32], b: _ArrayLike[np.complex64], axes: Iterable[int] | None = None
+    a: _ArrayLike[_inexact32],
+    b: _ArrayJustND[np.complex64],
+    axes: Iterable[int] | None = None,
 ) -> NDArray[np.complex64]: ...
-@overload  # +complex, +complex
+@overload  # 2d +f64, 1d +f64
 def tensorsolve(
-    a: _ArrayLikeComplex_co, b: _ArrayLikeComplex_co, axes: Iterable[int] | None = None
-) -> NDArray[np.complex128 | Any]: ...
+    a: _ArrayLike2D2[_to_float64, float],
+    b: _ArrayLike1D2[_to_float64, float],
+    axes: Iterable[int] | None = None,
+) -> _Array1D[np.float64]: ...
+@overload  # 2d ~c128, 1d +c128
+def tensorsolve(
+    a: _AsArrayC128_2d,
+    b: _ArrayLike1D2[_to_inexact64, complex],
+    axes: Iterable[int] | None = None,
+) -> _Array1D[np.complex128]: ...
+@overload  # 2d +c128, 1d ~c128
+def tensorsolve(
+    a: _ArrayLike2D2[_to_inexact64, complex],
+    b: _AsArrayC128_1d,
+    axes: Iterable[int] | None = None,
+) -> _Array1D[np.complex128]: ...
+@overload  # 2d ~f32|c64, 1d ~f32|c64
+def tensorsolve[ScalarT: (np.float32, np.complex64)](
+    a: _ArrayLike2D[ScalarT],
+    b: _ArrayLike1D[ScalarT],
+    axes: Iterable[int] | None = None,
+) -> _Array1D[ScalarT]: ...
+@overload  # 3d +f64, 1d +f64
+def tensorsolve(
+    a: _ArrayLike3D2[_to_float64, float],
+    b: _ArrayLike1D2[_to_float64, float],
+    axes: Iterable[int] | None = None,
+) -> _Array2D[np.float64]: ...
+@overload  # 3d ~c128, 1d +c128
+def tensorsolve(
+    a: _AsArrayC128_3d,
+    b: _ArrayLike1D2[_to_inexact64, complex],
+    axes: Iterable[int] | None = None,
+) -> _Array2D[np.complex128]: ...
+@overload  # 3d +c128, 1d ~c128
+def tensorsolve(
+    a: _ArrayLike3D2[_to_inexact64, complex],
+    b: _AsArrayC128_1d,
+    axes: Iterable[int] | None = None,
+) -> _Array2D[np.complex128]: ...
+@overload  # 3d ~f32|c64, 1d ~f32|c64
+def tensorsolve[ScalarT: (np.float32, np.complex64)](
+    a: _ArrayLike3D[ScalarT],
+    b: _ArrayLike1D[ScalarT],
+    axes: Iterable[int] | None = None,
+) -> _Array2D[ScalarT]: ...
+@overload  # 3d +f64, 2d +f64
+def tensorsolve(
+    a: _ArrayLike3D2[_to_float64, float],
+    b: _ArrayLike2D2[_to_float64, float],
+    axes: Iterable[int] | None = None,
+) -> _Array1D[np.float64]: ...
+@overload  # 3d ~c128, 2d +c128
+def tensorsolve(
+    a: _AsArrayC128_3d,
+    b: _ArrayLike2D2[_to_inexact64, complex],
+    axes: Iterable[int] | None = None,
+) -> _Array1D[np.complex128]: ...
+@overload  # 3d +c128, 2d ~c128
+def tensorsolve(
+    a: _ArrayLike3D2[_to_inexact64, complex],
+    b: _AsArrayC128_2d,
+    axes: Iterable[int] | None = None,
+) -> _Array1D[np.complex128]: ...
+@overload  # 3d ~f32|c64, 2d ~f32|c64
+def tensorsolve[ScalarT: (np.float32, np.complex64)](
+    a: _ArrayLike3D[ScalarT],
+    b: _ArrayLike2D[ScalarT],
+    axes: Iterable[int] | None = None,
+) -> _Array1D[ScalarT]: ...
+@overload  # ?d ~f64, ?d +f64
+def tensorsolve(
+    a: _ToArrayF64,
+    b: _ArrayLikeFloat_co,
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.float64]: ...
+@overload  # ?d +f64, ?d ~f64
+def tensorsolve(
+    a: _ArrayLikeFloat_co,
+    b: _ToArrayF64,
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.float64]: ...
+@overload  # ?d ~f32, ?d ~f32
+def tensorsolve(
+    a: _ArrayLike[np.float32],
+    b: _ArrayLike[np.float32],
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.float32]: ...
+@overload  # ?d +floating, ?d +floating
+def tensorsolve(
+    a: _ArrayLikeFloat_co,
+    b: _ArrayLikeFloat_co,
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.float64 | Any]: ...
+@overload  # ?d ~c128, ?d +c128
+def tensorsolve(
+    a: _AsArrayC128,
+    b: _ArrayLikeComplex_co,
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # ?d +c128, ?d ~c128
+def tensorsolve(
+    a: _ArrayLikeComplex_co,
+    b: _AsArrayC128,
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.complex128]: ...
+@overload  # ?d ~c64, ?d +c64
+def tensorsolve(
+    a: _ArrayLike[np.complex64],
+    b: _ArrayLike[_inexact32],
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.complex64]: ...
+@overload  # ?d +c64, ?d ~c64
+def tensorsolve(
+    a: _ArrayLike[_inexact32],
+    b: _ArrayLike[np.complex64],
+    axes: Iterable[int] | None = None,
+) -> NDArray[np.complex64]: ...
+@overload  # fallback
+def tensorsolve(
+    a: _ArrayLikeComplex_co,
+    b: _ArrayLikeComplex_co,
+    axes: Iterable[int] | None = None,
+) -> NDArray[Any]: ...
 
-# keep in sync with `tensorsolve`
+#
 @overload  # ?d +f64, ?d +f64 (workaround)
 def solve(a: _ArrayJustND[_to_float64], b: _ToArrayF64) -> NDArray[np.float64]: ...
 @overload  # ?d +f64, ?d +f64 (workaround)
@@ -305,21 +453,21 @@ def solve(a: _AsArrayC128_3d, b: _ArrayLike3D2[_to_inexact64, complex]) -> _Arra
 def solve(a: _ArrayLike3D2[_to_inexact64, complex], b: _AsArrayC128_3d) -> _Array3D[np.complex128]: ...
 @overload  # 3d ~f32|c64, 3d ~f32|c64
 def solve[ScalarT: (np.float32, np.complex64)](a: _ArrayLike3D[ScalarT], b: _ArrayLike3D[ScalarT]) -> _Array3D[ScalarT]: ...
-@overload  # ~f64, +f64
+@overload  # ?d ~f64, ?d +f64
 def solve(a: _ToArrayF64, b: _ArrayLikeFloat_co) -> NDArray[np.float64]: ...
-@overload  # +f64, ~f64
+@overload  # ?d +f64, ?d ~f64
 def solve(a: _ArrayLikeFloat_co, b: _ToArrayF64) -> NDArray[np.float64]: ...
-@overload  # ~f32, ~f32
+@overload  # ?d ~f32, ?d ~f32
 def solve(a: _ArrayLike[np.float32], b: _ArrayLike[np.float32]) -> NDArray[np.float32]: ...
-@overload  # +floating, +floating
+@overload  # ?d +floating, ?d +floating
 def solve(a: _ArrayLikeFloat_co, b: _ArrayLikeFloat_co) -> NDArray[np.float64 | Any]: ...
-@overload  # ~c128, +c128
+@overload  # ?d ~c128, ?d +c128
 def solve(a: _AsArrayC128, b: _ArrayLikeComplex_co) -> NDArray[np.complex128]: ...
-@overload  # +c128, ~c128
+@overload  # ?d +c128, ?d ~c128
 def solve(a: _ArrayLikeComplex_co, b: _AsArrayC128) -> NDArray[np.complex128]: ...
-@overload  # ~c64, +c64
+@overload  # ?d ~c64, ?d +c64
 def solve(a: _ArrayLike[np.complex64], b: _ArrayLike[_inexact32]) -> NDArray[np.complex64]: ...
-@overload  # +c64, ~c64
+@overload  # ?d +c64, ?d ~c64
 def solve(a: _ArrayLike[_inexact32], b: _ArrayLike[np.complex64]) -> NDArray[np.complex64]: ...
 @overload  # fallback
 def solve(a: _ArrayLikeComplex_co, b: _ArrayLikeComplex_co) -> NDArray[Any]: ...

--- a/numpy/typing/tests/data/reveal/linalg.pyi
+++ b/numpy/typing/tests/data/reveal/linalg.pyi
@@ -58,6 +58,7 @@ AR_b_2d: _Array2D[np.bool]
 
 AR_i8_1d: _Array1D[np.int64]
 AR_i8_2d: _Array2D[np.int64]
+AR_i8_3d: _Array3D[np.int64]
 
 SC_f8: np.float64
 AR_f8_0d: np.ndarray[tuple[()], np.dtype[np.float64]]
@@ -89,9 +90,25 @@ AR_c16_4d: _Array4D[np.complex128]
 assert_type(np.linalg.tensorsolve(AR_i8, AR_i8), npt.NDArray[np.float64])
 assert_type(np.linalg.tensorsolve(AR_i8, AR_f8), npt.NDArray[np.float64])
 assert_type(np.linalg.tensorsolve(AR_f4, AR_f4), npt.NDArray[np.float32])
-assert_type(np.linalg.tensorsolve(AR_c16, AR_f8), npt.NDArray[np.complex128])
-assert_type(np.linalg.tensorsolve(AR_c8, AR_f4), npt.NDArray[np.complex64])
 assert_type(np.linalg.tensorsolve(AR_f4, AR_c8), npt.NDArray[np.complex64])
+assert_type(np.linalg.tensorsolve(AR_c8, AR_f4), npt.NDArray[np.complex64])
+assert_type(np.linalg.tensorsolve(AR_c16, AR_f8), npt.NDArray[np.complex128])
+assert_type(np.linalg.tensorsolve(AR_i8_2d, AR_i8_1d), _Array1D[np.float64])
+assert_type(np.linalg.tensorsolve(AR_f8_2d, AR_f8_1d), _Array1D[np.float64])
+assert_type(np.linalg.tensorsolve(AR_c16_2d, AR_c16_1d), _Array1D[np.complex128])
+assert_type(np.linalg.tensorsolve(AR_c16_2d, AR_f8_1d), _Array1D[np.complex128])
+assert_type(np.linalg.tensorsolve(AR_f8_2d, AR_c16_1d), _Array1D[np.complex128])
+assert_type(np.linalg.tensorsolve(AR_f4_2d, AR_f4_1d), _Array1D[np.float32])
+assert_type(np.linalg.tensorsolve(AR_c8_2d, AR_c8_1d), _Array1D[np.complex64])
+assert_type(np.linalg.tensorsolve(AR_i8_3d, AR_i8_1d), _Array2D[np.float64])
+assert_type(np.linalg.tensorsolve(AR_f8_3d, AR_f8_1d), _Array2D[np.float64])
+assert_type(np.linalg.tensorsolve(AR_c16_3d, AR_c16_1d), _Array2D[np.complex128])
+assert_type(np.linalg.tensorsolve(AR_c16_3d, AR_f8_1d), _Array2D[np.complex128])
+assert_type(np.linalg.tensorsolve(AR_f4_3d, AR_f4_1d), _Array2D[np.float32])
+assert_type(np.linalg.tensorsolve(AR_c8_3d, AR_c8_1d), _Array2D[np.complex64])
+assert_type(np.linalg.tensorsolve(AR_f8_3d, AR_f8_2d), _Array1D[np.float64])
+assert_type(np.linalg.tensorsolve(AR_c16_3d, AR_c16_2d), _Array1D[np.complex128])
+assert_type(np.linalg.tensorsolve(AR_f4_3d, AR_f4_2d), _Array1D[np.float32])
 
 assert_type(np.linalg.solve(AR_i8, AR_i8), npt.NDArray[np.float64])
 assert_type(np.linalg.solve(AR_i8, AR_f8), npt.NDArray[np.float64])


### PR DESCRIPTION
Similar to the shape-typing improvements for `linalg.solve` from #32402, this addresses `linalg.tensorsolve`. 

---

It's pretty similar to `linalg.solve`, so I had AI write this, then fixed some minur stuff myself.