### PR TITLE
CI: use ARM64 runner and add test timing output for Mac Conda CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,11 +22,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  x86_conda:
-    name: macOS x86-64 conda
+  aarch64_conda:
+    name: macOS aarch64 conda
     # To enable this workflow on a fork, comment out:
     if: github.repository == 'numpy/numpy'
-    runs-on: macos-15-intel
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:
@@ -99,7 +99,7 @@ jobs:
       run: |
         conda activate numpy-dev
         export OMP_NUM_THREADS=2
-        spin test -j2 -m full
+        spin test -j2 -m full -- --durations=10
 
     - name: Ccache statistics
       shell: bash -l {0}


### PR DESCRIPTION
### PR summary
I noticed this CI job was very slow today. Almost an hour here: https://github.com/numpy/numpy/actions/runs/33208012014/job/98973946126?pr=32095.

Let's try to understand exactly which tests are slow in the future and use faster runners.

#### AI Disclosure
No AI