### PR TITLE
ENH: use the vectorcall protocol for the scalar method forwarders

### DIFF
--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -159,17 +159,19 @@ array_fill(PyArrayObject *self, PyObject *args)
 }
 
 static PyObject *
-array_put(PyArrayObject *self, PyObject *args, PyObject *kwds)
+array_put(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     PyObject *indices, *values;
     NPY_CLIPMODE mode = NPY_RAISE;
-    static char *kwlist[] = {"indices", "values", "mode", NULL};
+    NPY_PREPARE_ARGPARSER;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO|O&:put", kwlist,
-                                     &indices,
-                                     &values,
-                                     PyArray_ClipmodeConverter, &mode))
+    if (npy_parse_arguments("put", args, len_args, kwnames,
+            {"indices", NULL, &indices},
+            {"values", NULL, &values},
+            {"|mode", &PyArray_ClipmodeConverter, &mode}) < 0) {
         return NULL;
+    }
     return PyArray_PutTo(self, values, indices, mode);
 }
 
@@ -443,16 +445,16 @@ PyArray_GetField(PyArrayObject *self, PyArray_Descr *typed, int offset)
 }
 
 static PyObject *
-array_getfield(PyArrayObject *self, PyObject *args, PyObject *kwds)
+array_getfield(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
-
     PyArray_Descr *dtype = NULL;
     int offset = 0;
-    static char *kwlist[] = {"dtype", "offset", 0};
+    NPY_PREPARE_ARGPARSER;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|i:getfield", kwlist,
-                                     PyArray_DescrConverter, &dtype,
-                                     &offset)) {
+    if (npy_parse_arguments("getfield", args, len_args, kwnames,
+            {"dtype", &PyArray_DescrConverter, &dtype},
+            {"|offset", &PyArray_PythonPyIntFromInt, &offset}) < 0) {
         Py_XDECREF(dtype);
         return NULL;
     }
@@ -619,13 +621,14 @@ array_tolist(PyArrayObject *self, PyObject *args)
 
 
 static PyObject *
-array_tobytes(PyArrayObject *self, PyObject *args, PyObject *kwds)
+array_tobytes(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     NPY_ORDER order = NPY_CORDER;
-    static char *kwlist[] = {"order", NULL};
+    NPY_PREPARE_ARGPARSER;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O&:tobytes", kwlist,
-                                     PyArray_OrderConverter, &order)) {
+    if (npy_parse_arguments("tobytes", args, len_args, kwnames,
+            {"|order", &PyArray_OrderConverter, &order}) < 0) {
         return NULL;
     }
     return PyArray_ToString(self, order);
@@ -1226,14 +1229,16 @@ array_resize(PyArrayObject *self, PyObject *args, PyObject *kwds)
 }
 
 static PyObject *
