### PR TITLE
TYP: ``einsum`` shape-typing

### DIFF
--- a/numpy/_core/einsumfunc.pyi
+++ b/numpy/_core/einsumfunc.pyi
@@ -5,19 +5,11 @@ import numpy as np
 from numpy import _OrderKACF
 from numpy._typing import (
     NDArray,
-    _ArrayLikeBool_co,
+    _ArrayLike,
     _ArrayLikeComplex_co,
-    _ArrayLikeFloat_co,
-    _ArrayLikeInt_co,
     _ArrayLikeObject_co,
-    _ArrayLikeUInt_co,
-    _DTypeLikeBool,
-    _DTypeLikeComplex,
     _DTypeLikeComplex_co,
-    _DTypeLikeFloat,
-    _DTypeLikeInt,
     _DTypeLikeObject,
-    _DTypeLikeUInt,
 )
 
 __all__ = ["einsum", "einsum_path"]
@@ -26,150 +18,263 @@ type _OptimizeKind = bool | Literal["greedy", "optimal"] | Sequence[Any] | None
 type _CastingSafe = Literal["no", "equiv", "safe", "same_kind"]
 type _CastingUnsafe = Literal["unsafe"]
 
-# TODO: Properly handle the `casting`-based combinatorics
-# Something like `is_scalar = bool(__subscripts.partition("->")[-1])`
-@overload
+# These literals are the 112 most frequent subscript values (per output rank) from an
+# AST survey of `einsum` call sites in 167 downstream projects (23_735 call sites,
+# 10_171 distinct strings), which cover ~41% of the surveyed calls, plus 11 common
+# single- and triple-operand forms.
+type _Subscripts0D = Literal[
+    "i->",
+    "ii",
+    ",i->",
+    "i,->",
+    "i,i",
+    "i,i->",
+    "ij,ij",
+    "ij,ij->",
+    "ij,ji->",
+    "mo,mo->",
+    "nm,nm->",
+]
+type _Subscripts1D = Literal[
+    "ii->i",
+    ",i->i",
+    "i,->i",
+    "i,i->i",
+    "ij,j",
+    "bn,bn->b",
+    "ca,ca->c",
+    "ij,ij->i",
+    "ij,ij->j",
+    "ij,ji->i",
+    "ij,ki->k",
+    "ik,ik->k",
+    "ji,ij->j",
+    "ni,ni->n",
+    "ny,ny->y",
+    "yx,xy->y",
+]
+type _Subscripts2D = Literal[
+    "ij->ji",
+    "ji",
+    "aabb->ab",
+    "abbc",
+    "abcb",
+    "ijik->jk",
+    "ijkl->ij",
+    "ijkl->jl",
+    "illj",
+    "llij",
+    "prrs",
+    "b,a->ba",
+    "i,j",
+    "i,j->ij",
+    "i,j->ji",
+    "m,d->md",
+    "ab,ab->ab",
+    "bi,bj->ij",
+    "bi,fb->if",
+    "ij,ik->jk",
+    "ij,jk",
+    "ij,jk->ik",
+    "ij,ki->ki",
+    "ij,kj->ik",
+    "ik,jk->ij",
+    "ik,kj->ij",
+    "ji,jk->ik",
+    "ji,ki->jk",
+    "ki,kj->ij",
+    "nk,km->nm",
+    "nm,no->mo",
+    "nw,nx->wx",
+    "ij,ijk->ij",
+    "ij,ijk->ik",
+    "ij,ijk->jk",
+    "ij,ikj->ik",
+    "ik,ijk->ij",
+    "jk,ijk->ij",
+    "ijk,ij->ik",
+    "ijk,ik->ij",
+    "ijk,jk->ik",
+    "ijk,kj->ki",
+    "ikj,ik->ij",
+    "mnq,nm->mq",
+    "nij,nj->ni",
+    "nmq,nm->nq",
+    "nmq,nq->nm",
+    "svt,vt->st",
+    "ajk,ajl->kl",
+    "ijk,ijk->ij",
+    "ijk,ijk->ik",
+    "ijk,jil->kl",
+    "ijk,jlk->il",
+    "ijk,lkj->il",
+    "ijl,jik->kl",
+    "kij,kil",
+    "nft,ftm->nm",
+]
+type _Subscripts3D = Literal[
+    "ab,bso->aso",
+    "cl,cpx->lpx",
+    "cv,zac->zav",
+    "gi,ghj->hij",
+    "ij,jab->iab",
+    "ij,njk->nik",
+    "nm,ftm->nft",
+    "qp,iaq->iap",
+    "ijk,jk->ijk",
+    "ijk,jl",
+    "ijk,mk->ijm",
+    "nft,nm->ftm",
+    "nij,jk->nik",
+    "rtp,pm->rtm",
+    "zac,cv->zav",
+    "aij,ajk->aik",
+    "aij,jka->aik",
+    "bij,bjk->bik",
+    "btk,bnk->btn",
+    "fij,ftj->fti",
+    "ija,ajk->aik",
+    "ijk,ikl->ijl",
+    "ijk,ikm->ijm",
+    "ijk,jkl->ikl",
+    "nfk,nft->nkt",
+    "nfm,ftm->nft",
+    "nft,ftm->nfm",
+    "nft,nfm->ftm",
+    "nij,njk->nik",
+    "nkt,nft->nfk",
+    "tij,tjk->tik",
+    "i,j,k->ijk",
+]
+type _Subscripts4D = Literal[
+    "abcd,cdjk->abjk",
+    "badc,cdjk->abjk",
+    "BNTS,BSNH->BTNH",
+    "BTNH,BSNH->BNTS",
+    "iAjB,AkBl->ikjl",
+    "ijmn,ijnk->ijmk",
+    "tpqi,trsi->pqrs",
+]
+
+###
+
+@overload  # 0d T, optimize=False
+def einsum[ScalarT: np.bool | np.number](
+    subscripts: _Subscripts0D,
+    /,
+    *operands: _ArrayLike[ScalarT],
+    out: None = None,
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    casting: _CastingSafe = "safe",
+    optimize: Literal[False] = False,
+) -> ScalarT: ...
+@overload  # 0d T, optimize=<given>
+def einsum[ScalarT: np.bool | np.number](
+    subscripts: _Subscripts0D,
+    /,
+    *operands: _ArrayLike[ScalarT],
+    out: None = None,
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    casting: _CastingSafe = "safe",
+    optimize: Literal[True, "greedy", "optimal"] | Sequence[Any] | None,
+) -> ScalarT | np.ndarray[tuple[()], np.dtype[ScalarT]]: ...
+@overload  # 1d T
+def einsum[ScalarT: np.bool | np.number | np.object_](
+    subscripts: _Subscripts1D,
+    /,
+    *operands: _ArrayLike[ScalarT],
+    out: None = None,
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    casting: _CastingSafe = "safe",
+    optimize: _OptimizeKind = False,
+) -> np.ndarray[tuple[int], np.dtype[ScalarT]]: ...
+@overload  # 2d T
+def einsum[ScalarT: np.bool | np.number | np.object_](
+    subscripts: _Subscripts2D,
+    /,
+    *operands: _ArrayLike[ScalarT],
+    out: None = None,
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    casting: _CastingSafe = "safe",
+    optimize: _OptimizeKind = False,
+) -> np.ndarray[tuple[int, int], np.dtype[ScalarT]]: ...
+@overload  # 3d T
+def einsum[ScalarT: np.bool | np.number | np.object_](
+    subscripts: _Subscripts3D,
+    /,
+    *operands: _ArrayLike[ScalarT],
+    out: None = None,
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    casting: _CastingSafe = "safe",
+    optimize: _OptimizeKind = False,
+) -> np.ndarray[tuple[int, int, int], np.dtype[ScalarT]]: ...
+@overload  # 4d T
+def einsum[ScalarT: np.bool | np.number | np.object_](
+    subscripts: _Subscripts4D,
+    /,
+    *operands: _ArrayLike[ScalarT],
+    out: None = None,
+    dtype: None = None,
+    order: _OrderKACF = "K",
+    casting: _CastingSafe = "safe",
+    optimize: _OptimizeKind = False,
+) -> np.ndarray[tuple[int, int, int, int], np.dtype[ScalarT]]: ...
+@overload  # ?d
 def einsum(
     subscripts: str | _ArrayLikeComplex_co,
     /,
-    *operands: _ArrayLikeBool_co,
+    *operands: _ArrayLikeComplex_co | _ArrayLikeObject_co,
     out: None = None,
-    dtype: _DTypeLikeBool | None = ...,
-    order: _OrderKACF = ...,
-    casting: _CastingSafe = ...,
+    dtype: _DTypeLikeComplex_co | _DTypeLikeObject | None = None,
+    order: _OrderKACF = "K",
+    casting: _CastingSafe = "safe",
     optimize: _OptimizeKind = False,
 ) -> Any: ...
