### PR TITLE
TYP: ``squeeze`` shape-typing when ``axis`` is given

### DIFF
--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -1103,13 +1103,35 @@ def resize[AnyShapeT: (_0D, _1D, _2D, _3D, _4D)](a: ArrayLike, new_shape: AnySha
 @overload
 def resize(a: ArrayLike, new_shape: _ShapeLike) -> NDArray[Any]: ...
 
-# TODO: Fix overlapping overloads: https://github.com/numpy/numpy/issues/27032
-@overload
+#
+@overload  # 0d T
 def squeeze[ScalarT: np.generic](a: ScalarT, axis: _ShapeLike | None = None) -> ScalarT: ...
-@overload
-def squeeze[ScalarT: np.generic](a: _ArrayLike[ScalarT], axis: _ShapeLike | None = None) -> NDArray[ScalarT]: ...
-@overload
-def squeeze(a: ArrayLike, axis: _ShapeLike | None = None) -> NDArray[Any]: ...
+@overload  # 0d  (the generic shape catches `tuple[Any, ...]`)
+def squeeze[ShapeT: _0D, DTypeT: np.dtype](
+    a: np.ndarray[ShapeT, DTypeT], axis: SupportsIndex | tuple[SupportsIndex, ...] | None = None
+) -> np.ndarray[ShapeT, DTypeT]: ...
+@overload  # 1d, axis=<single>
+def squeeze[DTypeT: np.dtype](
+    a: np.ndarray[_1D, DTypeT], axis: SupportsIndex | tuple[SupportsIndex]
+) -> np.ndarray[_0D, DTypeT]: ...
+@overload  # 2d, axis=<single>
+def squeeze[DTypeT: np.dtype](
+    a: np.ndarray[_2D, DTypeT], axis: SupportsIndex | tuple[SupportsIndex]
+) -> np.ndarray[_1D, DTypeT]: ...
+@overload  # 3d, axis=<single>
+def squeeze[DTypeT: np.dtype](
+    a: np.ndarray[_3D, DTypeT], axis: SupportsIndex | tuple[SupportsIndex]
+) -> np.ndarray[_2D, DTypeT]: ...
+@overload  # 4d, axis=<single>
+def squeeze[DTypeT: np.dtype](
+    a: np.ndarray[_4D, DTypeT], axis: SupportsIndex | tuple[SupportsIndex]
+) -> np.ndarray[_3D, DTypeT]: ...
+@overload  # Nd T
+def squeeze[ScalarT: np.generic](
+    a: NDArray[ScalarT] | _NestedSequence[_SupportsArray[np.dtype[ScalarT]]], axis: _ShapeLike | None = None
+) -> NDArray[ScalarT]: ...
+@overload  # fallback
+def squeeze(a: ArrayLike, axis: _ShapeLike | None = None) -> NDArray[Any] | Any: ...
 
 # keep in sync with `ma.core.diagonal`
 @overload  # ?d  (workaround)

--- a/numpy/typing/tests/data/reveal/fromnumeric.pyi
+++ b/numpy/typing/tests/data/reveal/fromnumeric.pyi
@@ -225,10 +225,15 @@ assert_type(np.resize(AR_b, (5, 5)), np.ndarray[tuple[int, int], np.dtype[np.boo
 assert_type(np.resize(AR_f4, (5, 5)), np.ndarray[tuple[int, int], np.dtype[np.float32]])
 
 assert_type(np.squeeze(b), np.bool)
-assert_type(np.squeeze(f4), np.float32)
-assert_type(np.squeeze(f), npt.NDArray[Any])
 assert_type(np.squeeze(AR_b), npt.NDArray[np.bool])
+assert_type(np.squeeze(AR_i8_0d), np.ndarray[tuple[()], np.dtype[np.int64]])
+assert_type(np.squeeze(f4), np.float32)
+assert_type(np.squeeze(AR_f4_1d, 0), np.ndarray[tuple[()], np.dtype[np.float32]])
+assert_type(np.squeeze(AR_f4_2d, axis=0), _Array1D[np.float32])
+assert_type(np.squeeze(AR_f4_3d, (0,)), _Array2D[np.float32])
+assert_type(np.squeeze(AR_f4_4d, axis=(1,)), _Array3D[np.float32])
 assert_type(np.squeeze(AR_f4), npt.NDArray[np.float32])
+assert_type(np.squeeze(f), npt.NDArray[Any] | Any)
 
 assert_type(np.diagonal(AR_b), npt.NDArray[np.bool])
 assert_type(np.diagonal(AR_f4), npt.NDArray[np.float32])


### PR DESCRIPTION
For <=4d array-likes and with `axis` given and singular, `np.squeeze` will now return an array with exact shape-type.

---

Pair programmed with AI.