### PR TITLE
DOC: increase open PR limit to two

### DIFF
--- a/doc/source/dev/development_workflow.rst
+++ b/doc/source/dev/development_workflow.rst
@@ -110,7 +110,7 @@ In more detail
    -a``. The extra ``-a`` flag automatically commits all modified files and
    removes all deleted files. This can save you some typing of numerous ``git
    add`` commands; however, it can add unwanted changes to a commit if you're
-   not careful. 
+   not careful.
 
 #. Push the changes to your fork on GitHub::
 
@@ -257,7 +257,7 @@ OK to ping the list again.
 Asking for your changes to be merged with the main repo
 =======================================================
 
-When you feel your work is finished, you can create a pull request (PR). 
+When you feel your work is finished, you can create a pull request (PR).
 If your changes involve modifications to the API or addition/modification of a
 function, add a release note to the ``doc/release/upcoming_changes/``
 directory, following the instructions and format in the
@@ -273,8 +273,8 @@ of your PR.
 Open pull request limit
 =======================
 
-To keep the review queue manageable, GitHub is configured to allow only one
-open non-draft pull request per non-maintainer at a time. Draft pull requests
+To keep the review queue manageable, GitHub is configured to allow only two
+open non-draft pull requests per non-maintainer at a time. Draft pull requests
 do not count towards the limit. The maintainer team can, at its discretion,
 add contributors to the list of accounts allowed to open more pull requests
 at once. We liberally add contributors who attend the community and triage


### PR DESCRIPTION
### PR summary

At the [August 12, 2026 community meeting](https://github.com/numpy/archive/blob/main/community_meetings/2026/community-2026-08-12.md), the decision was made to increase the limit on open non-draft PRs for non-maintainers from one to two. This PR updates the contributor documentation to reflect the decision.

#### AI Disclosure

No AI tools used

