### PR TITLE
TST: Add broadcasting unit test for RandomState.randint

### DIFF
--- a/numpy/random/tests/test_random.py
+++ b/numpy/random/tests/test_random.py
@@ -1061,8 +1061,21 @@ class TestBroadcast:
     # correctly when presented with non-scalar arguments
     seed = 123456789
 
-    # TODO: Include test for randint once it can broadcast
-    # Can steal the test written in PR #6938
+    def test_randint(self):
+        low = [0]
+        high = [10]
+        bad_high = [0]
+        desired = np.array([3, 4, 7])
+
+        rng = random.RandomState(self.seed)
+        actual = rng.randint(low * 3, high)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, rng.randint, low * 3, bad_high)
+
+        rng = random.RandomState(self.seed)
+        actual = rng.randint(low, high * 3)
+        assert_array_equal(actual, desired)
+        assert_raises(ValueError, rng.randint, low, bad_high * 3)
 
     def test_uniform(self):
         low = [0]


### PR DESCRIPTION
## Description
This Pull Request adds unit tests for `numpy.random.RandomState.randint` broadcasting support under the `TestBroadcast` suite and removes an obsolete `TODO` comment in `numpy/random/tests/test_random.py`.

### Changes Proposed
- Added `test_randint(self)` method to `TestBroadcast` class in `numpy/random/tests/test_random.py`.
- Tested parameter broadcasting when `low` and `high` are passed as list/array inputs.
- Tested exception handling (`ValueError`) when invalid bounds (`low >= high`) are passed as array inputs.
- Removed legacy `# TODO: Include test for randint once it can broadcast` comment.

### Verification
- The added test suite follows the established pattern of `TestBroadcast` (`test_uniform`, `test_normal`, `test_beta`).
