### PR TITLE
DOC: fix scipy docs links in intersphinx mapping

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -419,7 +419,8 @@ texinfo_documents = [
 intersphinx_mapping = {
     'neps': ('https://numpy.org/neps', None),
     'python': ('https://docs.python.org/3', None),
-    'scipy': ('https://static.scipy.org/doc/scipy', None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/",
+              "https://static.scipy.org/doc/scipy/objects.inv"),
     'matplotlib': ('https://matplotlib.org/stable', None),
     'imageio': ('https://imageio.readthedocs.io/en/stable', None),
     'skimage': ('https://scikit-image.org/docs/stable', None),


### PR DESCRIPTION
### PR summary
Followup for #32503, taking the advice from https://github.com/scipy/docs.scipy.org/issues/102#issuecomment-5547829643

I manually verified that scipy intersphinx links are correct with this applied.

#### AI Disclosure
No AI use