### PR TITLE
TYP: ``take`` shape-typing

### DIFF
--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -168,50 +168,205 @@ class _CanArray[ArrayT: np.ndarray](Protocol):
 type _ArrayLike1D = _CanArray[_Array1D[Any]] | Sequence[_ScalarLike_co]
 type _ArrayLikeInt1D = _CanArray[_Array1D[np.integer]] | Sequence[int | np.integer]
 
+type _ToInt0D = _IntLike_co | np.ndarray[_0D, np.dtype[np.integer | np.bool]]
+type _ToInt1D = _ToArray1D2[np.integer | np.bool, _IntLike_co]
+type _ToInt2D = _ToArray2D2[np.integer | np.bool, _IntLike_co]
+
 ###
 
-# TODO: Fix overlapping overloads: https://github.com/numpy/numpy/issues/27032
-@overload
+@overload  # Nd, ?d  (workaround)
 def take[ScalarT: np.generic](
     a: _ArrayLike[ScalarT],
-    indices: _IntLike_co,
-    axis: None = None,
-    out: None = None,
-    mode: _ModeKind = "raise",
-) -> ScalarT: ...
-@overload
-def take(
-    a: ArrayLike,
-    indices: _IntLike_co,
-    axis: SupportsIndex | None = None,
-    out: None = None,
-    mode: _ModeKind = "raise",
-) -> Any: ...
-@overload
-def take[ScalarT: np.generic](
-    a: _ArrayLike[ScalarT],
-    indices: _ArrayLikeInt_co,
+    indices: _ArrayJustND[np.integer | np.bool],
     axis: SupportsIndex | None = None,
     out: None = None,
     mode: _ModeKind = "raise",
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # Nd, ?d  (workaround)
 def take(
     a: ArrayLike,
-    indices: _ArrayLikeInt_co,
+    indices: _ArrayJustND[np.integer | np.bool],
     axis: SupportsIndex | None = None,
     out: None = None,
     mode: _ModeKind = "raise",
 ) -> NDArray[Any]: ...
-@overload
-def take[ArrayT: np.ndarray](
+@overload  # Nd, 0d, axis=None  (default)
+def take[ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    indices: _ToInt0D,
+    axis: None = None,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> ScalarT: ...
+@overload  # Nd, 0d, axis=None  (default)
+def take(
+    a: ArrayLike,
+    indices: _ToInt0D,
+    axis: None = None,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> Any: ...
+@overload  # Nd, 1d, axis=None  (default)
+def take[ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    indices: _ToInt1D,
+    axis: None = None,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> _Array1D[ScalarT]: ...
+@overload  # Nd, 1d, axis=None  (default)
+def take(
+    a: ArrayLike,
+    indices: _ToInt1D,
+    axis: None = None,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> _Array1D[Any]: ...
+@overload  # Nd, 2d, axis=None  (default)
+def take[ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    indices: _ToInt2D,
+    axis: None = None,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> _Array2D[ScalarT]: ...
+@overload  # Nd, 2d, axis=None  (default)
+def take(
+    a: ArrayLike,
+    indices: _ToInt2D,
+    axis: None = None,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> _Array2D[Any]: ...
+@overload  # fallback, axis=None  (default)
+def take[ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    indices: _ArrayLikeInt_co,
+    axis: None = None,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> NDArray[ScalarT] | Any: ...
+@overload  # fallback, axis=None  (default)
+def take(
     a: ArrayLike,
     indices: _ArrayLikeInt_co,
-    axis: SupportsIndex | None,
-    out: ArrayT,
+    axis: None = None,
+    out: None = None,
     mode: _ModeKind = "raise",
-) -> ArrayT: ...
-@overload
+) -> Any: ...
+@overload  # ?d, 0d, axis=<given>  (workaround)
+def take[ScalarT: np.generic](
+    a: _ArrayJustND[ScalarT],
+    indices: _ToInt0D,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> NDArray[ScalarT] | Any: ...
+@overload  # ?d, ?d, axis=<given>  (workaround)
+def take[ScalarT: np.generic](
+    a: _ArrayJustND[ScalarT],
+    indices: _ArrayLikeInt_co,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> NDArray[ScalarT]: ...
+@overload  # >=1d, 1d, axis=<given>
+def take[ShapeT: tuple[int, *tuple[int, ...]], ScalarT: np.generic](
+    a: np.ndarray[ShapeT, np.dtype[ScalarT]],
+    indices: _ToInt1D,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> np.ndarray[ShapeT, np.dtype[ScalarT]]: ...
+@overload  # 1d, 0d, axis=<given>
+def take[ScalarT: np.generic](
+    a: _ToArray1D[ScalarT],
+    indices: _ToInt0D,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> ScalarT: ...
+@overload  # 1d, 2d, axis=<given>
+def take[ScalarT: np.generic](
+    a: _ToArray1D[ScalarT],
+    indices: _ToInt2D,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> _Array2D[ScalarT]: ...
+@overload  # 2d, 0d, axis=<given>
+def take[ScalarT: np.generic](
+    a: _ToArray2D[ScalarT],
+    indices: _ToInt0D,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> _Array1D[ScalarT]: ...
+@overload  # 2d, 2d, axis=<given>
+def take[ScalarT: np.generic](
+    a: _ToArray2D[ScalarT],
+    indices: _ToInt2D,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> _Array3D[ScalarT]: ...
+@overload  # 3d, 0d, axis=<given>
+def take[ScalarT: np.generic](
+    a: _ToArray3D[ScalarT],
+    indices: _ToInt0D,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> _Array2D[ScalarT]: ...
+@overload  # 3d, 2d, axis=<given>
+def take[ScalarT: np.generic](
+    a: _ToArray3D[ScalarT],
+    indices: _ToInt2D,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> _Array4D[ScalarT]: ...
+@overload  # 4d, 0d, axis=<given>
+def take[ScalarT: np.generic](
+    a: _ToArray4D[ScalarT],
+    indices: _ToInt0D,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> _Array3D[ScalarT]: ...
+@overload  # fallback, 0d, axis=<given>
+def take[ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    indices: _ToInt0D,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> NDArray[ScalarT] | Any: ...
+@overload  # fallback, 0d, axis=<given>
+def take(
+    a: ArrayLike,
+    indices: _ToInt0D,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> Any: ...
+@overload  # fallback, axis=<given>
+def take[ScalarT: np.generic](
+    a: _ArrayLike[ScalarT],
+    indices: _ArrayLikeInt_co,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> NDArray[ScalarT]: ...
+@overload  # fallback, axis=<given>
+def take(
+    a: ArrayLike,
+    indices: _ArrayLikeInt_co,
+    axis: SupportsIndex,
+    out: None = None,
+    mode: _ModeKind = "raise",
+) -> NDArray[Any]: ...
+@overload  # out=<given>  (keyword)
 def take[ArrayT: np.ndarray](
     a: ArrayLike,
     indices: _ArrayLikeInt_co,
@@ -220,7 +375,16 @@ def take[ArrayT: np.ndarray](
     out: ArrayT,
     mode: _ModeKind = "raise",
 ) -> ArrayT: ...
+@overload  # out=<given>  (positional)
+def take[ArrayT: np.ndarray](
+    a: ArrayLike,
+    indices: _ArrayLikeInt_co,
+    axis: SupportsIndex | None,
+    out: ArrayT,
+    mode: _ModeKind = "raise",
+) -> ArrayT: ...
 
+#
 def top_k(
     a: ArrayLike,
     k: int,

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -13,11 +13,14 @@ AR_f4: npt.NDArray[np.float32]
 AR_f4_1d: np.ndarray[tuple[int], np.dtype[np.float32]]
 AR_f4_2d: np.ndarray[tuple[int, int], np.dtype[np.float32]]
 AR_f4_3d: np.ndarray[tuple[int, int, int], np.dtype[np.float32]]
+AR_f4_4d: np.ndarray[tuple[int, int, int, int], np.dtype[np.float32]]
 AR_c8: npt.NDArray[np.complex64]
 AR_c16: npt.NDArray[np.complex128]
 AR_i1: npt.NDArray[np.int8]
 AR_u8: npt.NDArray[np.uint64]
 AR_i8: npt.NDArray[np.int64]
+AR_i8_0d: np.ndarray[tuple[()], np.dtype[np.int64]]
+AR_i8_2d: np.ndarray[tuple[int, int], np.dtype[np.int64]]
 AR_O: npt.NDArray[np.object_[int]]
 AR_subclass: NDArraySubclass
 AR_m_ns: npt.NDArray[np.timedelta64[int]]
@@ -49,16 +52,30 @@ AR_sub_i: NDArrayIntSubclass
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
 type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
+type _Array4D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int, int], np.dtype[ScalarT]]
 
-assert_type(np.take(b, 0), np.bool)
-assert_type(np.take(f4, 0), np.float32)
 assert_type(np.take(f, 0), Any)
-assert_type(np.take(AR_b, 0), np.bool)
 assert_type(np.take(AR_f4, 0), np.float32)
-assert_type(np.take(AR_b, [0]), npt.NDArray[np.bool])
-assert_type(np.take(AR_f4, [0]), npt.NDArray[np.float32])
-assert_type(np.take([1], [0]), npt.NDArray[Any])
+assert_type(np.take(AR_f4, [0]), _Array1D[np.float32])
+assert_type(np.take(AR_f4, [[0]]), _Array2D[np.float32])
+assert_type(np.take(AR_f4, [[[0]]]), npt.NDArray[np.float32] | Any)
+assert_type(np.take(AR_f4, AR_i8), npt.NDArray[np.float32])
+assert_type(np.take([1], [0]), _Array1D[Any])
+assert_type(np.take(_py_list_2d, [[0]]), _Array2D[Any])
+assert_type(np.take(AR_f4, 0, axis=0), npt.NDArray[np.float32] | Any)
+assert_type(np.take(AR_f4, [0], axis=0), npt.NDArray[np.float32])
+assert_type(np.take(AR_f4_1d, 0, axis=0), np.float32)
+assert_type(np.take(AR_f4_1d, [0], axis=0), _Array1D[np.float32])
+assert_type(np.take(AR_f4_1d, [[0]], axis=0), _Array2D[np.float32])
+assert_type(np.take(_py_list_1d, 0, axis=0), Any)
+assert_type(np.take(AR_f4_2d, 0, axis=1), _Array1D[np.float32])
+assert_type(np.take(AR_f4_2d, AR_i8_2d, axis=0), _Array3D[np.float32])
+assert_type(np.take(AR_f4_3d, 0, axis=1), _Array2D[np.float32])
+assert_type(np.take(AR_f4_3d, [[0]], axis=0), _Array4D[np.float32])
+assert_type(np.take(AR_f4_4d, AR_i8_0d, axis=1), _Array3D[np.float32])
+assert_type(np.take(AR_f4_4d, [[0]], axis=0), npt.NDArray[np.float32])
 assert_type(np.take(AR_f4, [0], out=AR_subclass), NDArraySubclass)
+assert_type(np.take(AR_f4, [0], 0, AR_subclass), NDArraySubclass)
 
 assert_type(np.reshape(b, 1), np.ndarray[tuple[int], np.dtype[np.bool]])
 assert_type(np.reshape(f4, 1), np.ndarray[tuple[int], np.dtype[np.float32]])


### PR DESCRIPTION
This adds shape-typing support to `np.take` for <=4d input. This also 

---

This is very similar to `ndarray.take` from #32485, so I had AI do the mechanical work, and of course carefully reviewed it afterwards.