### PR TITLE
TYP: ``count_nonzero`` shape-typing

### DIFF
--- a/numpy/_core/numeric.pyi
+++ b/numpy/_core/numeric.pyi
@@ -651,6 +651,12 @@ type _Array3D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[S
 type _Array4D[ScalarT: np.generic] = np.ndarray[tuple[int, int, int, int], np.dtype[ScalarT]]
 type _ArrayJustND[ScalarT: np.generic] = np.ndarray[tuple[Never, ...], np.dtype[ScalarT]]
 
+type _ToArray0D = _Array0D[Any] | complex | str | np.generic
+type _ToArray1D = _Array1D[Any] | Sequence[complex | np.generic]
+type _ToArray2D = _Array2D[Any] | Sequence[Sequence[complex | np.generic]]
+type _ToArray3D = _Array3D[Any] | Sequence[Sequence[Sequence[complex | np.generic]]]
+type _ToArray4D = _Array4D[Any] | Sequence[Sequence[Sequence[Sequence[complex | np.generic]]]]
+
 type _TensorAxes = int | tuple[_ShapeLike, _ShapeLike]
 
 type _Int_co = np.integer | np.bool
@@ -1256,15 +1262,40 @@ def full_like(
 ) -> NDArray[Any]: ...
 
 #
-@overload
+@overload  # Nd, keepdims=True
+def count_nonzero[ShapeT: tuple[int, *tuple[int, ...]]](
+    a: np.ndarray[ShapeT, Any],
+    axis: _ShapeLike | None = None,
+    *,
+    keepdims: L[True],
+) -> np.ndarray[ShapeT, np.dtype[np.intp]]: ...
+@overload  # ?d, axis=<given>  (workaround)
+def count_nonzero(a: _ArrayJustND[Any], axis: _ShapeLike, *, keepdims: L[False] = False) -> NDArray[np.intp] | Any: ...
+@overload  # 0d, keepdims=True
+def count_nonzero(a: _ToArray0D, axis: _ShapeLike | None = None, *, keepdims: L[True]) -> np.intp: ...
+@overload  # 1d, keepdims=True
+def count_nonzero(a: _ToArray1D, axis: _ShapeLike | None = None, *, keepdims: L[True]) -> _Array1D[np.intp]: ...
+@overload  # 1d, axis=<given>
+def count_nonzero(a: _ToArray1D, axis: int | tuple[int], *, keepdims: L[False] = False) -> np.intp: ...
+@overload  # 2d, keepdims=True
+def count_nonzero(a: _ToArray2D, axis: _ShapeLike | None = None, *, keepdims: L[True]) -> _Array2D[np.intp]: ...
+@overload  # 2d, axis=<given>
+def count_nonzero(a: _ToArray2D, axis: int | tuple[int], *, keepdims: L[False] = False) -> _Array1D[np.intp]: ...
+@overload  # 3d, keepdims=True
+def count_nonzero(a: _ToArray3D, axis: _ShapeLike | None = None, *, keepdims: L[True]) -> _Array3D[np.intp]: ...
+@overload  # 3d, axis=<given>
+def count_nonzero(a: _ToArray3D, axis: int | tuple[int], *, keepdims: L[False] = False) -> _Array2D[np.intp]: ...
+@overload  # 4d, keepdims=True
+def count_nonzero(a: _ToArray4D, axis: _ShapeLike | None = None, *, keepdims: L[True]) -> _Array4D[np.intp]: ...
+@overload  # 4d, axis=<given>
+def count_nonzero(a: _ToArray4D, axis: int | tuple[int], *, keepdims: L[False] = False) -> _Array3D[np.intp]: ...
+@overload  # Nd, axis=None  (default)
 def count_nonzero(a: ArrayLike, axis: None = None, *, keepdims: L[False] = False) -> np.intp: ...
-@overload
-def count_nonzero(a: _ScalarLike_co, axis: _ShapeLike | None = None, *, keepdims: L[True]) -> np.intp: ...
-@overload
-def count_nonzero(
-    a: NDArray[Any] | _NestedSequence[ArrayLike], axis: _ShapeLike | None = None, *, keepdims: L[True]
-) -> NDArray[np.intp]: ...
-@overload
+@overload  # Nd, keepdims=True  (fallback)
+def count_nonzero(a: _NestedSequence[ArrayLike], axis: _ShapeLike | None = None, *, keepdims: L[True]) -> NDArray[np.intp]: ...
+@overload  # Nd, axis=<given>  (fallback)
+def count_nonzero(a: ArrayLike, axis: _ShapeLike, *, keepdims: L[False] = False) -> NDArray[np.intp] | Any: ...
+@overload  # fallback
 def count_nonzero(a: ArrayLike, axis: _ShapeLike | None = None, *, keepdims: py_bool = False) -> Any: ...
 
 #

--- a/numpy/typing/tests/data/reveal/numeric.pyi
+++ b/numpy/typing/tests/data/reveal/numeric.pyi
@@ -17,6 +17,11 @@ i8: np.int64
 AR_b: npt.NDArray[np.bool]
 AR_u8: npt.NDArray[np.uint64]
 AR_i8: npt.NDArray[np.int64]
+AR_i8_0d: np.ndarray[tuple[()], np.dtype[np.int64]]
+AR_i8_1d: np.ndarray[tuple[int], np.dtype[np.int64]]
+AR_i8_2d: np.ndarray[tuple[int, int], np.dtype[np.int64]]
+AR_i8_3d: np.ndarray[tuple[int, int, int], np.dtype[np.int64]]
+AR_i8_4d: np.ndarray[tuple[int, int, int, int], np.dtype[np.int64]]
 AR_f8: npt.NDArray[np.float64]
 AR_c16: npt.NDArray[np.complex128]
 AR_m: npt.NDArray[np.timedelta64]
@@ -34,9 +39,20 @@ _to_1d_complex: list[complex]
 
 assert_type(np.count_nonzero(i8), np.intp)
 assert_type(np.count_nonzero(AR_i8), np.intp)
-assert_type(np.count_nonzero(_to_1d_int), np.intp)
+assert_type(np.count_nonzero(AR_i8, axis=0), npt.NDArray[np.intp] | Any)
+assert_type(np.count_nonzero(AR_i8_1d, axis=0), np.intp)
+assert_type(np.count_nonzero(AR_i8_2d, axis=0), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(np.count_nonzero(AR_i8_3d, axis=(0,)), np.ndarray[tuple[int, int], np.dtype[np.intp]])
+assert_type(np.count_nonzero(AR_i8_4d, axis=1), np.ndarray[tuple[int, int, int], np.dtype[np.intp]])
+assert_type(np.count_nonzero(AR_i8_0d, keepdims=True), np.intp)
 assert_type(np.count_nonzero(AR_i8, keepdims=True), npt.NDArray[np.intp])
-assert_type(np.count_nonzero(AR_i8, axis=0), Any)
+assert_type(np.count_nonzero(AR_i8_2d, keepdims=True), np.ndarray[tuple[int, int], np.dtype[np.intp]])
+assert_type(np.count_nonzero(AR_i8_2d, axis=(0, 1)), npt.NDArray[np.intp] | Any)
+assert_type(np.count_nonzero(_to_1d_int), np.intp)
+assert_type(np.count_nonzero(_to_1d_int, axis=0), np.intp)
+assert_type(np.count_nonzero(_to_2d_float, axis=0), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(np.count_nonzero(_to_1d_int, keepdims=True), np.ndarray[tuple[int], np.dtype[np.intp]])
+assert_type(np.count_nonzero(_to_2d_float, keepdims=True), np.ndarray[tuple[int, int], np.dtype[np.intp]])
 
 assert_type(np.isfortran(i8), bool)
 assert_type(np.isfortran(AR_i8), bool)


### PR DESCRIPTION
`np.count_nonzero` now returns an array with exact shape-type for <=4d array likes and in general when `keepdims=True`.

---

P*ai*r programmed with AI.