### PR TITLE
BUG: fix np.average on timedelta64 arrays

### DIFF
--- a/doc/release/upcoming_changes/32530.bugfix.rst
+++ b/doc/release/upcoming_changes/32530.bugfix.rst
@@ -1,0 +1,1 @@
+``np.average`` now works on ``timedelta64`` arrays, matching the behavior of ``np.mean``. (GH32530)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -587,7 +587,13 @@ def average(a, axis=None, weights=None, returned=False, *,
     if weights is None:
         avg = a.mean(axis, **keepdims_kw)
         avg_as_array = np.asanyarray(avg)
-        scl = avg_as_array.dtype.type(a.size / avg_as_array.size)
+        if avg_as_array.dtype.kind in 'mM':
+            # datetime64/timedelta64 have no scalar type, so the sum of the
+            # (all-ones) weights is kept as a float instead of being cast to
+            # the array's dtype.
+            scl = np.float64(a.size / avg_as_array.size)
+        else:
+            scl = avg_as_array.dtype.type(a.size / avg_as_array.size)
     else:
         wgt = _weights_are_valid(weights=weights, a=a, axis=axis)
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -384,6 +384,22 @@ class TestAverage:
         assert wsum.shape == np.shape(expected_wsum)
         assert_array_equal(wsum, expected_wsum)
 
+    def test_average_timedelta64(self):
+        # Regression test for gh-27204: np.average used to fail on
+        # timedelta64 arrays because the sum of the (all-ones) weights was
+        # cast to the array's dtype, which has no scalar type.
+        a = np.array([1, 3, 5], dtype='timedelta64[D]')
+        assert_array_equal(np.average(a), np.timedelta64(3, 'D'))
+        avg, scl = np.average(a, returned=True)
+        assert avg == np.timedelta64(3, 'D')
+        assert scl == 3.0
+        # axis reduction and keepdims
+        b = np.array([[1, 2, 3], [4, 5, 6]], dtype='timedelta64[D]')
+        assert_array_equal(np.average(b, axis=1),
+                           np.array([2, 5], dtype='timedelta64[D]'))
+        assert_array_equal(np.average(b, axis=0, keepdims=True),
+                           np.array([[2, 3, 4]], dtype='timedelta64[D]'))
+
     def test_weights(self):
         y = np.arange(10)
         w = np.arange(10)


### PR DESCRIPTION
Fixes gh-27204.

`np.average` on `timedelta64` arrays raised
`ValueError: Could not convert object to NumPy timedelta` even though
`np.mean` (and the array method) work fine on the same data. The
`weights=None` path computed the sum of the all-ones weights as
`avg_as_array.dtype.type(a.size / avg_as_array.size)`, and
`timedelta64` (like `datetime64`) has no scalar type, so the cast
failed.

The sum of the weights is a plain count, so for `datetime64`/
`timedelta64` results it is now kept as a `float64` instead of being
cast to the array's dtype. All numeric dtypes go through the exact
same code path as before.

Verified against a source build (2.6.0.dev0): RED before the patch,
GREEN after; `test_function_base.py` full run 1472 passed, 79 skipped,
1 xfailed (zero regressions), plus a new regression test
`TestAverage::test_average_timedelta64`.

---

This PR was created with the assistance of an AI coding agent
(hermes agent) and verified by the account owner (reproducing the
bug on a pristine build, applying the patch, and running the test
suite).