### PR TITLE
BUG: corrcoef returns finite value for constant vectors instead of NaN

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3061,8 +3061,18 @@ def corrcoef(x, y=None, rowvar=True, *,
         # nan if incorrect value (nan, inf, 0), 1 otherwise
         return c / c
     stddev = sqrt(d.real)
-    c /= stddev[:, None]
-    c /= stddev[None, :]
+
+    # corrcoef is undefined when either input has zero variance;
+    # use np.errstate to suppress warnings from division by zero.
+    with np.errstate(divide='ignore', invalid='ignore'):
+        c /= stddev[:, None]
+        c /= stddev[None, :]
+
+    # Set correlation coefficients to NaN where either variable
+    # has zero variance (correlation is mathematically undefined).
+    zero_std = stddev == 0
+    if np.any(zero_std):
+        c[zero_std[:, None] | zero_std[None, :]] = np.nan
 
     # Clip real and imaginary parts to [-1, 1].  This does not guarantee
     # abs(a[i,j]) <= 1 for complex arrays, but is the best we can do without

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -2872,6 +2872,29 @@ class TestCorrCoef:
         res = corrcoef(cast_A, dtype=test_type)
         assert test_type == res.dtype
 
+    def test_constant_vector(self):
+        # Regression test for gh-32446
+        # corrcoef should return NaN for constant vectors since
+        # Pearson correlation is undefined when either input has zero variance
+        x = np.ones(1448)
+        res = corrcoef(x)
+        assert np.isnan(res)
+
+        # Two constant vectors should also give NaN
+        y = np.ones(1448) * 2
+        res_xy = corrcoef(x, y)
+        assert np.all(np.isnan(res_xy))
+
+        # Mixed constant and non-constant should give NaN for the
+        # constant row/column
+        z = np.array([1, 2, 3, 4, 5])
+        res_xz = corrcoef(x[:5], z)
+        # First row/column should be NaN due to constant x
+        assert np.isnan(res_xz[0, 1])
+        assert np.isnan(res_xz[1, 0])
+        # But the correlation of z with itself should be 1
+        assert res_xz[1, 1] == 1.0
+
 
 class TestCov:
     x1 = np.array([[0, 2], [1, 1], [2, 0]]).T


### PR DESCRIPTION
Fixes #32446

Pearson correlation is undefined when either input has zero variance, so the mathematically expected result for constant columns is NaN.

This fix checks if either input has zero standard deviation and sets the correlation coefficient to NaN in that case, matching the behavior of pandas DataFrame.corr.