### PR TITLE
TST: add regression test for repr inside __array_finalize__ (gh-8509)

### DIFF
--- a/numpy/_core/tests/test_regression.py
+++ b/numpy/_core/tests/test_regression.py
@@ -2670,3 +2670,19 @@ class TestRegression:
         x = np.array([(0, 1.)], dtype=[('time', '<i8'), ('value', '<f8')])
         y = np.array((0, 0.), dtype=[('time', '<i8'), ('value', '<f8')])
         x.searchsorted(y)
+
+    def test_array_finalize_repr_recursion(self):
+        # gh-8509: repr() of an array with ndim > 1 used to index into it,
+        # and indexing creates a view, which calls __array_finalize__ on
+        # that view. Calling repr() inside __array_finalize__ (as the
+        # subclassing docs long did) therefore recursed until
+        # RecursionError: repr(parent) -> parent[0] -> finalize(view) ->
+        # repr(parent) -> ...
+        class ReprFinalize(np.ndarray):
+            def __array_finalize__(self, obj):
+                repr(self)
+                repr(obj)
+
+        arr = np.arange(10.0).reshape(5, 2).view(ReprFinalize)
+        assert type(arr) is ReprFinalize
+        repr(arr)


### PR DESCRIPTION
Adds the regression test that gh-8509 was kept open for. The underlying recursion was fixed as a side effect of gh-10164, but never got a test ("we're bound to reintroduce this if we don't write tests").

Background: `repr()` of an array with `ndim > 1` used to index into the array while formatting, and indexing creates a view, which calls `__array_finalize__` on that view. A subclass calling `repr()` inside `__array_finalize__` — as the subclassing docs example long did — therefore recursed until `RecursionError`: `repr(parent) -> parent[0] -> finalize(view) -> repr(parent) -> ...`. 1-D input was unaffected, which is why the docs example only blew up for higher dimensions.

On the [earlier concern](https://github.com/numpy/numpy/issues/8509#issuecomment-533076142) that the test couldn't be validated without a commit that reproduces the bug: I checked its sensitivity by wrapping the current repr implementation (`numpy._core.arrayprint._default_array_repr`, patched before the C slot caches it) with one that first indexes the array — i.e. the pre-gh-10164 behavior. The test then fails with `RecursionError` as expected, and passes unpatched.

Closes gh-8509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDRPDZSRiTU3XT7BpmH9vd
