### PR TITLE
ENH: Fix np.maximum and np.minimum for string arrays

### DIFF
--- a/doc/release/upcoming_changes/32504.improvement.rst
+++ b/doc/release/upcoming_changes/32504.improvement.rst
@@ -1,0 +1,6 @@
+``np.maximum``/``np.minimum`` now support string arrays
+---------------------------------------------------------
+np.maximum, np.minimum, np.max, np.min now work on arrays of dtype
+``bytes_`` and ``str_``, comparing elements lexicographically.
+Previously these ufuncs raised a ``TypeError`` for string dtypes even
+though comparisons, ``sort``, and ``argmax``/``argmin`` already worked.

--- a/numpy/_core/code_generators/ufunc_docstrings.py
+++ b/numpy/_core/code_generators/ufunc_docstrings.py
@@ -2530,6 +2530,9 @@ add_newdoc('numpy._core.umath', 'maximum',
     neither x1 nor x2 are nans, but it is faster and does proper
     broadcasting.
 
+    For string arrays (dtype ``bytes_`` or ``str_``), elements are compared
+    lexicographically; there is no concept of NaN for strings.
+
     Examples
     --------
     >>> import numpy as np
@@ -2589,6 +2592,9 @@ add_newdoc('numpy._core.umath', 'minimum',
     The minimum is equivalent to ``np.where(x1 <= x2, x1, x2)`` when
     neither x1 nor x2 are NaNs, but it is faster and does proper
     broadcasting.
+
+    For string arrays (dtype ``bytes_`` or ``str_``), elements are compared
+    lexicographically; there is no concept of NaN for strings.
 
     Examples
     --------

--- a/numpy/_core/src/umath/string_ufuncs.cpp
+++ b/numpy/_core/src/umath/string_ufuncs.cpp
@@ -100,6 +100,44 @@ string_comparison_loop(PyArrayMethod_Context *context,
 }
 
 
+enum class MINMAX { MIN, MAX };
+
+template <bool rstrip, MINMAX minmax, ENCODING enc>
+static int
+string_minmax_loop(PyArrayMethod_Context *context,
+        char *const data[], npy_intp const dimensions[],
+        npy_intp const strides[], NpyAuxData *NPY_UNUSED(auxdata))
+{
+    int elsize1 = context->descriptors[0]->elsize;
+    int elsize2 = context->descriptors[1]->elsize;
+    int outsize = context->descriptors[2]->elsize;
+
+    char *in1 = data[0];
+    char *in2 = data[1];
+    char *out = data[2];
+
+    npy_intp N = dimensions[0];
+
+    while (N--) {
+        Buffer<enc> buf1(in1, elsize1);
+        Buffer<enc> buf2(in2, elsize2);
+        Buffer<enc> outbuf(out, outsize);
+        int cmp = buf1.strcmp(buf2, rstrip);
+        Buffer<enc> &winner = (minmax == MINMAX::MIN)
+                ? (cmp <= 0 ? buf1 : buf2)
+                : (cmp >= 0 ? buf1 : buf2);
+        size_t winner_len = winner.num_codepoints();
+        winner.buffer_memcpy(outbuf, winner_len);
+        outbuf.buffer_fill_with_zeros_after_index(winner_len);
+
+        in1 += strides[0];
+        in2 += strides[1];
+        out += strides[2];
+    }
+    return 0;
+}
+
+
 template <ENCODING enc>
 static int
 string_str_len_loop(PyArrayMethod_Context *context,
@@ -771,6 +809,37 @@ string_addition_resolve_descriptors(
         return _NPY_ERROR_OCCURRED_IN_CAST;
     }
     loop_descrs[2]->elsize += loop_descrs[1]->elsize;
+
+    return NPY_NO_CASTING;
+}
+
+
+static NPY_CASTING
+string_minmax_resolve_descriptors(
+        PyArrayMethodObject *NPY_UNUSED(self),
+        PyArray_DTypeMeta *const NPY_UNUSED(dtypes[3]),
+        PyArray_Descr *const given_descrs[3],
+        PyArray_Descr *loop_descrs[3],
+        npy_intp *NPY_UNUSED(view_offset))
+{
+    loop_descrs[0] = NPY_DT_CALL_ensure_canonical(given_descrs[0]);
+    if (loop_descrs[0] == NULL) {
+        return _NPY_ERROR_OCCURRED_IN_CAST;
+    }
+
+    loop_descrs[1] = NPY_DT_CALL_ensure_canonical(given_descrs[1]);
+    if (loop_descrs[1] == NULL) {
+        Py_DECREF(loop_descrs[0]);
+        return _NPY_ERROR_OCCURRED_IN_CAST;
+    }
+
+    loop_descrs[2] = PyArray_DescrNew(loop_descrs[0]);
+    if (loop_descrs[2] == NULL) {
+        Py_DECREF(loop_descrs[0]);
+        Py_DECREF(loop_descrs[1]);
+        return _NPY_ERROR_OCCURRED_IN_CAST;
+    }
+    loop_descrs[2]->elsize = PyArray_MAX(loop_descrs[0]->elsize, loop_descrs[1]->elsize);
 
     return NPY_NO_CASTING;
 }
@@ -1508,6 +1577,32 @@ init_string_ufuncs(PyObject *umath)
             umath, "add", 2, 1, dtypes, ENCODING::UTF32,
             string_add_loop<ENCODING::UTF32>, string_addition_resolve_descriptors,
             NULL) < 0) {
+        return -1;
+    }
+
+    dtypes[0] = dtypes[1] = dtypes[2] = NPY_OBJECT;
+    if (init_ufunc(
+            umath, "minimum", 2, 1, dtypes, ENCODING::ASCII,
+            string_minmax_loop<false, MINMAX::MIN, ENCODING::ASCII>,
+            string_minmax_resolve_descriptors, NULL) < 0) {
+        return -1;
+    }
+    if (init_ufunc(
+            umath, "minimum", 2, 1, dtypes, ENCODING::UTF32,
+            string_minmax_loop<false, MINMAX::MIN, ENCODING::UTF32>,
+            string_minmax_resolve_descriptors, NULL) < 0) {
+        return -1;
+    }
+    if (init_ufunc(
+            umath, "maximum", 2, 1, dtypes, ENCODING::ASCII,
+            string_minmax_loop<false, MINMAX::MAX, ENCODING::ASCII>,
+            string_minmax_resolve_descriptors, NULL) < 0) {
+        return -1;
+    }
+    if (init_ufunc(
+            umath, "maximum", 2, 1, dtypes, ENCODING::UTF32,
+            string_minmax_loop<false, MINMAX::MAX, ENCODING::UTF32>,
+            string_minmax_resolve_descriptors, NULL) < 0) {
         return -1;
     }
 

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -115,6 +115,33 @@ def test_string_minmax_ufuncs(op, ufunc, name, dtypes):
     assert_array_equal(ufunc(arr2, arr), expected)
 
 
