### PR TITLE
BUG: validate arguments in incref_elide test helpers (gh-28829)

### DIFF
--- a/numpy/_core/src/multiarray/_multiarray_tests.c.src
+++ b/numpy/_core/src/multiarray/_multiarray_tests.c.src
@@ -618,13 +618,20 @@ static PyObject *
 incref_elide(PyObject *dummy, PyObject *args)
 {
     PyObject *arg = NULL, *res, *tup;
-    if (!PyArg_ParseTuple(args, "O", &arg)) {
+    if (!PyArg_ParseTuple(args, "O!", &PyArray_Type, &arg)) {
         return NULL;
     }
 
     /* refcount 1 array but should not be elided */
     arg = PyArray_NewCopy((PyArrayObject*)arg, NPY_KEEPORDER);
+    if (arg == NULL) {
+        return NULL;
+    }
     res = PyNumber_Add(arg, arg);
+    if (res == NULL) {
+        Py_DECREF(arg);
+        return NULL;
+    }
 
     /* return original copy, should be equal to input */
     tup = PyTuple_Pack(2, arg, res);
@@ -638,12 +645,15 @@ static PyObject *
 incref_elide_l(PyObject *dummy, PyObject *args)
 {
     PyObject *arg = NULL, *r, *res;
-    if (!PyArg_ParseTuple(args, "O", &arg)) {
+    if (!PyArg_ParseTuple(args, "O!", &PyList_Type, &arg)) {
         return NULL;
     }
     /* get item without increasing refcount, item may still be on the python
      * stack but above the inaccessible top */
     r = PyList_GetItem(arg, 4); // noqa: borrowed-ref OK
+    if (r == NULL) {
+        return NULL;
+    }
     res = PyNumber_Add(r, r);
 
     return res;


### PR DESCRIPTION
### PR summary
This PR resolves item 2 in #28829, which is basically dealing with SIGBUS because different types are being fed. 
The key is the type check O! with a specified type name (_i.e._, PyArray_Type or PyList_Type) so that whenever unspecified types are fed, it returns NULL. This should eventually raise a TypeError.
Added some more null checks in case we have a RuntimeError (PyArrayNewCopy), addition failure, or IndexError (PyList_GetItem).

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
I've created this code, including test cases, using AI (Claude Opus 5), but I've done thorough research, so I should know what I'm doing. 
