### PR TITLE
ENH: Immortalize builtin constants on free-threaded build

### DIFF
--- a/doc/release/upcoming_changes/32513.performance.rst
+++ b/doc/release/upcoming_changes/32513.performance.rst
@@ -1,6 +1,6 @@
 Better multithreaded scaling of ufunc calls on free-threaded Python
 -------------------------------------------------------------------
-On free-threaded builds, the builtin ufuncs and DType classes are now
-immortal, which removes reference count contention between threads calling
-ufuncs concurrently. Small-array ufunc calls now scale nearly linearly with
-the number of threads.
+On free-threaded builds, the builtin ufuncs, DType classes and float
+constants such as ``np.pi`` are now immortal, which removes reference count
+contention between threads using them concurrently. Small-array ufunc calls
+now scale nearly linearly with the number of threads.

--- a/doc/release/upcoming_changes/32513.performance.rst
+++ b/doc/release/upcoming_changes/32513.performance.rst
@@ -2,5 +2,4 @@ Better multithreaded scaling of ufunc calls on free-threaded Python
 -------------------------------------------------------------------
 On free-threaded builds, the builtin ufuncs, DType classes and float
 constants such as ``np.pi`` are now immortal, which removes reference count
-contention between threads using them concurrently. Small-array ufunc calls
-now scale nearly linearly with the number of threads.
+contention between threads using them concurrently.

--- a/doc/release/upcoming_changes/32513.performance.rst
+++ b/doc/release/upcoming_changes/32513.performance.rst
@@ -1,0 +1,6 @@
+Better multithreaded scaling of ufunc calls on free-threaded Python
+-------------------------------------------------------------------
+On free-threaded builds, the builtin ufuncs and DType classes are now
+immortal, which removes reference count contention between threads calling
+ufuncs concurrently. Small-array ufunc calls now scale nearly linearly with
+the number of threads.

--- a/doc/release/upcoming_changes/32513.performance.rst
+++ b/doc/release/upcoming_changes/32513.performance.rst
@@ -1,5 +1,5 @@
 Better multithreaded scaling of ufunc calls on free-threaded Python
 -------------------------------------------------------------------
-On free-threaded builds, the builtin ufuncs, DType classes and float
-constants such as ``np.pi`` are now immortal, which removes reference count
-contention between threads using them concurrently.
+On free-threaded builds, the builtin ufuncs and float constants such
+as ``np.pi`` are now immortal, which removes reference count contention
+between threads using them concurrently.

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -4667,6 +4667,14 @@ set_typeinfo(PyObject *dict)
     if (dtypemeta == NULL) {
         return -1;
     }
+#if defined(Py_GIL_DISABLED) && PY_VERSION_HEX >= 0x030e0000
+    /* Avoid refcount contention; a type is never uniquely referenced
+     * (its __mro__ points back at it), so PyUnstable_SetImmortal can't be used. */
+    {
+        PyAPI_FUNC(void) _Py_SetImmortal(PyObject *op);
+        _Py_SetImmortal((PyObject *)dtypemeta);
+    }
+#endif
     NPY_DT_SLOTS(dtypemeta)->setitem = @NAME@_setitem;
     NPY_DT_SLOTS(dtypemeta)->get_constant = @NAME@_get_constant;
 

--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -4667,14 +4667,6 @@ set_typeinfo(PyObject *dict)
     if (dtypemeta == NULL) {
         return -1;
     }
-#if defined(Py_GIL_DISABLED) && PY_VERSION_HEX >= 0x030e0000
-    /* Avoid refcount contention; a type is never uniquely referenced
-     * (its __mro__ points back at it), so PyUnstable_SetImmortal can't be used. */
-    {
-        PyAPI_FUNC(void) _Py_SetImmortal(PyObject *op);
-        _Py_SetImmortal((PyObject *)dtypemeta);
-    }
-#endif
     NPY_DT_SLOTS(dtypemeta)->setitem = @NAME@_setitem;
     NPY_DT_SLOTS(dtypemeta)->get_constant = @NAME@_get_constant;
 

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -183,7 +183,6 @@ int initumath(PyObject *m)
     UFUNC_FLOATING_POINT_SUPPORT = 0;
 #endif
 
-    /* Add some symbolic constants to the module */
     d = PyModule_GetDict(m);
 
     if (InitOperators(d) < 0) {
@@ -207,6 +206,7 @@ int initumath(PyObject *m)
     }
 #endif
 
