### PR TITLE
TYP: ``ndarray.__eq__`` shape-typing

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -6096,6 +6096,17 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def __iter__(self, /) -> Iterator[Any]: ...
 
     #
+    @override  # type: ignore[override]
+    @overload  # 0d
+    def __eq__[ShapeT: _Shape](
+        self: ndarray[ShapeT, Any],
+        other: _ScalarLike_co | ndarray[ShapeT, Any],
+        /,
+    ) -> ndarray[ShapeT, _dtype[bool_]]: ...
+    @overload  # ?d
+    def __eq__(self, other: object, /) -> NDArray[bool_]: ...  # pyright: ignore[reportIncompatibleMethodOverride]
+
+    #
     @overload  # 0d +number
     def __lt__[ShapeT: _Shape](
         self: ndarray[ShapeT, _dtype[number | bool_]],

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -6107,6 +6107,17 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def __eq__(self, other: object, /) -> NDArray[bool_]: ...  # pyright: ignore[reportIncompatibleMethodOverride]
 
     #
+    @override  # type: ignore[override]
+    @overload  # 0d
+    def __ne__[ShapeT: _Shape](
+        self: ndarray[ShapeT, Any],
+        other: _ScalarLike_co | ndarray[ShapeT, Any],
+        /,
+    ) -> ndarray[ShapeT, _dtype[bool_]]: ...
+    @overload  # ?d
+    def __ne__(self, other: object, /) -> NDArray[bool_]: ...  # pyright: ignore[reportIncompatibleMethodOverride]
+
+    #
     @overload  # 0d +number
     def __lt__[ShapeT: _Shape](
         self: ndarray[ShapeT, _dtype[number | bool_]],

--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -6096,26 +6096,38 @@ class ndarray(_ArrayOrScalarCommon, Generic[_ShapeT_co, _DTypeT_co]):
     def __iter__(self, /) -> Iterator[Any]: ...
 
     #
-    @override  # type: ignore[override]
-    @overload  # 0d
+    @override
+    @overload  # 0d | Nd
     def __eq__[ShapeT: _Shape](
         self: ndarray[ShapeT, Any],
         other: _ScalarLike_co | ndarray[ShapeT, Any],
         /,
     ) -> ndarray[ShapeT, _dtype[bool_]]: ...
     @overload  # ?d
-    def __eq__(self, other: object, /) -> NDArray[bool_]: ...  # pyright: ignore[reportIncompatibleMethodOverride]
+    def __eq__(
+        self,
+        other: ndarray[Any, Any] | _NestedSequence[_ScalarLike_co],
+        /,
+    ) -> NDArray[bool_]: ...
+    @overload  # fallback
+    def __eq__(self, other: object, /) -> Any: ...
 
     #
-    @override  # type: ignore[override]
-    @overload  # 0d
+    @override
+    @overload  # 0d | Nd
     def __ne__[ShapeT: _Shape](
         self: ndarray[ShapeT, Any],
         other: _ScalarLike_co | ndarray[ShapeT, Any],
         /,
     ) -> ndarray[ShapeT, _dtype[bool_]]: ...
     @overload  # ?d
-    def __ne__(self, other: object, /) -> NDArray[bool_]: ...  # pyright: ignore[reportIncompatibleMethodOverride]
+    def __ne__(
+        self,
+        other: ndarray[Any, Any] | _NestedSequence[_ScalarLike_co],
+        /,
+    ) -> NDArray[bool_]: ...
+    @overload  # fallback
+    def __ne__(self, other: object, /) -> Any: ...
 
     #
     @overload  # 0d +number

--- a/numpy/_core/defchararray.pyi
+++ b/numpy/_core/defchararray.pyi
@@ -150,9 +150,9 @@ class chararray(ndarray[_ShapeT_co, _CharDTypeT_co]):
 
     #
     @overload  # type: ignore[override]
-    def __ne__(self: _CharArray[str_], other: U_co, /) -> NDArray[np.bool]: ...
+    def __ne__(self: _CharArray[str_], other: U_co, /) -> NDArray[np.bool]: ...  # pyrefly: ignore[bad-override]
     @overload
-    def __ne__(self: _CharArray[bytes_], other: S_co, /) -> NDArray[np.bool]: ...
+    def __ne__(self: _CharArray[bytes_], other: S_co, /) -> NDArray[np.bool]: ...  # pyright: ignore[reportIncompatibleMethodOverride]
 
     #
     @overload  # type: ignore[override]

--- a/numpy/_core/defchararray.pyi
+++ b/numpy/_core/defchararray.pyi
@@ -144,9 +144,9 @@ class chararray(ndarray[_ShapeT_co, _CharDTypeT_co]):
 
     #
     @overload  # type: ignore[override]
-    def __eq__(self: _CharArray[str_], other: U_co, /) -> NDArray[np.bool]: ...
+    def __eq__(self: _CharArray[str_], other: U_co, /) -> NDArray[np.bool]: ...  # pyrefly: ignore[bad-override]
     @overload
-    def __eq__(self: _CharArray[bytes_], other: S_co, /) -> NDArray[np.bool]: ...
+    def __eq__(self: _CharArray[bytes_], other: S_co, /) -> NDArray[np.bool]: ...  # pyright: ignore[reportIncompatibleMethodOverride]
 
     #
     @overload  # type: ignore[override]

--- a/numpy/typing/tests/data/reveal/comparisons.pyi
+++ b/numpy/typing/tests/data/reveal/comparisons.pyi
@@ -265,7 +265,7 @@ assert_type(i > u4, np.bool)
 assert_type(AR > u4, np.ndarray[tuple[int], np.dtype[np.bool]])
 assert_type(SEQ > u4, npt.NDArray[np.bool])
 
-# equality
+#
 
 assert_type(AR == i, np.ndarray[tuple[int], np.dtype[np.bool]])
 assert_type(AR == f8, np.ndarray[tuple[int], np.dtype[np.bool]])
@@ -274,3 +274,11 @@ assert_type(AR == "x", np.ndarray[tuple[int], np.dtype[np.bool]])
 assert_type(AR == AR, np.ndarray[tuple[int], np.dtype[np.bool]])
 assert_type(AR == AR_2d, npt.NDArray[np.bool])
 assert_type(AR == SEQ, npt.NDArray[np.bool])
+
+assert_type(AR != i, np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(AR != f8, np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(AR != b_, np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(AR != "x", np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(AR != AR, np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(AR != AR_2d, npt.NDArray[np.bool])
+assert_type(AR != SEQ, npt.NDArray[np.bool])

--- a/numpy/typing/tests/data/reveal/comparisons.pyi
+++ b/numpy/typing/tests/data/reveal/comparisons.pyi
@@ -28,6 +28,8 @@ i = 0
 AR = np.array([0], dtype=np.int64)
 AR.setflags(write=False)
 
+AR_2d: np.ndarray[tuple[int, int], np.dtype[np.int64]]
+
 SEQ = (0, 1, 2, 3, 4)
 
 # object-like comparisons
@@ -262,3 +264,13 @@ assert_type(b > u4, np.bool)
 assert_type(i > u4, np.bool)
 assert_type(AR > u4, np.ndarray[tuple[int], np.dtype[np.bool]])
 assert_type(SEQ > u4, npt.NDArray[np.bool])
+
+# equality
+
+assert_type(AR == i, np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(AR == f8, np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(AR == b_, np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(AR == "x", np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(AR == AR, np.ndarray[tuple[int], np.dtype[np.bool]])
+assert_type(AR == AR_2d, npt.NDArray[np.bool])
+assert_type(AR == SEQ, npt.NDArray[np.bool])


### PR DESCRIPTION
This adds shape-typing support for `==` and `!=` comparisons of shaped `ndarray`s with scalars and other `ndarray`s with same shape-type.

---

AI did most; it's very straightforward, after all.