### PR TITLE
DEV: Add .venv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ doc/cdoc/build
 pip-wheel-metadata
 .python-version
 # virtual envs
+.venv/
 numpy-dev/
 venv/
 # cibuildwheel output directory


### PR DESCRIPTION
### PR summary
Add `.venv/` to the virtual environments section of `.gitignore`.

`.venv` is a common convention for virtual environments (hidden folder, doesn't clutter `ls` output) and complements the existing `venv/` entry added in #27879.

**How I discovered this:** While following the [development environment setup docs](https://numpy.org/doc/stable/dev/development_environment.html), I used the virtualenv approach (not conda) and created my environment with `python -m venv .venv`. When I opened the project in VS Code, I saw 10,000+ untracked files from `.venv/` in the Source Control panel:
<img width="958" height="1056" alt="Screenshot 2026-08-27 at 3 38 25 PM" src="https://github.com/user-attachments/assets/63395ea1-2644-437c-a1ba-0dff242a0318" />


### First time committer introduction
Hi! I'm Abhinay, a software engineer at Amazon focused on test automation. I'm participating in the NumFOCUS Sustaining Open Source Series (a 10-week mentorship program starting Sep 14, 2026) and was matched to contribute to NumPy.

I'm ramping back up on Python after a few years and excited to contribute to a project I've used in my work. This is my first open source contribution — I noticed this `.gitignore` gap while setting up my local dev environment following the docs, and figured it would be a good small fix to start with.


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

Used [Kiro](https://kiro.dev/) (AI assistant) for workflow guidance and drafting this description. The code change is from my own experience setting up the dev environment.
