### PR TITLE
ENH: Improvements and fixes for stringdtype hashing

### DIFF
--- a/doc/release/upcoming_changes/32563.improvement.rst
+++ b/doc/release/upcoming_changes/32563.improvement.rst
@@ -1,5 +1,5 @@
 StringDType descriptor hashing with NaN sentinels
------------------------------------------------
+-------------------------------------------------
 ``StringDType`` descriptors with equivalent floating-point NaN sentinels now
 have equal hashes. Previously, distinct NaN objects could produce equal
 descriptors with different hashes, causing dictionary lookups and set

--- a/doc/release/upcoming_changes/32563.improvement.rst
+++ b/doc/release/upcoming_changes/32563.improvement.rst
@@ -1,0 +1,7 @@
+StringDType descriptor hashing with NaN sentinels
+-----------------------------------------------
+``StringDType`` descriptors with equivalent floating-point NaN sentinels now
+have equal hashes. Previously, distinct NaN objects could produce equal
+descriptors with different hashes, causing dictionary lookups and set
+deduplication to fail, including after pickling a descriptor. Descriptor
+equality rules are unchanged.

--- a/numpy/_core/src/multiarray/stringdtype/dtype.c
+++ b/numpy/_core/src/multiarray/stringdtype/dtype.c
@@ -1011,10 +1011,21 @@ PyArray_StringDType_hash(PyObject *self)
     PyArray_StringDTypeObject *sself = (PyArray_StringDTypeObject *)self;
     PyObject *hash_tup = NULL;
     if (sself->na_object != NULL) {
-        hash_tup = Py_BuildValue("(iO)", sself->coerce, sself->na_object);
+        if (PyFloat_Check(sself->na_object) &&
+                npy_isnan(PyFloat_AS_DOUBLE(sself->na_object))) {
+            // na_eq_cmp treats distinct float NaNs as equal, so use a fixed
+            // value instead of their identity-dependent hashes.
+            hash_tup = Py_BuildValue("(ii)", sself->coerce, 0);
+        }
+        else {
+            hash_tup = Py_BuildValue("(iO)", sself->coerce, sself->na_object);
+        }
     }
     else {
         hash_tup = Py_BuildValue("(i)", sself->coerce);
+    }
+    if (hash_tup == NULL) {
+        return -1;
     }
 
     Py_hash_t ret = PyObject_Hash(hash_tup);

--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -318,9 +318,18 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
      * This function uses hashing to identify uniqueness efficiently.
      */
 
