### PR TITLE
BUG: fix two possible crashes in the ufunc.accumulate implementation

### DIFF
--- a/numpy/_core/src/umath/ufunc_object.c
+++ b/numpy/_core/src/umath/ufunc_object.c
@@ -3105,6 +3105,16 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
         }
     }
 
+    if (PyArray_NDIM(op[0]) != PyArray_NDIM(op[1]) ||
+            !PyArray_CompareLists(PyArray_DIMS(op[0]),
+                                  PyArray_DIMS(op[1]),
+                                  PyArray_NDIM(op[0]))) {
+        PyErr_SetString(PyExc_ValueError,
+                "provided out is the wrong size "
+                "for the accumulation.");
+        goto fail;
+    }
+
     /* The loop descriptors borrow from the final iterator/array operands. */
     PyArray_Descr *loop_descrs[3] = {
             PyArray_DESCR(op[0]), PyArray_DESCR(op[1]), PyArray_DESCR(op[0])};
@@ -3242,15 +3252,6 @@ PyUFunc_Accumulate(PyUFuncObject *ufunc, PyArrayObject *arr, PyArrayObject *out,
 
         NPY_UF_DBG_PRINT("UFunc: Reduce loop with no iterators\n");
 
-        if (PyArray_NDIM(op[0]) != PyArray_NDIM(op[1]) ||
-                !PyArray_CompareLists(PyArray_DIMS(op[0]),
-                                      PyArray_DIMS(op[1]),
-                                      PyArray_NDIM(op[0]))) {
-            PyErr_SetString(PyExc_ValueError,
-                    "provided out is the wrong size "
-                    "for the accumulation.");
-            goto fail;
-        }
         stride0 = PyArray_STRIDE(op[0], axis);
 
         /* Turn the two items into three for the inner loop */

--- a/numpy/_core/src/umath/ufunc_type_resolution.c
+++ b/numpy/_core/src/umath/ufunc_type_resolution.c
@@ -599,6 +599,9 @@ PyUFunc_SimpleUniformOperationTypeResolver(
                     out_dtypes[iop] = PyArray_DESCR(operands[iop]);
                     Py_INCREF(out_dtypes[iop]);
                 }
+                for (; iop < nop; iop++) {
+                    out_dtypes[iop] = NULL;
+                }
                 raise_no_loop_found_error(ufunc, (PyObject **)out_dtypes);
                 for (iop = 0; iop < ufunc->nin; iop++) {
                     Py_DECREF(out_dtypes[iop]);

--- a/numpy/_core/tests/test_ufunc.py
+++ b/numpy/_core/tests/test_ufunc.py
@@ -2757,6 +2757,20 @@ class TestUfunc:
         with pytest.raises(ValueError, match="(shape|size)"):
             np.add.accumulate(arr, out=out)
 
+    @pytest.mark.parametrize("shape, out_shape", [
+        ((0,), (1,)),       # Empty input must not bypass shape validation.
+        ((1, 3), (2, 3)),   # The outer iterator must not broadcast the input.
+    ])
+    def test_accumulate_out_shape_mismatch(self, shape, out_shape):
+        arr = np.ones(shape, dtype=np.int64)
+        out = np.empty(out_shape, dtype=arr.dtype)
+        with pytest.raises(ValueError, match="(shape|size)"):
+            np.add.accumulate(arr, out=out)
+
+    def test_cumsum_scalar_out_shape_mismatch(self):
+        with pytest.raises(ValueError, match="(shape|size)"):
+            np.array(1).cumsum(out=np.empty((), dtype=np.intp))
+
     def test_reduceat_and_accumulate_out_dtype_resolution_failure(self):
         # gh-31691: the out= error path leaked a reference to out when the
         # ufunc dtype resolution failed (no matching loop for the out dtype).
@@ -2768,6 +2782,12 @@ class TestUfunc:
 
         with pytest.raises(np._core._exceptions._UFuncNoLoopError):
             np.add.accumulate(arr, out=out)
+
+        with pytest.raises(np._core._exceptions._UFuncNoLoopError) as exc:
+            np.array(b"1").cumsum(
+                dtype="timedelta64[D]", out=np.empty(1)
+            )
+        assert exc.value.dtypes[2] is None
 
     @pytest.mark.parametrize('out_shape',
                              [(), (1,), (3,), (1, 1), (1, 3), (4, 3)])


### PR DESCRIPTION
### PR summary
It's possible to crash `ufunc.accumulate` by passing an `out` array that does not match the shape of the input. The fix for that is to check the `out` shape before relying on it matching.

It's also possible to trigger a read of uninitialized memory while constructing the error for e.g. `np.array(b"1").cumsum(dtype="timedelta64[D]", out=np.empty(1))`. The fix is to zero-initialize the `out_dtypes` array.

Also adds new tests for these cases.

#### AI Disclosure
I triggered crashes related to this during AI-assisted code review. It is not terribly likely for a user to hit these in the real world but I figure it's worth fixing.

I used an AI model to iterate on and review the correctness of the fixes and help write the tests.