-array_repeat(PyArrayObject *self, PyObject *args, PyObject *kwds) {
+array_repeat(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
+{
     PyObject *repeats;
     int axis = NPY_RAVEL_AXIS;
-    static char *kwlist[] = {"repeats", "axis", NULL};
+    NPY_PREPARE_ARGPARSER;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&:repeat", kwlist,
-                                     &repeats,
-                                     PyArray_AxisConverter, &axis)) {
+    if (npy_parse_arguments("repeat", args, len_args, kwnames,
+            {"repeats", NULL, &repeats},
+            {"|axis", &PyArray_AxisConverter, &axis}) < 0) {
         return NULL;
     }
     return PyArray_Return((PyArrayObject *)PyArray_Repeat(self, repeats, axis));
@@ -2554,17 +2559,18 @@ array_variance(PyArrayObject *self,
 }
 
 static PyObject *
-array_compress(PyArrayObject *self, PyObject *args, PyObject *kwds)
+array_compress(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     int axis = NPY_RAVEL_AXIS;
     PyObject *condition;
     PyArrayObject *out = NULL;
-    static char *kwlist[] = {"condition", "axis", "out", NULL};
+    NPY_PREPARE_ARGPARSER;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O&O&:compress", kwlist,
-                                     &condition,
-                                     PyArray_AxisConverter, &axis,
-                                     PyArray_OutputConverter, &out)) {
+    if (npy_parse_arguments("compress", args, len_args, kwnames,
+            {"condition", NULL, &condition},
+            {"|axis", &PyArray_AxisConverter, &axis},
+            {"|out", &PyArray_OutputConverter, &out}) < 0) {
         return NULL;
     }
 
@@ -2657,16 +2663,17 @@ array_conjugate(PyArrayObject *self, PyObject *args)
 
 
 static PyObject *
-array_diagonal(PyArrayObject *self, PyObject *args, PyObject *kwds)
+array_diagonal(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     int axis1 = 0, axis2 = 1, offset = 0;
-    static char *kwlist[] = {"offset", "axis1", "axis2", NULL};
     PyArrayObject *ret;
+    NPY_PREPARE_ARGPARSER;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iii:diagonal", kwlist,
-                                     &offset,
-                                     &axis1,
-                                     &axis2)) {
+    if (npy_parse_arguments("diagonal", args, len_args, kwnames,
+            {"|offset", &PyArray_PythonPyIntFromInt, &offset},
+            {"|axis1", &PyArray_PythonPyIntFromInt, &axis1},
+            {"|axis2", &PyArray_PythonPyIntFromInt, &axis2}) < 0) {
         return NULL;
     }
 
@@ -2706,15 +2713,16 @@ array_ravel(PyArrayObject *self,
 
 
 static PyObject *
-array_round(PyArrayObject *self, PyObject *args, PyObject *kwds)
+array_round(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
     int decimals = 0;
     PyArrayObject *out = NULL;
-    static char *kwlist[] = {"decimals", "out", NULL};
+    NPY_PREPARE_ARGPARSER;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iO&:round", kwlist,
-                                     &decimals,
-                                     PyArray_OutputConverter, &out)) {
+    if (npy_parse_arguments("round", args, len_args, kwnames,
+            {"|decimals", &PyArray_PythonPyIntFromInt, &decimals},
+            {"|out", &PyArray_OutputConverter, &out}) < 0) {
         return NULL;
     }
 
@@ -2997,7 +3005,7 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"compress",
         (PyCFunction)array_compress,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"conj",
         (PyCFunction)array_conjugate,
         METH_VARARGS, NULL},
@@ -3015,7 +3023,7 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"diagonal",
         (PyCFunction)array_diagonal,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"dot",
         (PyCFunction)array_dot,
         METH_FASTCALL | METH_KEYWORDS, NULL},
@@ -3027,7 +3035,7 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"getfield",
         (PyCFunction)array_getfield,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"item",
         (PyCFunction)array_toscalar,
         METH_VARARGS, NULL},
@@ -3051,13 +3059,13 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"put",
         (PyCFunction)array_put,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"ravel",
         (PyCFunction)array_ravel,
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"repeat",
         (PyCFunction)array_repeat,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"reshape",
         (PyCFunction)array_reshape,
         METH_VARARGS | METH_KEYWORDS, NULL},
@@ -3066,7 +3074,7 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"round",
         (PyCFunction)array_round,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"searchsorted",
         (PyCFunction)array_searchsorted,
         METH_FASTCALL | METH_KEYWORDS, NULL},
@@ -3096,7 +3104,7 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"tobytes",
         (PyCFunction)array_tobytes,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"tofile",
         (PyCFunction)array_tofile,
         METH_VARARGS | METH_KEYWORDS, NULL},

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -127,6 +127,28 @@ gentype_free(PyObject *v)
 
 
 static PyObject *
