### PR TITLE
ENH: avoid DType class reference counting in scalar coercion, result_type and array-function dispatch

### DIFF
--- a/doc/release/upcoming_changes/32538.performance.rst
+++ b/doc/release/upcoming_changes/32538.performance.rst
@@ -1,0 +1,6 @@
+Better multithreaded scaling of array coercion and promotion
+------------------------------------------------------------
+On free-threaded Python, converting scalars to arrays (e.g.
+``np.asarray(scalar)``, ``arr[i] = value``), ``np.result_type`` and
+dispatching through ``__array_function__`` no longer contend on shared
+reference counts, so these calls now scale across threads.

--- a/numpy/_core/src/multiarray/array_coercion.c
+++ b/numpy/_core/src/multiarray/array_coercion.c
@@ -28,6 +28,7 @@
 #include "npy_static_data.h"
 #include "module_state.h"
 #include "refcount.h"
+#include "scalartypes.h"
 
 #include "umathmodule.h"
 
@@ -218,7 +219,9 @@ _PyArray_MapPyTypeToDType(
  * Lookup the DType for a registered known python scalar type.
  *
  * @param pytype Python Type to look up
- * @return DType, None if it is a known non-scalar, or NULL if an unknown object.
+ * @return Borrowed DType (kept alive by the pytype-to-DType mapping, whose
+ *         entries are never removed, or a builtin/static DType), None if it
+ *         is a known non-scalar, or NULL if an unknown object.
  */
 static inline PyArray_DTypeMeta *
 npy_discover_dtype_from_pytype(PyTypeObject *pytype)
@@ -226,23 +229,26 @@ npy_discover_dtype_from_pytype(PyTypeObject *pytype)
     PyObject *DType;
 
     if (pytype == &PyArray_Type) {
-        DType = Py_NewRef(Py_None);
+        return (PyArray_DTypeMeta *)Py_None;
     }
     else if (pytype == &PyFloat_Type) {
-        DType = Py_NewRef((PyObject *)&PyArray_PyFloatDType);
+        return &PyArray_PyFloatDType;
     }
     else if (pytype == &PyLong_Type) {
-        DType = Py_NewRef((PyObject *)&PyArray_PyLongDType);
+        return &PyArray_PyLongDType;
     }
-    else {
-        int res = PyDict_GetItemRef(_npy_module_state->global_pytype_to_type_dict,
-                                    (PyObject *)pytype, (PyObject **)&DType);
-
-        if (res <= 0) {
-            /* the python type is not known or an error was set */
-            return NULL;
-        }
+    /* Builtin scalar types: avoid the dict lookup (it must take a reference) */
+    int typenum = _typenum_fromtypeobj((PyObject *)pytype, 0);
+    if (typenum != NPY_NOTYPE) {
+        return typenum_to_dtypemeta(typenum);
     }
+    int res = PyDict_GetItemRef(_npy_module_state->global_pytype_to_type_dict,
+                                (PyObject *)pytype, &DType);
+    if (res <= 0) {
+        /* the python type is not known or an error was set */
+        return NULL;
+    }
+    Py_DECREF(DType);  /* the dict keeps it alive */
     assert(DType == Py_None || PyObject_TypeCheck(DType, (PyTypeObject *)&PyArrayDTypeMeta_Type));
     return (PyArray_DTypeMeta *)DType;
 }
@@ -250,6 +256,7 @@ npy_discover_dtype_from_pytype(PyTypeObject *pytype)
 /*
  * Note: This function never fails, but will return `NULL` for unknown scalars or
  *       known array-likes (e.g. tuple, list, ndarray).
+ *       The returned reference is borrowed.
  */
 NPY_NO_EXPORT PyObject *
 PyArray_DiscoverDTypeFromScalarType(PyTypeObject *pytype)
@@ -274,7 +281,8 @@ PyArray_DiscoverDTypeFromScalarType(PyTypeObject *pytype)
  *        flags is NULL, this is not
  * @param fixed_DType if not NULL, will be checked first for whether or not
  *        it can/wants to handle the (possible) scalar value.
- * @return New reference to either a DType class, Py_None, or NULL on error.
+ * @return Borrowed reference to either a DType class, Py_None, or NULL on
+ *         error.
  */
 static inline PyArray_DTypeMeta *
 discover_dtype_from_pyobject(
@@ -290,7 +298,6 @@ discover_dtype_from_pyobject(
          */
         if ((Py_TYPE(obj) == fixed_DType->scalar_type) ||
                 NPY_DT_CALL_is_known_scalar_type(fixed_DType, Py_TYPE(obj))) {
-            Py_INCREF(fixed_DType);
             return fixed_DType;
         }
     }
@@ -312,7 +319,6 @@ discover_dtype_from_pyobject(
         }
     }
     else if (flags == NULL) {
-        Py_INCREF(Py_None);
         return (PyArray_DTypeMeta *)Py_None;
     }
     else if (PyBytes_Check(obj)) {
@@ -326,8 +332,7 @@ discover_dtype_from_pyobject(
     }
 
     if (legacy_descr != NULL) {
-        DType = NPY_DTYPE(legacy_descr);
-        Py_INCREF(DType);
+        DType = NPY_DTYPE(legacy_descr);  /* legacy DTypes are never freed */
         Py_DECREF(legacy_descr);
         /* TODO: Enable warning about subclass handling */
         if ((0) && !((*flags) & GAVE_SUBCLASS_WARNING)) {
@@ -343,7 +348,6 @@ discover_dtype_from_pyobject(
         }
         return DType;
     }
-    Py_INCREF(Py_None);
     return (PyArray_DTypeMeta *)Py_None;
 }
 
@@ -506,8 +510,6 @@ PyArray_Pack(PyArray_Descr *descr, void *item, PyObject *value)
          *       so in some contexts we need to let it handled like a scalar.
          *       (If we manage to deprecate the above, we can do that.)
          */
-        Py_DECREF(DType);
-
         PyArrayObject *arr = (PyArrayObject *)value;
         if (PyArray_DESCR(arr) == descr && !PyDataType_REFCHK(descr)) {
             /* light-weight fast-path for when the descrs obviously matches */
@@ -520,12 +522,10 @@ PyArray_Pack(PyArray_Descr *descr, void *item, PyObject *value)
     }
     if (DType == NPY_DTYPE(descr) || DType == (PyArray_DTypeMeta *)Py_None) {
         /* We can set the element directly (or at least will try to) */
-        Py_XDECREF(DType);
         return NPY_DT_CALL_setitem(descr, value, item);
     }
     PyArray_Descr *tmp_descr;
     tmp_descr = NPY_DT_CALL_discover_descr_from_pyobject(DType, value);
-    Py_DECREF(DType);
     if (tmp_descr == NULL) {
         return -1;
     }
@@ -835,7 +835,7 @@ find_descriptor_from_array(
                 return -1;
             }
             if (item_DType == (PyArray_DTypeMeta *)Py_None) {
-                Py_SETREF(item_DType, NULL);
+                item_DType = NULL;
             }
             int flat_max_dims = 0;
             if (handle_scalar(elem, 0, &flat_max_dims, out_descr,
@@ -843,10 +843,8 @@ find_descriptor_from_array(
                 Py_DECREF(iter);
                 Py_DECREF(elem);
                 Py_XDECREF(*out_descr);
-                Py_XDECREF(item_DType);
                 return -1;
             }
-            Py_XDECREF(item_DType);
             Py_DECREF(elem);
             PyArray_ITER_NEXT(iter);
         }
@@ -1018,14 +1016,10 @@ PyArray_DiscoverDTypeAndShape_Recursive(
     if (DType == NULL) {
         return -1;
     }
-    else if (DType == (PyArray_DTypeMeta *)Py_None) {
-        Py_DECREF(Py_None);
-    }
-    else {
+    else if (DType != (PyArray_DTypeMeta *)Py_None) {
         max_dims = handle_scalar(
                 obj, curr_dims, &max_dims, out_descr, out_shape, fixed_DType,
                 flags, DType);
-        Py_DECREF(DType);
         return max_dims;
     }
 

--- a/numpy/_core/src/multiarray/arrayfunction_override.c
+++ b/numpy/_core/src/multiarray/arrayfunction_override.c
@@ -18,14 +18,15 @@
 /*
  * Get an object's __array_function__ method in the fastest way possible.
  * Never raises an exception. Returns NULL if the method doesn't exist.
+ * The reference to `ndarray.__array_function__` is borrowed (owned by the
+ * module state); release the result with `release_array_function`.
  */
 static PyObject *
 get_array_function(PyObject *obj)
 {
     multiarray_umath_state *state = _npy_module_state;
-    /* Fast return for ndarray */
+    /* Fast return for ndarray (borrowed) */
     if (PyArray_CheckExact(obj)) {
-        Py_INCREF(state->static_pydata.ndarray_array_function);
         return state->static_pydata.ndarray_array_function;
     }
 
@@ -34,8 +35,32 @@ get_array_function(PyObject *obj)
             obj, state->interned_str.array_function, &array_function) < 0) {
         PyErr_Clear(); /* TODO[gh-14801]: propagate crashes during attribute access? */
     }
+    if (array_function == state->static_pydata.ndarray_array_function) {
+        /* ndarray subclass without override: borrowed as well */
+        Py_DECREF(array_function);
+    }
 
     return array_function;
+}
+
+
+/*
+ * Is this object ndarray.__array_function__?
+ */
+static int
+is_default_array_function(PyObject *obj)
+{
+    return obj == _npy_module_state->static_pydata.ndarray_array_function;
+}
+
+
+/* Release a method returned by `get_array_function`. */
+static inline void
+release_array_function(PyObject *method)
+{
+    if (!is_default_array_function(method)) {
+        Py_DECREF(method);
+    }
 }
 
 
@@ -91,7 +116,7 @@ get_implementing_args_and_methods(PyObject *relevant_args,
                         "maximum number (%d) of distinct argument types " \
                         "implementing __array_function__ exceeded",
                         NPY_MAXARGS);
-                    Py_DECREF(method);
+                    release_array_function(method);
                     goto fail;
                 }
 
@@ -119,20 +144,12 @@ get_implementing_args_and_methods(PyObject *relevant_args,
 fail:
     for (int j = 0; j < num_implementing_args; j++) {
         Py_DECREF(implementing_args[j]);
-        Py_DECREF(methods[j]);
+        release_array_function(methods[j]);
     }
     return -1;
 }
 
 
-/*
- * Is this object ndarray.__array_function__?
- */
-static int
-is_default_array_function(PyObject *obj)
-{
-    return obj == _npy_module_state->static_pydata.ndarray_array_function;
-}
 
 
 /*
@@ -294,7 +311,7 @@ array_implement_c_array_function_creation(
          * Return a borrowed reference of Py_NotImplemented to defer back to
          * the original function.
          */
-        Py_DECREF(method);
+        release_array_function(method);
         return Py_NotImplemented;
     }
 
@@ -350,7 +367,7 @@ array_implement_c_array_function_creation(
     }
 
   finish:
-    Py_DECREF(method);
+    release_array_function(method);
     Py_XDECREF(args);
     Py_XDECREF(kwargs);
     Py_XDECREF(dispatch_types);
@@ -403,7 +420,7 @@ array__get_implementing_args(
 cleanup:
     for (int j = 0; j < num_implementing_args; j++) {
         Py_DECREF(implementing_args[j]);
-        Py_DECREF(array_function_methods[j]);
+        release_array_function(array_function_methods[j]);
     }
     Py_DECREF(relevant_args);
     return result;
@@ -511,16 +528,37 @@ try_reduction(PyArray_ArrayFunctionDispatcherObject *self,
 }
 
 
-static void
-dispatcher_dealloc(PyArray_ArrayFunctionDispatcherObject *self)
+static int
+dispatcher_traverse(PyArray_ArrayFunctionDispatcherObject *self,
+                    visitproc visit, void *arg)
+{
+    Py_VISIT(self->relevant_arg_func);
+    Py_VISIT(self->default_impl);
+    Py_VISIT(self->reduction);
+    Py_VISIT(self->dict);
+    return 0;
+}
+
+
+static int
+dispatcher_clear(PyArray_ArrayFunctionDispatcherObject *self)
 {
     Py_CLEAR(self->relevant_arg_func);
     Py_CLEAR(self->default_impl);
     Py_CLEAR(self->reduction);
     Py_CLEAR(self->dict);
+    return 0;
+}
+
+
+static void
+dispatcher_dealloc(PyArray_ArrayFunctionDispatcherObject *self)
+{
+    PyObject_GC_UnTrack(self);
+    dispatcher_clear(self);
     Py_CLEAR(self->dispatcher_name);
     Py_CLEAR(self->public_name);
-    PyObject_FREE(self);
+    PyObject_GC_Del(self);
 }
 
 
@@ -732,7 +770,7 @@ dispatcher_vectorcall(PyArray_ArrayFunctionDispatcherObject *self,
 cleanup:
     for (int j = 0; j < num_implementing_args; j++) {
         Py_DECREF(implementing_args[j]);
-        Py_DECREF(array_function_methods[j]);
+        release_array_function(array_function_methods[j]);
     }
     Py_XDECREF(packed_args);
     Py_XDECREF(packed_kwargs);
@@ -757,7 +795,9 @@ dispatcher_new(PyTypeObject *NPY_UNUSED(cls), PyObject *args, PyObject *kwargs)
         return NULL;
     }
 
-    self = PyObject_New(
+    /* GC tracked: holds Python functions and a dict (and on free-threaded
+     * CPython 3.15+ this enables deferred refcounting for `np.<func>`). */
+    self = PyObject_GC_New(
             PyArray_ArrayFunctionDispatcherObject,
             &PyArrayFunctionDispatcher_Type);
     if (self == NULL) {
@@ -822,6 +862,7 @@ dispatcher_new(PyTypeObject *NPY_UNUSED(cls), PyObject *args, PyObject *kwargs)
     if (self->dict == NULL) {
         goto fail;
     }
+    PyObject_GC_Track(self);
     return (PyObject *)self;
 
 fail:
@@ -895,14 +936,15 @@ NPY_NO_EXPORT PyTypeObject PyArrayFunctionDispatcher_Type = {
      PyVarObject_HEAD_INIT(NULL, 0)
      .tp_name = "numpy._ArrayFunctionDispatcher",
      .tp_basicsize = sizeof(PyArray_ArrayFunctionDispatcherObject),
-     /* We have a dict, so in theory could traverse, but in practice... */
      .tp_dictoffset = offsetof(PyArray_ArrayFunctionDispatcherObject, dict),
      .tp_dealloc = (destructor)dispatcher_dealloc,
+     .tp_traverse = (traverseproc)dispatcher_traverse,
+     .tp_clear = (inquiry)dispatcher_clear,
      .tp_new = (newfunc)dispatcher_new,
      .tp_str = (reprfunc)dispatcher_str,
      .tp_repr = (reprfunc)dispatcher_repr,
      .tp_flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VECTORCALL
-                  | Py_TPFLAGS_METHOD_DESCRIPTOR),
+                  | Py_TPFLAGS_METHOD_DESCRIPTOR | Py_TPFLAGS_HAVE_GC),
      .tp_methods = func_dispatcher_methods,
      .tp_getset = func_dispatcher_getset,
      .tp_descr_get = func_dispatcher___get__,

--- a/numpy/_core/src/multiarray/convert_datatype.c
+++ b/numpy/_core/src/multiarray/convert_datatype.c
@@ -1694,6 +1694,8 @@ PyArray_ResultType(
         npy_intp ndtypes, PyArray_Descr *descrs[])
 {
     PyArray_Descr *result = NULL;
+    PyArray_DTypeMeta *common_dtype = NULL;
+    npy_bool own_common_dtype = NPY_FALSE;
 
     if (narrs + ndtypes <= 1) {
         /* If the input is a single value, skip promotion. */
@@ -1748,10 +1750,21 @@ PyArray_ResultType(
         }
     }
 
-    PyArray_DTypeMeta *common_dtype = PyArray_PromoteDTypeSequence(
-            narrs+ndtypes, all_DTypes);
-    if (common_dtype == NULL) {
-        goto error;
+    /* If all DTypes are identical, skip promotion and borrow the DType. */
+    common_dtype = all_DTypes[0];
+    for (npy_intp i = 1; i < narrs + ndtypes; i++) {
+        if (all_DTypes[i] != common_dtype) {
+            common_dtype = NULL;
+            break;
+        }
+    }
+    if (common_dtype == NULL || NPY_DT_is_abstract(common_dtype)) {
+        common_dtype = PyArray_PromoteDTypeSequence(
+                narrs+ndtypes, all_DTypes);
+        if (common_dtype == NULL) {
+            goto error;
+        }
+        own_common_dtype = NPY_TRUE;
     }
 
     if (NPY_DT_is_abstract(common_dtype)) {
@@ -1761,7 +1774,11 @@ PyArray_ResultType(
             goto error;
         }
         Py_INCREF(NPY_DTYPE(tmp_descr));
-        Py_SETREF(common_dtype, NPY_DTYPE(tmp_descr));
+        if (own_common_dtype) {
+            Py_DECREF(common_dtype);
+        }
+        common_dtype = NPY_DTYPE(tmp_descr);
+        own_common_dtype = NPY_TRUE;
         Py_DECREF(tmp_descr);
     }
 
@@ -1801,13 +1818,17 @@ PyArray_ResultType(
         }
     }
 
-    Py_DECREF(common_dtype);
+    if (own_common_dtype) {
+        Py_DECREF(common_dtype);
+    }
     npy_free_workspace(workspace);
     return result;
 
   error:
     Py_XDECREF(result);
-    Py_XDECREF(common_dtype);
+    if (own_common_dtype) {
+        Py_DECREF(common_dtype);
+    }
     npy_free_workspace(workspace);
     return NULL;
 }

--- a/numpy/_core/src/multiarray/descriptor.c
+++ b/numpy/_core/src/multiarray/descriptor.c
@@ -1637,11 +1637,10 @@ _convert_from_type(PyObject *obj) {
         return PyArray_DescrFromType(NPY_OBJECT);
     }
     else {
+        /* borrowed reference */
         PyObject *DType = PyArray_DiscoverDTypeFromScalarType(typ);
         if (DType != NULL) {
-            PyArray_Descr *ret = PyArray_GetDefaultDescr((PyArray_DTypeMeta *)DType);
-            Py_DECREF(DType);
-            return ret;
+            return PyArray_GetDefaultDescr((PyArray_DTypeMeta *)DType);
         }
         PyArray_Descr *ret = _try_convert_from_dtype_attr(obj);
         if ((PyObject *)ret != Py_NotImplemented) {

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -386,6 +386,7 @@ PyArray_DescrFromTypeObject(PyObject *type)
         return (PyArray_Descr *)new;
     }
 
+    /* borrowed reference */
     PyObject *DType = PyArray_DiscoverDTypeFromScalarType((PyTypeObject *)type);
     if (DType != NULL) {
         return PyArray_GetDefaultDescr((PyArray_DTypeMeta *)DType);
@@ -411,12 +412,10 @@ PyArray_DescrFromScalar(PyObject *sc)
      * correct instance-specific descriptor (handling void, datetime, string,
      * and new-style user-defined parametric dtypes correctly).
      */
-    PyArray_DTypeMeta *DType =
+    PyArray_DTypeMeta *DType =  /* borrowed */
             (PyArray_DTypeMeta *)PyArray_DiscoverDTypeFromScalarType(Py_TYPE(sc));
     if (DType != NULL) {
-        PyArray_Descr *result = NPY_DT_CALL_discover_descr_from_pyobject(DType, sc);
-        Py_DECREF(DType);
-        return result;
+        return NPY_DT_CALL_discover_descr_from_pyobject(DType, sc);
     }
 
     /*

--- a/numpy/_core/tests/test_overrides.py
+++ b/numpy/_core/tests/test_overrides.py
@@ -888,3 +888,25 @@ def test_function_like():
     bound = np.mean.__get__(MyClass)  # classmethod
     with pytest.raises(TypeError, match="unsupported operand type"):
         bound()
+
+
+def test_dispatcher_is_gc_tracked():
+    # The dispatcher holds Python functions and a dict, so it takes part in
+    # garbage collection.  (On free-threaded CPython 3.15+ this also lets the
+    # interpreter use deferred reference counting for `np.<func>` lookups.)
+    import gc
+    assert gc.is_tracked(np.sum)
+    assert gc.is_tracked(np.concatenate)
+
+    def dispatcher(a):
+        return (a,)
+
+    def implementation(a):
+        return a
+
+    func = _ArrayFunctionDispatcher(dispatcher, implementation)
+    # Create a reference cycle through the dispatcher's __dict__:
+    func.self = func
+    assert gc.is_tracked(func)
+    del func
+    gc.collect()

--- a/tools/ci/lsan_suppressions.txt
+++ b/tools/ci/lsan_suppressions.txt
@@ -31,3 +31,8 @@
 #23 0xffffb1c61b44 in initialize_static_globals ../numpy/_core/src/multiarray/npy_static_data.c:124
 
 leak:initialize_static_globals
+# The same two stat-timestamp float leaks, matched right above the
+# allocation: with a deep (nested) import chain the captured stack can end
+# before reaching initialize_static_globals, in which case the suppression
+# above does not match and the leak is reported.
+leak:fill_time


### PR DESCRIPTION
### PR summary

Follow-up to gh-32531: borrow references to DType classes (and to `ndarray.__array_function__`) where the object is kept alive elsewhere, so that common small calls do not touch shared reference counts on free-threaded builds.

* `array_coercion.c`: `discover_dtype_from_pyobject` and `PyArray_DiscoverDTypeFromScalarType` return borrowed references (the DType is owned by the caller's `fixed_DType`, the pytype-to-DType mapping, or is a builtin/static DType). Builtin scalar types are looked up via the scalar type table instead of the dict. Also fixes a leaked DType reference in `PyArray_DescrFromTypeObject`.
* `PyArray_ResultType`: skip promotion when all DTypes are identical.
* `get_array_function` returns a borrowed `ndarray.__array_function__`.

Scaling on 6 threads with CPython 3.15t (`time(1 thread) * 6 / time(6 threads)`, so `6.0x` is perfect), threads pinned to distinct physical cores, `main` at e765e6725e:

| benchmark | main | PR |
|---|---|---|
| `np.result_type(a, a)` | 1.2x | 5.7x |
| `np.asarray(np.float64(1.5))` | 1.6x | 5.4x |
| `np.asarray(1.5)` | 3.0x | 5.3x |
| `np.array([1.0, 2.0, 3.0])` | 1.8x | 5.7x |
| `np.sqrt(np.float64(1.5))` | 1.9x | 5.6x |
| `a[0] = 1.5` | 1.0x | 5.7x |
| `np.add(a, 1.5)` | 5.3x | 5.9x |
| `np.concatenate([a, b])` | 5.1x | 5.8x |
| `np.result_type(f8, i8)` | 1.2x | 2.4x |
| `np.sum(a)` | 5.8x | 5.9x |
| `np.sin(a)`, 100k elements (control) | 6.0x | 6.0x |

Promotion of different DTypes improves but does not scale fully: `__common_dtype__` must return a new reference.

<details>
<summary>Benchmark script</summary>

```python
# Free-threading scaling benchmarks for numpy scalar coercion, promotion and
# __array_function__ dispatch (numpy/numpy#32538), modelled on CPython's
# Tools/ftscalingbench/ftscalingbench.py.
#
# Every thread works on thread-local data, so any lack of scaling comes from
# contention on shared state (reference counts of DType classes etc.).
# Threads are pinned to distinct physical performance cores.

import os
import queue
import sys
import threading
import time

import numpy as np

WORK_SCALE = 100

ALL_BENCHMARKS = {}

threads = []
in_queues = []
out_queues = []


def register_benchmark(func):
    ALL_BENCHMARKS[func.__name__] = func
    return func


@register_benchmark
def result_type_same():
    a = np.arange(4.0)
    f = np.result_type
    for _ in range(1000 * WORK_SCALE):
        f(a, a)


@register_benchmark
def result_type_mixed():
    # different DTypes: __common_dtype__ returns a new reference
    a = np.arange(4.0)
    b = np.arange(4)
    f = np.result_type
    for _ in range(1000 * WORK_SCALE):
        f(a, b)


@register_benchmark
def asarray_numpy_scalar():
    x = np.float64(1.5)
    f = np.asarray
    for _ in range(1000 * WORK_SCALE):
        f(x)


@register_benchmark
def asarray_python_float():
    f = np.asarray
    for _ in range(1000 * WORK_SCALE):
        f(1.5)


@register_benchmark
def array_from_list():
    f = np.array
    lst = [1.0, 2.0, 3.0]
    for _ in range(300 * WORK_SCALE):
        f(lst)


@register_benchmark
def sqrt_numpy_scalar():
    x = np.float64(1.5)
    f = np.sqrt
    for _ in range(1000 * WORK_SCALE):
        f(x)


@register_benchmark
def add_array_python_float():
    a = np.arange(4.0)
    f = np.add
    for _ in range(1000 * WORK_SCALE):
        f(a, 1.5)


@register_benchmark
def setitem_python_float():
    a = np.arange(4.0)
    for _ in range(1000 * WORK_SCALE):
        a[0] = 1.5


@register_benchmark
def concatenate_small():
    a = np.arange(4.0)
    b = np.arange(4.0)
    f = np.concatenate
    for _ in range(300 * WORK_SCALE):
        f([a, b])


@register_benchmark
def sum_small():
    # __array_function__ dispatch + reduction
    a = np.arange(4.0)
    f = np.sum
    for _ in range(300 * WORK_SCALE):
        f(a)


@register_benchmark
def sin_large_control():
    a = np.arange(100_000.0)
    for _ in range(10 * WORK_SCALE):
        np.sin(a)


def bench_one_thread(func):
    t0 = time.perf_counter_ns()
    func()
    t1 = time.perf_counter_ns()
    return t1 - t0


def bench_parallel(func):
    t0 = time.perf_counter_ns()
    for inq in in_queues:
        inq.put(func)
    for outq in out_queues:
        outq.get()
    t1 = time.perf_counter_ns()
    return t1 - t0


def benchmark(func, repeat):
    delta_one_thread = min(bench_one_thread(func) for _ in range(repeat))
    delta_many_threads = min(bench_parallel(func) for _ in range(repeat))

    speedup = delta_one_thread * len(threads) / delta_many_threads
    if speedup >= 1:
        factor = speedup
        direction = "faster"
    else:
        factor = 1 / speedup
        direction = "slower"

    use_color = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
    color = reset_color = ""
    if use_color:
        if speedup <= 1.1:
            color = "\x1b[31m"  # red
        elif speedup < len(threads) / 2:
            color = "\x1b[33m"  # yellow
        reset_color = "\x1b[0m"

    print(f"{color}{func.__name__:<25} {round(factor, 1):>4}x {direction}"
          f"{reset_color}   (1 thread: {delta_one_thread / 1e6:7.1f} ms, "
          f"{len(threads)} threads: {delta_many_threads / 1e6:7.1f} ms)")
    return delta_one_thread, delta_many_threads, speedup


def determine_cpus():
    """Distinct physical performance cores on NUMA node 0 (like ftscalingbench).

    ftscalingbench keeps only cores whose MAXMHZ equals the global maximum;
    on hybrid Intel parts a couple of P-cores are binned slightly higher, so
    accept every core within 10% of the maximum instead.
    """
    if sys.platform != "linux":
        return [None] * os.cpu_count()
    import subprocess
    try:
        output = subprocess.check_output(["lscpu", "-p=cpu,node,core,MAXMHZ"],
                                         text=True, env={"LC_NUMERIC": "C"})
    except (FileNotFoundError, subprocess.CalledProcessError):
        return [None] * os.cpu_count()
    table = []
    for line in output.splitlines():
        if line.startswith("#"):
            continue
        cpu, node, core, maxhz = line.split(",")
        table.append((int(cpu), int(node), int(core), float(maxhz or "0")))
    max_mhz_all = max(row[3] for row in table)
    cpus, cores = [], set()
    for cpu, node, core, maxmhz in table:
        if node == 0 and core not in cores and maxmhz >= 0.9 * max_mhz_all:
            cpus.append(cpu)
            cores.add(core)
    return cpus


def thread_run(cpu, in_queue, out_queue):
    if cpu is not None and hasattr(os, "sched_setaffinity"):
        os.sched_setaffinity(0, (cpu,))
    while True:
        func = in_queue.get()
        if func is None:
            break
        func()
        out_queue.put(None)


def initialize_threads(opts):
    cpus = determine_cpus()
    if opts.threads != -1:
        if opts.threads <= len(cpus):
            cpus = cpus[:opts.threads]      # still pinned to P-cores
        else:
            cpus = [None] * opts.threads    # more threads than P-cores: no pinning
    print(f"Running benchmarks with {len(cpus)} threads"
          f" (pinned to cpus {cpus})" if cpus[0] is not None else
          f"Running benchmarks with {len(cpus)} threads (no affinity)")
    for cpu in cpus:
        inq, outq = queue.Queue(), queue.Queue()
        in_queues.append(inq)
        out_queues.append(outq)
        t = threading.Thread(target=thread_run, args=(cpu, inq, outq), daemon=True)
        threads.append(t)
        t.start()


def main(opts):
    global WORK_SCALE
    if not hasattr(sys, "_is_gil_enabled") or sys._is_gil_enabled():
        sys.stderr.write("expected to be run with the GIL disabled\n")
    print(f"python {sys.version.split()[0]}, numpy {np.__version__} "
          f"from {os.path.dirname(np.__file__)}")

    names = opts.benchmarks or list(ALL_BENCHMARKS)
    for name in names:
        if name not in ALL_BENCHMARKS:
            sys.exit(f"Unknown benchmark: {name}")
    WORK_SCALE = opts.scale
    initialize_threads(opts)

    # pin the main thread (single-thread baseline) to the first chosen cpu too
    cpu0 = determine_cpus()[0]
    if cpu0 is not None and hasattr(os, "sched_setaffinity"):
        os.sched_setaffinity(0, (cpu0,))

    results = {}
    for name in names:
        results[name] = benchmark(ALL_BENCHMARKS[name], opts.repeat)
    if opts.json:
        import json
        with open(opts.json, "w") as f:
            json.dump({"threads": len(threads), "results": results}, f)


if __name__ == "__main__":
    import argparse
    parser = argparse.ArgumentParser()
    parser.add_argument("-t", "--threads", type=int, default=-1)
    parser.add_argument("--scale", type=int, default=100)
    parser.add_argument("--repeat", type=int, default=3,
                        help="take the best of N runs for each measurement")
    parser.add_argument("--json", help="write raw timings to this file")
    parser.add_argument("benchmarks", nargs="*")
    main(parser.parse_args())
```

</details>

#### AI Disclosure

Claude Code was used to audit reference ownership, write the benchmark and refcount scripts, and draft the changes.

