### PR TITLE
BUG: Fix permission denied error in devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/universal:2",
 	"features": {},
 
-	"onCreateCommand": ".devcontainer/setup.sh",
+	"onCreateCommand": "bash .devcontainer/setup.sh",
 	"postCreateCommand": "",
 
 	"customizations": {


### PR DESCRIPTION
### PR summary

Explicitly invoke bash for `.devcontainer/setup.sh` in `devcontainer.json`.
This resolves a permission issue that caused the setup script to fail 
when directly creating a GitHub Codespace.

Below is a certain section of `/vscode/workspace/.codespaces/.persistedshare/creation.log` file that shows the error : 

```
2026-09-06 21:51:57.759Z: Running the onCreateCommand from devcontainer.json...

2026-09-06 21:51:57.759Z: .devcontainer/setup.sh
2026-09-06 21:52:01.036Z: /bin/sh: 1: .devcontainer/setup.sh: Permission denied
2026-09-06 21:52:01.044Z: onCreateCommand from devcontainer.json failed with exit code 126. Skipping any further user-provided commands.

2026-09-06 21:52:01.044Z: Error: Command failed: /bin/sh -c .devcontainer/setup.sh
2026-09-06 21:52:01.044Z: {"outcome":"error","message":"Command failed: /bin/sh -c .devcontainer/setup.sh","description":"onCreateCommand from devcontainer.json failed.","containerId":"4e5cbd417d689bc5833d317edcb3ce8adc7175a7b9f359e5bf6bd27722d70c54"}
```

### First time committer introduction

Hi, I use NumPy for my daily Python & Machine Learning work. I wanted to contribute to NumPy and wanted to have a look at its source code. Since I often work on codespaces, creating one on this gave me an error, prompting me to look at its creation log.

#### AI Disclosure

Claude was used in analyzing a certain section of `creation.log` file.
