### PR TITLE
BUG: apply NEP 50 scalar rules in concatenate and choose, and make casting="no" match "equiv"

### DIFF
--- a/doc/release/upcoming_changes/32497.compatibility.rst
+++ b/doc/release/upcoming_changes/32497.compatibility.rst
@@ -1,0 +1,15 @@
+Python scalars in ``concatenate`` and ``choose`` follow NEP 50 value rules
+--------------------------------------------------------------------------
+`numpy.concatenate` with ``axis=None`` and `numpy.choose` now convert Python
+scalars with the result dtype, as ufuncs and `numpy.copyto` do. A Python
+integer that does not fit the result dtype raises ``OverflowError`` instead of
+wrapping. For example, ``np.concatenate((np.ones(2, "int8"), 300), axis=None)``
+previously returned ``44`` for the new element.
+
+``casting="no"`` rejects a Python scalar that changes dtype
+-----------------------------------------------------------
+A Python scalar that would be converted to a dtype other than its default
+(``int64``, ``float64`` or ``complex128``) or ``object`` now raises
+``TypeError`` under ``casting="no"``, as it already did under
+``casting="equiv"``. This applies to ufuncs, `numpy.copyto` and
+`numpy.concatenate`.

--- a/doc/release/upcoming_changes/32497.improvement.rst
+++ b/doc/release/upcoming_changes/32497.improvement.rst
@@ -1,0 +1,8 @@
+Cast safety of Python scalars is applied uniformly
+--------------------------------------------------
+The ``casting`` argument treats a Python ``int``, ``float`` or ``complex`` by
+its kind in ufuncs, `numpy.copyto`, `numpy.concatenate` and `numpy.choose`.
+An ``int`` into any integer dtype or a ``float`` into any floating point dtype
+is "safe", lowering the kind requires ``"unsafe"``, and a value that does not
+fit raises ``OverflowError``. These rules are now documented in
+:ref:`arrays.promotion.python-scalar-casting`.

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -288,6 +288,9 @@ Glossary
          casts within a kind, like float64 to float32.
        - ``unsafe``: any data conversions may be done.
 
+       Python ``int``, ``float`` and ``complex`` scalars are treated by kind
+       rather than by dtype, see :ref:`arrays.promotion.python-scalar-casting`.
+
    column-major
        See `Row- and column-major order <https://en.wikipedia.org/wiki/Row-_and_column-major_order>`_.
 

--- a/doc/source/reference/arrays.promotion.rst
+++ b/doc/source/reference/arrays.promotion.rst
@@ -132,6 +132,44 @@ overflows:
 Note that NumPy warns when overflows occur for scalars, but not for arrays;
 e.g., ``np.array(100, dtype=np.uint8) + 100`` will *not* warn.
 
+.. _arrays.promotion.python-scalar-casting:
+
+Cast safety of Python scalars
+-----------------------------
+The ``casting`` argument of ufuncs, `numpy.copyto` and `numpy.concatenate`
+treats a Python ``int``, ``float`` or ``complex`` by its kind, since the
+scalar has no precision of its own. Converting a Python ``int`` to any NumPy
+integer dtype or a Python ``float`` to any NumPy floating point dtype counts
+as "safe", even though the value may not fit or may lose precision. An
+integer that does not fit raises ``OverflowError`` on conversion, as shown
+above, while a ``float`` is rounded to the lower precision, or overflows to
+``inf`` with a ``RuntimeWarning``. Lowering the kind, such as a Python
+``float`` into an integer dtype, requires ``casting="unsafe"``.
+
+  >>> arr_int8 = np.array([1, 2], dtype=np.int8)
+  >>> np.concatenate((arr_int8, 3), axis=None, casting="safe")
+  array([1, 2, 3], dtype=int8)
+  >>> np.copyto(arr_int8, 300, casting="safe")
+  Traceback (most recent call last):
+    ...
+  OverflowError: Python integer 300 out of bounds for int8
+  >>> np.copyto(arr_int8, 3.0, casting="same_kind")
+  Traceback (most recent call last):
+    ...
+  TypeError: Cannot cast scalar from dtype('float64') to dtype('int8') according to the rule 'same_kind'
+
+Under ``casting="equiv"`` and ``casting="no"`` a Python scalar must convert
+to its default dtype (``int64``, ``float64`` or ``complex128``) or to
+``object``; any other conversion raises ``TypeError``:
+
+  >>> np.copyto(np.array([1, 2]), 3, casting="no")
+  >>> np.copyto(arr_int8, 3, casting="no")
+  Traceback (most recent call last):
+    ...
+  TypeError: cannot cast Python int to int8 under the casting rule 'no'
+
+`numpy.can_cast` does not accept Python scalars.
+
 Numerical promotion
 -------------------
 

