### PR TITLE
BUG: Reset an unrepresentable fill_value on a dtype change  (#32508)

### DIFF
--- a/doc/release/upcoming_changes/32508.change.rst
+++ b/doc/release/upcoming_changes/32508.change.rst
@@ -1,0 +1,7 @@
+A ``MaskedArray`` fill_value that cannot be represented in a new dtype is now
+reset to the default for that dtype in more cases.  Previously only casts that
+raised were detected.  A floating point fill_value that overflows an integer
+dtype fails through the floating point error state instead, and the resulting
+out-of-range value was kept together with a ``RuntimeWarning``.  Reading
+``arr.fill_value`` before a dtype change was enough to reach this, since
+reading it stores the default fill_value on the array.

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -2320,7 +2320,7 @@ def masked_object(x, value, copy=True, shrink=True):
     else:
         condition = umath.equal(np.asarray(x), value)
         mask = nomask
-    mask = mask_or(mask, make_mask(condition, shrink=shrink))
+    mask = mask_or(mask, make_mask(condition, shrink=shrink), shrink=shrink)
     return masked_array(x, mask=mask, copy=copy, fill_value=value)
 
 

--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -3039,9 +3039,12 @@ class MaskedArray(ndarray):
             _optinfo.update(getattr(obj, '__dict__', {}))
         _fill_value = getattr(obj, '_fill_value', None)
         if _fill_value is not None and getattr(obj, 'dtype', None) != self.dtype:
+            # _check_fill_value does not raise when a float overflows an
+            # integer dtype; that failure only shows up as an FP error.
             try:
-                _fill_value = _check_fill_value(_fill_value, self.dtype)
-            except (TypeError, ValueError, OverflowError):
+                with np.errstate(invalid='raise'):
+                    _fill_value = _check_fill_value(_fill_value, self.dtype)
+            except (TypeError, ValueError, OverflowError, FloatingPointError):
                 _fill_value = None
         _dict = {'_fill_value': _fill_value,
                      '_hardmask': getattr(obj, '_hardmask', False),

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -49,6 +49,7 @@ from numpy.ma.core import (
     array,
     asarray,
     choose,
+    common_fill_value,
     concatenate,
     conjugate,
     cos,

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -2691,6 +2691,37 @@ class TestFillingValues:
         assert_equal(a["f0"].fill_value, default_fill_value(b"spam"))
         assert_equal(a["f1"].fill_value, default_fill_value("eggs"))
 
+    def test_common_fill_value(self):
+        # Test with matching fill value, across different dtypes and shapes.
+        a = array([1, 2, 3], dtype=int, fill_value=10)
+        b = array([[4, 5], [6, 7]], dtype=float, fill_value=10)
+        assert_equal(common_fill_value(a, b), 10)
+
+        # Test with non-matching fill value.
+        b.fill_value = -10
+        assert common_fill_value(a, b) is None
+
+    @pytest.mark.skipif(IS_WASM, reason="fp errors don't work in wasm")
+    def test_fillvalue_reset_on_lossy_float_cast(self):
+        # gh-28255
+        a = arange(9.0)
+        untouched = np.ones_like(a, dtype="int64")
+        a.fill_value  # materialise the default fill_value
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            touched = np.ones_like(a, dtype="int64")
+        assert_equal(touched.fill_value, untouched.fill_value)
+        assert_equal(touched.fill_value, default_fill_value(touched.dtype))
+
+    def test_fillvalue_kept_on_exact_float_cast(self):
+        a = array([1.0, 2.0], mask=[0, 1], fill_value=5.0)
+        assert_equal(np.ones_like(a, dtype="int64").fill_value, 5)
+
+    def test_fillvalue_setter_still_raises(self):
+        a = array([1, 2], dtype="int64")
+        with pytest.raises(TypeError):
+            a.fill_value = 1e20
+
 
 class TestUfuncs:
     # Test class for the application of ufuncs on MaskedArrays.
@@ -4792,10 +4823,12 @@ class TestMaskedArrayFunctions:
         tmp[(xm <= 2).filled(True)] = True
         assert_equal(d._mask, tmp)
 
-        with np.errstate(invalid="warn"):
-            # The fill value is 1e20, it cannot be converted to `int`:
-            with pytest.warns(RuntimeWarning, match="invalid value"):
-                ixm = xm.astype(int)
+        # The fill value is 1e20, it cannot be converted to `int`, so the
+        # cast falls back to the default fill_value (gh-28255):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            ixm = xm.astype(int)
+        assert_equal(ixm.fill_value, default_fill_value(ixm.dtype))
         d = where(ixm > 2, ixm, masked)
         assert_equal(d, [-9, -9, -9, -9, -9, 4, -9, -9, 10, -9, -9, 3])
         assert_equal(d.dtype, ixm.dtype)

--- a/numpy/ma/tests/test_core.py
+++ b/numpy/ma/tests/test_core.py
@@ -90,6 +90,7 @@ from numpy.ma.core import (
     masked_less,
     masked_less_equal,
     masked_not_equal,
+    masked_object,
     masked_outside,
     masked_print_option,
     masked_values,
@@ -5781,8 +5782,22 @@ class TestMaskedConstant:
 
 
 class TestMaskedWhereAliases:
+    def test_masked_object(self):
+        food = np.array(['green_eggs', 'ham'], dtype=object)
+        res = masked_object(food, 'green_eggs')
+        assert_equal(res.mask, [True, False])
+        assert_(res[0] is masked)
+        assert_equal(res.fill_value, 'green_eggs')
 
-    # TODO: Test masked_object, masked_equal, ...
+        res = masked_object(food, 'cheese')
+        assert_(res.mask is nomask)
+
+        res = masked_object(food, 'cheese', shrink=False)
+        assert_equal(res.mask, [False, False])
+
+        xm = array(['a', 'b', 'c'], mask=[1, 0, 0], dtype=object)
+        res = masked_object(xm, 'c')
+        assert_equal(res.mask, [True, False, True])
 
     def test_masked_values(self):
         res = masked_values(np.array([-32768.0]), np.int16(-32768))


### PR DESCRIPTION
Backport of #32508 and #32358.

### PR summary

As discussed in gh-28255. Since #32423, `MaskedArray._update_from` validates an inherited `fill_value` against the new dtype and falls back to the default when the cast fails. It decides "fails" by catching an exception, which misses casts that fail through the floating point error state instead.

    >>> a = np.ma.arange(9.0)
    >>> np.ones_like(a, dtype='int64').fill_value
    np.int64(999999)
    >>> a.fill_value          # only reads it
    np.float64(1e+20)
    >>> np.ones_like(a, dtype='int64').fill_value
    RuntimeWarning: invalid value encountered in cast
    np.int64(-9223372036854775808)

`1e20` is not a value the user picked, it is the default fill_value for float64, and reading the attribute stores it as a 0-d array. Casting that stored `np.float64(1e20)` to int64 does not raise: it sets the `invalid` flag, warns, and returns an out-of-range integer (INT64_MIN on x86; INT64_MAX on the macOS machine in the issue thread). A Python float `1e20` passed directly goes through the scalar path and raises, which is why `fill_value=1e20` at construction already fails cleanly.

This wraps that call in `np.errstate(invalid='raise')` and adds `FloatingPointError` to the except clause, so the fallback added in #32423 also runs for this case.

Scope:

- Only `invalid` is raised. `over` is left alone on purpose: a float fill_value that saturates to `inf` in a narrower float dtype is still a usable fill_value, and replacing it with the default would not be an improvement.
- Whether a lossy float-to-integer cast sets the `invalid` flag is platform dependent. `-1.0` to `uint8` sets no flag on x86 and wraps to 255, so this change does not touch it there; on platforms where it does set the flag (gh-28403), the fill_value now falls back to the default instead of a platform-specific value.
- `arr.fill_value = ...` still raises, since the setter calls `_check_fill_value` directly.
- The wider questions raised in gh-28255 (reading `fill_value` storing the default, separating default and user fill values) are not addressed here.

Tests: the new test compares against the result when `fill_value` was never read rather than against a specific number, so it does not depend on the platform or on the default integer width. In gh-28255 I said this would not touch existing tests; running the full `numpy/ma` suite showed that `TestMaskedArrayFunctions.test_where` in `numpy/ma/tests/test_core.py` asserted the `RuntimeWarning` from exactly this cast (`set_fill_value(1e20)` followed by `astype(int)`). It now asserts that the cast emits no warning and that `ixm.fill_value` is the default for the new dtype. The rest of `numpy/ma` passes unchanged (run against 2.5.2 with the change applied).

Fixes #28255

### First time committer introduction

Not my first PR (#32405 was a whitespace fix), but my first change to `numpy.ma`. I came to `numpy.ma` through gh-15601, which I am also preparing a fix for, and found this one while going through open `ma` issues around the time #32423 was being reviewed.

#### AI Disclosure

I used Claude throughout: to help investigate the cause, to draft the two-line change, the tests, and the release note from my notes, and to put this description and the code comments into English. I reviewed and applied the changes, and ran the reproducer, the new tests, and the `numpy/ma` suite myself.