### PR TITLE
BUG: restore MSVC complex typedefs for icx on Windows

### DIFF
--- a/numpy/_core/include/numpy/npy_common.h
+++ b/numpy/_core/include/numpy/npy_common.h
@@ -392,11 +392,11 @@ typedef struct
 #include <complex.h>
 
 
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__INTEL_LLVM_COMPILER)
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 typedef _Dcomplex npy_cdouble;
 typedef _Fcomplex npy_cfloat;
 typedef _Lcomplex npy_clongdouble;
-#else /* !defined(_MSC_VER) || defined(__INTEL_COMPILER) && !defined(__INTEL_LLVM_COMPILER) */
+#else /* !defined(_MSC_VER) || defined(__INTEL_COMPILER) */
 typedef double _Complex npy_cdouble;
 typedef float _Complex npy_cfloat;
 typedef longdouble_t _Complex npy_clongdouble;


### PR DESCRIPTION
## Summary
After gh-31389, `npy_common.h` excludes `__INTEL_LLVM_COMPILER` from the `_MSC_VER` branch, so icx on Windows gets `double _Complex` for `npy_cdouble` while `npy_math.h` still calls UCRT `creal`/`cimag` (which expect `_Dcomplex`). Including `<numpy/npy_math.h>` alone then fails to compile.

This restores the 2.4.4 typedef selection in `npy_common.h` (drop the `__INTEL_LLVM_COMPILER` exclusion), matching the small back-portable fix preferred in the issue discussion. The `meson.build` part of gh-31389 is left alone.

## Test plan
- [ ] Confirm the C typedef branch for `_MSC_VER && !__INTEL_COMPILER` again selects `_Dcomplex` / `_Fcomplex` / `_Lcomplex` (including when `__INTEL_LLVM_COMPILER` is defined)
- [ ] Downstream/icx header include of `<numpy/npy_math.h>` on Windows should compile again (repro from #32482)

Fixes #32482