### PR TITLE
MAINT: skip failing cython limited API tests on Cython 3.3.0 (#32407)

### DIFF
--- a/numpy/_core/tests/test_limited_api.py
+++ b/numpy/_core/tests/test_limited_api.py
@@ -197,8 +197,15 @@ def limited_api_module_names():
 
 
 def limited_api_cython_module_names():
-    return _module_names("limited_api_cython", _PY_ABI3_VERSIONS)
-
+    # see https://github.com/cython/cython/issues/7914
+    skip_3_11 = pytest.mark.skipif(
+        cython is not None
+        and _pep440.parse(cython_version) == _pep440.Version("3.3.0"),
+        reason="abi3 3.11 module is unimportable with Cython 3.3.0")
+    return [
+        pytest.param(name, marks=skip_3_11) if "_3_11_" in name else name
+        for name in _module_names("limited_api_cython", _PY_ABI3_VERSIONS)
+    ]
 
 @pytest.mark.skipif(
     IS_WASM, reason="platform cannot start subprocesses"


### PR DESCRIPTION
Backport of #32407.

### PR summary
Alternative to https://github.com/numpy/numpy/pull/32393.

See upstream report at https://github.com/cython/cython/issues/7914 as well.

Implements @rgommers' suggested alternative to pinning: https://github.com/numpy/numpy/pull/32393#issuecomment-5397066939

I'm checking for exactly Cython 3.3.0 under the theory that 3.3.1 will have a fix.

#### AI Disclosure
No AI used.
