### PR TITLE
ENH: branchless sign selection in random_standard_normal

### DIFF
--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -21,6 +21,13 @@ static inline float next_float(bitgen_t *bitgen_state) {
   return (next_uint32(bitgen_state) >> 8) * (1.0f / 16777216.0f);
 }
 
+/* Multiplying by +/-1.0 is exact in IEEE-754 for every finite value, including
+ * the 0.0 -> -0.0 case, so indexing these tables with the random sign bit
+ * reproduces `if (sign) x = -x;` bit for bit while avoiding a branch on a
+ * uniformly distributed (hence unpredictable) bit. */
+static const double ziggurat_sign_double[2] = {1.0, -1.0};
+static const float ziggurat_sign_float[2] = {1.0f, -1.0f};
+
 /* Random generators for external use */
 float random_standard_uniform_f(bitgen_t *bitgen_state) {
     return next_float(bitgen_state);
@@ -137,7 +144,6 @@ void random_standard_exponential_inv_fill_f(bitgen_t * bitgen_state, npy_intp cn
 
 double random_standard_normal(bitgen_t *bitgen_state) {
   uint64_t r;
-  int sign;
   uint64_t rabs;
   int idx;
   double x, xx, yy;
@@ -146,11 +152,8 @@ double random_standard_normal(bitgen_t *bitgen_state) {
     r = next_uint64(bitgen_state);
     idx = r & 0xff;
     r >>= 8;
-    sign = r & 0x1;
     rabs = (r >> 1) & 0x000fffffffffffff;
-    x = rabs * wi_double[idx];
-    if (sign & 0x1)
-      x = -x;
+    x = rabs * wi_double[idx] * ziggurat_sign_double[r & 0x1];
     if (rabs < ki_double[idx])
       return x; /* 99.3% of the time return here */
     if (idx == 0) {
@@ -179,7 +182,6 @@ void random_standard_normal_fill(bitgen_t *bitgen_state, npy_intp cnt, double *o
 
 float random_standard_normal_f(bitgen_t *bitgen_state) {
   uint32_t r;
-  int sign;
   uint32_t rabs;
   int idx;
   float x, xx, yy;
@@ -187,11 +189,8 @@ float random_standard_normal_f(bitgen_t *bitgen_state) {
     /* r = n23sb8 */
     r = next_uint32(bitgen_state);
     idx = r & 0xff;
-    sign = (r >> 8) & 0x1;
     rabs = (r >> 9) & 0x0007fffff;
-    x = rabs * wi_float[idx];
-    if (sign & 0x1)
-      x = -x;
+    x = rabs * wi_float[idx] * ziggurat_sign_float[(r >> 8) & 0x1];
     if (rabs < ki_float[idx])
       return x; /* # 99.3% of the time return here */
     if (idx == 0) {


### PR DESCRIPTION
### PR summary
random_standard_normal and random_standard_normal_f apply the sign of the variate with:

```C
    x = rabs * wi_double[idx];
    if (sign & 0x1)
      x = -x;
```

Where `sign` is a single uniformly distributed bit. Both gcc and clang compile this to a conditional branch on x86-64 at -O1, -O2 and -O3. This branch is on a very frequent path (99.3% of the cases) and is very hard for the cpu to predict as it is essentially a coin flip. We replace the if statement by a +1.0/-1.0 multiply: 

```C
    static const double ziggurat_sign_double[2] = {1.0, -1.0};
    ...
    x = rabs * wi_double[idx] * ziggurat_sign_double[r & 0x1];
```

Multiplication by +1.0 and -1.0 is exact in IEEE-754, which ensures the output stream is bit-for-bit identical.

Results:
`asv continuous 36ffce44 33872476 -b "RNG.time_normal_zig|Random.time_rng"`

```
| Change | Before [36ffce44] | After [33872476] | Ratio | Benchmark (Parameter)
|--------|-------------------|------------------|-------|----------------------------------
| -      | 907±10μs          | 614±30μs         |  0.68 | RNG.time_normal_zig('SFC64')
| -      | 1.35±0.02ms       | 890±3μs          |  0.66 | RNG.time_normal_zig('Philox')
| -      | 1.37±0ms          | 858±2μs          |  0.63 | RNG.time_normal_zig('MT19937')
| -      | 1.07±0ms          | 622±20μs         |  0.58 | RNG.time_normal_zig('PCG64')
```

- x86-64: Intel Xeon Gold 6134 @ 3.20GHz (Skylake-SP), Ubuntu 22.04, gcc 11.4.0 / clang 18.1.8.

Dissasembly:

Hot path of `random_standard_normal`, x86-64, `-O2` (numpy builds`buildtype=debugoptimized`, i.e. `-O2`).


**gcc 11.4.0 — before**
```asm
    cvtsi2sdq  %rsi, %xmm1
    mulsd      0(%r13,%rcx,8), %xmm1     ; x = rabs * wi_double[idx]
    testb      $1, %ah                   ; the sign bit
    je         .L2                       ; <-- branch
    xorpd      .LC0(%rip), %xmm1         ; x = -x
.L2:
    cmpq       %rsi, (%r12,%rcx,8)
```

**gcc 11.4.0 — after**
```asm
    cvtsi2sdq  %rdi, %xmm0
    mulsd      (%r14,%rcx,8), %xmm0      ; x = rabs * wi_double[idx]
    mulsd      0(%r13,%rax,8), %xmm0     ; * ziggurat_sign_double[r & 1]
    movsd      %xmm0, (%rsp)
    cmpq       %rdi, (%r12,%rcx,8)
```

**clang 18.1.8 — before**
```asm
    mulsd      (%r15,%rsi,8), %xmm0
    testl      $256, %eax
    je         .LBB0_3                   ; <-- branch
    xorpd      .LCPI0_0(%rip), %xmm0
.LBB0_3:
```

**clang 18.1.8 — after**
```asm
    mulsd      (%r15,%rsi,8), %xmm0
    movl       %eax, %edi
    shrl       $5, %edi
    andl       $8, %edi
    mulsd      (%rdi,%r12), %xmm0
```

### First time committer introduction
I am a Phd student in applied Mathematics. I have used numpy extensively in the past for numerical simulations. I have lately been doing my projects in C with no external dependencies and have thus had to write my own prngs. I used numpy's implementation for standard normals as a reference. That is how this optimisation came about.

#### AI Disclosure
I used Claude Opus through out my investigation and benchmarks. The code change and comment above the the two `{-1.0, 1.0}` arrays 
were written by Claude. I also used Claude for the disassembly and for running benchmarks.