### PR TITLE
DOC: add correlate lag indexing example

### DIFF
--- a/numpy/_core/numeric.py
+++ b/numpy/_core/numeric.py
@@ -758,6 +758,17 @@ def correlate(a, v, mode='valid'):
     .. math:: c'_k = \sum_n a_{n} \cdot \overline{v_{n+k}}
 
     which is related to :math:`c_k` by :math:`c'_k = c_{-k}`.
+    For example:
+
+    >>> np.correlate([1, 1], [1, 2, 3, 4, 5, 6], "valid")
+    array([11,  9,  7,  5,  3])
+
+    Using NumPy's definition, the valid correlation values correspond to
+    the lags -4, -3, -2, -1, and 0, so the returned values correspond to
+    :math:`[c_{-4}, c_{-3}, c_{-2}, c_{-1}, c_0]`.
+
+    Under the alternative definition, :math:`c'_k = c_{-k}`, the same
+    correlation values are associated with the opposite lag sign.
 
     `numpy.correlate` may perform slowly in large arrays (i.e. n = 1e5)
     because it does not use the FFT to compute the convolution; in that case,


### PR DESCRIPTION
Addresses gh-20090.
**PR Summary**
The documentation currently states that the alternative correlation definition is related to NumPy's definition by 
`c'_k = c_{-k}`, but does not provide a concrete example showing how this affects the returned output.

This PR adds a small worked example illustrating the lag indexing convention used by `numpy.correlate`. The example uses `mode="valid"` for brevity, but the clarification applies generally and is intended to make the relation `c'_k = c_{-k}` more concrete.

**My introduction**
Hi! I'm a math & scientific computing student who is starting to contribute to open source. I wanted to contribute to a project that I regularly use, and while reading the `numpy.correlate` documentation and the discussion in gh-20090, I saw an opportunity to improve the explanation with an example.

I wanted to contribute a small documentation improvement that would make the lag indexing convention easier to understand for users encountering this behavior for the first time.

**AI Disclosure**
AI tools were used for discussion and review of proposed documentation wording. All investigation, validation of the issue, verification of example output locally, and final decisions were performed by me.
