### PR TITLE
DOC: add details about Cython in NumPy C-API reference

### DIFF
--- a/doc/source/reference/c-api/index.rst
+++ b/doc/source/reference/c-api/index.rst
@@ -35,6 +35,56 @@ becoming familiar with the compiled-level work that can be done with
 NumPy in order to squeeze that last bit of necessary speed out of your
 code.
 
+.. _cython-c-api:
+
+Using the C-API from Cython
+===========================
+
+The NumPy C API can be used from Cython. Cython translates Python or Cython
+source into C code, which is then compiled into a native Python extension
+module. The extension still runs as part of Python rather than becoming an
+independent C program. NumPy provides Cython declaration files (``.pxd`` files)
+that give Cython access to NumPy C-API types and functions. These declarations
+require Cython 3.0 or newer.
+
+In a Cython source file, ``cimport numpy`` loads these declarations at compile
+time, while a regular ``import numpy`` imports the Python package at runtime.
+The regular import is only needed when the extension also uses Python-level
+NumPy functions, such as ``numpy.asarray`` or ``numpy.empty``. For example:
+
+.. code-block:: cython
+
+   import numpy as np
+   cimport numpy as cnp
+
+   cnp.import_array()
+
+   def ensure_2d(obj):
+       cdef cnp.ndarray arr = np.asarray(obj)
+       if cnp.PyArray_NDIM(arr) != 2:
+           raise ValueError("expected a two-dimensional array")
+       return arr
+
+Here, ``np.asarray`` is looked up through NumPy's Python API at runtime, while
+``cnp.ndarray`` and ``cnp.PyArray_NDIM`` come from the declarations loaded by
+``cimport``. Calling ``cnp.import_array()`` initializes the NumPy C-API when
+the extension module is imported. Cython 3 can add this call automatically
+when it is needed, but explicitly calling it is recommended.
+
+.. note::
+
+   For efficient access to array elements, typed memoryviews are generally
+   preferred over the older NumPy-specific ``cnp.ndarray[...]`` buffer syntax.
+   Typed memoryviews use Python's buffer protocol and therefore work with
+   NumPy arrays and other compatible buffer providers. They do not require
+   ``cimport numpy`` unless the code also uses NumPy-specific declarations.
+   See `Cython's typed memoryview documentation
+   <https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html>`__.
+
+For a longer introduction to building Cython extensions that use NumPy, see
+`Cython's Working with NumPy tutorial
+<https://cython.readthedocs.io/en/latest/src/userguide/numpy_tutorial.html>`__.
+
 .. currentmodule:: numpy-c-api
 
 .. toctree::


### PR DESCRIPTION
### PR summary
The [C-API landing page](https://numpy.org/devdocs/reference/c-api/index.html) does not introduce the Cython interface. As per the issue gh-27951 I am adding a focused section which covers Cython introduction, covers some basic details about `.pxd` declarations, `cimport numpy`, `import_array()` and memoryviews. I am also introducing a simple example and links to the more detailed Cython documentation for further reading. 
I have validated the changes by running spin docs command in my local and navigated to locally generated documentation in html files. 
This PR is to close gh-27951 

### First time committer introduction
I am a new contributor who has used NumPy in the past. I am here to contribute as part of the NumFOCUS Volunteer Sprints Fall 2026 cohort. I worked on this issue because I understand how Python heavily relies on C and saw a genuine documentation gap after I saw the issue gh-27951.  

#### AI Disclosure
I used AI (OpenAI Codex specifically 5.6-Sol) to understand some aspects of the issue and also to understand deeper details about Cython concepts like typed `memoryviews`, `.pxd `declarations. I made research notes myself on all the relevant details that could be used in the documentation updates and then used AI to refine my text and suggest any gaps present. I used AI to assist with the changes instead of letting it do the changes by itself. I read, reviewed and revised AI written text in the changes. I did not use AI to write any commit messages, PR description and any communication on the issue. I fully understand all the concepts around the documentation that I am adding and take full responsibility for these changes. 
