### PR TITLE
MAINT: add missing space in warning and error messages (#32405)

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -398,7 +398,7 @@ def lint(ctx, fix):
 )
 @click.option(
     '--cpu-affinity', default=None, multiple=False,
-    help="Set CPU affinity for running the benchmark, in format: 0 or 0,1,2 or 0-3."
+    help="Set CPU affinity for running the benchmark, in format: 0 or 0,1,2 or 0-3. "
          "Default: not set"
 )
 @click.argument(

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -2455,7 +2455,7 @@ def sum(a, axis=None, dtype=None, out=None, keepdims=np._NoValue,
     if isinstance(a, _gentype):
         # 2018-02-25, 1.15.0
         raise TypeError(
-            "Calling np.sum(generator) is deprecated."
+            "Calling np.sum(generator) is deprecated. "
             "Use np.sum(np.fromiter(generator)) or "
             "the python sum builtin instead.",
         )

--- a/numpy/_core/src/_simd/_simd.dispatch.c.src
+++ b/numpy/_core/src/_simd/_simd.dispatch.c.src
@@ -244,7 +244,7 @@ simd__intrin_@intrin@_@sfx@(PyObject* NPY_UNUSED(self), PyObject *args)
     // overflow guard
     if (cur_seq_len < min_seq_len) {
         PyErr_Format(PyExc_ValueError,
-            "@intrin@_@sfx@(), according to provided stride %d, the"
+            "@intrin@_@sfx@(), according to provided stride %d, the "
             "minimum acceptable size of the required sequence is %d, given(%d)",
             stride, min_seq_len, cur_seq_len
         );

--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -2331,7 +2331,7 @@ static PyMethodDef Multiarray_TestsMethods[] = {
     {"get_all_cast_information",
         get_all_cast_information,
         METH_NOARGS,
-        "Return a list with info on all available casts. Some of the info"
+        "Return a list with info on all available casts. Some of the info "
         "may differ for an actual cast if it uses value-based casting "
         "(flexible types)."},
     {"create_identity_hash",

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -181,7 +181,7 @@ validate_spec(PyArrayMethod_Spec *spec)
     /* Check the passed spec for invalid fields/values */
     if (spec->nin < 0 || spec->nout < 0 || nargs > NPY_MAXARGS) {
         PyErr_Format(PyExc_ValueError,
-                "ArrayMethod inputs and outputs must be greater zero and"
+                "ArrayMethod inputs and outputs must be greater zero and "
                 "not exceed %d. (method: %s)", NPY_MAXARGS, spec->name);
         return -1;
     }
@@ -224,7 +224,7 @@ validate_spec(PyArrayMethod_Spec *spec)
         }
         if (!PyObject_TypeCheck(spec->dtypes[i], &PyArrayDTypeMeta_Type)) {
             PyErr_Format(PyExc_TypeError,
-                    "ArrayMethod provided object %R is not a DType."
+                    "ArrayMethod provided object %R is not a DType. "
                     "(method: %s)", spec->dtypes[i], spec->name);
             return -1;
         }

--- a/numpy/_core/src/multiarray/buffer.c
+++ b/numpy/_core/src/multiarray/buffer.c
@@ -625,7 +625,7 @@ _buffer_info_untag(
     if (NPY_UNLIKELY(((uintptr_t)tagged_buffer_info & 0x7) != 3)) {
         PyErr_Format(PyExc_RuntimeError,
                 "Object of type %S appears to be C subclassed NumPy array, "
-                "void scalar, or allocated in a non-standard way."
+                "void scalar, or allocated in a non-standard way. "
                 "NumPy reserves the right to change the size of these "
                 "structures. Projects are required to take this into account "
                 "by either recompiling against a specific NumPy version or "

--- a/numpy/_core/src/multiarray/ctors.c
+++ b/numpy/_core/src/multiarray/ctors.c
@@ -1230,7 +1230,7 @@ _array_from_buffer_3118(PyObject *memoryview)
     if (view->suboffsets != NULL) {
         PyErr_SetString(PyExc_BufferError,
                 "NumPy currently does not support importing buffers which "
-                "include suboffsets as they are not compatible with the NumPy"
+                "include suboffsets as they are not compatible with the NumPy "
                 "memory layout without a copy.  Consider copying the original "
                 "before trying to convert it to a NumPy array.");
         return NULL;

--- a/numpy/_core/src/multiarray/datetime.c
+++ b/numpy/_core/src/multiarray/datetime.c
@@ -2390,7 +2390,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
             if (DEPRECATE(
                         "The 'generic' unit for NumPy timedelta is deprecated, "
                         "and will raise an error in the future. "
-                        "This includes implicit conversion of bare integers (e.g. `+ 1`)."
+                        "This includes implicit conversion of bare integers (e.g. `+ 1`). "
                         "Please use a specific unit instead.") < 0) {
                 return -1;
             }
@@ -2526,7 +2526,7 @@ convert_pyobject_to_datetime(PyArray_DatetimeMetaData *meta, PyObject *obj,
             if (DEPRECATE(
                         "The 'generic' unit for NumPy timedelta is deprecated, "
                         "and will raise an error in the future. "
-                        "This includes implicit conversion of bare integers (e.g. `+ 1`)."
+                        "This includes implicit conversion of bare integers (e.g. `+ 1`). "
                         "Please use a specific unit instead.") < 0) {
                 return -1;
             }
@@ -2612,7 +2612,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
                 if (DEPRECATE(
                             "The 'generic' unit for NumPy timedelta is deprecated, "
                             "and will raise an error in the future. "
-                            "This includes implicit conversion of bare integers (e.g. `+ 1`)."
+                            "This includes implicit conversion of bare integers (e.g. `+ 1`). "
                             "Please use a specific unit instead.") < 0) {
                     return -1;
                 }
@@ -2638,7 +2638,7 @@ convert_pyobject_to_timedelta(PyArray_DatetimeMetaData *meta, PyObject *obj,
             if (DEPRECATE(
                     "The 'generic' unit for NumPy timedelta is deprecated, "
                     "and will raise an error in the future. "
-                    "This includes implicit conversion of bare integers (e.g. `+ 1`)."
+                    "This includes implicit conversion of bare integers (e.g. `+ 1`). "
                     "Please use a specific unit instead.") < 0) {
                 return -1;
             }

--- a/numpy/_core/src/multiarray/nditer_constr.c
+++ b/numpy/_core/src/multiarray/nditer_constr.c
@@ -1427,7 +1427,7 @@ npyiter_check_reduce_ok_and_set_flags(
                     "result of a reduction");
             return 0;
         }
-        NPY_IT_DBG_PRINT("Iterator: Indicating that a reduction is"
+        NPY_IT_DBG_PRINT("Iterator: Indicating that a reduction is "
                          "occurring\n");
 
         NIT_ITFLAGS(iter) |= NPY_ITFLAG_REDUCE;

--- a/numpy/_core/src/multiarray/textreading/field_types.c
+++ b/numpy/_core/src/multiarray/textreading/field_types.c
@@ -187,7 +187,7 @@ field_types_create(PyArray_Descr *descr, field_type **ft)
          * so it is an awkward corner case that probably never really worked.
          */
         PyErr_SetString(PyExc_TypeError,
-                "file reader does not support subarray dtypes.  You can"
+                "file reader does not support subarray dtypes.  You can "
                 "put the dtype into a structured one using "
                 "`np.dtype(('name', dtype))` to avoid this limitation.");
         return -1;

--- a/numpy/conftest.py
+++ b/numpy/conftest.py
@@ -85,7 +85,7 @@ def pytest_addoption(parser):
                            "test suite. This can result to tests requiring "
                            "especially large amounts of memory to be skipped. "
                            "Equivalent to setting environment variable "
-                           "NPY_AVAILABLE_MEM. Default: determined"
+                           "NPY_AVAILABLE_MEM. Default: determined "
                            "automatically."))
 
 

--- a/numpy/f2py/f2py2e.py
+++ b/numpy/f2py/f2py2e.py
@@ -659,7 +659,7 @@ def run_compile():
         v = '--fcompiler='
         if s[:len(v)] == v:
             outmess(
-                "--fcompiler cannot be used with meson,"
+                "--fcompiler cannot be used with meson, "
                 "set compiler with the FC environment variable\n"
                 )
     for s in del_list:

--- a/numpy/fft/_pocketfft.py
+++ b/numpy/fft/_pocketfft.py
@@ -72,7 +72,7 @@ def _raw_fft(a, n, axis, is_real, is_forward, norm, out=None):
     elif norm == "forward":
         fct = reciprocal(n, dtype=real_dtype)
     else:
-        raise ValueError(f'Invalid norm value {norm}; should be "backward",'
+        raise ValueError(f'Invalid norm value {norm}; should be "backward", '
                          '"ortho" or "forward".')
 
     n_out = n

--- a/numpy/lib/_format_impl.py
+++ b/numpy/lib/_format_impl.py
@@ -432,7 +432,7 @@ def _wrap_header_guess_version(header):
     except UnicodeEncodeError:
         pass
     else:
-        warnings.warn("Stored array in format 2.0. It can only be"
+        warnings.warn("Stored array in format 2.0. It can only be "
                       "read by NumPy >= 1.9", UserWarning, stacklevel=2)
         return ret
 

--- a/numpy/lib/_twodim_base_impl.py
+++ b/numpy/lib/_twodim_base_impl.py
@@ -462,7 +462,7 @@ def tri(N, M=None, k=0, dtype=float, *, like=None):
     # Deprecation in NumPy 2.5, 2026-03
     if warning_for_type:
         warnings.warn(
-            (f"Cannot convert {(warning_for_type).__name__} safely to an integer."
+            (f"Cannot convert {(warning_for_type).__name__} safely to an integer. "
              "This will raise an error in future versions (Deprecated NumPy 2.5)"),
             DeprecationWarning,
             skip_file_prefixes=(os.path.dirname(__file__),),
@@ -1167,7 +1167,7 @@ def triu_indices(n, k=0, m=None):
         if not isinstance(k, type(k - 1)):
             # Deprecated in NumPy 2.5, 2026-03
             warnings.warn(
-                (f"Cannot convert {type(k).__name__} safely to an integer."
+                (f"Cannot convert {type(k).__name__} safely to an integer. "
                  "This will raise an error in future versions (Deprecated NumPy 2.5)"),
                 DeprecationWarning,
                 skip_file_prefixes=(os.path.dirname(__file__),),

--- a/numpy/ma/mrecords.py
+++ b/numpy/ma/mrecords.py
@@ -194,7 +194,7 @@ class MaskedRecords(ma.MaskedArray):
         _data = np.ndarray.view(self, _localdict['_baseclass'])
         obj = _data.getfield(*res)
         if obj.dtype.names is not None:
-            raise NotImplementedError("MaskedRecords is currently limited to"
+            raise NotImplementedError("MaskedRecords is currently limited to "
                                       "simple records.")
         # Get some special attributes
         # Reset the object's mask


### PR DESCRIPTION
Backport of #32405.

### PR summary

Five user-facing messages run two sentences together because adjacent string
literals are concatenated without a trailing space:

    >>> np.sum(i for i in range(3))
    TypeError: Calling np.sum(generator) is deprecated.Use np.sum(...)

This is the counterpart of b8c885d09 ("DOC: add space between words across
lines"), which fixed the format 3.0 warning in what is now `_format_impl.py`
(then `numpy/lib/format.py`); the format 2.0 warning five lines above it still
lacks the space. The other sites are in `_core/fromnumeric.py`,
`ma/mrecords.py`, and `lib/_twodim_base_impl.py` (×2).

One space per site, no logic changed. These are all the occurrences I found in
the package — similar-looking joins that are intentional (the regex fragments in
`_core/_internal.py`, the C macro template in `code_generators/genapi.py`,
fragments whose continuation begins with `\n`) were left alone. No test asserts
across any of these boundaries.

### First time committer introduction

Hi, I work in Python for data analysis and data science, and lately I've been
building LLM agents on the side. I was reading through the error-handling code
of another library when I noticed this string-concatenation pattern, and since
NumPy is the library I use most, I checked whether it had the same issue — it
did, in five places. This is my first contribution to NumPy.

#### AI Disclosure

I used an AI assistant (Claude) to help scan for these sites and to draft and
polish this description. I ran and verified everything myself: all five messages
were reproduced locally on NumPy 2.5.2, the excluded cases were reviewed one by
one, and the 2019 precedent was confirmed in the git history. The change is five
single-space insertions with no logic change.