### PR TITLE
BUG: fix SeedSequence.spawn and set_bit_generator thread-safety (gh-32063)

### DIFF
--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -83,6 +83,36 @@ def test_parallel_bit_generator_state_access(bitgen_name):
 
     run_threaded(func, pass_count=True, pass_barrier=True)
 
+@pytest.mark.thread_unsafe(
+    reason="np.random.set_bit_generator affects global state")
+def test_parallel_singleton_bit_generator_swap():
+    # gh-32063: RandomState uses its bit generator's lock, and
+    # set_bit_generator replaced that lock.  Call sites read the lock and only
+    # acquire it some time later, so a thread holding the old lock could sit
+    # in the critical section at the same moment as one that acquired the new
+    # lock -- with an instrumented build this put up to 4 threads inside it at
+    # once, all using the same cached bitgen_t.
+    orig = np.random.get_bit_generator()
+    try:
+        np.random.set_bit_generator(np.random.PCG64(0))
+
+        def func(i, barrier):
+            rnd = random.Random(i)
+            barrier.wait()
+            for _ in range(200):
+                if rnd.randrange(4) == 0:
+                    np.random.set_bit_generator(
+                        np.random.PCG64(rnd.randrange(1000)))
+                else:
+                    vals = np.random.random(4)
+                    assert ((vals >= 0) & (vals < 1)).all()
+
+        run_threaded(func, pass_count=True, pass_barrier=True)
+        # The singleton survives the hammering and is still usable.
+        assert np.random.random(4).shape == (4,)
+    finally:
+        np.random.set_bit_generator(orig)
+
 def test_parallel_seed_sequence_spawn():
     # gh-32063: SeedSequence.spawn read n_children_spawned, built the children
     # (running Python code, so the GIL could be released), and only then

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -83,6 +83,38 @@ def test_parallel_bit_generator_state_access(bitgen_name):
 
     run_threaded(func, pass_count=True, pass_barrier=True)
 
+def test_parallel_seed_sequence_spawn():
+    # gh-32063: SeedSequence.spawn read n_children_spawned, built the children
+    # (running Python code, so the GIL could be released), and only then
+    # advanced the counter.  Concurrent spawns therefore started from the same
+    # index and handed out duplicate spawn keys, i.e. bit generators with
+    # identical streams.
+    n_threads = 8
+    n_spawns = 250
+    seed_seq = np.random.SeedSequence(12345)
+    spawn_keys = []
+    results_lock = threading.Lock()
+
+    def func(barrier):
+        barrier.wait()
+        children = seed_seq.spawn(n_spawns)
+        with results_lock:
+            spawn_keys.extend(child.spawn_key for child in children)
+
+    # Switch threads aggressively so the window between reading the counter
+    # and advancing it is actually hit on the GIL-enabled build.
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        run_threaded(func, max_workers=n_threads, pass_barrier=True)
+    finally:
+        sys.setswitchinterval(old_interval)
+
+    expected = n_threads * n_spawns
+    # Every key handed out exactly once, and the counter agrees.
+    assert sorted(spawn_keys) == [(i,) for i in range(expected)]
+    assert seed_seq.n_children_spawned == expected
+
 def test_parallel_ufunc_execution():
     # if the loop data cache or dispatch cache are not thread-safe
     # computing ufuncs simultaneously in multiple threads leads

--- a/numpy/random/bit_generator.pyx
+++ b/numpy/random/bit_generator.pyx
@@ -35,10 +35,11 @@ SOFTWARE.
 
 import abc
 from itertools import cycle
+from operator import index
 import re
 from secrets import randbits
 
-from threading import RLock
+from threading import Lock, RLock
 
 from cpython.pycapsule cimport PyCapsule_New
 
@@ -62,6 +63,21 @@ cdef uint32_t MIX_MULT_L = 0xca01f9dd
 cdef uint32_t MIX_MULT_R = 0x4973f715
 cdef uint32_t XSHIFT = np.dtype(np.uint32).itemsize * 8 // 2
 cdef uint32_t MASK32 = 0xFFFFFFFF
