### PR TITLE
BUG: floor timedelta64 // int for negative values

### DIFF
--- a/doc/release/upcoming_changes/32526.change.rst
+++ b/doc/release/upcoming_changes/32526.change.rst
@@ -1,0 +1,7 @@
+``timedelta64 // int`` floors for negative values
+-------------------------------------------------
+Floor division of a negative ``timedelta64`` by an integer previously
+truncated toward zero because ``floor_divide`` reused the true-division
+loop. It now floors, matching ``int64 // int``, ``timedelta64 // timedelta64``,
+and Python's ``datetime.timedelta // int``. True division
+(``timedelta64 / int``) is unchanged.

--- a/numpy/_core/code_generators/generate_umath.py
+++ b/numpy/_core/code_generators/generate_umath.py
@@ -409,7 +409,7 @@ defdict = {
           TD(ints, cfunc_alias='divide',
               dispatch=[('loops_arithmetic', 'bBhHiIlLqQ')]),
           TD(flts),
-          [TypeDescription('m', FullTypeDescr, 'mq', 'm', cfunc_alias='divide',
+          [TypeDescription('m', FullTypeDescr, 'mq', 'm',
                            dispatch='loops_arithmetic_timedelta'),
            TypeDescription('m', FullTypeDescr, 'md', 'm'),
            TypeDescription('m', FullTypeDescr, 'mm', 'q',

--- a/numpy/_core/src/umath/loops.h.src
+++ b/numpy/_core/src/umath/loops.h.src
@@ -750,6 +750,9 @@ TIMEDELTA_md_m_divide(char **args, npy_intp const *dimensions, npy_intp const *s
 NPY_NO_EXPORT void
 TIMEDELTA_mm_d_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
 
+NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void TIMEDELTA_mq_m_floor_divide,
+    (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func)))
+
 NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void TIMEDELTA_mm_q_floor_divide,
     (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func)))
 

--- a/numpy/_core/src/umath/loops_arithmetic_timedelta.dispatch.cpp
+++ b/numpy/_core/src/umath/loops_arithmetic_timedelta.dispatch.cpp
@@ -170,6 +170,102 @@ simd_floor_divide_by_scalar_contig_timedelta(char **args, npy_intp len,
 
 #endif // NPY_SIMD && !SIMD_DISABLE_DIV64_OPT
 
+/*
+ * Floor quotient of two nonzero, non-NaT int64 values.
+ * Matches Python/NumPy integer floor division (round toward -inf).
+ */
+static NPY_INLINE npy_int64
+timedelta_floor_quotient(npy_int64 a, npy_int64 b)
+{
+    npy_int64 quo = a / b;
+    if (((a > 0) != (b > 0)) && (quo * b != a)) {
+        quo -= 1;
+    }
+    return quo;
+}
+
+/*
+ * Shared implementation for timedelta floor division by an int64-like divisor.
+ *
+ * propagate_nat true  (m // q -> m): NaT and divide-by-zero become NaT.
+ * propagate_nat false (m // m -> q): NaT becomes 0 with invalid status,
+ *                                    divide-by-zero becomes 0 with divbyzero.
+ * For !propagate_nat, a NaT divisor is also treated as invalid -> 0.
+ */
+static void
+timedelta_floor_divide_by_int64(char **args, npy_intp const *dimensions,
+                                npy_intp const *steps, bool propagate_nat)
+{
+    BINARY_DEFS
+
+    if (steps[1] == 0) {
+        if (n == 0) {
+            return;
+        }
+
+        const npy_int64 in2 = *(npy_int64 *)ip2;
+
+        if (in2 == 0) {
+            npy_set_floatstatus_divbyzero();
+            BINARY_LOOP_SLIDING {
+                *((npy_int64 *)op1) = propagate_nat ? NPY_DATETIME_NAT : 0;
+            }
+        }
+        else if (!propagate_nat && in2 == NPY_DATETIME_NAT) {
+            npy_set_floatstatus_invalid();
+            BINARY_LOOP_SLIDING {
+                *((npy_int64 *)op1) = 0;
+            }
+        }
+        else {
+#if NPY_SIMD && !defined(SIMD_DISABLE_DIV64_OPT)
+            if (IS_BLOCKABLE_BINARY_SCALAR2(sizeof(npy_timedelta), NPY_SIMD_WIDTH)) {
+                simd_floor_divide_by_scalar_contig_timedelta(args, n, propagate_nat);
+                return;
+            }
+#endif
+            BINARY_LOOP_SLIDING {
+                const npy_int64 in1 = *(npy_int64 *)ip1;
+                if (in1 == NPY_DATETIME_NAT) {
+                    if (propagate_nat) {
+                        *((npy_int64 *)op1) = NPY_DATETIME_NAT;
+                    }
+                    else {
+                        npy_set_floatstatus_invalid();
+                        *((npy_int64 *)op1) = 0;
+                    }
+                }
+                else {
+                    *((npy_int64 *)op1) = timedelta_floor_quotient(in1, in2);
+                }
+            }
+        }
+    }
+    else {
+        BINARY_LOOP_SLIDING {
+            const npy_int64 in1 = *(npy_int64 *)ip1;
+            const npy_int64 in2 = *(npy_int64 *)ip2;
+            if (in1 == NPY_DATETIME_NAT ||
+                    (!propagate_nat && in2 == NPY_DATETIME_NAT)) {
+                if (propagate_nat) {
+                    *((npy_int64 *)op1) = NPY_DATETIME_NAT;
+                }
+                else {
+                    npy_set_floatstatus_invalid();
+                    *((npy_int64 *)op1) = 0;
+                }
+            }
+            else if (in2 == 0) {
+                npy_set_floatstatus_divbyzero();
+                *((npy_int64 *)op1) = propagate_nat ? NPY_DATETIME_NAT : 0;
+            }
+            else {
+                *((npy_int64 *)op1) = timedelta_floor_quotient(in1, in2);
+            }
+        }
+    }
+}
+
 /********************************************************************************
  ** Dispatched loops
  ********************************************************************************/
@@ -231,139 +327,11 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(TIMEDELTA_mq_m_divide)
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(TIMEDELTA_mm_q_floor_divide)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
-    BINARY_DEFS
-
-    /* When the divisor is a scalar, we can vectorize the division */
-    if (steps[1] == 0) {
-        /* In case of empty array, just return */
-        if (n == 0) {
-            return;
-        }
-
-        const npy_timedelta in2 = *(npy_timedelta *)ip2;
-
-        /* If divisor is 0 or NAT, we need not compute anything */
-        if (in2 == 0) {
-            npy_set_floatstatus_divbyzero();
-            BINARY_LOOP_SLIDING {
-                *((npy_int64 *)op1) = 0;
-            }
-        }
-        else if (in2 == NPY_DATETIME_NAT) {
-            npy_set_floatstatus_invalid();
-            BINARY_LOOP_SLIDING {
-                *((npy_int64 *)op1) = 0;
-            }
-        }
-        else {
-#if NPY_SIMD && !defined(SIMD_DISABLE_DIV64_OPT)
-            /* contiguous block of memory with a non-zero, non-NAT scalar divisor */
-            if (IS_BLOCKABLE_BINARY_SCALAR2(sizeof(npy_timedelta), NPY_SIMD_WIDTH)) {
-                simd_floor_divide_by_scalar_contig_timedelta(args, n, false);
-                return;
-            }
-#endif
-            BINARY_LOOP_SLIDING {
-                const npy_timedelta in1 = *(npy_timedelta *)ip1;
-                if (in1 == NPY_DATETIME_NAT) {
-                    npy_set_floatstatus_invalid();
-                    *((npy_int64 *)op1) = 0;
-                }
-                else {
-                    npy_int64 quo = in1 / in2;
-                    /* Negative quotients needs to be rounded down */
-                    if (((in1 > 0) != (in2 > 0)) && (quo * in2 != in1)) {
-                        quo -= 1;
-                    }
-                    *((npy_int64 *)op1) = quo;
-                }
-            }
-        }
-    }
-    else {
-        BINARY_LOOP_SLIDING {
-            const npy_timedelta in1 = *(npy_timedelta *)ip1;
-            const npy_timedelta in2 = *(npy_timedelta *)ip2;
-            if (in1 == NPY_DATETIME_NAT || in2 == NPY_DATETIME_NAT) {
-                npy_set_floatstatus_invalid();
-                *((npy_int64 *)op1) = 0;
-            }
-            else if (in2 == 0) {
-                npy_set_floatstatus_divbyzero();
-                *((npy_int64 *)op1) = 0;
-            }
-            else {
-                npy_int64 quo = in1 / in2;
-                /* Negative quotients needs to be rounded down */
-                if (((in1 > 0) != (in2 > 0)) && (quo * in2 != in1)) {
-                    quo -= 1;
-                }
-                *((npy_int64 *)op1) = quo;
-            }
-        }
-    }
+    timedelta_floor_divide_by_int64(args, dimensions, steps, false);
 }
 
 NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(TIMEDELTA_mq_m_floor_divide)
 (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
-    BINARY_DEFS
-
-    /* When the divisor is a scalar, we can vectorize the division */
-    if (steps[1] == 0) {
-        /* In case of empty array, just return */
-        if (n == 0) {
-            return;
-        }
-
-        const npy_int64 in2 = *(npy_int64 *)ip2;
-
-        /* If divisor is 0, we need not compute anything */
-        if (in2 == 0) {
-            npy_set_floatstatus_divbyzero();
-            BINARY_LOOP_SLIDING {
-                *((npy_timedelta *)op1) = NPY_DATETIME_NAT;
-            }
-        }
-        else {
-#if NPY_SIMD && !defined(SIMD_DISABLE_DIV64_OPT)
-            /* contiguous block of memory with a non-zero scalar divisor */
-            if (IS_BLOCKABLE_BINARY_SCALAR2(sizeof(npy_timedelta), NPY_SIMD_WIDTH)) {
-                simd_floor_divide_by_scalar_contig_timedelta(args, n, true);
-                return;
-            }
-#endif
-            BINARY_LOOP_SLIDING {
-                const npy_timedelta in1 = *(npy_timedelta *)ip1;
-                if (in1 == NPY_DATETIME_NAT) {
-                    *((npy_timedelta *)op1) = NPY_DATETIME_NAT;
-                }
-                else {
-                    npy_timedelta quo = in1 / in2;
-                    /* Negative quotients needs to be rounded down */
-                    if (((in1 > 0) != (in2 > 0)) && (quo * in2 != in1)) {
-                        quo -= 1;
-                    }
-                    *((npy_timedelta *)op1) = quo;
-                }
-            }
-        }
-    }
-    else {
-        BINARY_LOOP_SLIDING {
-            const npy_timedelta in1 = *(npy_timedelta *)ip1;
-            const npy_int64 in2 = *(npy_int64 *)ip2;
-            if (in1 == NPY_DATETIME_NAT || in2 == 0) {
-                *((npy_timedelta *)op1) = NPY_DATETIME_NAT;
-            }
-            else {
-                npy_timedelta quo = in1 / in2;
-                /* Negative quotients needs to be rounded down */
-                if (((in1 > 0) != (in2 > 0)) && (quo * in2 != in1)) {
-                    quo -= 1;
-                }
-                *((npy_timedelta *)op1) = quo;
-            }
-        }
-    }
+    timedelta_floor_divide_by_int64(args, dimensions, steps, true);
 }

--- a/numpy/_core/src/umath/loops_arithmetic_timedelta.dispatch.cpp
+++ b/numpy/_core/src/umath/loops_arithmetic_timedelta.dispatch.cpp
@@ -102,8 +102,14 @@ simd_divide_by_scalar_contig_timedelta(char **args, npy_intp len)
     }
 }
 
