### PR TITLE
ENH: guard the Limited API target on free-threaded builds and fix bare Py_LIMITED_API tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,13 +14,6 @@ project(
   ],
 )
 
-# Target version for the Limited C API, used by extension modules that
-# have been ported. Controlled by python.allow_limited_api (default: false).
-# The hex form is the same version, for targets that must define
-# `Py_LIMITED_API` themselves; keep the two in sync.
-py_limited_api = '3.13'
-py_limited_api_hex = '0x030d0000'
-
 fs = import('fs')
 
 cc = meson.get_compiler('c')
@@ -44,6 +37,23 @@ if not cy.version().version_compare('>=3.1.0')
 endif
 
 py = import('python').find_installation(pure: false)
+
+# Target version for the Limited C API, used by extension modules that
+# have been ported. Controlled by python.allow_limited_api (default: false).
+# The hex form is the same version, for targets that must define
+# `Py_LIMITED_API` themselves; keep the two in sync.
+#
+# `Py_LIMITED_API` selects abi3, which is non-free-threaded only; the
+# free-threaded ABI (abi3t) needs Python 3.15. Leave both empty on a
+# free-threaded build, where a `limited_api:` kwarg would otherwise be acted
+# on and produce a module that cannot be built.
+if py.get_variable('Py_GIL_DISABLED', 0) == 0
+  py_limited_api = '3.13'
+  py_limited_api_hex = '0x030d0000'
+else
+  py_limited_api = ''
+  py_limited_api_hex = ''
+endif
 py_dep = py.dependency()
 
 if not cc.has_header('Python.h', dependencies: py_dep)

--- a/numpy/_core/include/numpy/ufuncobject.h
+++ b/numpy/_core/include/numpy/ufuncobject.h
@@ -183,7 +183,7 @@ typedef struct _tagPyUFuncObject {
          * but this was never implemented. (This is also why the above
          * selector is called the "legacy" selector.)
          */
-        #if !defined(Py_LIMITED_API) || Py_LIMITED_API >= 0x030C0000
+        #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030C0000
             vectorcallfunc vectorcall;
         #else
             void *vectorcall;

--- a/numpy/_core/meson.build
+++ b/numpy/_core/meson.build
@@ -870,7 +870,8 @@ py.extension_module('_multiarray_tests',
 # library linked into one is still built against the unrestricted API and must
 # be passed these args too. Drop this once
 # https://github.com/mesonbuild/meson/issues/13824 is resolved.
-py_limited_api_args = get_option('python.allow_limited_api') \
+py_limited_api_args = (get_option('python.allow_limited_api')
+                       and py_limited_api_hex != '') \
   ? ['-DPy_LIMITED_API=' + py_limited_api_hex] : []
 
 _umath_tests_mtargets = mod_features.multi_targets(

--- a/numpy/fft/_pocketfft_umath.cpp
+++ b/numpy/fft/_pocketfft_umath.cpp
@@ -422,7 +422,7 @@ static struct PyModuleDef_Slot _pocketfft_umath_slots[] = {
 #if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
     {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
 #endif
-#if PY_VERSION_HEX >= 0x030d00f0 && (!defined(Py_LIMITED_API) || Py_LIMITED_API >= 0x030d0000) // Python 3.13+
+#if PY_VERSION_HEX >= 0x030d00f0 && (!defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030d0000) // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->

Related to: https://github.com/numpy/numpy/issues/31913
- `Py_LIMITED_API` may be defined with no value which the docs allow. `Py_LIMITED_API >= X` is a preprocessor error and hence CPython use `Py_LIMITED_API+0 >=` everywhere. 

-  `abi3` is non-free-threaded only and Meson does not check `Py_GIL_DISABLED`, so `-Dpython.allow_limited_api=true` on a free-threaded build is broken. The target is now empty there, making the option a no-op.


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
For review with claude opus 5 extra high.