### PR TITLE
BUG: preserve StringDType strings in isin

### DIFF
--- a/numpy/lib/_arraysetops_impl.py
+++ b/numpy/lib/_arraysetops_impl.py
@@ -806,7 +806,13 @@ def setxor1d(ar1, ar2, assume_unique=False):
 def _isin(ar1, ar2, assume_unique=False, invert=False, *, kind=None):
     # Ravel both arrays, behavior for the first array could be different
     ar1 = np.asarray(ar1).ravel()
-    ar2 = np.asarray(ar2).ravel()
+    ar2_array = np.asarray(ar2)
+    # Convert Python strings with the StringDType descriptor so trailing
+    # NUL characters are not lost to fixed-width Unicode inference.
+    if ar1.dtype.kind == "T" and ar2_array.dtype.kind == "U":
+        ar2 = np.asarray(ar2, dtype=ar1.dtype).ravel()
+    else:
+        ar2 = ar2_array.ravel()
 
     # Ensure that iteration through object arrays yields size-1 arrays
     if ar2.dtype == object:

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -343,6 +343,16 @@ class TestSetOps:
 
         assert_array_equal(c, ec)
 
+    def test_isin_stringdtype_trailing_null(self):
+        a = np.array(["a", "x\0"], dtype=StringDType())
+
+        assert_array_equal(isin(a, ["x\0"]), [False, True])
+        assert_array_equal(isin(a, ["x\0"], invert=True), [True, False])
+
+    def test_isin_stringdtype_does_not_coerce_non_string_needles(self):
+        no_coerce = np.array(["1"], dtype=StringDType(coerce=False))
+        assert_array_equal(isin(no_coerce, [1]), [False])
+
     @pytest.mark.parametrize("kind", [None, "sort", "table"])
     def test_isin_invert(self, kind):
         "Test isin's invert parameter"


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->Related issue: gh-32431

This PR fixes the trailing-NUL issue in np.isin; np.append, np.select, and np.pad remain unchanged.

The issue occurred because test_elements was converted without knowledge of the StringDType descriptor. Consequently, Python strings were inferred as fixed-width Unicode strings and lost their trailing NUL characters.

When the input uses StringDType and test_elements is inferred as Unicode, this change converts the original values using the input array’s descriptor before flattening them.



#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->I used Codex to help select the issue and to generate the initial _isin implementation and regression tests. Codex also assisted with verification and grammar editing of this description. I reviewed and understood the code and tests, and I am personally submitting the PR and handling all maintainer communication.
