### PR TITLE
ENH: avoid per-call reference counting of DTypes and ufuncs in ufunc calls

### DIFF
--- a/numpy/_core/src/multiarray/abstractdtypes.h
+++ b/numpy/_core/src/multiarray/abstractdtypes.h
@@ -43,8 +43,8 @@ initialize_abstract_dtypes(void);
  *
  * @param obj The original Python object.
  * @param arr The array into which the Python object was converted.
- * @param[in,out] **dtype A pointer to the array's DType, if not NULL it will be
- *        replaced with the abstract DType.
+ * @param[in,out] **dtype A borrowed pointer to the array's DType, if not NULL
+ *        it will be replaced with the (effectively immortal) abstract DType.
  * @return 0 if the `obj` was not a python scalar, and 1 if it was.
  */
 static inline int
@@ -54,24 +54,21 @@ npy_mark_tmp_array_if_pyscalar(
     if (PyLong_CheckExact(obj)) {
         _PyArray_GET_ITEM_DATA(arr)->flags |= NPY_ARRAY_WAS_PYTHON_INT;
         if (dtype != NULL) {
-            Py_INCREF(&PyArray_PyLongDType);
-            Py_SETREF(*dtype, &PyArray_PyLongDType);
+            *dtype = &PyArray_PyLongDType;
         }
         return 1;
     }
     else if (PyFloat_CheckExact(obj)) {
         _PyArray_GET_ITEM_DATA(arr)->flags |= NPY_ARRAY_WAS_PYTHON_FLOAT;
         if (dtype != NULL) {
-            Py_INCREF(&PyArray_PyFloatDType);
-            Py_SETREF(*dtype, &PyArray_PyFloatDType);
+            *dtype = &PyArray_PyFloatDType;
         }
         return 1;
     }
     else if (PyComplex_CheckExact(obj)) {
         _PyArray_GET_ITEM_DATA(arr)->flags |= NPY_ARRAY_WAS_PYTHON_COMPLEX;
         if (dtype != NULL) {
-            Py_INCREF(&PyArray_PyComplexDType);
-            Py_SETREF(*dtype, &PyArray_PyComplexDType);
+            *dtype = &PyArray_PyComplexDType;
         }
         return 1;
     }

--- a/numpy/_core/src/multiarray/array_converter.c
+++ b/numpy/_core/src/multiarray/array_converter.c
@@ -95,7 +95,6 @@ array_converter_new(
         self->narrs++;
         Py_INCREF(item->object);
         item->DType = NPY_DTYPE(PyArray_DESCR(item->array));
-        Py_INCREF(item->DType);
 
         /*
          * Check whether we were passed an int/float/complex Python scalar.
@@ -119,6 +118,7 @@ array_converter_new(
                 self->flags &= ~(NPY_CH_ALL_PYSCALARS | NPY_CH_ALL_SCALARS);
             }
         }
+        Py_INCREF(item->DType);
     }
 
     return (PyObject *)self;

--- a/numpy/_core/src/multiarray/multiarraymodule.c
+++ b/numpy/_core/src/multiarray/multiarraymodule.c
@@ -1993,8 +1993,8 @@ array_copyto(PyObject *NPY_UNUSED(ignored),
     if (src == NULL) {
         goto fail;
     }
+    /* borrowed, `src` keeps it alive */
     PyArray_DTypeMeta *DType = NPY_DTYPE(PyArray_DESCR(src));
-    Py_INCREF(DType);
     int is_pyscalar = npy_mark_tmp_array_if_pyscalar(src_obj, src, &DType);
     if (is_pyscalar || npy_mark_tmp_array_if_pystr(src_obj, src)) {
         PyArray_Descr *descr;
@@ -2010,7 +2010,6 @@ array_copyto(PyObject *NPY_UNUSED(ignored),
             descr = npy_find_descr_for_scalar(src_obj, PyArray_DESCR(src), DType,
                                               dst_DType);
         }
-        Py_DECREF(DType);
         if (descr == NULL) {
             goto fail;
         }
@@ -2019,9 +2018,6 @@ array_copyto(PyObject *NPY_UNUSED(ignored),
         if (res < 0) {
             goto fail;
         }
-    }
-    else {
-        Py_DECREF(DType);
     }
 
     if (wheremask_in != NULL) {

--- a/numpy/_core/src/umath/dispatching.cpp
+++ b/numpy/_core/src/umath/dispatching.cpp
@@ -886,8 +886,8 @@ legacy_promote_using_legacy_type_resolver(PyUFuncObject *ufunc,
      */
     for (int i = 0; i < nargs; i++) {
         if (signature[i] != NULL && signature[i] != operation_DTypes[i]) {
-            Py_INCREF(operation_DTypes[i]);
-            Py_SETREF(signature[i], operation_DTypes[i]);
+            /* borrowed, legacy DTypes are effectively immortal */
+            signature[i] = operation_DTypes[i];
             *out_cacheable = 0;
         }
     }
@@ -1113,10 +1113,12 @@ promote_and_get_info_and_ufuncimpl(PyUFuncObject *ufunc,
  * @param ops The array operands (used only for the fallback).
  * @param signature As input, the DType signature fixed explicitly by the user.
  *        The signature is *filled* in with the operation signature we end up
- *        using.
+ *        using.  Entries are borrowed (owned by the append-only
+ *        `ufunc->_loops`).
  * @param op_dtypes The operand DTypes (without casting) which are specified
  *        either by the `signature` or by an `operand`.
  *        (outputs and the second input can be NULL for reductions).
+ *        Entries are borrowed (kept alive by the operands).
  *        NOTE: In some cases, the promotion machinery may currently modify
  *        these including clearing the output.
  * @param force_legacy_promotion If set, we have to use the old type resolution
@@ -1158,8 +1160,7 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
              * ignore the operand input, we cannot overwrite signature yet
              * since it is fixed (cannot be promoted!)
              */
-            Py_INCREF(signature[i]);
-            Py_XSETREF(op_dtypes[i], signature[i]);
+            op_dtypes[i] = signature[i];
             assert(i >= ufunc->nin || !NPY_DT_is_abstract(signature[i]));
         }
         else if (i >= nin) {
@@ -1169,7 +1170,7 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
              * loops which include the cast).
              * (See also comment in resolve_implementation_info.)
              */
-            Py_CLEAR(op_dtypes[i]);
+            op_dtypes[i] = NULL;
         }
         /*
          * If the op_dtype ends up being a non-legacy one, then we cannot use
@@ -1205,7 +1206,6 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
     if (ensure_reduce_compatible && signature[0] == NULL &&
             PyTuple_GET_ITEM(all_dtypes, 0) != PyTuple_GET_ITEM(all_dtypes, 2)) {
         signature[0] = (PyArray_DTypeMeta *)PyTuple_GET_ITEM(all_dtypes, 2);
-        Py_INCREF(signature[0]);
         return promote_and_get_ufuncimpl(ufunc,
                 ops, signature, op_dtypes,
                 force_legacy_promotion,
@@ -1215,7 +1215,6 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
     for (int i = 0; i < nargs; i++) {
         if (signature[i] == NULL) {
             signature[i] = (PyArray_DTypeMeta *)PyTuple_GET_ITEM(all_dtypes, i);
-            Py_INCREF(signature[i]);
         }
         else if ((PyObject *)signature[i] != PyTuple_GET_ITEM(all_dtypes, i)) {
             /*

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -2452,7 +2452,7 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
  *        the array itself to the type-resolution.
  * @param signature The DType signature, which may already be set due to the
  *        dtype passed in by the user, or the special cases (add, multiply).
- *        (Contains strong references and may be modified.)
+ *        (Contains borrowed references and may be modified.)
  * @param enforce_uniform_args If `NPY_TRUE` fully uniform dtypes/descriptors
  *        are enforced as required for accumulate and (currently) reduceat.
  * @param out_descrs New references to the resolved descriptors (on success).
@@ -2489,19 +2489,20 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
                 && ((strcmp(ufunc->name, "add") == 0)
                     || (strcmp(ufunc->name, "multiply") == 0))) {
             if (PyTypeNum_ISBOOL(typenum)) {
-                typenum = NPY_INTP;
+                signature[0] = &PyArray_IntpDType;
             }
             else if ((size_t)PyArray_ITEMSIZE(arr) < sizeof(npy_intp)) {
                 if (PyTypeNum_ISUNSIGNED(typenum)) {
-                    typenum = NPY_UINTP;
+                    signature[0] = &PyArray_UIntpDType;
                 }
                 else {
-                    typenum = NPY_INTP;
+                    signature[0] = &PyArray_IntpDType;
                 }
             }
-            /* borrow, builtin DTypes are effectively immortal */
-            signature[0] = PyArray_DTypeFromTypeNum(typenum);
-            Py_DECREF(signature[0]);
+            else {
+                /* borrowed, `arr` keeps it alive */
+                signature[0] = NPY_DTYPE(PyArray_DESCR(arr));
+            }
         }
     }
     assert(signature[2] == NULL);  /* we always fill it here */

--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -626,6 +626,7 @@ _wheremask_converter(PyObject *obj, PyArrayObject **wheremask)
  *
  * `*operand` must be an owned reference to a temporary array (freshly
  * converted from `obj`); it may be replaced with a new reference.
+ * `*DType` is borrowed and replaced with the pyscalar DType
  *
  * Returns 1 if `obj` was a Python int, float, or complex, and 0 otherwise.
  */
@@ -704,8 +705,8 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
             /* Does not affect promotion, only conversion after resolution. */
             npy_mark_tmp_array_if_pystr(obj, out_op[i]);
         }
+        /* borrowed, the operand keeps it alive */
         out_op_DTypes[i] = NPY_DTYPE(PyArray_DESCR(out_op[i]));
-        Py_INCREF(out_op_DTypes[i]);
 
         if (nin == 1) {
             /*
@@ -748,7 +749,6 @@ convert_ufunc_arguments(PyUFuncObject *ufunc,
             }
             if (out_op[i] != NULL) {
                 out_op_DTypes[i + nin] = NPY_DTYPE(PyArray_DESCR(out_op[i]));
-                Py_INCREF(out_op_DTypes[i + nin]);
             }
         }
     }
@@ -2347,7 +2347,7 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
 
     for (int i = 0; i < nin; i++) {
         ops[i] = arr;
-        Py_INCREF(stream_DType);
+        /* borrowed, `arr` keeps it alive */
         operation_DTypes[i] = stream_DType;
     }
     /*
@@ -2364,9 +2364,7 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
         else if (signature[0] != NULL) {
             out_DType = signature[0];
         }
-        Py_XINCREF(out_DType);
         operation_DTypes[nin + i] = out_DType;
-        Py_XINCREF(signature[0]);
         fwd_signature[nin + i] = signature[0];
     }
 
@@ -2374,21 +2372,12 @@ reducelike_promote_and_resolve_multi(PyUFuncObject *ufunc,
             ops, fwd_signature, operation_DTypes, NPY_FALSE, NPY_FALSE, NPY_FALSE);
 
     if (ufuncimpl == NULL) {
-        for (int i = 0; i < fwd_nargs; i++) {
-            Py_XDECREF(operation_DTypes[i]);
-            Py_XDECREF(fwd_signature[i]);
-        }
         return NULL;
     }
 
     PyArray_Descr *fwd_descrs[NPY_MAXARGS];
     int res = resolve_descriptors(fwd_nargs, ufunc, ufuncimpl,
             ops, fwd_descrs, fwd_signature, operation_DTypes, NULL, casting);
-
-    for (int i = 0; i < fwd_nargs; i++) {
-        Py_XDECREF(operation_DTypes[i]);
-        Py_XDECREF(fwd_signature[i]);
-    }
     if (res < 0) {
         return NULL;
     }
@@ -2510,11 +2499,12 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
                     typenum = NPY_INTP;
                 }
             }
+            /* borrow, builtin DTypes are effectively immortal */
             signature[0] = PyArray_DTypeFromTypeNum(typenum);
+            Py_DECREF(signature[0]);
         }
     }
     assert(signature[2] == NULL);  /* we always fill it here */
