### PR TITLE
MAINT: bump ``ruff`` to 0.16.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -45,7 +45,7 @@ dependencies:
   - breathe>4.33.0
   # For linting
   - cython-lint
-  - ruff==0.16.4
+  - ruff==0.16.6
   - gitpython
   # Used in some tests
   - cffi

--- a/numpy/typing/__init__.pyi
+++ b/numpy/typing/__init__.pyi
@@ -1,8 +1,3 @@
-from numpy._typing import (  # type: ignore[deprecated]
-    ArrayLike,
-    DTypeLike,
-    NBitBase,
-    NDArray,
-)
+from numpy._typing import ArrayLike, DTypeLike, NBitBase, NDArray  # type: ignore[deprecated]
 
 __all__ = ["ArrayLike", "DTypeLike", "NBitBase", "NDArray"]

--- a/requirements/linter_requirements.txt
+++ b/requirements/linter_requirements.txt
@@ -1,5 +1,5 @@
 # keep in sync with `environment.yml`
 cython-lint
-ruff==0.16.5
+ruff==0.16.6
 GitPython==3.1.61
 spin


### PR DESCRIPTION
Manual upgrade of ruff, because #32580 resulted in a new lint error in the stubs.

---

No AI.