### PR TITLE
PERF: use vectorcall in PyArray_GenericReduce/AccumulateFunction

### DIFF
--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -2442,18 +2442,19 @@ array_sum(PyArrayObject *self,
 
 
 static PyObject *
-array_cumsum(PyArrayObject *self, PyObject *args, PyObject *kwds)
+array_cumsum(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     int axis = NPY_RAVEL_AXIS;
     PyArray_Descr *dtype = NULL;
     PyArrayObject *out = NULL;
     int rtype;
-    static char *kwlist[] = {"axis", "dtype", "out", NULL};
+    NPY_PREPARE_ARGPARSER;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&O&:cumsum", kwlist,
-                                     PyArray_AxisConverter, &axis,
-                                     PyArray_DescrConverter2, &dtype,
-                                     PyArray_OutputConverter, &out)) {
+    if (npy_parse_arguments("cumsum", args, len_args, kwnames,
+            {"|axis", &PyArray_AxisConverter, &axis},
+            {"|dtype", &PyArray_DescrConverter2, &dtype},
+            {"|out", &PyArray_OutputConverter, &out}) < 0) {
         Py_XDECREF(dtype);
         return NULL;
     }
@@ -2471,18 +2472,19 @@ array_prod(PyArrayObject *self,
 }
 
 static PyObject *
-array_cumprod(PyArrayObject *self, PyObject *args, PyObject *kwds)
+array_cumprod(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     int axis = NPY_RAVEL_AXIS;
     PyArray_Descr *dtype = NULL;
     PyArrayObject *out = NULL;
     int rtype;
-    static char *kwlist[] = {"axis", "dtype", "out", NULL};
+    NPY_PREPARE_ARGPARSER;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&O&O&:cumprod", kwlist,
-                                     PyArray_AxisConverter, &axis,
-                                     PyArray_DescrConverter2, &dtype,
-                                     PyArray_OutputConverter, &out)) {
+    if (npy_parse_arguments("cumprod", args, len_args, kwnames,
+            {"|axis", &PyArray_AxisConverter, &axis},
+            {"|dtype", &PyArray_DescrConverter2, &dtype},
+            {"|out", &PyArray_OutputConverter, &out}) < 0) {
         Py_XDECREF(dtype);
         return NULL;
     }
@@ -3007,10 +3009,10 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"cumprod",
         (PyCFunction)array_cumprod,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"cumsum",
         (PyCFunction)array_cumsum,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"diagonal",
         (PyCFunction)array_diagonal,
         METH_VARARGS | METH_KEYWORDS, NULL},