+
+# Serializes the ``n_children_spawned`` bookkeeping of `SeedSequence.spawn`
+# across all `SeedSequence` instances.  Handing the same spawn key to two
+# threads gives them bit generators with identical streams, so the reservation
+# of a block of keys has to be atomic (see gh-32063).
+#
+# This is deliberately a single module-level lock rather than a per-instance
+# one: adding an attribute to the `SeedSequence` cdef class changes the
+# checksum that Cython's auto-generated unpickler validates, which would make
+# every already-written pickle of a `SeedSequence`, `BitGenerator` or
+# `Generator` fail to load.  Only the few operations needed to reserve a range
+# of keys are done under the lock -- constructing the children, which is the
+# expensive part, happens outside it -- so the shared scope costs nothing in
+# practice.
+_spawn_lock = Lock()
 
 def _int_to_uint32_array(n):
     arr = []
@@ -484,19 +500,30 @@ cdef class SeedSequence:
 
         """
         cdef uint32_t i
+        cdef uint32_t first_child
 
         if n_children < 0:
             raise ValueError("n_children must be non-negative")
+        # Reject non-integers before touching the shared counter, keeping the
+        # error identical to the one ``range`` used to raise below.
+        n_children = index(n_children)
+
+        # Reserve the whole block of spawn keys up front.  Building the
+        # children runs Python code (``np.concatenate`` inside
+        # ``get_assembled_entropy``, and any subclass ``__init__``), so it can
+        # release the GIL; doing the bookkeeping afterwards let concurrent
+        # spawns observe the same starting index and hand out duplicate keys.
+        with _spawn_lock:
+            first_child = self.n_children_spawned
+            self.n_children_spawned = first_child + n_children
 
         seqs = []
-        for i in range(self.n_children_spawned,
-                       self.n_children_spawned + n_children):
+        for i in range(first_child, first_child + n_children):
             seqs.append(type(self)(
                 self.entropy,
                 spawn_key=self.spawn_key + (i,),
                 pool_size=self.pool_size,
             ))
-        self.n_children_spawned += n_children
         return seqs
 
 

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -214,16 +214,35 @@ cdef class RandomState:
         return __randomstate_ctor, (self._bit_generator, ), self.get_state(legacy=False)
 
     cdef _initialize_bit_generator(self, bit_generator):
-        self._bit_generator = bit_generator
+        # Validate before mutating anything.  Assigning ``self._bit_generator``
+        # first would drop the last reference to the bit generator currently in
+        # use -- freeing the state that ``self._bitgen.state`` still points at --
+        # and then leave the object wedged that way when the check below fails.
         capsule = bit_generator.capsule
         cdef const char *name = "BitGenerator"
         if not PyCapsule_IsValid(capsule, name):
             raise ValueError("Invalid bit generator. The bit generator must "
                              "be instantized.")
-        self._bitgen = (<bitgen_t *> PyCapsule_GetPointer(capsule, name))[0]
-        self._aug_state.bit_generator = &self._bitgen
-        self.lock = bit_generator.lock
-        self._reset_gauss()
+
+        # ``self.lock`` is None only while ``__init__`` runs, when no other
+        # thread can reach this object yet.  Otherwise hold the lock belonging
+        # to the bit generator being replaced: distribution methods read
+        # ``self._bitgen`` (a *copy* of the function pointers and state pointer)
+        # under that lock with the GIL released, so swapping without it lets
+        # them observe a half-written struct or a pointer into a bit generator
+        # that has just been deallocated.  See gh-32063.
+        old_lock = self.lock
+        if old_lock is not None:
+            old_lock.acquire()
+        try:
+            self._bit_generator = bit_generator
+            self._bitgen = (<bitgen_t *> PyCapsule_GetPointer(capsule, name))[0]
+            self._aug_state.bit_generator = &self._bitgen
+            self.lock = bit_generator.lock
+            self._reset_gauss()
+        finally:
+            if old_lock is not None:
+                old_lock.release()
 
     cdef _reset_gauss(self):
         with self.lock:

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -118,6 +118,60 @@ cdef object int64_to_long(object x):
     return x.astype('l', casting='unsafe')
 
 
+@cython.final
+cdef class _StableLock:
+    """A lock handle for `RandomState` whose identity never changes.
+
+    `RandomState` uses the lock of its bit generator, so that a `Generator`
+    built on the same bit generator serializes against it.  That makes
+    ``set_bit_generator`` replace the lock, which alone is not enough to make
+    the swap safe: call sites read ``self.lock`` and acquire it only some time
+    later -- ``cont()`` and friends allocate the output array in between -- so
+    a thread holding the old lock can sit in the critical section at the same
+    moment as one that acquired the new lock, and both then use the same
+    ``self._bitgen``.
+
+    A `RandomState` is given one of these the first time its bit generator is
+    replaced, and keeps it from then on, so what callers read never goes
+    stale.  Acquiring re-checks the lock afterwards and retries if a swap won
+    the race.  Only ever one lock is held, so this cannot deadlock against
+    code holding a bit generator's lock directly.
+
+    Instances that are never swapped (every `RandomState` but the
+    ``numpy.random`` singleton, which is the only one ``set_bit_generator``
+    can reach) keep using the bare lock and pay nothing for this.
+    """
+    cdef object _lock
+    cdef object _acquire
+
+    def __cinit__(self, lock):
+        self._lock = lock
+        self._acquire = lock.acquire
+
+    cdef _set(self, lock):
+        # Only ever called while the outgoing lock is held.
+        self._lock = lock
+        self._acquire = lock.acquire
+
+    def __enter__(self):
+        cdef object lock
+        while True:
+            lock = self._lock
+            self._acquire()
+            if lock is self._lock:
+                return None
+            # A swap slipped in between reading the lock and acquiring it.
+            # Drop the stale one and take whatever is current now.
+            lock.release()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # A swap cannot complete while this lock is held, because
+        # ``_initialize_bit_generator`` acquires it first, so ``_lock`` is
+        # still the one that ``__enter__`` took.
+        self._lock.release()
+        return False
+
+
 cdef class RandomState:
     # the first line is used to populate `__text_signature__`
     """RandomState(seed=None)\n--
