### PR TITLE
BUG: fix error handling in StringDType to fixed-width bytes case

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -1972,9 +1972,6 @@ string_to_bytes(PyArrayMethod_Context *context, char *const data[],
                 PyMem_RawFree(bad);
 
                 if (str == NULL) {
-                    PyErr_SetString(
-                        PyExc_UnicodeEncodeError, "Invalid character encountered during unicode encoding."
-                    );
                     return -1;
                 }
 

--- a/numpy/_core/tests/test_cython.py
+++ b/numpy/_core/tests/test_cython.py
@@ -374,6 +374,14 @@ def test_npystring_pack_invalid_utf8(install_temp):
     assert np.strings.find(bad, "z")[0] == -1
     assert np.strings.count(bad, "z")[0] == 0
 
+    # casts that hit the stored bytes report where they stop being UTF-8
+    assert checks.npystring_pack_invalid_utf8(bad, b"\xffbc") == 0
+    with pytest.raises(UnicodeDecodeError) as excinfo:
+        bad.astype("S3")
+    exc = excinfo.value
+    assert (exc.encoding, exc.object, exc.start, exc.end) == (
+        "utf-8", b"\xffbc", 0, 1)
+
 
 @pytest.mark.skipif(sysconfig.get_platform() == 'win-arm64',
                     reason='no checks module on win-arm64')


### PR DESCRIPTION
### PR summary
There's already an active `UnicodeDecodeError` in this error branch, so setting another error is incorrect. `UnicodeDecodeError` also has five arguments, so this is malformed anyway.

#### AI Disclosure
An AI model spotted the bug.
