### PR TITLE
DOC: use static scipy doc site for intershpinx (#32503)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -419,7 +419,8 @@ texinfo_documents = [
 intersphinx_mapping = {
     'neps': ('https://numpy.org/neps', None),
     'python': ('https://docs.python.org/3', None),
-    'scipy': ('https://static.scipy.org/doc/scipy', None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/",
+              "https://static.scipy.org/doc/scipy/objects.inv"),
     'matplotlib': ('https://matplotlib.org/stable', None),
     'imageio': ('https://imageio.readthedocs.io/en/stable', None),
     'skimage': ('https://scikit-image.org/docs/stable', None),

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -419,7 +419,7 @@ texinfo_documents = [
 intersphinx_mapping = {
     'neps': ('https://numpy.org/neps', None),
     'python': ('https://docs.python.org/3', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy', None),
+    'scipy': ('https://static.scipy.org/doc/scipy', None),
     'matplotlib': ('https://matplotlib.org/stable', None),
     'imageio': ('https://imageio.readthedocs.io/en/stable', None),
     'skimage': ('https://scikit-image.org/docs/stable', None),


### PR DESCRIPTION
Backport of #32503 and #32507.

### PR summary
See https://github.com/scipy/docs.scipy.org/issues/102#issuecomment-5535454644.

This should (hopefully) fix the sporadic doc build failures we've been seeing the past few days.

#### AI Disclosure
No AI use
