### PR TITLE
BUG: restore inheriting the .dtype attribute of np.void subclasses

### DIFF
--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -364,25 +364,29 @@ PyArray_DescrFromTypeObject(PyObject *type)
                     return NULL;
                 }
             }
+            else {
+                /* inherit from the attribute below (steals the reference) */
+                conv = (_PyArray_LegacyDescr *)attr;
+            }
         }
 
-        _PyArray_LegacyDescr *new = (_PyArray_LegacyDescr  *)PyArray_DescrNewFromType(NPY_VOID);
+        _PyArray_LegacyDescr *new;
+        if (conv != NULL && PyDataType_ISLEGACY(conv)
+                && conv->type_num == NPY_VOID) {
+            /* copies fields, names, elsize and subarray */
+            new = (_PyArray_LegacyDescr *)PyArray_DescrNew((PyArray_Descr *)conv);
+        }
+        else {
+            new = (_PyArray_LegacyDescr *)PyArray_DescrNewFromType(NPY_VOID);
+            if (new != NULL && conv != NULL && PyDataType_ISLEGACY(conv)) {
+                new->elsize = conv->elsize;
+            }
+        }
+        Py_XDECREF(conv);
         if (new == NULL) {
             return NULL;
         }
-        if (conv != NULL && PyDataType_ISLEGACY(conv)) {
-            new->fields = conv->fields;
-            Py_XINCREF(new->fields);
-            new->names = conv->names;
-            Py_XINCREF(new->names);
-            new->elsize = conv->elsize;
-            new->subarray = conv->subarray;
-            conv->subarray = NULL;
-        }
-        Py_XDECREF(conv);
-        Py_XDECREF(new->typeobj);
-        new->typeobj = (PyTypeObject *)type;
-        Py_INCREF(type);
+        Py_XSETREF(new->typeobj, (PyTypeObject *)Py_NewRef(type));
         return (PyArray_Descr *)new;
     }
 

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -373,13 +373,26 @@ PyArray_DescrFromTypeObject(PyObject *type)
         _PyArray_LegacyDescr *new;
         if (conv != NULL && PyDataType_ISLEGACY(conv)
                 && conv->type_num == NPY_VOID) {
-            /* copies fields, names, elsize and subarray */
+            /* the same kind of descriptor, so copy it wholesale */
             new = (_PyArray_LegacyDescr *)PyArray_DescrNew((PyArray_Descr *)conv);
         }
         else {
+            /* otherwise only the layout can be inherited onto a void descr */
             new = (_PyArray_LegacyDescr *)PyArray_DescrNewFromType(NPY_VOID);
             if (new != NULL && conv != NULL && PyDataType_ISLEGACY(conv)) {
                 new->elsize = conv->elsize;
+                /*
+                 * A registered legacy user dtype is not NPY_VOID but may
+                 * still be structured (see `PyArray_RegisterDataType`);
+                 * `flags` and `alignment` describe that same layout.
+                 */
+                if (conv->names != NULL) {
+                    new->names = Py_NewRef(conv->names);
+                    new->fields = conv->fields == Py_None
+                            ? NULL : Py_XNewRef(conv->fields);
+                    new->flags = conv->flags;
+                    new->alignment = conv->alignment;
+                }
             }
         }
         Py_XDECREF(conv);

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1643,11 +1643,14 @@ class TestFromDTypeAttribute:
         assert np.dtype(dt(1)) == dt.dtype
 
         if HAS_REFCOUNT:
-            # this used to leak one reference to the attribute per call
+            # this used to leak one reference to the attribute per call.
+            # Count outside the `assert`: pytest's assertion rewriting
+            # hoists `dt.dtype` and would hold a reference of its own.
             expected = sys.getrefcount(dt.dtype)
-            for _ in range(10):
+            for _ in range(20):
                 np.dtype(dt)
-            assert sys.getrefcount(dt.dtype) == expected
+            count = sys.getrefcount(dt.dtype)
+            assert count == expected
 
     def test_void_subtype_subarray(self):
         # subarray info is inherited by copy; the attribute itself
@@ -1659,6 +1662,45 @@ class TestFromDTypeAttribute:
         assert res.subdtype == (np.dtype("f4"), (2,))
         assert res.itemsize == dt.dtype.itemsize
         assert dt.dtype.subdtype == (np.dtype("f4"), (2,))
