### PR TITLE
REL: Prepare for the NumPy 2.5.3 release

### DIFF
--- a/doc/changelog/2.5.3-changelog.rst
+++ b/doc/changelog/2.5.3-changelog.rst
@@ -1,38 +1,3 @@
-.. currentmodule:: numpy
-
-=========================
-NumPy 2.5.3 Release Notes
-=========================
-
-The NumPy 2.5.3 is a patch release that fixes bugs discovered after the 2.5.2
-release. Apart from the usual bug and maintenance work, there are a number of
-StringDType related fixes for problems discovered during the ongoing string
-work in the main branch.
-
-This release supports Python versions 3.12-3.15
-
-
-Changes
-=======
-
-* Casting a fixed-width byte string array (``np.bytes_``) to ``StringDType``
-  now raises ``TypeError`` when the bytes are not valid UTF-8. Previously the
-  invalid bytes were stored as-is and later caused undefined behavior in
-  string operations.
-
-  (`gh-32296 <https://github.com/numpy/numpy/pull/32296>`__)
-
-* ``MaskedArray._fill_value`` would become stale when ufuncs that change dtype
-  left the result holding a fill_value typed for the old dtype. The mismatch
-  was silent until something later called ``_check_fill_value``, such as
-  ``.view()``, and then a ``TypeError`` would be raised.  Now, when the copied
-  fill_value is no longer valid for the new dtype, fall back to the
-  default fill_value for that dtype instead of propagating the stale value.
-  This may raise a ``ComplexWarning`` if the fill_value is complex and the
-  new dtype is real.
-
-  (`gh-32423 <https://github.com/numpy/numpy/pull/32423>`__)
-
 
 Contributors
 ============
@@ -49,7 +14,6 @@ names contributed a patch for the first time.
 * Nathan Goldbaum
 * Shikhar Goel +
 * Yeonho Kim +
-
 
 Pull requests merged
 ====================

--- a/doc/release/upcoming_changes/32296.change.rst
+++ b/doc/release/upcoming_changes/32296.change.rst
@@ -1,4 +1,0 @@
-* Casting a fixed-width byte string array (``np.bytes_``) to ``StringDType``
-  now raises ``TypeError`` when the bytes are not valid UTF-8. Previously the
-  invalid bytes were stored as-is and later caused undefined behavior in
-  string operations.

--- a/doc/release/upcoming_changes/32423.change.rst
+++ b/doc/release/upcoming_changes/32423.change.rst
@@ -1,8 +1,0 @@
-`MaskedArray._fill_value` would become stale when ufuncs that change dtype
-left the result holding a fill_value typed for the old dtype. The mismatch
-was silent until something later called `_check_fill_value`, such as
-`.view()`, and then a `TypeError` would be raised.  Now, when the copied
-fill_value is no longer valid for the new dtype, fall back to the
-default fill_value for that dtype instead of propagating the stale value.
-This can now raise a `ComplexWarning` if the fill_value is complex and the
-new dtype is real.

--- a/requirements/ci32_requirements.txt
+++ b/requirements/ci32_requirements.txt
@@ -1,3 +1,3 @@
 spin
 # Keep this in sync with ci_requirements.txt
-scipy-openblas32==0.3.33.112.0
+scipy-openblas32==0.3.34.106.0

--- a/requirements/ci_requirements.txt
+++ b/requirements/ci_requirements.txt
@@ -1,4 +1,4 @@
 spin
 # Keep this in sync with ci32_requirements.txt
-scipy-openblas32==0.3.33.112.0
-scipy-openblas64==0.3.33.112.0
+scipy-openblas32==0.3.34.106.0
+scipy-openblas64==0.3.34.106.0


### PR DESCRIPTION
* Create 2.5.3-changelog.rst
* Update 2.5.3-notes.rst
* Update openblas to 0.3.34.106.0
* Delete release fragments.

No AI