-    Py_XINCREF(signature[0]);
     signature[2] = signature[0];
 
     /*
@@ -2531,25 +2521,19 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
      *       value.  As of 1.20, it returned an integer, so that should
      *       probably go to an error/warning first.
      */
+    /* borrowed, the operands keep them alive */
     PyArray_DTypeMeta *operation_DTypes[3] = {
             NULL, NPY_DTYPE(PyArray_DESCR(arr)), NULL};
-    Py_INCREF(operation_DTypes[1]);
 
     if (_out != NULL) {
         operation_DTypes[0] = NPY_DTYPE(PyArray_DESCR(_out));
-        Py_INCREF(operation_DTypes[0]);
         operation_DTypes[2] = operation_DTypes[0];
-        Py_INCREF(operation_DTypes[2]);
     }
 
     PyArrayMethodObject *ufuncimpl = promote_and_get_ufuncimpl(ufunc,
             ops, signature, operation_DTypes, NPY_FALSE, NPY_FALSE, NPY_TRUE);
 
     if (ufuncimpl == NULL) {
-        /* DTypes may currently get filled in fallbacks and XDECREF for error: */
-        Py_XDECREF(operation_DTypes[0]);
-        Py_XDECREF(operation_DTypes[1]);
-        Py_XDECREF(operation_DTypes[2]);
         return NULL;
     }
 
