### PR TITLE
MAINT: `np.spacing`: avoid warnings with NaN input

### DIFF
--- a/numpy/_core/src/npymath/halffloat.cpp
+++ b/numpy/_core/src/npymath/halffloat.cpp
@@ -67,7 +67,9 @@ npy_half npy_half_spacing(npy_half h)
     npy_half ret;
     npy_uint16 h_exp = h&0x7c00u;
     npy_uint16 h_sig = h&0x03ffu;
-    if (h_exp == 0x7c00u) {
+    if (h_exp == 0x7c00u && h_sig != 0) {
+        ret = NPY_HALF_NAN;
+    } else if (h_exp == 0x7c00u) {
 #if NPY_HALF_GENERATE_INVALID
         npy_set_floatstatus_invalid();
 #endif

--- a/numpy/_core/src/npymath/ieee754.c.src
+++ b/numpy/_core/src/npymath/ieee754.c.src
@@ -304,6 +304,9 @@ static npy_longdouble _nextl(npy_longdouble x, int p)
 @type@ npy_spacing@suff@(@type@ x)
 {
     /* XXX: npy isnan/isinf may be optimized by bit twiddling */
+    if (npy_isnan(x)) {
+        return x;
+    }
     if (npy_isinf(x)) {
         return NPY_NAN@SUFF@;
     }

--- a/numpy/_core/tests/test_half.py
+++ b/numpy/_core/tests/test_half.py
@@ -558,13 +558,13 @@ class TestHalf:
             # Invalid value errors
             assert_raises_fpe('invalid', np.divide, float16(np.inf), float16(np.inf))
             assert_raises_fpe('invalid', np.spacing, float16(np.inf))
-            assert_raises_fpe('invalid', np.spacing, float16(np.nan))
 
             # These should not raise
             float16(65472) + float16(32)
             float16(2**-13) / float16(2)
             float16(2**-14) / float16(2**10)
             np.spacing(float16(-65504))
+            np.spacing(float16(np.nan))
             np.nextafter(float16(65504), float16(-np.inf))
             np.nextafter(float16(-65504), float16(np.inf))
             np.nextafter(float16(np.inf), float16(0))

--- a/numpy/_core/tests/test_umath.py
+++ b/numpy/_core/tests/test_umath.py
@@ -1966,16 +1966,10 @@ class TestSpecialFloats:
             return
         # FIXME: NAN raises FP invalid exception:
         #  - ceil/float16 on MSVC:32-bit
-        #  - spacing/float16 on almost all platforms
-        #  - spacing/float32,float64 on Windows MSVC with VS2022
         #  - arccos/float16,float32 on Android
-        if ufunc in (np.spacing, np.ceil) and dtype == 'e':
+        if ufunc is np.ceil and dtype == 'e':
             return
-        # Skip spacing tests with NaN on Windows MSVC (all dtypes)
-        import platform
-        if ((ufunc, platform.system()) in [
-                (np.spacing, 'Windows'), (np.arccos, 'Android')
-            ] and
+        if (ufunc is np.arccos and platform.system() == 'Android' and
             any(np.isnan(d) if isinstance(d, (int, float)) else False for d in data)):
             pytest.skip(f"{ufunc} with NaN generates warnings on this platform")
         array = np.array(data, dtype=dtype)
@@ -5112,6 +5106,14 @@ def test_spacingf():
                     reason="IBM double double")
 def test_spacingl():
     return _test_spacing(np.longdouble)
+
+@pytest.mark.parametrize(
+    "dtype", [np.float16, np.float32, np.float64, np.longdouble]
+)
+def test_spacing_nan_no_warning(dtype):
+    with np.errstate(all="raise"):
+        assert np.isnan(np.spacing(dtype(np.nan)))
+
 
 def test_spacing_gfortran():
     # Reference from this fortran file, built with gfortran 4.3.3 on linux


### PR DESCRIPTION
### PR summary
On some platforms, including my Windows machine:
```python3
import numpy as np
np.spacing(np.nan)
```
emits `RuntimeWarning: invalid value encountered in spacing`. Based on the behavior of similar functions and the comments in the code, I don't think this was intentional. This PR eliminates the inadvertent warning by special-casing NaN input.

### Additional information
I encountered this while developing SciPy. I thought it would be better to fix the source rather than leaving the `np.errstate` in the code indefinitely.

There are comments in the tests about similar issues in `ceil` and `arccos`. I set Codex on those, too, but the diffs are a bit larger, so I thought I'd start with this simple one. If you'd be be interested in a PR to fix those, I can update this PR to include those commits, available here:
https://github.com/mdhaber/numpy/pull/new/fix_spacing_ceil_arccos_nan_warning

I'd also love it if we could eliminate the warnings I get with `np.log(np.nan + 0j)`. `np.logaddexp(x, y)` where either `x` or `y` is NaN, and similar issues with `np.exp` I've only seen in SciPy CI.

#### AI Disclosure
OpenAI Codex was used to inspect the relevant implementation and tests, draft
the code changes and regression tests, and prepare this AI disclosure.