### PR TITLE
TYP: ``nan_to_num`` improved shape-typing

### DIFF
--- a/numpy/lib/_type_check_impl.pyi
+++ b/numpy/lib/_type_check_impl.pyi
@@ -126,15 +126,23 @@ def iscomplexobj(x: _HasDType[Any] | ArrayLike) -> bool: ...
 def isrealobj(x: _HasDType[Any] | ArrayLike) -> bool: ...
 
 #
-@overload  # np.generic | np.ndarray  (`ndarray` subclasses pass through)
-def nan_to_num[ScalarOrArrayT: np.generic | np.ndarray](
+@overload  # 0d | Nd T  (`ndarray` subclasses pass through)
+def nan_to_num[ScalarOrArrayT: np.generic | np.ndarray[tuple[int, *tuple[int, ...]], Any]](
     x: ScalarOrArrayT,
     copy: bool = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> ScalarOrArrayT: ...
-@overload  # >0-d <known dtype>
+@overload  # 0d T
+def nan_to_num[ScalarT: np.generic](
+    x: np.ndarray[tuple[()], np.dtype[ScalarT]],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> ScalarT: ...
+@overload  # Nd T
 def nan_to_num[ScalarT: np.generic](
     x: _NestedSequence[_ArrayLike[ScalarT]],
     copy: bool = True,
@@ -142,7 +150,7 @@ def nan_to_num[ScalarT: np.generic](
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> NDArray[ScalarT]: ...
-@overload  # ?-d <known dtype>
+@overload  # ?d T
 def nan_to_num[DTypeT: np.dtype](
     x: _SupportsArray[DTypeT],
     copy: bool = True,
@@ -150,7 +158,7 @@ def nan_to_num[DTypeT: np.dtype](
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> np.ndarray[_AnyShape, DTypeT] | Any: ...
-@overload  # 0-d ~bool
+@overload  # 0d bool
 def nan_to_num(
     x: bool,
     copy: bool = True,
@@ -158,7 +166,7 @@ def nan_to_num(
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> np.bool: ...
-@overload  # 0-d +int
+@overload  # 0d ~int  (overlaps with bool)
 def nan_to_num(
     x: int,
     copy: bool = True,
@@ -166,7 +174,7 @@ def nan_to_num(
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> np.int_ | Any: ...
-@overload  # 0-d +float
+@overload  # 0d ~float  (overlaps with int)
 def nan_to_num(
     x: float,
     copy: bool = True,
@@ -174,7 +182,7 @@ def nan_to_num(
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> np.float64 | Any: ...
-@overload  # 0-d +complex
+@overload  # 0d ~complex  (overlaps with float)
 def nan_to_num(
     x: complex,
     copy: bool = True,
@@ -182,7 +190,71 @@ def nan_to_num(
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> np.complex128 | Any: ...
-@overload  # >0-d ~bool
+@overload  # 1d bool
+def nan_to_num(
+    x: Sequence[bool],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> _Array1D[np.bool]: ...
+@overload  # 1d ~int
+def nan_to_num(
+    x: list[int],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> _Array1D[np.int_]: ...
+@overload  # 1d ~float
+def nan_to_num(
+    x: list[float],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> _Array1D[np.float64]: ...
+@overload  # 1d ~complex
+def nan_to_num(
+    x: list[complex],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> _Array1D[np.complex128]: ...
+@overload  # 2d bool
+def nan_to_num(
+    x: Sequence[Sequence[bool]],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> _Array2D[np.bool]: ...
+@overload  # 2d ~int
+def nan_to_num(
+    x: Sequence[list[int]],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> _Array2D[np.int_]: ...
+@overload  # 2d ~float
+def nan_to_num(
+    x: Sequence[list[float]],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> _Array2D[np.float64]: ...
+@overload  # 2d ~complex
+def nan_to_num(
+    x: Sequence[list[complex]],
+    copy: bool = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> _Array2D[np.complex128]: ...
+@overload  # Nd bool
 def nan_to_num(
     x: _NestedSequence[bool],
     copy: bool = True,
@@ -190,7 +262,7 @@ def nan_to_num(
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> NDArray[np.bool]: ...
-@overload  # >0-d ~int
+@overload  # Nd ~int
 def nan_to_num(
     x: _NestedSequence[list[int]] | list[int],
     copy: bool = True,
@@ -198,7 +270,7 @@ def nan_to_num(
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> NDArray[np.int_]: ...
-@overload  # >0-d ~float
+@overload  # Nd ~float
 def nan_to_num(
     x: _NestedSequence[list[float]] | list[float],
     copy: bool = True,
@@ -206,7 +278,7 @@ def nan_to_num(
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> NDArray[np.float64]: ...
-@overload  # >0-d ~complex
+@overload  # Nd ~complex
 def nan_to_num(
     x: _NestedSequence[list[complex]] | list[complex],
     copy: bool = True,
@@ -214,22 +286,22 @@ def nan_to_num(
     posinf: float | None = None,
     neginf: float | None = None,
 ) -> NDArray[np.complex128]: ...
-@overload  # >0-d <unknown dtype>
+@overload  # Nd  (fallback)
 def nan_to_num(
     x: _NestedSequence[ArrayLike],
     copy: bool = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
-) -> np.ndarray: ...
-@overload  # ?-d <unknown dtype>
+) -> NDArray[Any]: ...
+@overload  # ?d  (fallback)
 def nan_to_num(
     x: ArrayLike,
     copy: bool = True,
     nan: float = 0.0,
     posinf: float | None = None,
     neginf: float | None = None,
-) -> np.ndarray | Any: ...
+) -> NDArray[Any] | Any: ...
 
 #
 @overload

--- a/numpy/typing/tests/data/reveal/type_check.pyi
+++ b/numpy/typing/tests/data/reveal/type_check.pyi
@@ -16,6 +16,7 @@ AR_f16: npt.NDArray[np.longdouble]
 AR_c8: npt.NDArray[np.complex64]
 AR_c16: npt.NDArray[np.complex128]
 
+AR_f8_0d: np.ndarray[tuple[()], np.dtype[np.float64]]
 AR_f8_1d: np.ndarray[tuple[int], np.dtype[np.float64]]
 AR_f8_2d: np.ndarray[tuple[int, int], np.dtype[np.float64]]
 AR_c16_1d: np.ndarray[tuple[int], np.dtype[np.complex128]]
@@ -92,16 +93,21 @@ assert_type(np.nan_to_num(i4), np.int32)
 assert_type(np.nan_to_num(f8), np.float64)
 assert_type(np.nan_to_num(m8_ns), np.timedelta64[int])
 assert_type(np.nan_to_num(M8_ns), np.datetime64[int])
-assert_type(np.nan_to_num(AR_LIKE_b), npt.NDArray[np.bool])
-assert_type(np.nan_to_num(AR_LIKE_i), npt.NDArray[np.int_])
-assert_type(np.nan_to_num(AR_LIKE_f), npt.NDArray[np.float64])
-assert_type(np.nan_to_num(AR_LIKE_c), npt.NDArray[np.complex128])
 assert_type(np.nan_to_num(AR_f8), npt.NDArray[np.float64])
 assert_type(np.nan_to_num(AR_c16), npt.NDArray[np.complex128])
-assert_type(np.nan_to_num(AR_f8_1d), np.ndarray[tuple[int], np.dtype[np.float64]])
-assert_type(np.nan_to_num(AR_f8_2d), np.ndarray[tuple[int, int], np.dtype[np.float64]])
-assert_type(np.nan_to_num(AR_c16_1d), np.ndarray[tuple[int], np.dtype[np.complex128]])
-assert_type(np.nan_to_num(AR_c16_2d), np.ndarray[tuple[int, int], np.dtype[np.complex128]])
+assert_type(np.nan_to_num(AR_f8_0d), np.float64)
+assert_type(np.nan_to_num(AR_f8_1d), _Array1D[np.float64])
+assert_type(np.nan_to_num(AR_f8_2d), _Array2D[np.float64])
+assert_type(np.nan_to_num(AR_c16_1d), _Array1D[np.complex128])
+assert_type(np.nan_to_num(AR_c16_2d), _Array2D[np.complex128])
+assert_type(np.nan_to_num(AR_LIKE_b), _Array1D[np.bool])
+assert_type(np.nan_to_num(AR_LIKE_i), _Array1D[np.int_])
+assert_type(np.nan_to_num(AR_LIKE_f), _Array1D[np.float64])
+assert_type(np.nan_to_num(AR_LIKE_c), _Array1D[np.complex128])
+assert_type(np.nan_to_num(AR_LIKE_b_2d), _Array2D[np.bool])
+assert_type(np.nan_to_num(AR_LIKE_i_2d), _Array2D[np.int_])
+assert_type(np.nan_to_num(AR_LIKE_f_2d), _Array2D[np.float64])
+assert_type(np.nan_to_num(AR_LIKE_c_2d), _Array2D[np.complex128])
 
 assert_type(np.real_if_close(AR_LIKE_f), npt.NDArray[Any])
 assert_type(np.real_if_close(AR_f8), npt.NDArray[np.float64])


### PR DESCRIPTION
Similar to #32579 and #32581, `np.nan_to_num` not also return exact shape-types for 1-d and 2-d nested sequences of python builtin scalars.

---

Pair programmed with AI