### PR TITLE
TYP: ``loadtxt`` shape-typing

### DIFF
--- a/numpy/lib/_npyio_impl.pyi
+++ b/numpy/lib/_npyio_impl.pyi
@@ -49,6 +49,9 @@ type _FNameWriteBytes = StrPath | SupportsWrite[bytes]
 type _FNameWrite = _FNameWriteBytes | SupportsWrite[str]
 
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
+
+type _Converters = Mapping[int | str, Callable[[str], Any]] | Callable[[str], Any]
 
 @type_check_only
 class _SupportsReadSeek[T](SupportsRead[T], Protocol):
@@ -118,15 +121,116 @@ def save(file: _FNameWriteBytes, arr: ArrayLike, allow_pickle: bool = True) -> N
 def savez(file: _FNameWriteBytes, *args: ArrayLike, allow_pickle: bool = True, **kwds: ArrayLike) -> None: ...
 def savez_compressed(file: _FNameWriteBytes, *args: ArrayLike, allow_pickle: bool = True, **kwds: ArrayLike) -> None: ...
 
-# File-like objects only have to implement `__iter__` and,
-# optionally, `encoding`
-@overload
+# File-like objects only have to implement `__iter__` and, optionally, `encoding`
+@overload  # Nd +f64, dtype=None, ndmin<2
 def loadtxt(
     fname: _FName,
     dtype: None = None,
     comments: str | Sequence[str] | None = "#",
     delimiter: str | None = None,
-    converters: Mapping[int | str, Callable[[str], Any]] | Callable[[str], Any] | None = None,
+    converters: _Converters | None = None,
+    skiprows: int = 0,
+    usecols: int | Sequence[int] | None = None,
+    unpack: bool = False,
+    ndmin: L[0, 1] = 0,
+    encoding: str | None = None,
+    max_rows: int | None = None,
+    *,
+    quotechar: str | None = None,
+    like: _SupportsArrayFunc | None = None,
+) -> NDArray[np.float64]: ...
+@overload  # Nd T, dtype=<known>, ndmin<2
+def loadtxt[ScalarT: np.generic](
+    fname: _FName,
+    dtype: _DTypeLike[ScalarT],
+    comments: str | Sequence[str] | None = "#",
+    delimiter: str | None = None,
+    converters: _Converters | None = None,
+    skiprows: int = 0,
+    usecols: int | Sequence[int] | None = None,
+    unpack: bool = False,
+    ndmin: L[0, 1] = 0,
+    encoding: str | None = None,
+    max_rows: int | None = None,
+    *,
+    quotechar: str | None = None,
+    like: _SupportsArrayFunc | None = None,
+) -> NDArray[ScalarT]: ...
+@overload  # Nd, ndmin<2  (fallback)
+def loadtxt(
+    fname: _FName,
+    dtype: DTypeLike | None,
+    comments: str | Sequence[str] | None = "#",
+    delimiter: str | None = None,
+    converters: _Converters | None = None,
+    skiprows: int = 0,
+    usecols: int | Sequence[int] | None = None,
+    unpack: bool = False,
+    ndmin: L[0, 1] = 0,
+    encoding: str | None = None,
+    max_rows: int | None = None,
+    *,
+    quotechar: str | None = None,
+    like: _SupportsArrayFunc | None = None,
+) -> NDArray[Any]: ...
+@overload  # 2d +f64, dtype=None (default), ndmin=2
+def loadtxt(
+    fname: _FName,
+    dtype: None = None,
+    comments: str | Sequence[str] | None = "#",
+    delimiter: str | None = None,
+    converters: _Converters | None = None,
+    skiprows: int = 0,
+    usecols: int | Sequence[int] | None = None,
+    unpack: bool = False,
+    *,
+    ndmin: L[2],
+    encoding: str | None = None,
+    max_rows: int | None = None,
+    quotechar: str | None = None,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array2D[np.float64]: ...
+@overload  # 2d T, dtype=<known>, ndmin=2
+def loadtxt[ScalarT: np.generic](
+    fname: _FName,
+    dtype: _DTypeLike[ScalarT],
+    comments: str | Sequence[str] | None = "#",
+    delimiter: str | None = None,
+    converters: _Converters | None = None,
+    skiprows: int = 0,
+    usecols: int | Sequence[int] | None = None,
+    unpack: bool = False,
+    *,
+    ndmin: L[2],
+    encoding: str | None = None,
+    max_rows: int | None = None,
+    quotechar: str | None = None,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array2D[ScalarT]: ...
+@overload  # 2d, ndmin=2  (fallback)
+def loadtxt(
+    fname: _FName,
+    dtype: DTypeLike | None,
+    comments: str | Sequence[str] | None = "#",
+    delimiter: str | None = None,
+    converters: _Converters | None = None,
+    skiprows: int = 0,
+    usecols: int | Sequence[int] | None = None,
+    unpack: bool = False,
+    *,
+    ndmin: L[2],
+    encoding: str | None = None,
+    max_rows: int | None = None,
+    quotechar: str | None = None,
+    like: _SupportsArrayFunc | None = None,
+) -> _Array2D[Any]: ...
+@overload  # Nd +f64, dtype=None, ndmin<3  (fallback)
+def loadtxt(
+    fname: _FName,
+    dtype: None = None,
+    comments: str | Sequence[str] | None = "#",
+    delimiter: str | None = None,
+    converters: _Converters | None = None,
     skiprows: int = 0,
     usecols: int | Sequence[int] | None = None,
     unpack: bool = False,
@@ -137,13 +241,13 @@ def loadtxt(
     quotechar: str | None = None,
     like: _SupportsArrayFunc | None = None,
 ) -> NDArray[np.float64]: ...
-@overload
+@overload  # Nd T, dtype=<known>, ndmin<3  (fallback)
 def loadtxt[ScalarT: np.generic](
     fname: _FName,
     dtype: _DTypeLike[ScalarT],
     comments: str | Sequence[str] | None = "#",
     delimiter: str | None = None,
-    converters: Mapping[int | str, Callable[[str], Any]] | Callable[[str], Any] | None = None,
+    converters: _Converters | None = None,
     skiprows: int = 0,
     usecols: int | Sequence[int] | None = None,
     unpack: bool = False,
@@ -154,13 +258,13 @@ def loadtxt[ScalarT: np.generic](
     quotechar: str | None = None,
     like: _SupportsArrayFunc | None = None,
 ) -> NDArray[ScalarT]: ...
-@overload
+@overload  # Nd, ndmin<3  (fallback)
 def loadtxt(
     fname: _FName,
     dtype: DTypeLike | None,
     comments: str | Sequence[str] | None = "#",
     delimiter: str | None = None,
-    converters: Mapping[int | str, Callable[[str], Any]] | Callable[[str], Any] | None = None,
+    converters: _Converters | None = None,
     skiprows: int = 0,
     usecols: int | Sequence[int] | None = None,
     unpack: bool = False,

--- a/numpy/typing/tests/data/reveal/npyio.pyi
+++ b/numpy/typing/tests/data/reveal/npyio.pyi
@@ -19,6 +19,7 @@ AR_i8: npt.NDArray[np.int64]
 AR_LIKE_f8: list[float]
 
 type _Array1D[ScalarT: np.generic] = np.ndarray[tuple[int], np.dtype[ScalarT]]
+type _Array2D[ScalarT: np.generic] = np.ndarray[tuple[int, int], np.dtype[ScalarT]]
 
 class BytesWriter:
     def write(self, data: bytes) -> None: ...
@@ -62,13 +63,16 @@ assert_type(np.savez_compressed(str_path, AR_LIKE_f8, ar1=AR_i8), None)
 assert_type(np.savez_compressed(bytes_writer, AR_LIKE_f8, ar1=AR_i8), None)
 
 assert_type(np.loadtxt(bytes_file), npt.NDArray[np.float64])
+assert_type(np.loadtxt(str_file, comments=""), npt.NDArray[np.float64])
+assert_type(np.loadtxt(str_file, comments=None), npt.NDArray[np.float64])
+assert_type(np.loadtxt(str_path, delimiter=""), npt.NDArray[np.float64])
+assert_type(np.loadtxt(str_path, ndmin=1), npt.NDArray[np.float64])
+assert_type(np.loadtxt([""]), npt.NDArray[np.float64])
 assert_type(np.loadtxt(pathlib_path, dtype=np.str_), npt.NDArray[np.str_])
 assert_type(np.loadtxt(str_path, dtype=str, skiprows=2), npt.NDArray[Any])
-assert_type(np.loadtxt(str_file, comments="test"), npt.NDArray[np.float64])
-assert_type(np.loadtxt(str_file, comments=None), npt.NDArray[np.float64])
-assert_type(np.loadtxt(str_path, delimiter="\n"), npt.NDArray[np.float64])
-assert_type(np.loadtxt(str_path, ndmin=2), npt.NDArray[np.float64])
-assert_type(np.loadtxt(["1", "2", "3"]), npt.NDArray[np.float64])
+assert_type(np.loadtxt(str_path, ndmin=2), _Array2D[np.float64])
+assert_type(np.loadtxt(pathlib_path, dtype=np.str_, ndmin=2), _Array2D[np.str_])
+assert_type(np.loadtxt(str_path, dtype=str, ndmin=2), _Array2D[Any])
 
 assert_type(np.fromregex(bytes_file, "test", np.float64), _Array1D[np.float64])
 assert_type(np.fromregex(str_file, b"test", dtype=float), _Array1D[Any])


### PR DESCRIPTION
`np.loadtxt` now returns arrays with rank 2 shape type when `ndmin=2`.

---

Pair programmed with AI