### PR TITLE
DOC: use static scipy doc site for intershpinx

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -419,7 +419,7 @@ texinfo_documents = [
 intersphinx_mapping = {
     'neps': ('https://numpy.org/neps', None),
     'python': ('https://docs.python.org/3', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy', None),
+    'scipy': ('https://static.scipy.org/doc/scipy', None),
     'matplotlib': ('https://matplotlib.org/stable', None),
     'imageio': ('https://imageio.readthedocs.io/en/stable', None),
     'skimage': ('https://scikit-image.org/docs/stable', None),


### PR DESCRIPTION
### PR summary
See https://github.com/scipy/docs.scipy.org/issues/102#issuecomment-5535454644.

This should (hopefully) fix the sporadic doc build failures we've been seeing the past few days.

#### AI Disclosure
No AI use
