### PR TITLE
ENH: Vectorcall argument parsing for `reshape`, the scalar constructors and `__array_function__`

### DIFF
--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -1140,14 +1140,17 @@ cleanup:
 }
 
 static PyObject *
-array_function(PyArrayObject *NPY_UNUSED(self), PyObject *c_args, PyObject *c_kwds)
+array_function(PyArrayObject *NPY_UNUSED(self),
+        PyObject *const *argv, Py_ssize_t len_args, PyObject *kwnames)
 {
+    NPY_PREPARE_ARGPARSER;
     PyObject *func, *types, *args, *kwargs, *result;
-    static char *kwlist[] = {"func", "types", "args", "kwargs", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(
-            c_args, c_kwds, "OOOO:__array_function__", kwlist,
-            &func, &types, &args, &kwargs)) {
+    if (npy_parse_arguments("__array_function__", argv, len_args, kwnames,
+            {"func", NULL, &func},
+            {"types", NULL, &types},
+            {"args", NULL, &args},
+            {"kwargs", NULL, &kwargs}) < 0) {
         return NULL;
     }
     if (!PyTuple_CheckExact(args)) {
@@ -2931,7 +2934,7 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_VARARGS | METH_KEYWORDS, NULL},
     {"__array_function__",
         (PyCFunction)array_function,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
 
     /* for the sys module */
     {"__sizeof__",

--- a/numpy/_core/src/multiarray/methods.c
+++ b/numpy/_core/src/multiarray/methods.c
@@ -176,46 +176,52 @@ array_put(PyArrayObject *self,
 }
 
 static PyObject *
-array_reshape(PyArrayObject *self, PyObject *args, PyObject *kwds)
+array_reshape(PyArrayObject *self,
+        PyObject *const *args, Py_ssize_t len_args, PyObject *kwnames)
 {
-    static char *keywords[] = {"order", "copy", NULL};
+    NPY_PREPARE_ARGPARSER;
     PyArray_Dims newshape;
     PyObject *ret;
     NPY_ORDER order = NPY_CORDER;
     NPY_COPYMODE copy = NPY_COPY_IF_NEEDED;
-    Py_ssize_t n = PyTuple_Size(args);
 
-    if (!NpyArg_ParseKeywords(kwds, "|$O&O&", keywords,
-                PyArray_OrderConverter, &order,
-                PyArray_CopyConverter, &copy)) {
-        return NULL;
-    }
-
-    if (n <= 1) {
-        if (n != 0 && PyTuple_GET_ITEM(args, 0) == Py_None) {
-            return PyArray_View(self, NULL, NULL);
-        }
-        if (!PyArg_ParseTuple(args, "O&:reshape", PyArray_IntpConverter,
-                              &newshape)) {
+    if (kwnames != NULL) {
+        /* keyword only, and stored after the positional arguments */
+        if (npy_parse_arguments("reshape", args + len_args, 0, kwnames,
+                {"$order", &PyArray_OrderConverter, &order},
+                {"$copy", &PyArray_CopyConverter, &copy}) < 0) {
             return NULL;
         }
     }
+
+    if (len_args == 1) {
+        if (args[0] == Py_None) {
+            return PyArray_View(self, NULL, NULL);
+        }
+        if (!PyArray_IntpConverter(args[0], &newshape)) {
+            return NULL;
+        }
+    }
+    else if (len_args == 0) {
+        PyErr_SetString(PyExc_TypeError,
+                "reshape() takes exactly 1 argument (0 given)");
+        return NULL;
+    }
     else {
-        if (!PyArray_IntpConverter(args, &newshape)) {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError,
-                                "invalid shape");
-            }
-            goto fail;
+        /* shape given as separate integers */
+        PyObject *shape = PyTuple_FromArray(args, len_args);
+        if (shape == NULL) {
+            return NULL;
+        }
+        int converted = PyArray_IntpConverter(shape, &newshape);
+        Py_DECREF(shape);
+        if (!converted) {
+            return NULL;
         }
     }
     ret = _reshape_with_copy_arg(self, &newshape, order, copy);
     npy_free_cache_dim_obj(newshape);
     return ret;
-
- fail:
-    npy_free_cache_dim_obj(newshape);
-    return NULL;
 }
 
 static PyObject *
@@ -3068,7 +3074,7 @@ NPY_NO_EXPORT PyMethodDef array_methods[] = {
         METH_FASTCALL | METH_KEYWORDS, NULL},
     {"reshape",
         (PyCFunction)array_reshape,
-        METH_VARARGS | METH_KEYWORDS, NULL},
+        METH_FASTCALL | METH_KEYWORDS, NULL},
     {"resize",
         (PyCFunction)array_resize,
         METH_VARARGS | METH_KEYWORDS, NULL},

--- a/numpy/_core/src/multiarray/scalartypes.c.src
+++ b/numpy/_core/src/multiarray/scalartypes.c.src
@@ -3561,6 +3561,27 @@ unicode_arrtype_dealloc(PyObject *v)
     PyUnicode_Type.tp_dealloc(v);
 }
 
+static inline int
+scalar_new_parse_posargs(PyObject *args, PyObject *kwds, const char *format,
+        char **kwnames, PyObject **arg0)
+{
+    Py_ssize_t nargs = PyTuple_GET_SIZE(args);
+
+    assert(format[0] == '|' && format[1] == 'O');
+    assert(kwnames[0] != NULL && kwnames[1] == NULL);
+    if (NPY_LIKELY(nargs <= 1
+                   && (kwds == NULL || PyDict_GET_SIZE(kwds) == 0))) {
+        if (nargs == 1) {
+            *arg0 = PyTuple_GET_ITEM(args, 0);
+        }
+        return 0;
+    }
+    /* Always an error; the generic parser phrases it. */
+    return PyArg_ParseTupleAndKeywords(args, kwds, format, kwnames,
+                                       arg0) ? 0 : -1;
+}
+
+
 /**begin repeat
  * #name = byte, short, int, long, longlong, ubyte, ushort, uint, ulong,
  *         ulonglong, half, float, double, longdouble, cfloat, cdouble,
@@ -3631,7 +3652,7 @@ static PyObject *
     }
 #else
     static char *kwnames[] = {"", NULL};  /* positional-only */
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kwnames, &obj)) {
+    if (scalar_new_parse_posargs(args, kwds, "|O", kwnames, &obj) < 0) {
         return NULL;
     }
 #endif
@@ -3721,7 +3742,7 @@ object_arrtype_new(PyTypeObject *NPY_UNUSED(type), PyObject *args, PyObject *kwd
 {
     PyObject *obj = Py_None;
     static char *kwnames[] = {"", NULL};  /* positional-only */
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:object_", kwnames, &obj)) {
+    if (scalar_new_parse_posargs(args, kwds, "|O:object_", kwnames, &obj) < 0) {
         return NULL;
     }
     PyArray_Descr *typecode = PyArray_DescrFromType(NPY_OBJECT);
@@ -3817,7 +3838,7 @@ bool_arrtype_new(PyTypeObject *NPY_UNUSED(type), PyObject *args, PyObject *kwds)
     PyArrayObject *arr;
 
     static char *kwnames[] = {"", NULL};  /* positional-only */
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:bool_", kwnames, &obj)) {
+    if (scalar_new_parse_posargs(args, kwds, "|O:bool_", kwnames, &obj) < 0) {
         return NULL;
     }
     if (obj == NULL) {


### PR DESCRIPTION
### PR summary

`PyArg_ParseTupleAndKeywords` does not cache the keyword strings it compares against, and it forces `METH_VARARGS | METH_KEYWORDS`. NumPy already has the replacement (`npy_parse_arguments` with `METH_FASTCALL | METH_KEYWORDS`); this converts three of the remaining users.

- **`ndarray.reshape`**, the last common ndarray method on `METH_VARARGS`. It also
  used `NpyArg_ParseKeywords`.
- **The single-argument scalar `tp_new` slots** get a fast path; everything else
  is an error and still goes to `PyArg_ParseTupleAndKeywords`.
- **`ndarray.__array_function__`**. This helps subclasses forwarding via `super().__array_function__()`.

| case | main | branch | speedup |
| --- | --- | --- | --- |
| `a.reshape((2, 3), order='F')` | 295 ns | 150 ns | 1.97x |
| `a.reshape((2, 3))` | 183 ns | 103 ns | 1.77x |
| `a.reshape(-1)` | 159 ns | 91 ns | 1.74x |
| `a.reshape(6)` | 157 ns | 93 ns | 1.70x |
| `a.reshape(2, 3)` | 155 ns | 125 ns | 1.24x |
| `np.bool_(True)` | 69 ns | 53 ns | 1.30x |
| `np.int64(3)` | 329 ns | 291 ns | 1.13x |
| `np.float32(1.5)` | 318 ns | 282 ns | 1.13x |
| `ndarray.__array_function__(...)` | 1172 ns | 1129 ns | 1.04x |

The only user visible change is that four `TypeError` messages for invalid arguments to `reshape` / `__array_function__` now name the function, e.g. `reshape() got an unexpected keyword argument 'zz'`.

<details>
<summary>Benchmark code</summary>

Run against a `main` build and a branch build staged separately, alternating their
order between rounds and taking the per-case minimum (Windows/MSVC, min-of-5 over
5 rounds).

```python
import json, timeit

SETUP = """
import numpy as np
a = np.arange(6)
m = np.ndarray.__array_function__
tup = (2, 3)
"""

CASES = [
    ("reshape(2,3)",             "a.reshape(2, 3)"),
    ("reshape((2,3))",           "a.reshape(tup)"),
    ("reshape(6)",               "a.reshape(6)"),
    ("reshape(-1)",              "a.reshape(-1)"),
    ("reshape((2,3),order='F')", "a.reshape(tup, order='F')"),
    ("bool_(True)",              "np.bool_(True)"),
    ("int64(3)",                 "np.int64(3)"),
    ("float32(1.5)",             "np.float32(1.5)"),
    ("__array_function__ call",  "m(a, np.sum, (np.ndarray,), (a,), {})"),
]

n, r = 30000, 5
print(json.dumps({k: min(timeit.repeat(s, setup=SETUP, number=n, repeat=r)) / n * 1e9
                  for k, s in CASES}))
```

</details>


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://numpy.org/devdocs/dev/ai_policy.html.

In particular, all interaction is to be done by humans, including submission of PRs.
-->
Generated with [Claude Code](https://claude.com/claude-code)