### PR TITLE
ENH: Support optional modulo 3rd argument in NDArrayOperatorsMixin.__pow__

### DIFF
--- a/numpy/lib/mixins.py
+++ b/numpy/lib/mixins.py
@@ -42,6 +42,18 @@ def _inplace_binary_method(ufunc, name):
     return func
 
 
+def _pow_method(ufunc, name):
+    """Implement a forward pow method with a ufunc, accepting optional modulo."""
+    def func(self, other, modulo=None):
+        if modulo is not None:
+            return NotImplemented
+        if _disables_array_ufunc(other):
+            return NotImplemented
+        return ufunc(self, other)
+    func.__name__ = f'__{name}__'
+    return func
+
+
 def _numeric_methods(ufunc, name):
     """Implement forward, reflected and inplace binary methods with a ufunc."""
     return (_binary_method(ufunc, name),
@@ -162,9 +174,9 @@ class NDArrayOperatorsMixin:
     __mod__, __rmod__, __imod__ = _numeric_methods(um.remainder, 'mod')
     __divmod__ = _binary_method(um.divmod, 'divmod')
     __rdivmod__ = _reflected_binary_method(um.divmod, 'divmod')
-    # __idivmod__ does not exist
-    # TODO: handle the optional third argument for __pow__?
-    __pow__, __rpow__, __ipow__ = _numeric_methods(um.power, 'pow')
+    __pow__ = _pow_method(um.power, 'pow')
+    __rpow__ = _reflected_binary_method(um.power, 'pow')
+    __ipow__ = _inplace_binary_method(um.power, 'pow')
     __lshift__, __rlshift__, __ilshift__ = _numeric_methods(
         um.left_shift, 'lshift')
     __rshift__, __rrshift__, __irshift__ = _numeric_methods(

--- a/numpy/lib/tests/test_mixins.py
+++ b/numpy/lib/tests/test_mixins.py
@@ -213,3 +213,12 @@ class TestNDArrayOperatorsMixin:
             np.frexp(ArrayLike(2 ** -3)), expected)
         _assert_equal_type_and_value(
             np.frexp(ArrayLike(np.array(2 ** -3))), expected)
+
+    def test_pow_modulo(self):
+        x = ArrayLike(2)
+        _assert_equal_type_and_value(pow(x, 3, None), ArrayLike(8))
+        _assert_equal_type_and_value(x.__pow__(3, None), ArrayLike(8))
+        assert_(x.__pow__(3, 5) is NotImplemented)
+        with assert_raises(TypeError):
+            pow(x, 3, 5)
+


### PR DESCRIPTION
## Description
This PR adds support for the optional 3rd argument `modulo=None` in `NDArrayOperatorsMixin.__pow__` in `numpy/lib/mixins.py` and resolves the corresponding `TODO` comment.

### Changes Proposed
- Added `_pow_method` helper function to `numpy/lib/mixins.py` to support `__pow__(self, other, modulo=None)`.
- Defer to `um.power(self, other)` when `modulo is None` (e.g., `pow(x, y, None)` or `x.__pow__(y, None)`).
- Return `NotImplemented` when `modulo is not None` to align with `numpy.ndarray.__pow__` behavior where modular exponentiation is not supported.
- Added `test_pow_modulo` to `TestNDArrayOperatorsMixin` in `numpy/lib/tests/test_mixins.py`.

### Verification
- Tested `pow(ArrayLike(2), 3, None)` returns `ArrayLike(8)`.
- Tested `pow(ArrayLike(2), 3, 5)` raises `TypeError`.