-@overload
-def einsum(
-    subscripts: str | _ArrayLikeComplex_co,
-    /,
-    *operands: _ArrayLikeUInt_co,
-    out: None = None,
-    dtype: _DTypeLikeUInt | None = ...,
-    order: _OrderKACF = ...,
-    casting: _CastingSafe = ...,
-    optimize: _OptimizeKind = False,
-) -> Any: ...
-@overload
-def einsum(
-    subscripts: str | _ArrayLikeComplex_co,
-    /,
-    *operands: _ArrayLikeInt_co,
-    out: None = None,
-    dtype: _DTypeLikeInt | None = ...,
-    order: _OrderKACF = ...,
-    casting: _CastingSafe = ...,
-    optimize: _OptimizeKind = False,
-) -> Any: ...
-@overload
-def einsum(
-    subscripts: str | _ArrayLikeComplex_co,
-    /,
-    *operands: _ArrayLikeFloat_co,
-    out: None = None,
-    dtype: _DTypeLikeFloat | None = ...,
-    order: _OrderKACF = ...,
-    casting: _CastingSafe = ...,
-    optimize: _OptimizeKind = False,
-) -> Any: ...
-@overload
-def einsum(
-    subscripts: str | _ArrayLikeComplex_co,
-    /,
-    *operands: _ArrayLikeComplex_co,
-    out: None = None,
-    dtype: _DTypeLikeComplex | None = ...,
-    order: _OrderKACF = ...,
-    casting: _CastingSafe = ...,
-    optimize: _OptimizeKind = False,
-) -> Any: ...
-@overload
+@overload  # ?d, casting="unsafe"
 def einsum(
     subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: Any,
-    casting: _CastingUnsafe,
-    dtype: _DTypeLikeComplex_co | None = ...,
     out: None = None,
-    order: _OrderKACF = ...,
+    dtype: _DTypeLikeComplex_co | _DTypeLikeObject | None = None,
+    order: _OrderKACF = "K",
+    casting: _CastingUnsafe,
     optimize: _OptimizeKind = False,
 ) -> Any: ...
