### PR TITLE
DOC: linalg: Remove description of casting in eig

### DIFF
--- a/numpy/linalg/_linalg.py
+++ b/numpy/linalg/_linalg.py
@@ -1356,10 +1356,9 @@ def eig(a):
     eigenvalues : (..., M) array
         The eigenvalues, each repeated according to its multiplicity.
         The eigenvalues are not necessarily ordered. The resulting
-        array will be of complex type, unless the imaginary part is
-        zero in which case it will be cast to a real type. When `a`
-        is real the resulting eigenvalues will be real (0 imaginary
-        part) or occur in conjugate pairs
+        array will be of complex type. When `a` is real the resulting
+        eigenvalues will be real (0 imaginary part) or occur in
+        conjugate pairs.
 
     eigenvectors : (..., M, M) array
         The normalized (unit "length") eigenvectors, such that the


### PR DESCRIPTION

### PR summary

#30411 missed to update a part of the [documentation of `eig`](https://numpy.org/doc/stable/reference/generated/numpy.linalg.eig.html). It still reads "The resulting array will be of complex type, _unless the imaginary part is zero in which case it will be cast to a real type_." This PR removes the _italic_ part of the cited documentation.

### First time committer introduction

I maintain university computers and got an error when testing the installation with NumPy 2.5.

#### AI Disclosure

No AI used.
