### PR TITLE
BUG: show the indexing object type in invalid-index error

### DIFF
--- a/doc/release/upcoming_changes/32529.improvement.rst
+++ b/doc/release/upcoming_changes/32529.improvement.rst
@@ -1,0 +1,6 @@
+Invalid index error message now shows the type of the indexing object
+---------------------------------------------------------------------
+The error raised when an array is indexed with an invalid object is now
+the short ``cannot index with <type>`` form (showing the type of the
+object used for indexing) instead of enumerating the accepted index
+types (gh-26115).

--- a/numpy/_core/src/multiarray/iterators.c
+++ b/numpy/_core/src/multiarray/iterators.c
@@ -534,10 +534,8 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
     }
 
     else if (indices[0].type == HAS_NEWAXIS) {
-        PyErr_SetString(PyExc_IndexError,
-            "only integers, slices (`:`), ellipsis (`...`) and integer or boolean "
-            "arrays are valid indices"
-        );
+        PyErr_Format(PyExc_IndexError, "cannot index with %R",
+                     Py_TYPE(ind));
         goto finish;
     }
 
@@ -654,10 +652,7 @@ iter_subscript(PyArrayIterObject *self, PyObject *ind)
         goto finish;
     }
 
-    PyErr_SetString(PyExc_IndexError,
-        "only integers, slices (`:`), ellipsis (`...`) and integer or boolean "
-        "arrays are valid indices"
-    );
+    PyErr_Format(PyExc_IndexError, "cannot index with %R", Py_TYPE(ind));
 finish:
     NPY_cast_info_xfree(&cast_info);
     for (int i = 0; i < index_num; i++) {
@@ -803,10 +798,8 @@ iter_ass_subscript(PyArrayIterObject *self, PyObject *ind, PyObject *val)
         goto finish;
     }
     else if (indices[0].type == HAS_NEWAXIS) {
-        PyErr_SetString(PyExc_IndexError,
-            "only integers, slices (`:`), ellipsis (`...`) and integer or boolean "
-            "arrays are valid indices"
-        );
+        PyErr_Format(PyExc_IndexError, "cannot index with %R",
+                     Py_TYPE(ind));
         goto finish;
     }
 
@@ -927,10 +920,7 @@ iter_ass_subscript(PyArrayIterObject *self, PyObject *ind, PyObject *val)
         goto finish;
     }
 