+/*
+ * Floor division by an invariant scalar. When propagate_nat is true (m // q),
+ * NaT dividends become NaT. Otherwise (m // m -> q), NaT becomes 0 and sets
+ * the invalid float status, matching TIMEDELTA_mm_q_floor_divide.
+ */
 static void HWY_ATTR
-simd_floor_divide_by_scalar_contig_timedelta(char **args, npy_intp len)
+simd_floor_divide_by_scalar_contig_timedelta(char **args, npy_intp len,
+                                             bool propagate_nat)
 {
     const int64_t *src = (const int64_t *)args[0];
     int64_t scalar     = *(const int64_t *)args[1];
@@ -118,13 +124,14 @@ simd_floor_divide_by_scalar_contig_timedelta(char **args, npy_intp len)
     const VI64 vzero       = hn::Zero(d);
     const VI64 vone        = hn::Set(d, 1);
     const VI64 nsign_d     = hn::Set(d, (npy_int64)(scalar < 0)); // 0 or 1
+    const VI64 nat_out     = propagate_nat ? vnat : vzero;
     bool any_nat = false;
 
     npy_intp i = 0;
     for (; i + vstep <= len; i += vstep) {
         VI64 a   = hn::LoadU(d, src + i);
         auto nat = hn::Eq(a, vnat);
-        if (!hn::AllFalse(d, nat)) {
+        if (!propagate_nat && !hn::AllFalse(d, nat)) {
             any_nat = true;
         }
         VI64 nsign_a   = hn::IfThenElse(hn::Lt(a, nsign_d), vone, vzero);
@@ -132,7 +139,7 @@ simd_floor_divide_by_scalar_contig_timedelta(char **args, npy_intp len)
         VI64 to_ninf   = hn::Xor(nsign_a, nsign_d);
         VI64 trunc     = simd_trunc_divide_s64(hn::Add(a, diff_sign), mv, p.sh, dsignv);
         VI64 floor     = hn::Sub(trunc, to_ninf);
-        floor = hn::IfThenElse(nat, vzero, floor);
+        floor = hn::IfThenElse(nat, nat_out, floor);
         hn::StoreU(floor, d, dst + i);
     }
     if (any_nat) {
@@ -142,8 +149,13 @@ simd_floor_divide_by_scalar_contig_timedelta(char **args, npy_intp len)
     for (; i < len; ++i) {
         const npy_int64 a = src[i];
         if (a == NPY_DATETIME_NAT) {
-            npy_set_floatstatus_invalid();
-            dst[i] = 0;
+            if (propagate_nat) {
+                dst[i] = NPY_DATETIME_NAT;
+            }
+            else {
+                npy_set_floatstatus_invalid();
+                dst[i] = 0;
+            }
         }
         else {
             npy_int64 r = a / scalar;
@@ -247,7 +259,7 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(TIMEDELTA_mm_q_floor_divide)
 #if NPY_SIMD && !defined(SIMD_DISABLE_DIV64_OPT)
             /* contiguous block of memory with a non-zero, non-NAT scalar divisor */
             if (IS_BLOCKABLE_BINARY_SCALAR2(sizeof(npy_timedelta), NPY_SIMD_WIDTH)) {
-                simd_floor_divide_by_scalar_contig_timedelta(args, n);
+                simd_floor_divide_by_scalar_contig_timedelta(args, n, false);
                 return;
             }
 #endif
@@ -287,6 +299,70 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(TIMEDELTA_mm_q_floor_divide)
                     quo -= 1;
                 }
                 *((npy_int64 *)op1) = quo;
+            }
+        }
+    }
+}
+
+NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(TIMEDELTA_mq_m_floor_divide)
+(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+{
+    BINARY_DEFS
+
+    /* When the divisor is a scalar, we can vectorize the division */
+    if (steps[1] == 0) {
+        /* In case of empty array, just return */
+        if (n == 0) {
+            return;
+        }
+
+        const npy_int64 in2 = *(npy_int64 *)ip2;
+
+        /* If divisor is 0, we need not compute anything */
+        if (in2 == 0) {
+            npy_set_floatstatus_divbyzero();
+            BINARY_LOOP_SLIDING {
+                *((npy_timedelta *)op1) = NPY_DATETIME_NAT;
+            }
+        }
+        else {
+#if NPY_SIMD && !defined(SIMD_DISABLE_DIV64_OPT)
+            /* contiguous block of memory with a non-zero scalar divisor */
+            if (IS_BLOCKABLE_BINARY_SCALAR2(sizeof(npy_timedelta), NPY_SIMD_WIDTH)) {
+                simd_floor_divide_by_scalar_contig_timedelta(args, n, true);
+                return;
+            }
+#endif
+            BINARY_LOOP_SLIDING {
+                const npy_timedelta in1 = *(npy_timedelta *)ip1;
+                if (in1 == NPY_DATETIME_NAT) {
+                    *((npy_timedelta *)op1) = NPY_DATETIME_NAT;
+                }
+                else {
+                    npy_timedelta quo = in1 / in2;
+                    /* Negative quotients needs to be rounded down */
+                    if (((in1 > 0) != (in2 > 0)) && (quo * in2 != in1)) {
+                        quo -= 1;
+                    }
+                    *((npy_timedelta *)op1) = quo;
+                }
+            }
+        }
+    }
+    else {
+        BINARY_LOOP_SLIDING {
+            const npy_timedelta in1 = *(npy_timedelta *)ip1;
+            const npy_int64 in2 = *(npy_int64 *)ip2;
+            if (in1 == NPY_DATETIME_NAT || in2 == 0) {
+                *((npy_timedelta *)op1) = NPY_DATETIME_NAT;
+            }
+            else {
+                npy_timedelta quo = in1 / in2;
+                /* Negative quotients needs to be rounded down */
+                if (((in1 > 0) != (in2 > 0)) && (quo * in2 != in1)) {
+                    quo -= 1;
+                }
+                *((npy_timedelta *)op1) = quo;
             }
         }
     }

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1814,6 +1814,29 @@ class TestDateTime:
         exp = [0 if v == imin else int(v) // d for v in vals]
         assert_array_equal(got, np.array(exp, dtype=np.int64))
 
+    @pytest.mark.parametrize("d", [1, 2, 3, 7, -4, 999983])
+    def test_timedelta_floor_divide_by_int_scalar_simd(self, d):
+        # m8 // int -> floor division (TIMEDELTA_mq_m_floor_divide); gh-32522
+        imin = np.iinfo(np.int64).min
+        vals = self._simd_timedelta_operands()
+        got = (vals.view('m8[s]') // np.int64(d)).view(np.int64)
+        exp = [imin if v == imin else int(v) // d for v in vals]
+        assert_array_equal(got, np.array(exp, dtype=np.int64))
+
+    def test_timedelta_floor_divide_by_int_matches_int64(self):
+        # Negative timedelta // int must floor like int64 // int (gh-32522)
+        delta = np.timedelta64(-7, "us")
+        assert_equal(delta // 2, np.timedelta64(-4, "us"))
+        assert_equal(delta // np.int64(2), np.timedelta64(-4, "us"))
+        assert_equal(
+            int((delta // 2) / np.timedelta64(1, "us")),
+            int(np.int64(-7) // 2),
+        )
+        assert_equal(
+            int(delta // np.timedelta64(2, "us")),
+            int(np.int64(-7) // 2),
+        )
+
     def test_generic_timedelta_floor_divide(self):
         with pytest.warns(
             DeprecationWarning,

--- a/numpy/_core/tests/test_datetime.py
+++ b/numpy/_core/tests/test_datetime.py
@@ -1837,6 +1837,25 @@ class TestDateTime:
             int(np.int64(-7) // 2),
         )
 
+    def test_timedelta_floor_divide_by_int_array(self):
+        # Non-scalar divisor path (steps[1] != 0) in TIMEDELTA_mq_m_floor_divide
+        vals = np.array([-7, -8, -1, 0, 1, 7, -7], dtype=np.int64)
+        divs = np.array([2, 3, 2, 2, 2, -2, 0], dtype=np.int64)
+        with np.errstate(divide='ignore'):
+            got = (vals.view('m8[us]') // divs).view(np.int64)
+        exp = np.array(
+            [v // d if d != 0 else np.iinfo(np.int64).min for v, d in zip(vals, divs)],
+            dtype=np.int64,
+        )
+        assert_array_equal(got, exp)
+
+        # NaT dividend stays NaT
+        nat = np.iinfo(np.int64).min
+        left = np.array([nat, -7], dtype=np.int64).view('m8[us]')
+        right = np.array([2, 2], dtype=np.int64)
+        got_nat = (left // right).view(np.int64)
+        assert_array_equal(got_nat, np.array([nat, -4], dtype=np.int64))
+
     def test_generic_timedelta_floor_divide(self):
         with pytest.warns(
             DeprecationWarning,

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -637,6 +637,11 @@ class TestDivision:
              (np.timedelta64(-2, 'Y'), -2, np.timedelta64(1, 'Y')),
              (np.timedelta64(-2, 'Y'), -2, np.timedelta64(1, 'Y')),
              (np.timedelta64(-2, 'Y'), -3, np.timedelta64(0, 'Y')),
+             # Floor, not toward-zero truncation; see gh-32522
+             (np.timedelta64(-7, 'us'), 2, np.timedelta64(-4, 'us')),
+             (np.timedelta64(7, 'us'), -2, np.timedelta64(-4, 'us')),
+             (np.timedelta64(-7, 'us'), -2, np.timedelta64(3, 'us')),
+             (np.timedelta64(-7, 'us'), 3, np.timedelta64(-3, 'us')),
              (np.timedelta64(-2, 'Y'), 0, np.timedelta64('Nat', 'Y')),
             ])
     def test_division_int_timedelta(self, dividend, divisor, quotient):


### PR DESCRIPTION
### PR summary

`timedelta64 // int` was wired to the same loop as true division (`TIMEDELTA_mq_m_divide`), which uses C truncating `/`. For negative values that means rounding toward zero, while `int64 // int`, `timedelta64 // timedelta64`, and Python `datetime.timedelta // int` all floor.

This adds a real `TIMEDELTA_mq_m_floor_divide` loop (including the existing SIMD floor path with NaT propagation for the `mQ->m` result) and stops aliasing `floor_divide` `mq` to `divide`. True division `timedelta64 / int` is unchanged and still truncates.

Closes #32522

### First time committer introduction

I use NumPy in day to day Python work and was looking for a small, well scoped correctness bug to contribute. Issue #32522 is a clear ufunc contract mismatch with a focused fix path, so I worked through the timedelta division loops and tests there.

#### AI Disclosure

Cursor (Composer agent) was used to help locate the `mq` floor_divide alias in `generate_umath.py` / `loops_arithmetic_timedelta.dispatch.cpp`, draft the `TIMEDELTA_mq_m_floor_divide` implementation and tests, build locally on Windows, and open this PR. I reviewed the change, checked it against the issue reproduction and related floor vs trunc cases, and am responsible for the submitted code and this description.