### PR TITLE
CI: Make the LSAN `os.stat` suppression independent of stack depth

### DIFF
--- a/tools/ci/lsan_suppressions.txt
+++ b/tools/ci/lsan_suppressions.txt
@@ -31,3 +31,13 @@
 #23 0xffffb1c61b44 in initialize_static_globals ../numpy/_core/src/multiarray/npy_static_data.c:124
 
 leak:initialize_static_globals
+
+# The same two leaks are also reached through more deeply nested Python
+# imports. Those stacks exhaust malloc_context_size (30 by default) about
+# three import levels in, while still inside CPython's import machinery, so
+# initialize_static_globals is never recorded and the suppression above cannot
+# match. Raising malloc_context_size only moves that cliff, since the depth
+# depends on how deeply nested the importing test module is. Match on
+# fill_time instead: it sits at frame #2 regardless of depth, and it allocates
+# nothing but the float timestamps of an os.stat() result.
+leak:fill_time


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request, using the questions below as
  guidance, and link to any relevant issues and PRs.

  
  Also, have you hit all [the guidelines](https://numpy.org/devdocs/dev/index.html#guidelines)?
  And have you filled out the disclosure section below?

-->
PR failure: https://github.com/numpy/numpy/actions/runs/34350823217/job/102463384124?pr=32502

The `clang_ASAN` job suppresses two known CPython leaks, the float timestamps in an `os.stat()` result during import, by matching `initialize_static_globals`. That frame is about 23 frames above the allocation, while ASAN only records 30 frames (`malloc_context_size`). Any change that nests those imports a little deeper can push the NumPy frame out of the recorded trace, making the job fail on an unchanged leak. This happened with #32502 and #32552, where all tests passed and the only failure was 48 bytes in two allocations, with no NumPy frame in either stack.

Match fill_time instead, which is the second frame in the trace. It allocates nothing but os.stat timestamps, so it cannot mask a numpy leak.

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
Took AI's help in finding the actual cause of the failure and for writing comments later.  