-    PyErr_SetString(PyExc_IndexError,
-        "only integers, slices (`:`), ellipsis (`...`) and integer or boolean "
-        "arrays are valid indices"
-    );
+    PyErr_Format(PyExc_IndexError, "cannot index with %R", Py_TYPE(ind));
 finish:
     NPY_cast_info_xfree(&cast_info);
     for (int i = 0; i < index_num; i++) {

--- a/numpy/_core/src/multiarray/mapping.c
+++ b/numpy/_core/src/multiarray/mapping.c
@@ -437,11 +437,8 @@ prepare_index_noarray(int array_ndims, npy_intp *array_dims, PyObject *index,
                 if (arr == NULL) {
                     // Raise a helpful error if this was a ValueError (i.e. could not cast)
                     if (PyErr_ExceptionMatches(PyExc_ValueError)) {
-                        PyErr_Format(PyExc_IndexError,
-                            "only integers, slices (`:`), ellipsis (`...`)%s and integer or boolean "
-                            "arrays are valid indices",
-                            is_flatiter_object ? "" : ", numpy.newaxis (`None`)"
-                        );
+                        PyErr_Format(PyExc_IndexError, "cannot index with %R",
+                                     Py_TYPE(index));
                     }
                     goto failed_building_indices;
                 }
@@ -618,11 +615,8 @@ prepare_index_noarray(int array_ndims, npy_intp *array_dims, PyObject *index,
         }
         else {
             /* The input was not an array, so give a general error message */
-            PyErr_Format(PyExc_IndexError,
-                    "only integers, slices (`:`), ellipsis (`...`)%s and integer or boolean "
-                    "arrays are valid indices",
-                    is_flatiter_object ? "" : ", numpy.newaxis (`None`)"
-                );
+            PyErr_Format(PyExc_IndexError, "cannot index with %R",
+                         Py_TYPE(index));
         }
         goto failed_building_indices;
     }

--- a/numpy/_core/tests/test_indexing.py
+++ b/numpy/_core/tests/test_indexing.py
@@ -1434,6 +1434,17 @@ class TestMultipleEllipsisError:
         assert_raises(IndexError, a.__getitem__, ((Ellipsis,) * 3,))
 
 
+class TestInvalidIndexErrorMessage:
+    """The invalid index error should point at the indexing object (gh-26115).
+
+    """
+    def test_list_of_slices(self):
+        a = np.zeros((5, 5))
+        with pytest.raises(IndexError,
+                           match=r"cannot index with <class 'list'>"):
+            a[[slice(None), slice(None)]]
+
+
 class TestCApiAccess:
     def test_getitem(self):
         subscript = functools.partial(array_indexing, 0)
@@ -1540,9 +1551,7 @@ class TestFlatiterIndexing:
     def test_flatiter_indexing_not_supported_newaxis_mutlidimensional_float(self):
         a = np.arange(9).reshape((3, 3))
         with pytest.raises(IndexError,
-                           match=r"only integers, slices \(`:`\), "
-                                 r"ellipsis \(`\.\.\.`\) and "
-                                 r"integer or boolean arrays are valid indices"):
+                           match=r"cannot index with <class 'NoneType'>"):
             a.flat[None]
 
         with pytest.raises(IndexError,
@@ -1665,9 +1674,7 @@ class TestFlatiterIndexing:
     def test_flatiter_indexing_not_supported_newaxis_mutlid_float_assign(self):
         a = np.arange(9).reshape((3, 3))
         with pytest.raises(IndexError,
-                           match=r"only integers, slices \(`:`\), "
-                                 r"ellipsis \(`\.\.\.`\) and "
-                                 r"integer or boolean arrays are valid indices"):
+                           match=r"cannot index with <class 'NoneType'>"):
             a.flat[None] = 10
 
         a.flat[[1, 2]] = 10
@@ -1697,8 +1704,7 @@ class TestFlatiterIndexing:
         a = np.arange(9).reshape((3, 3))
         b = np.array(["a"], dtype="S")
         with pytest.raises(IndexError,
-                match=r"only integers, slices \(`:`\), ellipsis \(`\.\.\.`\) "
-                      r"and integer or boolean arrays are valid indices"):
+                match=r"cannot index with <class 'numpy.flatiter'>"):
             a.flat[b.flat]
 
 


### PR DESCRIPTION
The error raised for invalid indices enumerates everything that is accepted, which is getting too long and still sends users debugging the individual indices instead of the indexing object itself (gh-26115).

Following the direction suggested on gh-26120, the message now reflects that the particular indexing construct is not accepted: all six sites in `mapping.c` and `iterators.c` raise `IndexError: cannot index with <type>`, with the type printed via `PyErr_Format(..., "%R", Py_TYPE(index))`. The existing tests pinning the old wording are updated, and a regression test covers the list-of-slices case from the issue plus the `flatiter` paths (`a.flat[None]`, `a.flat[b.flat]`).

```python
>>> a = np.zeros((5, 5))
a[[slice(None), slice(None)]]
IndexError: cannot index with <class 'list'>
>>> a.flat[None]
IndexError: cannot index with <class 'NoneType'>
```

Closes gh-26115 (follow-up to gh-26120, per maintainer review there).

### AI Disclosure

Generated with AI assistance (an AI agent produced the change); the account owner verified the red/green test results and the full indexing test-suite run before submitting.

- [ ] I have read the [Contributor Guide] and signed the [CLA].

[Contributor Guide]: https://numpy.org/doc/stable/dev/contributor_guide.html
[CLA]: https://cla.developers.google.com/review/google-python-numpy