@@ -225,24 +279,44 @@ cdef class RandomState:
                              "be instantized.")
 
         # ``self.lock`` is None only while ``__init__`` runs, when no other
-        # thread can reach this object yet.  Otherwise hold the lock belonging
-        # to the bit generator being replaced: distribution methods read
-        # ``self._bitgen`` (a *copy* of the function pointers and state pointer)
-        # under that lock with the GIL released, so swapping without it lets
-        # them observe a half-written struct or a pointer into a bit generator
-        # that has just been deallocated.  See gh-32063.
-        old_lock = self.lock
-        if old_lock is not None:
-            old_lock.acquire()
-        try:
-            self._bit_generator = bit_generator
-            self._bitgen = (<bitgen_t *> PyCapsule_GetPointer(capsule, name))[0]
-            self._aug_state.bit_generator = &self._bitgen
+        # thread can reach this object yet.
+        cdef _StableLock guard
+        if self.lock is None:
             self.lock = bit_generator.lock
-            self._reset_gauss()
+            self._swap_bit_generator(bit_generator, capsule, name)
+            return
+
+        # Hold the lock that is in use across the whole swap.  Distribution
+        # methods read ``self._bitgen`` -- a *copy* of the bit generator's
+        # function pointers and state pointer -- under it with the GIL
+        # released, so rewriting it unsynchronized lets them observe a
+        # half-written struct, or a pointer into a bit generator that has just
+        # been deallocated.  See gh-32063.
+        if isinstance(self.lock, _StableLock):
+            guard = <_StableLock>self.lock
+            base = guard._lock
+        else:
+            guard = None
+            base = self.lock
+
+        base.acquire()
+        try:
+            self._swap_bit_generator(bit_generator, capsule, name)
+            # Publish the new lock only once the swap is complete.  A thread
+            # that already read the old lock blocks on it above, then sees the
+            # identity change and retries against the new one.
+            if guard is None:
+                self.lock = _StableLock(bit_generator.lock)
+            else:
+                guard._set(bit_generator.lock)
         finally:
