### PR TITLE
TYP: ``trace`` shape-typing

### DIFF
--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -983,28 +983,195 @@ def diagonal(
     axis2: SupportsIndex = 1,
 ) -> NDArray[Any]: ...
 
-# keep in sync with `ma.core.trace`
-@overload
+#
+@overload  # ?d  (workaround)
+def trace[ScalarT: np.inexact | np.timedelta64 | np.object_](
+    a: _ArrayJustND[ScalarT],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: None = None,
+    out: None = None,
+) -> NDArray[ScalarT] | Any: ...
+@overload  # ?d, +integer  (workaround)
 def trace(
-    a: ArrayLike,  # >= 2D array
+    a: _ArrayJustND[np.integer | np.bool],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: None = None,
+    out: None = None,
+) -> NDArray[np.int_] | Any: ...
+@overload  # ?d, dtype=<known>  (workaround)
+def trace[ScalarT: np.generic](
+    a: _ArrayJustND[np.number | np.bool | np.object_ | np.timedelta64],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    out: None = None,
+) -> NDArray[ScalarT] | Any: ...
+@overload  # ?d, dtype=<unknown>  (workaround)
+def trace(
+    a: _ArrayJustND[np.number | np.bool | np.object_ | np.timedelta64],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: DTypeLike | None = None,
+    out: None = None,
+) -> np.ndarray | Any: ...
+@overload  # 2d
+def trace[ScalarT: np.inexact | np.timedelta64](
+    a: _ToArray2D[ScalarT],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: None = None,
+    out: None = None,
+) -> ScalarT: ...
+@overload  # 2d, +integer
+def trace(
+    a: _ToArray2D2[np.integer | np.bool, int],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: None = None,
+    out: None = None,
+) -> np.int_: ...
+@overload  # 2d, dtype=<known>
+def trace[ScalarT: np.generic](
+    a: _ToNumeric2D,
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    out: None = None,
+) -> ScalarT: ...
+@overload  # 2d, dtype=<unknown>
+def trace(
+    a: _ToNumeric2D,
     offset: SupportsIndex = 0,
     axis1: SupportsIndex = 0,
     axis2: SupportsIndex = 1,
     dtype: DTypeLike | None = None,
     out: None = None,
 ) -> Any: ...
-@overload
+@overload  # 3d
+def trace[ScalarT: np.inexact | np.timedelta64 | np.object_](
+    a: _ToArray3D[ScalarT],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: None = None,
+    out: None = None,
+) -> _Array1D[ScalarT]: ...
+@overload  # 3d, +integer
+def trace(
+    a: _ToArray3D2[np.integer | np.bool, int],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: None = None,
+    out: None = None,
+) -> _Array1D[np.int_]: ...
+@overload  # 3d, dtype=<known>
+def trace[ScalarT: np.generic](
+    a: _ToNumeric3D,
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    out: None = None,
+) -> _Array1D[ScalarT]: ...
+@overload  # 3d, dtype=<unknown>
+def trace(
+    a: _ToNumeric3D,
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: DTypeLike | None = None,
+    out: None = None,
+) -> _Array1D[Any]: ...
+@overload  # 4d
+def trace[ScalarT: np.inexact | np.timedelta64 | np.object_](
+    a: _ToArray4D[ScalarT],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: None = None,
+    out: None = None,
+) -> _Array2D[ScalarT]: ...
+@overload  # 4d, +integer
+def trace(
+    a: _ToArray4D2[np.integer | np.bool, int],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: None = None,
+    out: None = None,
+) -> _Array2D[np.int_]: ...
+@overload  # 4d, dtype=<known>
+def trace[ScalarT: np.generic](
+    a: _ToNumeric4D,
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    out: None = None,
+) -> _Array2D[ScalarT]: ...
+@overload  # 4d, dtype=<unknown>
+def trace(
+    a: _ToNumeric4D,
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: DTypeLike | None = None,
+    out: None = None,
+) -> _Array2D[Any]: ...
+@overload  # Nd  (fallback)
+def trace[ScalarT: np.inexact | np.timedelta64 | np.object_](
+    a: _ArrayLike[ScalarT],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: None = None,
+    out: None = None,
+) -> NDArray[ScalarT] | Any: ...
+@overload  # Nd, +integer  (fallback)
+def trace(
+    a: _ArrayLike[np.integer | np.bool] | _NestedSequence[int],
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: None = None,
+    out: None = None,
+) -> NDArray[np.int_] | Any: ...
+@overload  # Nd, dtype=<known>  (fallback)
+def trace[ScalarT: np.generic](
+    a: _ArrayLikeNumeric_co,
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    *,
+    dtype: _DTypeLike[ScalarT],
+    out: None = None,
+) -> NDArray[ScalarT] | Any: ...
+@overload  # Nd, dtype=<unknown>  (fallback)
+def trace(
+    a: _ArrayLikeNumeric_co,
+    offset: SupportsIndex = 0,
+    axis1: SupportsIndex = 0,
+    axis2: SupportsIndex = 1,
+    dtype: DTypeLike | None = None,
+    out: None = None,
+) -> Any: ...
+@overload  # out=<given>  (keyword)
 def trace[ArrayT: np.ndarray](
-    a: ArrayLike,  # >= 2D array
-    offset: SupportsIndex,
-    axis1: SupportsIndex,
-    axis2: SupportsIndex,
-    dtype: DTypeLike | None,
-    out: ArrayT,
-) -> ArrayT: ...
-@overload
-def trace[ArrayT: np.ndarray](
-    a: ArrayLike,  # >= 2D array
+    a: ArrayLike,
     offset: SupportsIndex = 0,
     axis1: SupportsIndex = 0,
     axis2: SupportsIndex = 1,
@@ -1012,7 +1179,17 @@ def trace[ArrayT: np.ndarray](
     *,
     out: ArrayT,
 ) -> ArrayT: ...
+@overload  # out=<given>  (positional)
+def trace[ArrayT: np.ndarray](
+    a: ArrayLike,
+    offset: SupportsIndex,
+    axis1: SupportsIndex,
+    axis2: SupportsIndex,
+    dtype: DTypeLike | None,
+    out: ArrayT,
+) -> ArrayT: ...
 
+#
 @overload
 def ravel[ScalarT: np.generic](a: _ArrayLike[ScalarT], order: _OrderKACF = "C") -> _Array1D[ScalarT]: ...
 @overload

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -13,6 +13,7 @@ AR_f4: npt.NDArray[np.float32]
 AR_f4_1d: np.ndarray[tuple[int], np.dtype[np.float32]]
 AR_f4_2d: np.ndarray[tuple[int, int], np.dtype[np.float32]]
 AR_f4_3d: np.ndarray[tuple[int, int, int], np.dtype[np.float32]]
+AR_f4_4d: np.ndarray[tuple[int, int, int, int], np.dtype[np.float32]]
 AR_c8: npt.NDArray[np.complex64]
 AR_c16: npt.NDArray[np.complex128]
 AR_i1: npt.NDArray[np.int8]
@@ -49,6 +50,7 @@ AR_sub_i: NDArrayIntSubclass
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
 type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
 type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]
