### PR TITLE
MAINT: exit deadlock tests quickly on slow hardware

### DIFF
--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -561,7 +561,7 @@ def assert_no_deadlock(workload, *, args=(), helpers=(), timeout=30,
 
 
 def threaded_deadlock_reproducer(operation, nworkers, niters, stall,
-                                 time_budget=2.0):
+                                 time_budget_secs=2.0):
     import faulthandler
     import os
     import sys
@@ -575,7 +575,7 @@ def threaded_deadlock_reproducer(operation, nworkers, niters, stall,
     def worker(idx):
         try:
             barrier.wait()
-            deadline = time.monotonic() + time_budget
+            deadline = time.monotonic() + time_budget_secs
             for _ in range(niters):
                 operation(idx)
                 progress[idx] += 1

--- a/numpy/_core/tests/test_multithreading.py
+++ b/numpy/_core/tests/test_multithreading.py
@@ -560,7 +560,8 @@ def assert_no_deadlock(workload, *, args=(), helpers=(), timeout=30,
         ) from None
 
 
-def threaded_deadlock_reproducer(operation, nworkers, niters, stall):
+def threaded_deadlock_reproducer(operation, nworkers, niters, stall,
+                                 time_budget=2.0):
     import faulthandler
     import os
     import sys
@@ -574,9 +575,12 @@ def threaded_deadlock_reproducer(operation, nworkers, niters, stall):
     def worker(idx):
         try:
             barrier.wait()
+            deadline = time.monotonic() + time_budget
             for _ in range(niters):
                 operation(idx)
                 progress[idx] += 1
+                if time.monotonic() > deadline:
+                    break
         except BaseException as exc:
             errors.append(exc)
             raise


### PR DESCRIPTION
### PR summary
See https://github.com/numpy/numpy/issues/32461.

@h-vetinari mentioned that he has some tests that use this helper skipped for riscv and ppc on conda-forge because they take longer than 30 seconds and lead to test failures.

Rather than skipping these tests, let's add a second way for these tests to exit if no deadlock happens.

On a fast machine, these tests all pass in less than a second. On a slow machine, we're still testing for deadlocks, but we don't spend 30 seconds chewing on contended memory and instead exit if we're still making forward progress after 2 seconds. We'll never reach the `break` if there's a deadlock so a real deadlock will still hit the 30s timeout.

#### AI Disclosure
I used an AI to think about the problem. I implemented the fix.