@@ -2562,10 +2546,6 @@ reducelike_promote_and_resolve(PyUFuncObject *ufunc,
      */
     int res = resolve_descriptors(3, ufunc, ufuncimpl,
             ops, out_descrs, signature, operation_DTypes, NULL, casting);
-
-    Py_XDECREF(operation_DTypes[0]);
-    Py_XDECREF(operation_DTypes[1]);
-    Py_XDECREF(operation_DTypes[2]);
     if (res < 0) {
         return NULL;
     }
@@ -4139,10 +4119,6 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
         Py_XDECREF(out[i]);
     }
 
-    for (int i = 0; i < NPY_MAXARGS; i++) {
-        Py_XDECREF(signature[i]);
-    }
-
     Py_DECREF(mp);
     multi_XDECREF(ufunc_input, nin_args);
 
@@ -4201,10 +4177,6 @@ PyUFunc_GenericReduction(PyUFuncObject *ufunc,
 fail:
     for (int i = 0; i < ufunc->nout; i++) {
         Py_XDECREF(out[i]);
-    }
-
-    for (int i = 0; i < NPY_MAXARGS; i++) {
-        Py_XDECREF(signature[i]);
     }
 
     Py_XDECREF(mp);
@@ -4266,11 +4238,13 @@ _check_and_copy_sig_to_signature(
  * parsing should eventually be adapted to prefer classes and possible
  * deprecated instances. (Users should not notice that much, since `np.float64`
  * or "float64" usually denotes the DType class rather than the instance.)
+ *
+ * Returns a borrowed reference: `dtype_obj` itself, or a legacy DType (which
+ * is effectively immortal).
  */
 static PyArray_DTypeMeta *
 _get_dtype(PyObject *dtype_obj) {
     if (PyObject_TypeCheck(dtype_obj, &PyArrayDTypeMeta_Type)) {
-        Py_INCREF(dtype_obj);
         return (PyArray_DTypeMeta *)dtype_obj;
     }
     else {
@@ -4302,7 +4276,6 @@ _get_dtype(PyObject *dtype_obj) {
                 return NULL;
             }
         }
-        Py_INCREF(out);
         Py_DECREF(descr);
         return out;
     }
@@ -4316,8 +4289,8 @@ _get_dtype(PyObject *dtype_obj) {
  * descriptor).
  * Unlike the dtype of an `out` array, it influences loop selection!
  *
- * It is the callers responsibility to clean `signature` and NULL it before
- * calling.
+ * The caller must NULL `signature` before calling.  The entries are borrowed
+ * (kept alive by the passed objects, or effectively immortal legacy DTypes).
  */
 static int
 _get_fixed_signature(PyUFuncObject *ufunc,
@@ -4346,10 +4319,8 @@ _get_fixed_signature(PyUFuncObject *ufunc,
             return -1;
         }
         for (int i = nin; i < nop; i++) {
-            Py_INCREF(dtype);
             signature[i] = dtype;
         }
-        Py_DECREF(dtype);
         return 0;
     }
 
@@ -4447,8 +4418,8 @@ _get_fixed_signature(PyUFuncObject *ufunc,
                     Py_DECREF(str_object);
                     return -1;
                 }
+                /* borrowed, builtin DTypes are effectively immortal */
                 signature[i] = NPY_DTYPE(descr);
-                Py_INCREF(signature[i]);
                 Py_DECREF(descr);
             }
             Py_DECREF(str_object);
@@ -4919,6 +4890,10 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
     }
     memset(scratch_objs, 0, sizeof(void *) * (nop * 4 + 2 + nop));
 