+@pytest.mark.parametrize(["op", "ufunc", "name"], MINMAX)
+def test_mixed_string_minmax_ufuncs_fail(op, ufunc, name):
+    arr_string = np.array(["a", "b"], dtype="S")
+    arr_unicode = np.array(["a", "c"], dtype="U")
+
+    with pytest.raises(TypeError, match="did not contain a loop"):
+        ufunc(arr_string, arr_unicode)
+
+    with pytest.raises(TypeError, match="did not contain a loop"):
+        ufunc(arr_unicode, arr_string)
+
+
+@pytest.mark.parametrize(["op", "ufunc", "name"], MINMAX)
+def test_mixed_string_minmax_ufuncs_with_cast(op, ufunc, name):
+    arr_string = np.array(["a", "b"], dtype="S")
+    arr_unicode = np.array(["a", "c"], dtype="U")
+
+    # While there is no loop, manual casting is acceptable:
+    res1 = ufunc(arr_string, arr_unicode, signature="UU->U", casting="unsafe")
+    res2 = ufunc(arr_string, arr_unicode, signature="SS->S", casting="unsafe")
+
+    expected = [op(d1, d2) for d1, d2 in
+                zip(arr_string.astype("U").tolist(), arr_unicode.tolist())]
+    assert_array_equal(res1, expected)
+    assert_array_equal(res2, np.array(expected, dtype="S"))
+
+
 @pytest.mark.parametrize("dt", ["S", "U"])
 def test_string_array_max_min(dt):
     # gh-1914: ndarray.max()/.min() reduce via np.maximum/np.minimum

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -94,6 +94,35 @@ def test_string_comparisons_empty(op, ufunc, sym, dtypes):
     )
 
 
