### PR TITLE
BUG: fix stale fill_value after ufuncs change MaskedArray dtype (#32423)

### DIFF
--- a/doc/release/upcoming_changes/32423.change.rst
+++ b/doc/release/upcoming_changes/32423.change.rst
@@ -1,0 +1,8 @@
+`MaskedArray._fill_value` would become stale when ufuncs that change dtype
+left the result holding a fill_value typed for the old dtype. The mismatch
+was silent until something later called `_check_fill_value`, such as
+`.view()`, and then a `TypeError` would be raised.  Now, when the copied
+fill_value is no longer valid for the new dtype, fall back to the
+default fill_value for that dtype instead of propagating the stale value.
+This can now raise a `ComplexWarning` if the fill_value is complex and the
+new dtype is real.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3037,7 +3037,13 @@ class MaskedArray(ndarray):
         _optinfo.update(getattr(obj, '_basedict', {}))
         if not isinstance(obj, MaskedArray):
             _optinfo.update(getattr(obj, '__dict__', {}))
-        _dict = {'_fill_value': getattr(obj, '_fill_value', None),
+        _fill_value = getattr(obj, '_fill_value', None)
+        if _fill_value is not None and getattr(obj, 'dtype', None) != self.dtype:
+            try:
+                _fill_value = _check_fill_value(_fill_value, self.dtype)
+            except (TypeError, ValueError, OverflowError):
+                _fill_value = None
+        _dict = {'_fill_value': _fill_value,
                      '_hardmask': getattr(obj, '_hardmask', False),
                      '_sharedmask': getattr(obj, '_sharedmask', False),
                      '_isfield': getattr(obj, '_isfield', False),

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -1285,8 +1285,11 @@ class TestMaskedArrayArithmetic:
         assert_equal(np.arctan(z), arctan(zm))
         assert_equal(np.arctan2(x, y), arctan2(xm, ym))
         assert_equal(np.absolute(x), absolute(xm))
-        assert_equal(np.angle(x + 1j * y), angle(xm + 1j * ym))
-        assert_equal(np.angle(x + 1j * y, deg=True), angle(xm + 1j * ym, deg=True))
+        # Complex fill_value becomes real, raising ComplexWarning
+        with pytest.warns(np.exceptions.ComplexWarning):
+            assert_equal(np.angle(x + 1j * y), angle(xm + 1j * ym))
+        with pytest.warns(np.exceptions.ComplexWarning):
+            assert_equal(np.angle(x + 1j * y, deg=True), angle(xm + 1j * ym, deg=True))
         assert_equal(np.equal(x, y), equal(xm, ym))
         assert_equal(np.not_equal(x, y), not_equal(xm, ym))
         assert_equal(np.less(x, y), less(xm, ym))
@@ -2624,6 +2627,62 @@ class TestFillingValues:
         # array with a large fill_value).
         y = x.view(dtype=np.int32)
         assert_(y.fill_value == 999999)
+
+    def test_fillvalue_reset_after_dtype_changing_ufunc(self):
+        # Test that a fill_value which no longer matches the dtype of the
+        # result of a ufunc (because the ufunc changed the dtype) is reset
+        # to the default for the new dtype.
+        a = array(['foo', 'bar', 'baz'], mask=False, fill_value='N/A')
+        result = np.strings.find(a, 'foo')
+
+        # np.strings.find returns the platform default int dtype
+        assert_(result.dtype.kind == 'i')
+        assert_equal(result.fill_value, default_fill_value(result.dtype))
+        assert_equal(result.filled().dtype, result.dtype)
+
+        viewed = result.view(MaskedArray)
+        assert_equal(viewed.fill_value, default_fill_value(result.dtype))
+
+    def test_fillvalue_castable_after_dtype_changing_ufunc(self):
+        # Test that fill_values that *can* be cast into the new dtype.
+        # The cast value should be kept rather than being reset to the default,
+        # and .filled() should not be forced to fall back to `object` dtype.
+        a = array(['ab', 'cd'], mask=[0, 1], fill_value='-1')
+        result = np.strings.find(a, 'a')
+        assert_(result.dtype.kind == 'i')
+        assert_equal(result.fill_value, -1)
+        assert_equal(result.filled(), [0, -1])
+        assert_equal(result.filled().dtype, result.dtype)
+
+        x = array([1.5, np.nan, 2.5], mask=[0, 0, 1], fill_value=1e20)
+        y = np.isnan(x)
+        assert_equal(y.dtype, np.dtype(bool))
+        assert_equal(y.fill_value, True)
+        assert_equal(y.filled(), [False, True, True])
+        assert_equal(y.filled().dtype, y.dtype)
+
+        d = array(np.array(['2020-01-01', '2020-01-02'], 'M8[D]'), mask=[0, 1])
+        d.set_fill_value(np.datetime64('NaT', 'D'))
+        z = d - np.datetime64('2020-01-01', 'D')
+        assert_equal(z.dtype, np.dtype('timedelta64[D]'))
+        assert_(np.isnat(z.fill_value))
+        assert_equal(z.filled().dtype, z.dtype)
+
+        # the fill_value's complex dtype is cast into the new real dtype
+        c = array([1 + 1j, 2j], mask=[0, 1], fill_value=2 + 3j)
+        with pytest.warns(np.exceptions.ComplexWarning):
+            r = np.abs(c)
+        assert_equal(r.dtype, np.dtype(float))
+        assert_equal(r.fill_value, 2.0)
+        assert_equal(r.filled().dtype, r.dtype)
+
+        # a fill_value that overflows the new dtype during the cast
+        wide = np.dtype([('id', object)])
+        narrow = np.dtype([('id', 'i8')])
+        e = array([(1,), (2,)], dtype=wide, mask=[0, 1], fill_value=(10 ** 30,))
+        f = e.astype(narrow)
+        assert_equal(f.fill_value, default_fill_value(narrow))
+        assert_equal(f.filled().dtype, f.dtype)
 
     def test_fillvalue_bytes_or_str(self):
         # Test whether fill values work as expected for structured dtypes


### PR DESCRIPTION
Backport of #32423.

### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

`MaskedArray._update_from` copied `_fill_value` from the input array unconditionally, with no check that it was still valid for the result's dtype. Ufuncs that change dtype (e.g. `np.strings.find` on a string masked array, which returns an integer array) left the result holding a fill_value of the old, invalid dtype. The mismatch was silent until something later called `_check_fill_value` (e.g. `.view()`), then raising an exception.

`_update_from` is the common path for both direct ufunc calls (via `__array_wrap__`) and `np.ma`'s own wrapped ufuncs, so fixing it here covers all dtype-changing ufuncs. When the copied `fill_value` is no longer valid for the new dtype, fall back to the default fill_value for that dtype instead of propagating the stale value; when it's still valid, keep it unmodified.

Fixes #32401

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->
I develop code for the astropy ecosystem, and this bug was found downstream in `astropy.table.MaskedColumn` which subclasses `numpy.ma.MaskedArray`, where string searches in column data are common.  We are fixing it over it on the astropy side (https://github.com/astropy/astropy/pull/20265), but it would be nice to fix it here as well.

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
AI models were used to help diagnose the bug and fix it.