### PR TITLE
PERF: Avoid refilling buffers for operands broadcast over them

### DIFF
--- a/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
+++ b/numpy/_core/src/multiarray/lowlevel_strided_loops.c.src
@@ -1357,22 +1357,71 @@ PyArray_TransferNDimToStrided(npy_intp ndim,
     /* Finish off dimension 1 */
     M = (shape1 - coord1 - 1);
     N = shape0*M;
-    for (i = 0; i < M; ++i) {
+
+    /*
+     * When the source does not advance along this dimension it is broadcast
+     * over it, so every repetition writes byte-identical data.  If the
+     * destination is contiguous we can call the transfer function once and
+     * then grow the result by repeatedly doubling it, which turns O(M)
+     * transfer calls into O(log M).  This matters a lot when `shape0` is
+     * small (e.g. filling a buffer from a length-3 row vector), where the
+     * plain loop degenerates into thousands of tiny copies.
+     *
+     * Restricted to dtypes without references: doubling duplicates raw
+     * destination bytes without adjusting reference counts, and it also
+     * invokes the transfer function fewer times, which would be observable
+     * for casts with side effects (as object casts can have).
+     */
+    if (M > 0 && count > 0 && src_stride1 == 0
+            && dst_stride == cast_info->context.descriptors[1]->elsize
+            && !PyDataType_REFCHK(cast_info->context.descriptors[0])
+            && !PyDataType_REFCHK(cast_info->context.descriptors[1])) {
+        npy_intp dst_itemsize = dst_stride;
+        npy_intp todo = shape0 * M;
+        int finishes = (todo >= count);
+        npy_intp nwrite = finishes ? count : todo;
+        npy_intp first = (shape0 < nwrite) ? shape0 : nwrite;
+        npy_intp filled;
+
+        /* Produce the first repetition through the transfer function */
         args[0] = src; args[1] = dst;
-        if (shape0 >= count) {
-            return cast_info->func(&cast_info->context,
-                    args, &count, strides, cast_info->auxdata);
+        if (cast_info->func(&cast_info->context,
+                args, &first, strides, cast_info->auxdata) < 0) {
+            return -1;
         }
-        else {
-            res = cast_info->func(&cast_info->context,
-                    args, &shape0, strides, cast_info->auxdata);
-            if (res < 0) {
-                return -1;
+
+        /* Grow the written region by doubling it until `nwrite` is reached */
+        for (filled = first; filled < nwrite; ) {
+            npy_intp chunk = (filled <= nwrite - filled) ? filled : nwrite - filled;
+            memmove(dst + filled*dst_itemsize, dst, chunk*dst_itemsize);
+            filled += chunk;
+        }
+
+        if (finishes) {
+            return 0;
+        }
+        count -= todo;
+        dst += todo*dst_stride;
+        /* `src` is unchanged because `src_stride1 == 0` */
+    }
+    else {
+        for (i = 0; i < M; ++i) {
+            args[0] = src; args[1] = dst;
+            if (shape0 >= count) {
+                return cast_info->func(&cast_info->context,
+                        args, &count, strides, cast_info->auxdata);
             }
+            else {
+                res = cast_info->func(&cast_info->context,
+                        args, &shape0, strides, cast_info->auxdata);
+                if (res < 0) {
+                    return -1;
+                }
+            }
+            count -= shape0;
+            src += src_stride1;
+            dst += shape0*dst_stride;
         }
-        count -= shape0;
-        src += src_stride1;
-        dst += shape0*dst_stride;
     }
 
     /* If it's 2-dimensional, there's no more to copy */

--- a/numpy/_core/src/multiarray/nditer_templ.c.src
+++ b/numpy/_core/src/multiarray/nditer_templ.c.src
@@ -220,6 +220,7 @@ npyiter_buffered_iternext(NpyIter *iter)
     int nop = NIT_NOP(iter);
 
     NpyIter_BufferData *bufferdata = NIT_BUFFERDATA(iter);
+    char **ptrs = NIT_USERPTRS(iter);
 
     /*
      * If the iterator handles the inner loop, need to increment all
@@ -230,10 +231,8 @@ npyiter_buffered_iternext(NpyIter *iter)
         if (++NIT_ITERINDEX(iter) < NBF_BUFITEREND(bufferdata)) {
             int iop;
             npy_intp *strides;
-            char **ptrs;
 
             strides = NBF_STRIDES(bufferdata);
-            ptrs = NIT_USERPTRS(iter);
             for (iop = 0; iop < nop; ++iop) {
                 ptrs[iop] += strides[iop];
             }
@@ -243,6 +242,17 @@ npyiter_buffered_iternext(NpyIter *iter)
     else {
         NIT_ITERINDEX(iter) += NBF_SIZE(bufferdata);
     }
+
+    /*
+     * Save the previously used data pointers in the user pointers so that
+     * `npyiter_copy_to_buffers()` can skip the copy for operands whose data
+     * pointer did not change (e.g. an operand broadcast over the buffered
+     * dimensions, whose buffer content is identical for every fill).
+     * This mirrors what the buffered *reduce* iternext already does.
+     * NB: `npyiter_goto_iterindex()` does not clobber the user pointers in
+     * the buffered case, and a non-zero `coreoffset` disables the re-use.
+     */
+    memcpy(ptrs, NIT_DATAPTRS(iter), NPY_SIZEOF_INTP*nop);
 
     /* Write back to the arrays */
     if (npyiter_copy_from_buffers(iter) < 0) {
@@ -261,7 +271,7 @@ npyiter_buffered_iternext(NpyIter *iter)
     }
 
     /* Prepare the next buffers and set iterend/size */
-    if (npyiter_copy_to_buffers(iter, NULL) < 0) {
+    if (npyiter_copy_to_buffers(iter, ptrs) < 0) {
         npyiter_clear_buffers(iter);
         return 0;
     }


### PR DESCRIPTION
Filling the iterator buffer for an operand that is broadcast over the buffered
dimensions is dominated by copy overhead rather than by the work it performs.

For `matrix(100000, 3) += vector(3,)` with a C-ordered `matrix`, a `perf`
profile attributes roughly 96% of the run time to the transfer machinery
(`_contig_to_contig`, `PyArray_TransferNDimToStrided`) and only about 5% to the
arithmetic loop (`FLOAT_add`). The same operation on an F-ordered array, where
neither operand needs buffering, is ~30x faster.

This has been reported before, from different angles, in gh-13307 (broadcasting
performance on C-contiguous arrays) and gh-17471 (ufuncs using unnecessary
buffering).

## Cause

Two independent problems, both addressed here.

**1. Buffer re-use is never enabled for non-reduce iteration.**

`npyiter_copy_to_buffers()` can skip refilling an operand's buffer when that
operand's data pointer did not move since the previous buffer. That is
precisely the situation for an operand broadcast over the buffered dimensions:
its buffer content is identical for every single fill.

The buffered *reduce* iternext saves the previous data pointers and passes them
in so this can trigger, but the plain buffered iternext passed `NULL`, so the
re-use branch was unreachable for regular iteration. The re-use machinery
itself is recent; the non-reduce path simply was not wired up to it.

**2. Repeating the inner block costs O(M) transfer calls.**

`PyArray_TransferNDimToStrided()` repeats the inner block by calling the
transfer function once per repetition. When the source does not advance along
the dimension, it is broadcast over it and every repetition writes
byte-identical data. With a small inner shape this degenerates badly: filling
one 8190 element buffer from a length-3 row vector takes 2730 `memmove()` calls
of 12 bytes each.

## Changes

1. Save the previous data pointers in the user pointers before advancing and
   pass them to `npyiter_copy_to_buffers()`, mirroring the reduce variant.
   This is safe because `npyiter_goto_iterindex()` does not clobber the user
   pointers in the buffered case, and a non-zero `coreoffset` already disables
   re-use.

2. Call the transfer function once and then grow the written region by
   repeatedly doubling it, turning O(M) transfer calls into O(log M).

   The fast path is taken only for a contiguous destination and dtypes without
   references, because it duplicates raw destination bytes (which would not
   adjust reference counts) and invokes the transfer function fewer times
   (observable for casts with side effects, as object casts can have).
   Everything else falls through to the original loop, unchanged.

## Benchmarks

`asv continuous` against `main`, on the existing benchmark:

| Benchmark | Before | After | Ratio |
| --- | --- | --- | --- |
| `bench_ufunc.Broadcast.time_broadcast` | 9.58±0.2ms | 8.41±0.1ms | 0.88 |

That benchmark broadcasts a length-100 vector, which is a mild case: the number
of copies needed to fill one buffer scales as `buffersize / trailing`, so a
short trailing axis is where this hurts. Running the same benchmark shape
parametrised by the trailing axis length, with the total size held constant at
3,000,000 float64 elements:

| trailing axis | Before | After | Ratio |
| --- | --- | --- | --- |
| 1 | 3.08±0.6ms | unchanged | - |
| 3 | 9.23±0.4ms | 3.45±0.3ms | **0.37** |
| 10 | 5.37±1ms | 2.95±0.07ms | **0.55** |
| 100 | 3.31±0.5ms | unchanged | - |

Nothing regresses: `trailing=1` already takes a single-stride fast path, and at
`trailing=100` the operation is memory-bandwidth bound.

For a smaller, cache-resident case the effect is larger. `matrix(100000, 3) +=
vector(3,)`, float32, C order, measured with `timeit`:

| | time |
| --- | --- |
| before | 818 us |
| change 1 only | 52 us |
| changes 1 and 2 | **40 us** |
| F-ordered reference (no buffering needed) | 25 us |

Cost per element there no longer depends on the length of the trailing
dimension: it previously spanned 2.42 ns/element at `trailing=3` down to 0.19 at
`trailing=1000`, and is now flat at roughly 0.11 to 0.13.

Change 1 alone does not help when the whole iteration fits in a single buffer,
since there is no second fill to skip; change 2 covers that case (19.6 us ->
2.4 us for a single-buffer array).

I have deliberately not added the parametrised benchmark to `bench_ufunc.py`, to
keep this PR to the two source changes, but I am happy to add it if you would
like the case covered.

## Testing

- Full suite: 48676 passed, 0 failed.
- `numpy/_core/tests/test_nditer.py`: 905 passed.
- Additional ad-hoc checks against references computed from materialised
  (non-broadcast) arrays, covering: buffer-aligned and unaligned sizes,
  operands whose data pointer *does* move between buffers (re-use must not
  trigger), `object` dtype, casting between several dtype pairs,
  non-contiguous operands, 3-D broadcasts and three-operand expressions.

The two changes are independent, so I am happy to split this into two commits
or two PRs if that is easier to review.

Refs gh-13307, gh-17471

---

AI Supported by Claude.
I iterated with Claude Opus 5 on this.