--- a/numpy/_core/src/multiarray/abstractdtypes.c
+++ b/numpy/_core/src/multiarray/abstractdtypes.c
@@ -10,6 +10,7 @@
 
 #include "dtypemeta.h"
 #include "abstractdtypes.h"
+#include "convert_datatype.h"
 #include "array_coercion.h"
 #include "common.h"
 #include "npy_pycompat.h"
@@ -373,20 +374,14 @@ npy_update_operand_for_scalar(
             return 0;
         }
     }
-    else if (NPY_UNLIKELY(casting == NPY_EQUIV_CASTING) &&
+    else if (NPY_UNLIKELY(casting <= NPY_EQUIV_CASTING) &&
              descr->type_num != NPY_OBJECT) {
-        /*
-         * incredibly niche, but users could pass equiv casting and we
-         * actually need to cast.  Let object pass (technically correct) but
-         * in all other cases, we don't technically consider equivalent.
-         * NOTE(seberg): I don't think we should be beholden to this logic.
-         */
         const char *name = (scalar != NULL) ? Py_TYPE(scalar)->tp_name :
                 ((PyArray_FLAGS(*operand) & NPY_ARRAY_WAS_PYTHON_INT) ? "int" :
                  ((PyArray_FLAGS(*operand) & NPY_ARRAY_WAS_PYTHON_FLOAT) ? "float" : "complex"));
         PyErr_Format(PyExc_TypeError,
-            "cannot cast Python %s to %S under the casting rule 'equiv'",
-            name, descr);
+            "cannot cast Python %s to %S under the casting rule %s",
+            name, descr, npy_casting_to_string(casting));
         return -1;
     }
 
