### PR TITLE
BUG: fix np.strings.replace truncating old/new to a's

### DIFF
--- a/numpy/_core/strings.py
+++ b/numpy/_core/strings.py
@@ -1339,8 +1339,8 @@ def replace(a, old, new, count=-1):
         return _replace(arr, old, new, count)
 
     a_dt = arr.dtype
-    old = old.astype(old_dtype or a_dt, copy=False)
-    new = new.astype(new_dtype or a_dt, copy=False)
+    old = old.astype(old_dtype or a_dt.char, copy=False)
+    new = new.astype(new_dtype or a_dt.char, copy=False)
     max_int64 = np.iinfo(np.int64).max
     counts = _count_ufunc(arr, old, 0, max_int64)
     counts = np.where(count < 0, counts, np.minimum(counts, count))
@@ -1583,7 +1583,7 @@ def partition(a, sep):
     if np.result_type(a, sep).char == "T":
         return _partition(a, sep)
 
-    sep = sep.astype(a.dtype, copy=False)
+    sep = sep.astype(a.dtype.char, copy=False)
     pos = _find_ufunc(a, sep, 0, MAX)
     a_len = str_len(a)
     sep_len = str_len(sep)
@@ -1652,7 +1652,7 @@ def rpartition(a, sep):
     if np.result_type(a, sep).char == "T":
         return _rpartition(a, sep)
 
-    sep = sep.astype(a.dtype, copy=False)
+    sep = sep.astype(a.dtype.char, copy=False)
     pos = _rfind_ufunc(a, sep, 0, MAX)
     a_len = str_len(a)
     sep_len = str_len(sep)

--- a/numpy/_core/tests/test_strings.py
+++ b/numpy/_core/tests/test_strings.py
@@ -1437,6 +1437,13 @@ class TestReplaceOnArrays:
             ["01234ABCDE6789" * i for i in range(3)]
             + ["01234ABCDE6789" + "0123456789" * 2], dtype=dt))
 
+    def test_replace_old_new_not_truncated(self, dt):
+        a = np.array(["a"], dtype=dt)
+        r1 = np.strings.replace(a, "ab", "X")
+        assert_array_equal(r1, np.array(["a"], dtype=dt))
+        r2 = np.strings.replace(a, "a", "XY")
+        assert_array_equal(r2, np.array(["XY"], dtype=dt))
+
     def test_replace_broadcasting(self, dt):
         a = np.array("0,0,0", dtype=dt)
         r1 = np.strings.replace(a, "0", "1", np.arange(3))


### PR DESCRIPTION
### PR summary
Backport of #32519. Dropped tests that fail on 2.5.x because we didn't backport #32040.


#### AI Disclosure
No AI use
