### PR TITLE
DOC: Clarify copy parameter semantics in nan_to_num (gh-29045)

### DIFF
--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -388,11 +388,13 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     ----------
     x : scalar or array_like
         Input data.
-    copy : bool, optional
-        Whether to create a copy of `x` (True) or to replace values
-        in-place (False). The in-place operation only occurs if
-        casting to an array does not require a copy.
-        Default is True.
+    copy : bool or None, optional
+        Whether to create a copy of `x` (``True``) or to replace values
+        in-place (``False``). If ``False``, a ``ValueError`` is raised if
+        a copy cannot be avoided. If ``None``, a copy is made only if needed
+        (e.g., when converting a sequence to an array or when casting is
+        required), otherwise values are replaced in-place.
+        Default is ``True``.
     nan : int, float, or bool or array_like of int, float, or bool, optional
         Values to be used to fill NaN values. If no values are passed
         then NaN values will be replaced with 0.0.
@@ -408,8 +410,8 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
     Returns
     -------
     out : ndarray
-        `x`, with the non-finite values replaced. If `copy` is False, this may
-        be `x` itself.
+        `x`, with the non-finite values replaced. If `copy` is False or None,
+        this may be `x` itself.
 
     See Also
     --------

--- a/numpy/lib/_type_check_impl.py
+++ b/numpy/lib/_type_check_impl.py
@@ -390,10 +390,12 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
         Input data.
     copy : bool or None, optional
         Whether to create a copy of `x` (``True``) or to replace values
-        in-place (``False``). If ``False``, a ``ValueError`` is raised if
-        a copy cannot be avoided. If ``None``, a copy is made only if needed
-        (e.g., when converting a sequence to an array or when casting is
-        required), otherwise values are replaced in-place.
+        in-place (``False``). The in-place operation only occurs if
+        casting to an array does not require a copy. If ``False``, a
+        ``ValueError`` is raised if a copy cannot be avoided. If ``None``,
+        a copy is made only if needed (e.g., when converting a sequence
+        to an array or when casting is required), otherwise values are
+        replaced in-place.
         Default is ``True``.
     nan : int, float, or bool or array_like of int, float, or bool, optional
         Values to be used to fill NaN values. If no values are passed

--- a/numpy/lib/_type_check_impl.pyi
+++ b/numpy/lib/_type_check_impl.pyi
@@ -102,7 +102,7 @@ def isrealobj(x: _HasDType[Any] | ArrayLike) -> bool: ...
 @overload  # np.generic | np.ndarray  (`ndarray` subclasses pass through)
 def nan_to_num[ScalarOrArrayT: np.generic | np.ndarray](
     x: ScalarOrArrayT,
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -110,7 +110,7 @@ def nan_to_num[ScalarOrArrayT: np.generic | np.ndarray](
 @overload  # >0-d <known dtype>
 def nan_to_num[ScalarT: np.generic](
     x: _NestedSequence[_ArrayLike[ScalarT]],
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -118,7 +118,7 @@ def nan_to_num[ScalarT: np.generic](
 @overload  # ?-d <known dtype>
 def nan_to_num[DTypeT: np.dtype](
     x: _SupportsArray[DTypeT],
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -126,7 +126,7 @@ def nan_to_num[DTypeT: np.dtype](
 @overload  # 0-d ~bool
 def nan_to_num(
     x: bool,
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -134,7 +134,7 @@ def nan_to_num(
 @overload  # 0-d +int
 def nan_to_num(
     x: int,
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -142,7 +142,7 @@ def nan_to_num(
 @overload  # 0-d +float
 def nan_to_num(
     x: float,
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -150,7 +150,7 @@ def nan_to_num(
 @overload  # 0-d +complex
 def nan_to_num(
     x: complex,
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -158,7 +158,7 @@ def nan_to_num(
 @overload  # >0-d ~bool
 def nan_to_num(
     x: _NestedSequence[bool],
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -166,7 +166,7 @@ def nan_to_num(
 @overload  # >0-d ~int
 def nan_to_num(
     x: _NestedSequence[list[int]] | list[int],
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -174,7 +174,7 @@ def nan_to_num(
 @overload  # >0-d ~float
 def nan_to_num(
     x: _NestedSequence[list[float]] | list[float],
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -182,7 +182,7 @@ def nan_to_num(
 @overload  # >0-d ~complex
 def nan_to_num(
     x: _NestedSequence[list[complex]] | list[complex],
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -190,7 +190,7 @@ def nan_to_num(
 @overload  # >0-d <unknown dtype>
 def nan_to_num(
     x: _NestedSequence[ArrayLike],
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
@@ -198,7 +198,7 @@ def nan_to_num(
 @overload  # ?-d <unknown dtype>
 def nan_to_num(
     x: ArrayLike,
-    copy: bool = True,
+    copy: bool | None = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,


### PR DESCRIPTION
### PR summary
Closes gh-29045

This PR updates the docstring of `np.nan_to_num` and its `Returns` section in `numpy/lib/_type_check_impl.py` to accurately reflect NumPy 2.0+ `copy` keyword semantics:
- Updates `copy` parameter description from `bool` to `bool or None`.
- Clarifies that in NumPy 2.0+, `copy=False` raises a `ValueError` if a copy cannot be avoided (such as when passing sequences or when type casting is required), rather than silently copying.
- Documents that `copy=None` provides the "copy only if needed" behavior (or in-place if possible).
- Updates the `Returns` section to state that `x` itself may be returned when `copy` is `False` or `None`.

This follows the guidance from @seberg on gh-29045 noting that this was purely a documentation discrepancy with the NumPy 2.0 copy keyword policy.

### First time committer introduction
Hi everyone! I am Anush,  first-time contributor to NumPy. I use Python and NumPy regularly for my projects and open-source learning. I noticed this documentation discrepancy regarding NumPy 2.0's copy semantics in `nan_to_num` and wanted to contribute by clarifying it for users.

#### AI Disclosure
An AI coding assistant (Google Antigravity / Gemini) was used to help locate the issue and draft the initial docstring wording. The changes, runtime behavior (`copy=True`, `copy=False`, `copy=None`), and edge cases were manually tested and verified locally, and this pull request is reviewed and submitted by me.