@@ -406,32 +401,35 @@ npy_update_operand_for_scalar(
 
 
 /*
- * If `*operand` (converted from item `i` of sequence `op`) is marked with
- * NPY_ARRAY_WAS_PYTHON_STR, convert it again from the original str once the
- * operation's target descriptor is known, so that the fixed-width unicode
- * temporary cannot lose trailing nulls.
+ * If `*operand` (converted from item `i` of sequence `op`) is marked as a
+ * Python int, float, complex or str, convert it again from the original
+ * object once the operation's target descriptor is known, with the same
+ * rules as ufuncs and `copyto`.
  */
 NPY_NO_EXPORT int
-npy_update_operand_if_pystr(
+npy_update_operand_if_pyscalar(
     PyArrayObject **operand, PyObject *op, Py_ssize_t i,
-    PyArray_Descr *target)
+    PyArray_Descr *target, NPY_CASTING casting)
 {
-    if (!(PyArray_FLAGS(*operand) & NPY_ARRAY_WAS_PYTHON_STR)) {
+    if (!(PyArray_FLAGS(*operand) &
+            (NPY_ARRAY_WAS_PYTHON_LITERAL | NPY_ARRAY_WAS_PYTHON_STR))) {
         return 0;
     }
     PyObject *scalar = PySequence_GetItem(op, i);
     if (scalar == NULL) {
         return -1;
     }
+    PyArray_DTypeMeta *DType = NPY_DTYPE(PyArray_DESCR(*operand));
+    Py_INCREF(DType);
+    npy_mark_tmp_array_if_pyscalar(scalar, *operand, &DType);
     PyArray_Descr *descr = npy_find_descr_for_scalar(
-            scalar, PyArray_DESCR(*operand),
-            NPY_DTYPE(PyArray_DESCR(*operand)), NPY_DTYPE(target));
+            scalar, PyArray_DESCR(*operand), DType, NPY_DTYPE(target));
+    Py_DECREF(DType);
     if (descr == NULL) {
         Py_DECREF(scalar);
         return -1;
     }
-    int res = npy_update_operand_for_scalar(
-            operand, scalar, descr, NPY_SAFE_CASTING);
+    int res = npy_update_operand_for_scalar(operand, scalar, descr, casting);
     Py_DECREF(scalar);
     Py_DECREF(descr);
     return res;

--- a/numpy/_core/src/multiarray/abstractdtypes.h
+++ b/numpy/_core/src/multiarray/abstractdtypes.h
@@ -103,9 +103,9 @@ npy_update_operand_for_scalar(
 
 
 NPY_NO_EXPORT int
-npy_update_operand_if_pystr(
+npy_update_operand_if_pyscalar(
     PyArrayObject **operand, PyObject *op, Py_ssize_t i,
-    PyArray_Descr *target);
+    PyArray_Descr *target, NPY_CASTING casting);
 
 
 NPY_NO_EXPORT PyArray_Descr *

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -2035,7 +2035,8 @@ PyArray_ConvertToCommonType(PyObject *op, int *retn)
     for (i = 0; i < n; i++) {
         int flags = NPY_ARRAY_CARRAY;
 
-        if (npy_update_operand_if_pystr(&mps[i], op, i, common_descr) < 0) {
+        if (npy_update_operand_if_pyscalar(&mps[i], op, i, common_descr,
+                                           NPY_SAFE_CASTING) < 0) {
             goto fail;
         }
 

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -532,9 +532,8 @@ PyArray_ConcatenateArrays(int narrays, PyArrayObject **arrays, int axis,
 
 /*
  * Concatenates a list of ndarrays, flattening each in the specified order.
- * `op` is the sequence `arrays` were converted from; any exact Python str in
- * it is converted again with the result descriptor so that trailing nulls
- * survive.
+ * `op` is the sequence `arrays` were converted from; any Python scalar in it
+ * is converted again with the result descriptor.
  */
 NPY_NO_EXPORT PyArrayObject *
 PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
@@ -621,8 +620,8 @@ PyArray_ConcatenateFlattenedArrays(int narrays, PyArrayObject **arrays,
     }
 
     for (iarrays = 0; iarrays < narrays; ++iarrays) {
-        if (npy_update_operand_if_pystr(&arrays[iarrays], op, iarrays,
-                                        PyArray_DESCR(ret)) < 0) {
+        if (npy_update_operand_if_pyscalar(&arrays[iarrays], op, iarrays,
+                                           PyArray_DESCR(ret), casting) < 0) {
             Py_DECREF(sliding_view);
             Py_DECREF(ret);
             return NULL;

--- a/numpy/_core/tests/test_api.py
+++ b/numpy/_core/tests/test_api.py
@@ -470,11 +470,18 @@ def test_copyto_cast_safety():
     np.copyto(np.arange(3., dtype="float32"), 3., casting="safe")
 
     # But not equiv:
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="under the casting rule 'equiv'"):
         np.copyto(np.arange(3, dtype="uint8"), 3, casting="equiv")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="under the casting rule 'equiv'"):
         np.copyto(np.arange(3., dtype="float32"), 3., casting="equiv")
+
+    # and neither "no", which is stricter:
+    np.copyto(np.arange(3), 3, casting="no")
+    with pytest.raises(TypeError, match="under the casting rule 'no'"):
+        np.copyto(np.arange(3, dtype="uint8"), 3, casting="no")
+    with pytest.raises(TypeError, match="under the casting rule 'no'"):
+        np.copyto(np.arange(3., dtype="float32"), 3., casting="no")
 
     # As a special thing, object is equiv currently:
     np.copyto(np.arange(3, dtype=object), 3, casting="equiv")

--- a/numpy/_core/tests/test_multiarray.py
+++ b/numpy/_core/tests/test_multiarray.py
@@ -8811,13 +8811,21 @@ class TestChoose:
         assert_equal(A, [[2, 2, 3], [2, 2, 3]])
 
     @pytest.mark.parametrize("ops",
-        [(1000, np.array([1], dtype=np.uint8)),
-         (-1, np.array([1], dtype=np.uint8)),
+        [(100, np.array([1], dtype=np.uint8)),
+         (-1, np.array([1], dtype=np.int8)),
          (1., np.float32(3)),
          (1., np.array([3], dtype=np.float32))],)
     def test_output_dtype(self, ops):
         expected_dt = np.result_type(*ops)
         assert np.choose([0], ops).dtype == expected_dt
+
+    @pytest.mark.parametrize("scalar", [1000, -1])
+    def test_pyscalar_out_of_bounds(self, scalar):
+        arr = np.array([1], dtype=np.uint8)
+        with pytest.raises(OverflowError):
+            np.choose([0], (scalar, arr))
+        with pytest.raises(OverflowError):
+            np.choose([1], (arr, scalar))
 
     def test_dimension_and_args_limit(self):
         # Maxdims for the legacy iterator is 32, but the maximum number

--- a/numpy/_core/tests/test_shape_base.py
+++ b/numpy/_core/tests/test_shape_base.py
@@ -441,6 +441,61 @@ class TestConcatenate:
         with assert_raises(TypeError):
             concatenate(to_concat, out=out, dtype=out_dtype, axis=axis)
 
+    @pytest.mark.parametrize("scalar, dtype",
+        [(300, "int8"), (-1, "uint8"), (2**64, "int64")])
+    def test_pyscalar_out_of_bounds(self, scalar, dtype):
+        arr = np.ones(2, dtype=dtype)
+        with pytest.raises(OverflowError):
+            concatenate((arr, scalar), axis=None)
+        with pytest.raises(OverflowError):
+            concatenate((scalar, arr), axis=None, out=np.empty(3, dtype=dtype))
+
+    @pytest.mark.parametrize("scalar, dtype",
+        [(3, "uint8"), (3, "float32"), (3.0, "float32"), (3.0, "complex64"),
+         (300, "int8"), (3.0, "int64"), (1j, "float64"), (3, bool),
+         (3, object), ("x", np.dtypes.StringDType()), ("x", "U5")])
+    @pytest.mark.parametrize("casting",
+        ["no", "equiv", "safe", "same_kind", "unsafe"])
+    def test_pyscalar_casting_matches_copyto(self, scalar, dtype, casting):
+        # dtype= fixes the result so that only the scalar's conversion differs
+        arr = np.ones(2, dtype=dtype)
+
+        def outcome(func):
+            try:
+                return func()
+            except Exception as e:
+                return type(e)
+
+        dst = arr.copy()
+        expected = outcome(lambda: np.copyto(dst, scalar, casting=casting))
+        res = outcome(lambda: concatenate(
+                (arr, scalar), axis=None, dtype=arr.dtype, casting=casting))
+        if isinstance(expected, type):
+            assert res is expected
+        else:
+            assert_array_equal(res, np.array([1, 1, dst[0]], dtype=arr.dtype))
+
+    @pytest.mark.parametrize("scalar, dtype",
+        [(3, "uint8"), (3, "float32"), (3.0, "float32"), (3.0, "complex64"),
+         (300, "int8"), (3, object), ("x", np.dtypes.StringDType())])
+    @pytest.mark.parametrize("casting",
+        ["no", "equiv", "safe", "same_kind", "unsafe"])
+    def test_pyscalar_casting_matches_ufunc(self, scalar, dtype, casting):
+        arr = np.ones(2, dtype=dtype)
+
+        def outcome(func):
+            try:
+                return func()
+            except Exception as e:
+                return type(e)
+
+        expected = outcome(lambda: np.copyto(arr.copy(), scalar, casting=casting))
+        res = outcome(lambda: np.add(arr, scalar, casting=casting))
+        if isinstance(expected, type):
+            assert res is expected
+        else:
+            assert res.dtype == arr.dtype
+
     @pytest.mark.parametrize("axis", [None, 0])
     @pytest.mark.parametrize("string_dt", ["S", "U", "S0", "U0"])
     @pytest.mark.parametrize("arrs",

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -346,11 +346,6 @@ def test_pystr_scalar_concatenate_preserves_nulls(dtype):
     res = np.concatenate((scalar,), axis=None, dtype=dtype)
     assert res[0] == scalar
 
-    # like a Python int, the str is not cast, so any casting rule allows it
-    for casting in ["no", "equiv", "safe", "same_kind", "unsafe"]:
-        res = np.concatenate((arr, "z"), axis=None, casting=casting)
-        assert res[1] == "z"
-
 
 def test_pystr_scalar_choose_preserves_nulls(dtype):
     scalar = "x\0"

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -640,6 +640,8 @@ class TestUfunc:
         with pytest.raises(TypeError):
             # We accept python float as float64 but not float32 for equiv.
             ufunc(3., 4., dtype="float32", casting="equiv")
+        with pytest.raises(TypeError):
+            ufunc(3., 4., dtype="float32", casting="no")
 
         # Special case for object and equal (note that equiv implies safe)
         ufunc(3, 4, dtype=object, casting="equiv")
@@ -3290,12 +3292,13 @@ class TestLowlevelAPIAccess:
         r = np.add.resolve_dtypes((f4, int, None))
         assert r == (f4, f4, f4)
 
-        msg = r"cannot cast Python.*under the casting rule 'equiv'"
+        msg = r"cannot cast Python.*under the casting rule '{}'"
         for pytype, dtype in [(int, "uint8"), (float, "float32"),
                               (complex, "complex64")]:
-            with pytest.raises(TypeError, match=msg):
-                np.add.resolve_dtypes((np.dtype(dtype), pytype, None),
-                                      casting="equiv")
+            for casting in ["equiv", "no"]:
+                with pytest.raises(TypeError, match=msg.format(casting)):
+                    np.add.resolve_dtypes((np.dtype(dtype), pytype, None),
+                                          casting=casting)
 
         with pytest.raises(TypeError):
             np.add.resolve_dtypes((i4, f4, None), casting="no")


### PR DESCRIPTION
Closes #32491

## Problem & Background
In ufuncs and `np.copyto`, passing `casting="no"` with a Python scalar whose target dtype differs from its default dtype (e.g. `int64` for Python `int`, `float64` for Python `float`) was previously accepted, while `casting="equiv"` raised a `TypeError`:

>>> np.copyto(np.zeros(3, dtype="uint8"), 3, casting="no")      # SUCCEEDED
>>> np.copyto(np.zeros(3, dtype="uint8"), 3, casting="equiv")   # FAILED with TypeError

Because "no" casting is strictly more restrictive than "equiv", "no" should never succeed where "equiv" fails.

Root Cause
In numpy/_core/src/multiarray/abstractdtypes.c, npy_update_operand_for_scalar specifically checked for casting == NPY_EQUIV_CASTING. When casting == NPY_NO_CASTING was passed, it fell through, recreated the temporary array with the target descriptor, and the subsequent cast-safety check compared identical dtypes.

Additionally:

np.concatenate(axis=None) and np.choose did not convert Python scalars using NEP 50 value bounds, causing out-of-bounds integers to silently wrap instead of raising OverflowError (e.g., np.concatenate((np.ones(2, "int8"), 300), axis=None) returned 44 for 300).
In abstractdtypes.c, npy_update_operand_if_pystr was only handling Python str, but the same scalar re-conversion logic was needed for all Python literals/scalars (NPY_ARRAY_WAS_PYTHON_LITERAL).
Changes Made

1. Multiarray Core C Engine

abstractdtypes.c:
Included convert_datatype.h for npy_casting_to_string.
Changed condition in npy_update_operand_for_scalar from casting == NPY_EQUIV_CASTING to casting <= NPY_EQUIV_CASTING, rejecting both "no" and "equiv" when the scalar's default dtype does not match the target. Formatted the exception message dynamically using npy_casting_to_string(casting).
Generalized npy_update_operand_if_pystr to npy_update_operand_if_pyscalar, handling NPY_ARRAY_WAS_PYTHON_LITERAL | NPY_ARRAY_WAS_PYTHON_STR and forwarding the operation's casting argument.

abstractdtypes.h:
Updated prototype for npy_update_operand_if_pyscalar.

convert_datatype.c:
Updated PyArray_ConvertToCommonType (used in np.choose) to call npy_update_operand_if_pyscalar(&mps[i], op, i, common_descr, NPY_SAFE_CASTING).

multiarraymodule.c:
Updated PyArray_ConcatenateFlattenedArrays (np.concatenate(..., axis=None)) to call npy_update_operand_if_pyscalar(&arrays[iarrays], op, iarrays, PyArray_DESCR(ret), casting).

2. Documentation & Release Notes
Added Towncrier release notes:
doc/release/upcoming_changes/32497.compatibility.rst
doc/release/upcoming_changes/32497.improvement.rst
Updated doc/source/glossary.rst casting definition with reference to scalar rules.
Added a dedicated section Cast safety of Python scalars in doc/source/reference/arrays.promotion.rst documenting kind-based promotion, precision loss, out-of-bounds OverflowError, and "no" / "equiv" restrictions.

3. Unit Tests
test_api.py: Added assertions in test_copyto_cast_safety verifying that casting="no" raises TypeError when target dtypes differ.
test_multiarray.py: Fixed in-bounds scalar values in test_output_dtype and added test_pyscalar_out_of_bounds for np.choose.
test_shape_base.py: Added test_pyscalar_out_of_bounds, test_pyscalar_casting_matches_copyto, and test_pyscalar_casting_matches_ufunc.
test_stringdtype.py: Removed obsolete assertions in test_pystr_scalar_concatenate_preserves_nulls that expected "no" and "equiv" to succeed for Python strings.
test_ufunc.py: Added casting="no" tests for scalar operands in test_cast_safety_scalar and test_resolve_dtypes_basic.

Result
1) Consistent Casting Rules:
casting="no" and casting="equiv" now behave consistently: if converting a scalar to a non-default dtype fails under "equiv", it also fails under "no".

>>> np.copyto(np.zeros(3, dtype="uint8"), 3, casting="no")
TypeError: cannot cast Python int to uint8 under the casting rule 'no'

2) Safe Python Scalar Handling in concatenate and choose:
Out-of-bounds scalar values now consistently raise OverflowError rather than silently overflowing or wrapping:

>>> np.concatenate((np.ones(2, "int8"), 300), axis=None)
OverflowError: Python integer 300 out of bounds for int8

>>> np.choose([0], (-1, np.array([1], dtype=np.uint8)))
OverflowError: Python integer -1 out of bounds for uint8

Full Parity Across Operations:
np.concatenate(axis=None), np.choose, np.copyto, and ufuncs now share the exact same scalar casting and conversion behavior.