### PR TITLE
BUG: Fix truncation of scalar arguments in np.strings.replace

### DIFF
--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -1343,8 +1343,8 @@ def replace(a, old, new, count=-1):
         return _replace(a, old, new, count)
 
     a_dt = arr.dtype
-    old = old_arr.astype(old_dtype or a_dt, copy=False)
-    new = new_arr.astype(new_dtype or a_dt, copy=False)
+    old = old_arr.astype(old_dtype or a_dt.type, copy=False)
+    new = new_arr.astype(new_dtype or a_dt.type, copy=False)
     max_int64 = np.iinfo(np.int64).max
     counts = _count_ufunc(arr, old, 0, max_int64)
     counts = np.where(count < 0, counts, np.minimum(counts, count))

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -797,6 +797,15 @@ class TestMethods:
         res = np.array(res, dtype=dt)
         assert_array_equal(np.strings.replace(buf, old, new, count), res)
 
+    def test_replace_scalar_truncation(self):
+        # Test for issue #32518
+        a = np.array(["a"])
+        res = np.strings.replace(a, "ab", "X")
+        assert_array_equal(res, np.array(["a"])) # "ab" is not found
+
+        res = np.strings.replace(a, "a", "XY")
+        assert_array_equal(res, np.array(["XY"]))
+
     @pytest.mark.parametrize("buf,sub,start,end,res", [
         ("abcdefghiabc", "", 0, None, 0),
         ("abcdefghiabc", "def", 0, None, 3),

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -797,14 +797,15 @@ class TestMethods:
         res = np.array(res, dtype=dt)
         assert_array_equal(np.strings.replace(buf, old, new, count), res)
 
-    def test_replace_scalar_truncation(self):
-        # Test for issue #32518
-        a = np.array(["a"])
-        res = np.strings.replace(a, "ab", "X")
-        assert_array_equal(res, np.array(["a"])) # "ab" is not found
+    def test_replace_scalar_truncation(self, dt):
+    # Test for issue #32518
+    a = np.array(["a"], dtype=dt)
 
-        res = np.strings.replace(a, "a", "XY")
-        assert_array_equal(res, np.array(["XY"]))
+    res = np.strings.replace(a, "ab", "X")
+    assert_array_equal(res, np.array(["a"], dtype=dt))
+
+    res = np.strings.replace(a, "a", "XY")
+    assert_array_equal(res, np.array(["XY"], dtype=dt))
 
     @pytest.mark.parametrize("buf,sub,start,end,res", [
         ("abcdefghiabc", "", 0, None, 0),


### PR DESCRIPTION
### PR summary
Fixes Issue #32518.

When Python strings were used with `np.strings.replace` on fixed-width string arrays, longer strings could be cut off to match the length of the strings already in the array.

This change fixes that behavior so that the strings passed to `replace` keep their full length.

I have also added a test in test_strings.py to check that this behavior is covered.

### First-time committer introduction
Hi! I'm Dhyey, a Computer Science student at IIT Gandhinagar. I've been using NumPy as part of my coursework and while learning machine learning and data science.

This is my first contribution to the NumPy project, and I wanted to solve an issue where I could genuinely understand the issue and the fix. I was looking for a good first issue to start contributing to and came across this particular bug report. 

#### AI Disclosure
I used an AI coding assistant (Gemini) to help me locate the bug in strings.py and understand how the .astype() was truncating the scalars. The final code change and test were suggested by the AI, which I reviewed, understood, and manually applied.