--- a/numpy/_core/src/multiarray/module_state_fields.h
+++ b/numpy/_core/src/multiarray/module_state_fields.h
@@ -70,7 +70,9 @@ extern "C" {
     F(microsecond)          \
     F(tzinfo)               \
     F(utcoffset)            \
-    F(total_seconds)
+    F(total_seconds)        \
+    F(reduce)               \
+    F(accumulate)
 
 #define NPY_STATIC_PYDATA_FIELDS(F) \
     F(default_truediv_type_tup)    \
@@ -107,6 +109,9 @@ extern "C" {
     F(kwnames_is_copy)             \
     F(wrapit_kwnames_subok)        \
     F(wrapit_kwnames_to_scalar)    \
+    F(kwnames_dtype)               \
+    F(kwnames_out)                 \
+    F(kwnames_dtype_out)           \
     F(axes_1d_obj_kwargs)          \
     F(axes_2d_obj_kwargs)          \
     F(cpu_dispatch_registry)       \

--- a/numpy/_core/src/multiarray/npy_static_data.c
+++ b/numpy/_core/src/multiarray/npy_static_data.c
@@ -92,6 +92,8 @@ intern_strings(void)
     INTERN_STRING(tzinfo, "tzinfo");
     INTERN_STRING(utcoffset, "utcoffset");
     INTERN_STRING(total_seconds, "total_seconds");
+    INTERN_STRING(reduce, "reduce");
+    INTERN_STRING(accumulate, "accumulate");
     return 0;
 }
 
@@ -219,6 +221,22 @@ initialize_static_globals(void)
 
     static_pydata->wrapit_kwnames_to_scalar = PyTuple_Pack(1, interned_str->to_scalar);
     if (static_pydata->wrapit_kwnames_to_scalar == NULL) {
+        return -1;
+    }
+
+    static_pydata->kwnames_dtype = PyTuple_Pack(1, interned_str->dtype);
+    if (static_pydata->kwnames_dtype == NULL) {
+        return -1;
+    }
+
+    static_pydata->kwnames_out = PyTuple_Pack(1, interned_str->out);
+    if (static_pydata->kwnames_out == NULL) {
+        return -1;
+    }
+
+    static_pydata->kwnames_dtype_out = PyTuple_Pack(
+            2, interned_str->dtype, interned_str->out);
+    if (static_pydata->kwnames_dtype_out == NULL) {
         return -1;
     }
 

--- a/numpy/_core/src/multiarray/npy_static_data.h
+++ b/numpy/_core/src/multiarray/npy_static_data.h
@@ -73,6 +73,8 @@ typedef struct npy_interned_str_struct {
     PyObject *tzinfo;
     PyObject *utcoffset;
     PyObject *total_seconds;
+    PyObject *reduce;
+    PyObject *accumulate;
 } npy_interned_str_struct;
 
 /*
@@ -169,6 +171,10 @@ typedef struct npy_static_pydata_struct {
      */
     PyObject *wrapit_kwnames_subok;
     PyObject *wrapit_kwnames_to_scalar;
+
+    PyObject *kwnames_dtype;
+    PyObject *kwnames_out;
+    PyObject *kwnames_dtype_out;
 
     /*
      * Used in __imatmul__ to avoid building tuples inline

--- a/numpy/_core/src/multiarray/number.c
+++ b/numpy/_core/src/multiarray/number.c
@@ -141,50 +141,58 @@ _PyArray_SetNumericOps(PyObject *dict)
 }
 
 
+/* Call `op.<method_name>(m1, axis, [dtype=rtype], [out=out])` via vectorcall */
 static PyObject *
-_get_keywords(int rtype, PyArrayObject *out)
+_call_reduce_like(PyObject *method_name, PyArrayObject *m1, PyObject *op,
+                  int axis, int rtype, PyArrayObject *out)
 {
-    PyObject *kwds = NULL;
-    if (rtype != NPY_NOTYPE || out != NULL) {
-        kwds = PyDict_New();
-        if (kwds == NULL) {
+    multiarray_umath_state *state = _npy_module_state;
+    PyObject *args[5];
+    PyObject *kwnames = NULL;
+    PyObject *descr = NULL;
+    Py_ssize_t nargs = 3;
+
+    PyObject *axis_obj = PyLong_FromLong(axis);
+    if (axis_obj == NULL) {
+        return NULL;
+    }
+    args[0] = op;
+    args[1] = (PyObject *)m1;
+    args[2] = axis_obj;
+
+    if (rtype != NPY_NOTYPE) {
+        descr = (PyObject *)PyArray_DescrFromType(rtype);
+        if (descr == NULL) {
+            Py_DECREF(axis_obj);
             return NULL;
         }
-        if (rtype != NPY_NOTYPE) {
-            PyArray_Descr *descr;
-            descr = PyArray_DescrFromType(rtype);
-            if (descr) {
-                PyDict_SetItemString(kwds, "dtype", (PyObject *)descr);
-                Py_DECREF(descr);
-            }
-        }
+        args[nargs++] = descr;
         if (out != NULL) {
-            PyDict_SetItemString(kwds, "out", (PyObject *)out);
+            args[nargs++] = (PyObject *)out;
+            kwnames = state->static_pydata.kwnames_dtype_out;
+        }
+        else {
+            kwnames = state->static_pydata.kwnames_dtype;
         }
     }
-    return kwds;
+    else if (out != NULL) {
+        args[nargs++] = (PyObject *)out;
+        kwnames = state->static_pydata.kwnames_out;
+    }
+
+    PyObject *ret = PyObject_VectorcallMethod(
+            method_name, args, 3 | PY_VECTORCALL_ARGUMENTS_OFFSET, kwnames);
+    Py_DECREF(axis_obj);
+    Py_XDECREF(descr);
+    return ret;
 }
 
 NPY_NO_EXPORT PyObject *
 PyArray_GenericReduceFunction(PyArrayObject *m1, PyObject *op, int axis,
                               int rtype, PyArrayObject *out)
 {
-    PyObject *args, *ret = NULL, *meth;
-    PyObject *kwds;
-
-    args = Py_BuildValue("(Oi)", m1, axis);
-    if (args == NULL) {
-        return NULL;
-    }
-    kwds = _get_keywords(rtype, out);
-    meth = PyObject_GetAttrString(op, "reduce");
-    if (meth && PyCallable_Check(meth)) {
-        ret = PyObject_Call(meth, args, kwds);
-    }
-    Py_DECREF(args);
-    Py_XDECREF(meth);
-    Py_XDECREF(kwds);
-    return ret;
+    return _call_reduce_like(_npy_module_state->interned_str.reduce,
+                             m1, op, axis, rtype, out);
 }
 
 
@@ -192,22 +200,8 @@ NPY_NO_EXPORT PyObject *
 PyArray_GenericAccumulateFunction(PyArrayObject *m1, PyObject *op, int axis,
                                   int rtype, PyArrayObject *out)
 {
-    PyObject *args, *ret = NULL, *meth;
-    PyObject *kwds;
-
-    args = Py_BuildValue("(Oi)", m1, axis);
-    if (args == NULL) {
-        return NULL;
-    }
-    kwds = _get_keywords(rtype, out);
-    meth = PyObject_GetAttrString(op, "accumulate");
-    if (meth && PyCallable_Check(meth)) {
-        ret = PyObject_Call(meth, args, kwds);
-    }
-    Py_DECREF(args);
-    Py_XDECREF(meth);
-    Py_XDECREF(kwds);
-    return ret;
+    return _call_reduce_like(_npy_module_state->interned_str.accumulate,
+                             m1, op, axis, rtype, out);
 }
 
 


### PR DESCRIPTION
### PR summary
`PyArray_GenericReduceFunction` and `PyArray_GenericAccumulateFunction` build an argument tuple, a kwargs dict and a bound method (via `PyObject_GetAttrString`) on every call. This PR replaces that with `PyObject_VectorcallMethod` using interned `"reduce"`/`"accumulate"` strings and pre-built kwnames tuples in the module static data.

`ndarray.cumsum` and `ndarray.cumprod` are also converted from `METH_VARARGS` to `METH_FASTCALL`. 

Benchmark results:

| case | main | this PR | speedup |
|---|---|---|---|
| `a.cumsum(out=out)` | 705 ns | 343 ns | **2.1x** |
| `a.cumsum(axis=0, dtype=np.int64)` | 810 ns | 465 ns | **1.7x** |
| `np.cumsum(a)` | 858 ns | 596 ns | **1.4x** |
| `np.cumprod(a)` | 863 ns | 598 ns | **1.4x** |
| `a.cumsum()` | 507 ns | 378 ns | 1.3x |
| `3 in a` | 1121 ns | 901 ns | 1.2x |
| `np.trace(m)` | 827 ns | 737 ns | 1.1x |
| `np.add.accumulate(a)` *(control)* | 374 ns | 374 ns | ~1.0x |
| `np.sum(a)` *(control)* | 426 ns | 436 ns | ~1.0x |

The C-API entry points `PyArray_Sum`/`Prod`/`Max`/`Min`/`Mean` also improve performance.

<details>
<summary>Benchmark script</summary>

```python
import timeit
import numpy as np

a = np.arange(10, dtype=np.int64)
m = np.arange(16, dtype=np.float64).reshape(4, 4)
out = np.empty(10, dtype=np.int64)

CASES = {
    "np.cumsum(a)": lambda: np.cumsum(a),
    "np.cumprod(a)": lambda: np.cumprod(a),
    "a.cumsum()": lambda: a.cumsum(),
    "a.cumsum(axis=0, dtype=np.int64)": lambda: a.cumsum(axis=0, dtype=np.int64),
    "a.cumsum(out=out)": lambda: a.cumsum(out=out),
    "np.trace(m)": lambda: np.trace(m),
    "3 in a": lambda: 3 in a,
    "np.add.accumulate(a)  (control)": lambda: np.add.accumulate(a),
    "np.sum(a)  (control)": lambda: np.sum(a),
}
n = 100_000
for name, f in CASES.items():
    t = min(timeit.repeat(f, number=n, repeat=15)) / n * 1e9
    print(f"{name:36s} {t:7.1f} ns")
```
</details>

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
Claude was used in indentifyng `cumsum` performance bottlenecks and in generation of the PR.