+MINMAX = [
+    (min, np.minimum, "minimum"),
+    (max, np.maximum, "maximum"),
+]
+
+
+@pytest.mark.parametrize(["op", "ufunc", "name"], MINMAX)
+@pytest.mark.parametrize("dtypes", [
+        ("S2", "S2"), ("S2", "S10"),
+        ("<U1", "<U1"), ("<U1", ">U1"), (">U1", ">U1"),
+        ("<U1", "<U10"), ("<U1", ">U10")])
+def test_string_minmax_ufuncs(op, ufunc, name, dtypes):
+    # gh-1914
+    arr = np.array(["abc", "abd", "ab", "b", ""], dtype=dtypes[0])
+    arr2 = np.array(["abd", "abc", "abcd", "a", "a"], dtype=dtypes[1])
+
+    expected = [op(d1, d2) for d1, d2 in zip(arr.tolist(), arr2.tolist())]
+    assert_array_equal(ufunc(arr, arr2), expected)
+    assert_array_equal(ufunc(arr2, arr), expected)
+
+
+@pytest.mark.parametrize("dt", ["S", "U"])
+def test_string_array_max_min(dt):
+    # gh-1914: ndarray.max()/.min() reduce via np.maximum/np.minimum
+    arr = np.array(["ab", "cd", "ba"], dtype=dt)
+    assert arr.max() == arr.astype(object).max()
+    assert arr.min() == arr.astype(object).min()
+
+
 @pytest.mark.parametrize("str_dt", ["S", "U"])
 @pytest.mark.parametrize("float_dt", np.typecodes["AllFloat"])
 def test_float_to_string_cast(str_dt, float_dt):

--- a/numpy/lib/tests/test_arraypad.py
+++ b/numpy/lib/tests/test_arraypad.py
@@ -158,11 +158,23 @@ class TestConditionalShortcuts:
             result = np.pad(test, 0, mode="linear_ramp", end_values=1 + 2j)
         assert_array_equal(test, result)
 
-    @pytest.mark.parametrize("mode", ["maximum", "mean", "median", "minimum"])
+    @pytest.mark.parametrize("mode", ["mean", "median"])
     def test_zero_padding_stat_modes_validate_string_dtype(self, mode):
         test = np.array(["a", "b"])
         with pytest.raises(TypeError):
             np.pad(test, 0, mode=mode)
+
+    @pytest.mark.parametrize("mode", ["maximum", "minimum"])
+    @pytest.mark.parametrize("dt", ["U", "S"])
+    def test_zero_padding_minmax_modes_string_dtype(self, mode, dt):
+        # maximum/minimum ufuncs support string dtypes, so these stat
+        # modes now work rather than raising (see gh-32504).
+        test = np.array(["ab", "abc", "b"], dtype=dt)
+        result = np.pad(test, (1, 1), mode=mode)
+        pad = test.min() if mode == "minimum" else test.max()
+        assert result.dtype == test.dtype
+        assert_array_equal(
+            result, np.array([pad, "ab", "abc", "b", pad], dtype=dt))
 
     @pytest.mark.parametrize("mode", ["maximum", "mean", "median", "minimum"])
     def test_zero_padding_stat_modes_validate_object_dtype(self, mode):


### PR DESCRIPTION

### PR summary
Adds ufuncs for minimum/maximum of string dtypes. Fixes gh-1914.

`np.maximum` and `np.minimum` had no ufunc loops for `'S'`/`'U'` dtype, so `ndarray.max()`/`.min()` would fail on string arrays, even though comparisons, `sort`, and `argmax`/`argmin` all worked. This PR adds templated loops alongside the existing string comparison ufuncs (following gh-21041), reusing the same `Buffer`/`strcmp` machinery.

#### AI Disclosure
I used claude to outline and first-draft the fix, and to draft docstings and  tests.  I checked all its work.  I verified the tests fail on an unpatched numpy and pass with the fix.