+    /*
+     * `signature` and `operand_DTypes` are borrowed (kept alive by the
+     * operands, the arguments, or `ufunc->_loops`).
+     */
     PyArray_DTypeMeta **signature = (PyArray_DTypeMeta **)scratch_objs;
     PyArrayObject **operands = (PyArrayObject **)(signature + nop);
     PyArray_DTypeMeta **operand_DTypes = (PyArray_DTypeMeta **)(operands + nop + 1);
@@ -5193,8 +5168,6 @@ ufunc_generic_fastcall(PyUFuncObject *ufunc,
      */
     Py_XDECREF(wheremask);
     for (int i = 0; i < nop; i++) {
-        Py_DECREF(signature[i]);
-        Py_XDECREF(operand_DTypes[i]);
         Py_DECREF(operation_descrs[i]);
         if (i < nin) {
             Py_DECREF(operands[i]);
@@ -5223,8 +5196,6 @@ fail:
     Py_XDECREF(wheremask);
     for (int i = 0; i < ufunc->nargs; i++) {
         Py_XDECREF(operands[i]);
-        Py_XDECREF(signature[i]);
-        Py_XDECREF(operand_DTypes[i]);
         Py_XDECREF(operation_descrs[i]);
     }
     npy_free_workspace(scratch_objs);
@@ -5372,11 +5343,7 @@ PyUFunc_FromFuncAndDataAndSignatureAndIdentity(PyUFuncGenericFunction *func, voi
     }
 
     ufunc = PyObject_GC_New(PyUFuncObject, &PyUFunc_Type);
-    /*
-     * We use GC_New here for ufunc->obj, but do not use GC_Track since
-     * ufunc->obj is still NULL at the end of this function.
-     * See ufunc_frompyfunc where ufunc->obj is set and GC_Track is called.
-     */
+    /* GC tracked at the end of this function, once fully initialized. */
     if (ufunc == NULL) {
         return NULL;
     }
@@ -5502,6 +5469,13 @@ PyUFunc_FromFuncAndDataAndSignatureAndIdentity(PyUFuncGenericFunction *func, voi
      *       datetimes, this meant that `timedelta.sum(dtype="f8")` returned
      *       datetimes (and not floats or error), arguably wrong, but...
      */
+
+    /*
+     * Track the ufunc: on free-threaded CPython 3.15+ the specializer enables
+     * deferred refcounting for GC tracked module attributes, which removes the
+     * per-call refcount contention on the ufunc object.
+     */
+    PyObject_GC_Track(ufunc);
     return (PyObject *)ufunc;
 }
 
@@ -6573,9 +6547,9 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
          *       operand array is special (it is written to) similar to reductions.
          *       Using unsafe-casting as done here, is likely not desirable.
          */
+        /* borrowed, the operands keep the DTypes alive */
         tmp_operands[0] = op1_array;
         operand_DTypes[0] = NPY_DTYPE(PyArray_DESCR(op1_array));
-        Py_INCREF(operand_DTypes[0]);
         int force_legacy_promotion = 0;
 
         npy_bool op2_is_pyscalar = NPY_FALSE;
@@ -6585,7 +6559,6 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
             tmp_operands[1] = op2_array;
             Py_INCREF(tmp_operands[1]);
             operand_DTypes[1] = NPY_DTYPE(PyArray_DESCR(op2_array));
-            Py_INCREF(operand_DTypes[1]);
             multiarray_umath_state *state = _npy_module_state;
             if (mark_pyscalar_operand(
                     state, op2, &tmp_operands[1], &operand_DTypes[1])) {
@@ -6596,7 +6569,6 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
             }
             tmp_operands[2] = tmp_operands[0];
             operand_DTypes[2] = operand_DTypes[0];
-            Py_INCREF(operand_DTypes[2]);
 
             if ((PyArray_NDIM(op1_array) == 0)
                     != (PyArray_NDIM(op2_array) == 0)) {
@@ -6607,7 +6579,6 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
         else {
             tmp_operands[1] = tmp_operands[0];
             operand_DTypes[1] = operand_DTypes[0];
-            Py_INCREF(operand_DTypes[1]);
             tmp_operands[2] = NULL;
         }
 
@@ -6631,10 +6602,6 @@ ufunc_at(PyUFuncObject *ufunc, PyObject *args)
 
         if (op2_array != NULL) {
             Py_SETREF(op2_array, tmp_operands[1]);
-        }
-        for (int i = 0; i < 3; i++) {
-            Py_XDECREF(signature[i]);
-            Py_XDECREF(operand_DTypes[i]);
         }
         if (resolve_result < 0) {
             goto fail;
@@ -6894,8 +6861,8 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
             if (dummy_arrays[i] == NULL) {
                 goto finish;
             }
+            /* borrowed, the dummy array owns it */
             DTypes[i] = NPY_DTYPE(descr);
-            Py_INCREF(DTypes[i]);
         }
         /* Explicitly allow int, float, and complex for the "weak" types. */
         else if (descr_obj == (PyObject *)&PyLong_Type && i < ufunc -> nin) {
@@ -6905,7 +6872,6 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
                 goto finish;
             }
             PyArray_ENABLEFLAGS(dummy_arrays[i], NPY_ARRAY_WAS_PYTHON_INT);
-            Py_INCREF(&PyArray_PyLongDType);
             DTypes[i] = &PyArray_PyLongDType;
             promoting_pyscalars = NPY_TRUE;
         }
@@ -6916,7 +6882,6 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
                 goto finish;
             }
             PyArray_ENABLEFLAGS(dummy_arrays[i], NPY_ARRAY_WAS_PYTHON_FLOAT);
-            Py_INCREF(&PyArray_PyFloatDType);
             DTypes[i] = &PyArray_PyFloatDType;
             promoting_pyscalars = NPY_TRUE;
         }
@@ -6927,7 +6892,6 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
                 goto finish;
             }
             PyArray_ENABLEFLAGS(dummy_arrays[i], NPY_ARRAY_WAS_PYTHON_COMPLEX);