-    auto hash = [equal_nan](const npy_static_string *value) -> size_t {
+    auto *descr = reinterpret_cast<PyArray_StringDTypeObject *>(
+            PyArray_DESCR(self));
+    bool equal_nulls = equal_nan || !descr->has_nan_na;
+    const npy_static_string *na_string =
+            descr->has_string_na ? &descr->default_string : nullptr;
+
+    auto hash = [equal_nulls, na_string](const npy_static_string *value) -> size_t {
         if (value->buf == NULL) {
-            if (equal_nan) {
+            if (na_string != nullptr) {
+                value = na_string;
+            }
+            else if (equal_nulls) {
                 return 0;
             } else {
                 return std::hash<const npy_static_string *>{}(value);
@@ -328,9 +337,18 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
         }
         return npy_fnv1a(value->buf, value->size * sizeof(char));
     };
-    auto equal = [equal_nan](const npy_static_string *lhs, const npy_static_string *rhs) -> bool {
+    auto equal = [equal_nulls, na_string](const npy_static_string *lhs, const npy_static_string *rhs) -> bool {
+        // String-valued nulls compare equal to their ordinary string value.
+        if (na_string != nullptr) {
+            if (lhs->buf == NULL) {
+                lhs = na_string;
+            }
+            if (rhs->buf == NULL) {
+                rhs = na_string;
+            }
+        }
         if (lhs->buf == NULL && rhs->buf == NULL) {
-            if (equal_nan) {
+            if (equal_nulls) {
                 return true;
             } else {
                 return lhs == rhs;
@@ -355,8 +373,6 @@ unique_vstring(PyArrayObject *self, npy_bool equal_nan)
     set_type hashset(std::min(isize, HASH_TABLE_INITIAL_BUCKETS), hash, equal);
 
     {
-        PyArray_StringDTypeObject *descr =
-            reinterpret_cast<PyArray_StringDTypeObject *>(PyArray_DESCR(self));
         np::raii::SaveThreadState save_thread_state{};
         np::raii::NpyStringAcquireAllocator alloc(descr);
 

--- a/numpy/_core/tests/test_stringdtype.py
+++ b/numpy/_core/tests/test_stringdtype.py
@@ -158,6 +158,17 @@ def test_dtype_equality(dtype):
         assert dtype != np.dtype(f"{ch}8")
 
 
+def test_dtype_hash(dtype, dtype2):
+    assert len({dtype, dtype2}) == (1 if dtype == dtype2 else 2)
+
+
+def test_dtype_hash_float64_nan(coerce):
+    dtype = StringDType(na_object=np.float64("nan"), coerce=coerce)
+    other = StringDType(na_object=float("nan"), coerce=coerce)
+    assert dtype == other
+    assert hash(dtype) == hash(other)
+
+
 def test_dtype_repr(dtype):
     if not hasattr(dtype, "na_object") and dtype.coerce:
         assert repr(dtype) == "StringDType()"
@@ -1010,6 +1021,7 @@ def test_pickle(dtype, string_list):
 
     assert_array_equal(res[0], arr)
     assert res[1] == dtype
+    assert hash(res[1]) == hash(dtype)
 
     os.remove(f.name)
 

--- a/numpy/lib/tests/test_arraysetops.py
+++ b/numpy/lib/tests/test_arraysetops.py
@@ -871,15 +871,18 @@ class TestUnique:
         # so we check them by sorting
         assert_array_equal(sorted(a1.tolist()), unq_sorted)
 
-    def test_unique_vstring_hash_based_equal_nan(self):
-        # test for unicode and nullable string arrays (equal_nan=True)
+    @pytest.mark.parametrize("equal_nan", [True, False])
+    @pytest.mark.parametrize("na_object", [None, object()], ids=["None", "object"])
+    def test_unique_vstring_hash_based(self, equal_nan, na_object):
+        # test for unicode and nullable string arrays
         a = np.array([
                 # short strings
+                '', '',
                 'straße',
-                None,
+                na_object,
                 'strasse',
                 'straße',
-                None,
+                na_object,
                 'niño',
                 'nino',
                 'élève',
@@ -889,31 +892,32 @@ class TestUnique:
                 # medium strings
                 'b' * 20,
                 'ß' * 30,
-                None,
+                na_object,
                 'é' * 30,
                 'e' * 20,
                 'ß' * 30,
                 'n' * 30,
                 'ñ' * 20,
-                None,
+                na_object,
                 'e' * 20,
                 'ñ' * 20,
                 # long strings
                 'b' * 300,
                 'ß' * 400,
-                None,
+                na_object,
                 'é' * 400,
                 'e' * 300,
                 'ß' * 400,
                 'n' * 400,
                 'ñ' * 300,
-                None,
+                na_object,
                 'e' * 300,
                 'ñ' * 300,
             ],
-            dtype=StringDType(na_object=None)
+            dtype=StringDType(na_object=na_object)
         )
-        unq_sorted_wo_none = [
+        unq_sorted_wo_na = [
+            '',
             'b' * 20,
             'b' * 300,
             'e' * 20,
@@ -934,90 +938,31 @@ class TestUnique:
             'ñ' * 300,
         ]
 
-        a1 = unique(a, sorted=False, equal_nan=True)
+        a1 = unique(a, sorted=False, equal_nan=equal_nan)
+        assert a1.dtype == a.dtype
         # the result varies depending on the impl of std::unordered_set,
         # so we check them by sorting
 
-        # a1 should have exactly one None
-        count_none = sum(x is None for x in a1)
-        assert_equal(count_none, 1)
+        # a1 should have exactly one na_object
+        count_na = sum(x is na_object for x in a1)
+        assert_equal(count_na, 1)
 
-        a1_wo_none = sorted(x for x in a1 if x is not None)
-        assert_array_equal(a1_wo_none, unq_sorted_wo_none)
+        a1_wo_na = sorted(x for x in a1 if x is not na_object)
+        assert_array_equal(a1_wo_na, unq_sorted_wo_na)
 
-    def test_unique_vstring_hash_based_not_equal_nan(self):
-        # test for unicode and nullable string arrays (equal_nan=False)
-        a = np.array([
-                # short strings
-                'straße',
-                None,
-                'strasse',
-                'straße',
-                None,
-                'niño',
-                'nino',
-                'élève',
-                'eleve',
-                'niño',
-                'élève',
-                # medium strings
-                'b' * 20,
-                'ß' * 30,
-                None,
-                'é' * 30,
-                'e' * 20,
-                'ß' * 30,
-                'n' * 30,
-                'ñ' * 20,
-                None,
-                'e' * 20,
-                'ñ' * 20,
-                # long strings
-                'b' * 300,
-                'ß' * 400,
-                None,
-                'é' * 400,
-                'e' * 300,
-                'ß' * 400,
-                'n' * 400,
-                'ñ' * 300,
-                None,
-                'e' * 300,
-                'ñ' * 300,
-            ],
-            dtype=StringDType(na_object=None)
-        )
-        unq_sorted_wo_none = [
-            'b' * 20,
-            'b' * 300,
-            'e' * 20,
-            'e' * 300,
-            'eleve',
-            'nino',
-            'niño',
-            'n' * 30,
-            'n' * 400,
-            'strasse',
-            'straße',
-            'ß' * 30,
-            'ß' * 400,
-            'élève',
-            'é' * 30,
-            'é' * 400,
-            'ñ' * 20,
-            'ñ' * 300,
-        ]
-
-        a1 = unique(a, sorted=False, equal_nan=False)
-        # the result varies depending on the impl of std::unordered_set,
-        # so we check them by sorting
-
-        # a1 should have exactly one None
-        count_none = sum(x is None for x in a1)
-        assert_equal(count_none, 6)
-
-        a1_wo_none = sorted(x for x in a1 if x is not None)
-        assert_array_equal(a1_wo_none, unq_sorted_wo_none)
+    @pytest.mark.parametrize("equal_nan", [True, False])
+    @pytest.mark.parametrize("na_object", ["", "NA", "NAé" * 10])
+    def test_unique_vstring_string_nulls(self, na_object, equal_nan):
+        dtype = StringDType(na_object=na_object)
+        # The plain StringDType array stores an ordinary string; the nullable
+        # array stores the same value as a null.
+        a = np.concatenate((
+            np.array([na_object, "value"], dtype="T"),
+            np.array([na_object, na_object, "value"], dtype=dtype),
+        ))
+        expected = np.array([na_object, "value"], dtype=dtype)
+        assert_array_equal(unique(a, equal_nan=equal_nan), expected)
+        assert_array_equal(unique(a[::-1], equal_nan=equal_nan), expected)
 
     def test_unique_vstring_errors(self):
         a = np.array(


### PR DESCRIPTION
### PR summary
This fixes some issues with hashing of StringDType objects of a `na_object` is defined. 

First, the hashing implementation in both `tp_hash` and the `np.unique` hash-based unique implementation did not properly take into account all kinds of missing data supported by StringDType. These could lead to inconsistent behavior. The former in more widespread situations: for example unpickling a dtype instance with `na_object=np.nan` would produce an object that compares equal but with a distinct hash because the unpickled object has a distinct `nan` instance.

The latter would lead to similar inconsistencies and duplicated values in `np.unique`. It also makes `np.unique(..., equal_nan=True)` do the right thing for nan-like sentinels.

#### AI Disclosure
I used an AI model to iterate on this.