-@overload
-def einsum[OutT: NDArray[np.bool | np.number]](
+@overload  # ?d, out=<given>
+def einsum[OutT: NDArray[np.bool | np.number | np.object_]](
     subscripts: str | _ArrayLikeComplex_co,
     /,
-    *operands: _ArrayLikeComplex_co,
+    *operands: _ArrayLikeComplex_co | _ArrayLikeObject_co,
     out: OutT,
-    dtype: _DTypeLikeComplex_co | None = ...,
-    order: _OrderKACF = ...,
-    casting: _CastingSafe = ...,
+    dtype: _DTypeLikeComplex_co | _DTypeLikeObject | None = None,
+    order: _OrderKACF = "K",
+    casting: _CastingSafe = "safe",
     optimize: _OptimizeKind = False,
 ) -> OutT: ...
-@overload
-def einsum[OutT: NDArray[np.bool | np.number]](
+@overload  # ?d, out=<given>, casting="unsafe"
+def einsum[OutT: NDArray[np.bool | np.number | np.object_]](
     subscripts: str | _ArrayLikeComplex_co,
     /,
     *operands: Any,
     out: OutT,
+    dtype: _DTypeLikeComplex_co | _DTypeLikeObject | None = None,
+    order: _OrderKACF = "K",
     casting: _CastingUnsafe,
-    dtype: _DTypeLikeComplex_co | None = ...,
-    order: _OrderKACF = ...,
     optimize: _OptimizeKind = False,
 ) -> OutT: ...
 
-@overload
-def einsum(
-    subscripts: str | _ArrayLikeComplex_co,
-    /,
-    *operands: _ArrayLikeObject_co,
-    out: None = None,
-    dtype: _DTypeLikeObject | None = ...,
-    order: _OrderKACF = ...,
-    casting: _CastingSafe = ...,
-    optimize: _OptimizeKind = False,
-) -> Any: ...
-@overload
-def einsum(
-    subscripts: str | _ArrayLikeComplex_co,
-    /,
-    *operands: Any,
-    casting: _CastingUnsafe,
-    dtype: _DTypeLikeObject | None = ...,
-    out: None = None,
-    order: _OrderKACF = ...,
-    optimize: _OptimizeKind = False,
-) -> Any: ...
-@overload
-def einsum[OutT: NDArray[np.bool | np.number]](
-    subscripts: str | _ArrayLikeComplex_co,
-    /,
-    *operands: _ArrayLikeObject_co,
-    out: OutT,
-    dtype: _DTypeLikeObject | None = ...,
-    order: _OrderKACF = ...,
-    casting: _CastingSafe = ...,
-    optimize: _OptimizeKind = False,
-) -> OutT: ...
-@overload
-def einsum[OutT: NDArray[np.bool | np.number]](
-    subscripts: str | _ArrayLikeComplex_co,
-    /,
-    *operands: Any,
-    out: OutT,
-    casting: _CastingUnsafe,
-    dtype: _DTypeLikeObject | None = ...,
-    order: _OrderKACF = ...,
-    optimize: _OptimizeKind = False,
-) -> OutT: ...
-
-# NOTE: `einsum_call` is a hidden kwarg unavailable for public use.
-# It is therefore excluded from the signatures below.
 # NOTE: In practice the list consists of a `str` (first element)
 # and a variable number of integer tuples.
 def einsum_path(
     subscripts: str | _ArrayLikeComplex_co,
     /,
-    *operands: _ArrayLikeComplex_co | _DTypeLikeObject,
+    *operands: _ArrayLikeComplex_co | _ArrayLikeObject_co,
     optimize: _OptimizeKind = "greedy",
     einsum_call: Literal[False] = False,
 ) -> tuple[list[Any], str]: ...

--- a/numpy/typing/tests/data/fail/einsumfunc.pyi
+++ b/numpy/typing/tests/data/fail/einsumfunc.pyi
@@ -1,12 +1,10 @@
 import numpy as np
 import numpy.typing as npt
 
-AR_i: npt.NDArray[np.int64]
-AR_f: npt.NDArray[np.float64]
-AR_m: npt.NDArray[np.timedelta64]
-AR_U: npt.NDArray[np.str_]
+_i64_nd: npt.NDArray[np.int64]
+_m64_nd: npt.NDArray[np.timedelta64]
+_U_nd: npt.NDArray[np.str_]
 
-np.einsum("i,i->i", AR_i, AR_m)  # type: ignore[arg-type]
-np.einsum("i,i->i", AR_f, AR_f, dtype=np.int32)  # type: ignore[arg-type]
-np.einsum("i,i->i", AR_i, AR_i, out=AR_U)  # type: ignore[type-var]
-np.einsum("i,i->i", AR_i, AR_i, out=AR_U, casting="unsafe")  # type: ignore[call-overload]
+np.einsum("i,i->i", _i64_nd, _m64_nd)  # type: ignore[arg-type]
+np.einsum("i,i->i", _i64_nd, _i64_nd, out=_U_nd)  # type: ignore[type-var]
+np.einsum("i,i->i", _i64_nd, _i64_nd, out=_U_nd, casting="unsafe")  # type: ignore[call-overload]

--- a/numpy/typing/tests/data/reveal/einsumfunc.pyi
+++ b/numpy/typing/tests/data/reveal/einsumfunc.pyi
@@ -3,44 +3,93 @@ from typing import Any, assert_type
 import numpy as np
 import numpy.typing as npt
 
-AR_LIKE_b: list[bool]
-AR_LIKE_u: list[np.uint32]
-AR_LIKE_i: list[int]
-AR_LIKE_f: list[float]
-AR_LIKE_c: list[complex]
-AR_LIKE_U: list[str]
-AR_o: npt.NDArray[np.object_]
+type _Array0D[ST: np.generic] = np.ndarray[tuple[()], np.dtype[ST]]
+type _Array1D[ST: np.generic] = np.ndarray[tuple[int], np.dtype[ST]]
+type _Array2D[ST: np.generic] = np.ndarray[tuple[int, int], np.dtype[ST]]
+type _Array3D[ST: np.generic] = np.ndarray[tuple[int, int, int], np.dtype[ST]]
+type _Array4D[ST: np.generic] = np.ndarray[tuple[int, int, int, int], np.dtype[ST]]
 
-OUT_f: npt.NDArray[np.float64]
+_py_U: str
+_py_b_1d: list[bool]
+_py_i_1d: list[int]
+_py_f_1d: list[float]
+_py_c_1d: list[complex]
+_py_U_1d: list[str]
 
-assert_type(np.einsum("i,i->i", AR_LIKE_b, AR_LIKE_b), Any)
-assert_type(np.einsum("i,i->i", AR_o, AR_o), Any)
-assert_type(np.einsum("i,i->i", AR_LIKE_u, AR_LIKE_u), Any)
-assert_type(np.einsum("i,i->i", AR_LIKE_i, AR_LIKE_i), Any)
-assert_type(np.einsum("i,i->i", AR_LIKE_f, AR_LIKE_f), Any)
-assert_type(np.einsum("i,i->i", AR_LIKE_c, AR_LIKE_c), Any)
-assert_type(np.einsum("i,i->i", AR_LIKE_b, AR_LIKE_i), Any)
-assert_type(np.einsum("i,i,i,i->i", AR_LIKE_b, AR_LIKE_u, AR_LIKE_i, AR_LIKE_c), Any)
+_u32_1d_list: list[np.uint32]
+_f64_1d: _Array1D[np.float64]
+_f64_2d: _Array2D[np.float64]
+_f64_3d: _Array3D[np.float64]
+_f64_4d: _Array4D[np.float64]
+_f64_nd: npt.NDArray[np.float64]
+_c128_nd: npt.NDArray[np.complex128]
 
-assert_type(np.einsum("i,i->i", AR_LIKE_c, AR_LIKE_c, out=OUT_f), npt.NDArray[np.float64])
-assert_type(np.einsum("i,i->i", AR_LIKE_U, AR_LIKE_U, dtype=bool, casting="unsafe", out=OUT_f), npt.NDArray[np.float64])
-assert_type(np.einsum("i,i->i", AR_LIKE_f, AR_LIKE_f, dtype="c16"), Any)
-assert_type(np.einsum("i,i->i", AR_LIKE_U, AR_LIKE_U, dtype=bool, casting="unsafe"), Any)
+###
+# einsum
 
-assert_type(np.einsum_path("i,i->i", AR_LIKE_b, AR_LIKE_b), tuple[list[Any], str])
-assert_type(np.einsum_path("i,i->i", AR_LIKE_u, AR_LIKE_u), tuple[list[Any], str])
-assert_type(np.einsum_path("i,i->i", AR_LIKE_i, AR_LIKE_i), tuple[list[Any], str])
-assert_type(np.einsum_path("i,i->i", AR_LIKE_f, AR_LIKE_f), tuple[list[Any], str])
-assert_type(np.einsum_path("i,i->i", AR_LIKE_c, AR_LIKE_c), tuple[list[Any], str])
-assert_type(np.einsum_path("i,i->i", AR_LIKE_b, AR_LIKE_i), tuple[list[Any], str])
-assert_type(np.einsum_path("i,i,i,i->i", AR_LIKE_b, AR_LIKE_u, AR_LIKE_i, AR_LIKE_c), tuple[list[Any], str])
+# 0d
 
-assert_type(np.einsum([[1, 1], [1, 1]], AR_LIKE_i, AR_LIKE_i), Any)
+assert_type(np.einsum("i->", _f64_1d), np.float64)
+assert_type(np.einsum("ii", _f64_2d), np.float64)
+assert_type(np.einsum("i,i", _f64_1d, _f64_1d), np.float64)
+assert_type(np.einsum("ij,ij->", _f64_nd, _f64_nd), np.float64)
+assert_type(np.einsum("i,i", _f64_1d, _f64_1d, optimize=True), np.float64 | _Array0D[np.float64])
 
-assert_type(np.einsum_path([[1, 1], [1, 1]], AR_LIKE_i, AR_LIKE_i), tuple[list[Any], str])
+# 1d
 
-# subscript-free calling convention with float and complex arrays
-AR_f: npt.NDArray[np.float64]
-AR_c: npt.NDArray[np.complex128]
-assert_type(np.einsum(AR_f, [0, 1], AR_f, [1, 0], [0]), Any)
-assert_type(np.einsum(AR_c, [0, 1], AR_c, [1, 0], [0]), Any)
+assert_type(np.einsum("ii->i", _f64_2d), _Array1D[np.float64])
+assert_type(np.einsum("ij,j", _f64_2d, _f64_1d), _Array1D[np.float64])
+assert_type(np.einsum("ij,ij->i", _f64_nd, _f64_nd), _Array1D[np.float64])
+assert_type(np.einsum("i,i->i", _u32_1d_list, _u32_1d_list), _Array1D[np.uint32])
+
+# 2d
+
+assert_type(np.einsum("ij->ji", _f64_2d), _Array2D[np.float64])
+assert_type(np.einsum("i,j->ij", _f64_1d, _f64_1d), _Array2D[np.float64])
+assert_type(np.einsum("ij,jk->ik", _f64_2d, _f64_2d), _Array2D[np.float64])
+assert_type(np.einsum("ij,jk", _f64_nd, _f64_nd, optimize=True), _Array2D[np.float64])
+assert_type(np.einsum("ijk,ij->ik", _f64_3d, _f64_2d), _Array2D[np.float64])
+
+# 3d
+
+assert_type(np.einsum("bij,bjk->bik", _f64_3d, _f64_3d), _Array3D[np.float64])
+assert_type(np.einsum("i,j,k->ijk", _f64_1d, _f64_1d, _f64_1d), _Array3D[np.float64])
+
+# 4d
+
+assert_type(np.einsum("abcd,cdjk->abjk", _f64_4d, _f64_4d), _Array4D[np.float64])
+
+# ?d
+
+assert_type(np.einsum(_py_U, _f64_nd, _f64_nd), Any)
+assert_type(np.einsum("ij,jk->ik", _f64_nd, _f64_nd, dtype=np.float32), Any)
+assert_type(np.einsum("ij,jk->ik", _f64_nd, _f64_nd, casting="unsafe"), Any)
+assert_type(np.einsum("ij,jk->ik", _f64_nd, _f64_nd, out=_f64_nd), npt.NDArray[np.float64])
+
+assert_type(np.einsum("i,i->i", _py_b_1d, _py_b_1d), Any)
+assert_type(np.einsum("i,i->i", _py_i_1d, _py_i_1d), Any)
+assert_type(np.einsum("i,i->i", _py_f_1d, _py_f_1d), Any)
+assert_type(np.einsum("i,i->i", _py_c_1d, _py_c_1d), Any)
+assert_type(np.einsum("i,i->i", _py_b_1d, _py_i_1d), Any)
+assert_type(np.einsum("i,i,i,i->i", _py_b_1d, _u32_1d_list, _py_i_1d, _py_c_1d), Any)
+assert_type(np.einsum("i,i->i", _py_f_1d, _py_f_1d, dtype="c16"), Any)
+assert_type(np.einsum("i,i->i", _py_c_1d, _py_c_1d, out=_f64_nd), npt.NDArray[np.float64])
+assert_type(np.einsum("i,i->i", _py_U_1d, _py_U_1d, dtype=bool, casting="unsafe"), Any)
+assert_type(np.einsum("i,i->i", _py_U_1d, _py_U_1d, dtype=bool, casting="unsafe", out=_f64_nd), npt.NDArray[np.float64])
+
+# sublist format
+
+assert_type(np.einsum([[1, 1], [1, 1]], _py_i_1d, _py_i_1d), Any)
+assert_type(np.einsum(_f64_nd, [0, 1], _f64_nd, [1, 0], [0]), Any)
+assert_type(np.einsum(_c128_nd, [0, 1], _c128_nd, [1, 0], [0]), Any)
+
+###
+#  einsum_path
+
+assert_type(np.einsum_path("i,i->i", _py_b_1d, _py_b_1d), tuple[list[Any], str])
+assert_type(np.einsum_path("i,i->i", _py_i_1d, _py_i_1d), tuple[list[Any], str])
+assert_type(np.einsum_path("i,i->i", _py_f_1d, _py_f_1d), tuple[list[Any], str])
+assert_type(np.einsum_path("i,i->i", _py_c_1d, _py_c_1d), tuple[list[Any], str])
+assert_type(np.einsum_path("i,i->i", _py_b_1d, _py_i_1d), tuple[list[Any], str])
+assert_type(np.einsum_path("i,i,i,i->i", _py_b_1d, _u32_1d_list, _py_i_1d, _py_c_1d), tuple[list[Any], str])
+assert_type(np.einsum_path([[1, 1], [1, 1]], _py_i_1d, _py_i_1d), tuple[list[Any], str])


### PR DESCRIPTION
At first I thought it would be impossible to shape-type `numpy.einsum`, because it's not possible to statically parse the einsum string using Python's type system. However, I had AI do a survey to see if there are certain einsum strings that are used often. And as it turns out, we can cover ~41% of the `np.einsum` calls using a subset of the 112 most frequently used einsum strings. These are then grouped by output rank, and for each group an overload is added. So this way, `einsum` is shape-typed for ~41% of the use cases :).

---

Researched and pair-programmed with AI.