### PR TITLE
BUG: write bytes to canonical byteorder in StringDType casts

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -344,8 +344,10 @@ string_to_fixed_width_resolve_descriptors(
         return (NPY_CASTING)-1;
     }
     else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
+        loop_descrs[1] = NPY_DT_CALL_ensure_canonical(given_descrs[1]);
+        if (loop_descrs[1] == NULL) {
+            return (NPY_CASTING)-1;
+        }
     }
 
     Py_INCREF(given_descrs[0]);
@@ -570,8 +572,10 @@ string_to_bool_resolve_descriptors(PyObject *NPY_UNUSED(self),
         loop_descrs[1] = PyArray_DescrNewFromType(NPY_BOOL);
     }
     else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
+        loop_descrs[1] = NPY_DT_CALL_ensure_canonical(given_descrs[1]);
+        if (loop_descrs[1] == NULL) {
+            return (NPY_CASTING)-1;
+        }
     }
 
     Py_INCREF(given_descrs[0]);
@@ -853,8 +857,10 @@ string_to_int_resolve_descriptors(
         loop_descrs[1] = PyArray_DescrNewFromType(typenum);
     }
     else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
+        loop_descrs[1] = NPY_DT_CALL_ensure_canonical(given_descrs[1]);
+        if (loop_descrs[1] == NULL) {
+            return (NPY_CASTING)-1;
+        }
     }
 
     Py_INCREF(given_descrs[0]);
@@ -1304,8 +1310,10 @@ string_to_float_resolve_descriptors(
         loop_descrs[1] = PyArray_DescrNewFromType(typenum);
     }
     else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
+        loop_descrs[1] = NPY_DT_CALL_ensure_canonical(given_descrs[1]);
+        if (loop_descrs[1] == NULL) {
+            return (NPY_CASTING)-1;
+        }
     }
 
     Py_INCREF(given_descrs[0]);
@@ -1582,8 +1590,10 @@ string_to_datetime_timedelta_resolve_descriptors(
         return (NPY_CASTING)-1;
     }
     else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
+        loop_descrs[1] = NPY_DT_CALL_ensure_canonical(given_descrs[1]);
+        if (loop_descrs[1] == NULL) {
+            return (NPY_CASTING)-1;
+        }
     }
 
     Py_INCREF(given_descrs[0]);

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1650,6 +1650,15 @@ def test_non_native_byteorder_to_string(dtype, values):
                        native.astype(StringDType()))
 
 
+@pytest.mark.parametrize("dtype, values", NON_NATIVE_BYTEORDER_CASES)
+def test_string_to_non_native_byteorder(dtype, values):
+    native = np.array(values, dtype=dtype)
+    swapped_dtype = native.dtype.newbyteorder("S")
+    res = native.astype(StringDType()).astype(swapped_dtype)
+    assert res.dtype == swapped_dtype
+    assert_array_equal(res, native)
+
+
 @pytest.mark.parametrize("typename", ["float16", "float32", "float64",
                                       "longdouble"])
 def test_setitem_nan_na_matches_float_cast(typename, nan_like_na_object):


### PR DESCRIPTION
### PR summary
Currently we're using the exact output descriptor for casts from string to types that support byte ordering. That's wrong and leads to incorrect answers when casting to an explicitly byteswapped dtype instance. See the new tests, which all fail with incorrect answers on `main`.


#### AI Disclosure
An AI spotted the bug and I used an AI to review the fix.