+
+    def test_void_subtype_non_void_attribute(self):
+        # A non-void `.dtype` attribute only contributes its itemsize
+        class dt(np.void):
+            dtype = np.dtype("f8")
+
+        res = np.dtype(dt)
+        assert res.itemsize == 8
+        assert res.names is None
+        assert res.subdtype is None
+        assert res.char == "V"
+
+    @pytest.mark.leaks_references(reason="dynamically creates custom dtype.")
+    @pytest.mark.thread_unsafe(
+        reason="crashes when GIL disabled, dtype setup is thread-unsafe",
+    )
+    @pytest.mark.xfail("LSAN_OPTIONS" in os.environ, reason="known leak", run=False)
+    def test_void_subtype_structured_user_dtype(self):
+        # A legacy user dtype is not NPY_VOID but can still be structured
+        # (see `PyArray_RegisterDataType`), so its fields are inherited too.
+        class mytype:
+            pass
+
+        user_dtype = create_custom_field_dtype(
+                np.dtype([("field", object)]), mytype, 0)
+        assert user_dtype.num != np.dtype("V").num
+        assert user_dtype.names == ("field",)
+
+        class dt(np.void):
+            dtype = user_dtype
+
+        res = np.dtype(dt)
+        assert res.names == ("field",)
+        assert res.fields["field"][0] == np.dtype(object)
+        assert res.itemsize == user_dtype.itemsize
+        assert res.alignment == user_dtype.alignment
+        # the flags must stay consistent with the inherited fields
+        assert res.hasobject
+        assert res.flags == user_dtype.flags
 
     def test_void_subtype_recursive(self):
         # Used to recurse, but dtype is now enforced to be a dtype instance

--- a/numpy/_core/tests/test_dtype.py
+++ b/numpy/_core/tests/test_dtype.py
@@ -1629,16 +1629,36 @@ class TestFromDTypeAttribute:
         with pytest.raises(ValueError):
             np.dtype(dt_instance)
 
-    @pytest.mark.xfail("LSAN_OPTIONS" in os.environ, reason="known leak", run=False)
     def test_void_subtype(self):
         class dt(np.void):
-            # This code path is fully untested before, so it is unclear
-            # what this should be useful for. Note that if np.void is used
-            # numpy will think we are deallocating a base type [1.17, 2019-02].
+            # Note that if np.void is used numpy will think we are
+            # deallocating a base type [1.17, 2019-02].
             dtype = np.dtype("f,f")
 
-        np.dtype(dt)
-        np.dtype(dt(1))
+        # the result inherits the fields of the `.dtype` attribute
+        res = np.dtype(dt)
+        assert res.names == ('f0', 'f1')
+        assert res.itemsize == dt.dtype.itemsize
+        assert res.type is dt
+        assert np.dtype(dt(1)) == dt.dtype
+
+        if HAS_REFCOUNT:
+            # this used to leak one reference to the attribute per call
+            expected = sys.getrefcount(dt.dtype)
+            for _ in range(10):
+                np.dtype(dt)
+            assert sys.getrefcount(dt.dtype) == expected
+
+    def test_void_subtype_subarray(self):
+        # subarray info is inherited by copy; the attribute itself
+        # must not be mutated (its subarray used to be stolen)
+        class dt(np.void):
+            dtype = np.dtype("(2,)f4")
+
+        res = np.dtype(dt)
+        assert res.subdtype == (np.dtype("f4"), (2,))
+        assert res.itemsize == dt.dtype.itemsize
+        assert dt.dtype.subdtype == (np.dtype("f4"), (2,))
 
     def test_void_subtype_recursive(self):
         # Used to recurse, but dtype is now enforced to be a dtype instance


### PR DESCRIPTION
### PR summary

Since 2.4.0 (gh-30179, @seberg), `np.dtype` of a `np.void` subclass with a `dtype` attribute returns an empty `dtype('V')` instead of inheriting the attribute's fields/itemsize, and leaks one reference to the attribute per call:

```python
import sys
import numpy as np

class dt(np.void):
    dtype = np.dtype("f4,f4")

print(np.dtype(dt))
r0 = sys.getrefcount(dt.dtype)
for _ in range(100):
    np.dtype(dt)
print("refcount delta:", sys.getrefcount(dt.dtype) - r0)
```
2.3.4 prints `dtype((__main__.dt, [('f0', '<f4'), ('f1', '<f4')]))` and delta 0; 2.5.1 and main print `V` and delta 100.

gh-30179 dropped the assignment of the fetched attribute to `conv` in `PyArray_DescrFromTypeObject`. This PR restores it, inheriting from a void attribute via `PyArray_DescrNew` — copying the subarray instead of stealing.

#### AI disclosure

Claude Code was used to bisect the leak, identify the causing commit, and verify the fix under ASAN+LSAN.