-            if old_lock is not None:
-                old_lock.release()
+            base.release()
+
+    cdef _swap_bit_generator(self, bit_generator, capsule, const char *name):
+        self._bit_generator = bit_generator
+        self._bitgen = (<bitgen_t *> PyCapsule_GetPointer(capsule, name))[0]
+        self._aug_state.bit_generator = &self._bitgen
+        self._reset_gauss()
 
     cdef _reset_gauss(self):
         with self.lock:

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -1,6 +1,7 @@
 import hashlib
 import pickle
 import sys
+import threading
 import warnings
 
 import pytest
@@ -2105,3 +2106,57 @@ def test_swapped_singleton_against_direct(restore_singleton_bitgen):
     rg = np.random.RandomState(PCG64(98765))
     non_singleton_vals = rg.randint(0, 2 ** 30, 10)
     assert_equal(non_singleton_vals, singleton_vals)
+
+
+class _NotABitGenerator:
+    """Passes the ``.capsule`` attribute lookup but fails validation."""
+    capsule = None
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+@pytest.mark.parametrize("bad", [object(), None, "PCG64", _NotABitGenerator()])
+def test_failed_swap_leaves_singleton_usable(restore_singleton_bitgen, bad):
+    # gh-32063: the bit generator was assigned before the capsule was
+    # validated, so a rejected argument dropped the last reference to the
+    # generator that ``_bitgen`` still pointed into and wedged the singleton.
+    keep_alive = PCG64(0)
+    np.random.set_bit_generator(keep_alive)
+    expected = np.random.get_state(legacy=False)
+
+    with pytest.raises((AttributeError, ValueError)):
+        np.random.set_bit_generator(bad)
+
+    assert np.random.get_bit_generator() is keep_alive
+    assert np.random.get_state(legacy=False) == expected
+    # The singleton must still produce values rather than read freed memory.
+    np.random.standard_normal(10)
+
+
+@pytest.mark.thread_unsafe(reason="np.random.set_bit_generator affects global state")
+def test_set_bit_generator_waits_for_lock(restore_singleton_bitgen):
+    # gh-32063: swapping the singleton's bit generator rewrites the cached
+    # ``bitgen_t`` struct and drops the reference to the old generator, so it
+    # must not run while another thread holds that generator's lock and is
+    # drawing from it.
+    old = PCG64(0)
+    new = PCG64(1)
+    np.random.set_bit_generator(old)
+
+    swapped = threading.Event()
+
+    def swap():
+        np.random.set_bit_generator(new)
+        swapped.set()
+
+    thread = threading.Thread(target=swap)
+    with old.lock:
+        thread.start()
+        # Cannot prove a negative, but with the swap unsynchronized this
+        # reliably completes immediately.
+        assert not swapped.wait(0.5), "swap ran while the old lock was held"
+        assert np.random.get_bit_generator() is old
+
+    thread.join(30)
+    assert not thread.is_alive()
+    assert swapped.is_set()
+    assert np.random.get_bit_generator() is new


### PR DESCRIPTION
Fixes both problems reported in gh-32063.

## 1. `SeedSequence.spawn` hands out duplicate spawn keys

`spawn` read `n_children_spawned`, constructed the children, and only then
advanced the counter. Constructing a child runs Python code (`np.concatenate`
inside `get_assembled_entropy`, plus any subclass `__init__`), so the GIL can
be released partway through and concurrent spawns start from the same index.
`BitGenerator.spawn` and `Generator.spawn` delegate here, so they inherit it.

With the reproducer from the issue, on the GIL-enabled build:

```
before:  2000 children spawned, 500 unique spawn keys
after:   2000 children spawned, 2000 unique spawn keys
```

Four threads were getting identical bit generator streams. The fix reserves
the block of keys under a lock before building any child; the children, which
are the expensive part, are still built outside it.

### Why a module-level lock rather than one per `SeedSequence`

