### PR TITLE
BUG: close duplicated file descriptor if fdopen fails (#32386)

### DIFF
--- a/numpy/_core/include/numpy/npy_3kcompat.h
+++ b/numpy/_core/include/numpy/npy_3kcompat.h
@@ -94,16 +94,18 @@ npy_PyFile_Dup2(PyObject *file, char *mode, npy_off_t *orig_pos)
         return NULL;
     }
     ret = PyObject_CallMethod(os, "dup", "i", fd);
-    Py_DECREF(os);
     if (ret == NULL) {
+        Py_DECREF(os);
         return NULL;
     }
     fd2_tmp = PyNumber_AsSsize_t(ret, PyExc_IOError);
     Py_DECREF(ret);
     if (fd2_tmp == -1 && PyErr_Occurred()) {
+        Py_DECREF(os);
         return NULL;
     }
     if (fd2_tmp < INT_MIN || fd2_tmp > INT_MAX) {
+        Py_DECREF(os);
         PyErr_SetString(PyExc_IOError,
                         "Getting an 'int' from os.dup() failed");
         return NULL;
@@ -119,12 +121,19 @@ npy_PyFile_Dup2(PyObject *file, char *mode, npy_off_t *orig_pos)
     handle = fdopen(fd2, mode);
 #endif
     if (handle == NULL) {
+        ret = PyObject_CallMethod(os, "close", "i", fd2);
+        Py_DECREF(os);
+        if (ret == NULL) {
+            PyErr_WriteUnraisable(NULL);
+        }
+        Py_XDECREF(ret);
         PyErr_SetString(PyExc_IOError,
                         "Getting a FILE* from a Python file object via "
                         "_fdopen failed. If you built NumPy, you probably "
                         "linked with the wrong debug/release runtime");
         return NULL;
     }
+    Py_DECREF(os);
 
     /* Record the original raw file handle position */
     *orig_pos = npy_ftell(handle);

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -40,6 +40,7 @@ from numpy.testing import (
     BLAS_SUPPORTS_FPE,
     HAS_REFCOUNT,
     IS_64BIT,
+    IS_MUSL,
     IS_WASM,
     assert_,
     assert_allclose,
@@ -6371,6 +6372,23 @@ class TestIO:
             for dup, exc in ((dup_str, TypeError), (dup_bigint, OSError)):
                 monkeypatch.setattr(os, "dup", dup)
                 assert_raises(exc, np.fromfile, f)
+
+    @pytest.mark.skipif(
+        IS_WASM or IS_MUSL,
+        reason="musl and emscripten libc fdopen do not validate the fd",
+    )
+    def test_fromfile_failed_fdopen_closes_dup(
+            self, tmp_path, param_filename, monkeypatch):
+        closed_fds = []
+        tmp_filename = normalize_filename(tmp_path, param_filename)
+
+        monkeypatch.setattr(os, "dup", lambda fd: -2)
+        monkeypatch.setattr(os, "close", closed_fds.append)
+
+        with open(tmp_filename, "wb") as f:
+            assert_raises(OSError, np.fromfile, f)
+
+        assert closed_fds == [-2]
 
     def _check_from(self, s, value, filename, **kw):
         if 'sep' not in kw:


### PR DESCRIPTION
Backport of #32386.

Fixes #32373 
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?
--> The duplicated file descriptor `fd2` was leaked which was created through Python’s `os.dup`.
The fix was done by making the `os` module reference retained until the conversion is finished. If 'fdopen' fails, the code calls `os.close(fd2)` before returning the existing error. Pairing `os.close` with `os.dup` is also safer for Windows runtime ownership.

The regression test makes `os.dup` return an invalid descriptor (-2) so `fdopen` fails, records calls to `os.close`, confirms `np.fromfile` raises OSError, and verifies that the descriptor was passed to os.close.



### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->
I use NumPy in machine-learning projects for numerical computations and data preprocessing, and this is my first contribution to NumPy.

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.

AI Disclosure
-->I used Codex 5.6 Sol High  for assistance with issue selection ,preparing the C fix, regression test, and verification and understanding the code.
 I have personally reviewed and understand the changes.