### PR TITLE
TYP: preserve shape in `datetime_as_string`

### DIFF
--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -2401,7 +2401,7 @@ def datetime_as_string(
     casting: _CastingKind = "same_kind",
 ) -> str_: ...
 @overload
-def datetime_as_string[ShapeT: _AnyShape](
+def datetime_as_string[ShapeT: tuple[int, *tuple[int, ...]]](
     arr: ndarray[ShapeT, dtype[datetime64]],
     unit: L["auto"] | _UnitKind | None = None,
     timezone: _TimezoneContext = "naive",

--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -2402,7 +2402,7 @@ def datetime_as_string(
 ) -> str_: ...
 @overload
 def datetime_as_string[ShapeT: tuple[int, *tuple[int, ...]]](
-    arr: ndarray[ShapeT, dtype[datetime64]],
+    arr: ndarray[ShapeT, dtype[datetime64[Any]]],
     unit: L["auto"] | _UnitKind | None = None,
     timezone: _TimezoneContext = "naive",
     casting: _CastingKind = "same_kind",

--- a/numpy/_core/multiarray.pyi
+++ b/numpy/_core/multiarray.pyi
@@ -2401,6 +2401,13 @@ def datetime_as_string(
     casting: _CastingKind = "same_kind",
 ) -> str_: ...
 @overload
+def datetime_as_string[ShapeT: _AnyShape](
+    arr: ndarray[ShapeT, dtype[datetime64]],
+    unit: L["auto"] | _UnitKind | None = None,
+    timezone: _TimezoneContext = "naive",
+    casting: _CastingKind = "same_kind",
+) -> ndarray[ShapeT, dtype[str_]]: ...
+@overload
 def datetime_as_string(
     arr: _ArrayLikeDT64_co | _NestedSequence[dt.date],
     unit: L["auto"] | _UnitKind | None = None,

--- a/numpy/typing/tests/data/reveal/multiarray.pyi
+++ b/numpy/typing/tests/data/reveal/multiarray.pyi
@@ -327,7 +327,8 @@ assert_type(np.is_busday("2012"), np.bool)
 assert_type(np.is_busday(date_scalar), np.bool)
 assert_type(np.is_busday(["2012"]), npt.NDArray[np.bool])
 
-# NOTE: Mypy incorrectly infers `Any`, but pyright behaves correctly.
+# NOTE: Mypy incorrectly infers `Any` for the scalar case and `ndarray[Any, Any]` for the
+# shaped cases, but pyright behaves correctly.
 assert_type(np.datetime_as_string(M), np.str_)  # type: ignore[assert-type]
 assert_type(np.datetime_as_string(AR_M), npt.NDArray[np.str_])
 assert_type(np.datetime_as_string(AR_M_1d), np.ndarray[tuple[int], np.dtype[np.str_]])  # type: ignore[assert-type]

--- a/numpy/typing/tests/data/reveal/multiarray.pyi
+++ b/numpy/typing/tests/data/reveal/multiarray.pyi
@@ -20,6 +20,8 @@ AR_b_2d: np.ndarray[tuple[int, int], np.dtype[np.bool]]
 AR_u1: npt.NDArray[np.uint8]
 AR_m: npt.NDArray[np.timedelta64]
 AR_M: npt.NDArray[np.datetime64]
+AR_M_1d: np.ndarray[tuple[int], np.dtype[np.datetime64]]
+AR_M_2d: np.ndarray[tuple[int, int], np.dtype[np.datetime64]]
 AR_O_nd: npt.NDArray[np.object_[int]]
 AR_O_1d: np.ndarray[tuple[int], np.dtype[np.object_[int]]]
 AR_O_2d: np.ndarray[tuple[int, int], np.dtype[np.object_[int]]]
@@ -328,6 +330,9 @@ assert_type(np.is_busday(["2012"]), npt.NDArray[np.bool])
 # NOTE: Mypy incorrectly infers `Any`, but pyright behaves correctly.
 assert_type(np.datetime_as_string(M), np.str_)  # type: ignore[assert-type]
 assert_type(np.datetime_as_string(AR_M), npt.NDArray[np.str_])
+assert_type(np.datetime_as_string(AR_M_1d), np.ndarray[tuple[int], np.dtype[np.str_]])  # type: ignore[assert-type]
+assert_type(np.datetime_as_string(AR_M_2d), np.ndarray[tuple[int, int], np.dtype[np.str_]])  # type: ignore[assert-type]
+assert_type(np.datetime_as_string(date_seq), npt.NDArray[np.str_])
 
 assert_type(np.busdaycalendar(holidays=date_seq), np.busdaycalendar)
 assert_type(np.busdaycalendar(holidays=[M]), np.busdaycalendar)


### PR DESCRIPTION
### PR summary
- Preserve input array shape in `np.datetime_as_string` type annotations.
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
- last test for generic array was suggested by ai when i asked for review 
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
