### PR TITLE
ENH: Support IEEE binary128 DLPack export

### DIFF
--- a/numpy/_core/src/common/npy_fpmath.h
+++ b/numpy/_core/src/common/npy_fpmath.h
@@ -19,6 +19,12 @@
     #error No long double representation defined
 #endif
 
+#if defined(HAVE_LDOUBLE_IEEE_QUAD_BE) || defined(HAVE_LDOUBLE_IEEE_QUAD_LE)
+    #define NPY_LDOUBLE_IS_IEEE_QUAD 1
+#else
+    #define NPY_LDOUBLE_IS_IEEE_QUAD 0
+#endif
+
 /* for back-compat, also keep old name for double-double */
 #ifdef HAVE_LDOUBLE_IBM_DOUBLE_DOUBLE_LE
     #define HAVE_LDOUBLE_DOUBLE_DOUBLE_LE

--- a/numpy/_core/src/multiarray/dlpack.c
+++ b/numpy/_core/src/multiarray/dlpack.c
@@ -7,6 +7,7 @@
 #include "dlpack/dlpack.h"
 #include "numpy/arrayobject.h"
 #include "scalartypes.h"
+#include "npy_fpmath.h"
 #include "npy_pycompat.h"
 #include "npy_argparse.h"
 #include "npy_dlpack.h"
@@ -293,9 +294,7 @@ fill_dl_tensor_information(
         managed_dtype.code = kDLUInt;
     }
     else if (PyDataType_ISFLOAT(dtype)) {
-        // We can't be sure that the dtype is
-        // IEEE or padded.
-        if (itemsize > 8) {
+        if (itemsize > 8 && !(itemsize == 16 && NPY_LDOUBLE_IS_IEEE_QUAD)) {
             PyErr_SetString(PyExc_BufferError,
                     "DLPack only supports IEEE floating point types "
                     "without padding (longdouble typically is not IEEE).");
@@ -849,6 +848,11 @@ from_dlpack(PyObject *self,
             case 16: typenum = NPY_FLOAT16; break;
             case 32: typenum = NPY_FLOAT32; break;
             case 64: typenum = NPY_FLOAT64; break;
+            case 128:
+                if (NPY_LDOUBLE_IS_IEEE_QUAD) {
+                    typenum = NPY_FLOAT128;
+                }
+                break;
         }
         break;
     case kDLComplex:

--- a/numpy/_core/tests/test_dlpack.py
+++ b/numpy/_core/tests/test_dlpack.py
@@ -76,6 +76,21 @@ class TestDLPack:
         assert y.dtype == x.dtype
         assert_array_equal(x, y)
 
+    @pytest.mark.parametrize("arr", new_and_old_dlpack())
+    def test_longdouble(self, arr):
+        dtype = np.dtype(np.longdouble)
+        x = arr.astype(dtype)
+
+        is_ieee_quad = dtype.itemsize == 16 and np.finfo(dtype).nmant == 112
+
+        if is_ieee_quad:
+            y = np.from_dlpack(x)
+            assert y.dtype == x.dtype
+            assert_array_equal(x, y)
+        else:
+            with pytest.raises(BufferError):
+                np.from_dlpack(x)
+
     def test_invalid_dtype(self):
         x = np.asarray(np.datetime64('2021-05-27'))
 


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

#### Export IEEE binary128 to DLPack

- Export existing IEEE binary128 variables to DLPack `kDLFloat`, only on platforms where `longdouble`/`float128` is already IEEE binary128.
- Consumers such as `nanobind` can then import the variables as IEEE binary128.
- On platform not supported such as x87 `longdouble`, it will throw a `BufferError`, same as the current behavior.

### Validation
- Local tests passed.

### First time committer introduction
<!-- If you are new to the NumPy community, please introduce yourself. How do you
 use NumPy, what prompted you to make this contribution? We are a community of
 mostly volunteers, and getting to know you helps us trust your judgement
 and welcome you into the community.
-->
- I maintain several atmospheric sciences packages and is a contributor to [`ducc`](https://github.com/mreineck/ducc/) and scipy.

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
- ChatGPT and Codex were used to research the problem and propose solutions. I wrote the code myself.
