### PR TITLE
MAINT: Only run nightly BLAS tests on main.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -146,7 +146,7 @@ jobs:
       run: |
         pip install -r requirements/build_requirements.txt
         pip install -r requirements/test_requirements.txt
-    - name: Install gfortran and setup OpenBLAS (MacPython build)
+    - name: Install gfortran and setup OpenBLAS 32 bits
       run: |
         set -xe
         sudo apt update

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -58,17 +58,10 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  openblas32_stable_nightly:
-    # To enable this workflow on a fork, comment out:
-    if: github.repository == 'numpy/numpy'
+  openblas32_nightly:
+    if: github.repository == 'numpy/numpy' && github.base_ref == 'main'
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        USE_NIGHTLY_OPENBLAS: [false, true]
-    env:
-      USE_NIGHTLY_OPENBLAS: ${{ matrix.USE_NIGHTLY_OPENBLAS }}
-    name: "Test Linux (${{ matrix.USE_NIGHTLY_OPENBLAS && 'nightly' || 'stable' }} OpenBLAS)"
+    name: "Test Linux (nightly OpenBLAS)"
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -82,12 +75,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build_requirements.txt -r requirements/test_requirements.txt
-        # Install OpenBLAS
-        if [[ $USE_NIGHTLY_OPENBLAS == "true" ]]; then
-            python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy-openblas32
-        else
-            python -m pip install -r requirements/ci32_requirements.txt
-        fi
+        python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy-openblas32
         mkdir -p ./.openblas
         python -c"import scipy_openblas32 as ob32; print(ob32.get_pkg_config())" > ./.openblas/scipy-openblas.pc
 
@@ -95,16 +83,14 @@ jobs:
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       env:
         TERM: xterm-256color
-      run:
-        spin build -- --werror -Dallow-noblas=false -Dpkg_config_path=${PWD}/.openblas
+      run: spin build -- --werror -Dallow-noblas=false -Dpkg_config_path=${PWD}/.openblas
 
     - name: Check build-internal dependencies
-      run:
-        ninja -C build -t missingdeps
+      run: ninja -C build -t missingdeps
 
     - name: Check installed test and stub files
-      run:
-        python tools/check_installed_files.py $(find ./build-install -path '*/site-packages/numpy')
+      run: python tools/check_installed_files.py $(find ./build-install -path '*/site-packages/numpy')
+
     - name: Ensure scipy-openblas
       run: |
         set -ex
@@ -114,8 +100,7 @@ jobs:
       shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
       env:
         TERM: xterm-256color
-      run: |
-        spin test -j auto -- --timeout=600 --durations=10
+      run: spin test -j auto -- --timeout=600 --durations=10
 
 
   openblas_no_pkgconfig_fedora:


### PR DESCRIPTION
Remove the 32 bit stable BLAS test as it is already tested in linux.yml. The 32 bit nightly BLAS test is modified to only run on PRs against the main branch.

AI used to split the original test  code and make it main dependent.