+gentype_generic_vectorcall(PyObject *self, PyObject *const *args,
+        Py_ssize_t len_args, PyObject *kwnames, const char *str)
+{
+    PyObject *arr = PyArray_FromScalar(self, NULL);
+    if (arr == NULL) {
+        return NULL;
+    }
+    PyObject *meth = PyObject_GetAttrString(arr, str);
+    Py_DECREF(arr);
+    if (meth == NULL) {
+        return NULL;
+    }
+    PyObject *ret = PyObject_Vectorcall(meth, args, len_args, kwnames);
+    Py_DECREF(meth);
+    if (ret != NULL && PyArray_Check(ret)) {
+        return PyArray_Return((PyArrayObject *)ret);
+    }
+    return ret;
+}
+
+
+static PyObject *
 gentype_generic_method(PyObject *self, PyObject *args, PyObject *kwds,
         char *str)
 {
@@ -2263,7 +2285,7 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
 
 /*
  * These gentype_* functions take keyword arguments.
- * The proper flag is METH_VARARGS | METH_KEYWORDS.
+ * The proper flag is METH_FASTCALL | METH_KEYWORDS.
  */
 /**begin repeat
  *
@@ -2274,9 +2296,10 @@ gentype_byteswap(PyObject *self, PyObject *args, PyObject *kwds)
  *         flatten, ravel, squeeze#
  */
 static PyObject *
-gentype_@name@(PyObject *self, PyObject *args, PyObject *kwds)
+gentype_@name@(PyObject *self, PyObject *const *args, Py_ssize_t len_args,
+        PyObject *kwnames)
 {
-    return gentype_generic_method(self, args, kwds, "@name@");
+    return gentype_generic_vectorcall(self, args, len_args, kwnames, "@name@");
 }
 /**end repeat**/
 
@@ -2293,20 +2316,9 @@ static PyObject *
         return NULL;
     }
 
-    PyObject *tup;
-    if (ndigits == Py_None) {
-        tup = PyTuple_Pack(0);
-    }
-    else {
-        tup = PyTuple_Pack(1, ndigits);
-    }
-
-    if (tup == NULL) {
-        return NULL;
-    }
-
-    PyObject *obj = gentype_round(self, tup, NULL);
-    Py_DECREF(tup);
+    /* `ndigits` defaulting to None means it was not passed at all */
+    Py_ssize_t nargs = (ndigits == Py_None) ? 0 : 1;
+    PyObject *obj = gentype_round(self, &ndigits, nargs, NULL);
     if (obj == NULL) {
         return NULL;
     }
@@ -2731,28 +2743,28 @@ static PyMethodDef gentype_methods[] = {
         METH_VARARGS, NULL},
     {"tobytes",
         (PyCFunction)gentype_tobytes,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"tofile",
         (PyCFunction)gentype_tofile,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"byteswap",
         (PyCFunction)gentype_byteswap,
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"astype",
         (PyCFunction)gentype_astype,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"getfield",
         (PyCFunction)gentype_getfield,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"setfield",
         (PyCFunction)gentype_setfield,
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"copy",
         (PyCFunction)gentype_copy,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"resize",
         (PyCFunction)gentype_resize,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"__array__",
         (PyCFunction)gentype_getarray,
         METH_VARARGS, doc_getarray},
@@ -2797,61 +2809,61 @@ static PyMethodDef gentype_methods[] = {
         METH_VARARGS, NULL},
     {"take",
         (PyCFunction)gentype_take,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"put",
         (PyCFunction)gentype_put,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"repeat",
         (PyCFunction)gentype_repeat,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"choose",
         (PyCFunction)gentype_choose,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"sort",
         (PyCFunction)gentype_sort,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"argsort",
         (PyCFunction)gentype_argsort,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"searchsorted",
         (PyCFunction)gentype_searchsorted,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"argmax",
         (PyCFunction)gentype_argmax,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"argmin",
         (PyCFunction)gentype_argmin,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"reshape",
         (PyCFunction)gentype_reshape,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"squeeze",
         (PyCFunction)gentype_squeeze,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"view",
         (PyCFunction)gentype_view,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"swapaxes",
         (PyCFunction)gentype_swapaxes,
         METH_VARARGS, NULL},
     {"max",
         (PyCFunction)gentype_max,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"min",
         (PyCFunction)gentype_min,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"mean",
         (PyCFunction)gentype_mean,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"trace",
         (PyCFunction)gentype_trace,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"diagonal",
         (PyCFunction)gentype_diagonal,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"clip",
         (PyCFunction)gentype_clip,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"conj",
         (PyCFunction)gentype_conj,
         METH_VARARGS, NULL},
