### PR TITLE
BUG: ma.__array_wrap__ no longer propagates a dtype-invalid fill_value

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3152,6 +3152,21 @@ class MaskedArray(ndarray):
         else:
             result = obj.view(type(self))
             result._update_from(self)
+            if (result._fill_value is not None
+                    and result.dtype != self.dtype):
+                # The ufunc changed the dtype of the output relative to the
+                # input, so a fill_value copied over from `self` may no
+                # longer be valid (e.g., a string fill_value on an integer
+                # result). Revalidate it now instead of leaving the output
+                # in an inconsistent state that only surfaces later, when
+                # something calls `.view()` and __array_finalize__ runs
+                # _check_fill_value (gh-32401).
+                try:
+                    fill = _check_fill_value(result._fill_value,
+                                             result.dtype)
+                except (TypeError, ValueError):
+                    fill = None
+                result._fill_value = fill
 
         if context is not None:
             result._mask = result._mask.copy()

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2701,6 +2701,31 @@ class TestUfuncs:
         assert_equal(test.mask, control.mask)
         assert_(not isinstance(test.mask, MaskedArray))
 
+    def test_dtype_changing_ufunc_does_not_inherit_invalid_fill_value(self):
+        # gh-32401: when a ufunc changes the output dtype (e.g.
+        # np.strings.find maps a string array to int64 positions), the
+        # result inherited the input's raw _fill_value without checking
+        # that it is still valid for the new dtype.  The inconsistent
+        # state only surfaced later, when a .view() re-ran
+        # _check_fill_value via __array_finalize__ and raised.
+        col = masked_array(['foo', 'bar', 'baz'], mask=False,
+                           fill_value='N/A')
+        result = np.strings.find(col, 'foo')
+        assert_equal(result, [0, -1, -1])
+        # The string fill_value is invalid for the int64 result; it must
+        # not be carried over silently.
+        assert_(result._fill_value is None)
+        # Previously raised TypeError: Cannot convert fill_value
+        # N/A to dtype int64
+        result.view(MaskedArray)
+
+    def test_dtype_changing_ufunc_keeps_convertible_fill_value(self):
+        # A fill value that IS valid for the new dtype must survive the
+        # dtype change (converted), not be discarded.
+        col = masked_array(['foo', 'bar'], mask=False, fill_value=7)
+        result = np.strings.find(col, 'o')
+        assert_equal(result._fill_value.item(), 7)
+
     def test_treatment_of_NotImplemented(self):
         # Check that NotImplemented is returned at appropriate places
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title and details below -->

## Description

When a ufunc changes the output dtype of a `MaskedArray` (e.g. `np.strings.find` applied to a string masked array returns int64 match positions), the result inherits the *raw* `_fill_value` from its input via `_update_from` inside `MaskedArray.__array_wrap__`, without any validation against the new dtype.

That inconsistent state does not surface immediately — repr, indexing, etc. all work — but the next `.view()` re-runs `_check_fill_value` through `__array_finalize__` and raises:

```
TypeError: Cannot convert fill_value N/A to dtype int64
```

Minimal reproducer (from gh-32401):

```python
import numpy as np
col = np.ma.MaskedArray(['foo', 'bar', 'baz'], mask=False, fill_value='N/A')
result = np.strings.find(col, 'foo')   # dtype changes str -> int64
result.view(np.ma.MaskedArray)         # TypeError before this patch
```

This also breaks astropy's `MaskedColumn`, whose `.data` property calls `.view(np.ma.MaskedArray)` internally on every `__getitem__` (astropy/astropy#20257).

**Fix:** after `_update_from` in `__array_wrap__`, if the result dtype differs from the input dtype, revalidate the copied `_fill_value` with `_check_fill_value`:
* a fill value that is convertible to the new dtype is kept (converted), so e.g. a numeric fill value survives an `str -> int` transition;
* a fill value that cannot be represented is dropped, so the output falls back to its default fill value instead of carrying an invalid one;
* same-dtype ufuncs are untouched (the check is gated on `result.dtype != self.dtype`), preserving all existing behavior.

<!-- Remove the sections that don't apply -->
## Testing

Two regression tests added to `numpy/ma/tests/test_core.py::TestUfuncs`:

1. `test_dtype_changing_ufunc_does_not_inherit_invalid_fill_value` — the issue's reproducer; asserts the invalid fill value is not carried over and `.view(MaskedArray)` no longer raises. Fails on unpatched main with the reported `TypeError`.
2. `test_dtype_changing_ufunc_keeps_convertible_fill_value` — asserts a numeric fill value on a string array survives a `str -> int64` ufunc (converted, not discarded).

Full suite with the patch applied:

```
numpy/ma/tests/test_core.py      4172 passed, 1 skipped, 2 xfailed
numpy/ma/tests/test_extras.py    }
numpy/ma/tests/test_regression.py } 185 passed
numpy/ma/tests/test_mrecords.py  }
```

## Notes for reviewers

* The failure mode is "stale state discovered late", so I chose revalidation at wrap time over raising eagerly at wrap time — an eager raise would turn previously-working code paths (any dtype-changing ufunc on an array that happens to carry a fill value) into hard errors. Dropping to the default fill value keeps those paths functional while guaranteeing internal consistency.
* An alternative considered was validating inside `_update_from` itself, but that function is used by many non-ufunc callers (`__array_finalize__`, explicit attribute copies) where silently dropping the caller-provided fill value would be more surprising.