### PR TITLE
DOC: Fix tolerance wording in ma.allequal

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -8501,9 +8501,8 @@ def allequal(a, b, fill_value=True):
     Returns
     -------
     y : bool
-        Returns True if the two arrays are equal within the given
-        tolerance, False otherwise. If either array contains NaN,
-        then False is returned.
+        Returns True if the arrays are equal. If either array contains
+        NaN, then False is returned.
 
     See Also
     --------


### PR DESCRIPTION
### PR summary

This PR fixes the documentation for `numpy.ma.allequal`.

The current documentation says that the arrays are compared "within the given tolerance", but `ma.allequal` does not have a tolerance parameter. I updated the description to accurately state that the function returns `True` when the arrays are equal.

This is a documentation-only change; no behavior or API has been changed.

### First time committer introduction

Hi! This is my first contribution to NumPy.

I have been learning Python, NumPy, and machine learning, and I wanted to start contributing to a real open-source project. While going through the documentation, I noticed this wording in `ma.allequal` and thought it would be useful to correct it.

I'm looking forward to learning from the review process and contributing more to NumPy in the future.

#### AI Disclosure

AI was used during the preparation of this pull request for understanding the issue, navigating the repository, and discussing the meaning of the existing documentation. The final documentation change was reviewed and made by me.
