### PR TITLE
CI: increase ppc64le timeout to match other timeouts

### DIFF
--- a/.github/workflows/linux-ibm.yml
+++ b/.github/workflows/linux-ibm.yml
@@ -95,4 +95,4 @@ jobs:
 
     - name: Run Tests
       run: |
-        spin test -- --timeout=60 --durations=10
+        spin test -- --timeout=600 --durations=10


### PR DESCRIPTION
### PR summary
This short timeout is causing random test failures for the ppc64le CI. We use 600 seconds everywhere else and I think this was a typo.

See this CI failure: https://github.com/numpy/numpy/actions/runs/34495687057/job/102933832209?pr=32575

#### AI Disclosure
No AI
