### PR TITLE
BUG: Fix broadcasting error in polyfit with cov=True on rank-deficient inputs (gh-22380)

### DIFF
--- a/numpy/lib/_polynomial_impl.py
+++ b/numpy/lib/_polynomial_impl.py
@@ -675,6 +675,7 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
     scale = NX.sqrt((lhs * lhs).sum(axis=0))
     lhs /= scale
     c, resids, rank, s = lstsq(lhs, rhs, rcond)
+    c_lstsq = c
     c = (c.T / scale).T  # broadcast scale coefficients
 
     # warn on rank reduction, which indicates an ill conditioned matrix
@@ -697,6 +698,11 @@ def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
             # it was decided that the "- 2" (originally justified by "Bayesian
             # uncertainty analysis") is not what the user expects
             # (see gh-11196 and gh-11197)
+            if resids.size == 0:
+                if y.ndim == 1:
+                    resids = NX.sum((rhs - dot(lhs, c_lstsq))**2, keepdims=True)
+                else:
+                    resids = NX.sum((rhs - dot(lhs, c_lstsq))**2, axis=0)
             fac = resids / (len(x) - order)
         if y.ndim == 1:
             return c, Vbase * fac

--- a/numpy/lib/tests/test_polynomial.py
+++ b/numpy/lib/tests/test_polynomial.py
@@ -237,6 +237,30 @@ class TestPolynomial:
         assert_allclose(mean.std(), 0.5, atol=0.01)
         assert_almost_equal(np.sqrt(cov.mean()), 0.25)
 
+    def test_polyfit_cov_rank_deficient(self):
+        # gh-22380: lstsq returns empty residuals when rank < order,
+        # which previously caused a broadcasting error with cov=True.
+        from numpy.exceptions import RankWarning
+        x = np.array([-4.2073038, -3.01299361, 0.17435259, -0.45885279,
+                      -2.18740973, -1.65722718])
+        y = np.array([21.47761358, -3.06717015, -12.85000342, -10.2560546,
+                      0.03992826, 3.36907162])
+        w = np.array([4.73816559, 0.79306992, 4.84662284, 2.68313602,
+                      1.2997438, 1.09350907])
+        with pytest.warns(RankWarning, match="Polyfit may be poorly conditioned"):
+            p, cov = np.polyfit(x, y, deg=3, rcond=0.01, full=False, w=w, cov=True)
+        assert_equal(p.shape, (4,))
+        assert_equal(cov.shape, (4, 4))
+        assert_(not np.any(np.isnan(cov)))
+
+        # Also test 2D y case
+        y2 = np.column_stack([y, y])
+        with pytest.warns(RankWarning, match="Polyfit may be poorly conditioned"):
+            p2, cov2 = np.polyfit(x, y2, deg=3, rcond=0.01, full=False, w=w, cov=True)
+        assert_equal(p2.shape, (4, 2))
+        assert_equal(cov2.shape, (4, 4, 2))
+        assert_(not np.any(np.isnan(cov2)))
+
     def test_objects(self):
         from decimal import Decimal
         p = np.poly1d([Decimal('4.0'), Decimal('3.0'), Decimal('2.0')])


### PR DESCRIPTION
### PR summary

This PR fixes `ValueError: operands could not be broadcast together with shapes` in `np.polyfit` when `cov=True` is used with an ill-conditioned or rank-deficient matrix (where `rank < order`).

In `np.linalg.lstsq`, whenever `rank < N`, `resids` is returned as an empty array of shape `(0,)`. In `_polynomial_impl.py`, `polyfit` previously attempted to compute `fac = resids / (len(x) - order)` and then `Vbase * fac`, which caused a broadcasting failure between `(order, order)` and `(0,)`.

We fix this by calculating the sum of squared residuals from `(rhs - dot(lhs, c_lstsq))**2` when `resids.size == 0`, and added a test case in `test_polynomial.py`.

Closes gh-22380

### First time committer introduction

Hi, my name is Vimal. I'm a student and open-source enthusiast interested in Python and scientific computing. I use NumPy regularly for data analysis and numerical exercises, and I wanted to contribute a fix for this open edge-case issue in polyfit.

#### AI Disclosure

I used Google Antigravity / Gemini to help explore the repository, understand the `lstsq` specification, and write the reproduction script. The fix and regression test were tested and validated by me locally before submitting.