### PR TITLE
BUG: modernize PyArray_PythonPyIntFromInt behavior

### DIFF
--- a/numpy/_core/src/common/npy_argparse.c
+++ b/numpy/_core/src/common/npy_argparse.c
@@ -61,7 +61,23 @@ PyArray_PythonPyIntFromInt(PyObject *obj, int *value)
         return NPY_FAIL;
     }
 
-    long result = PyLong_AsLong(obj);
+    PyObject *integer = PyNumber_Index(obj);
+    if (integer == NULL) {
+        PyErr_Clear();
+        integer = PyNumber_Long(obj);
+        if (integer == NULL) {
+            return NPY_FAIL;
+        }
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                "Conversion of non-integer input to an integer is deprecated. "
+                "In a future version of NumPy, it will raise an error.", 1) < 0) {
+            Py_DECREF(integer);
+            return NPY_FAIL;
+        }
+    }
+
+    long result = PyLong_AsLong(integer);
+    Py_DECREF(integer);
     if (NPY_UNLIKELY((result == -1) && PyErr_Occurred())) {
         return NPY_FAIL;
     }
@@ -70,10 +86,8 @@ PyArray_PythonPyIntFromInt(PyObject *obj, int *value)
                         "Python int too large to convert to C int");
         return NPY_FAIL;
     }
-    else {
-        *value = (int)result;
-        return NPY_SUCCEED;
-    }
+    *value = (int)result;
+    return NPY_SUCCEED;
 }
 
 

--- a/numpy/_core/tests/test_argparse.py
+++ b/numpy/_core/tests/test_argparse.py
@@ -12,6 +12,7 @@ match exactly, and could be adjusted):
 """
 
 import threading
+import warnings
 
 import pytest
 
@@ -42,6 +43,22 @@ def test_invalid_integers():
         func(1.)
     with pytest.raises(OverflowError):
         func(2**100)
+
+
+def test_legacy_integer_conversion_warns():
+    class HasIndex:
+        def __index__(self):
+            return 1
+
+    class HasInt:
+        def __int__(self):
+            return 1
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        func(HasIndex(), None)
+    with pytest.warns(DeprecationWarning, match="non-integer input"):
+        func(HasInt(), None)
 
 
 def test_missing_arguments():


### PR DESCRIPTION
Closes gh-32590.\n\nPrefer the modern __index__ conversion path. Retain the legacy __int__ fallback temporarily, emitting a DeprecationWarning, and add parser-level regression coverage.