### PR TITLE
BUG: fix crash in ufunc.resolve_dtypes with a Python scalar type (#32496)

### DIFF
--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -410,9 +410,12 @@ npy_update_operand_for_scalar(
          * in all other cases, we don't technically consider equivalent.
          * NOTE(seberg): I don't think we should be beholden to this logic.
          */
+        const char *name = (scalar != NULL) ? Py_TYPE(scalar)->tp_name :
+                ((PyArray_FLAGS(*operand) & NPY_ARRAY_WAS_PYTHON_INT) ? "int" :
+                 ((PyArray_FLAGS(*operand) & NPY_ARRAY_WAS_PYTHON_FLOAT) ? "float" : "complex"));
         PyErr_Format(PyExc_TypeError,
             "cannot cast Python %s to %S under the casting rule 'equiv'",
-            Py_TYPE(scalar)->tp_name, descr);
+            name, descr);
         return -1;
     }
 

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -3256,6 +3256,13 @@ class TestLowlevelAPIAccess:
         r = np.add.resolve_dtypes((f4, int, None))
         assert r == (f4, f4, f4)
 
+        msg = r"cannot cast Python.*under the casting rule 'equiv'"
+        for pytype, dtype in [(int, "uint8"), (float, "float32"),
+                              (complex, "complex64")]:
+            with pytest.raises(TypeError, match=msg):
+                np.add.resolve_dtypes((np.dtype(dtype), pytype, None),
+                                      casting="equiv")
+
         with pytest.raises(TypeError):
             np.add.resolve_dtypes((i4, f4, None), casting="no")
 


### PR DESCRIPTION
Backport of #32496.

### PR summary
The Python `ufunc.resolve_dtypes` helper calls into this function without passing an explicit scalar object. This leads to a null-pointer dereference crash generating the error message for any of the cases in the test I added.

The fix is to check the operand flags if the scalar is NULL.

#### AI Disclosure
An AI model found the bug. I wrote the fix and had the model review it.
