### PR TITLE
BUG: fix for string missing data in stringdtype cast to bool and nonzero

### DIFF
--- a/doc/release/upcoming_changes/32418.improvement.rst
+++ b/doc/release/upcoming_changes/32418.improvement.rst
@@ -1,0 +1,4 @@
+* Casting a StringDType array to bool now correctly handles missing data
+  that is a string. Previously it would treat an empty string as truthy
+  and a non-empty string as falsey.
+* `numpy.nonzero` now correctly classifies non-empty strings as nonzero.

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -509,7 +509,7 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
                 }
             }
             else {
-                *out = (npy_bool)(default_string->size == 0);
+                *out = (npy_bool)(default_string->size != 0);
             }
         }
         else if (s.size == 0) {

--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -477,10 +477,6 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
 {
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)context->descriptors[0];
     npy_string_allocator *allocator = NpyString_acquire_allocator(descr);
-    int has_null = descr->na_object != NULL;
-    int has_string_na = descr->has_string_na;
-    int has_nan_na = descr->has_nan_na;
-    const npy_static_string *default_string = &descr->default_string;
 
     npy_intp N = dimensions[0];
     char *in = data[0];
@@ -499,24 +495,10 @@ string_to_bool(PyArrayMethod_Context *context, char *const data[],
             goto fail;
         }
         else if (is_null) {
-            if (has_null && !has_string_na) {
-                if (has_nan_na) {
-                    // numpy treats NaN as truthy, following python
-                    *out = NPY_TRUE;
-                }
-                else {
-                    *out = NPY_FALSE;
-                }
-            }
-            else {
-                *out = (npy_bool)(default_string->size != 0);
-            }
-        }
-        else if (s.size == 0) {
-            *out = NPY_FALSE;
+            *out = stringdtype_null_is_truthy(descr);
         }
         else {
-            *out = NPY_TRUE;
+            *out = (npy_bool)(s.size != 0);
         }
 
         in += in_stride;

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -484,15 +484,11 @@ nonzero(void *data, void *arr)
     int has_nan_na = descr->has_nan_na;
     int has_string_na = descr->has_string_na;
     if (has_null && NpyString_isnull((npy_packed_static_string *)data)) {
-        if (!has_string_na) {
-            if (has_nan_na) {
-                // numpy treats NaN as truthy, following python
-                return 1;
-            }
-            else {
-                return 0;
-            }
+        if (has_string_na) {
+            return descr->default_string.size != 0;
         }
+        // numpy treats NaN as truthy, following python
+        return has_nan_na;
     }
     return NpyString_size((npy_packed_static_string *)data) != 0;
 }

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -474,21 +474,26 @@ fail:
     return NULL;
 }
 
+NPY_NO_EXPORT npy_bool
+stringdtype_null_is_truthy(const PyArray_StringDTypeObject *descr)
+{
+    // nulls cannot be stored in an array without an na object
+    assert(descr->na_object != NULL);
+    if (descr->has_string_na) {
+        return (npy_bool)(descr->default_string.size != 0);
+    }
+    // numpy treats NaN as truthy, following python
+    return (npy_bool)descr->has_nan_na;
+}
+
 // PyArray_NonzeroFunc
 // Unicode strings are nonzero if their length is nonzero.
 static npy_bool
 nonzero(void *data, void *arr)
 {
     PyArray_StringDTypeObject *descr = (PyArray_StringDTypeObject *)PyArray_DESCR(arr);
-    int has_null = descr->na_object != NULL;
-    int has_nan_na = descr->has_nan_na;
-    int has_string_na = descr->has_string_na;
-    if (has_null && NpyString_isnull((npy_packed_static_string *)data)) {
-        if (has_string_na) {
-            return descr->default_string.size != 0;
-        }
-        // numpy treats NaN as truthy, following python
-        return has_nan_na;
+    if (NpyString_isnull((npy_packed_static_string *)data)) {
+        return stringdtype_null_is_truthy(descr);
     }
     return NpyString_size((npy_packed_static_string *)data) != 0;
 }

--- a/numpy/_core/src/multiarray/stringdtype/dtype.h
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.h
@@ -63,6 +63,9 @@ stringdtype_effective_na_descr(int ndescrs, PyArray_Descr *const descrs[]);
 NPY_NO_EXPORT int
 na_eq_cmp(PyObject *a, PyObject *b);
 
+NPY_NO_EXPORT npy_bool
+stringdtype_null_is_truthy(const PyArray_StringDTypeObject *descr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -918,8 +918,10 @@ def test_nonzero(strings, na_object):
 
     strings_with_na = np.array(strings + [na_object], dtype=dtype)
     is_nan = np.isnan(np.array([dtype.na_object], dtype=dtype))[0]
+    # a string sentinel null is truthy exactly when the sentinel is
+    is_truthy = is_nan or (isinstance(na_object, str) and na_object != "")
 
-    if is_nan:
+    if is_truthy:
         assert strings_with_na.nonzero()[0][-1] == 4
     else:
         assert strings_with_na.nonzero()[0][-1] == 3
@@ -2436,6 +2438,13 @@ def test_minimum_maximum_promote_fixed_width_and_str():
     fixed = np.array(["c", "c"])
     assert np.minimum(arr, fixed).tolist() == ["b", "c"]
     assert np.maximum(fixed, arr).dtype == StringDType()
+
+
+@pytest.mark.parametrize("na", ["", "x"])
+def test_string_na_cast_to_bool_matches_sentinel(na):
+    arr = np.array([na, "y"], dtype=StringDType(na_object=na))
+    assert arr.astype(bool).tolist() == [bool(na), True]
+    assert arr.nonzero()[0].tolist() == [i for i in range(2) if [na, "y"][i]]
 
 
 class TestImplementation:


### PR DESCRIPTION
### PR summary
Both nonzero and the string to bool cast incorrectly handled string missing data. The former is missing a case for `has_string_na`: all the logic in the `!has_string_na` branch, so string missing data falls through to the size check below, which always returns False. The latter gets the boolean condition inverted: the `default_string` is falsey if it's empty.

Even though these are logic errors, since this is changing the `nonzero` tests I'm not marking this as a backport.

#### AI Disclosure
An AI model spotted this bug and I used an AI for code review.