### PR TITLE
BUG: Backport StringDType byteorder fixes

### DIFF
--- a/numpy/_core/src/multiarray/stringdtype/casts.cpp
+++ b/numpy/_core/src/multiarray/stringdtype/casts.cpp
@@ -130,9 +130,11 @@ any_to_string_resolve_descriptors(
         Py_INCREF(given_descrs[1]);
         loop_descrs[1] = given_descrs[1];
     }
-
-    Py_INCREF(given_descrs[0]);
-    loop_descrs[0] = given_descrs[0];
+    loop_descrs[0] = NPY_DT_CALL_ensure_canonical(given_descrs[0]);
+    if (loop_descrs[0] == NULL) {
+        Py_DECREF(loop_descrs[1]);
+        return (NPY_CASTING)-1;
+    }
 
     return safety;
 }
@@ -339,8 +341,10 @@ string_to_fixed_width_resolve_descriptors(
         return (NPY_CASTING)-1;
     }
     else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
+        loop_descrs[1] = NPY_DT_CALL_ensure_canonical(given_descrs[1]);
+        if (loop_descrs[1] == NULL) {
+            return (NPY_CASTING)-1;
+        }
     }
 
     Py_INCREF(given_descrs[0]);
@@ -460,8 +464,10 @@ string_to_bool_resolve_descriptors(PyObject *NPY_UNUSED(self),
         loop_descrs[1] = PyArray_DescrNewFromType(NPY_BOOL);
     }
     else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
+        loop_descrs[1] = NPY_DT_CALL_ensure_canonical(given_descrs[1]);
+        if (loop_descrs[1] == NULL) {
+            return (NPY_CASTING)-1;
+        }
     }
 
     Py_INCREF(given_descrs[0]);
@@ -745,8 +751,10 @@ string_to_int_resolve_descriptors(
         loop_descrs[1] = PyArray_DescrNewFromType(typenum);
     }
     else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
+        loop_descrs[1] = NPY_DT_CALL_ensure_canonical(given_descrs[1]);
+        if (loop_descrs[1] == NULL) {
+            return (NPY_CASTING)-1;
+        }
     }
 
     Py_INCREF(given_descrs[0]);
@@ -1186,8 +1194,10 @@ string_to_float_resolve_descriptors(
         loop_descrs[1] = PyArray_DescrNewFromType(typenum);
     }
     else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
+        loop_descrs[1] = NPY_DT_CALL_ensure_canonical(given_descrs[1]);
+        if (loop_descrs[1] == NULL) {
+            return (NPY_CASTING)-1;
+        }
     }
 
     Py_INCREF(given_descrs[0]);
@@ -1433,8 +1443,10 @@ string_to_datetime_timedelta_resolve_descriptors(
         return (NPY_CASTING)-1;
     }
     else {
-        Py_INCREF(given_descrs[1]);
-        loop_descrs[1] = given_descrs[1];
+        loop_descrs[1] = NPY_DT_CALL_ensure_canonical(given_descrs[1]);
+        if (loop_descrs[1] == NULL) {
+            return (NPY_CASTING)-1;
+        }
     }
 
     Py_INCREF(given_descrs[0]);

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -1154,6 +1154,35 @@ def test_string_to_bytes_invalid_ascii_error():
     )
 
 
+NON_NATIVE_BYTEORDER_CASES = [
+    ("i4", [1, -2, 300]),
+    ("u2", [1, 2, 300]),
+    ("f2", [1.5, -2.0]),
+    ("f8", [1.5, -2.0]),
+    ("c16", [1.5 + 2j]),
+    ("M8[s]", ["2020-01-01", "NaT"]),
+    ("m8[s]", [5, "NaT"]),
+    ("U3", ["abc", "d"]),
+]
+
+
+@pytest.mark.parametrize("dtype, values", NON_NATIVE_BYTEORDER_CASES)
+def test_non_native_byteorder_to_string(dtype, values):
+    native = np.array(values, dtype=dtype)
+    swapped = native.astype(native.dtype.newbyteorder("S"))
+    assert_array_equal(swapped.astype(StringDType()),
+                       native.astype(StringDType()))
+
+
+@pytest.mark.parametrize("dtype, values", NON_NATIVE_BYTEORDER_CASES)
+def test_string_to_non_native_byteorder(dtype, values):
+    native = np.array(values, dtype=dtype)
+    swapped_dtype = native.dtype.newbyteorder("S")
+    res = native.astype(StringDType()).astype(swapped_dtype)
+    assert res.dtype == swapped_dtype
+    assert_array_equal(res, native)
+
+
 def test_void_to_string_invalid_utf8_error():
     # invalid UTF-8 in a void buffer used to surface as a confusing
     # MemoryError because the error return of utf8_buffer_size was


### PR DESCRIPTION
### PR summary
This backports #32474 and one hunk and test from #31825.

I had to extract one part of #31825 so this is done manually.

#### AI Disclosure
No AI use