@@ -2863,40 +2875,40 @@ static PyMethodDef gentype_methods[] = {
         METH_VARARGS, NULL},
     {"std",
         (PyCFunction)gentype_std,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"var",
         (PyCFunction)gentype_var,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"sum",
         (PyCFunction)gentype_sum,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"cumsum",
         (PyCFunction)gentype_cumsum,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"prod",
         (PyCFunction)gentype_prod,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"cumprod",
         (PyCFunction)gentype_cumprod,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"all",
         (PyCFunction)gentype_all,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"any",
         (PyCFunction)gentype_any,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"compress",
         (PyCFunction)gentype_compress,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"flatten",
         (PyCFunction)gentype_flatten,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"ravel",
         (PyCFunction)gentype_ravel,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"round",
         (PyCFunction)gentype_round,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     /* For the format function */
     {"__format__",
         gentype_format,


### PR DESCRIPTION
### PR summary

This came up when investigating the performance of https://github.com/numpy/numpy/pull/32379.

Most scalar methods (`np.float64(1.5).round()`, `.sum()`, `.astype(...)`, ...) are generated in `scalartypes.c.src`: they view the scalar as a 0-d array and re-dispatch to the matching `ndarray` method. We convert these methods from signature `METH_VARARGS | METH_KEYWORDS` to  `METH_FASTCALL | METH_KEYWORDS`. We also convert several array methods to vectorcall form.

Benchmarks:
| | main | PR | |
|---|---|---|---|
| `a.diagonal(offset=1)` | 218 ns | **138 ns** | 1.59x |
| `a.repeat(2, axis=0)` | 591 ns | **469 ns** | 1.27x |
| `a.tobytes()` | 61 ns | **50 ns** | 1.24x |
| `a.diagonal()` | 111 ns | **95 ns** | 1.18x |
| `a.round(decimals=2)` | 1487 ns | **1378 ns** | 1.09x |
| `a.round(2)` | 1398 ns | 1362 ns | 1.03x |
| `x.astype("f8", copy=True)` | 765 ns | **674 ns** | 1.14x |
| `np.int64(3).tobytes()` | 335 ns | **308 ns** | 1.10x |
| `x.round()` | 706 ns | **668 ns** | 1.06x |
| `x.round(2)` | 2593 ns | 2573 ns | 1.01x |
| `x.sum()` | 949 ns | 955 ns | 1.00x |
| control: `float(x)` | 40 ns | 41 ns | 0.99x |

`a = np.arange(12.).reshape(3, 4)`, `x = np.float64(1.5)`.

The saving is one tuple plus, when keywords are passed, one dict.

<details>
<summary>benchmark script</summary>

```python
import timeit

import numpy as np

x = np.float64(1.5)
a = np.arange(12.0).reshape(3, 4)

CASES = {
    "a.diagonal(offset=1)": lambda: a.diagonal(offset=1),
    "a.repeat(2, axis=0)": lambda: a.repeat(2, axis=0),
    "a.tobytes()": lambda: a.tobytes(),
    "a.diagonal()": lambda: a.diagonal(),
    "a.round(decimals=2)": lambda: a.round(decimals=2),
    "a.round(2)": lambda: a.round(2),
    "x.astype('f8', copy=True)": lambda: x.astype("f8", copy=True),
    "np.int64(3).tobytes()": lambda: np.int64(3).tobytes(),
    "x.round()": lambda: x.round(),
    "x.round(2)": lambda: x.round(2),
    "x.sum()": lambda: x.sum(),
    "float(x)  control": lambda: float(x),   # unaffected
}

print(np.__version__)
for name, fn in CASES.items():
    t = min(timeit.repeat(fn, number=20000, repeat=9)) / 20000
    print(f"  {name:28s} {t * 1e9:7.0f} ns")
```

</details>

**Behaviour**

One user-visible change: the seven converted methods now report argument errors in the argparser's wording, which makes them consistent with `take`, `trace` and the others already using it.

```python
a.diagonal(offset=1.5)
# main: TypeError: 'float' object cannot be interpreted as an integer
# PR:   TypeError: integer argument expected, got float

a.getfield()
# main: TypeError: getfield() missing required argument 'dtype' (pos 1)
# PR:   TypeError: getfield() missing required argument 'dtype' (pos 0)

a.tobytes("C", "F")
# main: TypeError: tobytes() takes at most 1 argument (2 given)
# PR:   TypeError: tobytes() takes from 0 to 1 positional arguments but 2 were given
```

On `main`, `a.take()` and `a.trace(offset=1.5)` already produce the second form, so this removes an inconsistency rather than introducing one.



<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->



#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
Generated with [Claude Code](https://claude.com/claude-code)
