### PR TITLE
TYP: ``linalg.multi_dot`` shape-typing

### DIFF
--- a/numpy/linalg/_linalg.pyi
+++ b/numpy/linalg/_linalg.pyi
@@ -1771,29 +1771,59 @@ def tensordot(
 ) -> NDArray[np.complex128 | Any]: ...
 
 #
-@overload
+@overload  # out=
 def multi_dot[ArrayT: np.ndarray](
-    arrays: Iterable[_ArrayLikeComplex_co | _ArrayLikeObject_co | _ArrayLikeTD64_co], *, out: ArrayT,
+    arrays: Iterable[_ArrayLikeComplex_co | _ArrayLikeObject_co | _ArrayLikeTD64_co],
+    *,
+    out: ArrayT,
 ) -> ArrayT: ...
-@overload
-def multi_dot[
-    AnyScalarT: (
-        np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64,
-        np.float16, np.float32, np.float64, np.longdouble, np.complex64, np.complex128, np.clongdouble,
-        np.object_, np.timedelta64,
-    ),
-](arrays: Sequence[_ArrayLike[AnyScalarT]], *, out: None = None) -> NDArray[AnyScalarT]: ...
-@overload
+@overload  # ?d ~T (workaround)
+def multi_dot(
+    arrays: Sequence[_ArrayJustND[_AnyNumberT]],
+    *,
+    out: None = None,
+) -> NDArray[_AnyNumberT]: ...
+@overload  # 2d ~T, .., 2d ~T
+def multi_dot(
+    arrays: Sequence[_Array2D[_AnyNumberT]],
+    *,
+    out: None = None,
+) -> _Array2D[_AnyNumberT]: ...
+@overload  # 1d ~T, .., 2d ~T
+def multi_dot(
+    arrays: tuple[_Array1D[_AnyNumberT], *tuple[_Array2D[_AnyNumberT], ...], _Array2D[_AnyNumberT]],
+    *,
+    out: None = None,
+) -> _Array1D[_AnyNumberT]: ...
+@overload  # 2d ~T, .., 1d ~T
+def multi_dot(
+    arrays: tuple[_Array2D[_AnyNumberT], *tuple[_Array2D[_AnyNumberT], ...], _Array1D[_AnyNumberT]],
+    *,
+    out: None = None,
+) -> _Array1D[_AnyNumberT]: ...
+@overload  # ?d ~T
+def multi_dot(
+    arrays: Sequence[_ArrayLike[_AnyNumberT]],
+    *,
+    out: None = None,
+) -> NDArray[_AnyNumberT]: ...
+@overload  # ?d ~T
+def multi_dot[AnyScalarT: (np.object_, np.timedelta64)](
+    arrays: Sequence[_ArrayLike[AnyScalarT]],
+    *,
+    out: None = None,
+) -> NDArray[AnyScalarT]: ...
+@overload  # ?d +bool
 def multi_dot(arrays: Sequence[_ArrayLikeBool_co], *, out: None = None) -> NDArray[np.bool]: ...
-@overload
+@overload  # ?d +i64
 def multi_dot(arrays: Sequence[_ArrayLikeInt_co], *, out: None = None) -> NDArray[np.int64 | Any]: ...
-@overload
+@overload  # ?d +f64
 def multi_dot(arrays: Sequence[_ArrayLikeFloat_co], *, out: None = None) -> NDArray[np.float64 | Any]: ...
-@overload
+@overload  # ?d +c128
 def multi_dot(arrays: Sequence[_ArrayLikeComplex_co], *, out: None = None) -> NDArray[np.complex128 | Any]: ...
-@overload
+@overload  # ?d +timedelta64
 def multi_dot(arrays: Sequence[_ArrayLikeTD64_co], *, out: None = None) -> NDArray[np.timedelta64 | Any]: ...
-@overload
+@overload  # fallback
 def multi_dot[ScalarT: np.number | np.object_ | np.timedelta64](
     arrays: Sequence[_ArrayLike[ScalarT]], *, out: None = None
 ) -> NDArray[ScalarT]: ...

--- a/numpy/typing/tests/data/reveal/linalg.pyi
+++ b/numpy/typing/tests/data/reveal/linalg.pyi
@@ -698,6 +698,17 @@ assert_type(np.linalg.multi_dot([AR_i8, AR_i8]), npt.NDArray[np.int64])
 assert_type(np.linalg.multi_dot([AR_f8, AR_f8]), npt.NDArray[np.float64])
 assert_type(np.linalg.multi_dot([AR_c16, AR_c16]), npt.NDArray[np.complex128])
 assert_type(np.linalg.multi_dot([AR_O, AR_O]), npt.NDArray[np.object_])
+assert_type(np.linalg.multi_dot([AR_i8_2d, AR_i8_2d]), _Array2D[np.int64])
+assert_type(np.linalg.multi_dot([AR_f4_2d, AR_f4_2d]), _Array2D[np.float32])
+assert_type(np.linalg.multi_dot([AR_f8_2d, AR_f8_2d, AR_f8_2d]), _Array2D[np.float64])
+assert_type(np.linalg.multi_dot([AR_c8_2d, AR_c8_2d]), _Array2D[np.complex64])
+assert_type(np.linalg.multi_dot([AR_c16_2d, AR_c16_2d]), _Array2D[np.complex128])
+assert_type(np.linalg.multi_dot((AR_f4_1d, AR_f4_2d)), _Array1D[np.float32])
+assert_type(np.linalg.multi_dot((AR_f8_1d, AR_f8_2d, AR_f8_2d)), _Array1D[np.float64])
+assert_type(np.linalg.multi_dot((AR_c16_1d, AR_c16_2d)), _Array1D[np.complex128])
+assert_type(np.linalg.multi_dot((AR_f4_2d, AR_f4_1d)), _Array1D[np.float32])
+assert_type(np.linalg.multi_dot((AR_f8_2d, AR_f8_2d, AR_f8_1d)), _Array1D[np.float64])
+assert_type(np.linalg.multi_dot((AR_c16_2d, AR_c16_1d)), _Array1D[np.complex128])
 # Mypy incorrectly infers `ndarray[Any, Any]`, but pyright behaves correctly.
 assert_type(np.linalg.multi_dot([AR_i8, AR_f8]), npt.NDArray[np.float64 | Any])  # type: ignore[assert-type]
 assert_type(np.linalg.multi_dot([AR_f8, AR_c16]), npt.NDArray[np.complex128 | Any])  # type: ignore[assert-type]


### PR DESCRIPTION
This improves shape-typing of `np.linalg.multi_dot` by  adding some special-cased overloads for array-like sequences with the shape-types, as well as for tuple-sequences of array-likes where either the first or the last array-like is 1d.
I also simplified one overload with huge type variable constraints by re-using the recently added `_AnyNumberT` from #32408 at the cost of one new overload.

---

I iterated on this using AI, and afterwards did a bunch of cleanup and apllied some consistency fixes myself.