### PR TITLE
TYP: fix `asarray_chkfinite` subclass return type

### DIFF
--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -450,9 +450,9 @@ def average(
 
 #
 @overload
-def asarray_chkfinite[ShapeT: _Shape, ScalarT: np.generic](
-    a: np.ndarray[ShapeT, np.dtype[ScalarT]], dtype: None = None, order: _OrderKACF = None
-) -> _Array[ShapeT, ScalarT]: ...
+def asarray_chkfinite[ShapeT: _Shape, DTypeT: np.dtype](
+    a: np.ndarray[ShapeT, DTypeT], dtype: None = None, order: _OrderKACF = None
+) -> np.ndarray[ShapeT, DTypeT]: ...
 @overload
 def asarray_chkfinite[ShapeT: _Shape, ScalarT: np.generic](
     a: np.ndarray[ShapeT], dtype: _DTypeLike[ScalarT], order: _OrderKACF = None

--- a/numpy/lib/_function_base_impl.pyi
+++ b/numpy/lib/_function_base_impl.pyi
@@ -450,7 +450,9 @@ def average(
 
 #
 @overload
-def asarray_chkfinite[ArrayT: np.ndarray](a: ArrayT, dtype: None = None, order: _OrderKACF = None) -> ArrayT: ...
+def asarray_chkfinite[ShapeT: _Shape, ScalarT: np.generic](
+    a: np.ndarray[ShapeT, np.dtype[ScalarT]], dtype: None = None, order: _OrderKACF = None
+) -> _Array[ShapeT, ScalarT]: ...
 @overload
 def asarray_chkfinite[ShapeT: _Shape, ScalarT: np.generic](
     a: np.ndarray[ShapeT], dtype: _DTypeLike[ScalarT], order: _OrderKACF = None

--- a/numpy/typing/tests/data/reveal/lib_function_base.pyi
+++ b/numpy/typing/tests/data/reveal/lib_function_base.pyi
@@ -27,7 +27,10 @@ AR_O: npt.NDArray[np.object_[int]]
 AR_b: npt.NDArray[np.bool]
 AR_U: npt.NDArray[np.str_]
 CHAR_AR_U: np.char.chararray[tuple[int], np.dtype[np.str_]]  # type: ignore[deprecated]
+MAT_f8: np.matrix[tuple[int, int], np.dtype[np.float64]]
+MAR_f8_1d: np.ma.MaskedArray[tuple[int], np.dtype[np.float64]]
 
+AR_f8_0d: np.ndarray[tuple[()], np.dtype[np.float64]]
 AR_f8_1d: np.ndarray[tuple[int], np.dtype[np.float64]]
 AR_f8_2d: np.ndarray[tuple[int, int], np.dtype[np.float64]]
 AR_f8_3d: np.ndarray[tuple[int, int, int], np.dtype[np.float64]]
@@ -101,6 +104,12 @@ assert_type(np.asarray_chkfinite(AR_f8), npt.NDArray[np.float64])
 assert_type(np.asarray_chkfinite(AR_LIKE_f8), np.ndarray)
 assert_type(np.asarray_chkfinite(AR_f8, dtype=np.float64), npt.NDArray[np.float64])
 assert_type(np.asarray_chkfinite(AR_f8, dtype=float), np.ndarray)
+assert_type(np.asarray_chkfinite(MAT_f8), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.asarray_chkfinite(MAR_f8_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
+assert_type(np.asarray_chkfinite(MAT_f8, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
+assert_type(np.asarray_chkfinite(AR_f8_0d), np.ndarray[tuple[()], np.dtype[np.float64]])
+assert_type(np.asarray_chkfinite(AR_f8_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
+assert_type(np.asarray_chkfinite(AR_f8_2d, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
 
 # piecewise
 assert_type(np.piecewise(AR_f8_1d, AR_b, [-1.0, 1.0]), np.ndarray[tuple[int], np.dtype[np.float64]])

--- a/numpy/typing/tests/data/reveal/lib_function_base.pyi
+++ b/numpy/typing/tests/data/reveal/lib_function_base.pyi
@@ -27,7 +27,6 @@ AR_O: npt.NDArray[np.object_[int]]
 AR_b: npt.NDArray[np.bool]
 AR_U: npt.NDArray[np.str_]
 CHAR_AR_U: np.char.chararray[tuple[int], np.dtype[np.str_]]  # type: ignore[deprecated]
-MAT_f8: np.matrix[tuple[int, int], np.dtype[np.float64]]
 MAR_f8_1d: np.ma.MaskedArray[tuple[int], np.dtype[np.float64]]
 
 AR_f8_0d: np.ndarray[tuple[()], np.dtype[np.float64]]
@@ -104,9 +103,7 @@ assert_type(np.asarray_chkfinite(AR_f8), npt.NDArray[np.float64])
 assert_type(np.asarray_chkfinite(AR_LIKE_f8), np.ndarray)
 assert_type(np.asarray_chkfinite(AR_f8, dtype=np.float64), npt.NDArray[np.float64])
 assert_type(np.asarray_chkfinite(AR_f8, dtype=float), np.ndarray)
-assert_type(np.asarray_chkfinite(MAT_f8), np.ndarray[tuple[int, int], np.dtype[np.float64]])
 assert_type(np.asarray_chkfinite(MAR_f8_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.asarray_chkfinite(MAT_f8, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])
 assert_type(np.asarray_chkfinite(AR_f8_0d), np.ndarray[tuple[()], np.dtype[np.float64]])
 assert_type(np.asarray_chkfinite(AR_f8_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
 assert_type(np.asarray_chkfinite(AR_f8_2d, dtype=np.float32), np.ndarray[tuple[int, int], np.dtype[np.float32]])


### PR DESCRIPTION
### PR summary

- fixed the `asarray_chkfinite` type so it correctly returns `ndarray` when given an array subclass, while preserving the correct shape and dtype.

```
>>> import numpy as np
>>> class MyArray(np.ndarray): pass
... x = np.array([[1, 2], [3, 4]]).view(MyArray)
... type(np.asarray_chkfinite(x))
...
<class 'numpy.ndarray'>
>>>
```

<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->

#### AI Disclosure
- took help in adding tests 
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
