### PR TITLE
DOC: clarify numpy.ma.allequal return value

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -8495,9 +8495,8 @@ def allequal(a, b, fill_value=True):
     Returns
     -------
     y : bool
-        Returns True if the two arrays are equal within the given
-        tolerance, False otherwise. If either array contains NaN,
-        then False is returned.
+        Returns True if the arrays are equal, False otherwise. If either
+        array contains NaN, then False is returned.
 
     See Also
     --------


### PR DESCRIPTION
### PR summary

This documentation-only change corrects the return-value description for `numpy.ma.allequal`.

The existing docstring says that values are compared “within the given tolerance,” but `allequal` has no tolerance parameter and performs an equality comparison. The wording now accurately states that the function returns `True` when the arrays are equal and `False` otherwise, while preserving the existing note that arrays containing NaN return `False`.

This addresses the first, narrowly scoped request in #32400 without changing the API or runtime behavior.

### Testing

- `git diff --check`
- `python3 -m py_compile numpy/ma/core.py`

Closes #32400.

### First-time contributor introduction

This is my first pull request to the NumPy repository. I reviewed the issue, checked the current implementation and surrounding documentation, kept the change limited to the requested docstring correction, and verified the resulting patch locally.

### AI disclosure

Manus AI assisted with issue discovery, repository inspection, and drafting the pull request text. The submitted code change was reviewed and limited to the two-line documentation correction shown in the diff; no runtime behavior, API, or generated files were changed.