-            Py_INCREF(&PyArray_PyComplexDType);
             DTypes[i] = &PyArray_PyComplexDType;
             promoting_pyscalars = NPY_TRUE;
         }
@@ -7052,10 +7016,8 @@ py_resolve_dtypes_generic(PyUFuncObject *ufunc, npy_bool return_context,
   finish:
     Py_XDECREF(result_dtype_tuple);
     for (int i = 0; i < ufunc->nargs; i++) {
-        Py_XDECREF(signature[i]);
         Py_XDECREF(dummy_arrays[i]);
         Py_XDECREF(operation_descrs[i]);
-        Py_XDECREF(DTypes[i]);
     }
 
     return result;

--- a/numpy/_core/src/umath/umathmodule.c
+++ b/numpy/_core/src/umath/umathmodule.c
@@ -161,7 +161,6 @@ ufunc_frompyfunc(PyObject *NPY_UNUSED(dummy), PyObject *args, PyObject *kwds) {
     self->ptr = ptr;
 
     self->type_resolver = &object_ufunc_type_resolver;
-    PyObject_GC_Track(self);
 
     return (PyObject *)self;
 }


### PR DESCRIPTION

### PR summary

This PR removes reference counting contention while calling ufuncs by using borrowed references where they are safe and significantly improves performance on free-threading. This has similar performance improvement as #32513 but achieves it without immortalization. 

Every ufunc call took and released references to the DType classes of its operands (in `convert_ufunc_arguments`, `promote_and_get_ufuncimpl` and the reduce, `at` and `resolve_dtypes` paths) and, through the module attribute lookup, to the ufunc object itself. 

* Treat the `signature` and `operand_DTypes` arrays of the call path as borrowed references.  The DTypes are kept alive by the operands, the `dtype`/`signature` arguments, or the ufunc's append-only loop registry (`ufunc->_loops`); builtin and legacy DTypes are effectively immortal. `npy_mark_tmp_array_if_pyscalar` no longer manages references either; `copyto` and the array converter are adjusted accordingly.
* GC track ufuncs when they are created.  The CPython 3.15+ specializer enables deferred reference counting for GC tracked module attributes, which removes the per-call refcount traffic on the ufunc object.

Benchmarks: ftscalingbench-style script from gh-32513, 4 threads on the performance cores of an Apple M4, CPython 3.15.0rc2 free-threaded, min of 3 runs, speedup = 1-thread time * 4 / 4-thread time.

| benchmark                            | main  | PR    |
|--------------------------------------|-------|-------|
| `np.sin(a)`, 4 elements              | 0.85x | 3.60x |
| `np.add(a, b)`, 4 elements           | 0.78x | 3.79x |
| `a + b`, 4 elements                  | 0.89x | 3.74x |
| `np.multiply(a, a, out=out)`         | 0.56x | 3.92x |
| `np.add(f8, i8)`, 4 elements         | 0.74x | 3.65x |
| `np.add.reduce(a)`, 4 elements       | 1.27x | 3.81x |
| `np.sin(a)`, 100k elements (control) | 3.49x | 3.54x |

Python scalar operands, same setup, one run each:

| benchmark            | main  | PR    |
|----------------------|-------|-------|
| `np.add(a, 1)`       | 1.11x | 3.18x |
| `np.multiply(a, 2.5)`| 0.41x | 3.38x |
| `a * 2.5`            | 0.86x | 3.35x |
| `np.copyto(out, 1)`  | 1.55x | 2.34x |

<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->

I used Claude to find out all places where dtypes were owned by input or output array as such borrowing is safe increfs/decrefs could be removed and for benchmarking.