The issue discussion suggested giving `SeedSequence` its own lock. That is not
possible without breaking pickles: adding any attribute to the cdef class
changes the checksum that Cython's auto-generated unpickler validates. Since
`BitGenerator.__reduce__` embeds its `SeedSequence`, every existing pickle of a
`SeedSequence`, `BitGenerator` or `Generator` then fails to load. Verified by
adding a dummy attribute and loading pickles written by the unpatched build:

```
PickleError: Incompatible checksums (0x3eaa222 vs (...) = (_experiment_lock, entropy, ...))
```

Only the counter reservation happens under the lock, so a single shared lock
costs nothing measurable.

As a side effect, an out-of-range `n_children` now raises `OverflowError`
immediately instead of first trying to build billions of children.

## 2. `set_bit_generator` is not thread-safe

Three separate problems.

**The swap was not validated before mutating.** `_initialize_bit_generator`
assigned `self._bit_generator` before checking the capsule, so a rejected
argument dropped the last reference to the bit generator that
`self._bitgen.state` still points into, and left the singleton wedged. Shown by
subclassing `MT19937` with a `__del__`:

```
>>> old bit generator DEALLOCATED (its C state is now freed)
raised: 'object' object has no attribute 'capsule'
```

Subsequent `np.random.random()` calls read that freed memory; they did not
crash only because the block had not been reused yet. Validation now happens
first, so a failed `set_bit_generator` is a no-op.

**The swap ran unsynchronized.** It rewrote the cached `bitgen_t` (function
pointers plus state pointer) while distribution methods read it with the GIL
released. It now holds the lock of the generator being replaced.

**Replacing the lock broke mutual exclusion.** This is the part flagged as
needing thought in the issue thread. `RandomState` uses its bit generator's
lock, so the swap replaces it, and call sites read `self.lock` well before they
acquire it — `cont()`/`disc()` allocate the output array in between. A thread
that read the old lock ends up in the critical section at the same time as one
that acquired the new lock, both using the same cached `_bitgen`.

I instrumented `double_fill` to count threads inside the critical section while
another thread swapped bit generators:

| | max threads inside the critical section |
|---|---|
| holding the outgoing lock only | **4** (3/3 runs) |
| with this patch | **1** |

The fix gives `RandomState` a lock handle whose identity never changes. It
acquires whichever lock is current, re-checks afterwards, and retries if a swap
won the race — that retry fired 12042 times in a 3000-swap stress run. Only one
lock is ever held, so it cannot deadlock against code holding a bit generator's
lock directly.

The handle is installed lazily, on the first swap, since the singleton is the
only `RandomState` that `set_bit_generator` can reach. Everything else keeps
using the bare lock. A/B/A benchmark, alternating builds to control for drift:

| case | no handle | with handle | delta |
|---|---|---|---|
| `RandomState.random_sample()` scalar | 145.9 ns | 144.8 ns | -0.8% |
| `RandomState.random_sample(10)` | 371.9 ns | 370.0 ns | -0.5% |
| `RandomState.random_sample(100_000)` | 337.8 us | 337.2 us | -0.2% |
| `RandomState.standard_normal()` scalar | 188.2 ns | 186.8 ns | -0.7% |
| `RandomState.randint(0, 100)` scalar | 1126.7 ns | 1127.1 ns | +0.0% |
| `Generator.random()` scalar | 249.2 ns | 247.2 ns | -0.8% |

against a 1.3-2.4% noise floor between two identical builds. Installing the
handle unconditionally instead cost 15% on scalar `RandomState.random_sample()`,
which is why it is lazy.

## Tests

- `test_parallel_seed_sequence_spawn` — fails 3/3 without the spawn fix, passes 10/10 with it.
- `test_failed_swap_leaves_singleton_usable` (4 cases) and `test_set_bit_generator_waits_for_lock` — all fail without the `mtrand` fix.
- `test_parallel_singleton_bit_generator_swap` — hammers swaps against concurrent draws.

Full suite: 47815 passed, 0 failed. `spin lint` clean. Built and tested on
macOS 15.7 arm64, Python 3.12, Accelerate.

## Notes

- No release note fragment, matching gh-32061 which fixed the same class of bug.
- Existing pickles were explicitly checked and still load.

