### PR TITLE
BUG: fix _ureduce reshape when a kept axis has size 0

### DIFF
--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -3905,7 +3905,7 @@ def _ureduce(a, func, keepdims=False, **kwargs):
             def reshape_arr(a):
                 # move axis that should not be reduced to front
                 a = np.moveaxis(a, keep, range(nkeep))
-                # merge reduced axis (-1 is ambiguous when the array is empty)
+                # merge reduced axis
                 return a.reshape(a.shape[:nkeep] + (math.prod(a.shape[nkeep:]),))
 
             a = reshape_arr(a)

--- a/numpy/lib/_function_base_impl.py
+++ b/numpy/lib/_function_base_impl.py
@@ -1,6 +1,7 @@
 import builtins
 import collections.abc
 import functools
+import math
 import operator
 import re
 import warnings
@@ -3904,8 +3905,8 @@ def _ureduce(a, func, keepdims=False, **kwargs):
             def reshape_arr(a):
                 # move axis that should not be reduced to front
                 a = np.moveaxis(a, keep, range(nkeep))
-                # merge reduced axis
-                return a.reshape(a.shape[:nkeep] + (-1,))
+                # merge reduced axis (-1 is ambiguous when the array is empty)
+                return a.reshape(a.shape[:nkeep] + (math.prod(a.shape[nkeep:]),))
 
             a = reshape_arr(a)
 

--- a/numpy/lib/tests/test_function_base.py
+++ b/numpy/lib/tests/test_function_base.py
@@ -4049,6 +4049,13 @@ class TestPercentile:
         assert_equal(np.percentile(d, 25, axis=(1, 3))[2, 2],
                      np.percentile(d[2, :, 2, :].flatten(), 25))
 
+    def test_extended_axis_empty_kept_dim(self):
+        # gh-32535
+        d = np.zeros((0, 3, 4))
+        assert_equal(np.percentile(d, 25, axis=(1, 2)).shape, (0,))
+        assert_equal(np.quantile(d, 0.25, axis=(1, 2)).shape, (0,))
+        assert_equal(np.percentile(d, [25, 50], axis=(1, 2)).shape, (2, 0))
+
     def test_extended_axis_invalid(self):
         d = np.ones((3, 5, 7, 11))
         assert_raises(AxisError, np.percentile, d, axis=-5, q=25)
@@ -5015,6 +5022,12 @@ class TestMedian:
                      np.median(d[2, :, :, 1].flatten()))
         assert_equal(np.median(d, axis=(1, 3))[2, 2],
                      np.median(d[2, :, 2, :].flatten()))
+
+    def test_extended_axis_empty_kept_dim(self):
+        # gh-32535
+        d = np.zeros((0, 3, 4))
+        assert_equal(np.median(d, axis=(1, 2)).shape, (0,))
+        assert_equal(np.median(d, axis=(1, 2), keepdims=True).shape, (0, 1, 1))
 
     def test_extended_axis_invalid(self):
         d = np.ones((3, 5, 7, 11))


### PR DESCRIPTION
### PR summary

`np.median`, `np.quantile` and `np.percentile` with a tuple axis raise `ValueError: cannot reshape array of size 0 into shape (0,newaxis)` when one of the kept dimensions has length 0. `_ureduce` merges the reduced axes with `a.reshape(a.shape[:nkeep] + (-1,))`, and `-1` cannot be resolved once the array is empty. Computing the merged length instead of letting `reshape` infer it fixes that, so the tuple-axis path now returns the same empty result as the single-axis path and as the other reductions.

Fixes #32535

#### AI Disclosure

I used Claude to draft the fix and the tests. I reviewed the change and ran the tests locally.