+type _Array4D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int, int], np.dtype[ScalarT]]
 
 assert_type(np.take(b, 0), np.bool)
 assert_type(np.take(f4, 0), np.float32)
@@ -218,10 +220,23 @@ assert_type(np.diagonal(AR_f4), npt.NDArray[np.float32])
 assert_type(np.diagonal(AR_f4_2d), np.ndarray[tuple[int], np.dtype[np.float32]])
 assert_type(np.diagonal(AR_f4_3d), np.ndarray[tuple[int, int], np.dtype[np.float32]])
 
-assert_type(np.trace(AR_b), Any)
-assert_type(np.trace(AR_f4), Any)
+assert_type(np.trace(AR_f4), npt.NDArray[np.float32] | Any)
+assert_type(np.trace(AR_i8), npt.NDArray[np.int_] | Any)
+assert_type(np.trace(AR_f4, dtype=np.float64), npt.NDArray[np.float64] | Any)
+assert_type(np.trace(AR_f4, dtype="f8"), np.ndarray | Any)
+assert_type(np.trace(AR_f4_2d), np.float32)
+assert_type(np.trace(_py_list_2d), np.int_)
+assert_type(np.trace(AR_f4_2d, dtype=np.float64), np.float64)
+assert_type(np.trace(AR_f4_2d, dtype="f8"), Any)
+assert_type(np.trace(AR_f4_3d), _Array1D[np.float32])
+assert_type(np.trace(_py_list_3d), _Array1D[np.int_])
+assert_type(np.trace(AR_f4_3d, dtype=np.float64), _Array1D[np.float64])
+assert_type(np.trace(AR_f4_3d, dtype="f8"), _Array1D[Any])
+assert_type(np.trace(AR_f4_4d), _Array2D[np.float32])
+assert_type(np.trace(AR_f4_4d, dtype=np.float64), _Array2D[np.float64])
+assert_type(np.trace(AR_f4_4d, dtype="f8"), _Array2D[Any])
 assert_type(np.trace(AR_f4, out=AR_subclass), NDArraySubclass)
-assert_type(np.trace(AR_f4, out=AR_subclass, dtype=None), NDArraySubclass)
+assert_type(np.trace(AR_f4, 0, 0, 1, None, AR_subclass), NDArraySubclass)
 
 assert_type(np.ravel(b), np.ndarray[tuple[int], np.dtype[np.bool]])
 assert_type(np.ravel(f4), np.ndarray[tuple[int], np.dtype[np.float32]])


### PR DESCRIPTION
Same story as #32543, but for `numpy.trace`.

---

This is very similar to `ndarray.take` from #32489, so I had AI do the mechanical work, and of course carefully reviewed it afterwards.