### PR TITLE
ENH: speed up the fixed-width string casts and unicode scalars

### DIFF
--- a/numpy/_core/src/multiarray/arraytypes.c.src
+++ b/numpy/_core/src/multiarray/arraytypes.c.src
@@ -1515,6 +1515,12 @@ BOOL_to_@TOTYPE@(void *input, void *output, npy_intp n,
 /**end repeat**/
 
 
+/* S/U can use the cheap getitem object; VOID needs a real scalar (gh-9847) */
+#define _GETOBJ_STRING(ip, aip) STRING_getitem(ip, aip)
+#define _GETOBJ_UNICODE(ip, aip) UNICODE_getitem(ip, aip)
+#define _GETOBJ_SCALAR(ip, aip) \
+    PyArray_Scalar(ip, PyArray_DESCR(aip), (PyObject *)(aip))
+
 /**begin repeat
  *
  * #from = STRING*23, UNICODE*23, VOID*23#
@@ -1537,6 +1543,9 @@ BOOL_to_@TOTYPE@(void *input, void *output, npy_intp n,
  * #oskip = 1*18,(PyArray_ITEMSIZE(aop))*3,1*2,
  *          1*18,(PyArray_ITEMSIZE(aop))*3,1*2,
  *          1*18,(PyArray_ITEMSIZE(aop))*3,1*2#
+ * #getobj = (_GETOBJ_STRING)*20, _GETOBJ_SCALAR, (_GETOBJ_STRING)*2,
+ *           (_GETOBJ_UNICODE)*20, _GETOBJ_SCALAR, (_GETOBJ_UNICODE)*2,
+ *           (_GETOBJ_SCALAR)*23#
  */
 
 static void
@@ -1552,7 +1561,7 @@ static void
     int oskip = @oskip@;
 
     for (i = 0; i < n; i++, ip+=skip, op+=oskip) {
-        PyObject *temp = PyArray_Scalar(ip, PyArray_DESCR(aip), (PyObject *)aip);
+        PyObject *temp = @getobj@(ip, aip);
         if (temp == NULL) {
             return;
         }

--- a/numpy/_core/src/multiarray/scalarapi.c
+++ b/numpy/_core/src/multiarray/scalarapi.c
@@ -500,25 +500,30 @@ PyArray_Scalar(void *data, PyArray_Descr *descr, PyObject *base)
         }
     }
     if (type_num == NPY_UNICODE) {
-        /* we need the full string length here, else copyswap will write too
-           many bytes */
-        void *buff = PyMem_RawMalloc(descr->elsize);
-        if (buff == NULL) {
-            return PyErr_NoMemory();
-        }
-        memcpy(buff, data, itemsize);
-        if (swap) {
-            byte_swap_vector(buff, itemsize / 4, 4);
+        void *buff = NULL;
+        const void *ucs4 = data;
+
+        /* only copy when the data cannot be handed to CPython as it is */
+        if (swap || !npy_is_aligned(data, NPY_ALIGNOF(Py_UCS4))) {
+            buff = PyMem_RawMalloc(descr->elsize);
+            if (buff == NULL) {
+                return PyErr_NoMemory();
+            }
+            memcpy(buff, data, itemsize);
+            if (swap) {
+                byte_swap_vector(buff, itemsize / 4, 4);
+            }
+            ucs4 = buff;
         }
 
         /* truncation occurs here */
-        PyObject *u = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, buff, itemsize / 4);
+        PyObject *u = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, ucs4, itemsize / 4);
         PyMem_RawFree(buff);
         if (u == NULL) {
             return NULL;
         }
 
-        PyObject *args = Py_BuildValue("(O)", u);
+        PyObject *args = PyTuple_FromArray(&u, 1);
         if (args == NULL) {
             Py_DECREF(u);
             return NULL;


### PR DESCRIPTION

### PR summary

Fixes #11014 and improves string conversions in general:

* The cast loops build an array scalar per element.** `STRING/UNICODE/VOID_to_<T>` in `arraytypes.c.src` calls `PyArray_Scalar` for every element and hands the result to the destination's `setitem`. For `S`/`U` sources the plain `bytes`/`str` from getitem behaves identically in every `setitem` and is cheaper
* `PyArray_Scalar` copies when it does not have to. If no swap is needed, we now skip the copy.
* Replace `Py_BuildValue`, with `PyTuple_FromArray` instead of `Py_BuildValue`

| | main | PR | |
|---|---|---|---|
| `np.array(U_arr, dtype=int)` | 60.3 ms | **20.8 ms** | 2.9x |
| `U_arr.astype(np.float64)` | 68.5 ms | **33.0 ms** | 2.1x |
| `S_arr.astype(np.int64)` | 20.9 ms | **15.1 ms** | 1.4x |
| `list(U_arr)` | 35.1 ms | **23.9 ms** | 1.47x |
| `list(U_arr)`, byte-swapped | 35.8 ms | **32.5 ms** | 1.10x |
| control: `U_arr.tolist()` | 7.11 ms | 6.98 ms | 1.02x |


<details>
<summary>benchmark script</summary>

```python
import timeit

import numpy as np

N = 200_000
sa = np.array(list(map(str, range(N))))            # 'U6'
fa = np.array([f"{i}.5" for i in range(N)])        # 'U8'
ba = sa.astype("S")                                # 'S6'
bs = sa.astype(">U6")
lst = sa.tolist()

CASES = {
    "np.array(U_arr, dtype=int)": lambda: np.array(sa, dtype=int),
    "np.array(U_arr.tolist(), int)": lambda: np.array(lst, dtype=int),
    "U -> float64": lambda: fa.astype(np.float64),
    "S -> int64": lambda: ba.astype(np.int64),
    "list(U_arr)": lambda: list(sa),
    "list(byteswapped)": lambda: list(bs),
    "U_arr.tolist()": lambda: sa.tolist(),         # control, unaffected
}

print(np.__version__)
for name, fn in CASES.items():
    t = min(timeit.repeat(fn, number=2, repeat=7)) / 2
    print(f"{name:32s} {t * 1e3:7.2f} ms  {t / N * 1e9:6.0f} ns/elem")
```

</details>


#### AI Disclosure
Generated with [Claude Code](https://claude.com/claude-code)
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
](https://github.com/numpy/numpy/issues/11232)