### PR TITLE
ENH: add promoters for StringDType np.min/np.max

### DIFF
--- a/doc/release/upcoming_changes/32419.improvement.rst
+++ b/doc/release/upcoming_changes/32419.improvement.rst
@@ -1,0 +1,5 @@
+* `numpy.minimum` and `numpy.maximum` along with the ``min`` and ``max``
+  reductions now correctly handle cases when one operand is a fixed-width
+  string array and one operand is StringDType. These cases use to raise
+  `numpy._UFuncNoLoopError`.
+  

--- a/doc/release/upcoming_changes/32419.improvement.rst
+++ b/doc/release/upcoming_changes/32419.improvement.rst
@@ -1,5 +1,5 @@
 * `numpy.minimum` and `numpy.maximum` along with the ``min`` and ``max``
   reductions now correctly handle cases when one operand is a fixed-width
-  string array and one operand is StringDType. These cases use to raise
+  string array and one operand is StringDType. These cases used to raise
   `numpy._UFuncNoLoopError`.
   

--- a/numpy/_core/src/umath/stringdtype_ufuncs.cpp
+++ b/numpy/_core/src/umath/stringdtype_ufuncs.cpp
@@ -2838,6 +2838,21 @@ init_stringdtype_ufuncs(PyObject *umath)
         return -1;
     }
 
+    for (int i = 0; i < 2; i++) {
+        if (add_promoter(umath, minimum_maximum_names[i], rall_strings_promoter_dtypes, 3,
+                         all_strings_promoter) < 0) {
+            return -1;
+        }
+        if (add_promoter(umath, minimum_maximum_names[i], lall_strings_promoter_dtypes, 3,
+                         all_strings_promoter) < 0) {
+            return -1;
+        }
+        if (add_promoter(umath, minimum_maximum_names[i], out_strings_promoter_dtypes, 3,
+                         all_strings_promoter) < 0) {
+            return -1;
+        }
+    }
+
     INIT_MULTIPLY(Int64, int64);
     INIT_MULTIPLY(UInt64, uint64);
 

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -2429,6 +2429,15 @@ def test_accumulation(string_array, tile):
         assert_array_equal(res, res_obj.astype(arr.dtype), strict=True)
 
 
+def test_minimum_maximum_promote_fixed_width_and_str():
+    arr = np.array(["b", "y"], dtype=StringDType())
+    assert np.minimum(arr, "c\x00").tolist() == ["b", "c\x00"]
+    assert np.maximum(arr, "c\x00").tolist() == ["c\x00", "y"]
+    fixed = np.array(["c", "c"])
+    assert np.minimum(arr, fixed).tolist() == ["b", "c"]
+    assert np.maximum(fixed, arr).dtype == StringDType()
+
+
 class TestImplementation:
     """Check that strings are stored in the arena when possible.
 


### PR DESCRIPTION
### PR summary
This makes all the cases in the test do the right thing. Currently they all raise `_UfuncNoLoopError`.


#### AI Disclosure
An AI model pointed out the issue and helped with the test.