+    /* Add some symbolic constants to the module */
     PyDict_SetItemString(d, "pi", s = PyFloat_FromDouble(NPY_PI));
     Py_DECREF(s);
     PyDict_SetItemString(d, "e", s = PyFloat_FromDouble(NPY_E));

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -174,6 +174,23 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds) {
 
 /* Setup the umath part of the module */
 
+/* Add a float constant; immortal on free-threaded builds to avoid
+ * refcount contention when threads read e.g. ``np.pi``. */
+static int
+add_float_constant(PyObject *m, const char *name, double value)
+{
+    PyObject *obj = PyFloat_FromDouble(value);
+    if (obj == NULL) {
+        return -1;
+    }
+#if defined(Py_GIL_DISABLED) && PY_VERSION_HEX >= 0x030e0000
+    PyUnstable_SetImmortal(obj);
+#endif
+    int res = PyModule_AddObjectRef(m, name, obj);
+    Py_DECREF(obj);
+    return res;
+}
+
 int initumath(PyObject *m)
 {
     PyObject *d, *s, *s2;
@@ -207,12 +224,11 @@ int initumath(PyObject *m)
 #endif
 
     /* Add some symbolic constants to the module */
-    PyDict_SetItemString(d, "pi", s = PyFloat_FromDouble(NPY_PI));
-    Py_DECREF(s);
-    PyDict_SetItemString(d, "e", s = PyFloat_FromDouble(NPY_E));
-    Py_DECREF(s);
-    PyDict_SetItemString(d, "euler_gamma", s = PyFloat_FromDouble(NPY_EULER));
-    Py_DECREF(s);
+    if (add_float_constant(m, "pi", NPY_PI) < 0
+            || add_float_constant(m, "e", NPY_E) < 0
+            || add_float_constant(m, "euler_gamma", NPY_EULER) < 0) {
+        return -1;
+    }
 
 #define ADDCONST(str) PyModule_AddIntConstant(m, #str, UFUNC_##str)
 #define ADDSCONST(str) PyModule_AddStringConstant(m, "UFUNC_" #str, UFUNC_##str)
@@ -233,11 +249,13 @@ int initumath(PyObject *m)
     Py_INCREF(npy_static_pydata.npy_extobj_contextvar);
     PyModule_AddObject(m, "_extobj_contextvar", npy_static_pydata.npy_extobj_contextvar);
 
-    PyModule_AddObject(m, "PINF", PyFloat_FromDouble(NPY_INFINITY));
-    PyModule_AddObject(m, "NINF", PyFloat_FromDouble(-NPY_INFINITY));
-    PyModule_AddObject(m, "PZERO", PyFloat_FromDouble(NPY_PZERO));
-    PyModule_AddObject(m, "NZERO", PyFloat_FromDouble(NPY_NZERO));
-    PyModule_AddObject(m, "NAN", PyFloat_FromDouble(NPY_NAN));
+    if (add_float_constant(m, "PINF", NPY_INFINITY) < 0
+            || add_float_constant(m, "NINF", -NPY_INFINITY) < 0
+            || add_float_constant(m, "PZERO", NPY_PZERO) < 0
+            || add_float_constant(m, "NZERO", NPY_NZERO) < 0
+            || add_float_constant(m, "NAN", NPY_NAN) < 0) {
+        return -1;
+    }
 
     s = PyDict_GetItemString(d, "divide"); // noqa: borrowed-ref OK
     PyDict_SetItemString(d, "true_divide", s);

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -174,8 +174,7 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds) {
 
 /* Setup the umath part of the module */
 
-/* Add a float constant; immortal on free-threaded builds to avoid
- * refcount contention when threads read e.g. ``np.pi``. */
+/* Add a float constant; immortal on free-threaded builds */
 static int
 add_float_constant(PyObject *m, const char *name, double value)
 {

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -193,17 +193,33 @@ int initumath(PyObject *m)
 #if defined(Py_GIL_DISABLED) && PY_VERSION_HEX >= 0x030e0000
     /* Immortalize the builtin ufuncs to avoid refcount contention. */
     {
-        PyObject *key, *value;
-        Py_ssize_t pos = 0;
-        while (PyDict_Next(d, &pos, &key, &value)) {
-            if (PyObject_TypeCheck(value, &PyUFunc_Type)) {
-                if (PyUnstable_SetImmortal(value) == 0) {
-                    PyErr_Format(PyExc_RuntimeError,
-                            "failed to immortalize ufunc %R", key);
-                    return -1;
-                }
-            }
+        PyObject *keys = PyDict_Keys(d);
+        if (keys == NULL) {
+            return -1;
         }
+        Py_ssize_t nkeys = PyList_Size(keys);
+        for (Py_ssize_t i = 0; i < nkeys; i++) {
+            PyObject *key = PyList_GetItemRef(keys, i);
+            PyObject *value = NULL;
+            if (key == NULL || PyDict_GetItemRef(d, key, &value) < 0) {
+                Py_XDECREF(key);
+                Py_DECREF(keys);
+                return -1;
+            }
+            int is_ufunc = PyObject_TypeCheck(value, &PyUFunc_Type);
+            /* The dict keeps the ufunc alive; drop our reference so that
+             * it is uniquely referenced, as PyUnstable_SetImmortal requires. */
+            Py_DECREF(value);
+            if (is_ufunc && PyUnstable_SetImmortal(value) == 0) {
+                PyErr_Format(PyExc_RuntimeError,
+                        "failed to immortalize ufunc %R", key);
+                Py_DECREF(key);
+                Py_DECREF(keys);
+                return -1;
+            }
+            Py_DECREF(key);
+        }
+        Py_DECREF(keys);
     }
 #endif
 

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -190,6 +190,23 @@ int initumath(PyObject *m)
         return -1;
     }
 
+#if defined(Py_GIL_DISABLED) && PY_VERSION_HEX >= 0x030e0000
+    /* Immortalize the builtin ufuncs to avoid refcount contention. */
+    {
+        PyObject *key, *value;
+        Py_ssize_t pos = 0;
+        while (PyDict_Next(d, &pos, &key, &value)) {
+            if (PyObject_TypeCheck(value, &PyUFunc_Type)) {
+                if (PyUnstable_SetImmortal(value) == 0) {
+                    PyErr_Format(PyExc_RuntimeError,
+                            "failed to immortalize ufunc %R", key);
+                    return -1;
+                }
+            }
+        }
+    }
+#endif
+
     PyDict_SetItemString(d, "pi", s = PyFloat_FromDouble(NPY_PI));
     Py_DECREF(s);
     PyDict_SetItemString(d, "e", s = PyFloat_FromDouble(NPY_E));

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -193,33 +193,17 @@ int initumath(PyObject *m)
 #if defined(Py_GIL_DISABLED) && PY_VERSION_HEX >= 0x030e0000
     /* Immortalize the builtin ufuncs to avoid refcount contention. */
     {
-        PyObject *keys = PyDict_Keys(d);
-        if (keys == NULL) {
-            return -1;
-        }
-        Py_ssize_t nkeys = PyList_Size(keys);
-        for (Py_ssize_t i = 0; i < nkeys; i++) {
-            PyObject *key = PyList_GetItemRef(keys, i);
-            PyObject *value = NULL;
-            if (key == NULL || PyDict_GetItemRef(d, key, &value) < 0) {
-                Py_XDECREF(key);
-                Py_DECREF(keys);
-                return -1;
+        PyObject *key, *value;
+        Py_ssize_t pos = 0;
+        while (PyDict_Next(d, &pos, &key, &value)) {  // noqa: borrowed-ref OK
+            if (PyObject_TypeCheck(value, &PyUFunc_Type)) {
+                if (PyUnstable_SetImmortal(value) == 0) {
+                    PyErr_Format(PyExc_RuntimeError,
+                            "failed to immortalize ufunc %R", key);
+                    return -1;
+                }
             }
-            int is_ufunc = PyObject_TypeCheck(value, &PyUFunc_Type);
-            /* The dict keeps the ufunc alive; drop our reference so that
-             * it is uniquely referenced, as PyUnstable_SetImmortal requires. */
-            Py_DECREF(value);
-            if (is_ufunc && PyUnstable_SetImmortal(value) == 0) {
-                PyErr_Format(PyExc_RuntimeError,
-                        "failed to immortalize ufunc %R", key);
-                Py_DECREF(key);
-                Py_DECREF(keys);
-                return -1;
-            }
-            Py_DECREF(key);
         }
-        Py_DECREF(keys);
     }
 #endif
 


### PR DESCRIPTION
### PR summary

**(updated)**

Immortalize the builtin constants like `numpy.pi` on free-threaded builds (`Py_GIL_DISABLED`, CPython 3.14+).

### Benchmarks

**(updated after merge of #32531)**

Scaling on 6 threads

| benchmark | 3.14t main | 3.14t PR | 3.15t main | 3.15t PR |
|---|--:|--:|--:|--:|
| `np.sin(a)`, 4 elements | 1.6x | 3.0x | 6.0x | 6.0x |
| `np.add(a, b)`, 4 elements | 1.5x | 4.6x | 6.0x | 5.9x |
| `a + b`, 4 elements | 5.9x | 5.8x | 5.9x | 5.9x |
| `np.add(f8, i8)`, 4 elements | 2.6x | 3.7x | 3.8x | 3.9x |
| `np.add.reduce(a)`, 4 elements | 1.4x | 2.3x | 5.8x | 5.9x |
| `np.sin(np.float64(0.5))` | 0.6x | 1.0x | 2.0x | 2.3x |
| `a * np.pi`, 4 elements | 1.5x | 4.9x | 1.6x | 5.6x |
| `np.sinc(a)`, 4 elements | 3.2x | 3.3x | 4.5x | 4.7x |
| `np.sin(a)`, 100k elements (control) | 6.0x | 6.0x | 6.0x | 6.0x |


<details>
<summary>Benchmark script</summary>

```python
# Free-threading scaling benchmarks for numpy's small-array ufunc call path,
# modelled on CPython's Tools/ftscalingbench/ftscalingbench.py.
#
# Each benchmark is a small loop that ought to scale linearly with the number
# of threads: every thread works on its own thread-local arrays, so any lack
# of scaling comes from contention on shared interpreter state (reference
# counts on shared singletons such as ufuncs and DType classes, or locks).
#
# As in ftscalingbench, on Linux the threads are pinned to distinct physical
# "performance" cores on a single NUMA node.  Turbo boost should be disabled
# for stable numbers (see the comment in the CPython script).

import os
import queue
import sys
import threading
import time

import numpy as np

WORK_SCALE = 100

ALL_BENCHMARKS = {}

threads = []
in_queues = []
out_queues = []


def register_benchmark(func):
    ALL_BENCHMARKS[func.__name__] = func
    return func


@register_benchmark
def ufunc_unary_small():
    # np.sin on a thread-local 4-element float64 array
    a = np.arange(4.0)
    for _ in range(1000 * WORK_SCALE):
        np.sin(a)


@register_benchmark
def ufunc_binary_small():
    # np.add on two thread-local 4-element float64 arrays
    a = np.arange(4.0)
    b = np.arange(4.0)
    for _ in range(1000 * WORK_SCALE):
        np.add(a, b)


@register_benchmark
def array_operator_small():
    # a + b: nb_add slot -> ufunc
    a = np.arange(4.0)
    b = np.arange(4.0)
    for _ in range(1000 * WORK_SCALE):
        a + b


@register_benchmark
def ufunc_out_small():
    # np.multiply with a preallocated output (no allocation in the loop)
    a = np.arange(4.0)
    out = np.empty(4)
    for _ in range(1000 * WORK_SCALE):
        np.multiply(a, a, out=out)


@register_benchmark
def ufunc_mixed_dtype_small():
    # float64 + int64: exercises promotion / DType class lookup
    a = np.arange(4.0)
    b = np.arange(4)
    for _ in range(1000 * WORK_SCALE):
        np.add(a, b)


@register_benchmark
def ufunc_reduce_small():
    # np.add.reduce on a thread-local 4-element array
    a = np.arange(4.0)
    for _ in range(1000 * WORK_SCALE):
        np.add.reduce(a)


@register_benchmark
def scalar_ufunc():
    # ufunc called on a numpy scalar
    x = np.float64(0.5)
    for _ in range(1000 * WORK_SCALE):
        np.sin(x)


@register_benchmark
def ufunc_unary_large():
    # control: 100k elements, dominated by the inner loop, should scale anyway
    a = np.arange(100_000.0)
    for _ in range(10 * WORK_SCALE):
        np.sin(a)


def bench_one_thread(func):
    t0 = time.perf_counter_ns()
    func()
    t1 = time.perf_counter_ns()
    return t1 - t0


def bench_parallel(func):
    t0 = time.perf_counter_ns()
    for inq in in_queues:
        inq.put(func)
    for outq in out_queues:
        outq.get()
    t1 = time.perf_counter_ns()
    return t1 - t0


def benchmark(func, repeat):
    delta_one_thread = min(bench_one_thread(func) for _ in range(repeat))
    delta_many_threads = min(bench_parallel(func) for _ in range(repeat))

    speedup = delta_one_thread * len(threads) / delta_many_threads
    if speedup >= 1:
        factor = speedup
        direction = "faster"
    else:
        factor = 1 / speedup
        direction = "slower"

    use_color = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
    color = reset_color = ""
    if use_color:
        if speedup <= 1.1:
            color = "\x1b[31m"  # red
        elif speedup < len(threads) / 2:
            color = "\x1b[33m"  # yellow
        reset_color = "\x1b[0m"

    print(f"{color}{func.__name__:<25} {round(factor, 1):>4}x {direction}"
          f"{reset_color}   (1 thread: {delta_one_thread / 1e6:7.1f} ms, "
          f"{len(threads)} threads: {delta_many_threads / 1e6:7.1f} ms)")
    return delta_one_thread, delta_many_threads, speedup


def determine_cpus():
    """Distinct physical performance cores on NUMA node 0 (like ftscalingbench).

    ftscalingbench keeps only cores whose MAXMHZ equals the global maximum;
    on hybrid Intel parts a couple of P-cores are binned slightly higher, so
    accept every core within 10% of the maximum instead.
    """
    if sys.platform != "linux":
        return [None] * os.cpu_count()
    import subprocess
    try:
        output = subprocess.check_output(["lscpu", "-p=cpu,node,core,MAXMHZ"],
                                         text=True, env={"LC_NUMERIC": "C"})
    except (FileNotFoundError, subprocess.CalledProcessError):
        return [None] * os.cpu_count()
    table = []
    for line in output.splitlines():
        if line.startswith("#"):
            continue
        cpu, node, core, maxhz = line.split(",")
        table.append((int(cpu), int(node), int(core), float(maxhz or "0")))
    max_mhz_all = max(row[3] for row in table)
    cpus, cores = [], set()
    for cpu, node, core, maxmhz in table:
        if node == 0 and core not in cores and maxmhz >= 0.9 * max_mhz_all:
            cpus.append(cpu)
            cores.add(core)
    return cpus


def thread_run(cpu, in_queue, out_queue):
    if cpu is not None and hasattr(os, "sched_setaffinity"):
        os.sched_setaffinity(0, (cpu,))
    while True:
        func = in_queue.get()
        if func is None:
            break
        func()
        out_queue.put(None)


def initialize_threads(opts):
    cpus = determine_cpus()
    if opts.threads != -1:
        if opts.threads <= len(cpus):
            cpus = cpus[:opts.threads]      # still pinned to P-cores
        else:
            cpus = [None] * opts.threads    # more threads than P-cores: no pinning
    print(f"Running benchmarks with {len(cpus)} threads"
          f" (pinned to cpus {cpus})" if cpus[0] is not None else
          f"Running benchmarks with {len(cpus)} threads (no affinity)")
    for cpu in cpus:
        inq, outq = queue.Queue(), queue.Queue()
        in_queues.append(inq)
        out_queues.append(outq)
        t = threading.Thread(target=thread_run, args=(cpu, inq, outq), daemon=True)
        threads.append(t)
        t.start()


def main(opts):
    global WORK_SCALE
    if not hasattr(sys, "_is_gil_enabled") or sys._is_gil_enabled():
        sys.stderr.write("expected to be run with the GIL disabled\n")
    print(f"python {sys.version.split()[0]}, numpy {np.__version__} "
          f"from {os.path.dirname(np.__file__)}")

    names = opts.benchmarks or list(ALL_BENCHMARKS)
    for name in names:
        if name not in ALL_BENCHMARKS:
            sys.exit(f"Unknown benchmark: {name}")
    WORK_SCALE = opts.scale
    initialize_threads(opts)

    # pin the main thread (single-thread baseline) to the first chosen cpu too
    cpu0 = determine_cpus()[0]
    if cpu0 is not None and hasattr(os, "sched_setaffinity"):
        os.sched_setaffinity(0, (cpu0,))

    results = {}
    for name in names:
        results[name] = benchmark(ALL_BENCHMARKS[name], opts.repeat)
    if opts.json:
        import json
        with open(opts.json, "w") as f:
            json.dump({"threads": len(threads), "results": results}, f)


if __name__ == "__main__":
    import argparse
    parser = argparse.ArgumentParser()
    parser.add_argument("-t", "--threads", type=int, default=-1)
    parser.add_argument("--scale", type=int, default=100)
    parser.add_argument("--repeat", type=int, default=3,
                        help="take the best of N runs for each measurement")
    parser.add_argument("--json", help="write raw timings to this file")
    parser.add_argument("benchmarks", nargs="*")
    main(parser.parse_args())
```

</details>

#### AI Disclosure

Claude was used for benchmarking and implementation.
